### PR TITLE
Fix cache fallback and visibility cleanup races

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -705,11 +705,18 @@ final class AppListModel {
         // One write for the whole check. The store batches every `record` /
         // `observeForChange` above into dirty flags precisely so a 100-app check
         // doesn't turn into 100 full-file atomic rewrites.
-        await releaseTimelineStore.flush()
-        // A duplicate version can still refresh display metadata after an app rename
-        // or bundle-id correction. Refresh once per batch so that store-only change is
-        // visible even though `record` correctly reports that it added no new event.
-        releaseTimelines = await releaseTimelineStore.snapshot()
+        //
+        // `flush` reports whether it actually rewrote the timelines, which is the
+        // signal to use rather than whether any `record` returned true: a duplicate
+        // version that only refreshed an app's name or bundle id is a real change to
+        // show and both recording calls correctly report it as "added nothing".
+        // Snapshotting unconditionally would sort every timeline and reassign an
+        // `@Observable` property on every idle check, redrawing the Release Log for
+        // no reason.
+        let timelinesChanged = await releaseTimelineStore.flush()
+        if timelinesChanged || releaseTimelines.isEmpty {
+            releaseTimelines = await releaseTimelineStore.snapshot()
+        }
     }
 
     /// Per-app load state for a recipe-backed changelog, keyed by

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -656,16 +656,16 @@ final class AppListModel {
 
     /// Log every release in `checked` that arrived with a trustworthy vendor
     /// timestamp into the release timeline, then refresh the UI snapshot. The
-    /// store dedupes by (app, version), so re-checks are cheap no-ops and only a
-    /// genuinely new release writes to disk. Results without a `publishedAt`
-    /// (vendor probes, MAS, Homebrew) are skipped by the store.
+    /// store dedupes by (app, version), so re-checks are cheap; only a genuinely
+    /// new release or changed display metadata writes the timeline file. Results
+    /// without a `publishedAt` (vendor probes, MAS, Homebrew) use the observation
+    /// path below rather than this exact-timestamp path.
     private func recordReleaseTimeline(for checked: [UpdateResult]) async {
-        var added = false
         for result in checked {
             guard let remote = result.remote else { continue }
             // The latest release (when it carries a date)…
             if remote.publishedAt != nil {
-                let didAdd = await releaseTimelineStore.record(
+                await releaseTimelineStore.record(
                     appID: result.app.id,
                     appName: result.app.name,
                     bundleID: result.app.bundleID,
@@ -673,13 +673,12 @@ final class AppListModel {
                     sourceName: remote.sourceName,
                     publishedAt: remote.publishedAt
                 )
-                added = added || didAdd
             }
             // …plus any prior releases the source surfaced (Sparkle appcast items,
             // a GitHub releases list), so an app's history backfills in one shot.
             // The store dedupes by version, so the latest overlapping here is free.
             for entry in remote.releaseHistory {
-                let didAdd = await releaseTimelineStore.record(
+                await releaseTimelineStore.record(
                     appID: result.app.id,
                     appName: result.app.name,
                     bundleID: result.app.bundleID,
@@ -687,7 +686,6 @@ final class AppListModel {
                     sourceName: remote.sourceName,
                     publishedAt: entry.publishedAt
                 )
-                added = added || didAdd
             }
             // Detection-only sources (a vendor probe, a Homebrew cask, the App
             // Store) report a version but no date. We can't know when they shipped,
@@ -695,25 +693,23 @@ final class AppListModel {
             // the reported version and, on a change, log an estimated window.
             if remote.publishedAt == nil, remote.releaseHistory.isEmpty,
                let v = remote.displayVersion {
-                let didAdd = await releaseTimelineStore.observeForChange(
+                await releaseTimelineStore.observeForChange(
                     appID: result.app.id,
                     appName: result.app.name,
                     bundleID: result.app.bundleID,
                     version: v,
                     sourceName: remote.sourceName
                 )
-                added = added || didAdd
             }
         }
         // One write for the whole check. The store batches every `record` /
         // `observeForChange` above into dirty flags precisely so a 100-app check
         // doesn't turn into 100 full-file atomic rewrites.
         await releaseTimelineStore.flush()
-        // Always refresh on first run (snapshot starts empty); otherwise only when
-        // something actually changed.
-        if added || releaseTimelines.isEmpty {
-            releaseTimelines = await releaseTimelineStore.snapshot()
-        }
+        // A duplicate version can still refresh display metadata after an app rename
+        // or bundle-id correction. Refresh once per batch so that store-only change is
+        // visible even though `record` correctly reports that it added no new event.
+        releaseTimelines = await releaseTimelineStore.snapshot()
     }
 
     /// Per-app load state for a recipe-backed changelog, keyed by

--- a/CLI/Sources/DuoKit/Visibility.swift
+++ b/CLI/Sources/DuoKit/Visibility.swift
@@ -103,7 +103,11 @@ public enum Visibility {
             var keys = Set(defaults.stringArray(forKey: UpdateSettings.ignoredKeysKey) ?? [])
             // Both forms, matching the app: un-ignoring must also clear a legacy
             // bundle-id entry, or the app would still consider it ignored.
-            let removed = keys.remove(key) != nil || keys.remove(legacy) != nil
+            // Evaluate both removals before combining the result. `||` short-circuits,
+            // which used to leave `legacy` behind whenever the path key also existed.
+            let removedCurrent = keys.remove(key) != nil
+            let removedLegacy = keys.remove(legacy) != nil
+            let removed = removedCurrent || removedLegacy
             guard removed else { return .failure("was not ignored") }
             defaults.set(Array(keys).sorted(), forKey: UpdateSettings.ignoredKeysKey)
             return .success("no longer ignored")
@@ -127,7 +131,11 @@ public enum Visibility {
         case .unskip:
             var skipped = defaults.dictionary(forKey: UpdateSettings.skippedVersionsKey)
                 as? [String: String] ?? [:]
-            let had = skipped.removeValue(forKey: key) ?? skipped.removeValue(forKey: legacy)
+            // As above, remove both spellings even when the current one supplies the
+            // value we report. `??` would otherwise skip evaluating the legacy removal.
+            let currentVersion = skipped.removeValue(forKey: key)
+            let legacyVersion = skipped.removeValue(forKey: legacy)
+            let had = currentVersion ?? legacyVersion
             guard let had else { return .failure("no skipped version") }
             defaults.set(skipped, forKey: UpdateSettings.skippedVersionsKey)
             return .success("no longer skipping \(had)")

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -222,15 +222,31 @@ import DuoUpdaterCore
         #expect(stored?[InstallPreferenceKey.key(for: app())] == "2.0")
     }
 
-    /// Un-ignoring must clear the legacy bundle-id form too, or the app — which
-    /// matches either key — would still consider it ignored.
-    @Test func unignoringClearsTheLegacyKeyAsWell() {
+    /// Migration can leave both the current path key and the legacy bundle-id key.
+    /// Un-ignoring must clear both, or the app still matches the one left behind.
+    @Test func unignoringClearsCurrentAndLegacyKeysTogether() {
         let defaults = scratchDefaults()
+        let current = InstallPreferenceKey.key(for: app())
         let legacy = InstallPreferenceKey.legacyKey(for: app())
-        defaults.set([legacy], forKey: UpdateSettings.ignoredKeysKey)
+        defaults.set([current, legacy], forKey: UpdateSettings.ignoredKeysKey)
         guard case .success = Visibility.apply(.unignore, to: result(hasUpdate: true), in: defaults) else {
-            Issue.record("unignore should clear a legacy entry"); return
+            Issue.record("unignore should clear both entry forms"); return
         }
         #expect(defaults.stringArray(forKey: UpdateSettings.ignoredKeysKey)?.isEmpty == true)
+    }
+
+    @Test func unskippingClearsCurrentAndLegacyKeysTogether() {
+        let defaults = scratchDefaults()
+        let current = InstallPreferenceKey.key(for: app())
+        let legacy = InstallPreferenceKey.legacyKey(for: app())
+        defaults.set(
+            [current: "2.0", legacy: "2.0"],
+            forKey: UpdateSettings.skippedVersionsKey)
+        guard case .success = Visibility.apply(.unskip, to: result(hasUpdate: true), in: defaults) else {
+            Issue.record("unskip should clear both entry forms"); return
+        }
+        let stored = defaults.dictionary(forKey: UpdateSettings.skippedVersionsKey)
+            as? [String: String]
+        #expect(stored?.isEmpty == true)
     }
 }

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -235,6 +235,33 @@ import DuoUpdaterCore
         #expect(defaults.stringArray(forKey: UpdateSettings.ignoredKeysKey)?.isEmpty == true)
     }
 
+    /// The state the legacy handling exists for: an app ignored before the move to
+    /// path keys has only the bundle-id entry on disk. Kept alongside the both-keys
+    /// test above, which cannot fail for this case — there the current key always
+    /// supplies the removal, so it would still pass if the legacy branch were lost.
+    @Test func unignoringClearsALegacyOnlyEntry() {
+        let defaults = scratchDefaults()
+        let legacy = InstallPreferenceKey.legacyKey(for: app())
+        defaults.set([legacy], forKey: UpdateSettings.ignoredKeysKey)
+        guard case .success = Visibility.apply(.unignore, to: result(hasUpdate: true), in: defaults) else {
+            Issue.record("unignore should clear a legacy-only entry"); return
+        }
+        #expect(defaults.stringArray(forKey: UpdateSettings.ignoredKeysKey)?.isEmpty == true)
+    }
+
+    /// Same migration state for a skipped version: only the legacy key is present.
+    @Test func unskippingClearsALegacyOnlyEntry() {
+        let defaults = scratchDefaults()
+        let legacy = InstallPreferenceKey.legacyKey(for: app())
+        defaults.set([legacy: "2.0"], forKey: UpdateSettings.skippedVersionsKey)
+        guard case .success = Visibility.apply(.unskip, to: result(hasUpdate: true), in: defaults) else {
+            Issue.record("unskip should clear a legacy-only entry"); return
+        }
+        let stored = defaults.dictionary(forKey: UpdateSettings.skippedVersionsKey)
+            as? [String: String]
+        #expect(stored?.isEmpty == true)
+    }
+
     @Test func unskippingClearsCurrentAndLegacyKeysTogether() {
         let defaults = scratchDefaults()
         let current = InstallPreferenceKey.key(for: app())

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
@@ -59,6 +59,7 @@ public actor ReleaseTimelineStore {
     /// gave no trustworthy date) or when we've already recorded this version for
     /// this app — each version is logged exactly once, at first sighting, so
     /// re-checks don't pile up duplicates or drift the recorded `detectedAt`.
+    /// Duplicate sightings may still refresh the timeline's display metadata.
     ///
     /// - Returns: true if this call added a new event (a release we hadn't seen).
     @discardableResult
@@ -80,6 +81,7 @@ public actor ReleaseTimelineStore {
         )
         // Keep display fields current — the app may have been renamed since an
         // earlier event was recorded.
+        let displayFieldsChanged = timeline.appName != appName || timeline.bundleID != bundleID
         timeline.appName = appName
         timeline.bundleID = bundleID
 
@@ -87,6 +89,7 @@ public actor ReleaseTimelineStore {
         guard !timeline.events.contains(where: { $0.version == version }) else {
             // Persist the refreshed name/bundle even when no event was added.
             timelines[appID] = timeline
+            if displayFieldsChanged { timelinesDirty = true }
             return false
         }
 
@@ -129,6 +132,16 @@ public actor ReleaseTimelineStore {
               !version.isEmpty else { return false }
 
         let prior = observations[appID]
+        // Display metadata can change while the reported version does not. Refresh
+        // an existing timeline before the version guard so that rename-only checks
+        // are still visible and persisted.
+        if var timeline = timelines[appID] {
+            let displayFieldsChanged = timeline.appName != appName || timeline.bundleID != bundleID
+            timeline.appName = appName
+            timeline.bundleID = bundleID
+            timelines[appID] = timeline
+            if displayFieldsChanged { timelinesDirty = true }
+        }
         // Update the baseline first; we always remember the latest sighting.
         defer {
             observations[appID] = Observation(version: version, lastSeenAt: now)
@@ -148,6 +161,7 @@ public actor ReleaseTimelineStore {
         var timeline = timelines[appID] ?? AppReleaseTimeline(
             appID: appID, appName: appName, bundleID: bundleID
         )
+        let displayFieldsChanged = timeline.appName != appName || timeline.bundleID != bundleID
         timeline.appName = appName
         timeline.bundleID = bundleID
 
@@ -155,6 +169,7 @@ public actor ReleaseTimelineStore {
         // landed for it earlier, or a beta flapped back).
         guard !timeline.events.contains(where: { $0.version == version }) else {
             timelines[appID] = timeline
+            if displayFieldsChanged { timelinesDirty = true }
             return false
         }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
@@ -158,18 +158,18 @@ public actor ReleaseTimelineStore {
         let start = min(prior.lastSeenAt, now)
         let range = DateInterval(start: start, end: now)
 
+        // Display fields are already current here: an existing timeline was
+        // refreshed and marked dirty above, and a timeline constructed by the `??`
+        // below is built from these very values. So there is nothing left to detect
+        // — a second `displayFieldsChanged` check here could never be true, and
+        // leaving one in would read as a safety net that does not exist.
         var timeline = timelines[appID] ?? AppReleaseTimeline(
             appID: appID, appName: appName, bundleID: bundleID
         )
-        let displayFieldsChanged = timeline.appName != appName || timeline.bundleID != bundleID
-        timeline.appName = appName
-        timeline.bundleID = bundleID
 
         // Don't double-record a version already known (e.g. a trustworthy event
         // landed for it earlier, or a beta flapped back).
         guard !timeline.events.contains(where: { $0.version == version }) else {
-            timelines[appID] = timeline
-            if displayFieldsChanged { timelinesDirty = true }
             return false
         }
 
@@ -196,7 +196,16 @@ public actor ReleaseTimelineStore {
     /// bounded by one check's duration, and this is a best-effort observational log:
     /// losing a few seconds of it to a crash costs nothing a later check won't
     /// re-derive.
-    public func flush() {
+    ///
+    /// - Returns: true if the timelines file was rewritten — i.e. this batch either
+    ///   logged a release or refreshed an app's display metadata. `record` and
+    ///   `observeForChange` each answer only for themselves and a rename reports
+    ///   `false` from both, so this is the only honest signal that the snapshot the
+    ///   UI holds is now out of date. The observations file is bookkeeping the UI
+    ///   never shows, so it deliberately doesn't count.
+    @discardableResult
+    public func flush() -> Bool {
+        let wroteTimelines = timelinesDirty
         if timelinesDirty {
             save()
             timelinesDirty = false
@@ -205,6 +214,7 @@ public actor ReleaseTimelineStore {
             saveObservations()
             observationsDirty = false
         }
+        return wroteTimelines
     }
 
     /// Per-app timelines, sorted by most-recent release first (apps that shipped

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCache.swift
@@ -76,8 +76,13 @@ public actor ChangelogCache {
         // fresh task under this URL — clearing the slot unconditionally would then
         // unregister *that* task, and every subsequent concurrent caller would miss
         // the coalescing check and start yet another redundant fetch.
-        if inflight[url] == task { inflight[url] = nil }
-        if let result { set(result, for: url) }
+        // Cache only while this task still owns the slot. `invalidate` deliberately
+        // removes that ownership; a fetch that ignores cancellation must not put its
+        // stale result back after the caller explicitly cleared the cache.
+        if inflight[url] == task {
+            inflight[url] = nil
+            if let result { set(result, for: url) }
+        }
         return result
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/HomebrewCaskCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/HomebrewCaskCatalog.swift
@@ -32,6 +32,10 @@ public actor HomebrewCaskCatalog {
     private var index: CaskIndex?
     private var indexLoadedAt: Date?
     private var loadTask: Task<CaskIndex, Error>?
+    /// A failed refresh should not make every subsequent lookup immediately retry
+    /// the same 5 MB request. While this is in the future, a stale index remains
+    /// usable and `isExpired` treats it as fresh enough to serve.
+    private var retryRefreshAfter: Date?
 
     /// How long a loaded index is reused before being refetched.
     ///
@@ -49,6 +53,7 @@ public actor HomebrewCaskCatalog {
     /// Only paid on machines that have casks installed at all; `HomebrewCaskSource`
     /// declines before touching the catalog when the Caskroom is empty.
     static let indexTTL: TimeInterval = 6 * 60 * 60
+    static let failedRefreshRetryDelay: TimeInterval = 5 * 60
 
     /// Test seam: an index seeded via `init(testIndex:)` never expires, so
     /// offline tests don't reach the network partway through.
@@ -67,6 +72,13 @@ public actor HomebrewCaskCatalog {
         self.indexNeverExpires = true
     }
 
+    /// Test seam for an expired, previously-good index plus a controlled session.
+    init(session: URLSession, staleTestIndex: CaskIndex, loadedAt: Date) {
+        self.session = session
+        self.index = staleTestIndex
+        self.indexLoadedAt = loadedAt
+    }
+
     /// Look up the cask that installs an app with the given bundle filename.
     public func entry(forAppFilename filename: String) async throws -> CaskEntry? {
         try await loadedIndex().byAppFilename[filename.lowercased()]
@@ -80,18 +92,31 @@ public actor HomebrewCaskCatalog {
     private func loadedIndex() async throws -> CaskIndex {
         if let index, !isExpired { return index }
         // Coalesce concurrent callers onto a single in-flight load.
-        if let loadTask { return try await loadTask.value }
+        if let loadTask { return try await resolve(loadTask) }
 
         let task = Task { try await Self.fetchAndIndex(session: session) }
         loadTask = task
+        return try await resolve(task)
+    }
+
+    /// Resolve the shared refresh for both its creator and every coalesced caller.
+    /// Keeping success/failure handling here is important: callers that merely join
+    /// the task must receive the same stale-on-error fallback as the creator.
+    private func resolve(_ task: Task<CaskIndex, Error>) async throws -> CaskIndex {
         do {
             let idx = try await task.value
-            index = idx
-            indexLoadedAt = Date()
-            loadTask = nil
+            if loadTask == task {
+                index = idx
+                indexLoadedAt = Date()
+                retryRefreshAfter = nil
+                loadTask = nil
+            }
             return idx
         } catch {
-            loadTask = nil
+            if loadTask == task {
+                loadTask = nil
+                retryRefreshAfter = Date().addingTimeInterval(Self.failedRefreshRetryDelay)
+            }
             // A refetch that fails keeps serving the last good index rather than
             // dropping every Homebrew row to "unknown" on one bad network moment.
             if let index { return index }
@@ -101,6 +126,7 @@ public actor HomebrewCaskCatalog {
 
     private var isExpired: Bool {
         guard !indexNeverExpires else { return false }
+        if let retryRefreshAfter, Date() < retryRefreshAfter { return false }
         guard let indexLoadedAt else { return true }
         return Date().timeIntervalSince(indexLoadedAt) >= Self.indexTTL
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogCacheTests.swift
@@ -8,6 +8,30 @@ import Foundation
 /// re-fetching vendor changelog pages on repeated detail-window opens.
 struct ChangelogCacheTests {
 
+    private actor FetchGate {
+        private var resultContinuation: CheckedContinuation<Changelog?, Never>?
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func fetch() async -> Changelog? {
+            await withCheckedContinuation { continuation in
+                resultContinuation = continuation
+                let waiters = startWaiters
+                startWaiters.removeAll()
+                waiters.forEach { $0.resume() }
+            }
+        }
+
+        func waitUntilStarted() async {
+            if resultContinuation != nil { return }
+            await withCheckedContinuation { startWaiters.append($0) }
+        }
+
+        func finish(with result: Changelog?) {
+            resultContinuation?.resume(returning: result)
+            resultContinuation = nil
+        }
+    }
+
     private static let url1 = URL(string: "https://example.com/releases")!
     private static let url2 = URL(string: "https://other.com/changelog")!
 
@@ -96,6 +120,22 @@ struct ChangelogCacheTests {
         let fresh = Self.makeChangelog(version: "2.0")
         await cache.set(fresh, for: Self.url1)
         #expect(await cache.get(for: Self.url1) == fresh)
+    }
+
+    @Test func invalidatedInflightFetchCannotRestoreItsStaleResult() async {
+        let cache = ChangelogCache(ttl: 3600)
+        let gate = FetchGate()
+        let stale = Self.makeChangelog(version: "1.0")
+
+        let loading = Task {
+            await cache.load(for: Self.url1) { await gate.fetch() }
+        }
+        await gate.waitUntilStarted()
+        await cache.invalidate(Self.url1)
+        await gate.finish(with: stale) // deliberately completes despite cancellation
+        _ = await loading.value
+
+        #expect(await cache.get(for: Self.url1) == nil)
     }
 
     // MARK: - invalidate(_:) — single key (used after an app updates on disk)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/HomebrewCaskCatalogTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/HomebrewCaskCatalogTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+@Suite(.serialized)
+struct HomebrewCaskCatalogTests {
+    private final class DelayedFailureProtocol: URLProtocol, @unchecked Sendable {
+        final class Counter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+
+            func increment() {
+                lock.lock()
+                value += 1
+                lock.unlock()
+            }
+
+            var count: Int {
+                lock.lock()
+                defer { lock.unlock() }
+                return value
+            }
+        }
+
+        static let counter = Counter()
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            Self.counter.increment()
+            // Leave enough time for the second actor call to join the in-flight task.
+            Thread.sleep(forTimeInterval: 0.1)
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+        }
+
+        override func stopLoading() {}
+    }
+
+    private static func failingSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DelayedFailureProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    @Test func concurrentFailedRefreshServesStaleIndexToEveryCaller() async throws {
+        let entry = CaskEntry(
+            token: "fixture", version: "2.0", url: nil,
+            autoUpdates: false, isPkg: false)
+        let index = CaskIndex(
+            byAppFilename: ["fixture.app": entry],
+            byBundleID: ["com.example.fixture": entry])
+        let before = DelayedFailureProtocol.counter.count
+        let catalog = HomebrewCaskCatalog(
+            session: Self.failingSession(),
+            staleTestIndex: index,
+            loadedAt: Date().addingTimeInterval(-HomebrewCaskCatalog.indexTTL - 1))
+
+        async let byName = catalog.entry(forAppFilename: "Fixture.app")
+        async let byID = catalog.entry(forBundleID: "com.example.fixture")
+        let (nameResult, idResult) = try await (byName, byID)
+
+        #expect(nameResult?.token == "fixture")
+        #expect(idResult?.token == "fixture")
+        #expect(DelayedFailureProtocol.counter.count - before == 1)
+
+        // The failure backoff serves stale data without immediately downloading the
+        // full catalog again for the next app in the same check.
+        let third = try await catalog.entry(forAppFilename: "Fixture.app")
+        #expect(third?.token == "fixture")
+        #expect(DelayedFailureProtocol.counter.count - before == 1)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
@@ -144,6 +144,30 @@ private let d3 = Date(timeIntervalSince1970: 1_720_000_000)
     await store.reset()
 }
 
+/// `flush` is what the model gates its snapshot refresh on, so it has to report a
+/// rename-only batch as a write — the case where both `record` and
+/// `observeForChange` correctly return false.
+@Test func flushReportsARenameOnlyBatchAsAWrite() async {
+    let store = ReleaseTimelineStore(fileURL: tempFileURL())
+    let id = "/Applications/Renamed.app"
+    await store.record(appID: id, appName: "OldName", bundleID: "com.old",
+        version: "1", sourceName: "Sparkle", publishedAt: d1)
+    #expect(await store.flush() == true)
+
+    // Nothing at all changed: same version, same name.
+    let addedAgain = await store.record(appID: id, appName: "OldName", bundleID: "com.old",
+        version: "1", sourceName: "Sparkle", publishedAt: d1)
+    #expect(!addedAgain)
+    #expect(await store.flush() == false)
+
+    // Same version, new display metadata — no event added, but the file changed.
+    let addedAfterRename = await store.record(appID: id, appName: "NewName", bundleID: "com.new",
+        version: "1", sourceName: "Sparkle", publishedAt: d1)
+    #expect(!addedAfterRename)
+    #expect(await store.flush() == true)
+    await store.reset()
+}
+
 @Test func ignoresEmptyVersion() async {
     let store = ReleaseTimelineStore(fileURL: tempFileURL())
     let added = await store.record(appID: "/e.app", appName: "E", bundleID: nil,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
@@ -124,6 +124,26 @@ private let d3 = Date(timeIntervalSince1970: 1_720_000_000)
     #expect(tl?.appName == "NewName")
 }
 
+@Test func sameVersionDisplayMetadataPersistsAcrossReload() async {
+    let url = tempFileURL()
+    let store = ReleaseTimelineStore(fileURL: url)
+    let id = "/Applications/Renamed.app"
+    await store.record(appID: id, appName: "OldName", bundleID: "com.old",
+        version: "1", sourceName: "Sparkle", publishedAt: d1)
+    await store.flush()
+
+    let added = await store.record(appID: id, appName: "NewName", bundleID: "com.new",
+        version: "1", sourceName: "Sparkle", publishedAt: d1)
+    #expect(!added)
+    await store.flush()
+
+    let reloaded = ReleaseTimelineStore(fileURL: url)
+    let timeline = await reloaded.timeline(forAppID: id)
+    #expect(timeline?.appName == "NewName")
+    #expect(timeline?.bundleID == "com.new")
+    await store.reset()
+}
+
 @Test func ignoresEmptyVersion() async {
     let store = ReleaseTimelineStore(fileURL: tempFileURL())
     let added = await store.record(appID: "/e.app", appName: "E", bundleID: nil,

--- a/README.md
+++ b/README.md
@@ -67,12 +67,18 @@ Apps are scanned from `/Applications`, `/Applications/Utilities`, and
    licence; omitted otherwise.
 7. **Vendor probes** — curated vendor-owned endpoints as the final fallback.
 
+The first source that recognises an app answers for it; a `nil` means "does not
+apply, try the next one". Two kinds of app never reach that stack at all:
+**JetBrains Toolbox**-managed apps and **TestFlight** builds are answered in
+`UpdateChecker` before the first source is consulted, because Toolbox and
+TestFlight each own the update and there is no second opinion worth having.
+
 It **respects each app's own update channel**:
 
 | Channel | Action |
 | --- | --- |
-| Sparkle | Native install — EdDSA when the app supplies a key, then code-signature + Team ID + bundle ID checks → swap → relaunch |
-| Mac App Store | Full store-daemon download by default; optional App Store UI route, with a deep-link fallback; region-locked apps are flagged |
+| Sparkle | Native install — EdDSA when the app supplies a key, then code-signature + Team ID + bundle ID + runnable-architecture checks → swap. The relaunch is a separate step (`autoRestartAfterUpdate`, on by default), not part of the installer |
+| Mac App Store | Full download through `mas` and the privileged helper. Where that is unavailable — helper not approved, or the app locked to another region — it falls back to a deep link or the App Store's own updates page; region-locked apps are flagged |
 | Self-updating (Electron/Squirrel) | Open the app and let it update itself |
 | Homebrew app cask | `brew install --cask --force` |
 | Homebrew `pkg` cask | Download the official package and open the system installer |
@@ -138,11 +144,11 @@ changes a private framework the App Store path has to be rebuilt.
 itself, which is what lets it also cover vendors that ship neither a Sparkle feed
 nor an App Store listing — per-app recipes against a vendor's own endpoint,
 GitHub releases, Homebrew casks, JetBrains Toolbox. Owning the install is what
-makes the checks in [Install safety](#install-safety) possible: EdDSA where a
-feed provides it, then a Developer ID signature, Team ID and bundle id that must
-match the app being replaced, plus a backup you can roll back to. Latest inherits
-whatever Sparkle and CommerceKit check and adds none of its own, and keeps no
-backup.
+makes the checks in [Install safety](#install-safety) possible: EdDSA where the
+app publishes a key, then a Developer ID signature, Team ID, bundle id and
+runnable architecture that must match the app being replaced, plus a backup you
+can roll back to. Latest inherits whatever Sparkle and CommerceKit check and adds
+none of its own, and keeps no backup.
 
 The trade is maintenance. Per-app recipes break whenever a vendor rewrites a
 download page, which is a real running cost — the same cost that a 100,000-app

--- a/README.md
+++ b/README.md
@@ -56,16 +56,23 @@ Apps are scanned from `/Applications`, `/Applications/Utilities`, and
 1. **Mac App Store** — iTunes lookup API, with storefront/region awareness
    (only native `mac-software` results are trusted; iOS-on-Mac apps are skipped
    to avoid phantom updates).
-2. **Sparkle** — the app's own `SUFeedURL` appcast.
-3. **Homebrew Cask** — matched by `.app` filename, falling back to bundle id
+2. **Xcode Releases** — non-App-Store Xcode beta and RC builds, matched to the
+   installed release channel.
+3. **Sparkle** — the app's own `SUFeedURL` appcast.
+4. **Homebrew Cask** — matched by `.app` filename, falling back to bundle id
    (so `pkg`-only casks like AweSun are still found).
+5. **GitHub Releases** — channel-aware release/tag matching for apps distributed
+   through GitHub, with installable assets only where an explicit rule vets one.
+6. **Alcove** — its authenticated update endpoint when the user has supplied a
+   licence; omitted otherwise.
+7. **Vendor probes** — curated vendor-owned endpoints as the final fallback.
 
 It **respects each app's own update channel**:
 
 | Channel | Action |
 | --- | --- |
-| Sparkle | Native install — download → EdDSA + code-signature + Team ID checks → swap → relaunch |
-| Mac App Store | Open the store page (deep link); region-locked apps are flagged |
+| Sparkle | Native install — EdDSA when the app supplies a key, then code-signature + Team ID + bundle ID checks → swap → relaunch |
+| Mac App Store | Full store-daemon download by default; optional App Store UI route, with a deep-link fallback; region-locked apps are flagged |
 | Self-updating (Electron/Squirrel) | Open the app and let it update itself |
 | Homebrew app cask | `brew install --cask --force` |
 | Homebrew `pkg` cask | Download the official package and open the system installer |


### PR DESCRIPTION
## Summary

- clear both current and legacy visibility keys when the CLI unignores or unskips an app
- give every coalesced Homebrew catalog caller the same stale-on-error fallback and add a short retry backoff
- prevent invalidated changelog fetches from restoring stale cache entries
- persist and publish release timeline display metadata changes even when the version is unchanged
- document the complete update source order plus the actual App Store and Sparkle install behavior

## Tests

- make test
  - Core: 11 XCTest tests and 812 Swift Testing tests passed, with 2 existing known issues
  - CLI: 113 tests passed
- xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug -derivedDataPath /tmp/duo-pr-derived CODE_SIGNING_ALLOWED=NO build
  - BUILD SUCCEEDED