### PR TITLE
Ignore version regressions in Release Log

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
@@ -27,6 +27,10 @@ public actor ReleaseTimelineStore {
     private struct Observation: Codable, Sendable {
         var version: String
         var lastSeenAt: Date
+        /// The source that established this baseline. Optional so observations
+        /// written before this field existed continue to decode and are adopted by
+        /// the next check.
+        var sourceName: String?
     }
     private var observations: [String: Observation]
     private let observationsURL: URL
@@ -109,7 +113,7 @@ public actor ReleaseTimelineStore {
     }
 
     /// Track a detection-only source's reported version for an app and, when it
-    /// *changes* from a previously-seen version, record an estimated release —
+    /// advances from a previously-seen version, record an estimated release —
     /// dated to the window `[last time we saw the old version, now]`. The first
     /// time we ever see an app there's no baseline to measure against, so nothing
     /// is recorded; we just remember the version for next time.
@@ -142,17 +146,43 @@ public actor ReleaseTimelineStore {
             timelines[appID] = timeline
             if displayFieldsChanged { timelinesDirty = true }
         }
-        // Update the baseline first; we always remember the latest sighting.
-        defer {
-            observations[appID] = Observation(version: version, lastSeenAt: now)
+
+        guard let prior else {
+            observations[appID] = Observation(
+                version: version, lastSeenAt: now, sourceName: sourceName)
+            observationsDirty = true
+            return false
+        }
+
+        // A different source is not evidence that this source just published a new
+        // version. Establish a fresh baseline instead of comparing unrelated version
+        // schemes (for example, a Homebrew build number against a vendor version).
+        if let priorSource = prior.sourceName, priorSource != sourceName {
+            observations[appID] = Observation(
+                version: version, lastSeenAt: now, sourceName: sourceName)
+            observationsDirty = true
+            return false
+        }
+
+        switch VersionComparator.compare(version, prior.version) {
+        case .orderedAscending:
+            // A transient endpoint rollback is not a release. Keep the higher
+            // high-water baseline so returning to it cannot be logged as one either.
+            return false
+        case .orderedSame:
+            // Equivalent spellings such as 1.2 and 1.2.0 are the same release. The
+            // latest confirmation still tightens the lower bound for a future update.
+            observations[appID] = Observation(
+                version: version, lastSeenAt: now, sourceName: sourceName)
+            observationsDirty = true
+            return false
+        case .orderedDescending:
+            observations[appID] = Observation(
+                version: version, lastSeenAt: now, sourceName: sourceName)
             observationsDirty = true
         }
 
-        // No baseline, or unchanged version → nothing to record (just (re)baseline
-        // via the defer; an unchanged sighting tightens the lower bound for later).
-        guard let prior, prior.version != version else { return false }
-
-        // The version moved. The release happened sometime after we last confirmed
+        // The version advanced. The release happened sometime after we last confirmed
         // the old version and by the time we first saw the new one. Guard against a
         // clock skew that would invert the interval.
         let start = min(prior.lastSeenAt, now)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
@@ -16,6 +16,7 @@ private func tempFileURL() -> URL {
 private let d1 = Date(timeIntervalSince1970: 1_700_000_000)
 private let d2 = Date(timeIntervalSince1970: 1_710_000_000)
 private let d3 = Date(timeIntervalSince1970: 1_720_000_000)
+private let d4 = Date(timeIntervalSince1970: 1_730_000_000)
 
 @Test func recordsAReleaseWithItsPublishedDate() async {
     let store = ReleaseTimelineStore(fileURL: tempFileURL())
@@ -192,6 +193,57 @@ private let d3 = Date(timeIntervalSince1970: 1_720_000_000)
         version: "2.0", sourceName: "Vendor", now: d3)
     #expect(!again)
     #expect(await store.totalEvents() == 0)
+}
+
+@Test func versionRegressionDoesNotBecomeAReleaseOrMoveTheHighWaterBaseline() async {
+    let store = ReleaseTimelineStore(fileURL: tempFileURL())
+    let id = "/v.app"
+    await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "2.0", sourceName: "Vendor", now: d1)
+
+    let regressed = await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "1.9", sourceName: "Vendor", now: d2)
+    let recovered = await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "2.0", sourceName: "Vendor", now: d3)
+    #expect(!regressed)
+    #expect(!recovered)
+    #expect(await store.totalEvents() == 0)
+
+    let advanced = await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "2.1", sourceName: "Vendor", now: d4)
+    #expect(advanced)
+    let event = await store.timeline(forAppID: id)?.events.first
+    #expect(event?.version == "2.1")
+    #expect(event?.estimatedRange?.start == d3)
+    #expect(event?.estimatedRange?.end == d4)
+}
+
+@Test func equivalentVersionSpellingsDoNotBecomeARelease() async {
+    let store = ReleaseTimelineStore(fileURL: tempFileURL())
+    let id = "/v.app"
+    await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "1.2", sourceName: "Vendor", now: d1)
+    let equivalent = await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "1.2.0", sourceName: "Vendor", now: d2)
+    #expect(!equivalent)
+    #expect(await store.totalEvents() == 0)
+}
+
+@Test func sourceChangeRebaselinesBeforeRecordingAnotherRelease() async {
+    let store = ReleaseTimelineStore(fileURL: tempFileURL())
+    let id = "/v.app"
+    await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "100", sourceName: "Vendor", now: d1)
+    let changedSource = await store.observeForChange(
+        appID: id, appName: "V", bundleID: nil,
+        version: "2.0", sourceName: "Homebrew", now: d2)
+    #expect(!changedSource)
+
+    let advanced = await store.observeForChange(appID: id, appName: "V", bundleID: nil,
+        version: "2.1", sourceName: "Homebrew", now: d3)
+    #expect(advanced)
+    let event = await store.timeline(forAppID: id)?.events.first
+    #expect(event?.estimatedRange?.start == d2)
 }
 
 @Test func estimatedBaselinePersistsAcrossReload() async {


### PR DESCRIPTION
## Summary

- record estimated releases only when a detection-only version advances
- keep the higher baseline across transient endpoint regressions so recovery is not logged as a release
- treat equivalent version spellings as unchanged
- rebaseline when the update source changes instead of comparing unrelated version schemes

> Stacked on #23 because both PRs touch ReleaseTimelineStore. Merge #23 first; GitHub will then retarget this PR cleanly.

## Tests

- make test on the combined #23 + #24 branch
  - Core: 11 XCTest tests and 815 Swift Testing tests passed, with 2 existing known issues
  - CLI: 113 tests passed