### PR TITLE
Audit the hard-coded version segment counts

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -487,7 +487,7 @@ public enum VendorProbeRegistry {
             bundleID: "net.whatsapp.WhatsApp",
             url: URL(string: "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_desktop_page")!,
             mode: .redirectFilename,
-            versionPattern: #"WhatsApp-2\.([0-9]+\.[0-9]+\.[0-9]+)\.dmg"#,
+            versionPattern: #"WhatsApp-[0-9]+\.([0-9]+(?:\.[0-9]+){1,2})\.dmg"#,
             changelogURL: URL(string: "https://web.whatsapp.com/desktop/mac_native/release-notes/"),
             install: VendorInstallSpec(
                 urlSource: .redirect(
@@ -555,7 +555,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.microsoft.VSCode",
             url: URL(string: "https://update.code.visualstudio.com/api/update/darwin-arm64/stable/latest")!,
             mode: .responseBody,
-            versionPattern: #""name"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""name"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             changelogURL: URL(string: "https://code.visualstudio.com/updates"),
             // `/latest/darwin-arm64/stable` 302-redirects to the official zip.
             install: VendorInstallSpec(
@@ -620,7 +620,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.jetbrains.intellij-EAP",
             url: URL(string: "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=eap")!,
             mode: .responseBody,
-            versionPattern: #""build"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""build"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             changelogURL: URL(string: "https://www.jetbrains.com/idea/whatsnew/"),
             versionIsBuild: true,
             install: VendorInstallSpec(
@@ -1052,7 +1052,7 @@ public enum VendorProbeRegistry {
             bundleID: "net.pornel.ImageOptim",
             url: URL(string: "https://imageoptim.com/appcast.xml")!,
             mode: .responseBody,
-            versionPattern: #"sparkle:shortVersionString="([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #"sparkle:shortVersionString="([0-9]+(?:\.[0-9]+){1,3})""#,
             changelogURL: URL(string: "https://imageoptim.com/changelog.html")!,
             // One-click verified 2026-08-09 on 1.9.3: `ImageOptim.app` in the
             // archive, bundle id net.pornel.ImageOptim, Team 59KZTZA4XR, accepted by
@@ -1627,7 +1627,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.todesktop.230313mzl4w4u92",
             url: URL(string: "https://api2.cursor.sh/updates/api/download/latest/darwin-arm64/cursor")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             downloadURL: URL(string: "https://www.cursor.com/downloads"),
             changelogURL: URL(string: "https://www.cursor.com/changelog"),
             install: VendorInstallSpec(
@@ -1642,7 +1642,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.raycast.macos",
             url: URL(string: "https://releases.raycast.com/releases/latest?build=universal")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             downloadURL: URL(string: "https://www.raycast.com/"),
             changelogURL: URL(string: "https://www.raycast.com/changelog"),
             install: VendorInstallSpec(
@@ -1745,7 +1745,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.anthropic.claudefordesktop",
             url: URL(string: "https://api.anthropic.com/api/desktop/darwin/universal/zip/latest/redirect")!,
             mode: .redirectFilename,
-            versionPattern: #"/darwin/universal/([0-9]+\.[0-9]+\.[0-9]+)/"#,
+            versionPattern: #"/darwin/universal/([0-9]+(?:\.[0-9]+){1,3})/"#,
             downloadURL: URL(string: "https://claude.ai/download"),
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(#"(https://downloads\.claude\.ai/releases/darwin/universal/[0-9.]+/Claude-[0-9a-f]+\.zip)"#),
@@ -1825,7 +1825,7 @@ public enum VendorProbeRegistry {
             bundleID: "app.chatwise",
             url: URL(string: "https://releases.chatwise.app/releases?version=0.0.0&platform=osx")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             changelogURL: URL(string: "https://chatwise.app/changelog"),
             // assets[] carries the arm64 zip and its SHA-512 (base64) — use both.
             install: VendorInstallSpec(
@@ -1839,7 +1839,7 @@ public enum VendorProbeRegistry {
             bundleID: "ai.elementlabs.lmstudio",
             url: URL(string: "https://versions-prod.lmstudio.ai/update/darwin/arm64/0.0.0")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             changelogURL: URL(string: "https://lmstudio.ai/changelog/lmstudio"),
             // Feed has no link — build the dmg path from version + build, both of
             // which are REQUIRED in the path (…/0.4.15-2/LM-Studio-0.4.15-2-arm64.dmg;
@@ -1855,7 +1855,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.conductor.app",
             url: URL(string: "https://cdn.crabnebula.app/update/melty/conductor/darwin-aarch64/0.0.0")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             changelogURL: URL(string: "https://conductor.build/changelog"),
             // Tauri updater `url` is the `Conductor.app.tar.gz` (CDN asset id, no
             // file extension — VendorInstaller renames by kind before unpacking).
@@ -1951,7 +1951,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.postmanlabs.mac",
             url: URL(string: "https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json")!,
             mode: .responseBody,
-            versionPattern: #""notes"\s*:\s*\[\s*\{[^}]*"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""notes"\s*:\s*\[\s*\{[^}]*"version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             downloadURL: URL(string: "https://www.postman.com/downloads/"),
             changelogURL: URL(string: "https://www.postman.com/release-notes/postman-app/"),
             install: VendorInstallSpec(
@@ -1986,7 +1986,7 @@ public enum VendorProbeRegistry {
             bundleID: "io.dcloud.HBuilderX",
             url: URL(string: "https://download1.dcloud.net.cn/hbuilderx/release.json")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             changelogURL: URL(string: "https://hx.dcloud.net.cn/Tutorial/HistoryVersion"),
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(
@@ -2177,7 +2177,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.hnc.Discord",
             url: URL(string: "https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=osx&arch=x64")!,
             mode: .responseBody,
-            versionPattern: #"discordapp\.net/distro/app/stable/osx/universal/([0-9]+\.[0-9]+\.[0-9]+)/"#,
+            versionPattern: #"discordapp\.net/distro/app/stable/osx/universal/([0-9]+(?:\.[0-9]+){1,3})/"#,
             downloadURL: URL(string: "https://discord.com/download"),
             changelogURL: URL(string: "https://discord.com/blog"),
             install: VendorInstallSpec(
@@ -2196,7 +2196,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.hnc.DiscordPTB",
             url: URL(string: "https://updates.discord.com/distributions/app/manifests/latest?channel=ptb&platform=osx&arch=x64")!,
             mode: .responseBody,
-            versionPattern: #"discordapp\.net/distro/app/ptb/osx/universal/([0-9]+\.[0-9]+\.[0-9]+)/"#,
+            versionPattern: #"discordapp\.net/distro/app/ptb/osx/universal/([0-9]+(?:\.[0-9]+){1,3})/"#,
             changelogURL: URL(string: "https://discord.com/blog"),
             // One-click verified 2026-08-09: `https://discord.com/api/download/ptb`
             // 302s to `…/apps/osx/0.0.252/DiscordPTB.dmg`, holding `Discord PTB.app`
@@ -2212,7 +2212,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.hnc.DiscordCanary",
             url: URL(string: "https://updates.discord.com/distributions/app/manifests/latest?channel=canary&platform=osx&arch=x64")!,
             mode: .responseBody,
-            versionPattern: #"discordapp\.net/distro/app/canary/osx/universal/([0-9]+\.[0-9]+\.[0-9]+)/"#,
+            versionPattern: #"discordapp\.net/distro/app/canary/osx/universal/([0-9]+(?:\.[0-9]+){1,3})/"#,
             changelogURL: URL(string: "https://discord.com/blog"),
             // Same stable "latest" redirect as PTB, on the canary track (the
             // manifest URL points at a `.dis` distro blob, not an app). Verified
@@ -2264,7 +2264,7 @@ public enum VendorProbeRegistry {
             bundleID: "md.obsidian",
             url: URL(string: "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json")!,
             mode: .responseBody,
-            versionPattern: #""latestVersion"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""latestVersion"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             downloadURL: URL(string: "https://obsidian.md/download"),
             changelogURL: URL(string: "https://obsidian.md/changelog/"),
             install: VendorInstallSpec(
@@ -2287,7 +2287,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.figma.Desktop",
             url: URL(string: "https://desktop.figma.com/mac-arm/RELEASE.json")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             downloadURL: URL(string: "https://www.figma.com/downloads/"),
             changelogURL: URL(string: "https://www.figma.com/release-notes/"),
             install: VendorInstallSpec(
@@ -2415,7 +2415,7 @@ public enum VendorProbeRegistry {
             bundleID: "com.sublimemerge",
             url: URL(string: "https://www.sublimemerge.com/download")!,
             mode: .responseBody,
-            versionPattern: #"class="latest"><i>Version:</i>\s*(Build\s+[0-9]{4})"#,
+            versionPattern: #"class="latest"><i>Version:</i>\s*(Build\s+[0-9]+)"#,
             changelogURL: URL(string: "https://www.sublimemerge.com/download"),
             // Same shape as Sublime Text: the page ships the download link as the
             // literal template `sublime_merge_build_${version}_mac.zip` for JS to
@@ -2447,6 +2447,13 @@ public enum VendorProbeRegistry {
             bundleID: "tv.plex.desktop",
             url: URL(string: "https://plex.tv/api/downloads/6.json")!,
             mode: .responseBody,
+            // NOT widened to a variable segment count like its neighbours. The feed's
+            // value is `1.115.0.426-4e960a1d` and this pattern has no closing
+            // delimiter, so the capture is bounded only by how many segments it
+            // asks for: three yields the marketing version, four would silently
+            // start reporting `1.115.0.426` — a build number the app does not
+            // report, which is a phantom update. Verified against the live feed
+            // 2026-08-19.
             versionPattern: #""MacOS"\s*:\s*\{[^}]*?"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)"#,
             downloadURL: URL(string: "https://www.plex.tv/media-server-downloads/?cat=plex+desktop"),
             changelogURL: URL(string: "https://www.plex.tv/media-server-downloads/?cat=plex+desktop"),
@@ -3088,7 +3095,7 @@ public enum VendorProbeRegistry {
             bundleID: "org.torproject.torbrowser",
             url: URL(string: "https://aus1.torproject.org/torbrowser/update_3/release/download-macos.json")!,
             mode: .responseBody,
-            versionPattern: #""version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             downloadURL: URL(string: "https://www.torproject.org/download/"),
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(#""binary"\s*:\s*"(https://[^"]+\.dmg)""#),
@@ -3318,7 +3325,7 @@ public enum VendorProbeRegistry {
             bundleID: "org.gimp.gimp",
             url: URL(string: "https://www.gimp.org/gimp_versions.json")!,
             mode: .responseBody,
-            versionPattern: #""STABLE"\s*:\s*\[\s*\{\s*"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#,
+            versionPattern: #""STABLE"\s*:\s*\[\s*\{\s*"version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,3})""#,
             downloadURL: URL(string: "https://www.gimp.org/downloads/"),
             changelogURL: URL(string: "https://www.gimp.org/news/"),
             install: VendorInstallSpec(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionSegmentCountTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionSegmentCountTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Zotero shipped `10.0` where every release before it had three segments, and
+/// the recipe's pattern demanded exactly three. Nothing errored — the app simply
+/// stopped appearing as updatable until a sweep noticed. These tests pin the two
+/// halves of the rule that came out of auditing the rest of the registry.
+struct VersionSegmentCountTests {
+
+    private func recipe(_ bundleID: String) -> VendorProbeRecipe? {
+        VendorProbeRegistry.recipes.first { $0.bundleID == bundleID }
+    }
+
+    private func extract(_ body: String, _ recipe: VendorProbeRecipe) -> String? {
+        VendorProbeRecipe.extractVersion(from: body, pattern: recipe.versionPattern)
+    }
+
+    // MARK: The widened patterns keep working, in both directions
+
+    @Test func aDelimitedPatternAcceptsFewerSegmentsThanBefore() throws {
+        // The Zotero shape: a major bump that drops a segment.
+        let recipe = try #require(recipe("com.microsoft.VSCode"))
+        #expect(extract(#"{"name":"1.133.0"}"#, recipe) == "1.133.0")
+        #expect(extract(#"{"name":"2.0"}"#, recipe) == "2.0")
+    }
+
+    @Test func aDelimitedPatternAcceptsMoreSegmentsThanBefore() throws {
+        // The other direction, which fails just as silently: a vendor adds a
+        // segment and the closing delimiter no longer follows the capture.
+        let recipe = try #require(recipe("com.microsoft.VSCode"))
+        #expect(extract(#"{"name":"1.133.0.5"}"#, recipe) == "1.133.0.5")
+    }
+
+    @Test func wideningCannotDriftOntoANeighbouringNumber() throws {
+        // Why only delimiter-bounded patterns were widened: the capture is pinned
+        // on both sides, so a shorter number elsewhere in the document cannot win.
+        let recipe = try #require(recipe("com.microsoft.VSCode"))
+        let body = #"{"schema":"2.1","other":"9.9","name":"1.133.0","build":"7.7"}"#
+        #expect(extract(body, recipe) == "1.133.0")
+    }
+
+    @Test func whatsAppNoLongerHardCodesItsMajorVersion() throws {
+        // The filename carries a leading component the bundle does not report, so
+        // it still has to be stripped — but which component it is was written as
+        // the literal `2.`, which would stop matching the day WhatsApp ships 3.x.
+        let recipe = try #require(recipe("net.whatsapp.WhatsApp"))
+        #expect(extract("WhatsApp-2.26.33.15.dmg", recipe) == "26.33.15")
+        #expect(extract("WhatsApp-3.26.33.15.dmg", recipe) == "26.33.15")
+    }
+
+    // MARK: The patterns deliberately left strict
+
+    @Test func plexStaysAtThreeSegmentsBecauseItHasNoClosingDelimiter() throws {
+        // Its feed value is `1.115.0.426-4e960a1d`. With nothing bounding the
+        // capture on the right, the segment count IS the boundary: a fourth
+        // segment would start reporting a build number the app never reports.
+        let recipe = try #require(recipe("tv.plex.desktop"))
+        let body = #"{"computer":{"MacOS":{"version":"1.115.0.426-4e960a1d"}}}"#
+        #expect(extract(body, recipe) == "1.115.0")
+    }
+
+    @Test func sublimeTextKeepsItsMajorPinned() throws {
+        // `Build 4NNN` looks like the same defect as WhatsApp's `2.` but is not:
+        // the bundle id is version-pinned (`com.sublimetext.4`), and Sublime's
+        // majors are the leading build digit. Widening it would offer a Sublime
+        // Text 4 install the build number of a paid major upgrade. If Sublime 5
+        // ever ships, this pattern stops matching and the sweep files an issue —
+        // a detected failure, which is the better trade.
+        let recipe = try #require(recipe("com.sublimetext.4"))
+        let body = #"class="latest"><i>Version:</i> Build 4200"#
+        #expect(extract(body, recipe) == "Build 4200")
+        let five = #"class="latest"><i>Version:</i> Build 5001"#
+        #expect(extract(five, recipe) == nil, "a Sublime 5 build must not be offered here")
+    }
+}


### PR DESCRIPTION
Zotero shipped `10.0` where every release before it had three segments, and the recipe demanded exactly three. Nothing errored — the app simply stopped appearing as updatable until a sweep noticed. **42 of the 118 recipes with a version pattern hard-code a segment count**, so this audits them instead of waiting for each to fail the same way.

## This is not a blanket loosening

Strictness is load-bearing wherever a document contains other numbers. Zotero's own page carries a three-segment `7.0.32` under `oldVersions` that a laxer pattern would have drifted onto — the fix there kept the `standaloneVersions.mac` scoping for exactly that reason.

So the rule applied here is narrow: **widen only where the capture is pinned by a delimiter on both sides** (quote to quote, slash to slash) **and the document holds a single candidate.** Drift is then impossible. That is 19 recipes, widened to `{1,3}` so they survive a segment being dropped *or* added — both fail silently today.

## What was excluded, and why

| excluded | reason |
|---|---|
| anything using `selectHighest` (Outlook, Bartender, Figma Beta, LibreOffice, Compass) | the document is a list; changing which values are eligible changes which one wins |
| **Plex** | feed value is `1.115.0.426-4e960a1d` and the pattern has **no closing delimiter**, so the segment count *is* the boundary |
| **Sublime Text** `Build 4NNN` | looks like the WhatsApp defect, isn't — see below |
| year-based `[0-9]{4}` (IntelliJ, Android Studio) | fine until the year 10000 |

**Plex is the one this nearly broke.** Widening it made the sweep resolve `1.115.0.426` — a build number the app does not report, i.e. a permanent phantom update. The sweep still called that run green; it was caught by diffing the *resolved version* of every touched recipe before and after, which is the check that actually matters here.

**Sublime Text** pins its major on purpose. The bundle id is version-pinned (`com.sublimetext.4`) and Sublime's major is the leading build digit, so widening would offer a Sublime Text 4 install the build number of a paid major upgrade. If Sublime 5 ships, the pattern stops matching and the sweep files an issue — a *detected* failure beats an *undetected wrong offer*.

## Two genuine hard-coded literals fixed

- **WhatsApp** anchored on the literal `WhatsApp-2.`. The leading component really does have to be stripped — the bundle reports `26.33.15` while the file is `WhatsApp-2.26.33.15.dmg`, and capturing it whole reads as a *newer* installed copy, hiding every update. But *which* component it is is now `[0-9]+`, so a 3.x filename keeps working.
- **Sublime Merge** required exactly four build digits with no major pinned, so it would have died silently at build 10000.

## Verification

Full `duo verify --vendor` before and after, comparing the resolved version of every touched recipe:

```
17 unchanged
 3 changed because the vendor genuinely released
   (Claude, VS Code, Postman — same segment count)
 1 changed by this edit (Plex) -> reverted
```

Final sweep: **119 ok, 0 broken.** Three warnings — Telegram, WeType, LibreOffice — none of them touched here. Telegram's `installURLUnresolved` is intermittent (one clean run in three) and predates this change; worth its own look, not folded in here.

`make test` -> 783 core / 104 CLI passing, 2 pre-existing known issues.

## Still open

The remaining ~23 rigid patterns are open-ended (no delimiter bounding the capture) or live in multi-candidate documents. They cannot be widened without per-vendor evidence about what that vendor's version strings actually look like, so they stay strict and the sweep — now every six hours instead of nightly — is what catches them.