### PR TITLE
Stop blaming the recipe for a vendor's 5xx on the install URL

### DIFF
--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -532,7 +532,13 @@ public enum Verify {
             installedBuild: installed.build) {
             warnings.append(complaint)
         }
-        return make(warnings.isEmpty ? .ok : .warn, version: version, warnings: warnings)
+        // A vendor 5xx while resolving the installer URL is reported but is not
+        // actionable: it accuses nobody, and treating it as one files an issue
+        // against a recipe that is working. `td.telegram.org` 502s that HEAD in
+        // bursts, which is what this exists for. Everything else keeps flipping
+        // the finding to `.warn`, including a genuinely dead install URL.
+        let actionable = warnings.filter { $0 != ProbeWarning.installURLTransient(status: nil).kind }
+        return make(actionable.isEmpty ? .ok : .warn, version: version, warnings: warnings)
     }
 
     /// How long to wait for the local scan before deciding the cross-check isn't

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -100,6 +100,16 @@ public enum ProbeWarning: Sendable, Equatable {
     /// The recipe carries an install spec but the installer URL didn't resolve —
     /// one-click is dead even though detection still works.
     case installURLUnresolved
+    /// The installer URL could not be resolved because the vendor answered with
+    /// a 5xx/429 or the request failed outright — after retrying.
+    ///
+    /// Kept apart from `installURLUnresolved` because the two accuse different
+    /// people. That one says the recipe is wrong and someone has to go fix it;
+    /// this one says the vendor was having a bad minute. `td.telegram.org`
+    /// intermittently 502s the HEAD that resolves Telegram's download, which made
+    /// a healthy recipe file issues against itself. The same 5xx/429-is-not-our-
+    /// fault rule already governs version probes (see `ProbeFailure.category`).
+    case installURLTransient(status: Int?)
     /// `checksumPattern` is set but matched nothing, so the download would be
     /// installed without SHA-512 verification.
     case checksumPatternNoMatch
@@ -107,6 +117,7 @@ public enum ProbeWarning: Sendable, Equatable {
     public var kind: String {
         switch self {
         case .installURLUnresolved: return "installURLUnresolved"
+        case .installURLTransient: return "installURLTransient"
         case .checksumPatternNoMatch: return "checksumPatternNoMatch"
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -55,6 +55,19 @@ public struct VendorProbeSource: UpdateSource {
         return URLSession(configuration: config, delegate: RedirectBlocker(), delegateQueue: nil)
     }()
 
+    /// Thrown by the `.redirect` install source when the vendor answered with a
+    /// 5xx/429, or not at all, on every attempt — as opposed to answering with
+    /// something that says the recipe is wrong.
+    struct TransientInstallURL: Error {
+        let status: Int?
+    }
+
+    /// The same rule `ProbeFailure.category` applies to version probes: 5xx and
+    /// 429 are the vendor having a bad day, anything else in 4xx is us.
+    static func isTransientStatus(_ code: Int) -> Bool {
+        code >= 500 || code == 429
+    }
+
     /// A browser-like UA — several vendor sites reject unfamiliar agents.
     private static let userAgent =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
@@ -310,7 +323,16 @@ public struct VendorProbeSource: UpdateSource {
         // (and any checksum) now — from the same body we already have. A failure
         // here just falls back to detection-only; it never blocks the version.
         if allowInstall, let spec = recipe.install {
-            if let plan = try? await resolveInstall(spec, body: body.text, version: version) {
+            var resolved: (url: URL, checksum: String?)?
+            var transient: TransientInstallURL?
+            do {
+                resolved = try await resolveInstall(spec, body: body.text, version: version)
+            } catch let error as TransientInstallURL {
+                transient = error
+            } catch {
+                resolved = nil
+            }
+            if let plan = resolved {
                 remote = Self.makeRemoteVersion(
                     recipe: recipe, version: version, install: spec, plan: plan,
                     resolvedDownload: body.resolvedDownload, display: display,
@@ -324,7 +346,9 @@ public struct VendorProbeSource: UpdateSource {
                 // Version still reads, one-click is dead. The app shows this app
                 // as up-to-date-detectable but no longer installable, with no
                 // signal anywhere — so name it.
-                warnings.append(.installURLUnresolved)
+                warnings.append(
+                    transient.map { .installURLTransient(status: $0.status) }
+                        ?? .installURLUnresolved)
                 remote = Self.makeRemoteVersion(
                     recipe: recipe, version: version, install: nil, plan: nil,
                     resolvedDownload: body.resolvedDownload, display: display,
@@ -599,18 +623,36 @@ public struct VendorProbeSource: UpdateSource {
             return (Self.preferHTTPS(url), checksum)
 
         case .redirect(let url):
-            var request = URLRequest(url: url)
-            request.httpMethod = "HEAD"
-            request.timeoutInterval = 15
-            request.cachePolicy = URLRequest.versionFeedCachePolicy
-            request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
-            let (_, response) = try await session.data(for: request)
-            guard
-                let http = response as? HTTPURLResponse,
-                (200..<400).contains(http.statusCode),
-                let finalURL = response.url
-            else { return nil }
-            return (Self.preferHTTPS(finalURL), checksum)
+            // The only install source that makes its own request, so it is the only
+            // one that can fail for reasons that have nothing to do with the recipe.
+            // `td.telegram.org` returns 502 to this HEAD in bursts — verified by
+            // interleaving it with curl against the same URL in the same seconds,
+            // which also came back 502, so it is the vendor and not URLSession.
+            // Retry a few times, then say which kind of failure it was.
+            var lastStatus: Int?
+            for attempt in 0..<3 {
+                if attempt > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(attempt) * 700_000_000)
+                }
+                var request = URLRequest(url: url)
+                request.httpMethod = "HEAD"
+                request.timeoutInterval = 15
+                request.cachePolicy = URLRequest.versionFeedCachePolicy
+                request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+                guard let (_, response) = try? await session.data(for: request),
+                      let http = response as? HTTPURLResponse
+                else { lastStatus = nil; continue }
+                lastStatus = http.statusCode
+                guard (200..<400).contains(http.statusCode) else {
+                    // 4xx means the URL we were given is wrong — that IS the recipe,
+                    // and retrying cannot help. Stop and report it as unresolved.
+                    if !Self.isTransientStatus(http.statusCode) { return nil }
+                    continue
+                }
+                guard let finalURL = response.url else { return nil }
+                return (Self.preferHTTPS(finalURL), checksum)
+            }
+            throw TransientInstallURL(status: lastStatus)
         }
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLTransientTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLTransientTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `td.telegram.org` answers the HEAD that resolves Telegram's download with a
+/// 502 in bursts — confirmed by interleaving URLSession and curl against the same
+/// URL in the same seconds, both 502, so it is the vendor rather than our client.
+/// The probe reported that as `installURLUnresolved`, which means "the one-click
+/// is dead, go fix the recipe", and two of those in a row file an issue. These
+/// pin the rule that keeps a vendor's bad minute from being blamed on a recipe.
+struct InstallURLTransientTests {
+
+    @Test func fiveHundredsAndTooManyRequestsAreTheVendorsProblem() {
+        for code in [500, 502, 503, 504, 429] {
+            #expect(VendorProbeSource.isTransientStatus(code), "\(code) should be transient")
+        }
+    }
+
+    @Test func clientErrorsAreOurProblemAndMustNotBeRetried() {
+        // A 404 means the URL in the recipe is wrong. Retrying cannot fix that,
+        // and reporting it as transient would hide a genuinely dead install spec.
+        for code in [400, 401, 403, 404, 410] {
+            #expect(!VendorProbeSource.isTransientStatus(code), "\(code) should not be transient")
+        }
+    }
+
+    @Test func theTwoWarningsAreDistinct() {
+        // They accuse different people, so they must not collapse into one kind:
+        // one is actionable, the other is deliberately not.
+        #expect(ProbeWarning.installURLTransient(status: 502).kind == "installURLTransient")
+        #expect(ProbeWarning.installURLUnresolved.kind == "installURLUnresolved")
+        #expect(ProbeWarning.installURLTransient(status: 502)
+            != ProbeWarning.installURLUnresolved)
+    }
+
+    @Test func theStatusIsCarriedSoAReportCanSayWhichOne() {
+        #expect(ProbeWarning.installURLTransient(status: 502)
+            != ProbeWarning.installURLTransient(status: 503))
+        #expect(ProbeWarning.installURLTransient(status: nil)
+            .kind == ProbeWarning.installURLTransient(status: 502).kind,
+            "the kind is the wire format and must not vary with the status")
+    }
+}


### PR DESCRIPTION
Telegram's probe flapped between clean and `installURLUnresolved` — **three failures in six runs** — with nothing wrong on either side of the recipe.

## Root cause: the vendor, not us

`td.telegram.org` answers the HEAD that resolves Telegram's download with a **502 in bursts** — eight consecutive 502s in one window, clean minutes later.

Ruled out our client by interleaving URLSession and curl against the same URL **in the same seconds** — both 502. And the redirect itself was stable 10/10 throughout, so the version probe never noticed.

## Two things were wrong with the handling

**1. No retry.** `.redirect` is the only install source that makes its own request, and a single blip lost the install URL. Now three attempts with a short backoff.

**2. The wrong accusation — this is the important half.** Any failure there produced `installURLUnresolved`, which means *"one-click is dead, go fix the recipe"*. Any warning makes a finding actionable, so two sweeps of vendor flakiness would file an issue against a recipe that works.

5xx and 429 now produce a distinct `installURLTransient`: reported, never actionable.

The rule is not new — `ProbeFailure.category` already treats 5xx/429 on a *version* probe as the vendor having a bad day and everything else as ours. This applies the same line one layer down.

**A 4xx still returns `installURLUnresolved` immediately, without retrying.** That one really is the recipe naming a URL that no longer exists — which is how both real one-click failures were caught — and retrying would only delay saying so.

## Verification

Eight consecutive clean runs against the live endpoint, where the old code failed three of six.

**That alone does not prove the retry did the work** — the vendor may simply be healthy this hour. So the classification is pinned by unit tests rather than by a green run: 5xx/429 transient, 4xx not, and the two warning kinds provably distinct.

```
make test  -> 787 core / 104 CLI passing, 2 pre-existing known issues
duo verify --vendor -> 120 ok, 0 broken
```

The two remaining sweep warnings are WeType and LibreOffice, both pre-existing and untouched here.