### PR TITLE
Harden the install gates and the sweep's noise floor (Phase 0)

### DIFF
--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1028,7 +1028,7 @@ private struct FormulaDetailPane: View {
         case .loaded(let release):
             if let changelog = release.changelog {
                 ChangelogEntriesView(changelog: changelog)
-            } else if let url = release.pageURL {
+            } else if let url = ChangelogURLPolicy.displayable(release.pageURL) {
                 CachedWebView(url: url)
             } else {
                 noNotes

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1059,7 +1059,8 @@ private struct DetailHeader: View {
 
     /// The vendor page to link out to in Release Notes mode.
     private var changelogURL: URL? {
-        result.remote?.changelogURL ?? ChangelogCatalog.url(forBundleID: result.app.bundleID)
+        ChangelogURLPolicy.displayable(
+            result.remote?.changelogURL ?? ChangelogCatalog.url(forBundleID: result.app.bundleID))
     }
 
     var body: some View {
@@ -1149,7 +1150,8 @@ private struct ReleaseNotesPane: View {
     @Bindable var model: AppListModel
 
     private var changelogURL: URL? {
-        result.remote?.changelogURL ?? ChangelogCatalog.url(forBundleID: result.app.bundleID)
+        ChangelogURLPolicy.displayable(
+            result.remote?.changelogURL ?? ChangelogCatalog.url(forBundleID: result.app.bundleID))
     }
 
     var body: some View {

--- a/CLI/Sources/DuoKit/Baseline.swift
+++ b/CLI/Sources/DuoKit/Baseline.swift
@@ -85,7 +85,14 @@ public struct Baseline: Codable, Sendable {
     }
 
     /// Actionable sweeps below this never produce an issue. One sweep of trouble
-    /// is noise; two consecutive sweeps a day apart is a pattern.
+    /// is noise; two consecutive sweeps is a pattern.
+    ///
+    /// Left at two when the sweep moved from nightly to every six hours, which
+    /// tightens the wait from two days to twelve hours. That is the point of the
+    /// change — a broken recipe is invisible until a sweep reports it — and it
+    /// stays safe because the noisy failures it could otherwise catch (a vendor's
+    /// maintenance window returning 5xx or 429) are classified `.infra`, not
+    /// actionable, and are gated separately below.
     public static let actionableThreshold = 2
 
     /// Consecutive *unreachable* sweeps before an endpoint is reported as gone.
@@ -93,10 +100,15 @@ public struct Baseline: Codable, Sendable {
     /// Much higher than `actionableThreshold` on purpose. Unreachability is the
     /// one signal that is routinely someone else's fault — a vendor's bad night,
     /// the runner's flaky uplink — so the bar has to be high enough that none of
-    /// those clear it. At one sweep a night, five is the better part of a week:
-    /// no CDN incident lasts that long, and no DNS record is missing that long
-    /// by accident.
-    public static let infraThreshold = 5
+    /// those clear it. The bar is expressed in sweeps but the property that
+    /// matters is wall-clock: it has to outlast any plausible outage. Nightly
+    /// sweeps made five the better part of a week; at every six hours five would
+    /// be thirty hours, which a long CDN incident or a bad uplink night can
+    /// clear. Twenty keeps the original ~5 days, so no CDN incident lasts that
+    /// long and no DNS record is missing that long by accident.
+    ///
+    /// If the sweep interval changes again, change this with it.
+    public static let infraThreshold = 20
 
     public init() {}
 

--- a/CLI/Sources/DuoKit/Reconcile.swift
+++ b/CLI/Sources/DuoKit/Reconcile.swift
@@ -27,9 +27,13 @@ public enum IssueAction: Equatable, Sendable {
 
 public enum Reconcile {
 
-    /// Comment on a still-broken issue only every Nth sweep. A daily job that
-    /// comments daily is a daily notification saying nothing new.
-    public static let commentEverySweeps = 7
+    /// Comment on a still-broken issue only every Nth sweep.
+    ///
+    /// Like `Baseline.infraThreshold` this is a wall-clock property counted in
+    /// sweeps: a job that comments every run is a notification saying nothing new.
+    /// Seven was a week of nightly sweeps; at six-hourly it would be under two
+    /// days, so it scales with the cadence to stay at roughly a week.
+    public static let commentEverySweeps = 28
 
     /// A recipe that broke again within this window reopens its old issue rather
     /// than opening a second one about the same thing.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -453,20 +453,40 @@ public actor PackageInstaller {
         // being updated is one of those destinations, which is what stops a
         // same-Team substitution (Google Earth's package targets
         // `/Applications/Google Earth.app`, never Chrome's bundle).
+        // An empty set means the package's layout could not be read — a bundle-format
+        // `.mpkg` is not a xar archive at all, and a component may be missing or
+        // unreadable — not that the package writes nowhere. Verified non-empty on
+        // Tailscale, Microsoft Word, Edge, OneDrive, WeChat DevTools and UU Remote,
+        // covering all three package shapes, but the remaining pkg recipes are
+        // untested, so an unreadable layout falls back to the Team-only gate rather
+        // than blocking an install that works today.
+        //
+        // Note what this gate does NOT cover: `preinstall`/`postinstall` scripts run
+        // as root whatever the declared destinations say. It narrows which package
+        // may be handed over; it does not make an accepted one harmless.
         let destinations = Self.declaredDestinations(toOpen)
-        // An empty set means the package's layout could not be read, not that it
-        // writes nowhere. Verified non-empty on Tailscale, Microsoft Word, Edge,
-        // OneDrive, WeChat DevTools and UU Remote — all three package shapes — but
-        // the remaining pkg recipes are untested, so an unreadable layout falls
-        // back to the Team-only gate rather than blocking an install that works
-        // today. Tighten to fail-closed once every pkg recipe is confirmed.
         guard !destinations.isEmpty else { return }
+
         let target = installedApp.resolvingSymlinksInPath().standardizedFileURL.path
-        guard destinations.contains(target) else {
-            throw PackageError.packageDestinationMismatch(
-                installed: target,
-                destinations: destinations.sorted())
+        guard !destinations.contains(target) else { return }
+
+        // The same app kept somewhere other than `/Applications` is still the same
+        // app. `AppScanner` also scans `~/Applications`, `/Applications/Utilities`
+        // and the Input Methods directories, and a vendor package always names the
+        // system location, so comparing full paths alone would refuse every pkg
+        // update for an app the user keeps elsewhere. Fall back to the bundle name,
+        // which is what actually distinguishes one product from another — Google
+        // Earth's package names `Google Earth.app`, never `Google Chrome.app`.
+        let targetName = (target as NSString).lastPathComponent
+        let namesMatch = destinations.contains {
+            ($0 as NSString).lastPathComponent.compare(
+                targetName, options: .caseInsensitive) == .orderedSame
         }
+        guard !namesMatch else { return }
+
+        throw PackageError.packageDestinationMismatch(
+            installed: target,
+            destinations: destinations.sorted())
     }
 
     /// The `.app` destinations a package declares, as absolute paths.
@@ -507,30 +527,62 @@ public actor PackageInstaller {
 
     /// Parse one `PackageInfo` body into absolute `.app` destinations. Split out so
     /// the path arithmetic is testable without building a package.
+    ///
+    /// Parsed as XML rather than scanned with regexes: an attribute pattern also
+    /// matches `search-path`, does not decode `&amp;` in an app name, and happily
+    /// reads a destination out of a commented-out element. None of those is a
+    /// signature bypass — `PackageInfo` is covered by the package signature, which
+    /// `pkgutil --check-signature` has already verified by this point — but each
+    /// one is a way to refuse a legitimate update.
     static func destinations(inPackageInfo body: String) -> Set<String> {
-        func attribute(_ name: String, in text: String) -> [String] {
-            let pattern = "\(name)=\"([^\"]*)\""
-            guard let re = try? NSRegularExpression(pattern: pattern) else { return [] }
-            let ns = text as NSString
-            return re.matches(in: text, range: NSRange(location: 0, length: ns.length))
-                .map { ns.substring(with: $0.range(at: 1)) }
-        }
+        guard let doc = try? XMLDocument(xmlString: body, options: [.nodePreserveWhitespace])
+        else { return [] }
 
-        let location = attribute("install-location", in: body).first ?? "/"
+        let location = (try? doc.nodes(forXPath: "/pkg-info/@install-location"))?
+            .first?.stringValue ?? "/"
         var out: Set<String> = []
         // The payload root itself, when the package unpacks straight into a bundle.
-        if location.hasSuffix(".app") {
+        if isAppBundlePath(location) {
             out.insert((location as NSString).standardizingPath)
         }
-        for path in attribute("path", in: body) {
+        for node in (try? doc.nodes(forXPath: "//bundle/@path")) ?? [] {
+            guard let path = node.stringValue else { continue }
             let joined = (location as NSString).appendingPathComponent(path)
-            let full = (joined as NSString).standardizingPath
-            // Keep the top-level bundle, not the helpers nested inside it.
-            guard let range = full.range(of: ".app") else { continue }
-            let top = String(full[full.startIndex..<range.upperBound])
-            if top.hasSuffix(".app") { out.insert(top) }
+            out.formUnion(appBundlePrefixes(in: (joined as NSString).standardizingPath))
         }
         return out
+    }
+
+    /// Every prefix of `path` that ends in an app bundle.
+    ///
+    /// Neither the first nor the last `.app` component is reliably the one that
+    /// matters. Taking the first truncates on a reverse-DNS directory such as
+    /// `com.vendor.app`, throwing away the real bundle further along — and because
+    /// the truncated prefix still ends in `.app` the result is non-empty but wrong,
+    /// which sails past the "could not read the layout" fallback and refuses a
+    /// legitimate update. Taking the last picks a helper out of a package whose
+    /// payload root is the app itself, as Tailscale's is.
+    ///
+    /// Returning every candidate keeps the real destination in the set whichever
+    /// shape the package has. The extra entries are all paths the package genuinely
+    /// writes, and none of them can make a different product match: the comparison
+    /// is against the installed bundle's own path and name, so Google Earth's
+    /// package still never resolves to Chrome.
+    static func appBundlePrefixes(in path: String) -> Set<String> {
+        var out: Set<String> = []
+        var walked: [String] = []
+        for component in (path as NSString).pathComponents {
+            walked.append(component)
+            if isAppBundlePath(component) {
+                out.insert(NSString.path(withComponents: walked))
+            }
+        }
+        return out
+    }
+
+    /// Case-insensitive because the filesystem is, and vendors are inconsistent.
+    private static func isAppBundlePath(_ component: String) -> Bool {
+        component.lowercased().hasSuffix(".app")
     }
 
     /// `runCapturingOutput`, but usable from the static helpers above and able to

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -50,6 +50,7 @@ public actor PackageInstaller {
         case noInstallablePackage
         case packageTeamIdentifierMissing
         case packageTeamIdentifierMismatch(installed: String, package: String)
+        case packageDestinationMismatch(installed: String, destinations: [String])
 
         public var errorDescription: String? {
             switch self {
@@ -61,6 +62,8 @@ public actor PackageInstaller {
                 return "The downloaded disk image did not contain an installer package DuoUpdater could verify. Nothing was opened."
             case .packageTeamIdentifierMissing:
                 return "Could not read the installer package's Developer ID team. Nothing was opened."
+            case .packageDestinationMismatch(let installed, let destinations):
+                return "This package installs to \(destinations.joined(separator: ", ")), not to \(installed). Refusing to install."
             case .packageTeamIdentifierMismatch(let installed, let package):
                 return "Installer Team Identifier mismatch: installed “\(installed)” vs package “\(package)”. Refusing to open it."
             }
@@ -437,6 +440,115 @@ public actor PackageInstaller {
                 installed: installedTeam,
                 package: packageTeam)
         }
+
+        // Team ID alone permits any app from the same vendor — the `.app` routes
+        // pair it with a bundle-identifier check (`SignatureVerifier` Gate 4,
+        // :181), but a `.pkg` has no single bundle identity to compare: it is a
+        // container that may declare hundreds of bundles (Microsoft Word's
+        // Distribution lists 206) or, like Tailscale's, not declare the app's own
+        // identifier at all. Comparing identifiers was measured against real
+        // vendor packages and rejects legitimate updates, so it is not the gate.
+        //
+        // What every package does declare is where it writes. Require that the app
+        // being updated is one of those destinations, which is what stops a
+        // same-Team substitution (Google Earth's package targets
+        // `/Applications/Google Earth.app`, never Chrome's bundle).
+        let destinations = Self.declaredDestinations(toOpen)
+        // An empty set means the package's layout could not be read, not that it
+        // writes nowhere. Verified non-empty on Tailscale, Microsoft Word, Edge,
+        // OneDrive, WeChat DevTools and UU Remote — all three package shapes — but
+        // the remaining pkg recipes are untested, so an unreadable layout falls
+        // back to the Team-only gate rather than blocking an install that works
+        // today. Tighten to fail-closed once every pkg recipe is confirmed.
+        guard !destinations.isEmpty else { return }
+        let target = installedApp.resolvingSymlinksInPath().standardizedFileURL.path
+        guard destinations.contains(target) else {
+            throw PackageError.packageDestinationMismatch(
+                installed: target,
+                destinations: destinations.sorted())
+        }
+    }
+
+    /// The `.app` destinations a package declares, as absolute paths.
+    ///
+    /// A flat component package carries one `PackageInfo`; a product archive
+    /// carries a `Distribution` plus one `PackageInfo` per nested component. Both
+    /// spell the destination the same way: `install-location` is the payload root,
+    /// and each `<bundle path=…>` is relative to it. Tailscale's package sets
+    /// `install-location` to the app bundle itself and lists only the bundles
+    /// *inside* it, so the root counts as a destination in its own right.
+    static func declaredDestinations(_ pkg: URL) -> Set<String> {
+        let listing = Self.runCapturing("/usr/bin/xar", ["-tf", pkg.path])
+        guard listing.code == 0 else { return [] }
+        let infos = listing.output
+            .split(separator: "\n")
+            .map(String.init)
+            .filter { $0 == "PackageInfo" || $0.hasSuffix("/PackageInfo") }
+        guard !infos.isEmpty else { return [] }
+
+        let fm = FileManager.default
+        let scratch = fm.temporaryDirectory
+            .appendingPathComponent("duo-pkg-dest-\(UUID().uuidString)", isDirectory: true)
+        guard (try? fm.createDirectory(at: scratch, withIntermediateDirectories: true)) != nil
+        else { return [] }
+        defer { try? fm.removeItem(at: scratch) }
+
+        var out: Set<String> = []
+        for name in infos {
+            guard Self.runCapturing(
+                "/usr/bin/xar", ["-xf", pkg.path, name], cwd: scratch).code == 0,
+                let body = try? String(
+                    contentsOf: scratch.appendingPathComponent(name), encoding: .utf8)
+            else { continue }
+            out.formUnion(Self.destinations(inPackageInfo: body))
+        }
+        return out
+    }
+
+    /// Parse one `PackageInfo` body into absolute `.app` destinations. Split out so
+    /// the path arithmetic is testable without building a package.
+    static func destinations(inPackageInfo body: String) -> Set<String> {
+        func attribute(_ name: String, in text: String) -> [String] {
+            let pattern = "\(name)=\"([^\"]*)\""
+            guard let re = try? NSRegularExpression(pattern: pattern) else { return [] }
+            let ns = text as NSString
+            return re.matches(in: text, range: NSRange(location: 0, length: ns.length))
+                .map { ns.substring(with: $0.range(at: 1)) }
+        }
+
+        let location = attribute("install-location", in: body).first ?? "/"
+        var out: Set<String> = []
+        // The payload root itself, when the package unpacks straight into a bundle.
+        if location.hasSuffix(".app") {
+            out.insert((location as NSString).standardizingPath)
+        }
+        for path in attribute("path", in: body) {
+            let joined = (location as NSString).appendingPathComponent(path)
+            let full = (joined as NSString).standardizingPath
+            // Keep the top-level bundle, not the helpers nested inside it.
+            guard let range = full.range(of: ".app") else { continue }
+            let top = String(full[full.startIndex..<range.upperBound])
+            if top.hasSuffix(".app") { out.insert(top) }
+        }
+        return out
+    }
+
+    /// `runCapturingOutput`, but usable from the static helpers above and able to
+    /// run in a working directory (`xar -xf` extracts relative to cwd).
+    private static func runCapturing(
+        _ launchPath: String, _ args: [String], cwd: URL? = nil
+    ) -> (code: Int32, output: String) {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: launchPath)
+        p.arguments = args
+        if let cwd { p.currentDirectoryURL = cwd }
+        let pipe = Pipe()
+        p.standardOutput = pipe
+        p.standardError = pipe
+        do { try p.run() } catch { return (-1, "") }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        p.waitUntilExit()
+        return (p.terminationStatus, String(decoding: data, as: UTF8.self))
     }
 
     /// Given a downloaded file, return the thing to hand to the system installer.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCatalog.swift
@@ -17,7 +17,7 @@ import Foundation
 /// update through brew (because it self-updates) can still show its release notes.
 public enum ChangelogCatalog {
     /// bundleID (lowercased) → changelog page.
-    private static let pages: [String: URL] = [
+    static let pages: [String: URL] = [
         // Ghostty — auto_updates cask, no Sparkle feed; official release notes.
         "com.mitchellh.ghostty": URL(string: "https://ghostty.org/docs/install/release-notes")!,
         // Ollama — auto_updates cask, Electron app; GitHub releases.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// What a changelog URL must look like before it is loaded in a web view.
+///
+/// Release-note URLs come from recipes, and a recipe's `changelogURL` is the one
+/// field that ends up as an attacker-choosable origin rendered in-process, next
+/// to a window that holds credentials for other services. Today every recipe is
+/// compiled into the signed binary, so this is defence in depth rather than a
+/// live hole — but it is the field most likely to be served remotely first, and
+/// the check costs nothing to have in place before that happens.
+///
+/// The rules are deliberately structural, not an allowlist of hosts: a per-recipe
+/// host binding only becomes meaningful once recipes stop being compiled in, and
+/// guessing at vendor domains now would break legitimate documentation sites that
+/// live on a different domain than the download endpoint.
+public enum ChangelogURLPolicy {
+
+    /// Whether `url` may be handed to a web view.
+    ///
+    /// Rejects anything but `https` (a plain-text page can be rewritten in
+    /// transit), URLs carrying credentials (`https://user:pass@host/` renders a
+    /// convincing origin and leaks the pair), IP-literal hosts (no certificate
+    /// name to reason about, and no vendor publishes notes at a bare address),
+    /// and non-standard ports.
+    public static func isDisplayable(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "https" else { return false }
+        guard url.user == nil, url.password == nil else { return false }
+        guard let host = url.host, !host.isEmpty else { return false }
+        guard !isIPLiteral(host) else { return false }
+        if let port = url.port, port != 443 { return false }
+        return true
+    }
+
+    /// `url` when it passes, `nil` when it does not — so a caller can fall through
+    /// to whatever it shows when there are no notes.
+    public static func displayable(_ url: URL?) -> URL? {
+        guard let url, isDisplayable(url) else { return nil }
+        return url
+    }
+
+    /// IPv4 dotted-quad, or IPv6 in either spelling. `URL.host` strips the
+    /// brackets off an IPv6 literal, so the colon is the reliable signal — and a
+    /// colon cannot appear in a hostname, so this does not catch a legitimate
+    /// vendor domain.
+    static func isIPLiteral(_ host: String) -> Bool {
+        if host.hasPrefix("[") || host.contains(":") { return true }
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        return parts.allSatisfy { part in
+            !part.isEmpty && part.allSatisfy(\.isNumber) && (Int(part) ?? 256) <= 255
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+struct ChangelogURLPolicyTests {
+
+    private func url(_ s: String) -> URL { URL(string: s)! }
+
+    @Test func realVendorChangelogURLsStillPass() {
+        // Sampled from the registry — the check must not cost any existing recipe
+        // its notes pane.
+        for s in [
+            "https://www.zotero.org/support/changelog",
+            "https://tailscale.com/changelog",
+            "https://code.visualstudio.com/updates",
+            "https://github.com/owner/repo/releases",
+        ] {
+            #expect(ChangelogURLPolicy.isDisplayable(url(s)), "\(s) should pass")
+        }
+    }
+
+    @Test func plainHTTPIsRejected() {
+        // A cleartext page can be rewritten in transit by anything on the path.
+        #expect(!ChangelogURLPolicy.isDisplayable(url("http://example.com/notes")))
+    }
+
+    @Test func credentialsInTheURLAreRejected() {
+        // `https://vendor.com@evil.example/` reads as the vendor at a glance.
+        #expect(!ChangelogURLPolicy.isDisplayable(url("https://user:pw@evil.example/notes")))
+    }
+
+    @Test func ipLiteralHostsAreRejected() {
+        #expect(!ChangelogURLPolicy.isDisplayable(url("https://192.168.1.10/notes")))
+        #expect(!ChangelogURLPolicy.isDisplayable(url("https://[::1]/notes")))
+    }
+
+    @Test func aHostThatMerelyLooksNumericIsNotAnIPLiteral() {
+        // Four dot-separated labels, but not a dotted quad — must still load.
+        #expect(ChangelogURLPolicy.isDisplayable(url("https://1.2.3.example.com/notes")))
+        #expect(!ChangelogURLPolicy.isIPLiteral("999.1.1.1"))
+    }
+
+    @Test func nonStandardPortsAreRejected() {
+        #expect(!ChangelogURLPolicy.isDisplayable(url("https://example.com:8443/notes")))
+        #expect(ChangelogURLPolicy.isDisplayable(url("https://example.com:443/notes")))
+    }
+
+    @Test func displayableReturnsNilSoCallersFallThrough() {
+        #expect(ChangelogURLPolicy.displayable(nil) == nil)
+        #expect(ChangelogURLPolicy.displayable(url("http://example.com")) == nil)
+        #expect(ChangelogURLPolicy.displayable(url("https://example.com")) != nil)
+    }
+
+    // MARK: Derived from the registries
+    //
+    // Hand-written lists drift; these walk what actually ships, so a recipe added
+    // later with an `http://` or credentialed URL fails here rather than silently
+    // losing its notes pane in the app.
+
+    @Test func everyVendorProbeChangelogURLPasses() {
+        for recipe in VendorProbeRegistry.recipes {
+            guard let url = recipe.changelogURL else { continue }
+            #expect(ChangelogURLPolicy.isDisplayable(url),
+                    "\(recipe.bundleID): \(url.absoluteString)")
+        }
+    }
+
+    @Test func everyChangelogRecipeSourcePasses() {
+        for recipe in ChangelogRecipeRegistry.recipes {
+            #expect(ChangelogURLPolicy.isDisplayable(recipe.source),
+                    "\(recipe.bundleID): \(recipe.source.absoluteString)")
+        }
+    }
+
+    @Test func everyCatalogPagePasses() {
+        for (bundleID, url) in ChangelogCatalog.pages {
+            #expect(ChangelogURLPolicy.isDisplayable(url),
+                    "\(bundleID): \(url.absoluteString)")
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
@@ -309,4 +309,81 @@ struct PackageInstallerTests {
         #expect(!PackageInstaller.discardWorkDirectory(containing: outsidePkg))
         #expect(fm.fileExists(atPath: outsidePkg.path))
     }
+
+    // MARK: Declared install destinations
+    //
+    // Bodies below are the real `PackageInfo` headers from vendor packages
+    // downloaded on 2026-08-19, trimmed to the attributes the parser reads. They
+    // cover all three shapes seen across the pkg recipes.
+
+    /// Tailscale unpacks straight into the app bundle: `install-location` IS the
+    /// destination, and every `<bundle path>` is a helper *inside* it. This is the
+    /// case that makes a bundle-identifier gate unworkable — the package never
+    /// declares `io.tailscale.ipn.macsys`, only its sub-bundles.
+    @Test func destinationIsThePayloadRootWhenItIsTheAppItself() {
+        let body = """
+        <pkg-info identifier="com.tailscale.ipn.macsys" version="1.102.2" \
+        install-location="/Applications/Tailscale.app" auth="root">
+            <bundle path="./Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app" \
+        id="org.sparkle-project.Sparkle.Updater"/>
+            <bundle path="./Contents/Library/LoginItems/TailscaleLoginItemHelper-macsys.app" \
+        id="io.tailscale.ipn.macsys.login-item-helper"/>
+        </pkg-info>
+        """
+        let dests = PackageInstaller.destinations(inPackageInfo: body)
+        #expect(dests.contains("/Applications/Tailscale.app"))
+        // The helpers nested inside the bundle must not become destinations of
+        // their own — only the top-level `.app` counts.
+        #expect(!dests.contains(
+            "/Applications/Tailscale.app/Contents/Library/LoginItems/TailscaleLoginItemHelper-macsys.app"))
+    }
+
+    /// WeChat DevTools is a flat component package rooted at `/`, so the
+    /// destination comes from joining the relative bundle path onto it.
+    @Test func destinationJoinsARelativeBundlePathOntoTheRoot() {
+        let body = """
+        <pkg-info identifier="com.tencent.wechatdevtools" version="2.02.2608182" \
+        install-location="/" auth="root">
+            <bundle path="./Applications/wechatwebdevtools.app" id="com.github.Electron"/>
+        </pkg-info>
+        """
+        #expect(PackageInstaller.destinations(inPackageInfo: body)
+            == ["/Applications/wechatwebdevtools.app"])
+    }
+
+    /// Office components install into `/Applications` by name, and a single
+    /// package legitimately writes more than one app.
+    @Test func aPackageMayDeclareSeveralDestinations() {
+        let body = """
+        <pkg-info identifier="com.microsoft.word" version="16.112" \
+        install-location="/Applications" auth="root">
+            <bundle path="Microsoft Word.app" id="com.microsoft.Word"/>
+            <bundle path="Microsoft AutoUpdate.app" id="com.microsoft.autoupdate"/>
+        </pkg-info>
+        """
+        let dests = PackageInstaller.destinations(inPackageInfo: body)
+        #expect(dests.contains("/Applications/Microsoft Word.app"))
+        #expect(dests.contains("/Applications/Microsoft AutoUpdate.app"))
+    }
+
+    /// The property that motivates the gate: a same-vendor package for a
+    /// *different* app resolves to a different destination, so it can be told
+    /// apart from a genuine update even though the Team ID matches.
+    @Test func aSiblingAppFromTheSameVendorIsADifferentDestination() {
+        let body = """
+        <pkg-info identifier="com.google.earth" install-location="/Applications" auth="root">
+            <bundle path="Google Earth Pro.app" id="com.google.GoogleEarthPro"/>
+        </pkg-info>
+        """
+        let dests = PackageInstaller.destinations(inPackageInfo: body)
+        #expect(!dests.contains("/Applications/Google Chrome.app"))
+        #expect(dests.contains("/Applications/Google Earth Pro.app"))
+    }
+
+    /// A body with nothing to go on yields no destinations, which the gate treats
+    /// as "cannot verify" and falls back to the Team-only check rather than
+    /// blocking a working install.
+    @Test func anUnreadableLayoutYieldsNoDestinations() {
+        #expect(PackageInstaller.destinations(inPackageInfo: "<pkg-info/>").isEmpty)
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
@@ -332,10 +332,11 @@ struct PackageInstallerTests {
         """
         let dests = PackageInstaller.destinations(inPackageInfo: body)
         #expect(dests.contains("/Applications/Tailscale.app"))
-        // The helpers nested inside the bundle must not become destinations of
-        // their own — only the top-level `.app` counts.
-        #expect(!dests.contains(
-            "/Applications/Tailscale.app/Contents/Library/LoginItems/TailscaleLoginItemHelper-macsys.app"))
+        // Helpers nested inside the bundle come along as candidates too. That is
+        // harmless: `AppScanner` only ever reports bundles sitting in the scanned
+        // directories, never one buried inside another app, so a nested path can
+        // never be the installed app the gate compares against.
+        #expect(dests.contains("/Applications/Tailscale.app"))
     }
 
     /// WeChat DevTools is a flat component package rooted at `/`, so the
@@ -351,19 +352,20 @@ struct PackageInstallerTests {
             == ["/Applications/wechatwebdevtools.app"])
     }
 
-    /// Office components install into `/Applications` by name, and a single
-    /// package legitimately writes more than one app.
+    /// A single component legitimately writes more than one app. Constructed, not
+    /// captured: the real Word archive spreads these across three components, and
+    /// AutoUpdate actually lands under `/Library/Application Support/Microsoft/MAU2.0`.
     @Test func aPackageMayDeclareSeveralDestinations() {
         let body = """
         <pkg-info identifier="com.microsoft.word" version="16.112" \
         install-location="/Applications" auth="root">
             <bundle path="Microsoft Word.app" id="com.microsoft.Word"/>
-            <bundle path="Microsoft AutoUpdate.app" id="com.microsoft.autoupdate"/>
+            <bundle path="Microsoft Excel.app" id="com.microsoft.Excel"/>
         </pkg-info>
         """
         let dests = PackageInstaller.destinations(inPackageInfo: body)
         #expect(dests.contains("/Applications/Microsoft Word.app"))
-        #expect(dests.contains("/Applications/Microsoft AutoUpdate.app"))
+        #expect(dests.contains("/Applications/Microsoft Excel.app"))
     }
 
     /// The property that motivates the gate: a same-vendor package for a
@@ -385,5 +387,90 @@ struct PackageInstallerTests {
     /// blocking a working install.
     @Test func anUnreadableLayoutYieldsNoDestinations() {
         #expect(PackageInstaller.destinations(inPackageInfo: "<pkg-info/>").isEmpty)
+    }
+
+    // MARK: Destination parsing traps
+    //
+    // Each of these was a real defect in the first version of this parser, which
+    // scanned for the substring ".app" with unanchored attribute regexes. They
+    // matter because the wrong answers were non-empty: a package that parses to a
+    // fabricated destination is REFUSED, so these bugs broke legitimate updates
+    // rather than merely weakening the gate.
+
+    /// A reverse-DNS directory component contains ".app" without being a bundle.
+    /// Truncating there both invents a destination and loses the real one.
+    @Test func aDirectoryNamedLikeABundleDoesNotTruncateThePath() {
+        let body = """
+        <pkg-info install-location="/">
+            <bundle path="./Library/Application Support/com.vendor.app/Real.app"/>
+        </pkg-info>
+        """
+        // The real bundle must survive. The `com.vendor.app` ancestor also ends in
+        // `.app` and is indistinguishable from a bundle by name, so it comes along
+        // as a candidate — harmless, since it is a path the package really writes
+        // and no installed app lives there.
+        #expect(PackageInstaller.destinations(inPackageInfo: body)
+            .contains("/Library/Application Support/com.vendor.app/Real.app"))
+    }
+
+    /// An `.appex` is not an `.app`, and one with no app ancestor installs no
+    /// application — it must contribute nothing rather than a fabricated sibling.
+    @Test func anAppExtensionDoesNotBecomeAnAppDestination() {
+        let body = #"<pkg-info install-location="/Applications"><bundle path="./Widget.appex"/></pkg-info>"#
+        #expect(PackageInstaller.destinations(inPackageInfo: body).isEmpty)
+    }
+
+    /// A plug-in inside a bundle resolves to the bundle, not to itself.
+    @Test func aNestedBundleResolvesToItsTopLevelApp() {
+        let body = """
+        <pkg-info install-location="/Applications/Tailscale.app">
+            <bundle path="./Contents/PlugIns/ShareExtension-macsys.appex"/>
+        </pkg-info>
+        """
+        #expect(PackageInstaller.destinations(inPackageInfo: body)
+            == ["/Applications/Tailscale.app"])
+    }
+
+    /// `search-path` also ends in "path". An unanchored attribute scan picked it
+    /// up and added a destination the installer never writes.
+    @Test func onlyTheBundlePathAttributeIsRead() {
+        let body = #"<pkg-info install-location="/Applications"><bundle search-path="/Evil.app" path="./Good.app"/></pkg-info>"#
+        #expect(PackageInstaller.destinations(inPackageInfo: body)
+            == ["/Applications/Good.app"])
+    }
+
+    /// A commented-out element declares nothing.
+    @Test func commentedOutBundlesAreNotDestinations() {
+        let body = """
+        <pkg-info install-location="/Applications">
+            <!-- <bundle path="./Victim.app"/> -->
+            <bundle path="./Real.app"/>
+        </pkg-info>
+        """
+        #expect(PackageInstaller.destinations(inPackageInfo: body) == ["/Applications/Real.app"])
+    }
+
+    /// Entities have to be decoded, or an app with `&` in its name is refused.
+    @Test func xmlEntitiesInAnAppNameAreDecoded() {
+        let body = #"<pkg-info install-location="/Applications"><bundle path="./Foo &amp; Bar.app"/></pkg-info>"#
+        #expect(PackageInstaller.destinations(inPackageInfo: body)
+            == ["/Applications/Foo & Bar.app"])
+    }
+
+    /// Single quotes are legal XML; the regex scan silently returned nothing.
+    @Test func singleQuotedAttributesParse() {
+        let body = "<pkg-info install-location='/Applications'><bundle path='./Foo.app'/></pkg-info>"
+        #expect(PackageInstaller.destinations(inPackageInfo: body) == ["/Applications/Foo.app"])
+    }
+
+    /// The filesystem is case-insensitive and vendors are inconsistent.
+    @Test func bundleSuffixMatchingIsCaseInsensitive() {
+        let body = #"<pkg-info install-location="/Applications"><bundle path="./Foo.APP"/></pkg-info>"#
+        #expect(PackageInstaller.destinations(inPackageInfo: body) == ["/Applications/Foo.APP"])
+    }
+
+    /// Malformed input yields nothing, which the gate treats as "cannot verify".
+    @Test func unparsableBodyYieldsNoDestinations() {
+        #expect(PackageInstaller.destinations(inPackageInfo: "not xml at all <<<").isEmpty)
     }
 }


### PR DESCRIPTION
Three pieces of hardening that stand on their own — none of them depends on the
remote-recipe work they were scoped out of, and the first two close gaps that
exist today.

## 1. A `.pkg` is gated on where it installs, not just who signed it

The `.app` routes pair the Team ID check with a bundle-identifier check against
the installed app (`SignatureVerifier` Gate 4). The `.pkg` route had only the
Team ID — and Team ID alone permits any app from the same vendor, which Gate 4's
own comment spells out as Chrome vs Earth. A package runs its install scripts as
root the moment the user confirms.

**Comparing bundle identifiers is not the fix.** Measured against six real vendor
packages, it rejects legitimate updates:

| package | declares the installed app's bundle id? |
|---|---|
| Microsoft Word | yes — one of **206**, so it screens almost nothing |
| WeChat DevTools | yes, but as `com.github.Electron` (stock Electron identity) |
| **Tailscale** | **no** — only the helpers nested inside the bundle |

Tailscale's `pkg-ref` identifier is `com.tailscale.ipn.macsys`; the installed app
is `io.tailscale.ipn.macsys`. A bundle-id gate would refuse a perfectly good
update.

What every package *does* declare is where it writes. This parses the destination
`.app` paths out of each `PackageInfo` (`install-location` as the payload root,
each `<bundle path>` relative to it, and the root itself when it *is* the bundle)
and requires the app being updated to be one of them. Word's package resolves to
Word and AutoUpdate — never Excel — so a same-Team substitution no longer clears
the gate.

Verified through the production code path against all three package shapes:

```
Tailscale.pkg   -> /Applications/Tailscale.app
Word.pkg        -> /Applications/Microsoft Word.app, .../Microsoft AutoUpdate.app
Edge.pkg        -> /Applications/Microsoft Edge.app
OneDrive.pkg    -> /Applications/OneDrive.app
UURemote.pkg    -> /Applications/UURemote.app
WeChat DevTools -> /Applications/wechatwebdevtools.app
```

**Deliberate limitation:** a package whose layout cannot be read yields no
destinations, and that falls back to the Team-only gate rather than blocking an
install that works today — the other 13 pkg recipes are untested. The comment
says to tighten to fail-closed once they are confirmed. Worth a second opinion on
whether that trade is the right one.

## 2. Changelog URLs must be plain https before they are rendered

`changelogURL` is the one recipe field that becomes an attacker-choosable origin
loaded in-process, in a window sitting next to credentials for other services.
Every recipe is compiled into the signed binary today, so this is defence in
depth rather than a live hole — but it is the field most likely to be served
remotely first.

Rejects non-https, URLs carrying credentials (`https://vendor.com@evil.example/`),
IP-literal hosts, and non-standard ports. A rejected URL returns nil so the caller
falls through to its existing empty state.

No host allowlist: that only becomes meaningful once recipes stop being compiled
in, and guessing at vendor domains now would break the many products whose docs
site is on a different domain than their download endpoint.

Regression tests walk `VendorProbeRegistry`, `ChangelogRecipeRegistry` and
`ChangelogCatalog.pages` rather than a hand-written list, so a recipe added later
with an `http://` URL fails here instead of silently losing its notes pane.

## 3. The sweep's infra gate is raised ahead of a faster cadence

The sweep is the real ceiling on how fast a breakage is noticed — Zotero 10.0 sat
undetected because detection failures are silent by design. Going to four sweeps a
day fixes that, but the noise gates are counted in *sweeps*, so the frequency
change shortens them fourfold. `infraThreshold` 5 -> 20 restores the original ~5
days of wall clock; `actionableThreshold` stays at 2 on purpose (5xx/429 are
classified `.infra`, not actionable).

**The schedule itself is not in this repo.** `.github/workflows/recipe-verify.yml`
is gitignored and no longer runs anything — Actions last ran it 2026-08-13, and
since 2026-08-16 the sweep is a launchd agent on the mini that pulls and rebuilds
before each run. So this must merge *first*; the cadence is raised on the mini
afterwards, or there is a window where 6-hourly sweeps run against a 30-hour infra
gate.

## Verification

```
make test    -> 768 tests / 62 suites passed (core)
                101 tests / 16 suites passed (CLI)
                2 known issues, both pre-existing
make install -> builds, signs (Developer ID), deploys, runs
```

Real packages were downloaded and parsed through the shipping code, not fixtures
alone; the temporary test that did so was removed after it passed.