### PR TITLE
Add Tailscale's Release Candidate channel

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -112,6 +112,7 @@ public enum ChannelProofRegistry {
         // MARK: Everything else
         ChannelProofKey("dev.warp.Warp-Preview", .preview): .artifact(#"channel=preview"#),
         ChannelProofKey("io.tailscale.ipn.macsys", .unstable): .artifact(#"/unstable/"#),
+        ChannelProofKey("io.tailscale.ipn.macsys", .rc): .artifact(#"/release-candidate/"#),
         ChannelProofKey("com.figma.DesktopBeta", .beta): .artifact(#"/beta/FigmaBeta-"#),
         // Alfred serves stable and pre-release from two endpoints that frequently
         // carry the SAME build (both were 5.7.3 (2320) on 2026-08-09), and the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -40,7 +40,8 @@ public struct ResolvedChannel: Sendable, Equatable {
 ///   * OrbStack → `UserDefaults[updates_optinChannel]`               (String: the channel name)
 ///   * TablePlus→ `UserDefaults[ViewSetting][IsReceiveBetaBuild]`     (Bool: true→beta, via header)
 ///   * CleanShot→ `UserDefaults[activationKey]`                       (String: license key → personalized feed)
-///   * Tailscale→ `UserDefaults[UnstableUpdatesEnabled]`             (Bool: true→unstable)
+///   * Tailscale→ `UserDefaults[UnstableUpdatesEnabled]` + `[RCUpdatesEnabled]`
+///                                                          (two Bools, three tracks)
 ///
 /// So there is no generic reader. `ChannelBinding` is the single authority the
 /// scanner consults; an app with no resolver returns nil and the generic

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TailscaleChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TailscaleChannel.swift
@@ -1,38 +1,88 @@
 import Foundation
 
 /// Tailscale (`io.tailscale.ipn.macsys`, the standalone "macsys" build, NOT the
-/// Mac App Store one) ships two public tracks the GUI lets a user opt into:
-///   * stable   → `pkgs.tailscale.com/stable`   (even minor, e.g. 1.98.x)
-///   * unstable → `pkgs.tailscale.com/unstable` (odd  minor, e.g. 1.99.x)
-/// (`pkgs.tailscale.com/rc` 404s — there's no third consumer track here.)
+/// Mac App Store one) ships THREE public tracks the "Update to:" GUI dropdown
+/// lets a user opt into:
+///   * stable             → `pkgs.tailscale.com/stable`             (even minor, e.g. 1.98.x)
+///   * release candidate  → `pkgs.tailscale.com/release-candidate/` (verified 2026-08-21, HTTP
+///     200 + the same JSON shape as the other two tracks)
+///   * unstable           → `pkgs.tailscale.com/unstable`           (odd  minor, e.g. 1.99.x)
+/// `pkgs.tailscale.com/rc` 404s — that guessed path name is just wrong, NOT
+/// evidence the track doesn't exist. The real path is `release-candidate`, found
+/// by reading the value out of the app's own preferences rather than guessing
+/// URLs (see below).
 ///
-/// Both tracks share one bundle id and one app name; the installed
+/// All three tracks share one bundle id and one app name; the installed
 /// `CFBundleShortVersionString` is a plain semver with no channel suffix, so the
-/// only reliable local signal is the app's own opt-in toggle, stored in
-/// UserDefaults as `UnstableUpdatesEnabled` (Bool: 1 → unstable). We read it like
-/// OrbStack's `updates_optinChannel` and let the VendorProbe channel gate route
-/// the install to the matching `pkgs.tailscale.com/<track>` endpoint.
+/// only reliable local signal is the app's own opt-in toggles, stored in
+/// UserDefaults as two Bools:
+///   * `UnstableUpdatesEnabled` (1 → unstable)
+///   * `RCUpdatesEnabled`       (1 → release candidate; absent until the user has
+///     switched to RC at least once)
+/// We read them like OrbStack's `updates_optinChannel` and let the VendorProbe
+/// channel gate route the install to the matching `pkgs.tailscale.com/<track>`
+/// endpoint.
+///
+/// The two keys were verified mutually exclusive by directly reading
+/// `~/Library/Preferences/io.tailscale.ipn.macsys.plist` through all three GUI
+/// dropdown positions on 2026-08-21/22, on the same machine, back to back:
+///     Stable             → UnstableUpdatesEnabled absent,  RCUpdatesEnabled absent
+///     Release candidates → UnstableUpdatesEnabled 0,       RCUpdatesEnabled 1
+///     Unstable versions  → UnstableUpdatesEnabled 1,       RCUpdatesEnabled 0
+/// Switching dropdown positions doesn't just add the newly-chosen key, it
+/// actively WRITES 0 into the one being left (RCUpdatesEnabled goes from 1 to a
+/// literal `0`, not removed, when the user moved from RC to Unstable) — so the
+/// two keys behave as one client-maintained tri-state, not independent toggles
+/// that could drift apart from normal use.
 ///
 /// Safety: a missing/unreadable key falls back to `.stable` — the shipped
-/// default — so we never push an unstable build at someone who didn't opt in.
+/// default — so we never push a non-stable build at someone who didn't opt in.
 enum TailscaleChannel {
     static let bundleID = "io.tailscale.ipn.macsys"
 
-    /// Map the `UnstableUpdatesEnabled` flag to a resolution. Pure and tested.
-    /// No feed override: each track is its own VendorProbe recipe, picked by the
-    /// channel gate — not a feed swap.
-    static func resolve(unstableEnabled: Bool) -> ResolvedChannel {
-        ResolvedChannel(channel: unstableEnabled ? .unstable : .stable)
+    /// Map the two flags to a resolution. Pure and tested. No feed override:
+    /// each track is its own VendorProbe recipe, picked by the channel gate —
+    /// not a feed swap.
+    ///
+    /// `unstableEnabled` is checked first, so a hypothetical on-disk state with
+    /// both flags true would resolve to `.unstable`. This is PURELY DEFENSIVE —
+    /// the empirical three-state check above found no GUI path that produces
+    /// it, and there is no evidence it can happen. It exists only so an
+    /// out-of-band write (a bug in a future Tailscale version, manual
+    /// `defaults write`, a corrupted plist) can't silently escalate someone
+    /// past what they opted into: `.unstable` is the noisier of the two
+    /// non-stable tracks, so if the keys ever did disagree, resolving to the
+    /// one further from stable is the same "never surprise the user with a
+    /// quieter build than the noisiest thing they might have picked" bias the
+    /// rest of this file already uses (`?? false` on a bad read still won't
+    /// escalate PAST stable). It is not proof of a real ordering — just a
+    /// documented tie-break for a case that has not been observed.
+    static func resolve(unstableEnabled: Bool, rcEnabled: Bool) -> ResolvedChannel {
+        if unstableEnabled { return ResolvedChannel(channel: .unstable) }
+        if rcEnabled { return ResolvedChannel(channel: .rc) }
+        return ResolvedChannel(channel: .stable)
     }
 
     static func resolveCurrent() -> ResolvedChannel {
-        resolve(unstableEnabled: readUnstableEnabled())
+        resolve(unstableEnabled: readUnstableEnabled(), rcEnabled: readRCEnabled())
     }
 
     /// Read `UnstableUpdatesEnabled` from Tailscale's preferences. Returns false
     /// (stable) when the key is absent — the conservative default.
     static func readUnstableEnabled() -> Bool {
-        (CFPreferencesCopyAppValue("UnstableUpdatesEnabled" as CFString,
+        readBoolPref("UnstableUpdatesEnabled")
+    }
+
+    /// Read `RCUpdatesEnabled` from Tailscale's preferences. Returns false
+    /// (stable) when the key is absent OR explicitly 0 — both are observed on
+    /// real installs (see the three-state check above: absent on Stable,
+    /// explicitly written back to 0 when the user leaves RC for Unstable).
+    static func readRCEnabled() -> Bool {
+        readBoolPref("RCUpdatesEnabled")
+    }
+
+    private static func readBoolPref(_ key: String) -> Bool {
+        (CFPreferencesCopyAppValue(key as CFString,
                                    bundleID as CFString) as? NSNumber)?.boolValue ?? false
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2022,10 +2022,15 @@ public enum VendorProbeRegistry {
             channel: .stable),
         // Tailscale release candidate — same JSON shape on the
         // `/release-candidate/` track. Only reached when the install opted in via
-        // `RCUpdatesEnabled`; the same Tailscale-signed pkg path. Note the vendor's
-        // RC build can trail stable in version number (both were 1.102.3 on
-        // 2026-08-21) — that's expected, RC is a promotion candidate, not
-        // necessarily newer.
+        // `RCUpdatesEnabled`; the same Tailscale-signed pkg path.
+        //
+        // On version numbers: per Tailscale's own docs the RC track carries the
+        // *next patch of the current stable line*, so it normally reads equal to
+        // stable (right after a promotion — both were 1.102.3 on 2026-08-21) or
+        // ahead of it (while a patch is being tested), not behind. Either way
+        // nothing here depends on that: `VersionComparator.isNewer` requires
+        // strictly-greater, so an equal or lower RC version offers no update
+        // rather than proposing a downgrade.
         VendorProbeRecipe(
             bundleID: "io.tailscale.ipn.macsys",
             url: URL(string: "https://pkgs.tailscale.com/release-candidate/?mode=json")!,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2000,9 +2000,12 @@ public enum VendorProbeRegistry {
 
         // Tailscale — official package index. `MacZipsVersion` is the macsys
         // build (top-level `Version` is the Linux/Windows train — wrong here).
-        // Two public tracks share `io.tailscale.ipn.macsys`; the channel gate
+        // Three public tracks share `io.tailscale.ipn.macsys`; the channel gate
         // routes each install to its own endpoint per the app's opt-in toggle
-        // (see `TailscaleChannel`). `pkgs.tailscale.com/rc` 404s — no third track.
+        // (see `TailscaleChannel`). `pkgs.tailscale.com/rc` 404s, but that's just
+        // the wrong guessed path — the real release-candidate track lives at
+        // `pkgs.tailscale.com/release-candidate/` (verified 2026-08-21: HTTP 200,
+        // same JSON shape as stable/unstable below).
         VendorProbeRecipe(
             bundleID: "io.tailscale.ipn.macsys",
             url: URL(string: "https://pkgs.tailscale.com/stable/?mode=json")!,
@@ -2017,6 +2020,24 @@ public enum VendorProbeRegistry {
                     base: URL(string: "https://pkgs.tailscale.com/stable/")!),
                 kind: .pkg),
             channel: .stable),
+        // Tailscale release candidate — same JSON shape on the
+        // `/release-candidate/` track. Only reached when the install opted in via
+        // `RCUpdatesEnabled`; the same Tailscale-signed pkg path. Note the vendor's
+        // RC build can trail stable in version number (both were 1.102.3 on
+        // 2026-08-21) — that's expected, RC is a promotion candidate, not
+        // necessarily newer.
+        VendorProbeRecipe(
+            bundleID: "io.tailscale.ipn.macsys",
+            url: URL(string: "https://pkgs.tailscale.com/release-candidate/?mode=json")!,
+            mode: .responseBody,
+            versionPattern: #""MacZipsVersion"\s*:\s*"([0-9.]+)""#,
+            changelogURL: URL(string: "https://tailscale.com/changelog"),
+            install: VendorInstallSpec(
+                urlSource: .bodyPatternRelative(
+                    #""universal-package"\s*:\s*"(Tailscale-[^"]+\.pkg)""#,
+                    base: URL(string: "https://pkgs.tailscale.com/release-candidate/")!),
+                kind: .pkg),
+            channel: .rc),
         // Tailscale unstable — same JSON shape on the `/unstable` track (odd
         // minor, e.g. 1.99.x). Only reached when the install opted in via
         // `UnstableUpdatesEnabled`; the same Tailscale-signed pkg path.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
@@ -91,19 +91,49 @@ import Foundation
     #expect(key == "a b&c")  // decodes back to the original
 }
 
-// MARK: - Tailscale (`UnstableUpdatesEnabled` Bool → channel tag, no feed swap)
+// MARK: - Tailscale (`UnstableUpdatesEnabled` / `RCUpdatesEnabled` Bools → channel
+// tag, no feed swap — three-way resolve, see `TailscaleChannel`)
 
 @Test func tailscaleUnstableEnabledMapsToUnstable() {
-    let r = TailscaleChannel.resolve(unstableEnabled: true)
+    let r = TailscaleChannel.resolve(unstableEnabled: true, rcEnabled: false)
     #expect(r.channel == .unstable)
     // Channel-tag app: never a feed override, the channel gate picks the recipe.
     #expect(r.feedOverride == nil)
 }
 
-@Test func tailscaleUnstableDisabledStaysStable() {
-    let r = TailscaleChannel.resolve(unstableEnabled: false)
+@Test func tailscaleRCEnabledMapsToRC() {
+    let r = TailscaleChannel.resolve(unstableEnabled: false, rcEnabled: true)
+    #expect(r.channel == .rc)
+    #expect(r.feedOverride == nil)
+}
+
+@Test func tailscaleBothDisabledStaysStable() {
+    let r = TailscaleChannel.resolve(unstableEnabled: false, rcEnabled: false)
     #expect(r.channel == .stable)
     #expect(r.feedOverride == nil)
+}
+
+// `resolve` takes plain Bools, so a key that is ABSENT from the plist and one
+// that is explicitly written `0` are indistinguishable once `readBoolPref`
+// has collapsed them (`?? false`) — both real shapes are confirmed on-disk
+// (Stable: RCUpdatesEnabled absent; Unstable: RCUpdatesEnabled explicitly 0,
+// read back with `defaults read` 2026-08-21/22), and both must resolve the
+// same way, which this pins at the `resolve` level.
+@Test func tailscaleBothKeysMissingOrExplicitlyZeroStaysStable() {
+    let r = TailscaleChannel.resolve(unstableEnabled: false, rcEnabled: false)
+    #expect(r.channel == .stable)
+}
+
+// Empirically, the GUI dropdown is exclusive — verified 2026-08-21/22 by
+// reading the plist through all three positions back to back, including that
+// leaving RC writes `RCUpdatesEnabled` back to 0 rather than removing it — so
+// this combination has not been observed from normal use. But the two keys
+// are still independent Bools on disk, not one tri-state enum enforced by
+// anything on our side, so pin the defensive tie-break anyway: unstable wins
+// (see the reasoning in `TailscaleChannel.resolve`).
+@Test func tailscaleBothEnabledPrefersUnstable() {
+    let r = TailscaleChannel.resolve(unstableEnabled: true, rcEnabled: true)
+    #expect(r.channel == .unstable)
 }
 
 // MARK: - IINA (`receiveBetaUpdate` Bool → feed swap)


### PR DESCRIPTION
Adds Tailscale's **Release Candidate** track as a third channel alongside stable and unstable, resolved from the app's own `RCUpdatesEnabled` preference.

The endpoint took two guesses to find: `pkgs.tailscale.com/rc` 404s (verified), the real one is `pkgs.tailscale.com/release-candidate/`.

## Verification

```
duo verify --only tailscale     vendor probe ✓ 3   changelog ✓ 1
swift test (channel filter)     20 passed
```

All three tracks return the same `MacZipsVersion` field and the same `Tailscale-<version>-macos.pkg` naming — stable and RC both read 1.102.3 today (just-promoted, equal), unstable reads 1.103.85 — so there is no version-scheme mismatch of the kind that produces a phantom update. `VendorProbeSource` filters recipes by exact channel equality, so an RC-opted install can only ever match the RC recipe.

## Review notes

Reviewed by a subagent against the live endpoints and Tailscale's official docs. Findings addressed in the second commit: `ChannelBinding`'s resolver table still described Tailscale as one Bool with two outcomes, and a comment claimed an RC build "can trail stable" — backwards, per the vendor's own docs RC carries the next patch of the current stable line. Nothing depends on it either way (`VersionComparator.isNewer` requires strictly-greater), but a comment that gets the vendor's model wrong is worse than none.

One reported finding was **not** actioned: that `verify/baseline.json` has no `:rc` entry. That file is written exclusively by the `duo-verify` bot (every commit touching it is authored by it), and a missing key is not treated as broken — `Baseline.swift`'s `.ok` branch clears `lastSignature` and the counters. Hand-adding an entry in a human PR would be the wrong move.

Independent of the other three PRs in this batch; reviewable in parallel.
