### PR TITLE
Name the segment-count change when a version pattern misses

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -34,6 +34,11 @@ public enum ProbeFailure: Error, Sendable, Equatable {
     /// **The signature failure of a broken recipe**: the endpoint answered, the
     /// body arrived, and `versionPattern` matched nothing in it.
     case versionPatternNoMatch(sampleBytes: Int)
+    /// The pattern matched nothing, but the same pattern with its segment count
+    /// made variable matches `wouldMatch`. That is a vendor changing how many
+    /// dot-separated numbers their version has — the Zotero `9.0.6` -> `10.0`
+    /// shape — and it says both what broke and what the answer is.
+    case versionSegmentCountChanged(wouldMatch: String, sampleBytes: Int)
 
     /// What a sweep should *do* about this failure.
     public enum Classification: String, Sendable {
@@ -56,7 +61,8 @@ public enum ProbeFailure: Error, Sendable, Equatable {
             // hold is wrong, which is a recipe problem.
             return (code >= 500 || code == 429) ? .infra : .recipe
         case .redirectMissingLocation, .malformedResolvedURL,
-             .archiveExtractionFailed, .plistKeyMissing, .versionPatternNoMatch:
+             .archiveExtractionFailed, .plistKeyMissing, .versionPatternNoMatch,
+             .versionSegmentCountChanged:
             return .recipe
         }
     }
@@ -73,6 +79,7 @@ public enum ProbeFailure: Error, Sendable, Equatable {
         case .archiveExtractionFailed: return "archiveExtractionFailed"
         case .plistKeyMissing: return "plistKeyMissing"
         case .versionPatternNoMatch: return "versionPatternNoMatch"
+        case .versionSegmentCountChanged: return "versionSegmentCountChanged"
         }
     }
 
@@ -87,6 +94,10 @@ public enum ProbeFailure: Error, Sendable, Equatable {
         case .archiveExtractionFailed(let why): return why
         case .plistKeyMissing(let entry, let key): return "\(entry) has no key '\(key)'"
         case .versionPatternNoMatch(let bytes): return "no match in \(bytes)-byte body"
+        case .versionSegmentCountChanged(let would, let bytes):
+            return "no match in \(bytes)-byte body, but the same pattern with a "
+                + "variable segment count matches \(would) — the vendor changed "
+                + "how many numbers are in the version"
         }
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -342,6 +342,40 @@ public struct VendorProbeRecipe: Sendable {
     /// — this is the fragile, format-specific bit, so it's factored out for
     /// unit testing without touching the network. Returns nil when the pattern
     /// is invalid or doesn't match (the caller then degrades to "unknown").
+    /// The same pattern with its fixed run of version segments made variable.
+    ///
+    /// A pattern that hard-codes how many dot-separated numbers a version has is
+    /// the single most common way a recipe dies silently: Zotero shipped `10.0`
+    /// where every release before it had three segments, the pattern stopped
+    /// matching, and the app simply vanished from the update list with no error
+    /// anywhere. 33 of the registry's patterns still pin an exact count — audited
+    /// 2026-08-19 against every live endpoint, and for all but one the count is
+    /// not load-bearing today, so widening them wholesale would be churn without
+    /// evidence. Detecting the day it stops being true is worth more.
+    ///
+    /// Returns nil when the pattern pins no segment run, so a caller can tell
+    /// "this diagnosis does not apply" from "it applies and found nothing".
+    static func segmentCountRelaxed(_ pattern: String) -> String? {
+        guard let re = try? NSRegularExpression(
+            pattern: #"\[0-9\]\+(?:\\\.\[0-9\]\+)+"#) else { return nil }
+        let ns = pattern as NSString
+        guard let m = re.firstMatch(
+            in: pattern, range: NSRange(location: 0, length: ns.length))
+        else { return nil }
+        return ns.replacingCharacters(
+            in: m.range, with: #"[0-9]+(?:\.[0-9]+){1,4}"#)
+    }
+
+    /// What a pattern WOULD have matched if it did not pin the segment count.
+    /// Used only to explain a miss; never to produce a version we act on.
+    static func versionIfSegmentCountRelaxed(
+        from body: String, pattern: String
+    ) -> String? {
+        guard let relaxed = segmentCountRelaxed(pattern), relaxed != pattern
+        else { return nil }
+        return extractVersion(from: body, pattern: relaxed)
+    }
+
     public static func extractVersion(from text: String, pattern: String) -> String? {
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
         let range = NSRange(text.startIndex..., in: text)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -295,6 +295,18 @@ public struct VendorProbeSource: UpdateSource {
             // until now it left no trace in the log at all.
             Log.source.error(
                 "vendor probe \(recipe.bundleID, privacy: .public) [\(recipe.channel.rawValue, privacy: .public)]: \(body.text.utf8.count) bytes fetched, none matched /\(recipe.versionPattern, privacy: .public)/")
+            // Before reporting a bare miss, try the one diagnosis that is cheap
+            // and accounts for the most common way these die: the vendor changed
+            // the number of segments in their version string. Saying so — with the
+            // value the pattern would have read — turns a "go read the page"
+            // investigation into a one-line fix.
+            if let would = VendorProbeRecipe.versionIfSegmentCountRelaxed(
+                from: body.text, pattern: recipe.versionPattern) {
+                return fail(
+                    .versionSegmentCountChanged(
+                        wouldMatch: would, sampleBytes: body.text.utf8.count),
+                    status: body.status, sample: sample)
+            }
             return fail(
                 .versionPatternNoMatch(sampleBytes: body.text.utf8.count),
                 status: body.status, sample: sample)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RecipeVerificationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RecipeVerificationTests.swift
@@ -99,7 +99,11 @@ import Network
 
         #expect(outcome.remote == nil)
         let failure = try #require(outcome.failure)
-        #expect(failure.kind == "versionPatternNoMatch")
+        // This miss has a specific, common cause — the vendor's version grew a
+        // fourth segment — and the probe now says so instead of reporting a bare
+        // "no match", naming the value the pattern would have read.
+        #expect(failure.kind == "versionSegmentCountChanged")
+        #expect(failure.detail.contains("2026.2.0.1"))
         #expect(failure.classification == .recipe, "a stale pattern must be actionable, not infra")
         // The body sample is what a human (or a triage step) needs to fix it.
         #expect(outcome.bodySample?.contains("2026.2.0.1") == true)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SegmentCountDiagnosisTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SegmentCountDiagnosisTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Zotero shipped `10.0` where every release before it had three segments. The
+/// pattern stopped matching, the probe reported a bare "no match", and the app
+/// vanished from the update list with no error anywhere — it took a human
+/// reading the page to work out what had changed.
+///
+/// 33 patterns in the registry still pin an exact segment count. Audited against
+/// every live endpoint on 2026-08-19: for all but one (Plex, whose count IS
+/// load-bearing and is deliberately strict) relaxing the count changes nothing
+/// today, so widening them wholesale would be churn without evidence. Detecting
+/// the day it stops being true is worth more, which is what this does.
+struct SegmentCountDiagnosisTests {
+
+    /// The real pattern that broke, against the real page shape that broke it.
+    @Test func theZoteroFailureNowExplainsItself() {
+        let brokenPattern = #""standaloneVersions"\s*:\s*\{\s*"mac"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#
+        let body = #"{"standaloneVersions":{"mac":"10.0","win32":"10.0"},"oldVersions":{"macOS":{"version":"7.0.32"}}}"#
+
+        // Red: this is exactly what the sweep saw on the day it broke.
+        #expect(VendorProbeRecipe.extractVersion(from: body, pattern: brokenPattern) == nil)
+
+        // Green: and this is what it would have said instead.
+        #expect(VendorProbeRecipe.versionIfSegmentCountRelaxed(
+            from: body, pattern: brokenPattern) == "10.0")
+    }
+
+    /// The other direction fails just as silently: a vendor ADDING a segment,
+    /// where a delimiter-bounded pattern stops matching entirely.
+    @Test func anAddedSegmentIsDiagnosedToo() {
+        let pattern = #""name"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#
+        let body = #"{"name":"1.133.0.4"}"#
+        #expect(VendorProbeRecipe.extractVersion(from: body, pattern: pattern) == nil)
+        #expect(VendorProbeRecipe.versionIfSegmentCountRelaxed(
+            from: body, pattern: pattern) == "1.133.0.4")
+    }
+
+    /// It must not fire on a miss that has nothing to do with segment counts —
+    /// a vendor renaming the key is a different problem with a different fix.
+    @Test func anUnrelatedMissIsNotBlamedOnSegmentCounts() {
+        let pattern = #""name"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)""#
+        let body = #"{"productVersion":"1.133.0"}"#
+        #expect(VendorProbeRecipe.versionIfSegmentCountRelaxed(
+            from: body, pattern: pattern) == nil)
+    }
+
+    /// A pattern that pins no segment run at all is not applicable, and must be
+    /// distinguishable from one that is applicable and found nothing.
+    @Test func aPatternWithNoSegmentRunIsNotApplicable() {
+        #expect(VendorProbeRecipe.segmentCountRelaxed(#"Build\s+([0-9]+)"#) == nil)
+        #expect(VendorProbeRecipe.segmentCountRelaxed(
+            #"([0-9]+\.[0-9]+\.[0-9]+)"#) != nil)
+    }
+
+    /// The diagnosis is advisory only — it must never become a version we act on,
+    /// or Plex would start reporting a build number the app never reports.
+    @Test func theRelaxedValueIsNeverUsedAsTheAnswer() throws {
+        let plex = try #require(
+            VendorProbeRegistry.recipes.first { $0.bundleID == "tv.plex.desktop" })
+        let body = #"{"computer":{"MacOS":{"version":"1.115.0.426-4e960a1d"}}}"#
+        // The strict pattern still matches, so the diagnosis never runs for Plex.
+        #expect(VendorProbeRecipe.extractVersion(
+            from: body, pattern: plex.versionPattern) == "1.115.0")
+    }
+}


### PR DESCRIPTION
The remaining strict version patterns, audited — and the conclusion is not "widen them".

## What the audit found

34 recipes still pin an exact number of dot-separated segments. I fetched **every one of their live endpoints** and compared what the shipping pattern captures against what the same pattern captures with the count made variable:

```
33 of 34 — identical
 1 of 34 — different: Plex
```

Plex is the one whose count is genuinely load-bearing: its feed says `1.115.0.426-4e960a1d`, and allowing a fourth segment starts reporting a build number the app never reports. It is already deliberately strict, with a comment saying why. (Slack came back as no-match in the harness — that is my probe feeding a `Location:` header line to a `^Slack-…$` anchored pattern, not a recipe defect; the sweep has it green.)

So for 33 of them **the strict count is not protecting anything today**. Widening them would be 33 speculative regex edits with no evidence behind any of them — exactly the batch loosening I argued against when Zotero broke, and the Plex near-miss is what that argument was protecting against.

## What this does instead

Detect the day one of them stops being true.

When a version pattern matches nothing, retry it with the segment run made variable *before* reporting the miss. If that matches, report `versionSegmentCountChanged` and name the value it would have read.

This is the Zotero failure exactly. `9.0.6` → `10.0` produced:

> `versionPatternNoMatch` — no match in 36416-byte body

…and it took a person reading the page to work out what changed. It now reports:

> no match in 36416-byte body, but the same pattern with a variable segment count matches **10.0** — the vendor changed how many numbers are in the version

A one-line fix instead of an investigation. It catches the opposite direction too — a vendor *adding* a segment, where a delimiter-bounded pattern stops matching entirely.

## Deliberately narrow

- **Diagnosis only.** The relaxed value is never used as a version, so Plex cannot start reporting a build number through this path.
- **Still `.recipe`, not `.infra`** — a vendor renumbering is ours to fix, and the finding must stay actionable.
- **Does not fire on unrelated misses.** A renamed JSON key still reports a plain `versionPatternNoMatch`, because the fix there is different.

## One test changed kind, correctly

`intelliJPreFixPatternIsReportedAsAPatternMiss` — written independently, before this — uses the fixture `"version":"2026.2.0.1"` against a three-segment pattern. That *is* a segment-count change, so it now reports the more specific kind. Its original property (actionable, not infra) is unchanged, and it now also asserts the value gets named. Independent confirmation that the diagnosis fires where it should.

## Verification

```
make test           -> 797 core / 110 CLI passing, 2 pre-existing known issues
duo verify --vendor -> 120 ok, 0 broken (unchanged)
```

The Zotero test is a genuine red→green against the real broken pattern and the real page shape, not a synthetic one.