### PR TITLE
Read a pkg's install destinations from its Bom as well

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -561,8 +561,55 @@ public actor PackageInstaller {
                     contentsOf: scratch.appendingPathComponent(name), encoding: .utf8)
             else { continue }
             out.formUnion(Self.destinations(inPackageInfo: body))
+
+            // The `<bundle>` elements are a vendor's *description* of the payload.
+            // The Bom beside them is the payload: the actual list of paths the
+            // installer will write. Reading both means a package that declares no
+            // bundles — which the XML path yields nothing for, and which now fails
+            // closed — is still understood, and it removes the dependence on each
+            // vendor's XML habits.
+            let bom = (name as NSString).deletingLastPathComponent.isEmpty
+                ? "Bom"
+                : (name as NSString).deletingLastPathComponent + "/Bom"
+            guard Self.runCapturing(
+                "/usr/bin/xar", ["-xf", pkg.path, bom], cwd: scratch).code == 0
+            else { continue }
+            let listing = Self.runCapturing(
+                "/usr/bin/lsbom", ["-s", scratch.appendingPathComponent(bom).path])
+            guard listing.code == 0 else { continue }
+            out.formUnion(Self.destinations(
+                inBomListing: listing.output,
+                installLocation: Self.installLocation(inPackageInfo: body)))
         }
         return out
+    }
+
+    /// Absolute `.app` destinations from one component's Bom listing.
+    ///
+    /// `lsbom -s` prints one payload path per line, relative to the component's
+    /// `install-location`. Only the lines that name an app bundle matter, and a
+    /// Bom lists every file inside one, so this keeps the bundle and discards its
+    /// contents rather than emitting thousands of paths.
+    static func destinations(
+        inBomListing listing: String, installLocation: String
+    ) -> Set<String> {
+        var out: Set<String> = []
+        for line in listing.split(separator: "\n") {
+            let path = String(line)
+            guard path.lowercased().contains(".app") else { continue }
+            let joined = (installLocation as NSString).appendingPathComponent(path)
+            out.formUnion(appBundlePrefixes(in: (joined as NSString).standardizingPath))
+        }
+        return out
+    }
+
+    /// The payload root a component unpacks into, defaulting to `/`.
+    static func installLocation(inPackageInfo body: String) -> String {
+        guard let doc = try? XMLDocument(xmlString: body, options: [.nodePreserveWhitespace]),
+              let value = (try? doc.nodes(forXPath: "/pkg-info/@install-location"))?
+                .first?.stringValue
+        else { return "/" }
+        return value.isEmpty ? "/" : value
     }
 
     /// Parse one `PackageInfo` body into absolute `.app` destinations. Split out so
@@ -613,6 +660,12 @@ public actor PackageInstaller {
         var walked: [String] = []
         for component in (path as NSString).pathComponents {
             walked.append(component)
+            // `._Foo.app` is an AppleDouble sidecar carrying another file's
+            // extended attributes, not a bundle. Reading the Bom surfaces them
+            // because they are genuinely in the payload — Shottr's package ships
+            // one next to the app — and treating them as destinations puts paths
+            // in a refusal message that no app was ever installed at.
+            guard !component.hasPrefix("._") else { continue }
             if isAppBundlePath(component) {
                 out.insert(NSString.path(withComponents: walked))
             }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageInstallerTests.swift
@@ -511,4 +511,60 @@ struct PackageInstallerTests {
         // for an installed /Applications/Foo.app rather than matching on the name.
         #expect(!dests.contains("/Applications/Foo.app"))
     }
+
+    // MARK: Destinations from the Bom
+    //
+    // The `<bundle>` elements are a vendor's description of the payload; the Bom
+    // is the payload. Reading both means a package that declares no bundles is
+    // still understood — which matters now that an unreadable layout is refused
+    // rather than waved through.
+
+    @Test func aBomListingResolvesAgainstTheInstallLocation() {
+        // Tailscale's shape: the payload root IS the app, so Bom paths are the
+        // bundle's own contents.
+        let listing = """
+        .
+        ./Contents
+        ./Contents/MacOS/Tailscale
+        ./Contents/Library/LoginItems/TailscaleLoginItemHelper-macsys.app
+        """
+        let d = PackageInstaller.destinations(
+            inBomListing: listing, installLocation: "/Applications/Tailscale.app")
+        #expect(d.contains("/Applications/Tailscale.app"))
+    }
+
+    @Test func aBomListingRootedAtSlashNamesTheAppDirectly() {
+        let listing = """
+        .
+        ./Applications
+        ./Applications/Foo.app
+        ./Applications/Foo.app/Contents/Info.plist
+        """
+        let d = PackageInstaller.destinations(inBomListing: listing, installLocation: "/")
+        #expect(d.contains("/Applications/Foo.app"))
+        // A Bom lists every file inside the bundle; only the bundle is a
+        // destination, not the thousands of paths under it.
+        #expect(!d.contains("/Applications/Foo.app/Contents/Info.plist"))
+    }
+
+    /// `._Foo.app` is an AppleDouble sidecar carrying another file's extended
+    /// attributes, not a bundle. The Bom surfaces them because they really are in
+    /// the payload — Shottr's package ships one — and treating them as
+    /// destinations puts paths in a refusal message that no app was installed at.
+    @Test func appleDoubleSidecarsAreNotDestinations() {
+        let listing = """
+        ./Applications/Shottr.app
+        ./Applications/._Shottr.app
+        """
+        let d = PackageInstaller.destinations(inBomListing: listing, installLocation: "/")
+        #expect(d == ["/Applications/Shottr.app"])
+    }
+
+    @Test func aMissingInstallLocationDefaultsToTheRoot() {
+        #expect(PackageInstaller.installLocation(inPackageInfo: "<pkg-info/>") == "/")
+        #expect(PackageInstaller.installLocation(
+            inPackageInfo: #"<pkg-info install-location=""/>"#) == "/")
+        #expect(PackageInstaller.installLocation(
+            inPackageInfo: #"<pkg-info install-location="/Applications"/>"#) == "/Applications")
+    }
 }


### PR DESCRIPTION
The follow-up the #9 review asked for, and the one that closes the known limitation left in #15.

## Why

The gate read destinations out of each component's `<bundle path>` elements. Those are the vendor's *description* of the payload. The **Bom** sitting beside them is the payload — the list of paths the installer will actually write.

That distinction started mattering in #15, when the gate went fail-closed: a package shipping no `<bundle>` metadata produces an empty set and is now **refused**. Its Bom still says exactly where it writes.

It also drops the dependence on each vendor's XML habits, which was the source of every parser defect found in review — entities, comments, single-quoted attributes, `search-path` matching an attribute pattern.

## Verified against all 16 real vendor packages

Every one still resolves to the app it updates. The Bom **adds detail rather than changing verdicts**:

```
Tailscale   1 -> 4 destinations      Word/Excel/PowerPoint  2 top-level, 7 total
UU Remote   1 -> 2                   Outlook                1 top-level, 3 total
ToDesk      7 top-level, 13 total    OneNote (standalone)   1 top-level, 2 total
```

Everything added is inside the bundle being updated.

## It found something

`/Applications/._Shottr.app`.

AppleDouble sidecars are genuinely in the payload, so the Bom lists them — but `._Foo.app` is another file's extended attributes, not a bundle. Treating one as a destination puts a path in a refusal message that no app was ever installed at. They are skipped now.

(Shottr's package really does ship one. This repo already has a rule about `._*` files polluting archives built on macOS; same family of problem, different direction.)

## Cost

10–740 ms for the whole parse depending on package size — Outlook's 1.3 GB archive is the worst case, and the gate runs 2–3 times per install, so under ~2s on the largest package we ship a recipe for. The destination set stays small (13 entries at most across the sixteen) because a Bom lists every file inside a bundle and only the bundle itself is kept.

## Verification

```
make test    -> 801 core / 110 CLI passing, 2 pre-existing known issues
make install -> builds, signs, deploys, runs
```

Four new tests cover the two install-location shapes, the AppleDouble skip, and the default when a component declares no `install-location`.