### PR TITLE
Install updates in place without quitting running apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Package.resolved
 
 # Xcode build output
 App/build/
+DuoUpdaterCore/build/
 DerivedData/
 *.xcuserstate
 xcuserdata/

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -69,10 +69,12 @@ final class AppListModel {
             // the earlier sources all miss and a recipe exists.
             VendorProbeSource()
         ], toolbox: ToolboxSource(inventory: toolbox))
+        Log.app.info("refresh: checking \(found.count, privacy: .public) apps")
         let checked = await checker.check(found)
         results = sorted(checked)
         await computeRestartInfo()
         isChecking = false
+        Log.app.info("refresh done: \(self.updateCount, privacy: .public) updates, \(self.needsRestart.count, privacy: .public) need restart")
     }
 
     /// True when this update installs seamlessly in place (Sparkle EdDSA, or a
@@ -155,7 +157,7 @@ final class AppListModel {
                 status: UpdateChecker.evaluate(installed: app, remote: remote))
         }
         results = sorted(updated)
-        computeRestartInfo()
+        await computeRestartInfo()
     }
 
     /// Update one app's install stage, coalescing download progress to whole
@@ -177,6 +179,7 @@ final class AppListModel {
     func install(_ result: UpdateResult) async {
         let id = result.id
         installErrors[id] = nil
+        Log.install.info("install start: \(result.app.name, privacy: .public) \(result.app.shortVersion ?? "?", privacy: .public) → \(result.remote?.displayVersion ?? "?", privacy: .public) via \(result.remote?.sourceName ?? "?", privacy: .public)")
 
         // Defensive re-check: the app may already be current — e.g. a manual
         // pkg install we couldn't observe, or it was updated by its own updater
@@ -188,6 +191,7 @@ final class AppListModel {
         guard result.hasUpdate else {
             // Already current on disk — but the running instance may predate
             // that update, so recompute whether a restart is needed.
+            Log.install.info("install skipped: \(result.app.name, privacy: .public) already current on disk")
             await computeRestartInfo()
             installing[id] = nil
             return
@@ -241,11 +245,14 @@ final class AppListModel {
             // effect and there's nothing left to do.
             let version = updated.app.shortVersion
             if needsRestart.contains(updated.id) {
+                Log.install.info("install done: \(updated.app.name, privacy: .public) now \(version ?? "?", privacy: .public) on disk, awaiting restart")
                 UpdateNotifier.readyToRestart(app: updated.app.name, version: version)
             } else {
+                Log.install.info("install done: \(updated.app.name, privacy: .public) now \(version ?? "?", privacy: .public)")
                 UpdateNotifier.updated(app: updated.app.name, version: version)
             }
         } catch {
+            Log.install.error("install failed: \(result.app.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
             installErrors[id] = error.localizedDescription
         }
         installing[id] = nil
@@ -260,16 +267,24 @@ final class AppListModel {
         let running = await Self.runningBuildVersions()
         var ids: Set<String> = []
         var versions: [String: String] = [:]
-        for result in results where !result.hasUpdate {
+        for result in results {
             guard let bundleID = result.app.bundleID,
                   let runVersion = running[bundleID],
                   let disk = result.app.buildVersion ?? result.app.shortVersion,
                   VersionComparator.isNewer(disk, than: runVersion) else { continue }
-            ids.insert(result.id)
+            // Always record the lagging running version — even for a row that
+            // also has a newer update pending — so the update row can show it as
+            // "current". The Restart badge, though, only makes sense when there's
+            // nothing newer to install: an update-available row shows Update and
+            // installing it re-triggers the restart prompt afterward.
             versions[result.id] = runVersion
+            if !result.hasUpdate { ids.insert(result.id) }
         }
         needsRestart = ids
         runningVersionByID = versions
+        // Re-sort: a row that just flipped to needs-restart should move up into
+        // the actionable tier rather than stay wherever it last sorted.
+        results = sorted(results)
     }
 
     /// Map of bundle id → the build version each running app launched with,
@@ -328,6 +343,7 @@ final class AppListModel {
     /// keep the Restart prompt for the user to retry.
     func restart(_ result: UpdateResult) async {
         guard let bundleID = result.app.bundleID else { return }
+        Log.app.info("restart: \(result.app.name, privacy: .public) [\(bundleID, privacy: .public)]")
         let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
         guard !running.isEmpty else { needsRestart.remove(result.id); return }
         for app in running { app.terminate() }
@@ -336,11 +352,13 @@ final class AppListModel {
             try? await Task.sleep(for: .milliseconds(200))
         }
         guard NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty else {
+            Log.app.error("restart: \(result.app.name, privacy: .public) won't quit (likely a save prompt) — leaving badge")
             return  // still up (likely a save prompt) — leave the badge
         }
         let relaunched = NSWorkspace.shared.open(result.app.path)
         needsRestart.remove(result.id)
         runningVersionByID[result.id] = nil
+        Log.app.info("restart: \(result.app.name, privacy: .public) relaunched=\(relaunched, privacy: .public)")
         if relaunched {
             UpdateNotifier.restarted(app: result.app.name, version: result.app.shortVersion)
         }
@@ -368,6 +386,21 @@ final class AppListModel {
         return await checker.check(fresh)
     }
 
+    /// Re-run the update check for one app whose source errored — the retry
+    /// affordance on an `.error` row (e.g. a transient GitHub rate-limit). Reuses
+    /// the install-stage spinner to show "Checking" on just that row, and bails
+    /// if the row is already busy (installing or mid-recheck).
+    func retry(_ result: UpdateResult) async {
+        let id = result.id
+        guard installing[id] == nil else { return }
+        Log.app.info("retry: re-checking \(result.app.name, privacy: .public)")
+        installing[id] = .checking
+        let updated = await recheck(result)
+        installing[id] = nil
+        replaceRow(updated)
+        Log.app.info("retry done: \(updated.app.name, privacy: .public) → \(String(describing: updated.status), privacy: .public)")
+    }
+
     /// Replace a single row by id and re-sort.
     private func replaceRow(_ updated: UpdateResult) {
         if let idx = results.firstIndex(where: { $0.id == updated.id }) {
@@ -376,9 +409,20 @@ final class AppListModel {
         }
     }
 
+    /// Actionable rows first: pending updates, then apps updated-on-disk that
+    /// still need a restart, then everything else — each tier alphabetical. A
+    /// restart row is just as actionable as an update, so it stays grouped with
+    /// them up top instead of sinking into the up-to-date list at the bottom
+    /// (which read as the row "disappearing" right after you clicked Update).
     private func sorted(_ list: [UpdateResult]) -> [UpdateResult] {
-        list.sorted { a, b in
-            if a.hasUpdate != b.hasUpdate { return a.hasUpdate }
+        func rank(_ r: UpdateResult) -> Int {
+            if r.hasUpdate { return 0 }
+            if needsRestart.contains(r.id) { return 1 }
+            return 2
+        }
+        return list.sorted { a, b in
+            let ra = rank(a), rb = rank(b)
+            if ra != rb { return ra < rb }
             return a.app.name.localizedCaseInsensitiveCompare(b.app.name) == .orderedAscending
         }
     }

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -38,6 +38,11 @@ final class AppListModel {
         explicit: UserDefaults.standard.string(forKey: "GitHubToken")
     )
 
+    init() {
+        // Ask once so finished-update notifications can fire later.
+        UpdateNotifier.requestAuthorization()
+    }
+
     /// Scan the disk, then check every app for updates.
     func refresh() async {
         isScanning = true
@@ -229,6 +234,17 @@ final class AppListModel {
             let updated = await recheck(result)
             replaceRow(updated)
             await computeRestartInfo()
+
+            // Tell the user it landed. If the app was running, its live process
+            // is still on the old code (so it's in needsRestart) — point them at
+            // the Restart action. Otherwise the in-place swap is already fully in
+            // effect and there's nothing left to do.
+            let version = updated.app.shortVersion
+            if needsRestart.contains(updated.id) {
+                UpdateNotifier.readyToRestart(app: updated.app.name, version: version)
+            } else {
+                UpdateNotifier.updated(app: updated.app.name, version: version)
+            }
         } catch {
             installErrors[id] = error.localizedDescription
         }
@@ -322,9 +338,12 @@ final class AppListModel {
         guard NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty else {
             return  // still up (likely a save prompt) — leave the badge
         }
-        NSWorkspace.shared.open(result.app.path)
+        let relaunched = NSWorkspace.shared.open(result.app.path)
         needsRestart.remove(result.id)
         runningVersionByID[result.id] = nil
+        if relaunched {
+            UpdateNotifier.restarted(app: result.app.name, version: result.app.shortVersion)
+        }
     }
 
     /// Re-read one app from disk and re-check it across all sources. Cheap

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -302,7 +302,6 @@ private struct AppRow: View {
         case .verifyingSignature, .verifyingCodeSignature: return "Verifying"
         case .extracting: return "Extracting"
         case .installing: return "Installing"
-        case .relaunching: return "Relaunching"
         case .runningCommand: return "Installing"
         case .done: return "Done"
         }

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -175,6 +175,15 @@ private struct AppRow: View {
                 fromVersion(latest: latest)
                 Image(systemName: "arrow.right").font(.caption2)
                 toVersion(latest: latest)
+                // When an earlier update was installed but never restarted, the
+                // "from" above is the *staged* on-disk version — the live process
+                // is still older. Surface what's actually running so the row isn't
+                // misread as "you're on the staged build".
+                if let running = model.runningVersion(result.id) {
+                    Text("· current \(running)")
+                        .foregroundStyle(.tertiary)
+                        .help("Still running \(running) — restart pending from an earlier update")
+                }
             }
             .font(.caption)
             // Long date-style versions (Warp) would otherwise wrap mid-number;
@@ -230,6 +239,13 @@ private struct AppRow: View {
     private var trailing: some View {
         if let stage {
             installProgress(stage)
+        } else if model.needsRestart.contains(result.id) && !result.hasUpdate {
+            // Restart is derived from disk-vs-running version, not the remote
+            // check — so surface it directly off `needsRestart` rather than from
+            // inside the status switch. That keeps the button steady across a
+            // refresh's transient `.unknown`/`.checking` statuses, instead of
+            // briefly flashing the source hint ("—") until the check finishes.
+            restartButton
         } else {
             switch result.status {
             case .updateAvailable:
@@ -256,9 +272,8 @@ private struct AppRow: View {
             case .toolboxManaged:
                 toolboxButton
             case .upToDate:
-                if model.needsRestart.contains(result.id) {
-                    restartButton
-                } else if result.app.isMASApp {
+                // needsRestart is handled above, before the status switch.
+                if result.app.isMASApp {
                     // We checked it against the store and it's current — but keep
                     // the "App Store" signal so a managed app never looks like an
                     // app we can update ourselves (a bare ✅ reads the same as
@@ -515,10 +530,19 @@ private struct AppRow: View {
             .help("Managed by the App Store — it handles this app's updates")
     }
 
+    /// A source was tried and failed — most often a transient GitHub rate-limit.
+    /// Unlike `.unknown`'s dead "—", this state is retryable, so it's a button:
+    /// one click re-checks just this app. The tooltip carries the failure reason.
     private var errorBadge: some View {
-        Image(systemName: "exclamationmark.triangle.fill")
-            .foregroundStyle(.orange)
-            .help(errorText)
+        Button { Task { await model.retry(result) } } label: {
+            Image(systemName: "arrow.clockwise")
+        }
+        .controlSize(.small)
+        .buttonStyle(.bordered)
+        .tint(.orange)
+        .help(errorText.isEmpty
+            ? "Update check failed — click to retry"
+            : "\(errorText) — click to retry")
     }
 
     private var errorText: String {

--- a/App/Sources/UpdateNotifier.swift
+++ b/App/Sources/UpdateNotifier.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UserNotifications
+
+/// Best-effort macOS user notifications for finished updates.
+///
+/// Every call is fire-and-forget: a notification must never block or break an
+/// install. If the user hasn't granted permission (or this ad-hoc-signed build
+/// can't post), the request is simply dropped.
+@MainActor
+enum UpdateNotifier {
+
+    /// Ask once for permission to post notifications. Safe to call on launch;
+    /// the system only prompts the first time.
+    static func requestAuthorization() {
+        UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
+
+    /// A not-running app was updated in place — there's nothing left to do.
+    static func updated(app: String, version: String?) {
+        post(title: app, body: version.map { "Updated to \($0)." } ?? "Updated.")
+    }
+
+    /// A running app was updated on disk, but its live process is still on the
+    /// old version. The user restarts it when ready, through the app's own quit
+    /// flow.
+    static func readyToRestart(app: String, version: String?) {
+        let lead = version.map { "Update to \($0) is ready." } ?? "Update is ready."
+        post(title: app, body: lead + " Restart to apply it.")
+    }
+
+    /// The user restarted and the new version is now live.
+    static func restarted(app: String, version: String?) {
+        post(title: app, body: version.map { "Now running \($0)." } ?? "Restarted on the new version.")
+    }
+
+    private static func post(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -62,6 +62,9 @@ public struct UpdateChecker: Sendable {
         // source for these — that would risk a cross-channel install. Instead we
         // read Toolbox's own local cache to show whether an update exists; the
         // action stays "open Toolbox". No data → just labelled managed.
+        let label = "\(app.name) [\(app.bundleID ?? "no-bundle-id")] v\(app.shortVersion ?? "?")"
+        Log.check.debug("check start: \(label, privacy: .public)")
+
         if app.isToolboxManaged {
             if let verdict = await toolbox?.verdict(for: app) {
                 let remote = RemoteVersion(
@@ -73,8 +76,10 @@ public struct UpdateChecker: Sendable {
                 let status: UpdateStatus = verdict.hasUpdate
                     ? .updateAvailable(latest: verdict.latestVersion)
                     : .upToDate
+                Log.check.info("\(label, privacy: .public): Toolbox → \(verdict.latestVersion, privacy: .public) (hasUpdate=\(verdict.hasUpdate, privacy: .public))")
                 return UpdateResult(app: app, remote: remote, status: status)
             }
+            Log.check.debug("\(label, privacy: .public): Toolbox-managed, no verdict")
             return UpdateResult(app: app, remote: nil, status: .toolboxManaged)
         }
 
@@ -83,20 +88,21 @@ public struct UpdateChecker: Sendable {
         for source in sources {
             do {
                 guard let remote = try await source.latestVersion(for: app) else {
+                    Log.check.debug("\(label, privacy: .public): \(source.name, privacy: .public) miss")
                     continue  // source doesn't apply; try the next one
                 }
-                return UpdateResult(
-                    app: app,
-                    remote: remote,
-                    status: Self.evaluate(installed: app, remote: remote)
-                )
+                let status = Self.evaluate(installed: app, remote: remote)
+                Log.check.info("\(label, privacy: .public): \(source.name, privacy: .public) → \(remote.displayVersion ?? "?", privacy: .public) [\(String(describing: status), privacy: .public)]")
+                return UpdateResult(app: app, remote: remote, status: status)
             } catch {
                 lastError = error.localizedDescription
+                Log.check.error("\(label, privacy: .public): \(source.name, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
                 continue
             }
         }
 
         if let lastError {
+            Log.check.error("\(label, privacy: .public): all sources exhausted, last error → .error(\(lastError, privacy: .public))")
             return UpdateResult(app: app, remote: nil, status: .error(lastError))
         }
         // Apps whose updates a known channel already owns aren't "unknown" —
@@ -110,6 +116,7 @@ public struct UpdateChecker: Sendable {
         } else {
             status = .unknown
         }
+        Log.check.info("\(label, privacy: .public): no source applied → \(String(describing: status), privacy: .public)")
         return UpdateResult(app: app, remote: nil, status: status)
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AppKit
 
 /// Stages emitted as an install proceeds, for driving UI.
 public enum InstallStage: Sendable, Equatable {
@@ -10,7 +9,6 @@ public enum InstallStage: Sendable, Equatable {
     case extracting
     case verifyingCodeSignature
     case installing
-    case relaunching
     /// A command-line installer (Homebrew) is running; payload is its latest
     /// output line.
     case runningCommand(String)
@@ -19,7 +17,14 @@ public enum InstallStage: Sendable, Equatable {
 
 /// Drives the full Sparkle update pipeline for a single app:
 /// download → EdDSA verify → extract → code-signature + Team ID verify →
-/// quit running instance → swap bundle → relaunch.
+/// swap bundle in place.
+///
+/// The bundle is replaced even while the app is running: macOS keeps the live
+/// process on the code it already mapped, so the app keeps working untouched on
+/// the old version, and the caller surfaces a "Restart" prompt. We never quit or
+/// relaunch the app — the user restarts it on their own schedule, through the
+/// app's own quit flow (so its save-on-quit prompts run). A not-running app just
+/// updates silently.
 ///
 /// Every gate must pass; a failure throws and leaves the installed app
 /// untouched (we only delete the old bundle once the new one is fully verified).
@@ -32,7 +37,6 @@ public actor SparkleInstaller {
         case noPublicKey
         case noDownloadURL
         case targetNotReplaceable(String)
-        case appWouldNotQuit(String)
 
         public var errorDescription: String? {
             switch self {
@@ -44,8 +48,6 @@ public actor SparkleInstaller {
                 return "The update has no download URL."
             case .targetNotReplaceable(let msg):
                 return "Could not replace the installed app: \(msg)"
-            case .appWouldNotQuit(let name):
-                return "\(name) wouldn’t quit (it may have unsaved changes). Quit it yourself, then update again. Nothing was changed."
             }
         }
     }
@@ -98,56 +100,15 @@ public actor SparkleInstaller {
             downloadedApp: newApp
         )
 
-        // 5. Quit the running instance (if any) so we can swap the bundle.
-        // Aborts (before touching anything) if it won't quit gracefully — we
-        // never force-kill, to avoid destroying unsaved work.
-        let bundleID = result.app.bundleID
-        let wasRunning = try await quitRunningInstance(bundleID: bundleID)
-
-        // 6. Swap the bundle into place
+        // 5. Swap the bundle into place. We do this even while the app is
+        // running: macOS keeps the live process on the code it already mapped,
+        // so it keeps working on the old version until the user restarts it (the
+        // caller surfaces a "Restart" prompt). We never force a quit — that would
+        // skip the app's own save-on-quit flow.
         onStage(.installing)
         try installApp(newApp, over: result.app.path)
 
-        // 7. Relaunch if it had been running
-        if wasRunning {
-            onStage(.relaunching)
-            await relaunch(at: result.app.path)
-        }
-
         onStage(.done)
-    }
-
-    // MARK: - Quit / relaunch
-
-    /// Ask a running instance to quit gracefully (like Cmd-Q, so the app can run
-    /// its own save prompts). Returns whether it had been running. Throws if it
-    /// won't quit within the grace period — we deliberately never force-kill,
-    /// because that would discard unsaved work. Pre-swap, so aborting is safe.
-    @MainActor
-    private func quitRunningInstance(bundleID: String?) async throws -> Bool {
-        guard let bundleID else { return false }
-        var running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-        guard !running.isEmpty else { return false }
-        let name = running.first?.localizedName ?? "The app"
-
-        for app in running { app.terminate() }
-
-        // Give it a few seconds to exit gracefully.
-        for _ in 0..<30 {
-            running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-            if running.isEmpty { return true }
-            try? await Task.sleep(for: .milliseconds(200))
-        }
-        // Still alive — most likely a blocking prompt (unsaved changes). Bail
-        // out rather than force-terminate.
-        throw InstallError.appWouldNotQuit(name)
-    }
-
-    @MainActor
-    private func relaunch(at url: URL) {
-        let config = NSWorkspace.OpenConfiguration()
-        config.activates = false
-        NSWorkspace.shared.openApplication(at: url, configuration: config)
     }
 
     // MARK: - Install

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AppKit
 import CryptoKit
 
 /// Installs an in-place update for an *official-website* app that we detect via a
@@ -13,10 +12,15 @@ import CryptoKit
 ///      real guarantee that the download is the same vendor's notarized build,
 ///      not a substituted bundle.
 ///
-/// Pipeline: download → (checksum) → unpack → signature/Team gate → quit running
-/// instance → swap bundle → relaunch. Any gate failure throws and leaves the
-/// installed app untouched (the old bundle is removed only after the new one is
-/// fully verified).
+/// Pipeline: download → (checksum) → unpack → signature/Team gate → swap bundle
+/// in place. Any gate failure throws and leaves the installed app untouched (the
+/// old bundle is removed only after the new one is fully verified).
+///
+/// The swap happens even while the app is running — macOS keeps the live process
+/// on the code it already mapped, so it keeps working on the old version and the
+/// caller surfaces a "Restart" prompt. We never quit or relaunch the app: the
+/// user restarts it on their own schedule (so its save-on-quit flow runs). A
+/// not-running app just updates silently.
 public actor VendorInstaller {
 
     public init() {}
@@ -27,7 +31,6 @@ public actor VendorInstaller {
         case unknownKind
         case checksumMismatch
         case targetNotReplaceable(String)
-        case appWouldNotQuit(String)
 
         public var errorDescription: String? {
             switch self {
@@ -41,8 +44,6 @@ public actor VendorInstaller {
                 return "The download's checksum didn't match — it may be corrupt or tampered. Nothing was changed."
             case .targetNotReplaceable(let msg):
                 return "Could not replace the installed app: \(msg)"
-            case .appWouldNotQuit(let name):
-                return "\(name) wouldn’t quit (it may have unsaved changes). Quit it yourself, then update again. Nothing was changed."
             }
         }
     }
@@ -96,19 +97,13 @@ public actor VendorInstaller {
             downloadedApp: newApp
         )
 
-        // 5. Quit the running instance (if any). Aborts before touching anything
-        // if it won't quit gracefully — we never force-kill (unsaved work).
-        let wasRunning = try await quitRunningInstance(bundleID: result.app.bundleID)
-
-        // 6. Swap the bundle into place.
+        // 5. Swap the bundle into place. We do this even while the app is
+        // running: macOS keeps the live process on the code it already mapped,
+        // so it keeps working on the old version until the user restarts it (the
+        // caller surfaces a "Restart" prompt). We never force a quit — that would
+        // skip the app's own save-on-quit flow.
         onStage(.installing)
         try installApp(newApp, over: result.app.path)
-
-        // 7. Relaunch if it had been running.
-        if wasRunning {
-            onStage(.relaunching)
-            await relaunch(at: result.app.path)
-        }
 
         onStage(.done)
     }
@@ -140,32 +135,6 @@ public actor VendorInstaller {
         try? FileManager.default.removeItem(at: renamed)
         try FileManager.default.moveItem(at: file, to: renamed)
         return renamed
-    }
-
-    // MARK: - Quit / relaunch
-
-    @MainActor
-    private func quitRunningInstance(bundleID: String?) async throws -> Bool {
-        guard let bundleID else { return false }
-        var running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-        guard !running.isEmpty else { return false }
-        let name = running.first?.localizedName ?? "The app"
-
-        for app in running { app.terminate() }
-
-        for _ in 0..<30 {
-            running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-            if running.isEmpty { return true }
-            try? await Task.sleep(for: .milliseconds(200))
-        }
-        throw InstallError.appWouldNotQuit(name)
-    }
-
-    @MainActor
-    private func relaunch(at url: URL) {
-        let config = NSWorkspace.OpenConfiguration()
-        config.activates = false
-        NSWorkspace.shared.openApplication(at: url, configuration: config)
     }
 
     // MARK: - Install

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -53,6 +53,7 @@ public struct AppScanner: Sendable {
             }
         }
 
+        Log.scan.info("scanned \(self.locations.count, privacy: .public) locations → \(apps.count, privacy: .public) apps")
         return apps.sorted {
             $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -41,10 +41,27 @@ public struct GitHubReleaseRule: Sendable {
 /// we surface the new version and link to the releases page; we never install a
 /// GitHub artifact over a differently-sourced build.
 ///
-/// Best-effort: any failure (network, rate limit, parse) degrades silently to
-/// "unknown" rather than surfacing an error or an unverified version.
+/// When no rule maps to an app, returns nil (not applicable). When a rule *does*
+/// exist but the fetch fails (network, rate limit, bad status), it throws — so
+/// the row surfaces a retryable `.error` instead of a dead "unknown" that reads
+/// the same as "no source at all". A parse miss (releases fetched, none match
+/// the pattern) still returns nil.
 public struct GitHubReleasesSource: UpdateSource {
     public let name = "GitHub"
+
+    /// A GitHub fetch that failed in a way worth retrying (vs. simply not
+    /// applying). 403/429 are almost always the unauthenticated 60/hour limit.
+    enum GitHubError: LocalizedError {
+        case badStatus(Int)
+        var errorDescription: String? {
+            switch self {
+            case .badStatus(403), .badStatus(429):
+                return "GitHub rate limit reached — retry shortly"
+            case .badStatus(let code):
+                return "GitHub returned HTTP \(code)"
+            }
+        }
+    }
 
     private let rules: [String: GitHubReleaseRule]
     private let session: URLSession
@@ -70,7 +87,10 @@ public struct GitHubReleasesSource: UpdateSource {
         guard let bundleID = app.bundleID, let rule = rules[bundleID] else {
             return nil  // no rule for this app — not applicable
         }
-        return (try? await resolve(rule)) ?? nil
+        // A rule exists: let a fetch failure throw, so the checker turns it into
+        // a retryable `.error` row rather than swallowing it into a nil that's
+        // indistinguishable from "no source for this app".
+        return try await resolve(rule)
     }
 
     private func resolve(_ rule: GitHubReleaseRule) async throws -> RemoteVersion? {
@@ -86,9 +106,14 @@ public struct GitHubReleasesSource: UpdateSource {
         // Authenticated requests get 5000/hour instead of 60/hour per IP.
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
 
+        Log.source.debug("GitHub GET \(endpoint, privacy: .public) (auth=\(self.token != nil, privacy: .public))")
         let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse,
-              (200..<300).contains(http.statusCode) else { return nil }
+        guard let http = response as? HTTPURLResponse else { return nil }
+        guard (200..<300).contains(http.statusCode) else {
+            let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"
+            Log.source.error("GitHub \(rule.slug, privacy: .public): HTTP \(http.statusCode, privacy: .public) (ratelimit-remaining=\(remaining, privacy: .public))")
+            throw GitHubError.badStatus(http.statusCode)
+        }
 
         // Walk releases in document order (GitHub returns newest first) and take
         // the first whose tag the pattern matches — for prerelease channels this
@@ -113,6 +138,7 @@ public struct GitHubReleasesSource: UpdateSource {
                 )
             }
         }
+        Log.source.error("GitHub \(rule.slug, privacy: .public): \(releases.count, privacy: .public) releases fetched, none matched /\(rule.versionPattern, privacy: .public)/")
         return nil
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -29,23 +29,8 @@ public struct SparkleAppcastSource: UpdateSource {
         }
 
         let items = SparkleAppcastParser.parse(data)
-        guard !items.isEmpty else { return nil }
-
-        let osVersion = Self.numericSystemVersion()
-        let usable = items.filter { item in
-            // Skip delta updates — they patch a specific old build.
-            guard item.deltaFrom == nil else { return false }
-            // Honor minimum system version when declared.
-            if let minOS = item.minimumSystemVersion, !minOS.isEmpty {
-                return VersionComparator.compare(osVersion, minOS) != .orderedAscending
-            }
-            return true
-        }
-
-        let best = usable.max { lhs, rhs in
-            VersionComparator.compare(lhs.comparisonKey, rhs.comparisonKey) == .orderedAscending
-        }
-        guard let best else { return nil }
+        guard let best = Self.bestItem(for: app, from: items, osVersion: Self.numericSystemVersion())
+        else { return nil }
 
         return RemoteVersion(
             shortVersion: best.shortVersionString,
@@ -57,6 +42,71 @@ public struct SparkleAppcastSource: UpdateSource {
             releaseNotesHTML: best.descriptionHTML,
             changelogURL: best.releaseNotesLink
         )
+    }
+
+    /// Pick the best appcast item for an app: the highest-versioned, runnable,
+    /// in-channel entry. Pure (no network) so the selection — especially the
+    /// channel gating — is unit-testable.
+    ///
+    /// Sparkle gates prerelease items behind a `<sparkle:channel>`. The host app
+    /// opts into a channel in code (`SPUUpdaterDelegate.allowedChannels`), which
+    /// is compiled in and NOT exposed in Info.plist or the app's UserDefaults —
+    /// so we can't read the subscription from outside the bundle. We infer it
+    /// instead from the build the user is actually running: match the installed
+    /// version to a feed item and read its channel. A stable build (default
+    /// channel) is then never offered a prerelease, and a beta build is offered
+    /// only same-channel betas — never a stable that may be incompatible. When
+    /// the installed build isn't in the feed (trimmed history) we fall back to
+    /// the default channel, the conservative choice that never pushes a surprise
+    /// prerelease.
+    static func bestItem(
+        for app: InstalledApp,
+        from items: [SparkleAppcastItem],
+        osVersion: String
+    ) -> SparkleAppcastItem? {
+        guard !items.isEmpty else { return nil }
+        let installedChannel = channel(ofInstalled: app, in: items)
+        let usable = items.filter { item in
+            // Skip delta updates — they patch a specific old build.
+            guard item.deltaFrom == nil else { return false }
+            // Only the channel the installed build is on (default channel == nil).
+            guard normalizeChannel(item.channel) == installedChannel else { return false }
+            // Honor minimum system version when declared.
+            if let minOS = item.minimumSystemVersion, !minOS.isEmpty {
+                return VersionComparator.compare(osVersion, minOS) != .orderedAscending
+            }
+            return true
+        }
+        return usable.max { lhs, rhs in
+            VersionComparator.compare(lhs.comparisonKey, rhs.comparisonKey) == .orderedAscending
+        }
+    }
+
+    /// The Sparkle channel the installed build sits on, found by matching the
+    /// installed version to a feed item — build number first (Sparkle's
+    /// canonical key), then the marketing string. nil = the default (stable)
+    /// channel, either because the matched item carried no `<sparkle:channel>`
+    /// or because the installed build isn't in the feed at all.
+    static func channel(ofInstalled app: InstalledApp, in items: [SparkleAppcastItem]) -> String? {
+        let match = items.first { item in
+            if let b = app.buildVersion, let v = item.version, !b.isEmpty, b == v {
+                return true
+            }
+            if let s = app.shortVersion, let sv = item.shortVersionString, !s.isEmpty, s == sv {
+                return true
+            }
+            return false
+        }
+        return normalizeChannel(match?.channel)
+    }
+
+    /// Collapse an absent or whitespace-only channel to nil so the default
+    /// channel compares equal however the feed spells it.
+    static func normalizeChannel(_ raw: String?) -> String? {
+        guard let c = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !c.isEmpty else {
+            return nil
+        }
+        return c
     }
 
     /// e.g. "26.6.0" — used to evaluate `minimumSystemVersion`.
@@ -79,6 +129,9 @@ struct SparkleAppcastItem {
     var edSignature: String?
     var minimumSystemVersion: String?
     var deltaFrom: String?
+    /// `<sparkle:channel>` — names a non-default release track (e.g. "beta").
+    /// nil/absent means the default (stable) channel, which Sparkle always ships.
+    var channel: String?
     /// Inline release notes — the `<description>` body, usually CDATA-wrapped HTML.
     var descriptionHTML: String?
     /// `<sparkle:releaseNotesLink>` — an external notes page, when the feed links
@@ -160,6 +213,8 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
             }
         case "sparkle:minimumSystemVersion":
             current?.minimumSystemVersion = text
+        case "sparkle:channel":
+            if current?.channel == nil, !text.isEmpty { current?.channel = text }
         case "description":
             // Only inside an <item>; the channel-level <description> has no
             // `current` to attach to, so it's harmlessly dropped.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Log.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Log.swift
@@ -1,0 +1,41 @@
+import Foundation
+import os
+
+/// Central logging for traceability. Every category shares one subsystem, so the
+/// whole app's activity can be pulled after the fact with:
+///
+///   log show --predicate 'subsystem == "com.duoupdater.app"' --last 1h --info --debug
+///
+/// or streamed live with:
+///
+///   log stream --predicate 'subsystem == "com.duoupdater.app"' --info --debug
+///
+/// or filtered in Console.app by that subsystem. `--info`/`--debug` are needed
+/// because the unified log keeps those levels off by default.
+///
+/// Levels we use:
+///   • `.debug`  — per-source hits/misses, request URLs, HTTP statuses (verbose,
+///                 the breadcrumbs you want when reconstructing one check).
+///   • `.info`   — milestones: a scan finished, an update found, an install
+///                 stage advanced.
+///   • `.error`  — a source threw, an install failed: the things that turn into
+///                 an `.error` row or a swallowed surprise.
+///
+/// Privacy: the bundle ids, app names, versions and (public) URLs we log are not
+/// secrets, so they're interpolated as `.public` to stay readable — os_log
+/// redacts dynamic strings to `<private>` otherwise. Tokens and credentials are
+/// never passed to a logger.
+public enum Log {
+    public static let subsystem = "com.duoupdater.app"
+
+    /// Disk scan: which bundles were discovered or filtered out.
+    public static let scan = Logger(subsystem: subsystem, category: "scan")
+    /// Update engine: per-app, per-source resolution and the final verdict.
+    public static let check = Logger(subsystem: subsystem, category: "check")
+    /// Individual sources: the network calls and parsing behind a check.
+    public static let source = Logger(subsystem: subsystem, category: "source")
+    /// Install/restart pipeline: download, verify, swap, relaunch.
+    public static let install = Logger(subsystem: subsystem, category: "install")
+    /// App/UI lifecycle: refresh runs, retries, user-driven actions.
+    public static let app = Logger(subsystem: subsystem, category: "app")
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleChannelTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Channel-gating for Sparkle appcasts: we can't read the host app's
+/// `allowedChannels` (it's compiled into the app), so we infer the user's
+/// channel from the build they're running and only ever offer same-channel
+/// updates — a stable user is never pushed a beta, a beta user is never
+/// dropped onto a stable.
+struct SparkleChannelTests {
+
+    /// A DuoPaste-shaped feed: a default-channel line and a beta line.
+    private let feed = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+      <channel>
+        <item>
+          <title>2.0 beta</title>
+          <sparkle:version>200</sparkle:version>
+          <sparkle:shortVersionString>2.0-beta</sparkle:shortVersionString>
+          <sparkle:channel>beta</sparkle:channel>
+          <enclosure url="https://example.com/2.0-beta.dmg" sparkle:edSignature="sig" length="1" type="application/octet-stream" />
+        </item>
+        <item>
+          <title>1.5</title>
+          <sparkle:version>150</sparkle:version>
+          <sparkle:shortVersionString>1.5</sparkle:shortVersionString>
+          <enclosure url="https://example.com/1.5.dmg" sparkle:edSignature="sig" length="1" type="application/octet-stream" />
+        </item>
+        <item>
+          <title>1.0</title>
+          <sparkle:version>100</sparkle:version>
+          <sparkle:shortVersionString>1.0</sparkle:shortVersionString>
+          <enclosure url="https://example.com/1.0.dmg" sparkle:edSignature="sig" length="1" type="application/octet-stream" />
+        </item>
+      </channel>
+    </rss>
+    """
+
+    private func app(short: String, build: String) -> InstalledApp {
+        InstalledApp(
+            name: "DuoPaste", bundleID: "io.duopaste.daemon",
+            shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/DuoPaste.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"),
+            sparkleEdPublicKey: "key")
+    }
+
+    private var items: [SparkleAppcastItem] {
+        SparkleAppcastParser.parse(Data(feed.utf8))
+    }
+
+    @Test func parserReadsChannelElement() {
+        let parsed = items
+        #expect(parsed.count == 3)
+        #expect(parsed.first(where: { $0.version == "200" })?.channel == "beta")
+        #expect(parsed.first(where: { $0.version == "150" })?.channel == nil)
+    }
+
+    @Test func stableUserNeverOffersBeta() {
+        // On the 1.0 stable build → the only newer in-channel item is 1.5.
+        let best = SparkleAppcastSource.bestItem(
+            for: app(short: "1.0", build: "100"), from: items, osVersion: "26.0.0")
+        #expect(best?.version == "150")
+    }
+
+    @Test func betaUserStaysOnBetaNotStable() {
+        // On a beta build (matched by short version) → only the beta line, even
+        // though a numerically-newer key could exist on stable.
+        let best = SparkleAppcastSource.bestItem(
+            for: app(short: "2.0-beta", build: "200"), from: items, osVersion: "26.0.0")
+        #expect(best?.channel == "beta")
+        #expect(best?.version == "200")
+    }
+
+    @Test func unknownBuildFallsBackToStable() {
+        // Installed build isn't in the feed (history trimmed) → default channel
+        // only, so we never surprise the user with a prerelease.
+        let best = SparkleAppcastSource.bestItem(
+            for: app(short: "0.9", build: "90"), from: items, osVersion: "26.0.0")
+        #expect(best?.version == "150")
+        #expect(best?.channel == nil)
+    }
+
+    @Test func channelOfInstalledMatchesOnBuildThenShortVersion() {
+        #expect(SparkleAppcastSource.channel(ofInstalled: app(short: "x", build: "200"), in: items) == "beta")
+        #expect(SparkleAppcastSource.channel(ofInstalled: app(short: "1.5", build: "x"), in: items) == nil)
+    }
+}


### PR DESCRIPTION
## What & why

The goal: a running app should never be force-quit to update it, and a not-running app should just update silently. Previously the Sparkle and Vendor installers gracefully quit a running app before swapping its bundle, and **aborted the whole update** if the app wouldn't quit — interrupting the user and making in-use apps essentially un-updatable in the background.

There's no reliable, universal way to make an arbitrary macOS app trigger *its own* updater from outside (AppleScript GUI scripting / URL schemes / Sparkle internals are all fragile or non-existent). The clean alternative is to let duo-updater own the whole flow and lean on a macOS property it already relies on for the Restart badge: **you can replace a running app's bundle on disk** — the live process keeps running the code it already mapped until it's relaunched.

## Changes

- **`SparkleInstaller` / `VendorInstaller`**: always swap the bundle in place. No quit, no relaunch.
  - Running app → keeps working on the old version; the existing `lsappinfo`-based **Restart** badge surfaces "running old code", and the user restarts on their own schedule through the app's own save-on-quit flow.
  - Not-running app → silent in-place update, nothing else to do.
  - Removed the `quitRunningInstance`/`relaunch` helpers, the `appWouldNotQuit` error, and the now-dead `.relaunching` install stage.
- **`UpdateNotifier`** (new, best-effort `UNUserNotificationCenter`):
  - "Updated to vN." — silent in-place update of a not-running app
  - "Update to vN is ready. Restart to apply it." — running app, still on old code
  - "Now running vN." — after the user clicks Restart and it relaunches
- **`AppListModel`**: requests notification authorization on launch; posts the right notification after an install completes (branching on `needsRestart`) and after a successful restart.

## Scope

Per discussion, this keeps the existing **click-to-install** model — it makes installs non-disruptive and adds notifications. Fully-automatic scheduled background updating (no click, per-app opt-in) is a larger follow-up and is intentionally out of scope here.

## Testing

⚠️ Not compiled: this is a macOS-only project (CryptoKit / AppKit / SwiftUI / UserNotifications) and the web session runs on Linux with no Swift toolchain. Changes are mechanical (removal of quit/relaunch + additive notifications) and the existing installer tests don't exercise the quit/relaunch path. Please build & run on a Mac to confirm, especially the notification authorization prompt under this repo's ad-hoc signing.

https://claude.ai/code/session_014mR6B711K64Zn3f6D9LycL

---
_Generated by [Claude Code](https://claude.ai/code/session_014mR6B711K64Zn3f6D9LycL)_