### PR TITLE
Don't compare a substituted build against the running one

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2524,6 +2524,23 @@ final class AppListModel {
             if let diskBuild = result.app.buildVersion, let marketing = result.app.shortVersion {
                 freshHistory[Preferences.marketingByBuildKey(path: runKey, build: diskBuild)] = marketing
             }
+            // Both sides of the comparison below have to come from the SAME field.
+            // `running` is `lsappinfo`, which can only ever report `CFBundleVersion`;
+            // for the handful of apps where `AppScanner` stores a DIFFERENT build in
+            // `buildVersion` (Xcode's `ProductBuildVersion`, 豆包输入法's
+            // `Wave Build Version Number`), the disk side is a foreign namespace and
+            // the comparison is meaningless. 豆包输入法 showed exactly that: disk
+            // `90602` against a running `CFBundleVersion` of `1` read as newer, so a
+            // freshly-launched, perfectly current input method wore a permanent
+            // Restart badge and a "0.9.6 (1) → 0.9.6 (90602)" line.
+            //
+            // Skipping is the honest answer, not a lost feature: an app in this set
+            // has a `CFBundleVersion` that `lsappinfo` and the scan would BOTH have to
+            // read for the check to mean anything, and where they differ the
+            // disk-vs-running signal is blind either way. Landed packages still reach
+            // `packageRestartPending` below, which decides on launch TIME instead —
+            // the same escape hatch frozen-version apps like WeChat DevTools use.
+            if AppScanner.buildVersionIsOverridden(bundleID: result.app.bundleID) { continue }
             guard let runVersion = running[runKey],
                   let disk = result.app.buildVersion ?? result.app.shortVersion,
                   VersionComparator.isNewer(disk, than: runVersion) else { continue }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -1446,6 +1446,30 @@ private let doubaoImeDownloadURLFixture = #"""
         == .updateAvailable(latest: "0.9.7"))
 }
 
+/// Why the disk-vs-running restart check must SKIP an app whose build `AppScanner`
+/// substitutes.
+///
+/// `lsappinfo` — the only source for what a running process is — reports
+/// `CFBundleVersion` and nothing else. For 豆包输入法 that is a flat `1`, while the
+/// scan reports `90602`. Compared against each other the disk side always wins, and
+/// a current, freshly-launched input method wears a permanent Restart badge reading
+/// `0.9.6 (1) → 0.9.6 (90602)`. That shipped, briefly, in the commit that introduced
+/// the substitution; `AppListModel.computeRestartInfo` now skips these apps.
+///
+/// This pins the PREMISE (the two namespaces really do compare that way), so the
+/// reason for the skip stays legible even though the skip itself lives in the app
+/// target, which has no test bundle.
+@Test func aSubstitutedBuildIsNotComparableWithTheRuntimeBuild() {
+    #expect(AppScanner.buildVersionIsOverridden(bundleID: "com.bytedance.inputmethod.doubaoime"))
+    #expect(AppScanner.buildVersionIsOverridden(bundleID: "com.apple.dt.Xcode"))
+    // The false "needs restart" in miniature.
+    #expect(VersionComparator.isNewer("90602", than: "1"))
+    // An app whose build is NOT substituted compares like-for-like and must keep
+    // working — this is the ordinary case the skip must not touch.
+    #expect(!AppScanner.buildVersionIsOverridden(bundleID: "com.tencent.inputmethod.wetype"))
+    #expect(VersionComparator.isNewer("657", than: "643"))
+}
+
 /// Detection-only, and — as with WeType — not because the artifact is missing: the
 /// response hands over a notarized installer zip. `UpdatePolicy.isInputMethod`
 /// refuses one-click for everything under `/Library/Input Methods` as a class.


### PR DESCRIPTION
Follow-up to #29, which introduced this. Caught only after deploying: it is visible **only** in the running menu-bar UI.

## What went wrong

`AppListModel.computeRestartInfo` decides "needs restart" by comparing the on-disk build against what the running process reports:

```swift
guard let runVersion = running[runKey],                 // lsappinfo → CFBundleVersion
      let disk = result.app.buildVersion ?? result.app.shortVersion,
      VersionComparator.isNewer(disk, than: runVersion) else { continue }
```

Both sides have to come from the **same field**. `lsappinfo` can only ever report `CFBundleVersion`. #29 made `AppScanner` store `Wave Build Version Number` (`90602`) in `buildVersion` for 豆包输入法, whose `CFBundleVersion` is a flat `1` — so the comparison became permanently true and a current, freshly-launched input method wore a Restart badge over a line reading `0.9.6 (1) → 0.9.6 (90602)`.

Xcode is in the same set (`ProductBuildVersion` vs `CFBundleVersion`) and escaped only by accident: the tokenizer happens to rank `27A5237l` below `25183.74.15`. It is now skipped deliberately rather than by luck.

## The fix

Skip apps whose build `AppScanner` substitutes. This is the honest answer, not a lost feature: where the two sides disagree, the disk-vs-running signal is blind either way. Landed packages still reach `packageRestartPending`, which decides on launch **time** instead — the same escape hatch frozen-version apps like WeChat DevTools already use.

## Why #29's verification missed it

Every gate that ran before merging was green and none of them could reach this code path:

| ran | covers |
|---|---|
| `make test` | core package — the restart logic lives in the app target, which has no test bundle |
| `duo verify`, `duo check`, `channel-verify` | the source chain and `evaluate()`, never `computeRestartInfo` |

The badge is produced by the app's own list model from `lsappinfo`, so it only appears in a deployed, running build. `duo check` reported `up-to-date` for the same app at the same moment. **A green CLI run is not sufficient evidence for a change that alters what `AppScanner` reports** — that value feeds UI paths the CLI never exercises.

The premise is pinned in the core tests (`aSubstitutedBuildIsNotComparableWithTheRuntimeBuild`) so the reason for the skip stays legible even though the skip itself cannot be unit-tested here.

## Verification

- `make test` — 823 + 119 green (2 pre-existing known issues)
- Deployed via `make install` and confirmed in the UI: the Restart badge is gone and the row reads `v0.9.6` with a ✓, matching WeType.

> Note: the first attempt to confirm this showed the row as `—` (unknown). That was unrelated — a concurrent session had deployed its own pre-#29 build over `/Applications/DuoUpdater.app` from a worktree still at `123ffb3`, and both were sharing `/tmp/duo-dd`. Re-deployed from this tree with a private derived-data path.