### PR TITLE
Verify every pkg recipe, close the gate, and stop OneNote installing all of Office

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -51,6 +51,7 @@ public actor PackageInstaller {
         case packageTeamIdentifierMissing
         case packageTeamIdentifierMismatch(installed: String, package: String)
         case packageDestinationMismatch(installed: String, destinations: [String])
+        case packageDestinationsUnreadable
 
         public var errorDescription: String? {
             switch self {
@@ -62,6 +63,8 @@ public actor PackageInstaller {
                 return "The downloaded disk image did not contain an installer package DuoUpdater could verify. Nothing was opened."
             case .packageTeamIdentifierMissing:
                 return "Could not read the installer package's Developer ID team. Nothing was opened."
+            case .packageDestinationsUnreadable:
+                return "Could not read where this package installs, so it was not opened."
             case .packageDestinationMismatch(let installed, let destinations):
                 return "This package installs to \(destinations.joined(separator: ", ")), not to \(installed). Refusing to install."
             case .packageTeamIdentifierMismatch(let installed, let package):
@@ -453,19 +456,43 @@ public actor PackageInstaller {
         // being updated is one of those destinations, which is what stops a
         // same-Team substitution (Google Earth's package targets
         // `/Applications/Google Earth.app`, never Chrome's bundle).
-        // An empty set means the package's layout could not be read — a bundle-format
-        // `.mpkg` is not a xar archive at all, and a component may be missing or
-        // unreadable — not that the package writes nowhere. Verified non-empty on
-        // Tailscale, Microsoft Word, Edge, OneDrive, WeChat DevTools and UU Remote,
-        // covering all three package shapes, but the remaining pkg recipes are
-        // untested, so an unreadable layout falls back to the Team-only gate rather
-        // than blocking an install that works today.
+        // Fail-closed: a package whose destinations cannot be read does not get
+        // handed to the installer.
+        //
+        // This started out fail-open, on the reasoning that most pkg recipes were
+        // untested and refusing an install that works today would be worse than
+        // letting an unreadable one through. That reasoning does not survive
+        // contact with what the gate is for: an attacker substituting a package
+        // does not need to defeat the parser, only to hand us one it cannot read,
+        // and "we could not check" is not a reason to install. Every pkg recipe in
+        // the registry has since been checked against its real vendor package, so
+        // the exemption has nothing left to protect.
+        //
+        // Checked against the real vendor package for all 16 pkg recipes, on
+        // 2026-08-19: Word, Excel, PowerPoint, OneNote, Outlook, Teams, Edge, Edge
+        // Beta, Edge Dev, OneDrive, Tailscale, WeChat DevTools, UU Remote, Shottr,
+        // ToDesk and AweSun. Every one is a flat xar archive and every one declares
+        // the app it updates, so there is no shape here this cannot read.
+        //
+        // ToDesk and AweSun took a second attempt worth recording: a plain `curl`
+        // gets a bot-challenge page from both (ToDesk a "Security Verification"
+        // page, AweSun an Aliyun WAF script), which looked like the one-click was
+        // broken. It is not — `Downloader` gets the real 375 MB and 145 MB payloads
+        // from the same URLs with the same declared headers. When checking a vendor
+        // endpoint, reproduce the production client; curl is not a stand-in for it,
+        // in either direction.
+        //
+        // A vendor that ships a shape this cannot read will fail closed and be
+        // reported rather than silently downgraded to the Team-only check — which
+        // is the outcome we want, because it is visible.
         //
         // Note what this gate does NOT cover: `preinstall`/`postinstall` scripts run
         // as root whatever the declared destinations say. It narrows which package
         // may be handed over; it does not make an accepted one harmless.
         let destinations = Self.declaredDestinations(toOpen)
-        guard !destinations.isEmpty else { return }
+        guard !destinations.isEmpty else {
+            throw PackageError.packageDestinationsUnreadable
+        }
 
         let target = installedApp.resolvingSymlinksInPath().standardizedFileURL.path
         guard !destinations.contains(target) else { return }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -940,21 +940,39 @@ public enum VendorProbeRegistry {
                 kind: .pkg),
             followRedirects: false),
 
-        // Microsoft OneNote — Office suite, unified version. No dedicated OneNote
-        // fwlink; uses the Office suite fwlink (linkid=525133) that redirects to
-        // the Microsoft_365_and_Office installer — same version. MAU-managed.
+        // Microsoft OneNote — Office suite, unified version. MAU-managed, and read
+        // from the MAU manifest rather than the suite fwlink, the same way Outlook
+        // is below.
+        //
+        // It used to use the suite fwlink (linkid=525133), on the reasoning that
+        // there is no dedicated OneNote fwlink and the suite reports the same
+        // version. That is true for DETECTION and wrong for INSTALL: that link
+        // serves `Microsoft_365_and_Office_<build>_Installer.pkg`, which declares
+        // eight destinations — Word, Excel, PowerPoint, Outlook, OneNote, OneDrive,
+        // AutoUpdate and a Defender shim. Someone who has only OneNote installed
+        // and clicks Update would have had the entire Office suite put on their
+        // machine. Verified 2026-08-19 by parsing the real 2.7 GB suite package.
+        //
+        // `FullUpdaterLocation` in the MAU manifest is a standalone 592 MB
+        // OneNote package that declares exactly one destination,
+        // `/Applications/Microsoft OneNote.app` (verified the same way), signed
+        // `Developer ID Installer: Microsoft Corporation (UBF8T346G9)`.
+        //
+        // It must be `FullUpdaterLocation` and not `Location`/`Payload`: those are
+        // deltas keyed to a specific starting build, and applying one without its
+        // baseline installs a broken app.
         VendorProbeRecipe(
             bundleID: "com.microsoft.onenote.mac",
-            url: URL(string: "https://go.microsoft.com/fwlink/p/?linkid=525133")!,
-            mode: .redirectFilename,
-            versionPattern: #"_(\d+\.\d+\.\d+)_Installer\.pkg"#,
+            url: URL(string: "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409ONMC2019.xml")!,
+            mode: .responseBody,
+            versionPattern: #"<key>Update Version</key>\s*<string>([0-9]+\.[0-9]+\.[0-9]+)</string>"#,
             downloadURL: URL(string: "https://www.microsoft.com/en-us/microsoft-365/onenote/digital-note-taking-app")!,
             changelogURL: URL(string: "https://learn.microsoft.com/en-us/officeupdates/release-notes-office-for-mac")!,
             versionIsBuild: true,
             install: VendorInstallSpec(
-                urlSource: .redirect(URL(string: "https://go.microsoft.com/fwlink/p/?linkid=525133")!),
-                kind: .pkg),
-            followRedirects: false),
+                urlSource: .bodyPattern(
+                    #"<key>FullUpdaterLocation</key>\s*<string>(https://[^<\s]+/Microsoft_OneNote_[0-9.]+_Updater\.pkg)</string>"#),
+                kind: .pkg)),
 
         // Microsoft Outlook — Office suite, unified version. Uses the Office
         // AutoUpdate XML manifest (same CDN product tree as the fwlinks), an

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GroupBProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GroupBProbeRecipeTests.swift
@@ -177,4 +177,60 @@ struct GroupBProbeRecipeTests {
             #expect(recipe.install != nil)
         }
     }
+
+    // MARK: OneNote — suite installer vs standalone
+
+    /// The `FullUpdaterLocation` entry from the real OneNote MAU manifest
+    /// (`0409ONMC2019.xml`), captured 2026-08-19, trimmed to the keys the recipe
+    /// reads. The delta entries around it are kept because picking one of those
+    /// instead is the mistake this pattern has to avoid.
+    @Test func oneNoteInstallsTheStandalonePackageNotADelta() throws {
+        let recipe = try #require(
+            VendorProbeRegistry.recipes.first { $0.bundleID == "com.microsoft.onenote.mac" })
+        let spec = try #require(recipe.install)
+        guard case .bodyPattern(let pattern) = spec.urlSource else {
+            Issue.record("expected a body pattern"); return
+        }
+        let body = """
+        <key>Payload</key>
+        <string>OneNote_16.109.26041922_to_16.109.26053122_Delta.pkg</string>
+        <key>Location</key>
+        <string>https://res.public.onecdn.static.microsoft/x/OneNote_16.109.26041922_to_16.109.26053122_Delta.pkg</string>
+        <key>FullUpdaterLocation</key>
+        <string>https://res.public.onecdn.static.microsoft/x/Microsoft_OneNote_16.109.26053122_Updater.pkg</string>
+        """
+        // A delta applied without its baseline installs a broken app, so the
+        // standalone updater is the only acceptable match.
+        #expect(VendorProbeRecipe.extractVersion(from: body, pattern: pattern)
+            == "https://res.public.onecdn.static.microsoft/x/Microsoft_OneNote_16.109.26053122_Updater.pkg")
+    }
+
+    /// The suite installer must not be reachable from this recipe any more. It
+    /// declares eight destinations — Word, Excel, PowerPoint, Outlook, OneNote,
+    /// OneDrive, AutoUpdate and a Defender shim — so installing it to update
+    /// OneNote put the whole of Office on the machine.
+    @Test func oneNoteDoesNotResolveTheWholeOfficeSuite() throws {
+        let recipe = try #require(
+            VendorProbeRegistry.recipes.first { $0.bundleID == "com.microsoft.onenote.mac" })
+        let spec = try #require(recipe.install)
+        guard case .bodyPattern(let pattern) = spec.urlSource else {
+            Issue.record("expected a body pattern"); return
+        }
+        let suite = """
+        <key>FullUpdaterLocation</key>
+        <string>https://res.public.onecdn.static.microsoft/x/Microsoft_365_and_Office_16.112.26081720_Installer.pkg</string>
+        """
+        #expect(VendorProbeRecipe.extractVersion(from: suite, pattern: pattern) == nil)
+    }
+
+    /// Detection reads the manifest's own version rather than a filename, and the
+    /// build is what the bundle reports (`versionIsBuild`).
+    @Test func oneNoteReadsTheManifestUpdateVersion() throws {
+        let recipe = try #require(
+            VendorProbeRegistry.recipes.first { $0.bundleID == "com.microsoft.onenote.mac" })
+        let body = "<key>Update Version</key><string>16.109.26053122</string>"
+        #expect(VendorProbeRecipe.extractVersion(from: body, pattern: recipe.versionPattern)
+            == "16.109.26053122")
+        #expect(recipe.versionIsBuild)
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
@@ -382,9 +382,9 @@ struct PackageInstallerTests {
         #expect(dests.contains("/Applications/Google Earth Pro.app"))
     }
 
-    /// A body with nothing to go on yields no destinations, which the gate treats
-    /// as "cannot verify" and falls back to the Team-only check rather than
-    /// blocking a working install.
+    /// A body with nothing to go on yields no destinations. The gate treats that
+    /// as a refusal, not as permission: an attacker substituting a package does
+    /// not have to defeat the parser, only hand us one it cannot read.
     @Test func anUnreadableLayoutYieldsNoDestinations() {
         #expect(PackageInstaller.destinations(inPackageInfo: "<pkg-info/>").isEmpty)
     }


### PR DESCRIPTION
Follow-up to #9. The pkg destination gate shipped fail-open because most pkg recipes were untested — the risk was left with users. This closes that, by doing the verification instead of keeping the exemption.

## Every pkg recipe is now checked against its real vendor package

All 16, downloaded and parsed through the shipping code on 2026-08-19:

| verified | |
|---|---|
| Word, Excel, PowerPoint, OneNote, Outlook, Teams | Office / MAU |
| Edge, Edge Beta, Edge Dev, OneDrive | Microsoft |
| Tailscale, WeChat DevTools, UU Remote, Shottr, ToDesk, AweSun | rest |

Every one is a flat xar archive and every one declares the app it updates. **Bundle-format packages were the shape most likely to fail closed** under this change — none of the sixteen is one, which is what made the gate safe to tighten.

## The gate is fail-closed now

A package whose destinations cannot be read is refused (`packageDestinationsUnreadable`) rather than silently downgraded to the Team-ID-only check.

The original reasoning does not survive contact with what the gate is for: an attacker substituting a package does not have to defeat the parser, only hand us one it cannot read, and "we could not check" is not a reason to install something that runs scripts as root.

## OneNote was installing the entire Office suite

Separate defect, found while verifying. `com.microsoft.onenote.mac` pointed its install spec at the Office suite fwlink, on the stated reasoning that there is no dedicated OneNote fwlink and the suite reports the same version — true for detection, wrong for install.

That link serves `Microsoft_365_and_Office_<build>_Installer.pkg`, which declares **eight** destinations:

```
/Applications/Microsoft Excel.app
/Applications/Microsoft OneNote.app
/Applications/Microsoft Outlook.app
/Applications/Microsoft PowerPoint.app
/Applications/Microsoft Word.app
/Applications/OneDrive.app
/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app
/private/tmp/com.microsoft.wdav.shim/Microsoft Defender Shim.app
```

Someone with only OneNote installed who clicked Update was having all of Office put on their machine. Outlook's equivalent declares one destination and Teams' declares two, so OneNote was the only recipe in this shape.

It now reads `FullUpdaterLocation` from the MAU manifest, exactly as the Outlook recipe already does — a standalone 592 MB package declaring exactly **one** destination, signed `Developer ID Installer: Microsoft Corporation (UBF8T346G9)`. It has to be `FullUpdaterLocation` and not the `Location`/`Payload` entries beside it: those are deltas keyed to a starting build, and applying one without its baseline installs a broken app. The test pins that choice against a manifest containing all three.

## One methodology note worth keeping

ToDesk and AweSun first looked broken: a plain `curl` gets a bot-challenge page from both. They are not broken — `Downloader` pulls the real 375 MB and 145 MB payloads from the same URLs with the same declared headers.

curl was wrong in **both directions today**: it also succeeded where URLSession got a 502 on Telegram's install URL (#13). When checking a vendor endpoint, reproduce the production client.

## Verification

```
make test           -> 790 core / 104 CLI passing, 2 pre-existing known issues
duo verify --vendor -> 120 ok, 0 broken (2 warnings, both pre-existing and unrelated)
duo verify --only com.microsoft.onenote.mac -> ok against the live MAU manifest
```