### PR TITLE
TestFlight channel support + Surge native changelog

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -49,8 +49,11 @@ final class AppListModel {
         // One Toolbox snapshot shared by the scan (to tag managed apps) and the
         // checker (to read latest-build info) — a single read of its local cache.
         let toolbox = ToolboxInventory()
+        // One TestFlight snapshot shared by the scan (to tag managed apps) and the
+        // checker (to read latest-build info) — a single read of its local cache.
+        let testflight = TestFlightInventory()
         let found = await Task.detached(priority: .userInitiated) {
-            AppScanner(toolbox: toolbox).scan()
+            AppScanner(toolbox: toolbox, testflight: testflight).scan()
         }.value
         results = found.map { UpdateResult(app: $0, remote: nil, status: .unknown) }
         lastScan = .now
@@ -68,7 +71,7 @@ final class AppListModel {
             // Last resort: bespoke per-vendor version endpoints. Only fires when
             // the earlier sources all miss and a recipe exists.
             VendorProbeSource()
-        ], toolbox: ToolboxSource(inventory: toolbox))
+        ], toolbox: ToolboxSource(inventory: toolbox), testflight: testflight)
         Log.app.info("refresh: checking \(found.count, privacy: .public) apps")
         let checked = await checker.check(found)
         results = sorted(checked)
@@ -147,9 +150,9 @@ final class AppListModel {
             guard let remote = was.remote else {
                 return UpdateResult(app: app, remote: nil, status: was.status)
             }
-            // Toolbox owns its apps' status (computed from its own cache, not a
-            // version compare) — keep it; don't re-evaluate locally.
-            guard remote.sourceName != "Toolbox" else {
+            // Toolbox and TestFlight own their apps' status (computed from their
+            // own cache, not a version compare) — keep it; don't re-evaluate.
+            guard remote.sourceName != "Toolbox", remote.sourceName != "TestFlight" else {
                 return UpdateResult(app: app, remote: remote, status: was.status)
             }
             return UpdateResult(
@@ -369,8 +372,9 @@ final class AppListModel {
     /// stale row.
     private func recheck(_ result: UpdateResult) async -> UpdateResult {
         let id = result.id
+        let testflight = TestFlightInventory()
         let apps = await Task.detached(priority: .userInitiated) {
-            AppScanner().scan()
+            AppScanner(testflight: testflight).scan()
         }.value
         guard let fresh = apps.first(where: { $0.id == id }) else { return result }
         let checker = UpdateChecker(sources: [
@@ -382,7 +386,7 @@ final class AppListModel {
             // Last resort: bespoke per-vendor version endpoints. Only fires when
             // the earlier sources all miss and a recipe exists.
             VendorProbeSource()
-        ], toolbox: ToolboxSource())
+        ], toolbox: ToolboxSource(), testflight: testflight)
         return await checker.check(fresh)
     }
 

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -252,6 +252,9 @@ private struct AppRow: View {
                 if result.remote?.sourceName == "Toolbox" {
                     // Detected via Toolbox's own cache — it installs, we just route.
                     toolboxButton
+                } else if result.remote?.sourceName == "TestFlight" {
+                    // Detected via TestFlight's cache — it installs, we just route.
+                    testFlightButton
                 } else if result.isMajorUpgrade && (model.canAutoInstall(result) || model.requiresInstaller(result)) {
                     majorUpgradeBadge
                 } else if model.canAutoInstall(result) {
@@ -271,6 +274,8 @@ private struct AppRow: View {
                 appStoreManagedLabel
             case .toolboxManaged:
                 toolboxButton
+            case .testFlightManaged:
+                testFlightManagedLabel
             case .upToDate:
                 // needsRestart is handled above, before the status switch.
                 if result.app.isMASApp {
@@ -279,6 +284,10 @@ private struct AppRow: View {
                     // app we can update ourselves (a bare ✅ reads the same as
                     // Sparkle/brew). Same label as `.appStoreManaged`.
                     appStoreManagedLabel
+                } else if result.app.isTestFlightApp {
+                    // Current on TestFlight — keep the channel tag rather than a
+                    // bare check, so it never reads like a self-updatable app.
+                    testFlightManagedLabel
                 } else {
                     Image(systemName: "checkmark").foregroundStyle(.secondary).font(.caption)
                 }
@@ -433,6 +442,23 @@ private struct AppRow: View {
         }
     }
 
+    /// TestFlight manages this beta's updates. There's no per-app deep link we can
+    /// rely on, so we just open TestFlight, where the user installs the update
+    /// through its own channel.
+    private var testFlightButton: some View {
+        Button("TestFlight") { openTestFlight() }
+            .controlSize(.small)
+            .buttonStyle(.bordered)
+            .help("Managed by TestFlight — open TestFlight to update \(result.app.name)")
+    }
+
+    private func openTestFlight() {
+        if let url = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.TestFlight") {
+            NSWorkspace.shared.openApplication(at: url, configuration: .init())
+        }
+    }
+
     private var openHelp: String {
         guard let url = result.remote?.downloadURL else { return "Reveal in Finder" }
         if let scheme = url.scheme, scheme != "http", scheme != "https" {
@@ -528,6 +554,14 @@ private struct AppRow: View {
     private var appStoreManagedLabel: some View {
         Text("App Store").font(.caption2).foregroundStyle(.tertiary)
             .help("Managed by the App Store — it handles this app's updates")
+    }
+
+    /// The "TestFlight" tag shown for a TestFlight-managed app that's current (or
+    /// whose cache returned nothing). Updates are TestFlight's job, so the row
+    /// shows the channel rather than an action we can't perform here.
+    private var testFlightManagedLabel: some View {
+        Text("TestFlight").font(.caption2).foregroundStyle(.tertiary)
+            .help("Managed by TestFlight — it handles this beta's updates")
     }
 
     /// A source was tried and failed — most often a transient GitHub rate-limit.

--- a/CHANGELOG_RECIPE_TODO.md
+++ b/CHANGELOG_RECIPE_TODO.md
@@ -1,0 +1,33 @@
+# Changelog Recipe 待接清单
+
+本机已安装第三方 app 中尚未注册 `ChangelogRecipe` 的，按优先级排列。
+完成一个就把 `[ ]` 改成 `[x]`。
+
+> 说明：MAS（App Store）安装的 app 走系统自更新，不接 changelog。
+> 下面只列 **非 MAS** 且未注册 recipe 的 app。
+
+## 待接
+- [x] Surge — `com.nssurge.surge-mac`
+      根因不是缺 recipe：appcast 用 `<markdownDescription>`（markdown），
+      而解析器只认 `<description>`(HTML) → 内联 notes 丢失 → 回退 webview。
+      已让 SparkleAppcastSource 解析 markdownDescription 为结构化 changelog
+      （新增 AppcastMarkdownParser）。两个通道当前 feed 完全相同。
+- [~] Mirage Host — `com.ethanlipnik.Mirage-Host`
+      不接：appcast 已带 releaseNotesLink，指向干净的单版本 HTML notes 页，
+      webview 已正常显示。URL 按版本固定，写死 recipe 每次发版即失效，不值。
+
+## 不接 — 其他原因
+- ToDesk `com.youqu.todesk.mac` — macOS changelog 去年停更，
+  与 Windows 不同步（macos/uplog.html 是死数据）
+- Claude desktop `com.anthropic.claudefordesktop` — 几乎没有 changelog
+
+## 不接 — MAS 安装（App Store 自更新）
+- Bob `com.hezongyidev.Bob`、Paste `com.wiheads.paste`、Spark `com.readdle.smartemail-Mac`
+- Telegram `ru.keepcoder.Telegram`、ScreenCam `cam.thescreen`、Mirage `com.ethanlipnik.Mirage`
+- DingTalk `com.dingtalk.mac`、WeChat `com.tencent.xinWeChat`、虎牙直播HD `com.yy.kiwihd`
+- Microsoft Excel / Word、TestFlight、Xcode
+
+## 不接 — 系统 / 大厂自更新 / 自研
+- Apple：Safari
+- 大厂自更新：Google Chrome、IntelliJ IDEA
+- 自研：DuoUpdater、DuoPaste、ClaudeUsageMenuBar、OCRIndexerApp、Claude Code URL Handler

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -13,14 +13,21 @@ public struct UpdateChecker: Sendable {
     /// When nil they're simply labelled managed without a version.
     public let toolbox: ToolboxSource?
 
+    /// When set, TestFlight-managed apps are version-checked against TestFlight's
+    /// local cache; the action stays "open TestFlight". When nil they're simply
+    /// labelled `.testFlightManaged` without a version.
+    public let testflight: TestFlightInventory?
+
     public init(
         sources: [any UpdateSource],
         maxConcurrency: Int = 12,
-        toolbox: ToolboxSource? = nil
+        toolbox: ToolboxSource? = nil,
+        testflight: TestFlightInventory? = nil
     ) {
         self.sources = sources
         self.maxConcurrency = max(1, maxConcurrency)
         self.toolbox = toolbox
+        self.testflight = testflight
     }
 
     /// Check every app, returning results in the same order as the input.
@@ -83,6 +90,35 @@ public struct UpdateChecker: Sendable {
             return UpdateResult(app: app, remote: nil, status: .toolboxManaged)
         }
 
+        // TestFlight owns its betas' updates the same way Toolbox does. Never probe
+        // another source (the App Store lookup would compare against the stable
+        // track); read TestFlight's cached latest build instead. The action stays
+        // "open TestFlight".
+        if app.isTestFlightApp {
+            if let latest = testflight?.latest(forBundleID: app.bundleID) {
+                let installedBuild = app.buildVersion ?? ""
+                let hasUpdate = VersionComparator.isNewer(latest.latestBuild, than: installedBuild)
+                // Beta builds often keep the same marketing version across builds,
+                // so disambiguate with the build number when the short string matches.
+                let display = (latest.latestShortVersion == app.shortVersion)
+                    ? "\(latest.latestShortVersion) (\(latest.latestBuild))"
+                    : latest.latestShortVersion
+                let remote = RemoteVersion(
+                    shortVersion: latest.latestShortVersion,
+                    version: latest.latestBuild,
+                    downloadURL: nil,
+                    sourceName: "TestFlight",
+                    requiresManualInstaller: true)
+                let status: UpdateStatus = hasUpdate
+                    ? .updateAvailable(latest: display)
+                    : .upToDate
+                Log.check.info("\(label, privacy: .public): TestFlight → \(latest.latestBuild, privacy: .public) (hasUpdate=\(hasUpdate, privacy: .public))")
+                return UpdateResult(app: app, remote: remote, status: status)
+            }
+            Log.check.debug("\(label, privacy: .public): TestFlight-managed, no cached build")
+            return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
+        }
+
         var lastError: String?
 
         for source in sources {
@@ -111,6 +147,8 @@ public struct UpdateChecker: Sendable {
         let status: UpdateStatus
         if app.isToolboxManaged {
             status = .toolboxManaged
+        } else if app.isTestFlightApp {
+            status = .testFlightManaged
         } else if app.isMASApp {
             status = .appStoreManaged
         } else {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
@@ -50,6 +50,14 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
     /// vendor endpoint nor offer an install — we just label it as managed.
     public let isToolboxManaged: Bool
 
+    /// True when this build was installed via TestFlight (it appears as a macOS
+    /// build in TestFlight's local DB). Updates flow through TestFlight, so — like
+    /// MAS/Toolbox — we never probe another source or offer an install; we read
+    /// TestFlight's cached "latest build" to show whether a newer beta exists.
+    /// A TestFlight app also carries a `_MASReceipt`, so this is decided *before*
+    /// the MAS flag to keep it from being mislabeled as an App Store install.
+    public let isTestFlightApp: Bool
+
     /// `SUFeedURL` from Info.plist — present when the app ships the Sparkle
     /// auto-update framework. This is our highest-signal update source.
     public let sparkleFeedURL: URL?
@@ -81,6 +89,7 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
         isMASApp: Bool,
         isiOSAppOnMac: Bool = false,
         isToolboxManaged: Bool = false,
+        isTestFlightApp: Bool = false,
         sparkleFeedURL: URL?,
         sparkleEdPublicKey: String? = nil,
         hasSelfUpdater: Bool = false,
@@ -94,6 +103,7 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
         self.isMASApp = isMASApp
         self.isiOSAppOnMac = isiOSAppOnMac
         self.isToolboxManaged = isToolboxManaged
+        self.isTestFlightApp = isTestFlightApp
         self.sparkleFeedURL = sparkleFeedURL
         self.sparkleEdPublicKey = sparkleEdPublicKey
         self.hasSelfUpdater = hasSelfUpdater

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -154,6 +154,11 @@ public enum UpdateStatus: Sendable, Equatable {
     /// endpoint would risk a cross-channel install, so we defer to Toolbox and
     /// label it as managed — informational, not actionable here.
     case toolboxManaged
+    /// TestFlight installed this beta and owns its updates. We read TestFlight's
+    /// local cache for the latest build but never install it ourselves — the
+    /// action is "open TestFlight". Used when no newer build is known (or the
+    /// cache is empty); a known newer build surfaces as `.updateAvailable`.
+    case testFlightManaged
     /// A source was tried but failed (network, parse, etc.).
     case error(String)
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -12,8 +12,17 @@ public struct AppScanner: Sendable {
     /// `state.json` so we can tag installs as Toolbox-managed.
     private let toolbox: ToolboxInventory
 
-    public init(locations: [URL]? = nil, toolbox: ToolboxInventory = ToolboxInventory()) {
+    /// TestFlight's macOS builds — read once per scan from its local DB so we can
+    /// tag installs as TestFlight-managed (and keep them out of the MAS path).
+    private let testflight: TestFlightInventory
+
+    public init(
+        locations: [URL]? = nil,
+        toolbox: ToolboxInventory = ToolboxInventory(),
+        testflight: TestFlightInventory = TestFlightInventory()
+    ) {
         self.toolbox = toolbox
+        self.testflight = testflight
         if let locations {
             self.locations = locations
         } else {
@@ -98,10 +107,16 @@ public struct AppScanner: Sendable {
             ?? bundleURL.deletingPathExtension().lastPathComponent
 
         // Wrapped iOS apps can only come from the Mac App Store; native Mac apps
-        // carry a `_MASReceipt` when bought there.
+        // carry a `_MASReceipt` when bought there. TestFlight builds ALSO carry a
+        // `_MASReceipt`, so decide TestFlight first (by matching the installed
+        // build against TestFlight's DB) and exclude it from the MAS flag — else a
+        // TestFlight app would be checked against the App Store's stable track.
         let receiptURL = bundleURL
             .appendingPathComponent("Contents/_MASReceipt/receipt")
-        let isMAS = isiOSAppOnMac || fm.fileExists(atPath: receiptURL.path)
+        let bundleID = plist["CFBundleIdentifier"] as? String
+        let buildVersion = plist["CFBundleVersion"] as? String
+        let isTestFlight = testflight.isManaged(bundleID: bundleID, installedBuild: buildVersion)
+        let isMAS = !isTestFlight && (isiOSAppOnMac || fm.fileExists(atPath: receiptURL.path))
 
         var feedURL: URL?
         if let feed = plist["SUFeedURL"] as? String {
@@ -123,8 +138,6 @@ public struct AppScanner: Sendable {
         let displayShortVersion = toolboxTool
             .map(\.displayVersion).flatMap { $0.isEmpty ? nil : $0 } ?? shortVersion
 
-        let bundleID = plist["CFBundleIdentifier"] as? String
-
         // Release channel (Stable/Beta/Canary/…). Chrome & other Keystone apps
         // declare it explicitly via `KSChannelID`; otherwise we infer it from the
         // bundle id suffix or a channel word in the display name. This gates
@@ -142,11 +155,12 @@ public struct AppScanner: Sendable {
             name: displayName,
             bundleID: bundleID,
             shortVersion: displayShortVersion,
-            buildVersion: plist["CFBundleVersion"] as? String,
+            buildVersion: buildVersion,
             path: bundleURL,
             isMASApp: isMAS,
             isiOSAppOnMac: isiOSAppOnMac,
             isToolboxManaged: toolbox.isManaged(appPath: bundleURL),
+            isTestFlightApp: isTestFlight,
             sparkleFeedURL: feedURL,
             sparkleEdPublicKey: (plist["SUPublicEDKey"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppcastMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppcastMarkdownParser.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Turns a Sparkle `<markdownDescription>` body into a flat list of change lines
+/// for one `Changelog.Entry`.
+///
+/// Unlike `GitHubMarkdownParser` — which is bullet-only because GitHub bodies are
+/// essentially bullet lists — vendor appcast notes (e.g. Surge's) mix section
+/// headings, prose paragraphs, bullets, and fenced code. Dropping everything but
+/// bullets would lose most of the content, so this parser keeps prose and folds
+/// headings in as their own lines, preserving the author's order. The detail view
+/// renders each returned string as one bulleted item.
+enum AppcastMarkdownParser {
+
+    /// Extract the change lines from a Markdown notes body, in document order.
+    static func items(from markdown: String) -> [String] {
+        var out: [String] = []
+        var inFence = false
+
+        for rawLine in markdown.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+
+            // Fenced code blocks: keep the inner lines verbatim, drop the ``` fences.
+            if line.hasPrefix("```") {
+                inFence.toggle()
+                continue
+            }
+            if inFence {
+                if !line.isEmpty { out.append(line) }
+                continue
+            }
+
+            if line.isEmpty { continue }
+
+            // Heading: strip the leading #'s and keep the title as its own line.
+            if line.hasPrefix("#") {
+                let heading = line.drop(while: { $0 == "#" })
+                    .trimmingCharacters(in: .whitespaces)
+                if !heading.isEmpty { out.append(stripInline(heading)) }
+                continue
+            }
+
+            // Bullet: `- `, `* `, `+ ` (top-level only; indented sub-bullets fold
+            // into the parent line below via the prose path, kept verbatim).
+            if let marker = ["- ", "* ", "+ "].first(where: { line.hasPrefix($0) }) {
+                let body = String(line.dropFirst(marker.count)).trimmingCharacters(in: .whitespaces)
+                if !body.isEmpty { out.append(stripInline(body)) }
+                continue
+            }
+
+            // Prose paragraph line.
+            out.append(stripInline(line))
+        }
+        return out
+    }
+
+    /// Normalize an item's publish date for display. Sparkle feeds spell `pubDate`
+    /// several ways; Surge uses a bare Unix epoch. Convert a numeric epoch to
+    /// `yyyy-MM-dd`; pass anything else through verbatim (the renderer already
+    /// formats ISO8601 and shows other strings as-is). nil stays nil.
+    static func displayDate(from pubDate: String?) -> String? {
+        guard let raw = pubDate?.trimmingCharacters(in: .whitespaces), !raw.isEmpty else {
+            return nil
+        }
+        if let epoch = TimeInterval(raw) {
+            let date = Date(timeIntervalSince1970: epoch)
+            return epochFormatter.string(from: date)
+        }
+        return raw
+    }
+
+    // MARK: - Internals
+
+    /// Strip the lightweight inline emphasis markers (`**`, `*`, `` ` ``) that
+    /// would otherwise render literally in the plain-text item view. Links and
+    /// emoji are left intact — they read fine as written.
+    private static func stripInline(_ text: String) -> String {
+        var s = text
+        for token in ["**", "`"] {
+            s = s.replacingOccurrences(of: token, with: "")
+        }
+        return s.trimmingCharacters(in: .whitespaces)
+    }
+
+    private static let epochFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .iso8601)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -29,8 +29,13 @@ public struct SparkleAppcastSource: UpdateSource {
         }
 
         let items = SparkleAppcastParser.parse(data)
-        guard let best = Self.bestItem(for: app, from: items, osVersion: Self.numericSystemVersion())
-        else { return nil }
+        let usable = Self.usableItems(for: app, from: items, osVersion: Self.numericSystemVersion())
+        guard let best = usable.first else { return nil }
+
+        // When the feed inlines Markdown notes (e.g. Surge's `<markdownDescription>`)
+        // rather than HTML, parse them into a native, multi-version changelog so the
+        // detail window renders entries instead of falling back to a web view.
+        let structured = Self.structuredChangelog(from: usable)
 
         return RemoteVersion(
             shortVersion: best.shortVersionString,
@@ -40,8 +45,26 @@ public struct SparkleAppcastSource: UpdateSource {
             minimumSystemVersion: best.minimumSystemVersion,
             sourceName: name,
             releaseNotesHTML: best.descriptionHTML,
+            structuredChangelog: structured,
             changelogURL: best.releaseNotesLink
         )
+    }
+
+    /// Build a native changelog from the in-channel items that ship inline
+    /// Markdown notes, newest first. Returns nil when no item carries Markdown
+    /// (the HTML `<description>` / web-view paths stay in charge for those feeds).
+    static func structuredChangelog(from usable: [SparkleAppcastItem]) -> Changelog? {
+        let entries: [Changelog.Entry] = usable.compactMap { item in
+            guard let md = item.markdownDescription else { return nil }
+            let notes = AppcastMarkdownParser.items(from: md)
+            guard !notes.isEmpty else { return nil }
+            let version = item.shortVersionString ?? item.version ?? ""
+            return Changelog.Entry(
+                version: version,
+                date: AppcastMarkdownParser.displayDate(from: item.pubDate),
+                items: notes)
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
     }
 
     /// Pick the best appcast item for an app: the highest-versioned, runnable,
@@ -64,7 +87,17 @@ public struct SparkleAppcastSource: UpdateSource {
         from items: [SparkleAppcastItem],
         osVersion: String
     ) -> SparkleAppcastItem? {
-        guard !items.isEmpty else { return nil }
+        usableItems(for: app, from: items, osVersion: osVersion).first
+    }
+
+    /// The runnable, in-channel items for an app, highest version first. The head
+    /// is the update we'd offer; the tail gives the changelog its version history.
+    static func usableItems(
+        for app: InstalledApp,
+        from items: [SparkleAppcastItem],
+        osVersion: String
+    ) -> [SparkleAppcastItem] {
+        guard !items.isEmpty else { return [] }
         let installedChannel = channel(ofInstalled: app, in: items)
         let usable = items.filter { item in
             // Skip delta updates — they patch a specific old build.
@@ -77,8 +110,8 @@ public struct SparkleAppcastSource: UpdateSource {
             }
             return true
         }
-        return usable.max { lhs, rhs in
-            VersionComparator.compare(lhs.comparisonKey, rhs.comparisonKey) == .orderedAscending
+        return usable.sorted { lhs, rhs in
+            VersionComparator.compare(lhs.comparisonKey, rhs.comparisonKey) == .orderedDescending
         }
     }
 
@@ -134,6 +167,15 @@ struct SparkleAppcastItem {
     var channel: String?
     /// Inline release notes — the `<description>` body, usually CDATA-wrapped HTML.
     var descriptionHTML: String?
+    /// Inline release notes shipped as Markdown via `<markdownDescription>` — some
+    /// feeds (e.g. Surge) publish only this and no HTML `<description>`. Parsed
+    /// into a structured changelog so the notes render natively instead of falling
+    /// back to a web view.
+    var markdownDescription: String?
+    /// `<pubDate>` — the item's publish date, verbatim. RSS spells this many ways
+    /// (RFC822, ISO8601, or a bare Unix epoch as Surge does); kept raw and
+    /// normalized only when we build a changelog entry.
+    var pubDate: String?
     /// `<sparkle:releaseNotesLink>` — an external notes page, when the feed links
     /// out instead of (or in addition to) inlining them.
     var releaseNotesLink: URL?
@@ -219,6 +261,12 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
             // Only inside an <item>; the channel-level <description> has no
             // `current` to attach to, so it's harmlessly dropped.
             if !text.isEmpty { current?.descriptionHTML = text }
+        case "markdownDescription", "sparkle:markdownDescription":
+            if current?.markdownDescription == nil, !text.isEmpty {
+                current?.markdownDescription = text
+            }
+        case "pubDate":
+            if current?.pubDate == nil, !text.isEmpty { current?.pubDate = text }
         case "sparkle:releaseNotesLink":
             if current?.releaseNotesLink == nil, !text.isEmpty {
                 current?.releaseNotesLink = URL(string: text)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -1,0 +1,146 @@
+import Foundation
+import SQLite3
+
+/// Reads the local TestFlight database to learn which installed apps came from
+/// TestFlight and what the newest available beta build is. Like `ToolboxInventory`,
+/// this is a read of another app's local cache — no network, no auth. TestFlight
+/// maintains the DB when it runs and via push when new builds drop; we never
+/// refresh it ourselves, so a reading is "as TestFlight last saw it" (the same
+/// freshness caveat the Toolbox cache carries).
+///
+/// The DB lives in TestFlight's sandbox container and stores one row per
+/// (app, build, platform) in `ZTFAPPBUNDLEMODEL`:
+///   - `ZPLATFORMRAW` 3 == macOS (1 == iOS); we only care about Mac builds.
+///   - `ZINSTALLSTATUSRAW` 1 == the build currently installed on this machine
+///     (its `ZBUNDLEVERSION` matches the app's on-disk `CFBundleVersion`).
+///   - The newest available build is the highest `ZBUNDLEVERSION` among an app's
+///     macOS rows.
+public struct TestFlightInventory: Sendable {
+
+    /// The macOS TestFlight builds known for one app, newest first by build.
+    public struct App: Sendable, Hashable {
+        public let bundleID: String
+        /// Marketing version of the newest available build (`ZSHORTVERSION`).
+        public let latestShortVersion: String
+        /// Build number of the newest available build (`ZBUNDLEVERSION`).
+        public let latestBuild: String
+
+        public init(bundleID: String, latestShortVersion: String, latestBuild: String) {
+            self.bundleID = bundleID
+            self.latestShortVersion = latestShortVersion
+            self.latestBuild = latestBuild
+        }
+    }
+
+    /// macOS builds present in the DB, keyed by bundle id. The value carries the
+    /// newest available build plus the full set of build numbers, so we can both
+    /// offer an update and recognize that an on-disk build is a TestFlight install.
+    private let appsByBundleID: [String: App]
+    /// Every (bundleID, build) macOS pair seen — used to confirm a given on-disk
+    /// app really is the TestFlight install (its build appears here).
+    private let buildsByBundleID: [String: Set<String>]
+
+    /// Default path to TestFlight's sandboxed Core Data store.
+    public static var defaultDatabaseURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
+            "Library/Containers/com.apple.TestFlight/Data/Library/Application Support/TestFlight/TestFlight.sqlite")
+    }
+
+    public init(databaseURL: URL? = nil) {
+        let url = databaseURL ?? Self.defaultDatabaseURL
+        let rows = Self.readMacRows(at: url)
+
+        var latest: [String: App] = [:]
+        var builds: [String: Set<String>] = [:]
+        for row in rows {
+            builds[row.bundleID, default: []].insert(row.build)
+            if let cur = latest[row.bundleID] {
+                if VersionComparator.isNewer(row.build, than: cur.latestBuild) {
+                    latest[row.bundleID] = App(
+                        bundleID: row.bundleID,
+                        latestShortVersion: row.shortVersion, latestBuild: row.build)
+                }
+            } else {
+                latest[row.bundleID] = App(
+                    bundleID: row.bundleID,
+                    latestShortVersion: row.shortVersion, latestBuild: row.build)
+            }
+        }
+        self.appsByBundleID = latest
+        self.buildsByBundleID = builds
+    }
+
+    /// Test seam: inject the parsed rows directly, skipping the DB read.
+    public init(macRows: [(bundleID: String, shortVersion: String, build: String)]) {
+        var latest: [String: App] = [:]
+        var builds: [String: Set<String>] = [:]
+        for row in macRows {
+            builds[row.bundleID, default: []].insert(row.build)
+            if let cur = latest[row.bundleID] {
+                if VersionComparator.isNewer(row.build, than: cur.latestBuild) {
+                    latest[row.bundleID] = App(bundleID: row.bundleID, latestShortVersion: row.shortVersion, latestBuild: row.build)
+                }
+            } else {
+                latest[row.bundleID] = App(bundleID: row.bundleID, latestShortVersion: row.shortVersion, latestBuild: row.build)
+            }
+        }
+        self.appsByBundleID = latest
+        self.buildsByBundleID = builds
+    }
+
+    /// Whether an on-disk app is a TestFlight install: its bundle id has macOS
+    /// rows in the DB and the installed build is one of them. Matching the build
+    /// (not just the bundle id) avoids mistaking an App Store copy of an app the
+    /// user merely *has access to* on TestFlight for a TestFlight install.
+    public func isManaged(bundleID: String?, installedBuild: String?) -> Bool {
+        guard let bundleID, let installedBuild,
+              let builds = buildsByBundleID[bundleID] else { return false }
+        return builds.contains(installedBuild)
+    }
+
+    /// The newest available macOS build for an app, if any.
+    public func latest(forBundleID bundleID: String?) -> App? {
+        guard let bundleID else { return nil }
+        return appsByBundleID[bundleID]
+    }
+
+    // MARK: - SQLite
+
+    private static func readMacRows(at url: URL)
+        -> [(bundleID: String, shortVersion: String, build: String)] {
+        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+
+        var db: OpaquePointer?
+        // Read-only; SQLITE_OPEN_READONLY still applies the -wal on open so we see
+        // TestFlight's most recent (uncheckpointed) writes.
+        guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            sqlite3_close(db)
+            Log.scan.error("TestFlight DB open failed at \(url.path, privacy: .public)")
+            return []
+        }
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION
+        FROM ZTFAPPBUNDLEMODEL
+        WHERE ZPLATFORMRAW = 3 AND ZBUNDLEID IS NOT NULL AND ZBUNDLEVERSION IS NOT NULL;
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            Log.scan.error("TestFlight DB prepare failed")
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var rows: [(bundleID: String, shortVersion: String, build: String)] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let bundleC = sqlite3_column_text(stmt, 0),
+                  let buildC = sqlite3_column_text(stmt, 2) else { continue }
+            let bundleID = String(cString: bundleC)
+            let short = sqlite3_column_text(stmt, 1).map { String(cString: $0) } ?? ""
+            let build = String(cString: buildC)
+            rows.append((bundleID, short, build))
+        }
+        return rows
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppcastMarkdownParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppcastMarkdownParserTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import DuoUpdaterCore
+
+final class AppcastMarkdownParserTests: XCTestCase {
+
+    func testKeepsHeadingsProseBulletsAndCode() {
+        let md = """
+        ### Logbook
+
+        The Logbook feature has now been added to Surge.
+
+        - Surge Dashboard supports reading Logbook content.
+
+        ### Proxy Protocol
+
+        - Added HTTP/2 CONNECT proxy support.
+
+        ```
+        Proxy = http, example.com, 8080
+        ```
+        """
+        let items = AppcastMarkdownParser.items(from: md)
+        // Heading kept, prose kept, bullets unwrapped, fenced code kept (no ```).
+        XCTAssertEqual(items.first, "Logbook")
+        XCTAssertTrue(items.contains("The Logbook feature has now been added to Surge."))
+        XCTAssertTrue(items.contains("Surge Dashboard supports reading Logbook content."))
+        XCTAssertTrue(items.contains("Added HTTP/2 CONNECT proxy support."))
+        XCTAssertTrue(items.contains("Proxy = http, example.com, 8080"))
+        XCTAssertFalse(items.contains(where: { $0.contains("```") }))
+    }
+
+    func testStripsInlineEmphasis() {
+        let items = AppcastMarkdownParser.items(from: "- Fixed **SNI** and `headers=` handling")
+        XCTAssertEqual(items, ["Fixed SNI and headers= handling"])
+    }
+
+    func testEpochPubDateBecomesYMD() {
+        // 1780324303 → 2026-06-01 (UTC).
+        XCTAssertEqual(AppcastMarkdownParser.displayDate(from: "1780324303"), "2026-06-01")
+        XCTAssertNil(AppcastMarkdownParser.displayDate(from: nil))
+        XCTAssertNil(AppcastMarkdownParser.displayDate(from: "  "))
+        // Non-epoch strings pass through verbatim.
+        XCTAssertEqual(AppcastMarkdownParser.displayDate(from: "March 2026"), "March 2026")
+    }
+
+    /// End-to-end against a real Surge appcast: markdownDescription items become a
+    /// multi-version structured changelog instead of a web-view fallback.
+    func testSurgeAppcastProducesStructuredChangelog() throws {
+        let xml = Self.surgeAppcast.data(using: .utf8)!
+        let parsed = SparkleAppcastParser.parse(xml)
+        XCTAssertEqual(parsed.count, 2)
+
+        let app = InstalledApp(
+            name: "Surge", bundleID: "com.nssurge.surge-mac",
+            shortVersion: "6.5.0", buildVersion: "10960",
+            path: URL(fileURLWithPath: "/Applications/Surge.app"),
+            isMASApp: false, sparkleFeedURL: nil)
+        let usable = SparkleAppcastSource.usableItems(for: app, from: parsed, osVersion: "26.0.0")
+        XCTAssertEqual(usable.first?.shortVersionString, "6.6.0", "highest version first")
+
+        let changelog = SparkleAppcastSource.structuredChangelog(from: usable)
+        XCTAssertEqual(changelog?.entries.count, 2)
+        let top = try XCTUnwrap(changelog?.entries.first)
+        XCTAssertEqual(top.version, "6.6.0")
+        XCTAssertEqual(top.date, "2026-06-01")
+        XCTAssertTrue(top.items.contains("Logbook"))
+        XCTAssertTrue(top.items.contains("Added HTTP/2 CONNECT proxy support."))
+    }
+
+    private static let surgeAppcast = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+      <item>
+        <title>Version 6.6.0</title>
+        <markdownDescription><![CDATA[
+    ### Logbook
+
+    - Added HTTP/2 CONNECT proxy support.
+    ]]></markdownDescription>
+        <pubDate>1780324303</pubDate>
+        <enclosure url="https://dl.nssurge.com/mac/Surge-6.6.0.zip" sparkle:version="11270" sparkle:shortVersionString="6.6.0"/>
+        <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      </item>
+      <item>
+        <title>Version 6.5.0</title>
+        <markdownDescription><![CDATA[
+    ### Fixes
+
+    - Fixed a crash.
+    ]]></markdownDescription>
+        <pubDate>1770000000</pubDate>
+        <enclosure url="https://dl.nssurge.com/mac/Surge-6.5.0.zip" sparkle:version="10960" sparkle:shortVersionString="6.5.0"/>
+        <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      </item>
+    </channel>
+    </rss>
+    """
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleSmokeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleSmokeTests.swift
@@ -34,6 +34,7 @@ import Foundation
         case .unknown: unknown += 1
         case .appStoreManaged: unknown += 1
         case .toolboxManaged: unknown += 1
+        case .testFlightManaged: unknown += 1
         case .error(let e): errors += 1; log("⚠️  \(r.app.name): \(e)")
         }
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import DuoUpdaterCore
+
+final class TestFlightInventoryTests: XCTestCase {
+
+    private func inventory() -> TestFlightInventory {
+        // Mirrors the real DB shape: multiple macOS builds per app, newest wins.
+        TestFlightInventory(macRows: [
+            (bundleID: "com.wiheads.paste", shortVersion: "6.5.3", build: "18655"),
+            (bundleID: "com.wiheads.paste", shortVersion: "6.6.1", build: "18706"),
+            (bundleID: "cam.thescreen", shortVersion: "1.0.0", build: "20260521180922"),
+            (bundleID: "cam.thescreen", shortVersion: "1.0.1", build: "20260601160715"),
+        ])
+    }
+
+    func testLatestPicksHighestBuild() {
+        let tf = inventory()
+        XCTAssertEqual(tf.latest(forBundleID: "com.wiheads.paste")?.latestBuild, "18706")
+        XCTAssertEqual(tf.latest(forBundleID: "com.wiheads.paste")?.latestShortVersion, "6.6.1")
+        XCTAssertEqual(tf.latest(forBundleID: "cam.thescreen")?.latestBuild, "20260601160715")
+        XCTAssertNil(tf.latest(forBundleID: "com.unknown.app"))
+    }
+
+    func testIsManagedRequiresBundleAndBuildMatch() {
+        let tf = inventory()
+        // An on-disk build that's one of the DB's macOS builds → managed.
+        XCTAssertTrue(tf.isManaged(bundleID: "com.wiheads.paste", installedBuild: "18706"))
+        XCTAssertTrue(tf.isManaged(bundleID: "com.wiheads.paste", installedBuild: "18655"))
+        // Bundle known, but this build isn't in the DB (e.g. an App Store copy).
+        XCTAssertFalse(tf.isManaged(bundleID: "com.wiheads.paste", installedBuild: "99999"))
+        // Unknown bundle / nil inputs.
+        XCTAssertFalse(tf.isManaged(bundleID: "com.unknown.app", installedBuild: "1"))
+        XCTAssertFalse(tf.isManaged(bundleID: nil, installedBuild: "18706"))
+        XCTAssertFalse(tf.isManaged(bundleID: "com.wiheads.paste", installedBuild: nil))
+    }
+
+    func testCheckerOffersBetaUpdateWhenNewerBuildExists() async {
+        let tf = inventory()
+        let checker = UpdateChecker(sources: [], testflight: tf)
+        let app = InstalledApp(
+            name: "Paste", bundleID: "com.wiheads.paste",
+            shortVersion: "6.5.3", buildVersion: "18655",
+            path: URL(fileURLWithPath: "/Applications/Paste.app"),
+            isMASApp: false, isTestFlightApp: true, sparkleFeedURL: nil)
+        let result = await checker.check(app)
+        XCTAssertEqual(result.remote?.sourceName, "TestFlight")
+        guard case .updateAvailable(let latest) = result.status else {
+            return XCTFail("expected an update, got \(result.status)")
+        }
+        XCTAssertEqual(latest, "6.6.1")  // short bumped, so build is not appended
+    }
+
+    func testCheckerUpToDateOnNewestBuild() async {
+        let tf = inventory()
+        let checker = UpdateChecker(sources: [], testflight: tf)
+        let app = InstalledApp(
+            name: "Paste", bundleID: "com.wiheads.paste",
+            shortVersion: "6.6.1", buildVersion: "18706",
+            path: URL(fileURLWithPath: "/Applications/Paste.app"),
+            isMASApp: false, isTestFlightApp: true, sparkleFeedURL: nil)
+        let result = await checker.check(app)
+        XCTAssertEqual(result.status, .upToDate)
+    }
+
+    func testCheckerManagedWhenNoCache() async {
+        // TestFlight app but the inventory has nothing for it → managed label.
+        let checker = UpdateChecker(sources: [], testflight: TestFlightInventory(macRows: []))
+        let app = InstalledApp(
+            name: "Mirage", bundleID: "com.ethanlipnik.Mirage",
+            shortVersion: "1.0.4", buildVersion: "388",
+            path: URL(fileURLWithPath: "/Applications/Mirage.app"),
+            isMASApp: false, isTestFlightApp: true, sparkleFeedURL: nil)
+        let result = await checker.check(app)
+        XCTAssertEqual(result.status, .testFlightManaged)
+    }
+}


### PR DESCRIPTION
Two related update-pipeline improvements.

## Surge-style markdown appcast notes
The Sparkle parser only read `<description>` (HTML). Feeds shipping notes as `<markdownDescription>` (e.g. Surge) lost their inline changelog and fell back to a web view. Now parsed into a native multi-version changelog (keeps headings, prose, bullets, code), plus `<pubDate>` normalization.

## TestFlight as a managed channel
TestFlight apps carry a `_MASReceipt`, so they were misclassified as Mac App Store installs and compared against the App Store *stable* track — a beta could be told it's "behind" the public release. Now detected by matching the installed build against TestFlight's local DB (`TestFlight.sqlite`, same no-network local-cache pattern as Toolbox), excluded from the MAS path, and surfaced with a `.testFlightManaged` status + "open TestFlight" action. Reads the newest available macOS build to show whether a newer beta exists.

Affected apps on a test machine: Paste, Mirage, ScreenCam now resolve via TestFlight instead of App Store.

All 106 core tests pass; app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)