### PR TITLE
Re-check an app when its vendor channel toggle changes

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4159,8 +4159,12 @@ final class AppListModel {
         let center = NSWorkspace.shared.notificationCenter
         for name in [NSWorkspace.didLaunchApplicationNotification,
                      NSWorkspace.didTerminateApplicationNotification] {
-            let observer = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
-                Task { @MainActor in self?.handleRunningAppsChange() }
+            let observer = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] note in
+                // Which app launched/quit, so the channel-switch pass below can skip
+                // the overwhelming majority of these events without doing any I/O.
+                let changed = (note.userInfo?[NSWorkspace.applicationUserInfoKey]
+                    as? NSRunningApplication)?.bundleIdentifier?.lowercased()
+                Task { @MainActor in self?.handleRunningAppsChange(changedBundleID: changed) }
             }
             runningAppObservers.append(observer)
         }
@@ -4176,7 +4180,7 @@ final class AppListModel {
     /// notification is the only live event that marks it. Without recomputing here the
     /// "Relaunch" badge lingered until the 180s backstop (or the user reopening the
     /// popover) — the "I restarted it myself but it still shows Relaunch" report.
-    private func handleRunningAppsChange() {
+    private func handleRunningAppsChange(changedBundleID: String? = nil) {
         refreshRunningApps()
         // Before the needs-restart early-out below: a quit hand-off fires exactly
         // on a terminate event, and usually with `needsRestart` empty.
@@ -4185,9 +4189,18 @@ final class AppListModel {
         // `windowAppeared`) we use to notice its channel toggle flipped in the
         // vendor app itself — the common "open Settings, flip the toggle, quit"
         // flow. Independent of the needs-restart early-out below: a channel switch
-        // has nothing to do with a pending restart. Free unless something actually
-        // changed (see `recheckChannelSwitches`).
-        Task { await recheckChannelSwitches(trigger: "running-apps-change") }
+        // has nothing to do with a pending restart.
+        //
+        // Gated on the app that actually changed. This notification fires for EVERY
+        // app on the machine — every helper, every menu-bar utility, all day — and
+        // the pass behind it reads one vendor preference per bound app (Surge's is a
+        // plist read off disk). Nine of those on every launch/quit event on the
+        // system is not what "free unless something changed" meant. A nil id (the
+        // notification arrived without one) still runs the pass rather than
+        // silently skipping a real switch.
+        if ChannelSwitchDetector.isWorthRecheckingAfterLaunchOrQuit(of: changedBundleID) {
+            Task { await recheckChannelSwitches(trigger: "running-apps-change") }
+        }
         // Nothing pending → nothing a relaunch could clear. A launch can't *create* a
         // needsRestart entry (that needs a newer on-disk build, which only a disk swap
         // produces — already covered by the FS watcher), so this stays a no-op on the
@@ -4311,18 +4324,29 @@ final class AppListModel {
     /// notifications can arrive back to back — queuing duplicate rechecks.
     @ObservationIgnored private var channelSwitchRecheckRunning = false
 
-    /// Freshly resolve every `ChannelBinding`-covered app currently on screen.
-    /// Cheap and network-free — each resolver just reads `CFPreferences` or a
-    /// small local plist (see `ChannelBinding`) — so this is safe to call from
-    /// any UI event; only an *actual* change goes on to spend a network request.
-    private func currentBoundChannelFingerprints() -> [String: String] {
+    /// The bound-app ids currently on screen. Main-actor (it reads `results`) but
+    /// pure memory — the disk-touching half is `fingerprints(forBoundIDs:)`.
+    private func onScreenBoundBundleIDs() -> [String] {
+        results.compactMap {
+            guard let id = $0.app.bundleID?.lowercased(),
+                  ChannelBinding.boundBundleIDs.contains(id)
+            else { return nil }
+            return id
+        }
+    }
+
+    /// Resolve each bound app's channel and fingerprint it. Network-free, but NOT
+    /// free: `ChannelBinding.resolve` reads another app's preferences, and Surge's
+    /// resolver reads a plist off disk with `Data(contentsOf:)`. Every other
+    /// `AppScanner`/resolver call site in this file is wrapped in `Task.detached`
+    /// for exactly that reason, and this one is called from an event that fires on
+    /// every app launch and quit on the machine — so it is `nonisolated` and runs
+    /// off the main actor like its neighbours, rather than being the one exception.
+    private nonisolated static func fingerprints(forBoundIDs ids: [String]) -> [String: String] {
         var out: [String: String] = [:]
-        for result in results {
-            guard let bundleID = result.app.bundleID?.lowercased(),
-                  ChannelBinding.boundBundleIDs.contains(bundleID),
-                  let resolved = ChannelBinding.resolve(bundleID: bundleID)
-            else { continue }
-            out[bundleID] = ChannelSwitchDetector.fingerprint(resolved)
+        for id in ids {
+            guard let resolved = ChannelBinding.resolve(bundleID: id) else { continue }
+            out[id] = ChannelSwitchDetector.fingerprint(resolved)
         }
         return out
     }
@@ -4354,7 +4378,11 @@ final class AppListModel {
         channelSwitchRecheckRunning = true
         defer { channelSwitchRecheckRunning = false }
 
-        let current = currentBoundChannelFingerprints()
+        let ids = onScreenBoundBundleIDs()
+        guard !ids.isEmpty else { return }
+        let current = await Task.detached(priority: .utility) {
+            Self.fingerprints(forBoundIDs: ids)
+        }.value
         let (changed, next) = ChannelSwitchDetector.changes(
             current: current, lastSeen: lastSeenChannelFingerprints)
         lastSeenChannelFingerprints = next

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -512,6 +512,11 @@ final class AppListModel {
         if NSApp.keyWindow == nil && NSApp.mainWindow == nil {
             NSApp.activate(ignoringOtherApps: true)
         }
+        // The user coming back to DuoUpdater is one of the two moments we use to
+        // notice a `ChannelBinding` app's channel toggle flipped in the vendor
+        // app itself (see `recheckChannelSwitches`) — free unless something
+        // actually changed.
+        Task { await recheckChannelSwitches(trigger: "window-appeared") }
     }
 
     /// Call from a window's `.onDisappear`. Kept for symmetric lifecycle sites: the
@@ -4176,6 +4181,13 @@ final class AppListModel {
         // Before the needs-restart early-out below: a quit hand-off fires exactly
         // on a terminate event, and usually with `needsRestart` empty.
         settleQuitHandoffs()
+        // A `ChannelBinding` app launching or quitting is the other moment (besides
+        // `windowAppeared`) we use to notice its channel toggle flipped in the
+        // vendor app itself — the common "open Settings, flip the toggle, quit"
+        // flow. Independent of the needs-restart early-out below: a channel switch
+        // has nothing to do with a pending restart. Free unless something actually
+        // changed (see `recheckChannelSwitches`).
+        Task { await recheckChannelSwitches(trigger: "running-apps-change") }
         // Nothing pending → nothing a relaunch could clear. A launch can't *create* a
         // needsRestart entry (that needs a newer on-disk build, which only a disk swap
         // produces — already covered by the FS watcher), so this stays a no-op on the
@@ -4286,6 +4298,82 @@ final class AppListModel {
             toolbox: ToolboxSource(inventory: toolbox),
             testflight: testflight)
         return await checker.check(fresh)
+    }
+
+    // MARK: - Channel-switch recheck
+
+    /// Bound-app id (lowercased bundle id) → fingerprint of the channel we last
+    /// resolved for it (see `ChannelSwitchDetector`). Empty until the first call
+    /// to `recheckChannelSwitches`; that first call seeds it rather than treating
+    /// every bound app as having just "changed".
+    @ObservationIgnored private var lastSeenChannelFingerprints: [String: String] = [:]
+    /// Guards against overlapping passes — a bound app's launch and terminate
+    /// notifications can arrive back to back — queuing duplicate rechecks.
+    @ObservationIgnored private var channelSwitchRecheckRunning = false
+
+    /// Freshly resolve every `ChannelBinding`-covered app currently on screen.
+    /// Cheap and network-free — each resolver just reads `CFPreferences` or a
+    /// small local plist (see `ChannelBinding`) — so this is safe to call from
+    /// any UI event; only an *actual* change goes on to spend a network request.
+    private func currentBoundChannelFingerprints() -> [String: String] {
+        var out: [String: String] = [:]
+        for result in results {
+            guard let bundleID = result.app.bundleID?.lowercased(),
+                  ChannelBinding.boundBundleIDs.contains(bundleID),
+                  let resolved = ChannelBinding.resolve(bundleID: bundleID)
+            else { continue }
+            out[bundleID] = ChannelSwitchDetector.fingerprint(resolved)
+        }
+        return out
+    }
+
+    /// Re-check any `ChannelBinding` app (Tailscale, Fork, Surge, …) whose own
+    /// channel toggle changed since we last looked — the fix for the bug where
+    /// switching Tailscale's Settings from Unstable back to Stable left its row
+    /// pinned to the old unstable target until the next scheduled check. The
+    /// channel choice lives entirely in the vendor app's own private preference,
+    /// so neither our FS watcher (it watches app *bundles*, not another app's
+    /// prefs) nor a networked check re-derives it on its own — the row is
+    /// otherwise stuck until the next scheduled check, up to an hour away.
+    ///
+    /// Resolves fresh and compares fingerprints (`ChannelSwitchDetector`) first —
+    /// free, no network, no I/O beyond a handful of `CFPreferences`/plist reads —
+    /// and only rechecks (a real scan + networked check, same path as
+    /// `recheckAfterUnignore`/`retry`) the rows that actually flipped.
+    ///
+    /// Called from two sites, chosen after checking on this machine that a
+    /// cross-process preference-change notification (`NSDistributedNotificationCenter`,
+    /// the Darwin notify center) is not reliably delivered here — see the report
+    /// alongside this change for the actual test and its output:
+    /// `handleRunningAppsChange` (a bound app launching/quitting — the common
+    /// "open Settings, flip the toggle, quit" flow) and `windowAppeared` (the
+    /// user comes back to DuoUpdater itself — the "leave the vendor app running"
+    /// flow). Coalesced against overlapping calls.
+    private func recheckChannelSwitches(trigger: String) async {
+        guard !results.isEmpty, !channelSwitchRecheckRunning else { return }
+        channelSwitchRecheckRunning = true
+        defer { channelSwitchRecheckRunning = false }
+
+        let current = currentBoundChannelFingerprints()
+        let (changed, next) = ChannelSwitchDetector.changes(
+            current: current, lastSeen: lastSeenChannelFingerprints)
+        lastSeenChannelFingerprints = next
+        guard !changed.isEmpty else { return }
+
+        let targets = results.filter {
+            guard let id = $0.app.bundleID?.lowercased() else { return false }
+            return changed.contains(id)
+        }
+        for result in targets {
+            guard installing[result.id] == nil else { continue }
+            installing[result.id] = .checking
+            let updated = await recheck(result)
+            installing[result.id] = nil
+            replaceRow(updated)
+            Log.app.info(
+                "channel switch re-check (\(trigger, privacy: .public)): \(updated.app.name, privacy: .public) → \(String(describing: updated.status), privacy: .public)")
+        }
+        syncDockBadge()
     }
 
     /// Re-run the update check for one app whose source errored — the retry

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -57,6 +57,26 @@ public struct ResolvedChannel: Sendable, Equatable {
 /// machine would never reach.
 public enum ChannelBinding {
 
+    /// Every bundle id (lower-cased) a resolver above covers — i.e. an app whose
+    /// channel choice hides in a private preference rather than in a bundle-id
+    /// suffix or a `<sparkle:channel>` tag. Used by the menu-bar app to scope its
+    /// "did the user just flip a channel toggle in the vendor app itself" recheck
+    /// to only these apps, instead of polling every installed app's prefs.
+    ///
+    /// Deliberately excludes Ghostty: its binding is a fixed stable-only feed
+    /// override with no user-settable preference, so there is nothing to watch.
+    public static let boundBundleIDs: Set<String> = [
+        DuoPasteChannel.bundleID.lowercased(),
+        ForkChannel.bundleID.lowercased(),
+        SurgeChannel.bundleID.lowercased(),
+        OrbStackChannel.bundleID.lowercased(),
+        TablePlusChannel.bundleID.lowercased(),
+        CleanShotChannel.bundleID.lowercased(),
+        TailscaleChannel.bundleID.lowercased(),
+        IINAChannel.bundleID.lowercased(),
+        AlfredChannel.bundleID.lowercased(),
+    ]
+
     /// The user-chosen channel (and feed, for feed-swap apps) for `bundleID`, or
     /// nil when no bespoke resolver exists.
     ///

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
@@ -78,4 +78,22 @@ public enum ChannelSwitchDetector {
         }
         return (changed, current)
     }
+
+    /// Whether an app launching or quitting is worth resolving channels for.
+    ///
+    /// `NSWorkspace`'s launch/terminate notifications fire for EVERY process on
+    /// the machine — helpers, menu-bar utilities, anything the user opens all day
+    /// — while the pass behind them reads one vendor preference per bound app, and
+    /// Surge's resolver reads a plist off disk. Without this gate that ran on every
+    /// such event; with it, it runs on the nine apps whose channel can actually
+    /// change.
+    ///
+    /// A nil id — the notification arrived without a bundle identifier — returns
+    /// true. Fail toward doing the work: a wasted pass costs a few preference
+    /// reads, a skipped one leaves a stale verdict on screen, which is the bug
+    /// this whole detector exists to fix.
+    public static func isWorthRecheckingAfterLaunchOrQuit(of bundleID: String?) -> Bool {
+        guard let bundleID else { return true }
+        return ChannelBinding.boundBundleIDs.contains(bundleID.lowercased())
+    }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
@@ -1,0 +1,81 @@
+import Foundation
+import CryptoKit
+
+/// Detects when a `ChannelBinding`-covered app's user-chosen channel has actually
+/// changed since we last looked — e.g. the user opened Tailscale's own
+/// Preferences and flipped Unstable→Stable. That choice lives entirely in the
+/// vendor app's private preference (see `ChannelBinding`), which our FS watcher
+/// never sees (it only watches app *bundles*, not another app's prefs) and no
+/// networked check re-derives on its own (the row keeps whatever channel it was
+/// last resolved against until the next scheduled check, which can be hours
+/// away).
+///
+/// This is the pure half of that fix: given a fresh `ResolvedChannel` per bound
+/// app (the caller does the actual `ChannelBinding.resolve` calls, which touch
+/// `CFPreferences`/disk and so aren't pure) and a fingerprint of what we saw last
+/// time, decide which ids actually flipped. Kept separate from the resolving and
+/// from the recheck side-effect so it's trivially testable and so the caller can
+/// decide, cheaply and without any network, whether a real recheck is warranted
+/// at all.
+///
+/// Why the *whole* `ResolvedChannel`, not just `.channel`: four of the ten bound
+/// apps are feed-swap or header-keyed (see `ChannelBinding`'s doc comment) —
+/// CleanShot in particular keeps `.channel == .stable` always and encodes the
+/// actual entitlement entirely in `feedOverride` (a personalized, license-keyed
+/// URL). Comparing `.channel` alone would see CleanShot as never changing and
+/// silently drop this fix for the one app whose bug shape is "feed changed,
+/// channel didn't."
+///
+/// Why a fingerprint and not the `ResolvedChannel` itself: `feedOverride` for
+/// CleanShot embeds the user's license key in the query string
+/// (`?key=<licenseKey>`, see `CleanShotChannel`). That key must never be logged
+/// or persisted in the clear (existing rule, audited in `CleanShotChannel`'s doc
+/// comment) — so what we cache and compare is a one-way SHA-256 digest of the
+/// resolved channel's fields, never the raw URL/headers.
+public enum ChannelSwitchDetector {
+
+    /// A one-way, non-reversible fingerprint of a `ResolvedChannel`. Safe to log,
+    /// persist, or compare — it never carries the license key (or anything else)
+    /// a `feedOverride`/`feedHTTPHeaders` might embed.
+    public static func fingerprint(_ resolved: ResolvedChannel) -> String {
+        // Headers sorted so the fingerprint doesn't depend on dictionary order.
+        let headerPart = resolved.feedHTTPHeaders
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: "&")
+        let raw = [
+            resolved.channel.rawValue,
+            resolved.feedOverride?.absoluteString ?? "",
+            headerPart,
+        ].joined(separator: "|")
+        let digest = SHA256.hash(data: Data(raw.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// - Parameters:
+    ///   - current: bound-app id → fingerprint of its freshly resolved channel,
+    ///     for every bound app currently installed (scanned).
+    ///   - lastSeen: the same shape, from the previous call.
+    /// - Returns:
+    ///   - changed: ids whose fingerprint differs from what we saw last time.
+    ///     Empty on the very first call for an id — seeing an id for the first
+    ///     time just seeds the cache, it never counts as a "switch" (an app
+    ///     appearing in the scan for the first time isn't a channel change, and
+    ///     without this a fresh install or app relaunch would trigger a needless
+    ///     recheck of every bound app it happens to include).
+    ///   - next: the cache to store for the next call — exactly `current`, so an
+    ///     id no longer present (the app was uninstalled or dropped out of the
+    ///     scan) is pruned and the map can't grow without bound.
+    public static func changes(
+        current: [String: String],
+        lastSeen: [String: String]
+    ) -> (changed: Set<String>, next: [String: String]) {
+        var changed = Set<String>()
+        for (id, fingerprint) in current {
+            if let prior = lastSeen[id], prior != fingerprint {
+                changed.insert(id)
+            }
+        }
+        return (changed, current)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
@@ -103,3 +103,23 @@ import Foundation
     #expect(!fp.contains(secret))
     #expect(fp.allSatisfy { $0.isHexDigit })
 }
+
+/// The launch/terminate gate. Derived from the registry, not a hand-written list,
+/// so a tenth bound app is covered the day it is added.
+@Test func onlyBoundAppsAreWorthRecheckingOnLaunchOrQuit() {
+    for id in ChannelBinding.boundBundleIDs {
+        #expect(ChannelSwitchDetector.isWorthRecheckingAfterLaunchOrQuit(of: id))
+        // Bundle ids are case-insensitive, and TablePlus really does ship
+        // `com.tinyapp.TablePlus` while its prefs live under the lowercased
+        // domain — a case-sensitive gate would silently skip it.
+        #expect(ChannelSwitchDetector.isWorthRecheckingAfterLaunchOrQuit(of: id.uppercased()))
+    }
+    // The overwhelming majority of these notifications: some other app entirely.
+    for other in ["com.apple.finder", "com.apple.Safari", "com.googlecode.iterm2"] {
+        #expect(!ChannelSwitchDetector.isWorthRecheckingAfterLaunchOrQuit(of: other),
+                "\(other) has no channel binding — resolving nine prefs for it is waste")
+    }
+    // Fail toward doing the work when the notification carries no id: a wasted
+    // pass is cheap, a missed switch is the bug this detector exists to fix.
+    #expect(ChannelSwitchDetector.isWorthRecheckingAfterLaunchOrQuit(of: nil))
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `ChannelSwitchDetector` is the pure comparison behind "recheck a
+/// `ChannelBinding` app the moment its own channel toggle flips" (the Tailscale
+/// Unstable→Stable bug: switching in Tailscale's own Settings left the row
+/// pinned to the old unstable target until the next scheduled check). These pin
+/// down: a real flip is reported, the first-ever sighting of an id never counts
+/// as one, a feed-only change (no `.channel` change) is still caught, and the
+/// fingerprint never leaks the raw feed/license data it's built from.
+
+@Test func detectsAFlippedChannel() {
+    let last = ["io.tailscale.ipn.macsys": ChannelSwitchDetector.fingerprint(.init(channel: .unstable))]
+    let current = ["io.tailscale.ipn.macsys": ChannelSwitchDetector.fingerprint(.init(channel: .stable))]
+    let (changed, next) = ChannelSwitchDetector.changes(current: current, lastSeen: last)
+    #expect(changed == ["io.tailscale.ipn.macsys"])
+    #expect(next == current)
+}
+
+@Test func noChangeReportsNothing() {
+    let fp = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    let last = ["com.nssurge.surge-mac": fp]
+    let current = ["com.nssurge.surge-mac": fp]
+    let (changed, next) = ChannelSwitchDetector.changes(current: current, lastSeen: last)
+    #expect(changed.isEmpty)
+    #expect(next == current)
+}
+
+/// First-ever observation of an id (fresh install, first scan after relaunch,
+/// or the id just entering `ChannelBinding`'s registry) must never read as a
+/// "switch" — otherwise every bound app would trigger one needless recheck the
+/// moment the menu-bar app (re)starts.
+@Test func firstObservationIsNotAChange() {
+    let fp = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    let (changed, next) = ChannelSwitchDetector.changes(
+        current: ["com.colliderli.iina": fp], lastSeen: [:])
+    #expect(changed.isEmpty)
+    #expect(next == ["com.colliderli.iina": fp])
+}
+
+/// Covers every id `ChannelBinding` currently registers, so a channel added to
+/// the registry later is automatically exercised here too — same "derive from
+/// the registry, don't hand-write a list that drifts" rule the recipe/proof
+/// tests already follow.
+@Test func everyBoundIDFlipIsDetected() {
+    let before = ChannelSwitchDetector.fingerprint(.init(channel: .stable))
+    let after = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    for id in ChannelBinding.boundBundleIDs {
+        let (changed, _) = ChannelSwitchDetector.changes(
+            current: [id: after], lastSeen: [id: before])
+        #expect(changed == [id], "bound id \(id) should report its own flip")
+    }
+}
+
+@Test func stalePrunedWhenAppDisappearsFromScan() {
+    let fp = ChannelSwitchDetector.fingerprint(.init(channel: .stable))
+    let last = [
+        "io.tailscale.ipn.macsys": fp,
+        "com.uninstalled.app": ChannelSwitchDetector.fingerprint(.init(channel: .beta)),
+    ]
+    let current = ["io.tailscale.ipn.macsys": fp]
+    let (changed, next) = ChannelSwitchDetector.changes(current: current, lastSeen: last)
+    #expect(changed.isEmpty)
+    #expect(next["com.uninstalled.app"] == nil)
+}
+
+/// The whole point of fingerprinting rather than caching `ResolvedChannel`
+/// itself: a feed-swap change (e.g. CleanShot's licensed-feed URL rotating)
+/// must be caught even though `.channel` alone never changes for that app.
+@Test func feedOnlyChangeIsDetectedEvenWhenChannelStaysStable() {
+    let licensedFeedA = URL(string: "https://legit.maketheweb.io/api/v1/appcast?key=AAA")!
+    let licensedFeedB = URL(string: "https://legit.maketheweb.io/api/v1/appcast?key=BBB")!
+    let before = ChannelSwitchDetector.fingerprint(.init(channel: .stable, feedOverride: licensedFeedA))
+    let after = ChannelSwitchDetector.fingerprint(.init(channel: .stable, feedOverride: licensedFeedB))
+    let (changed, _) = ChannelSwitchDetector.changes(
+        current: ["pl.maketheweb.cleanshotx": after],
+        lastSeen: ["pl.maketheweb.cleanshotx": before])
+    #expect(changed == ["pl.maketheweb.cleanshotx"])
+}
+
+/// A header-only change (TablePlus's `X-Tiny-Beta-Update` toggle) must also be
+/// caught — the fingerprint has to fold in `feedHTTPHeaders`, not just the feed
+/// URL and channel.
+@Test func headerOnlyChangeIsDetected() {
+    let before = ChannelSwitchDetector.fingerprint(.init(channel: .stable))
+    let after = ChannelSwitchDetector.fingerprint(
+        .init(channel: .beta, feedHTTPHeaders: ["X-Tiny-Beta-Update": "true"]))
+    let (changed, _) = ChannelSwitchDetector.changes(
+        current: ["com.tinyapp.tableplus": after],
+        lastSeen: ["com.tinyapp.tableplus": before])
+    #expect(changed == ["com.tinyapp.tableplus"])
+}
+
+/// The fingerprint is a SHA-256 hex digest — fixed-length, and must never embed
+/// the license key (or any other feed content) verbatim, since it's the thing we
+/// actually persist/compare/log.
+@Test func fingerprintNeverLeaksTheRawFeed() {
+    let secret = "super-secret-license-key-should-never-appear"
+    let feed = URL(string: "https://legit.maketheweb.io/api/v1/appcast?key=\(secret)")!
+    let fp = ChannelSwitchDetector.fingerprint(.init(channel: .stable, feedOverride: feed))
+    #expect(fp.count == 64, "SHA-256 hex digest is 64 characters")
+    #expect(!fp.contains(secret))
+    #expect(fp.allSatisfy { $0.isHexDigit })
+}


### PR DESCRIPTION
Some apps let the user pick their release channel inside the vendor's own app — Tailscale's Unstable toggle, Fork, Surge, OrbStack, TablePlus, CleanShot, IINA, Alfred, DuoPaste. That choice lives entirely in the vendor's private preferences, so when the user flips it, nothing on our side re-derives it: the FS watcher watches app *bundles*, not another app's prefs, and a networked check doesn't recompute the channel. The row stays pinned to the old channel's target until the next scheduled check, up to an hour away.

This fingerprints the whole `ResolvedChannel` (channel + feed override + sorted headers) and re-checks only the rows that actually flipped.

## Why polling, not notifications

Cross-process `CFPreferences` change notifications are not reliably delivered on macOS 27 — tested on this machine before choosing the design. So there are two trigger points instead: a bound app launching or quitting (the common "open Settings, flip the toggle, quit" flow) and the DuoUpdater window appearing (the "leave the vendor app running" flow).

**Known limit:** flip the toggle, leave the vendor app running, and never reopen the DuoUpdater window, and neither trigger fires. Not a new failure mode — `AppScanner` already re-resolves the channel on every full scan, so the periodic check still catches it. This only shortens the typical latency.

## Verification

```
swift test (ChannelSwitch filter)   9 passed
swift test (full core)              832 passed
xcodebuild App target               BUILD SUCCEEDED
```

## Review notes

A subagent review found one real defect, fixed in the second commit: `handleRunningAppsChange` fires for **every** process on the machine, and the channel pass hung off it unconditionally — nine vendor-preference reads (one of them a plist read off disk, Surge's) on the main actor, on every app launch and quit all day. Every other `AppScanner`/resolver call site in that file wraps this work in `Task.detached` for exactly that reason; this one was the exception while firing far more often than any of them. It now gates on the bundle id the notification already carried, and resolves off the main actor.

Two things the review confirmed are *not* problems, both worth recording since they're the failure modes this repo has hit before:

- The fingerprint is deterministic — built from an enum's `rawValue`, a URL string, and explicitly **sorted** headers, with no `String(describing:)` or `hashValue`. And it never touches disk (`@ObservationIgnored`, in-memory only), so there is no cross-launch stability requirement and no risk of a spurious re-check storm against GitHub's 60/hr anonymous limit.
- Keying by bundle id is correct here, unlike the pref-key bug fixed elsewhere: all nine bound apps are single-bundle-id apps whose channel is one global vendor preference, not one-per-install-path like Android Studio Canary/Stable.

Independent of the other three PRs in this batch; reviewable in parallel.
