### PR TITLE
Report an installer URL that has been failing for days

### DIFF
--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1889,6 +1889,16 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
         //     docs.x.com → x.com/docs is normal, and cancelling it just blanks the
         //     pane. The URL we start from comes from our own recipe registry, not
         //     from the page, so this is a usability boundary, not a trust boundary.
+        // One thing here IS a trust boundary: the scheme. `ChangelogURLPolicy` only
+        // vets the URL we start from, and a vendor page that redirects itself to
+        // `http://` would land cleartext content in this in-process web view
+        // anyway — which is the whole thing that policy exists to stop. Cross-host
+        // https redirects stay allowed; only the downgrade is refused.
+        if let url = navigationAction.request.url,
+           url.scheme?.lowercased() == "http" {
+            decisionHandler(.cancel); return
+        }
+
         guard navigationAction.navigationType == .linkActivated,
               navigationAction.targetFrame?.isMainFrame ?? true,
               let url = navigationAction.request.url,

--- a/CLI/Sources/DuoKit/Baseline.swift
+++ b/CLI/Sources/DuoKit/Baseline.swift
@@ -52,6 +52,19 @@ public struct Baseline: Codable, Sendable {
         /// Sweeps since the last comment on the open issue. Kept for the issue
         /// text ("still down, N sweeps"); the rate limit itself is `lastCommentedAt`.
         public var sweepsSinceComment = 0
+        /// When the installer URL first started failing for a reason we call
+        /// transient, and how many sweeps have seen it.
+        ///
+        /// A vendor 5xx on the install URL is deliberately not actionable — that
+        /// was the whole point of splitting it out of `installURLUnresolved`. But
+        /// "not actionable" was implemented as "never actionable", which recreated
+        /// the exact silent failure this sweep exists to end: an install URL that
+        /// 5xxs forever reported `.ok` on every run and could never be seen. It is
+        /// transient only for as long as it is brief; past that it is a dead
+        /// endpoint wearing a 5xx, and it ages into a report the same way
+        /// unreachability does.
+        public var installTransientSince: Date?
+        public var consecutiveInstallTransient = 0
         /// When the open issue was last commented on, for the nudge rate limit.
         /// A timestamp rather than a sweep count for the same reason as
         /// `infraSince`: the interval is meant to be a week of wall-clock, and a
@@ -79,6 +92,16 @@ public struct Baseline: Codable, Sendable {
         public func mayComment(now: Date = Date()) -> Bool {
             guard let lastCommentedAt else { return true }
             return now.timeIntervalSince(lastCommentedAt) >= Baseline.commentInterval
+        }
+
+        /// Whether the installer URL has been failing transiently for long enough,
+        /// and often enough, that "the vendor is having a bad minute" has stopped
+        /// being a credible explanation. Same window and same floor as
+        /// `isInfraReportable`, for the same reason.
+        public func isInstallTransientReportable(now: Date = Date()) -> Bool {
+            guard consecutiveInstallTransient >= Baseline.minInfraObservations,
+                  let since = installTransientSince else { return false }
+            return now.timeIntervalSince(since) >= Baseline.infraWindow
         }
 
         /// How long since the open issue was last nudged, or nil if never.
@@ -116,6 +139,10 @@ public struct Baseline: Codable, Sendable {
             closedAt = try c.decodeIfPresent(Date.self, forKey: .closedAt)
             sweepsSinceComment =
                 try c.decodeIfPresent(Int.self, forKey: .sweepsSinceComment) ?? 0
+            installTransientSince =
+                try c.decodeIfPresent(Date.self, forKey: .installTransientSince)
+            consecutiveInstallTransient =
+                try c.decodeIfPresent(Int.self, forKey: .consecutiveInstallTransient) ?? 0
             lastCommentedAt = try c.decodeIfPresent(Date.self, forKey: .lastCommentedAt)
             triagedSignature = try c.decodeIfPresent(String.self, forKey: .triagedSignature)
         }
@@ -228,6 +255,18 @@ public struct Baseline: Codable, Sendable {
             }
             entry.lastGoodVersion = version
             entry.lastGoodAt = Date()
+        }
+
+        // The installer URL's transient run is tracked on every status, because the
+        // finding it rides on stays `.ok` — there is no other place it would age.
+        if finding.warnings.contains(ProbeWarning.installURLTransient(status: nil).kind) {
+            entry.consecutiveInstallTransient += 1
+            if entry.installTransientSince == nil { entry.installTransientSince = Date() }
+        } else if finding.status != .skipped {
+            // A sweep that resolved the URL, or failed for a different reason,
+            // ends the run. `skipped` proves nothing either way.
+            entry.consecutiveInstallTransient = 0
+            entry.installTransientSince = nil
         }
 
         // Any status other than `infra` means we got an answer out of the host,

--- a/CLI/Sources/DuoKit/Reconcile.swift
+++ b/CLI/Sources/DuoKit/Reconcile.swift
@@ -61,6 +61,38 @@ public enum Reconcile {
         // pattern that stopped matching. Filing at that point is the difference
         // between the sweep noticing a vendor shutting a host down and never
         // noticing it at all.
+        // An installer URL that has been 5xx-ing past the window is not having a
+        // bad minute any more. The finding still reads `.ok` — detection works —
+        // so this is the only branch that can ever surface it.
+        if finding.status != .infra, entry.isInstallTransientReportable(now: now) {
+            let elapsed = entry.installTransientSince.map {
+                now.timeIntervalSince($0) / 86_400
+            }
+            guard let issue = entry.issueNumber else {
+                return .create(
+                    title: "One-click broken: \(finding.recipeID) — installer URL "
+                        + "unreachable for \(Report.duration(elapsed))",
+                    body: "Detection still works and the version still resolves, so "
+                        + "this recipe looks healthy in every other view.\n\n"
+                        + "`\(finding.endpointHost)` has answered the installer-URL "
+                        + "request with a 5xx/429 (or not at all) on "
+                        + "\(entry.consecutiveInstallTransient) consecutive sweeps "
+                        + "over \(Report.duration(elapsed)). That is past the point "
+                        + "where a vendor having a bad minute explains it.\n\n"
+                        + "Either the endpoint has been retired, or it now refuses "
+                        + "the request we make. Check what it returns before "
+                        + "changing the pattern.")
+            }
+            guard entry.mayComment(now: now) else {
+                return .none("install URL still failing, already open")
+            }
+            return .comment(
+                issue: issue,
+                body: "Still unable to resolve the installer URL as of "
+                    + "\(Self.day(now)) — \(Report.duration(elapsed)) across "
+                    + "\(entry.consecutiveInstallTransient) sweeps.")
+        }
+
         if finding.status == .infra {
             guard entry.isInfraReportable(now: now) else {
                 let elapsed = entry.infraElapsed(now: now).map { $0 / 86_400 }

--- a/CLI/Tests/DuoKitTests/InstallTransientAgingTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTransientAgingTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import DuoKit
+
+/// Splitting a vendor 5xx on the installer URL out of `installURLUnresolved` was
+/// right — it stopped a working recipe filing issues against itself. But "not
+/// actionable" was implemented as "never actionable", which recreated the failure
+/// this whole sweep exists to end: an installer URL that 5xxs forever reported
+/// `.ok` on every run and could never be seen by anyone. These pin both halves.
+struct InstallTransientAgingTests {
+
+    private let transientKind = "installURLTransient"
+
+    private func entry(sweeps: Int, daysAgo: Double?, issue: Int? = nil) -> Baseline.Entry {
+        var e = Baseline.Entry()
+        e.consecutiveInstallTransient = sweeps
+        e.installTransientSince = daysAgo.map { Date(timeIntervalSinceNow: -$0 * 86_400) }
+        e.issueNumber = issue
+        e.lastCommentedAt = issue.map { _ in Date(timeIntervalSinceNow: -30 * 86_400) }
+        return e
+    }
+
+    private func finding(warnings: [String]) -> Finding {
+        Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable",
+            status: .ok, version: "1.2.3", failureKind: nil, failureDetail: nil,
+            warnings: warnings, endpointHost: "example.invalid", pattern: "([0-9.]+)")
+    }
+
+    @Test func aBriefOutageStaysSilent() {
+        // The Telegram case: bursts of 502 lasting minutes. Nothing should be filed.
+        let action = Reconcile.decide(
+            finding(warnings: [transientKind]),
+            entry: entry(sweeps: 2, daysAgo: 0.5), reportable: false)
+        #expect(!action.isWrite)
+    }
+
+    @Test func aPermanentlyFailingInstallURLIsEventuallyReported() {
+        // The hole: before this, an endpoint could 5xx forever and stay `.ok`.
+        let action = Reconcile.decide(
+            finding(warnings: [transientKind]),
+            entry: entry(sweeps: 20, daysAgo: 6), reportable: false)
+        guard case .create(let title, let body) = action else {
+            Issue.record("expected an issue, got \(action)"); return
+        }
+        #expect(title.contains("One-click broken"))
+        // It must not read as a pattern problem — the pattern is fine.
+        #expect(body.contains("Detection still works"))
+    }
+
+    @Test func timeAloneIsNotEnough() {
+        // If the sweep itself stopped for a week, the first two runs back must not
+        // retire an endpoint on a timestamp that is already old.
+        let action = Reconcile.decide(
+            finding(warnings: [transientKind]),
+            entry: entry(sweeps: 2, daysAgo: 30), reportable: false)
+        #expect(!action.isWrite)
+    }
+
+    @Test func sweepsAloneAreNotEnough() {
+        let action = Reconcile.decide(
+            finding(warnings: [transientKind]),
+            entry: entry(sweeps: 50, daysAgo: 0.2), reportable: false)
+        #expect(!action.isWrite)
+    }
+
+    @Test func aResolvedInstallURLEndsTheRun() {
+        var baseline = Baseline()
+        let id = "vendor:com.example.app:stable"
+        for _ in 1...5 { _ = baseline.reconcile(finding(warnings: [transientKind])) }
+        #expect(baseline.entries[id]?.consecutiveInstallTransient == 5)
+        #expect(baseline.entries[id]?.installTransientSince != nil)
+
+        _ = baseline.reconcile(finding(warnings: []))
+        #expect(baseline.entries[id]?.consecutiveInstallTransient == 0)
+        #expect(baseline.entries[id]?.installTransientSince == nil,
+                "one good resolution means it was transient after all")
+    }
+
+    @Test func theGateIsWallClockNotSweepCount() {
+        var e = Baseline.Entry()
+        e.consecutiveInstallTransient = Baseline.minInfraObservations
+        let start = Date()
+        e.installTransientSince = start
+        #expect(!e.isInstallTransientReportable(now: start.addingTimeInterval(3_600)))
+        #expect(e.isInstallTransientReportable(
+            now: start.addingTimeInterval(Baseline.infraWindow + 60)))
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -504,6 +504,19 @@ public actor PackageInstaller {
         // update for an app the user keeps elsewhere. Fall back to the bundle name,
         // which is what actually distinguishes one product from another — Google
         // Earth's package names `Google Earth.app`, never `Google Chrome.app`.
+        //
+        // Only for an app that is NOT in `/Applications`, though. Allowing the name
+        // to stand in for the path unconditionally would let a same-Team package
+        // that installs a like-named app somewhere else entirely — say
+        // `/Library/Application Support/Vendor/Foo.app` — satisfy the gate for
+        // `/Applications/Foo.app`, which it never touches. Restricting the fallback
+        // to the case it was added for keeps the non-standard location working
+        // without opening that up.
+        guard !target.hasPrefix("/Applications/") else {
+            throw PackageError.packageDestinationMismatch(
+                installed: target,
+                destinations: destinations.sorted())
+        }
         let targetName = (target as NSString).lastPathComponent
         let namesMatch = destinations.contains {
             ($0 as NSString).lastPathComponent.compare(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
@@ -332,11 +332,17 @@ struct PackageInstallerTests {
         """
         let dests = PackageInstaller.destinations(inPackageInfo: body)
         #expect(dests.contains("/Applications/Tailscale.app"))
-        // Helpers nested inside the bundle come along as candidates too. That is
-        // harmless: `AppScanner` only ever reports bundles sitting in the scanned
-        // directories, never one buried inside another app, so a nested path can
-        // never be the installed app the gate compares against.
-        #expect(dests.contains("/Applications/Tailscale.app"))
+        // Helpers nested inside the bundle come along as candidates too, because
+        // every `.app`-suffixed prefix is collected. Assert that explicitly rather
+        // than leaving it implied — the nested entries are what make the "all
+        // prefixes" strategy safe to reason about.
+        #expect(dests.contains(
+            "/Applications/Tailscale.app/Contents/Library/LoginItems/TailscaleLoginItemHelper-macsys.app"))
+        // They are harmless as comparison targets: `AppScanner` only reports
+        // bundles sitting in the directories it scans, never one buried inside
+        // another app, so a nested path is never the installed app being updated.
+        #expect(dests.allSatisfy { $0.hasPrefix("/Applications/Tailscale.app") },
+                "every destination is inside the bundle this package updates")
     }
 
     /// WeChat DevTools is a flat component package rooted at `/`, so the
@@ -472,5 +478,37 @@ struct PackageInstallerTests {
     /// Malformed input yields nothing, which the gate treats as "cannot verify".
     @Test func unparsableBodyYieldsNoDestinations() {
         #expect(PackageInstaller.destinations(inPackageInfo: "not xml at all <<<").isEmpty)
+    }
+
+    // MARK: The bundle-name fallback, and its limit
+
+    /// Why the fallback exists: AppScanner also scans `~/Applications`, and a
+    /// vendor package always names `/Applications`, so a full-path comparison
+    /// alone would refuse every pkg update for an app kept elsewhere.
+    @Test func aNonStandardLocationFallsBackToTheBundleName() {
+        let body = #"<pkg-info install-location="/Applications"><bundle path="Foo.app"/></pkg-info>"#
+        let dests = PackageInstaller.destinations(inPackageInfo: body)
+        #expect(dests.contains("/Applications/Foo.app"))
+        // The gate compares last path components in this case, so a copy at
+        // ~/Applications/Foo.app is recognised as the same product.
+        let home = "/Users/someone/Applications/Foo.app"
+        #expect((home as NSString).lastPathComponent
+            == ("/Applications/Foo.app" as NSString).lastPathComponent)
+    }
+
+    /// …and why it must not apply in `/Applications`. Letting the name stand in
+    /// for the path unconditionally would let a same-Team package that installs a
+    /// like-named app somewhere else satisfy the gate for an app it never touches.
+    @Test func aLikeNamedAppElsewhereIsNotTheAppInApplications() {
+        let body = """
+        <pkg-info install-location="/Library/Application Support/Vendor">
+            <bundle path="Foo.app"/>
+        </pkg-info>
+        """
+        let dests = PackageInstaller.destinations(inPackageInfo: body)
+        #expect(dests == ["/Library/Application Support/Vendor/Foo.app"])
+        // Same last component, different product location — the gate refuses this
+        // for an installed /Applications/Foo.app rather than matching on the name.
+        #expect(!dests.contains("/Applications/Foo.app"))
     }
 }


### PR DESCRIPTION
Codex reviewed today's five merged PRs. This fixes what it found, led by one that matters more than the rest.

## The hole I introduced this morning

#13 split a vendor 5xx on the installer URL out of `installURLUnresolved`, so a working recipe would stop filing issues against itself when Telegram's CDN 502s in bursts. That was right.

But **"not actionable" was implemented as "never actionable"**. An installer URL that 5xxs *forever*:

- reports `.ok` on every sweep (the warning is filtered out of the actionable set)
- never enters the actionable streak
- never enters the infra streak — `consecutiveInfra` only moves on `.infra` status

…so it can never be seen by anyone. That is precisely the silent degradation this sweep exists to end, and I shipped it while fixing a different instance of the same thing.

**Transient is a claim about duration, so it now has to survive one.** The run is tracked on the baseline entry and ages into a report through the same wall-clock window and observation floor as unreachability (5 days, 3 observations). Brief bursts stay silent; five days of them do not. A single successful resolution ends the run.

The issue it files leads with "Detection still works", because every other view of the recipe looks healthy and the next person to read it would otherwise go hunting in the version pattern.

## Also fixed from the same review

**The bundle-name fallback was too broad.** It now applies only to an app outside `/Applications` — the case it was added for (AppScanner also scans `~/Applications` and Input Methods, while vendor packages always name the system location). Unconditionally, it let a same-Team package installing a like-named app somewhere else entirely — `/Library/Application Support/Vendor/Foo.app` — satisfy the gate for `/Applications/Foo.app`, which it never touches.

**A changelog page that redirects itself to `http://` is refused.** `ChangelogURLPolicy` only ever vetted the URL we start from; the web view's navigation delegate deliberately allows server-side redirects, so a downgrade put cleartext in an in-process web view anyway. Cross-host https redirects stay allowed — `docs.x.com → x.com/docs` is normal — only the scheme downgrade is refused.

**A Tailscale parser test asserted the same thing twice** and never checked the nested-helper destination it was written for.

## Where I disagree with the review

It flagged the "all `.app` prefixes" strategy as a possible false accept: a path like `/Applications/B.app/Contents/Helpers/A.app` emits `B.app` as well, so a package "only targeting the nested helper" would pass for `B.app`.

I do not think that is exploitable, and I did not change it. The ancestor in that path **is** `B.app` — a package declaring that path genuinely writes inside `B.app`, so accepting it as an update to `B.app` is correct rather than a bypass. For it to be a false accept, a package for one app would have to resolve to a prefix equal to a *different* installed app's path, which requires its payload to live inside that other app's bundle — in which case it modifies it. Tailscale's real package is exactly this shape and is a legitimate update. This is reasoning, not something I proved by construction; if there is a counterexample I would want to see it.

Two other findings I am leaving as known limitations rather than fixing here: script-only (`--nopayload`) packages and packages with no `<bundle>` metadata fail closed — all 16 pkg recipes were checked and none is that shape, and a vendor switching to one fails loudly rather than silently. And the actionable filter compares warning kinds by string; it is correct today and the material half of that finding is fixed above.

## Verification

```
make test    -> 792 core / 110 CLI passing, 2 pre-existing known issues
make install -> builds, signs, deploys, runs
```

Six new tests pin both halves of the aging rule: a brief outage stays silent, a permanent one is reported, time alone is not enough (a week-long gap in the sweep itself must not retire an endpoint on two observations), sweeps alone are not enough, and one good resolution ends the run.