### PR TITLE
Relay a bailed staged relaunch once the user confirms the quit

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -90,6 +90,38 @@ final class AppListModel {
     /// crucially, blocks re-entry: the swap can take tens of seconds, during which
     /// the Relaunch button must not fire a second quit.
     private(set) var relaunching: Set<String> = []
+    /// A staged relaunch that bailed because the app wouldn't quit within the
+    /// grace window — its own quit-confirmation dialog (a save prompt, Claude's
+    /// "active conversation" sheet) was up. If the user then confirms the quit by
+    /// hand, ShipIt swaps the bundle with nobody left to relaunch it: apps that
+    /// stage with `launchAfterInstallation=false` (Claude) end up updated but
+    /// closed, because `relaunchStagedUpdate` has long since returned and its
+    /// fallback launch never ran. This marker lets the NSWorkspace terminate
+    /// observer pick the hand-off back up — see `settleQuitHandoffs`.
+    struct StagedQuitHandoff: Sendable {
+        /// The row at bail time — the bundle to poll and the row to refresh.
+        let result: UpdateResult
+        /// Version of the build staged at bail time. The relay launches only once
+        /// disk shows this version (or newer), so the marker can't resurrect the
+        /// app on some later unrelated quit unless that exact swap really landed.
+        let stagedVersion: String
+        /// Whether relaunching should hand the app the front spot — it was
+        /// frontmost when we bailed (its quit dialog was up, over our click).
+        let activates: Bool
+        /// Bail time. A marker older than `quitHandoffMaxAge` is dropped instead
+        /// of relayed: past that, a quit is the user closing the app, not a late
+        /// answer to the dialog our relaunch attempt put up.
+        let armedAt: Date
+    }
+    /// Armed quit hand-offs by row id. In-memory only (the window is minutes);
+    /// reset by the next relaunch attempt for the row, dropped by
+    /// `computeSelfUpdateStaging` when the staging it was armed for goes away,
+    /// and consumed (at most once) by `settleQuitHandoffs`.
+    private var stagedQuitHandoffs: [String: StagedQuitHandoff] = [:]
+    /// How long an armed quit hand-off stays live. Generous enough to answer a
+    /// quit dialog after stepping away; short enough that a quit hours later is
+    /// clearly not this hand-off.
+    private static let quitHandoffMaxAge: TimeInterval = 10 * 60
     /// App ids for which an incremental (AX) App Store update has downloaded but the
     /// app is still running, so App Store is asking to quit it to finish installing.
     /// id → the app's display name (for the prompt). Drives a "Relaunch to finish
@@ -2486,6 +2518,14 @@ final class AppListModel {
             return map
         }.value
         pendingSelfUpdate = staged
+        // Drop armed quit hand-offs whose staging is gone or now points at a
+        // different version: each marker is bound to the exact build it was armed
+        // for, and must not outlive it. (A hand-off already relaying removed its
+        // marker synchronously in `settleQuitHandoffs`, so this can't cancel one
+        // in flight.)
+        stagedQuitHandoffs = stagedQuitHandoffs.filter {
+            pendingSelfUpdate[$0.key]?.version == $0.value.stagedVersion
+        }
         // Dismiss delivered "Relaunch to apply it" banners for apps that are no
         // longer actionable-staged, so a stale one doesn't linger.
         let nowActionable = Set(results.compactMap { actionableStaged($0) != nil ? $0.id : nil })
@@ -2864,6 +2904,8 @@ final class AppListModel {
         }
         relaunching.insert(result.id)
         defer { relaunching.remove(result.id) }
+        // A fresh attempt supersedes whatever a previous bail left armed.
+        stagedQuitHandoffs[result.id] = nil
         let running = AppRestarter.runningInstances(of: result.app)
         guard !running.isEmpty else {
             // Not running: the staged swap applies on the app's own next quit, not
@@ -2903,8 +2945,24 @@ final class AppListModel {
                 everQuit = true  // quit succeeded — now we're waiting on the swap
             } else if !everQuit && tick >= quitGraceTicks {
                 // Never quit → a save prompt (or similar) is keeping it up; the swap
-                // can't start, so don't block the long window on it.
+                // can't start, so don't block the long window on it. But giving up
+                // on *waiting* must not give up on the *hand-off*: if the user
+                // answers that prompt a minute from now, the quit completes, ShipIt
+                // swaps — and an app staged with launchAfterInstallation=false
+                // stays closed with nobody to relaunch it. Arm the terminate
+                // observer to finish the job (`settleQuitHandoffs`).
                 Log.app.info("relaunch-staged: \(result.app.name, privacy: .public) won't quit (likely a save prompt) — leaving it staged")
+                if let staged = pendingSelfUpdate[result.id] {
+                    stagedQuitHandoffs[result.id] = StagedQuitHandoff(
+                        result: result,
+                        stagedVersion: staged.version,
+                        // Its quit dialog is up right now, which usually means it
+                        // holds the front spot even if it didn't when we started.
+                        activates: wasFrontmost
+                            || AppRestarter.isFrontmost(AppRestarter.runningInstances(of: result.app)),
+                        armedAt: Date())
+                    Log.app.info("relaunch-handoff: armed for \(result.app.name, privacy: .public) → \(staged.version, privacy: .public) (relaunch if it quits and the swap lands)")
+                }
                 break
             }
         }
@@ -2926,6 +2984,86 @@ final class AppListModel {
             let version = await Self.readShortVersionOffMain(result.app.path)
             UpdateNotifier.restarted(app: result.app.name, version: version, appID: result.app.bundleID)
         }
+    }
+
+    /// Pick up any armed quit hand-off whose app has now actually terminated —
+    /// the user answered the quit dialog after `relaunchStagedUpdate` gave up
+    /// waiting. Runs on every NSWorkspace launch/terminate event; a no-op unless
+    /// a hand-off is armed, which is rare and short-lived.
+    ///
+    /// The marker is taken out of the map *synchronously, before any await*: it
+    /// must fire at most once, and `computeSelfUpdateStaging`'s sweep (which
+    /// drops markers once the staging disappears) must not be able to cancel a
+    /// relay that is already under way.
+    private func settleQuitHandoffs() {
+        guard !stagedQuitHandoffs.isEmpty else { return }
+        for (id, handoff) in stagedQuitHandoffs {
+            guard !relaunching.contains(id),
+                  AppRestarter.runningInstances(of: handoff.result.app).isEmpty
+            else { continue }
+            stagedQuitHandoffs[id] = nil
+            guard Date().timeIntervalSince(handoff.armedAt) < Self.quitHandoffMaxAge else {
+                // Too long since the bail: this quit is the user closing the app,
+                // not a late answer to that dialog. ShipIt still swaps — we just
+                // don't bring the app back unasked.
+                Log.app.info("relaunch-handoff: \(handoff.result.app.name, privacy: .public) marker expired — not relaunching")
+                continue
+            }
+            Task { @MainActor [weak self] in await self?.relayQuitHandoff(handoff) }
+        }
+    }
+
+    /// Finish a bailed staged relaunch: the app has terminated, so its own
+    /// updater is (or will shortly be) swapping the bundle. Wait for the swap to
+    /// land on disk, then launch the app — the step ShipIt skips when the vendor
+    /// stages with `launchAfterInstallation=false`. Same cardinal rule as
+    /// `relaunchStagedUpdate`: never open the app before the swap has landed, or
+    /// ShipIt aborts with "App Still Running".
+    private func relayQuitHandoff(_ handoff: StagedQuitHandoff) async {
+        let app = handoff.result.app
+        // Reuse the row spinner + re-entry block for the duration of the relay.
+        guard !relaunching.contains(handoff.result.id) else { return }
+        relaunching.insert(handoff.result.id)
+        defer { relaunching.remove(handoff.result.id) }
+        Log.app.info("relaunch-handoff: \(app.name, privacy: .public) quit after the prompt — waiting for the staged swap to land")
+        var applied = false
+        for _ in 0..<900 {  // same patience as `relaunchStagedUpdate`'s swap wait (~180s)
+            try? await Task.sleep(for: .milliseconds(200))
+            guard AppRestarter.runningInstances(of: app).isEmpty else {
+                // Back up without us — ShipIt relaunched it itself, or the user
+                // reopened it. Either way our job is done; just re-read the row.
+                Log.app.info("relaunch-handoff: \(app.name, privacy: .public) reappeared on its own — standing down")
+                await refreshRow(handoff.result)
+                return
+            }
+            if let disk = await Self.readShortVersionOffMain(app.path),
+               disk == handoff.stagedVersion
+                || VersionComparator.isNewer(disk, than: handoff.stagedVersion) {
+                applied = true
+                break
+            }
+        }
+        guard applied else {
+            // The swap never landed (or disk never reached the version this marker
+            // was armed for). Launching now could race a still-working ShipIt, and
+            // the marker's promise was specifically "that staged build" — so leave
+            // the app quit, exactly as if the user had closed it.
+            Log.app.info("relaunch-handoff: \(app.name, privacy: .public) swap never landed — leaving it quit")
+            await refreshRow(handoff.result)
+            return
+        }
+        // One beat of grace: if this vendor's ShipIt *does* relaunch after
+        // installing, its open lands right after the swap — don't double-launch.
+        try? await Task.sleep(for: .milliseconds(500))
+        guard AppRestarter.runningInstances(of: app).isEmpty else {
+            await refreshRow(handoff.result)
+            return
+        }
+        Log.app.info("relaunch-handoff: \(app.name, privacy: .public) staged \(handoff.stagedVersion, privacy: .public) landed — relaunching")
+        await AppRestarter.launchApp(app.path, activates: handoff.activates)
+        await refreshRow(handoff.result)
+        let version = await Self.readShortVersionOffMain(app.path)
+        UpdateNotifier.restarted(app: app.name, version: version, appID: app.bundleID)
     }
 
     /// `readShortVersion` off the main actor. The staged-relaunch poll calls it
@@ -3839,6 +3977,9 @@ final class AppListModel {
     /// popover) — the "I restarted it myself but it still shows Relaunch" report.
     private func handleRunningAppsChange() {
         refreshRunningApps()
+        // Before the needs-restart early-out below: a quit hand-off fires exactly
+        // on a terminate event, and usually with `needsRestart` empty.
+        settleQuitHandoffs()
         // Nothing pending → nothing a relaunch could clear. A launch can't *create* a
         // needsRestart entry (that needs a newer on-disk build, which only a disk swap
         // produces — already covered by the FS watcher), so this stays a no-op on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ reads the section matching the version being shipped and embeds it in the GitHub
 release and the Sparkle appcast, so this file is the single source of truth for
 "what's new" — keep each version's prose written for users, not commit-speak.
 
+## 0.3.49
+
+**Confirming a quit late no longer leaves the app updated but closed.** Some apps guard their own quit with a dialog — Claude, for one, asks about an active conversation — and that dialog could land in the middle of a Relaunch. Duo Updater rightly refuses to sit there while you decide (and it still won't force the quit past your unsaved work), but once it stepped aside it also stopped listening. Answer the dialog a minute later and the quit went through, the app's own updater swapped in the new version — and then nothing happened: some updaters deliberately don't reopen the app after installing, Duo Updater was no longer watching, and you were left staring at an app that had simply closed. It now leaves a note for itself when it steps aside: if you do confirm that quit within the next few minutes, it waits for the update to finish landing and then brings the app back, in front if that's where it was. Choosing Cancel changes nothing, and the note quietly expires — a quit hours later is just you closing the app, and stays that way.
+
 ## 0.3.48
 
 **No more Dock icon.** Duo Updater is a menu-bar app — everything it does starts from the icon up there — but it also held a Dock slot, and the only thing that slot ever did was open the same window the menu bar opens. It now runs from the menu bar alone. If you would rather keep the Dock icon, Settings ▸ General ▸ "Hide the Dock icon" turns it back on, and with it the badge that shows the number of pending updates; hidden, that count lives on the menu-bar icon instead.


### PR DESCRIPTION
## Problem

`relaunchStagedUpdate` gives up waiting (by design) when an app's own quit-confirmation dialog keeps it up past the ~5s grace — but it also gave up the hand-off. If the user confirmed the quit a minute later, ShipIt swapped the bundle with nobody left to relaunch it: apps that stage with `launchAfterInstallation=false` (Claude desktop, observed 2026-08-21) ended up **updated but closed**. The Relaunch row correctly disappeared (disk version advanced), yet the app just sat quit.

## Fix

Arm a per-row `StagedQuitHandoff` marker on the bail path and let the **existing** NSWorkspace terminate observer (`handleRunningAppsChange`) finish the job:

- On the app's real termination with a live marker, the marker is consumed **synchronously, at most once**, and a relay task polls disk (200ms × 900, same patience as the in-function wait) for the staged swap to land — never opening the app before it does, preserving the ShipIt "App Still Running" constraint.
- The relay launches the app only once disk shows **the exact version staged at bail time** (or newer), handing it the front spot if it held it when we bailed (its quit dialog was up).
- If the app comes back on its own (a vendor whose ShipIt does relaunch, or the user reopening it), the relay stands down silently.

Staleness guards (the main regression risk — a days-later normal quit must never trigger a surprise launch):

- marker bound to the staged version; disk must reach it before any launch
- 10-minute expiry, checked at terminate time (zero new resident timers)
- swept by `computeSelfUpdateStaging` when the staging it was armed for disappears or changes version
- reset by the next Relaunch attempt for the row
- in-memory only; Cancel on the dialog leaves it inert

Also adds the 0.3.49 CHANGELOG entry in the established user-facing voice.

## Verification status

⚠️ **Unverified** — authored in a Linux cloud container with no Swift toolchain, so not even compiled. Needs on a Mac:

1. `make test` (Core/CLI untouched, but run per repo rules)
2. `make install` (change is entirely in the App target, which `swift test` doesn't build)
3. End-to-end: Relaunch an app with a quit-confirm dialog → bail log → confirm quit by hand → observe `relaunch-handoff:` log lines (`armed` / `quit after the prompt` / `landed — relaunching`) via `/usr/bin/log stream --predicate 'subsystem == "com.duoupdater.app"' --level info` → app relaunched after the swap
4. Negative path: Cancel on the dialog leaves behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a1Jx52YD74paWVXxQYtjE

---
_Generated by [Claude Code](https://claude.ai/code/session_019a1Jx52YD74paWVXxQYtjE)_