### PR TITLE
Avoid a second app scan for TestFlight tagging

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1138,9 +1138,10 @@ final class AppListModel {
         if let tfLoader {
             if let loaded = await Self.firstResult(of: tfLoader, within: .seconds(2)), loaded.accessible {
                 testflight = loaded
+                let scanned = found
                 let retagged = testflight
                 found = await Task.detached(priority: .userInitiated) {
-                    AppScanner(extraLocations: extraScan, toolbox: toolbox, testflight: retagged).scan()
+                    AppScanner.applyingTestFlightInventory(retagged, to: scanned)
                 }.value
                 results = sorted(mergeScanned(found))
             } else {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -153,6 +153,46 @@ public struct AppScanner: Sendable {
         }
     }
 
+    /// Fold a completed TestFlight inventory into apps that were already scanned.
+    ///
+    /// The inventory read can block on macOS's app-data privacy prompt, so the app
+    /// intentionally scans first with an empty inventory. Once the read succeeds we
+    /// only need to correct store provenance: every other field came from the same
+    /// bundle and is independent of TestFlight. Rebuilding those fields here avoids
+    /// a second full directory/plist/receipt/channel scan.
+    public static func applyingTestFlightInventory(
+        _ inventory: TestFlightInventory,
+        to apps: [InstalledApp]
+    ) -> [InstalledApp] {
+        apps.map { app in
+            let isTestFlight = app.isTestFlightApp || inventory.isManaged(
+                bundleID: app.bundleID, installedBuild: app.buildVersion)
+            guard isTestFlight, !app.isTestFlightApp else { return app }
+
+            return InstalledApp(
+                name: app.name,
+                bundleID: app.bundleID,
+                shortVersion: app.shortVersion,
+                buildVersion: app.buildVersion,
+                path: app.path,
+                isMASApp: false,
+                isiOSAppOnMac: app.isiOSAppOnMac,
+                isToolboxManaged: app.isToolboxManaged,
+                isTestFlightApp: true,
+                sparkleFeedURL: app.sparkleFeedURL,
+                sparkleFeedHeaders: app.sparkleFeedHeaders,
+                sparkleEdPublicKey: app.sparkleEdPublicKey,
+                hasSelfUpdater: app.hasSelfUpdater,
+                releaseChannel: app.releaseChannel,
+                channelIsAuthoritative: app.channelIsAuthoritative,
+                toolboxInstalledBuild: app.toolboxInstalledBuild,
+                // A receipt-backed app already paid this Spotlight read in the first
+                // scan. The fallback covers a DB-matched bundle with no receipt.
+                appStoreAdamID: app.appStoreAdamID ?? appStoreAdamID(app.path)
+            )
+        }
+    }
+
     /// Scan all configured locations and return the apps found, sorted by name.
     public func scan() -> [InstalledApp] {
         let fm = FileManager.default

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
@@ -13,6 +13,63 @@ final class TestFlightInventoryTests: XCTestCase {
         ])
     }
 
+    private func installedApp(
+        build: String = "100",
+        isMAS: Bool = true,
+        isTestFlight: Bool = false
+    ) -> InstalledApp {
+        InstalledApp(
+            name: "Beta App", bundleID: "com.example.beta",
+            shortVersion: "1.0", buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/Beta App.app"),
+            isMASApp: isMAS, isTestFlightApp: isTestFlight,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"),
+            sparkleFeedHeaders: ["X-Channel": "beta"],
+            sparkleEdPublicKey: "fixture-key", hasSelfUpdater: true,
+            releaseChannel: .beta, channelIsAuthoritative: true,
+            toolboxInstalledBuild: "toolbox-build", appStoreAdamID: 123)
+    }
+
+    func testApplyingInventoryRetagsWithoutLosingScannedMetadata() {
+        let app = installedApp()
+        let inventory = TestFlightInventory(macRows: [
+            (bundleID: "com.example.beta", shortVersion: "1.1", build: "100")
+        ])
+
+        let retagged = AppScanner.applyingTestFlightInventory(inventory, to: [app])[0]
+
+        XCTAssertTrue(retagged.isTestFlightApp)
+        XCTAssertFalse(retagged.isMASApp)
+        XCTAssertEqual(retagged.name, app.name)
+        XCTAssertEqual(retagged.path, app.path)
+        XCTAssertEqual(retagged.sparkleFeedURL, app.sparkleFeedURL)
+        XCTAssertEqual(retagged.sparkleFeedHeaders, app.sparkleFeedHeaders)
+        XCTAssertEqual(retagged.sparkleEdPublicKey, app.sparkleEdPublicKey)
+        XCTAssertEqual(retagged.releaseChannel, app.releaseChannel)
+        XCTAssertEqual(retagged.toolboxInstalledBuild, app.toolboxInstalledBuild)
+        XCTAssertEqual(retagged.appStoreAdamID, app.appStoreAdamID)
+    }
+
+    func testApplyingInventoryDoesNotTagADifferentInstalledBuild() {
+        let app = installedApp(build: "99")
+        let inventory = TestFlightInventory(macRows: [
+            (bundleID: "com.example.beta", shortVersion: "1.1", build: "100")
+        ])
+
+        let unchanged = AppScanner.applyingTestFlightInventory(inventory, to: [app])[0]
+        XCTAssertEqual(unchanged, app)
+    }
+
+    func testApplyingInventoryKeepsLocalReceiptTagWhenDatabaseLags() {
+        let app = installedApp(build: "101", isMAS: false, isTestFlight: true)
+        let lagging = TestFlightInventory(macRows: [
+            (bundleID: "com.example.beta", shortVersion: "1.0", build: "100")
+        ])
+
+        let unchanged = AppScanner.applyingTestFlightInventory(lagging, to: [app])[0]
+        XCTAssertEqual(unchanged, app)
+    }
+
     func testLatestPicksHighestBuild() {
         let tf = inventory()
         XCTAssertEqual(tf.latest(forBundleID: "com.wiheads.paste")?.latestBuild, "18706")


### PR DESCRIPTION
## Summary

- apply a completed TestFlight inventory to the apps already found by the initial scan
- preserve every scanned field while correcting TestFlight and Mac App Store provenance
- keep receipt-detected TestFlight apps tagged when the local database lags
- avoid repeating directory traversal, plist reads, receipt checks, and channel detection during normal user-present refreshes

## Tests

- TestFlightInventoryTests: 10 passed, including 3 new retagging regressions
- generated the Xcode project with xcodegen and built the Debug app with signing disabled: BUILD SUCCEEDED
- make test
  - Core: 14 XCTest tests and 809 Swift Testing tests passed, with 2 existing known issues
  - CLI: 112 tests passed