### PR TITLE
Gate the sweep's noise floor on wall-clock, not sweep counts

### DIFF
--- a/CLI/Sources/DuoKit/Baseline.swift
+++ b/CLI/Sources/DuoKit/Baseline.swift
@@ -49,13 +49,49 @@ public struct Baseline: Codable, Sendable {
         /// Set by the reconcile step, read by it on the next run.
         public var issueNumber: Int?
         public var closedAt: Date?
-        /// Sweeps since the last comment on the open issue, for the rate limit
-        /// that keeps a daily job from producing a daily comment.
+        /// Sweeps since the last comment on the open issue. Kept for the issue
+        /// text ("still down, N sweeps"); the rate limit itself is `lastCommentedAt`.
         public var sweepsSinceComment = 0
+        /// When the open issue was last commented on, for the nudge rate limit.
+        /// A timestamp rather than a sweep count for the same reason as
+        /// `infraSince`: the interval is meant to be a week of wall-clock, and a
+        /// count only says that as long as the cadence never moves.
+        public var lastCommentedAt: Date?
         /// The failure signature the last LLM suggestion was written about, so
         /// a suggestion is posted once per distinct problem rather than every
         /// sweep, and is never shown against a failure it doesn't describe.
         public var triagedSignature: String?
+
+        /// Whether this endpoint has been unreachable long enough, and often
+        /// enough, that the network has stopped being a plausible explanation.
+        ///
+        /// Both conditions are load-bearing: see `Baseline.infraWindow` for why
+        /// the wall-clock one replaced a sweep count, and
+        /// `Baseline.minInfraObservations` for why a count still has to be there.
+        public func isInfraReportable(now: Date = Date()) -> Bool {
+            guard consecutiveInfra >= Baseline.minInfraObservations,
+                  let elapsed = infraElapsed(now: now) else { return false }
+            return elapsed >= Baseline.infraWindow
+        }
+
+        /// Whether the open issue may be nudged again yet. An issue that has never
+        /// been commented on is always eligible.
+        public func mayComment(now: Date = Date()) -> Bool {
+            guard let lastCommentedAt else { return true }
+            return now.timeIntervalSince(lastCommentedAt) >= Baseline.commentInterval
+        }
+
+        /// How long since the open issue was last nudged, or nil if never.
+        public func sinceLastComment(now: Date = Date()) -> TimeInterval? {
+            lastCommentedAt.map { now.timeIntervalSince($0) }
+        }
+
+        /// How long the current unreachable run has been going, or nil when the
+        /// endpoint is not currently in one.
+        public func infraElapsed(now: Date = Date()) -> TimeInterval? {
+            guard let infraSince else { return nil }
+            return now.timeIntervalSince(infraSince)
+        }
 
         public init() {}
 
@@ -80,6 +116,7 @@ public struct Baseline: Codable, Sendable {
             closedAt = try c.decodeIfPresent(Date.self, forKey: .closedAt)
             sweepsSinceComment =
                 try c.decodeIfPresent(Int.self, forKey: .sweepsSinceComment) ?? 0
+            lastCommentedAt = try c.decodeIfPresent(Date.self, forKey: .lastCommentedAt)
             triagedSignature = try c.decodeIfPresent(String.self, forKey: .triagedSignature)
         }
     }
@@ -100,15 +137,39 @@ public struct Baseline: Codable, Sendable {
     /// Much higher than `actionableThreshold` on purpose. Unreachability is the
     /// one signal that is routinely someone else's fault — a vendor's bad night,
     /// the runner's flaky uplink — so the bar has to be high enough that none of
-    /// those clear it. The bar is expressed in sweeps but the property that
-    /// matters is wall-clock: it has to outlast any plausible outage. Nightly
-    /// sweeps made five the better part of a week; at every six hours five would
-    /// be thirty hours, which a long CDN incident or a bad uplink night can
-    /// clear. Twenty keeps the original ~5 days, so no CDN incident lasts that
-    /// long and no DNS record is missing that long by accident.
+    /// those clear it.
     ///
-    /// If the sweep interval changes again, change this with it.
-    public static let infraThreshold = 20
+    /// Expressed as wall-clock rather than a sweep count, because wall-clock is
+    /// the property that actually matters: no CDN incident lasts five days and no
+    /// DNS record is missing that long by accident. Counting sweeps encoded the
+    /// same intent only as long as the cadence never moved — and when it did move
+    /// (nightly to six-hourly) the constant silently came to mean thirty hours,
+    /// which a long outage clears. Two separate constants had to be rescaled by
+    /// hand to fix that. This one cannot drift.
+    public static let infraWindow: TimeInterval = 5 * 24 * 60 * 60
+
+    /// How many unreachable sweeps must actually have been observed, on top of
+    /// `infraWindow` having elapsed.
+    ///
+    /// Time alone is not enough in the one case where the sweep itself is what
+    /// stopped: if the runner is off for a week, the first sweep back records an
+    /// `infraSince` and the second, minutes later, would satisfy any elapsed-time
+    /// test on a timestamp that is now days old — reporting a host as retired on
+    /// the strength of two observations. Requiring a handful of sweeps as well
+    /// keeps that honest without reintroducing the cadence coupling: at any
+    /// sensible interval the window is the binding constraint, and this only
+    /// takes over when sweeps are sparse.
+    public static let minInfraObservations = 3
+
+    /// How long to wait before nudging an issue that is still open and still
+    /// saying the same thing. A job that comments every run is a notification
+    /// that says nothing new.
+    ///
+    /// Wall-clock for the same reason as `infraWindow`: this was seven sweeps,
+    /// which meant a week nightly and under two days once the sweep moved to
+    /// six-hourly. Both constants had to be rescaled by hand for that one change;
+    /// neither can drift now.
+    public static let commentInterval: TimeInterval = 7 * 24 * 60 * 60
 
     public init() {}
 
@@ -182,6 +243,7 @@ public struct Baseline: Codable, Sendable {
             entry.consecutiveActionable = 0
             entry.lastSignature = nil
             entry.sweepsSinceComment = 0
+            entry.lastCommentedAt = nil
 
         case .broken, .warn:
             entry.consecutiveActionable += 1
@@ -230,8 +292,13 @@ public struct Baseline: Codable, Sendable {
 
     /// Whether this recipe's endpoint has been unreachable long enough that the
     /// network is no longer a plausible explanation.
-    public func isInfraReportable(_ recipeID: String) -> Bool {
-        (entries[recipeID]?.consecutiveInfra ?? 0) >= Self.infraThreshold
+    public func isInfraReportable(_ recipeID: String, now: Date = Date()) -> Bool {
+        entries[recipeID]?.isInfraReportable(now: now) ?? false
+    }
+
+    /// How long the current unreachable run has been going, for display.
+    public func infraElapsed(_ recipeID: String, now: Date = Date()) -> TimeInterval? {
+        entries[recipeID]?.infraElapsed(now: now)
     }
 
     public func infraStreak(_ recipeID: String) -> Int {

--- a/CLI/Sources/DuoKit/Reconcile.swift
+++ b/CLI/Sources/DuoKit/Reconcile.swift
@@ -27,13 +27,9 @@ public enum IssueAction: Equatable, Sendable {
 
 public enum Reconcile {
 
-    /// Comment on a still-broken issue only every Nth sweep.
-    ///
-    /// Like `Baseline.infraThreshold` this is a wall-clock property counted in
-    /// sweeps: a job that comments every run is a notification saying nothing new.
-    /// Seven was a week of nightly sweeps; at six-hourly it would be under two
-    /// days, so it scales with the cadence to stay at roughly a week.
-    public static let commentEverySweeps = 28
+    /// How long an open, unchanged issue is left alone before it is nudged again.
+    /// Lives on `Baseline` as a wall-clock interval; see `Baseline.commentInterval`.
+    public static var commentInterval: TimeInterval { Baseline.commentInterval }
 
     /// A recipe that broke again within this window reopens its old issue rather
     /// than opening a second one about the same thing.
@@ -66,10 +62,12 @@ public enum Reconcile {
         // between the sweep noticing a vendor shutting a host down and never
         // noticing it at all.
         if finding.status == .infra {
-            guard entry.consecutiveInfra >= Baseline.infraThreshold else {
+            guard entry.isInfraReportable(now: now) else {
+                let elapsed = entry.infraElapsed(now: now).map { $0 / 86_400 }
                 return .none(
-                    "infra — unreachable \(entry.consecutiveInfra)/"
-                        + "\(Baseline.infraThreshold) sweeps, still assuming the network")
+                    "infra — unreachable \(Report.duration(elapsed)) of "
+                        + "\(Report.duration(Baseline.infraWindow / 86_400)) "
+                        + "(\(entry.consecutiveInfra) sweeps), still assuming the network")
             }
             guard let issue = entry.issueNumber else {
                 return .create(
@@ -94,15 +92,18 @@ public enum Reconcile {
             // as everything else. No signature comparison: a dead host has no
             // shape to change, and transport errors flap between "no route" and
             // "TLS failed" for reasons that mean nothing.
-            guard entry.sweepsSinceComment >= commentEverySweeps else {
+            guard entry.mayComment(now: now) else {
                 return .none(
-                    "unreachable and already open (\(entry.sweepsSinceComment)/"
-                        + "\(commentEverySweeps) sweeps since last comment)")
+                    "unreachable and already open (nudged "
+                        + "\(Report.duration(entry.sinceLastComment(now: now).map { $0 / 86_400 })) "
+                        + "ago, waits \(Report.duration(Baseline.commentInterval / 86_400)))")
             }
             return .comment(
                 issue: issue,
                 body: "`\(finding.endpointHost)` is still unreachable as of "
-                    + "\(Self.day(now)) — \(entry.consecutiveInfra) consecutive sweeps"
+                    + "\(Self.day(now)) — unreachable for "
+                    + "\(Report.duration(entry.infraElapsed(now: now).map { $0 / 86_400 })) "
+                    + "across \(entry.consecutiveInfra) sweeps"
                     + (entry.infraSince.map { ", since \(Self.day($0))" } ?? "") + ".")
         }
 
@@ -162,10 +163,11 @@ public enum Reconcile {
                 body: "An automated analysis of the captured response is available.\n\n"
                     + suggestionBlock(suggestion))
         }
-        guard entry.sweepsSinceComment >= commentEverySweeps else {
+        guard entry.mayComment(now: now) else {
             return .none(
-                "already open, unchanged (\(entry.sweepsSinceComment)/"
-                    + "\(commentEverySweeps) sweeps since last comment)")
+                "already open, unchanged (nudged "
+                    + "\(Report.duration(entry.sinceLastComment(now: now).map { $0 / 86_400 })) "
+                    + "ago, waits \(Report.duration(Baseline.commentInterval / 86_400)))")
         }
         return .comment(
             issue: issue,
@@ -456,9 +458,11 @@ public enum Reconcile {
             baseline.entries[recipeID]?.issueNumber = number
             baseline.entries[recipeID]?.closedAt = nil
             baseline.entries[recipeID]?.sweepsSinceComment = 0
+            baseline.entries[recipeID]?.lastCommentedAt = Date()
         case .comment(let issue, let body):
             try GitHub.comment(issue: issue, body: body)
             baseline.entries[recipeID]?.sweepsSinceComment = 0
+            baseline.entries[recipeID]?.lastCommentedAt = Date()
         case .close(let issue, let comment):
             try GitHub.close(issue: issue, comment: comment)
             baseline.entries[recipeID]?.closedAt = Date()
@@ -466,6 +470,7 @@ public enum Reconcile {
             try GitHub.reopen(issue: issue, comment: comment)
             baseline.entries[recipeID]?.closedAt = nil
             baseline.entries[recipeID]?.sweepsSinceComment = 0
+            baseline.entries[recipeID]?.lastCommentedAt = Date()
         }
     }
 

--- a/CLI/Sources/DuoKit/Report.swift
+++ b/CLI/Sources/DuoKit/Report.swift
@@ -9,6 +9,20 @@ import DuoUpdaterCore
 /// constructed, so there is no formatting path that can leak a credential.
 public enum Report {
 
+    /// Days rendered for a human: "3 days", "1 day", "18 hours". Durations here
+    /// are always shown alongside a sweep count, so this only has to be readable,
+    /// not precise.
+    static func duration(_ days: Double?) -> String {
+        guard let days else { return "?" }
+        if days < 1 {
+            let hours = Int((days * 24).rounded())
+            return "\(hours) hour\(hours == 1 ? "" : "s")"
+        }
+        let whole = Int(days.rounded())
+        return "\(whole) day\(whole == 1 ? "" : "s")"
+    }
+
+
     // MARK: - terminal
 
     static func text(
@@ -48,11 +62,14 @@ public enum Report {
             print("\n  ~ INFRA (transient by default — reported once persistent)")
             for finding in infra {
                 let streak = baseline.infraStreak(finding.recipeID)
+                let days = baseline.infraElapsed(finding.recipeID).map { $0 / 86_400 }
                 let note: String
                 if baseline.isInfraReportable(finding.recipeID) {
-                    note = "   ← unreachable \(streak) sweeps running; treated as GONE"
-                } else if streak > 1 {
-                    note = "   (unreachable \(streak)/\(Baseline.infraThreshold) sweeps)"
+                    note = "   ← unreachable \(Self.duration(days)) "
+                        + "(\(streak) sweeps); treated as GONE"
+                } else if streak > 1, let days {
+                    note = "   (unreachable \(Self.duration(days)) of "
+                        + "\(Self.duration(Baseline.infraWindow / 86_400)))"
                 } else {
                     note = ""
                 }
@@ -150,7 +167,10 @@ public enum Report {
             }
             let infraStreak = baseline.infraStreak(finding.recipeID)
             if infraStreak > 0 {
-                out += "- **consecutive sweeps unreachable**: \(infraStreak)"
+                out += "- **unreachable for**: "
+                out += baseline.infraElapsed(finding.recipeID)
+                    .map { Self.duration($0 / 86_400) } ?? "?"
+                out += " (\(infraStreak) sweeps)"
                 out += baseline.entries[finding.recipeID]?.infraSince
                     .map { " (since \(ISO8601DateFormatter().string(from: $0).prefix(10)))" } ?? ""
                 out += "\n"

--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -68,15 +68,56 @@ import Foundation
     @Test func unreachabilityAccumulatesOnItsOwnCounter() {
         var baseline = Baseline()
         let id = "vendor:com.example.app:stable"
-        for _ in 1...(Baseline.infraThreshold - 1) {
+        let start = Date()
+        for _ in 1...6 {
             _ = baseline.reconcile(finding(status: .infra, failureKind: "transport"))
         }
-        #expect(!baseline.isInfraReportable(id), "a few bad nights is still the network")
+        // Enough sweeps, but the run is minutes old: still the network.
+        #expect(!baseline.isInfraReportable(id, now: start.addingTimeInterval(3_600)),
+                "a few bad sweeps in an hour is still the network")
+
+        // Same sweeps, now five days in.
+        let later = start.addingTimeInterval(Baseline.infraWindow + 60)
+        #expect(baseline.isInfraReportable(id, now: later))
+        #expect(baseline.infraStreak(id) == 6)
+        #expect(baseline.entries[id]?.infraSince != nil)
+    }
+
+    /// The gate is wall-clock, but wall-clock alone breaks in the one case where
+    /// the *sweep* is what stopped: after a week of downtime the first sweep back
+    /// records `infraSince`, and the second — minutes later — would otherwise
+    /// satisfy an elapsed-time test against a timestamp that is already days old.
+    /// Two observations must never retire a host.
+    @Test func aLongGapBetweenSweepsDoesNotRetireAHostOnTwoObservations() {
+        var baseline = Baseline()
+        let id = "vendor:com.example.app:stable"
+        let start = Date()
+        for _ in 1...2 {
+            _ = baseline.reconcile(finding(status: .infra, failureKind: "transport"))
+        }
+        let wayLater = start.addingTimeInterval(Baseline.infraWindow * 2)
+        #expect(!baseline.isInfraReportable(id, now: wayLater),
+                "two sweeps is not evidence, however old the first one is")
 
         _ = baseline.reconcile(finding(status: .infra, failureKind: "transport"))
-        #expect(baseline.isInfraReportable(id))
-        #expect(baseline.infraStreak(id) == Baseline.infraThreshold)
-        #expect(baseline.entries[id]?.infraSince != nil)
+        #expect(baseline.isInfraReportable(id, now: wayLater),
+                "the third observation clears the minimum")
+    }
+
+    /// The point of the change: the gate no longer moves when the sweep cadence
+    /// does. The same five days of downtime reports either way, whether it was
+    /// observed nightly or four times a day.
+    @Test func theGateDoesNotMoveWithTheSweepCadence() {
+        let start = Date()
+        let later = start.addingTimeInterval(Baseline.infraWindow + 60)
+        for sweepsOverTheWindow in [5, 20] {
+            var baseline = Baseline()
+            for _ in 1...sweepsOverTheWindow {
+                _ = baseline.reconcile(finding(status: .infra, failureKind: "transport"))
+            }
+            #expect(baseline.isInfraReportable("vendor:com.example.app:stable", now: later),
+                    "\(sweepsOverTheWindow) sweeps across the same five days must report")
+        }
     }
 
     /// Any answer at all — even a broken one — is proof the host is still there,
@@ -86,14 +127,17 @@ import Foundation
         let id = "vendor:com.example.app:stable"
         for reachable in [FindingStatus.ok, .broken, .warn] {
             var baseline = Baseline()
-            for _ in 1...Baseline.infraThreshold {
+            let start = Date()
+            let later = start.addingTimeInterval(Baseline.infraWindow + 60)
+            for _ in 1...6 {
                 _ = baseline.reconcile(finding(status: .infra))
             }
-            #expect(baseline.isInfraReportable(id))
+            #expect(baseline.isInfraReportable(id, now: later))
 
             _ = baseline.reconcile(finding(status: reachable, version: "1.0.0",
                                            failureKind: "versionPatternNoMatch"))
-            #expect(!baseline.isInfraReportable(id), "\(reachable.rawValue) proves the host is up")
+            #expect(!baseline.isInfraReportable(id, now: later),
+                    "\(reachable.rawValue) proves the host is up")
             #expect(baseline.infraStreak(id) == 0)
             #expect(baseline.entries[id]?.infraSince == nil)
         }
@@ -104,11 +148,12 @@ import Foundation
     /// those would report every one of them as a dead host within a week.
     @Test func skippedSweepsAreNotEvidenceOfADeadHost() {
         var baseline = Baseline()
-        for _ in 1...(Baseline.infraThreshold * 3) {
+        for _ in 1...60 {
             _ = baseline.reconcile(finding(status: .skipped))
         }
         #expect(baseline.infraStreak("vendor:com.example.app:stable") == 0)
-        #expect(!baseline.isInfraReportable("vendor:com.example.app:stable"))
+        #expect(!baseline.isInfraReportable("vendor:com.example.app:stable",
+                                            now: Date().addingTimeInterval(Baseline.infraWindow * 3)))
     }
 
     /// An unreachable sweep in the middle of a broken streak must not make the

--- a/CLI/Tests/DuoKitTests/ReconcileTests.swift
+++ b/CLI/Tests/DuoKitTests/ReconcileTests.swift
@@ -21,8 +21,9 @@ import Foundation
 
     private func entry(
         issue: Int? = nil, streak: Int = 0, signature: String? = nil,
-        closedAt: Date? = nil, sweepsSinceComment: Int = 0, lastGood: String? = nil,
-        infra: Int = 0
+        closedAt: Date? = nil, sweepsSinceComment: Int = 0, commentedDaysAgo: Double? = nil,
+        lastGood: String? = nil,
+        infra: Int = 0, infraDays: Double? = nil
     ) -> Baseline.Entry {
         var e = Baseline.Entry()
         e.issueNumber = issue
@@ -30,9 +31,15 @@ import Foundation
         e.lastSignature = signature
         e.closedAt = closedAt
         e.sweepsSinceComment = sweepsSinceComment
+        e.lastCommentedAt = commentedDaysAgo.map { Date(timeIntervalSinceNow: -$0 * 86_400) }
         e.lastGoodVersion = lastGood
         e.consecutiveInfra = infra
-        if infra > 0 { e.infraSince = Date(timeIntervalSinceNow: -Double(infra) * 86_400) }
+        // The gate is wall-clock now, so the age of the run matters, not just how
+        // many sweeps saw it. Default to one day per sweep — the old cadence —
+        // unless a test needs the two to disagree.
+        if infra > 0 {
+            e.infraSince = Date(timeIntervalSinceNow: -(infraDays ?? Double(infra)) * 86_400)
+        }
         return e
     }
 
@@ -57,7 +64,7 @@ import Foundation
     @Test func anEndpointUnreachableForAWeekIsReported() {
         let action = Reconcile.decide(
             finding(status: .infra, failureKind: "transport"),
-            entry: entry(infra: Baseline.infraThreshold), reportable: false)
+            entry: entry(infra: 6, infraDays: 6), reportable: false)
         guard case .create(let title, let body) = action else {
             Issue.record("expected an issue to be created, got \(action)")
             return
@@ -74,7 +81,7 @@ import Foundation
     /// as dead hosts would file an issue for each one within a week.
     @Test func skippedNeverFilesHoweverLongItPersists() {
         let action = Reconcile.decide(
-            finding(status: .skipped), entry: entry(infra: Baseline.infraThreshold * 5),
+            finding(status: .skipped), entry: entry(infra: 40, infraDays: 40),
             reportable: true)
         #expect(!action.isWrite)
     }
@@ -83,10 +90,10 @@ import Foundation
     @Test func aBriefOutageIsCountedButNotFiled() {
         let action = Reconcile.decide(
             finding(status: .infra, failureKind: "transport"),
-            entry: entry(infra: Baseline.infraThreshold - 1), reportable: true)
+            entry: entry(infra: 4, infraDays: 4), reportable: true)
         #expect(!action.isWrite)
         if case .none(let reason) = action {
-            #expect(reason.contains("\(Baseline.infraThreshold - 1)/\(Baseline.infraThreshold)"))
+            #expect(reason.contains("4 days of 5 days"))
         } else {
             Issue.record("expected no action")
         }
@@ -100,15 +107,16 @@ import Foundation
         let quiet = Reconcile.decide(
             finding(status: .infra, failureKind: "tlsFailure"),
             entry: entry(issue: 7, signature: "transport",
-                         sweepsSinceComment: 1, infra: Baseline.infraThreshold + 3),
+                         sweepsSinceComment: 1, commentedDaysAgo: 1,
+                         infra: 8, infraDays: 8),
             reportable: true)
         #expect(!quiet.isWrite, "a changed transport error is not news")
 
         let nudge = Reconcile.decide(
             finding(status: .infra, failureKind: "tlsFailure"),
             entry: entry(issue: 7, signature: "transport",
-                         sweepsSinceComment: Reconcile.commentEverySweeps,
-                         infra: Baseline.infraThreshold + 3),
+                         sweepsSinceComment: 9, commentedDaysAgo: 8,
+                         infra: 8, infraDays: 8),
             reportable: true)
         guard case .comment(let issue, let body) = nudge else {
             Issue.record("expected a nudge comment, got \(nudge)")
@@ -181,16 +189,31 @@ import Foundation
 
     // MARK: - not repeating yourself
 
-    /// A daily job that comments daily is a daily notification saying nothing
-    /// new. The issue is already open; silence is the correct output.
+    /// A job that comments every run is a notification saying nothing new. The
+    /// issue is already open; silence is the correct output. Counted in days now,
+    /// so the answer does not change when the sweep interval does.
     @Test func anUnchangedFailureStaysQuietBetweenNudges() {
-        for sweeps in 0..<Reconcile.commentEverySweeps {
+        for daysAgo in [0.0, 0.25, 1, 3, 6.9] {
             let action = Reconcile.decide(
                 finding(status: .broken, failureKind: "versionPatternNoMatch"),
                 entry: entry(issue: 7, streak: 5, signature: "versionPatternNoMatch",
-                             sweepsSinceComment: sweeps),
+                             commentedDaysAgo: daysAgo),
                 reportable: true)
-            #expect(!action.isWrite, "should stay silent at \(sweeps) sweeps since last comment")
+            #expect(!action.isWrite, "should stay silent \(daysAgo) days after the last nudge")
+        }
+    }
+
+    /// The whole point of the timestamp: the quiet period is the same length
+    /// however many sweeps happen inside it.
+    @Test func theNudgeIntervalDoesNotMoveWithTheSweepCadence() {
+        for sweepsInside in [7, 28] {
+            let action = Reconcile.decide(
+                finding(status: .broken, failureKind: "versionPatternNoMatch"),
+                entry: entry(issue: 7, streak: 5, signature: "versionPatternNoMatch",
+                             sweepsSinceComment: sweepsInside, commentedDaysAgo: 3),
+                reportable: true)
+            #expect(!action.isWrite,
+                    "three days is three days, whether that was \(sweepsInside) sweeps")
         }
     }
 
@@ -198,7 +221,7 @@ import Foundation
         let action = Reconcile.decide(
             finding(status: .broken, failureKind: "versionPatternNoMatch"),
             entry: entry(issue: 7, streak: 9, signature: "versionPatternNoMatch",
-                         sweepsSinceComment: Reconcile.commentEverySweeps),
+                         sweepsSinceComment: 9, commentedDaysAgo: 8),
             reportable: true)
         guard case .comment(let issue, _) = action else {
             Issue.record("expected a nudge, got \(action)")


### PR DESCRIPTION
Follow-up to #9, taking the reviewer's suggestion there.

Both of the verifier's rate limits express a span of *time* but were written as a number of *sweeps*, which only means the same thing for as long as the cadence never moves. It just moved — nightly to six-hourly — and both constants silently changed meaning:

| constant | intended | became at 6-hourly |
|---|---|---|
| `infraThreshold = 5` | ~5 days | 30 hours |
| `commentEverySweeps = 7` | ~1 week | under 2 days |

Both had to be found and rescaled by hand in #9, and one of them was missed on the first pass — it only turned up in review. That is the bug this removes, not the specific numbers.

## The change

Gate on time, using the `infraSince` timestamp that was **already persisted and already quoted in issue text, but never actually read for the decision**:

- `infraThreshold = 20` → `infraWindow = 5 days`
- `commentEverySweeps = 28` → `commentInterval = 7 days`, with a new `lastCommentedAt` written whenever an issue is created, commented on, or reopened

## Why there is still a count

Wall-clock alone breaks in exactly one case, and it is a case this setup can really hit: if the **sweep** is what stopped — the mini is off for a week — then the first sweep back records `infraSince`, and the second, minutes later, satisfies any elapsed-time test against a timestamp that is already days old. Two observations would retire a live host.

`minInfraObservations = 3` covers that. It does not reintroduce the coupling: at any sensible interval the window is the binding constraint, and the count only takes over when sweeps are sparse. There is a test for precisely this shape.

## Also

Reports and issue text now read `unreachable 6 days (7 sweeps)` instead of a bare sweep count — the duration is the fact that settles whether a host is having a bad week or has been retired.

## Migration

Entries written before this have no `lastCommentedAt`, and nil means eligible, so each currently-open issue may be nudged once on the first run. Two baseline entries carry an issue number and one issue is open, so that is at most one extra comment.

## Verification

```
make test  -> 777 core / 104 CLI passing, 2 pre-existing known issues
duo verify --vendor --only org.zotero.zotero  -> ok 1, and baseline.json unchanged
```