### PR TITLE
Release 0.3.43

### DIFF
--- a/App/project.yml
+++ b/App/project.yml
@@ -75,8 +75,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.app
-        MARKETING_VERSION: "0.3.42"
-        CURRENT_PROJECT_VERSION: "52"
+        MARKETING_VERSION: "0.3.43"
+        CURRENT_PROJECT_VERSION: "53"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Info.plist
         # Menu-bar-only app: no Dock icon, no main window.
@@ -188,8 +188,8 @@ targets:
         # plist's BundleProgram points at Contents/MacOS/DuoUpdaterHelper. The bundle
         # *identifier* (for signing / XPC pinning) is com.duoupdater.helper.
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.helper
-        MARKETING_VERSION: "0.3.42"
-        CURRENT_PROJECT_VERSION: "52"
+        MARKETING_VERSION: "0.3.43"
+        CURRENT_PROJECT_VERSION: "53"
         SWIFT_VERSION: "6.0"
         # Embed a generated Info.plist into the binary's __TEXT,__info_plist so the
         # helper has a bundle id/version (Bundle.main reads it) without a wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ reads the section matching the version being shipped and embeds it in the GitHub
 release and the Sparkle appcast, so this file is the single source of truth for
 "what's new" — keep each version's prose written for users, not commit-speak.
 
+## 0.3.43
+
+**Package updates are read more thoroughly before they are opened.** The check added in 0.3.41 asks an installer package where it installs, and refuses one that will not say. It was reading only the summary the package publishes about itself; it now also reads the package's own file list, which is what the installer actually follows. That means a package that keeps quiet in its summary is still understood instead of turned away. Every app that updates this way was re-checked against its real installer, and none of them changed.
+
 ## 0.3.42
 
 **A download link that stays broken now gets noticed.** When a vendor's server has a bad minute, Duo Updater waits it out rather than crying wolf — but that was letting a download link that had been broken for good slip by unremarked, because it looked the same as a bad minute on any single check. It now tells the difference: brief trouble is still ignored, trouble that lasts is flagged and fixed. Nothing changes on your Mac; this is about broken apps getting repaired sooner instead of quietly staying broken.


### PR DESCRIPTION
Version bump and release notes for the Bom-based pkg destination reading in #20 and the segment-count diagnosis in #19.