### PR TITLE
Decode changelog feeds instead of scraping them

### DIFF
--- a/App/Sources/Preferences.swift
+++ b/App/Sources/Preferences.swift
@@ -115,7 +115,14 @@ final class Preferences {
     /// `gh` CLI" — `GitHubToken.resolve` treats empty as no explicit value. Persisted
     /// to the Keychain (an empty value clears it).
     var githubToken: String {
-        didSet { Keychain.set(githubToken, account: Self.githubTokenKeychainAccount) }
+        didSet {
+            Keychain.set(githubToken, account: Self.githubTokenKeychainAccount)
+            // The changelog fetcher lives in the core package and cannot reach the
+            // Keychain; without this hand-off it resolves from the environment and
+            // `gh` only, which a launchd-started GUI has neither of. Pushed on
+            // every change so pasting or clearing a token takes effect immediately.
+            ChangelogService.setExplicitGitHubToken(githubToken)
+        }
     }
 
     /// The GitHub login the saved token last verified as, for display in
@@ -365,6 +372,11 @@ final class Preferences {
         self.stagedPackages =
             defaults.dictionary(forKey: Key.stagedPackages) as? [String: [String: String]] ?? [:]
         observeExternalWrites()
+        // `didSet` does not fire for assignments inside `init`, so the token read
+        // out of the Keychain a few lines up would otherwise never reach the core
+        // package — the launch path is precisely the one that has no environment
+        // and no `gh` to fall back on.
+        ChangelogService.setExplicitGitHubToken(self.githubToken)
     }
 
     // MARK: - Cross-process changes

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
@@ -190,7 +190,9 @@ public enum ChangelogExtractor {
 
     /// Turn line-breaking tags into spaces, then drop every remaining tag. Done in
     /// that order so `<br>`/`</p>`/`</li>` don't glue adjacent words together.
-    private static func stripTags(_ s: String) -> String {
+    /// Internal (not `private`) so `StructuredChangelogDecoder` can reuse it for
+    /// vendor HTML that arrives already JSON-unescaped by `Decodable`.
+    static func stripTags(_ s: String) -> String {
         let breaks = try? NSRegularExpression(
             pattern: #"<\s*/?\s*(br|p|li|div|ul|ol)\b[^>]*>"#,
             options: [.caseInsensitive])
@@ -210,7 +212,8 @@ public enum ChangelogExtractor {
     /// Decode the handful of entities that actually show up in changelogs, plus
     /// numeric (`&#39;`, `&#x2019;`) escapes. Deliberately small and pure — we
     /// avoid `NSAttributedString` HTML decoding (heavy and main-thread-only).
-    private static func decodeEntities(_ s: String) -> String {
+    /// Internal (not `private`) — see `stripTags`.
+    static func decodeEntities(_ s: String) -> String {
         var out = s
         let named: [String: String] = [
             "&amp;": "&", "&lt;": "<", "&gt;": ">",
@@ -319,7 +322,8 @@ public enum ChangelogExtractor {
         return out
     }
 
-    private static func collapseWhitespace(_ s: String) -> String {
+    /// Internal (not `private`) — see `stripTags`.
+    static func collapseWhitespace(_ s: String) -> String {
         let collapsed = s.replacingOccurrences(
             of: #"\s+"#, with: " ", options: .regularExpression)
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
@@ -185,7 +185,32 @@ public enum ChangelogExtractor {
                 s = decodeEntities(s)
             }
         }
+        if recipe.markdownSource { s = unwrapMarkdownInlineCode(s) }
         return collapseWhitespace(s)
+    }
+
+    /// Drop the backticks around Markdown inline code, keeping the code text.
+    /// `` 通过`CLI pack cancel`取消打包 `` → `通过CLI pack cancel取消打包`, which is
+    /// what the same note looked like when it came from HTML and `stripTags`
+    /// removed the `<code>` wrapper.
+    ///
+    /// ONE pass, alternating double- then single-backtick spans — not two passes.
+    /// Two passes is the obvious shape and it is wrong: unwrapping ``` ``a `b` c`` ```
+    /// to ``` a `b` c ``` leaves inner backticks that the second pass then eats,
+    /// turning the escape hatch for code-containing-a-backtick into `a b c`. A
+    /// single alternation consumes each span once and never revisits what it
+    /// produced. (Caught by a test, not by reading — the two-pass version looked
+    /// right.)
+    ///
+    /// A lone unpaired backtick stays put: both alternatives are confined to one
+    /// line, so an unterminated span simply doesn't match. The `$1$2` template
+    /// works because a non-participating group substitutes as empty.
+    static func unwrapMarkdownInlineCode(_ s: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: "``([^\n]*?)``|`([^`\n]+?)`")
+        else { return s }
+        return regex.stringByReplacingMatches(
+            in: s, range: NSRange(location: 0, length: (s as NSString).length),
+            withTemplate: "$1$2")
     }
 
     /// Turn line-breaking tags into spaces, then drop every remaining tag. Done in

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1148,27 +1148,70 @@ public enum ChangelogRecipeRegistry {
             itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#],
             maxEntries: 20),
 
-        // Figma (desktop) — figma.com/release-notes is Figma's *product*
-        // release-notes feed (Figma Design / Make / FigJam announcements), NOT
-        // desktop-app build notes: there is no per-entry app version. The desktop
-        // build version lives only at desktop.figma.com/mac/RELEASE.json with no
-        // human notes, so this product feed is the best changelog surface; a parse
-        // miss just falls back to embedding the page (low stakes). The page is
-        // fully server-rendered. Each post is an <article> with
-        //   <time dateTime="Jun 3, 2026">…</time><h2>Title</h2>…<p>…</p>…
-        // We surface the post title as the entry "version" and the post date as
-        // `date`. Figma's CSS class names are hashed per deploy (fig-XXXX), so we
-        // anchor ONLY on generic tags. The item pattern requires <p + whitespace/`>`
-        // so it cannot match the SVG <path> elements inside the "Copy link" button.
+        // Figma (desktop) — read the vendor's own Atom feed rather than the HTML
+        // page: `https://www.figma.com/release-notes/feed/atom.xml`. The `Content-Type`
+        // header on that response reads `application/rss+xml`, but the body is a
+        // standard Atom document (`<feed xmlns="http://www.w3.org/2005/Atom">`) —
+        // don't trust the header, trust the markup. Switched away from the page
+        // (which the entryPattern below used to scrape) because the page's markup is
+        // a client-hydrated shell with CSS classes hashed per deploy — the same
+        // fragility class as every other "scrape the rendered page" recipe in this
+        // file — while the feed's element names (`entry`/`title`/`updated`/`content`)
+        // are a published, stable contract. It also fixes a real bug in the old
+        // recipe: the page lazy-loads posts as you scroll, so the live DOM only ever
+        // had ~8 `<article>` blocks to match against however large `maxEntries` was
+        // set — the feed carries hundreds, so the existing `maxEntries: 20` cap now
+        // actually engages.
+        //
+        // Each entry (captured verbatim 2026-08-19):
+        //   <entry>
+        //       <title type="html"><![CDATA[Recommend resources you want users to discover and use]]></title>
+        //       <id>dece0d00-5f03-4a5d-aa04-3b0fad21b5eb</id>
+        //       <link href="https://www.figma.com/release-notes/?title=…"/>
+        //       <updated>2026-08-17T00:00:00.000Z</updated>
+        //       <content type="html"><![CDATA[Admins can now choose which resources…]]></content>
+        //   </entry>
+        // This is still Figma's *product* release-notes feed (Figma Design / Make /
+        // FigJam announcements), NOT desktop-app build notes — there is no per-entry
+        // app version. The desktop build version lives only at
+        // desktop.figma.com/mac/RELEASE.json with no human notes, so this remains the
+        // best changelog surface, and the post title still fills `version` / the post
+        // date still fills `date` — same mapping as the old page recipe, just read
+        // from a sturdier document.
+        //
+        // Both `title` and `content` are `<![CDATA[…]]>`-wrapped. A naive `<[^>]*>`
+        // tag-stripper applied BEFORE the CDATA payload is pulled out will eat the
+        // whole `<![CDATA[…]]>` construct, because `[^>]*` happily reads through to
+        // the `>` that closes `]]>` — so the capture groups below land strictly
+        // *inside* the CDATA delimiters (`<!\[CDATA\[(?<…>.*?)\]\]>`), and the
+        // generic stripTags/decodeEntities cleanup only ever runs on text already
+        // isolated that way. Checked against the live feed (444 entries, 2026-08-19):
+        // no entry's title or content carries embedded HTML tags today, so that
+        // cleanup is currently a no-op — but the ordering is still correct for the
+        // day one does.
+        //
+        // `date` truncates the ISO timestamp to just its date portion (`[^T]+` before
+        // the literal `T`) — the same convention already used for the GitHub-releases
+        // recipes (Ollama, RustDesk) reading `<relative-time datetime="…">`, and the
+        // prevailing `YYYY-MM-DD` shape most recipes in this file use.
+        //
+        // Trade-off (accepted, not a regression): `content` is a one-sentence
+        // summary, not the fuller multi-paragraph prose the HTML page rendered for
+        // its top posts. Verified against the same 8 posts on 2026-08-19: combined
+        // item text drops from 3390 to 1062 characters (31%) versus the old
+        // `<article>`/`<p>` scrape, while every title and date matches byte-for-byte.
+        // Chosen deliberately for stability over completeness.
         ChangelogRecipe(
             bundleID: "com.figma.Desktop",
-            source: URL(string: "https://www.figma.com/release-notes/")!,
+            source: URL(string: "https://www.figma.com/release-notes/feed/atom.xml")!,
             entryPattern:
-                #"<article[^>]*>.*?"#
-                + #"<time[^>]*dateTime="(?<date>[^"]+)"[^>]*>[^<]*</time>\s*"#
-                + #"<h2[^>]*>(?<version>.*?)</h2>"#
-                + #"(?<body>.*?)</article>"#,
-            itemPatterns: [#"<p(?:\s[^>]*)?>(?<item>.*?)</p>"#],
+                #"<entry>\s*"#
+                + #"<title type="html"><!\[CDATA\[(?<version>.*?)\]\]></title>\s*"#
+                + #"<id>[^<]*</id>\s*"#
+                + #"<link[^>]*/>\s*"#
+                + #"<updated>(?<date>[^T]+)T[^<]*</updated>\s*"#
+                + #"(?<body><content type="html"><!\[CDATA\[.*?\]\]></content>)"#,
+            itemPatterns: [#"<content type="html"><!\[CDATA\[(?<item>.*?)\]\]></content>"#],
             maxEntries: 20),
 
         // 1Password 8 (Mac) — the STABLE channel's RSS feed, `…/mac/stable/index.xml`,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -714,56 +714,93 @@ public enum ChangelogRecipeRegistry {
             maxEntries: 30,
             structuredFormat: .postmanReleaseNotes),
 
-        // HBuilderX (DCloud) — two-stage, and deliberately NOT pointed at
-        // update.dcloud.net.cn: that host 302s the changelog HTML to a per-request
-        // tokenized CDN node on a non-standard port (…qrstuvwxyzab.com:22443),
-        // which under many networks crawls past the 15s fetch timeout — the app
-        // then spins and degrades to the embedded web page. The download-site host
-        // download1.dcloud.net.cn serves the very same HTML directly (200, no
-        // redirect, ~0.3s), so we go there instead.
+        // HBuilderX (DCloud) — SINGLE-hop now, not two-stage: hx.dcloud.net.cn
+        // serves a plain markdown changelog directly (200, ~95 KB, no redirect,
+        // no per-request tokenized CDN hop), so there is no index page to follow
+        // and no `indexLinkPattern` here anymore (that's how the old
+        // download1.dcloud.net.cn/release.json + HTML-detail-page two-stage
+        // fetch worked; this recipe replaces it wholesale, not on top of it).
+        // NOT `structuredFormat`: that decoder path (`StructuredChangelogDecoder`)
+        // is for feeds too irregular for the regex extractor; this one is a
+        // clean, uniform `## <version>` / `* <item>` document that the regex
+        // path (same as com.anthropic.claudefordesktop above) handles
+        // directly — and `structuredFormat` would also disable
+        // `indexLinkPattern` handling in `ChangelogService`, which is irrelevant
+        // here anyway since there's no second hop to disable.
         //
-        // `source` is the download page's `release.json` config; `indexLinkPattern`
-        // follows its `release` field to the current changelog page on download1.
-        // That field always names the latest build, so this also retires the old
-        // version-pinned URL — a new HBuilderX release is picked up with no rebuild
-        // (same win as VLC/Ghostty). The detail page is a cumulative list: each
-        // release is an <h2>X.Y.Z</h2> (the build encodes YYYYMMDD, no separate
-        // date), then module-section <h3>s and <li> change items.
+        // Format: `## 5.24.2026081301` heading (the build IS the version, no
+        // separate date — same as the old HTML: there was never a `date` group
+        // there either, so this is not a regression), then `* ` bullet lines,
+        // e.g. `* 修复 ... [详情](https://issues.dcloud.net.cn/...)`. The
+        // trailing `[详情](url)` / `[文档](url)` markdown link (occasionally two
+        // in a row, occasionally followed by a bare `<url>` autolink) is stripped
+        // by the item pattern rather than kept literal — flattening it to just
+        // the link text (as `StructuredChangelogDecoder.bulletItems` does for
+        // the structured path) isn't reachable from here without a much bigger
+        // change to the regex extractor, so instead the pattern simply excludes
+        // any *trailing* link syntax from the captured item. This covers the
+        // overwhelming majority of lines (verified: 1301/1303 items across both
+        // documents — 618 in release, 685 in alpha — have their link(s) fully
+        // stripped this way; the sole exception in EACH document is one line
+        // where the link sits mid-sentence rather than at the end — that rare
+        // case is left with its `[text](url)` literal intact).
+        //
+        // Content scope: this md endpoint covers only the HBuilder IDE itself —
+        // the old HTML detail page's other module sections (uni-app x, uni-app,
+        // uts插件, uniCloud, App插件) aren't in it. That's an intentional
+        // narrowing (confirmed against the HTML: every md item matches an
+        // HBuilder-section item in the HTML verbatim, including issue ids — it's
+        // a subset, not a rewrite/summary), so fewer items per entry here vs.
+        // before is expected, not a parsing regression.
+        //
+        // Version group has no `-alpha` suffix, matching only bare `X.Y.Z`
+        // headings (the alpha recipe below requires the suffix) — moot in
+        // practice since the two channels are served from separate documents,
+        // but kept for the same belt-and-suspenders reason the old HTML regexes
+        // did.
         ChangelogRecipe(
             bundleID: "io.dcloud.HBuilderX",
-            source: URL(string: "https://download1.dcloud.net.cn/hbuilderx/release.json")!,
+            source: URL(
+                string: "https://hx.dcloud.net.cn/zh-cn/Tutorial/changelog/ReleaseNote_release.md")!,
             entryPattern:
-                #"<h2[^>]*>(?<version>[0-9]+\.[0-9]+\.[0-9]+)</h2>"#
+                #"## (?<version>[0-9]+\.[0-9]+\.[0-9]+)\n"#
                 + #"(?<body>.*?)"#
-                + #"(?=<h2[^>]*>[0-9]|$)"#,
-            itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#],
-            // The page is a years-long cumulative list (~28 builds, each with many
-            // module-section items); cap to the recent handful — the detail view
-            // only needs "what changed lately", and this also halts the parse early.
+                + #"(?=\n## |$)"#,
+            itemPatterns: [
+                #"(?:^|\n)[ \t]*\*[ \t]+(?<item>[^\n]+?)(?:\s*\[[^\]\n]*\]\([^)\n]*\))*(?:\s*<[^>\n]*>)?(?=\n|$)"#
+            ],
+            stripTags: false,
+            decodeEntities: false,
+            // The doc is a years-long cumulative list (32 versions); cap to the
+            // recent handful, same as before.
             maxEntries: 10,
-            minItemLength: 4,
-            indexLinkPattern: #""release"\s*:\s*"(?<link>https://[^"]+)""#),
+            minItemLength: 4),
 
         // HBuilderX Alpha (DCloud) — the alpha is a SEPARATE app (bundle id
         // io.dcloud.HBuilderXAlpha, ships as HBuilderX-Alpha.app), so it needs its
         // own recipe; the stable io.dcloud.HBuilderX one never matches it. Same
-        // two-stage shape as stable but reading `alpha.json`, whose `release` field
-        // points at the alpha changelog page on download1. The page is structured
-        // exactly like the stable one except every version <h2> carries an "-alpha"
-        // suffix (5.11.2026052520-alpha), so the version group requires it — which
-        // also means a stray stable <h2> could never be mis-captured here.
+        // single-hop markdown shape as stable, reading the alpha document
+        // instead, whose version headings all carry an "-alpha" suffix
+        // (5.23.2026080313-alpha) — the version group requires it, so a stray
+        // stable heading could never be mis-captured here. See the stable
+        // recipe above for the full rationale (single-hop rewrite, why not
+        // `structuredFormat`, link-stripping, and the HBuilder-IDE-only scope).
         ChangelogRecipe(
             bundleID: "io.dcloud.HBuilderXAlpha",
-            source: URL(string: "https://download1.dcloud.net.cn/hbuilderx/alpha.json")!,
+            source: URL(
+                string: "https://hx.dcloud.net.cn/zh-cn/Tutorial/changelog/ReleaseNote_alpha.md")!,
             entryPattern:
-                #"<h2[^>]*>(?<version>[0-9]+\.[0-9]+\.[0-9]+-alpha)</h2>"#
+                #"## (?<version>[0-9]+\.[0-9]+\.[0-9]+-alpha)\n"#
                 + #"(?<body>.*?)"#
-                + #"(?=<h2[^>]*>[0-9]|$)"#,
-            itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#],
-            // Alpha lists 60+ builds; same cap as stable — recent handful only.
+                + #"(?=\n## |$)"#,
+            itemPatterns: [
+                #"(?:^|\n)[ \t]*\*[ \t]+(?<item>[^\n]+?)(?:\s*\[[^\]\n]*\]\([^)\n]*\))*(?:\s*<[^>\n]*>)?(?=\n|$)"#
+            ],
+            stripTags: false,
+            decodeEntities: false,
+            // Alpha document lists 67 versions; same cap as stable.
             maxEntries: 10,
-            minItemLength: 4,
-            indexLinkPattern: #""release"\s*:\s*"(?<link>https://[^"]+)""#),
+            minItemLength: 4),
 
         // Ollama — GitHub releases page. Each release is a <section> with an
         // sr-only h2 (version tag, e.g. "v0.30.0"), a <relative-time> element

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -270,18 +270,19 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// The literal request body to send when `httpMethod == .post`, as raw bytes
     /// (already-encoded JSON, in practice). nil for every `.get` recipe.
     ///
-    /// ⚠️ Cache-key caveat: `ChangelogCache`/`ChangelogDiskCache` key on the
-    /// resolved *URL*, not on (URL, method, body) — a POST endpoint's URL is the
-    /// same for every request regardless of body. That is safe today only
-    /// because exactly one recipe (Notion) uses POST and its body is a fixed,
-    /// hardcoded literal — every fetch of that URL sends the identical body, so
-    /// there is nothing for the cache to confuse. If a second recipe is ever
-    /// added that POSTs a *different* body to the *same* URL (e.g. paginating
-    /// with a different cursor, or targeting a different page id on the same
-    /// host), it WILL read the first recipe's cached response instead of making
-    /// its own request. Fixing that properly means folding a body hash into the
-    /// cache key everywhere — not done here because it is unneeded until that
-    /// second case exists.
+    /// ⚠️ Cache-key caveat, stated precisely because the first version of this
+    /// comment named the wrong mechanism for both caches: `ChangelogCache` keys on
+    /// (resolved URL, channel) — no bundle id and no body — so two recipes POSTing
+    /// different bodies to the same URL on the same channel would collide, and the
+    /// second would read the first's response. `ChangelogDiskCache.Key` is
+    /// (bundleID, channel, version), which cannot collide on URL at all and is
+    /// therefore not part of this hazard.
+    ///
+    /// Safe today because exactly one recipe (Notion) uses POST and its body is a
+    /// fixed, hardcoded literal. Fixing it properly means folding a body hash into
+    /// `ChangelogCache`'s key — not done here because it is unneeded until a
+    /// second POST recipe exists (paginating with a different cursor, or another
+    /// page id on the same host).
     public let requestBody: Data?
 
     public init(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -169,6 +169,12 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// lost its last bullet). Decoding the JSON hands us real newlines and
         /// retires that whole class of bug.
         case chatwiseReleases
+        /// GitHub Desktop's `central.github.com/deployments/desktop/desktop/
+        /// changelog.json` (and its `?env=beta` twin, a separate URL/recipe) — a flat
+        /// array of `{name, notes, pub_date, version}`, newest-first, where `notes` is
+        /// already an array of one-line strings. No regex needed; the decoder just
+        /// walks the array.
+        case gitHubDesktopChangelog
     }
 
     /// Non-nil → this recipe is parsed by a structured decoder, not the regex
@@ -1466,36 +1472,30 @@ public enum ChangelogRecipeRegistry {
         // plain JSON array, newest-first, each element:
         //   {"name":"","notes":["[Fixed] …- #22219", …],
         //    "pub_date":"2026-06-01T17:43:05Z","version":"3.5.12"}
-        // `version` is LAST in each object, so the entry pattern walks name→notes→
-        // pub_date→version in document order; `body` is the notes array, sliced into
-        // items by the JSON-string pattern (each note keeps its `[Fixed]`/`[Added]`
-        // prefix and trailing `- #issue`). Stable feed carries bare `3.5.12`; beta
-        // carries `3.5.12-beta2`. JSON mode + decodeEntities unescapes the `\"` some
-        // beta notes contain. A parse miss just falls back to embedding the SPA.
+        // `notes` is already an array of one-line strings (each keeping the vendor's
+        // own `[Fixed]`/`[Added]`/`[Improved]` prefix and trailing `- #issue`) — this
+        // feed was structured JSON all along, so it's decoded by
+        // `StructuredChangelogDecoder.decodeGitHubDesktop` rather than regex-scraped;
+        // see `.gitHubDesktopChangelog` for the shape. Stable feed carries bare
+        // `3.5.12`; beta carries `3.5.12-beta2`. A parse miss just falls back to
+        // embedding the SPA. `channel` here is only for the recipe-registry lookup
+        // (`ChangelogRecipeRegistry.recipe(forBundleID:channel:)` picks stable vs.
+        // beta by it) — the decoder itself takes no channel, since stable and beta
+        // are two different URLs, not one document split by a channel key.
         ChangelogRecipe(
             bundleID: "com.github.GitHubClient",
             source: URL(string: "https://central.github.com/deployments/desktop/desktop/changelog.json")!,
-            entryPattern:
-                #"\{"name":"[^"]*","notes":\[(?<body>.*?)\],"#
-                + #""pub_date":"(?<date>\d{4}-\d{2}-\d{2})[^"]*","version":"(?<version>[^"]+)"\}"#,
-            itemPatterns: [#""(?<item>(?:\\.|[^"\\])*)""#],
-            mode: .json,
-            stripTags: false,
-            channel: .stable),
+            channel: .stable,
+            structuredFormat: .gitHubDesktopChangelog),
 
         // GitHub Desktop Beta — same feed with `?env=beta`, matched by `channel:
         // .beta` so a `-betaN`-detected install gets beta notes (`3.5.12-beta2`)
-        // instead of the stable train. Identical structure/patterns.
+        // instead of the stable train. Identical structured decoder.
         ChangelogRecipe(
             bundleID: "com.github.GitHubClient",
             source: URL(string: "https://central.github.com/deployments/desktop/desktop/changelog.json?env=beta")!,
-            entryPattern:
-                #"\{"name":"[^"]*","notes":\[(?<body>.*?)\],"#
-                + #""pub_date":"(?<date>\d{4}-\d{2}-\d{2})[^"]*","version":"(?<version>[^"]+)"\}"#,
-            itemPatterns: [#""(?<item>(?:\\.|[^"\\])*)""#],
-            mode: .json,
-            stripTags: false,
-            channel: .beta),
+            channel: .beta,
+            structuredFormat: .gitHubDesktopChangelog),
 
         // (No Alcove recipe. It parsed the `body` of update.tryalcove.com, which the
         // vendor retired outright — NXDOMAIN. Its replacement as the public version

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -169,6 +169,16 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// lost its last bullet). Decoding the JSON hands us real newlines and
         /// retires that whole class of bug.
         case chatwiseReleases
+        /// SunLogin/AweSun's `client-webapi.oray.com/softwares/…` API — the same
+        /// endpoint the `VendorProbeRecipe` reads for the version number. Its
+        /// top-level `logs` array holds one object per release, already
+        /// newest-first; each object's own `logs` field is a fixed
+        /// `<ol><li>version</li><li>item</li>…</ol>` HTML fragment (the first
+        /// `<li>` names the version, the rest are the change lines) alongside a
+        /// plain `updatedate` timestamp. Regex-extractable in principle (and
+        /// previously extracted that way), but JSONDecoder resolves the payload's
+        /// `\uXXXX`/`\/` escapes for free, which the regex path had to redo by hand.
+        case sunLoginSoftwareLogs
         /// GitHub Desktop's `central.github.com/deployments/desktop/desktop/
         /// changelog.json` (and its `?env=beta` twin, a separate URL/recipe) — a flat
         /// array of `{name, notes, pub_date, version}`, newest-first, where `notes` is
@@ -520,18 +530,15 @@ public enum ChangelogRecipeRegistry {
                 + #"<ul[^>]*>(?<body>.*?)</ul>"#,
             itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#]),
 
-        // AweSun (Oray) — same JSON API as the VendorProbeRecipe. The response is a
-        // top-level object; its `logs` array has one element per release. Each element
-        // has an HTML `logs` field (<ol><li>version<\/li><li>item…<\/li>…<\/ol>) and
-        // an ISO-date `updatedate`. Non-ASCII text is \uXXXX-encoded in the raw JSON;
-        // `decodeEntities` resolves those via the JSON-Unicode-escape pass.
+        // AweSun (Oray) — same JSON API as the VendorProbeRecipe (verified live
+        // 2026-08-21: GET returns 200/~15KB; the earlier "50 bytes" observation
+        // that prompted a re-check did not reproduce and the endpoint/logic are
+        // both healthy — see `sunLoginSoftwareLogs`'s doc comment for the shape).
         ChangelogRecipe(
             bundleID: "com.oray.sunlogin.macclient",
             source: URL(string: "https://client-webapi.oray.com/softwares/SUNLOGIN_X_MAC_ARM?versiontype=stable")!,
-            entryPattern:
-                #""logid":\d+.*?"logs":"<ol><li>(?<version>[^<]+)<\\/li>(?<body>.*?)<\\/ol>".*?"updatedate":"(?<date>\d{4}-\d{2}-\d{2})"#,
-            itemPatterns: [#"<li>(?<item>.*?)<\\/li>"#],
-            mode: .json),
+            mode: .json,
+            structuredFormat: .sunLoginSoftwareLogs),
 
         // WeType (微信输入法) — same official changelog page as its VendorProbe.
         // Next.js page with the data server-rendered inline (an `__next_f` RSC blob,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -80,6 +80,22 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// strip would eat exactly that.
     public var escapedMarkup: Bool
 
+    /// The captured text is Markdown source, not HTML — so the inline syntax that
+    /// `stripTags` would have removed from an HTML equivalent survives into the
+    /// rendered note as literal punctuation. HBuilderX's official release notes
+    /// spell inline code as `` `CLI pack cancel` ``; the HTML page they replaced
+    /// spelled it `<code>CLI pack cancel</code>`, which `stripTags` removed, so
+    /// without this the migration puts visible backticks in front of the user.
+    ///
+    /// Deliberately narrow: it unwraps inline code spans and nothing else. Bold,
+    /// emphasis and headings would need real Markdown rendering (`Changelog`
+    /// already has `.markdown` item syntax for producers that keep their source
+    /// intact); this flag exists for recipes whose *output contract is plain
+    /// text*, to restore the parity an HTML→Markdown source swap otherwise breaks.
+    /// Link syntax is not touched here — a recipe reading Markdown is expected to
+    /// consume links in its `itemPatterns`, as HBuilderX's does.
+    public var markdownSource: Bool
+
     /// Keep at most this many entries (changelogs run for years; the detail view
     /// only needs the recent ones). Nil = keep all. Default 40.
     public var maxEntries: Int?
@@ -277,6 +293,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         stripTags: Bool = true,
         decodeEntities: Bool = true,
         escapedMarkup: Bool = false,
+        markdownSource: Bool = false,
         maxEntries: Int? = 40,
         minItemLength: Int = 1,
         indexLinkPattern: String? = nil,
@@ -297,6 +314,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         self.stripTags = stripTags
         self.decodeEntities = decodeEntities
         self.escapedMarkup = escapedMarkup
+        self.markdownSource = markdownSource
         self.maxEntries = maxEntries
         self.minItemLength = minItemLength
         self.indexLinkPattern = indexLinkPattern
@@ -365,6 +383,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         stripTags = try c.decodeIfPresent(Bool.self, forKey: .stripTags) ?? true
         decodeEntities = try c.decodeIfPresent(Bool.self, forKey: .decodeEntities) ?? true
         escapedMarkup = try c.decodeIfPresent(Bool.self, forKey: .escapedMarkup) ?? false
+        markdownSource = try c.decodeIfPresent(Bool.self, forKey: .markdownSource) ?? false
         maxEntries = try c.decodeIfPresent(Int?.self, forKey: .maxEntries) ?? 40
         minItemLength = try c.decodeIfPresent(Int.self, forKey: .minItemLength) ?? 1
         indexLinkPattern = try c.decodeIfPresent(String.self, forKey: .indexLinkPattern)
@@ -845,6 +864,7 @@ public enum ChangelogRecipeRegistry {
             ],
             stripTags: false,
             decodeEntities: false,
+            markdownSource: true,
             // The doc is a years-long cumulative list (32 versions); cap to the
             // recent handful, same as before.
             maxEntries: 10,
@@ -872,6 +892,7 @@ public enum ChangelogRecipeRegistry {
             ],
             stripTags: false,
             decodeEntities: false,
+            markdownSource: true,
             // Alpha document lists 67 versions; same cap as stable.
             maxEntries: 10,
             minItemLength: 4),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -185,6 +185,15 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// already an array of one-line strings. No regex needed; the decoder just
         /// walks the array.
         case gitHubDesktopChangelog
+        /// Postman's `mkt.cdn.postman.com/.../app-release-notes.json` — a `notes[]`
+        /// array (newest-first) of `{version, content, createdAt}`, `content` being
+        /// markdown whose line separator is `\r\n` in *recent* entries but a bare
+        /// `\n` in older ones. The prior regex path only recognized the escaped
+        /// `\r\n` (`\\r\\n`) form and, worse, its item capture (`[^\\]{10,}`) stops
+        /// at the first backslash — so a line with an escaped quote (`\"8000\"`)
+        /// got silently truncated mid-sentence. Decoding the JSON for real yields
+        /// genuine newlines and un-escaped text, sidestepping both problems.
+        case postmanReleaseNotes
     }
 
     /// Non-nil → this recipe is parsed by a structured decoder, not the regex
@@ -684,25 +693,26 @@ public enum ChangelogRecipeRegistry {
             ],
             indexLinkPattern: #"href="(?<link>/docs/install/release-notes/\d[^"]*)""#),
 
-        // Postman — CDN-hosted JSON array under the "notes" key. Each element has
-        // "version", "content" (Markdown, \\r\\n line separators in raw JSON), and
-        // "createdAt" (ISO-8601). itemPattern strips the #### feature-heading prefix
-        // and skips ## / ### section headers and the trailing date line; plain
-        // description lines that follow a heading are also captured.
+        // Postman — CDN-hosted JSON array under the "notes" key (newest-first).
+        // Each element has "version", "content" (Markdown; `\r\n` line separators in
+        // recent entries, bare `\n` in older ones) and "createdAt" (ISO-8601).
+        // Structured decode (StructuredChangelogDecoder.decodePostman): split
+        // `content` on real newlines, strip the `#### ` feature-heading prefix
+        // (keeping the heading text as an item), skip `##`/`###` section headers and
+        // the "August 21, 2026"-style date line, drop lines under 10 chars, keep
+        // everything else (including markdown syntax like `**bold**` / `[t](url)`
+        // verbatim — nothing downstream strips it for this recipe). This replaces a
+        // regex itemPattern that only recognized the escaped `\\r\\n` form and, on
+        // top of that, truncated any line containing an escaped quote at the
+        // backslash (`[^\\]{10,}` stops there) — confirmed against the live feed:
+        // 2 of the 30 most recent releases had a mid-sentence truncation the old
+        // path produced silently.
         ChangelogRecipe(
             bundleID: "com.postmanlabs.mac",
             source: URL(string: "https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json")!,
-            entryPattern:
-                #""version"\s*:\s*"(?<version>[^"]+)""#
-                + #".*?"content"\s*:\s*"(?<body>(?:\\.|[^"\\])*)""#
-                + #".*?"createdAt"\s*:\s*"(?<date>[^"T]+)"#,
-            itemPatterns: [
-                #"\\r\\n(?:####\s+)?(?!##|\\r\\n|\w+ \d+, \d{4})(?<item>[^\\]{10,})"#,
-            ],
             mode: .json,
-            stripTags: false,
-            decodeEntities: false,
-            maxEntries: 30),
+            maxEntries: 30,
+            structuredFormat: .postmanReleaseNotes),
 
         // HBuilderX (DCloud) — two-stage, and deliberately NOT pointed at
         // update.dcloud.net.cn: that host 302s the changelog HTML to a per-request

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -158,6 +158,17 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// need the vendor's ordinal/marker decoration stripped and the category
         /// headings folded in, which the extractor has no shape for.
         case weChatDevToolsLog
+        /// ChatWise's `releases.chatwise.app/releases` — a newest-first ARRAY of
+        /// `{version, changelog, assets, date}` where `changelog` is a markdown
+        /// bullet list. Shallow enough for the regex path in principle, but the
+        /// notes live inside a JSON *string*, so every newline in them is a
+        /// two-character `\n` escape and an item pattern has to spell its
+        /// separators as `\\n` — a trap the shipped pattern fell into (its tail
+        /// alternative `\\n?$` read as "a backslash, optionally followed by an
+        /// `n`", so any entry whose notes did NOT end in a trailing `\n` escape
+        /// lost its last bullet). Decoding the JSON hands us real newlines and
+        /// retires that whole class of bug.
+        case chatwiseReleases
     }
 
     /// Non-nil → this recipe is parsed by a structured decoder, not the regex
@@ -347,27 +358,21 @@ public enum ChangelogRecipeRegistry {
             decodeEntities: false,
             maxEntries: 20),
 
-        // ChatWise — the /changelog page hydrates client-side from the public
-        // releases JSON endpoint. The current payload order is:
-        //   {"version":"26.5.3","changelog":"- Add Claude Opus 4.8...\\n",
-        //    "assets":[...],"date":"2026-05-29T07:02:44.116Z"}
-        // Notes are markdown bullet lines, so keep tags intact and split on `- `.
-        // We match the fields in the order the live endpoint currently emits them;
-        // a parse miss simply falls back to the page link, so shipping coverage is
-        // still the right bias here.
+        // ChatWise — the public /changelog page is a SvelteKit shell (a ~4 KB
+        // document with no notes in it) that hydrates from the releases JSON
+        // endpoint, so we read that endpoint directly. It is a newest-first array:
+        //   {"version":"26.6.0","changelog":"- new provider: cloudflare workers ai",
+        //    "assets":[...],"date":"2026-06-26T16:04:26.161Z"}
+        // Decoded as JSON rather than regex-scraped: the notes are a markdown
+        // bullet list living inside a JSON string, so on the regex path every
+        // newline is a literal `\n` escape that an item pattern must spell as
+        // `\\n` — see `.chatwiseReleases` for the last-bullet bug that cost us.
         ChangelogRecipe(
             bundleID: "app.chatwise",
             source: URL(string: "https://releases.chatwise.app/releases")!,
-            entryPattern:
-                #"\{\s*"version"\s*:\s*"(?<version>[^"]+)".*?"changelog"\s*:\s*"(?<body>(?:\\.|[^"\\])*)".*?"date"\s*:\s*"(?<date>[^"]+)""#,
-            itemPatterns: [
-                #"(?:^|\\n)-\s*(?<item>.*?)\s*(?=\\n-\s|\\n?$)"#,
-                #"\s*(?<item>.+?)\s*$"#
-            ],
             mode: .json,
-            stripTags: false,
-            decodeEntities: false,
-            maxEntries: 20),
+            maxEntries: 20,
+            structuredFormat: .chatwiseReleases),
 
         // VS Code — the official `/updates` page redirects to the latest stable
         // release page (e.g. /updates/v1_123). The top summary is:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -203,6 +203,26 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// entries. `Decodable` sidesteps it entirely — the JSON string is already
         /// unescaped by the time the decoder sees it.
         case jetBrainsProductReleases
+        /// The GitHub Releases API list for `zed-industries/zed`
+        /// (`api.github.com/repos/zed-industries/zed/releases?per_page=40`), read
+        /// instead of scraping `zed.dev/releases/{stable,preview}` — those pages
+        /// are 2+ MB of server-rendered HTML for content GitHub already serves as
+        /// compact JSON, and we already fetch this same endpoint for version
+        /// detection (`GitHubReleaseRule`, see `GitHubReleasesSource.swift`).
+        /// Verified 2026-08-21 that a release's `body` is byte-identical in
+        /// substance to the zed.dev page's rendered notes for that version (42/42
+        /// and 65/65 bullets matched exactly on a real stable and a real preview
+        /// release). One endpoint, both channels: `prerelease` (true ⟺ the tag
+        /// ends `-pre`, no exceptions in 100 sampled releases) selects Preview vs
+        /// Stable via the recipe's existing `channel` field, same as Warp's
+        /// `warpChannelVersions`. `per_page=40` is sized off a real sample where
+        /// stable/preview releases interleave roughly 1:1 with occasional bursts
+        /// of 2 in a row: the first 40 releases held 22 preview / 18 stable, both
+        /// comfortably over the `maxEntries: 15` this recipe (like the old one)
+        /// asks for. A single page, never paginated — GitHub's rate limit is
+        /// unauthenticated (60/hour/IP) and `ChangelogService` doesn't attach a
+        /// token.
+        case zedGitHubReleases
     }
 
     /// Non-nil → this recipe is parsed by a structured decoder, not the regex
@@ -843,42 +863,31 @@ public enum ChangelogRecipeRegistry {
                 + #"<div[^>]*class="markdown-body[^"]*"[^>]*>(?<body>.*?)</div>\s*</div>"#,
             itemPatterns: [#"<li>(?<item>.*?)</li>"#]),
 
-        // Zed Preview — zed.dev/releases/preview is a fully server-rendered page
-        // with all recent pre-release versions inline. Each version block is a
-        // <div id="zed-X.Y.Z"> with a two-cell header (version + date) and an
-        // <article> containing the notes — either a simple <ul><li>…</li></ul>
-        // for patch releases, or section <h2>/<h3> + nested <ul> for weekly
-        // feature releases. The item pattern picks up all <li> regardless of
-        // nesting depth. Entries with no <li> items (e.g. "No public-facing
-        // changes…") naturally produce zero items and are silently skipped.
+        // Zed Preview and Stable — both used to scrape the 2+ MB server-rendered
+        // zed.dev/releases/{preview,stable} pages (`<div id="zed-X.Y.Z">` blocks
+        // with an `<article>` of `<li>` items). Replaced 2026-08-21 with the
+        // GitHub Releases API list we already fetch for version detection
+        // (`GitHubReleaseRule` in `GitHubReleasesSource.swift`, bundle ids
+        // `dev.zed.Zed` / `dev.zed.Zed-Preview`): one JSON response instead of two
+        // multi-megabyte HTML pages, and verified byte-for-byte equivalent notes
+        // (see `StructuredFormat.zedGitHubReleases`). Both channels share this one
+        // recipe's URL; `StructuredChangelogDecoder` splits on `channel` the same
+        // way it does for Warp.
         ChangelogRecipe(
             bundleID: "dev.zed.Zed-Preview",
-            source: URL(string: "https://zed.dev/releases/preview")!,
-            entryPattern:
-                #"id="zed-(?<version>\d+\.\d+\.\d+)"[^>]*>.*?"#
-                + #"<p[^>]*whitespace-nowrap[^>]*>(?<date>[^<]+)</p>"#
-                + #".*?(?<body><article[^>]*>.*?</article>)"#,
-            itemPatterns: [
-                #"<li[^>]*>(?<item>.*?)</li>"#,
-                // Fallback for "no public-facing changes" entries that have
-                // only a <p> note and no <li> items.
-                #"<p[^>]*>(?<item>.+?)</p>"#,
-            ],
-            maxEntries: 15),
+            source: URL(
+                string: "https://api.github.com/repos/zed-industries/zed/releases?per_page=40")!,
+            maxEntries: 15,
+            channel: .preview,
+            structuredFormat: .zedGitHubReleases),
 
-        // Zed Stable — identical page structure, different channel URL.
         ChangelogRecipe(
             bundleID: "dev.zed.Zed",
-            source: URL(string: "https://zed.dev/releases/stable")!,
-            entryPattern:
-                #"id="zed-(?<version>\d+\.\d+\.\d+)"[^>]*>.*?"#
-                + #"<p[^>]*whitespace-nowrap[^>]*>(?<date>[^<]+)</p>"#
-                + #".*?(?<body><article[^>]*>.*?</article>)"#,
-            itemPatterns: [
-                #"<li[^>]*>(?<item>.*?)</li>"#,
-                #"<p[^>]*>(?<item>.+?)</p>"#,
-            ],
-            maxEntries: 15),
+            source: URL(
+                string: "https://api.github.com/repos/zed-industries/zed/releases?per_page=40")!,
+            maxEntries: 15,
+            channel: .stable,
+            structuredFormat: .zedGitHubReleases),
 
         // OrbStack — VitePress docs at docs.orbstack.dev/release-notes. The page
         // is server-side rendered with the full changelog inline. Each version is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -194,6 +194,15 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// got silently truncated mid-sentence. Decoding the JSON for real yields
         /// genuine newlines and un-escaped text, sidestepping both problems.
         case postmanReleaseNotes
+        /// JetBrains' `data.services.jetbrains.com/products/releases?code=<CODE>`
+        /// (shared by IntelliJ IDEA's `IIU` and Toolbox App's `TBA`) —
+        /// `{"<CODE>": [{date, version, whatsnew, …}]}`. Regex-extractable in
+        /// principle (and formerly regex-extracted), but `whatsnew` is JSON-escaped
+        /// HTML whose embedded `\n` is exactly the two-char-escape trap that motivated
+        /// this decoder family: an item pattern that gets that wrong silently drops
+        /// entries. `Decodable` sidesteps it entirely — the JSON string is already
+        /// unescaped by the time the decoder sees it.
+        case jetBrainsProductReleases
     }
 
     /// Non-nil → this recipe is parsed by a structured decoder, not the regex
@@ -1371,47 +1380,40 @@ public enum ChangelogRecipeRegistry {
             maxEntries: 20),
 
         // IntelliJ IDEA — same JetBrains data-services API as Toolbox (`IIU`
-        // product code, stable releases only via `type=release`). Each entry's
-        // `whatsnew` is well-structured HTML: a lead `<p>` summary then `<ul><li>`
-        // bug/feature bullets with YouTrack links. The item pattern sweeps `<li>`
-        // only — the lead `<p>` ("IntelliJ IDEA X is out with…") is a boilerplate
-        // intro, not a discrete change line, so skipping it is cleaner. Major
-        // releases (2026.1) carry a richer `whatsnew` with `<strong>` section
-        // headings inside `<p>` tags; those section labels are short enough to
-        // read as items, so the `<li>` pattern suffices for both shapes.
+        // product code, stable releases only via `type=release`). Structured decode
+        // (`StructuredChangelogDecoder.decodeJetBrainsProductReleases`): the old
+        // regex path read `whatsnew` as raw JSON-escaped text, where an embedded
+        // `\n` is a two-character escape a hand-written item pattern can silently
+        // mis-anchor on (the ChatWise-class bug this decoder family exists to avoid).
+        // `Decodable` unescapes the JSON string for us, so the decoder walks real
+        // HTML instead: `whatsnew` is a lead `<p>` summary then `<ul><li>` bullets,
+        // and only the `<li>` bullets count as discrete changes — the lead `<p>`
+        // is boilerplate ("IntelliJ IDEA X is out with…"). A hotfix release with no
+        // `<li>` at all (its content is plain `<p>` prose, or just a pointer to the
+        // release notes) yields zero items and is skipped, same as the regex did.
         ChangelogRecipe(
             bundleID: "com.jetbrains.intellij",
             source: URL(string: "https://data.services.jetbrains.com/products/releases?code=IIU&type=release")!,
-            entryPattern:
-                #""date"\s*:\s*"(?<date>\d{4}-\d{2}-\d{2})".*?"#
-                + #""version"\s*:\s*"(?<version>[^"]+)".*?"#
-                + #""whatsnew"\s*:\s*"(?<body>(?:\\.|[^"\\])*)""#,
-            itemPatterns: [#"<li>(?<item>.*?)</li>"#],
-            mode: .json,
-            maxEntries: 20),
+            maxEntries: 20,
+            structuredFormat: .jetBrainsProductReleases),
 
         // JetBrains Toolbox App — JetBrains publishes no public changelog page
         // (long-requested: YouTrack TBX-2807), but the official product-releases
         // API the download site itself uses returns the full history as JSON. The
-        // `TBA` product code is the Toolbox App; each element of the TBA array is
-        // one release with `version` ("3.5"), `build` ("3.5.0.84344"), `date`, and
-        // a `whatsnew` HTML string. Fields run date … version … build … whatsnew,
-        // so the entry anchors date→version→whatsnew. The whatsnew HTML mixes <h4>
-        // section headings with <p> feature paragraphs and <ul><li> bullet lists,
-        // so the single item pattern sweeps BOTH <p> and <li> (the <h4> labels are
-        // skipped) and a negative lookahead drops the trailing "See the full list…"
-        // footer <p>. Older releases omit whatsnew and are silently skipped; the
-        // top entries we keep all carry it and stay correctly attributed.
+        // `TBA` product code is the Toolbox App; each element of the TBA array has
+        // `version` ("3.7.2"), `date`, and a `whatsnew` HTML string. Structured
+        // decode, same reason and same decoder as IntelliJ IDEA above (shared
+        // endpoint shape, JSON-escaped HTML the regex path used to scrape as text).
+        // Toolbox's `whatsnew` is CUMULATIVE — each release concatenates its own
+        // `<li>` bullets with the full prior minor release's `<h3>`/`<h4>` + `<p>`
+        // write-up — so the decoder sweeps BOTH `<li>` and `<p>` (the decoder
+        // branches on the response's own top-level key, "TBA" vs "IIU") and drops
+        // only the trailing "See the full list of release notes…" `<p>` footer.
         ChangelogRecipe(
             bundleID: "com.jetbrains.toolbox",
             source: URL(string: "https://data.services.jetbrains.com/products/releases?code=TBA")!,
-            entryPattern:
-                #""date"\s*:\s*"(?<date>\d{4}-\d{2}-\d{2})".*?"#
-                + #""version"\s*:\s*"(?<version>[^"]+)".*?"#
-                + #""whatsnew"\s*:\s*"(?<body>(?:\\.|[^"\\])*)""#,
-            itemPatterns: [#"<(?:li|p)>\s*(?!See the full list)(?<item>.*?)</(?:li|p)>"#],
-            mode: .json,
-            maxEntries: 20),
+            maxEntries: 20,
+            structuredFormat: .jetBrainsProductReleases),
 
         // OpenCode (desktop) — github.com/anomalyco/opencode/releases (the repo
         // moved from sst/opencode via GitHub's org-rename redirect; we pin the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -223,11 +223,50 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// unauthenticated (60/hour/IP) and `ChangelogService` doesn't attach a
         /// token.
         case zedGitHubReleases
+        /// Notion's own desktop "What's New" page,
+        /// `notion.notion.site/What-s-New-Mac-Windows-…` — distinct from
+        /// `www.notion.com/releases`, which is Notion's *product* announcement feed
+        /// and carries no build numbers (see the `notion.id` recipe comment). The
+        /// rendered HTML is an empty Next.js shell; the real content is fetched
+        /// separately from Notion's internal, unauthenticated page API
+        /// (`notion.notion.site/api/v3/loadPageChunk`), which requires a POST with a
+        /// JSON body naming the page id — hence `ChangelogRecipe.httpMethod`/
+        /// `requestBody`. See `StructuredChangelogDecoder.decodeNotionPageChunk` for
+        /// the response shape and how release order is derived.
+        case notionPageChunk
     }
 
     /// Non-nil → this recipe is parsed by a structured decoder, not the regex
     /// extractor (see ``StructuredFormat``). nil for the common HTML/JSON-regex case.
     public let structuredFormat: StructuredFormat?
+
+    /// The HTTP method to fetch `source`/`resolvedSource(forVersion:)` with.
+    /// Default (and every recipe until Notion) is `.get`. `.post` exists solely
+    /// for endpoints — like Notion's internal page API — that only answer a
+    /// POST carrying a JSON body; there is no GET form of that endpoint at all.
+    public enum HTTPMethod: String, Codable, Sendable { case get, post }
+
+    /// The method to fetch this recipe's page with. Defaults to `.get` so every
+    /// existing recipe (and any future one that doesn't set this) is completely
+    /// unaffected.
+    public var httpMethod: HTTPMethod
+
+    /// The literal request body to send when `httpMethod == .post`, as raw bytes
+    /// (already-encoded JSON, in practice). nil for every `.get` recipe.
+    ///
+    /// ⚠️ Cache-key caveat: `ChangelogCache`/`ChangelogDiskCache` key on the
+    /// resolved *URL*, not on (URL, method, body) — a POST endpoint's URL is the
+    /// same for every request regardless of body. That is safe today only
+    /// because exactly one recipe (Notion) uses POST and its body is a fixed,
+    /// hardcoded literal — every fetch of that URL sends the identical body, so
+    /// there is nothing for the cache to confuse. If a second recipe is ever
+    /// added that POSTs a *different* body to the *same* URL (e.g. paginating
+    /// with a different cursor, or targeting a different page id on the same
+    /// host), it WILL read the first recipe's cached response instead of making
+    /// its own request. Fixing that properly means folding a body hash into the
+    /// cache key everywhere — not done here because it is unneeded until that
+    /// second case exists.
+    public let requestBody: Data?
 
     public init(
         bundleID: String,
@@ -245,7 +284,9 @@ public struct ChangelogRecipe: Codable, Sendable {
         sourceTemplate: String? = nil,
         newestLast: Bool = false,
         imagePattern: String? = nil,
-        structuredFormat: StructuredFormat? = nil
+        structuredFormat: StructuredFormat? = nil,
+        httpMethod: HTTPMethod = .get,
+        requestBody: Data? = nil
     ) {
         self.bundleID = bundleID
         self.source = source
@@ -263,6 +304,8 @@ public struct ChangelogRecipe: Codable, Sendable {
         self.sourceTemplate = sourceTemplate
         self.newestLast = newestLast
         self.imagePattern = imagePattern
+        self.httpMethod = httpMethod
+        self.requestBody = requestBody
     }
 
     /// The actual page URL to fetch for a given target version. When
@@ -329,6 +372,8 @@ public struct ChangelogRecipe: Codable, Sendable {
         sourceTemplate = try c.decodeIfPresent(String.self, forKey: .sourceTemplate)
         newestLast = try c.decodeIfPresent(Bool.self, forKey: .newestLast) ?? false
         imagePattern = try c.decodeIfPresent(String.self, forKey: .imagePattern)
+        httpMethod = try c.decodeIfPresent(HTTPMethod.self, forKey: .httpMethod) ?? .get
+        requestBody = try c.decodeIfPresent(Data.self, forKey: .requestBody)
     }
 }
 
@@ -1089,43 +1134,52 @@ public enum ChangelogRecipeRegistry {
             itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#],
             maxEntries: 30),
 
-        // Notion — www.notion.com/releases is Notion's *product* changelog: a
-        // server-rendered Next.js page of dated feature posts, NOT the desktop
-        // app's build version. There is no build number on the page, so the post
-        // title is used as the `version` string (e.g. "Plan Mode"). Acceptable
-        // because this is the low-stakes changelog tier — a miss just falls back
-        // to embedding the page. (notion.so/releases 301s here; /help/whats-new
-        // 404s.) Each post is:
-        //   <article class="release_release__…">
-        //     <time class="release_date__…">May 26, 2026</time>
-        //     <a class="release_titleLink__…"><h2 class="… release_title__…">Title</h2></a>
-        //     <article class="contentfulRichText_richText__…">
-        //       <p class="contentfulRichText_paragraph__…">…note…</p> …</article>
-        //   </article>
-        // Items target the rich-text paragraph class — one the decorative
-        // <p class="…errorLine…"> ad-blocker notices do NOT share, so they're
-        // skipped. The inner contentfulRichText article also closes with
-        // </article>, so the body bounds on the next release article.
+        // Notion — the DESKTOP app's real "What's New" page,
+        // `notion.notion.site/What-s-New-Mac-Windows-5936dabc8dd6497895786c91b9d6f12a`.
+        // This is the recipe wired up for `notion.id`; see `NOT REGISTERED` below
+        // for the *other* Notion recipe this replaces and why.
         //
-        // 2026-08-20: the page switched CSS-modules naming from `release_release__<hash>`
-        // to `release-module-scss-module__<hash>__release` — same markup, same
-        // nesting, every class renamed. Both spellings are accepted rather than
-        // just the new one: the rename is a build-tooling change that can be
-        // rolled back or served A/B, and carrying the old alternative costs one
-        // group. The hash stays unpinned in both, as it turns over on every deploy.
+        // The rendered HTML is a 19 KB empty Next.js shell — zero content. The real
+        // notes come from Notion's own internal, unauthenticated page-rendering API,
+        // which only answers a POST:
+        //   POST https://notion.notion.site/api/v3/loadPageChunk
+        //   {"pageId":"5936dabc-8dd6-4978-9578-6c91b9d6f12a","limit":50,
+        //    "cursor":{"stack":[]},"chunkNumber":0,"verticalColumns":false}
+        // (`source` below is set to that API URL directly — there is nothing
+        // useful to fetch at the human-facing page URL itself.) See
+        // `StructuredChangelogDecoder.decodeNotionPageChunk` for the response shape
+        // (`recordMap.block`, double-`value` wrapping, and the page block's
+        // `content` array as the true reading order) and how the header/text/
+        // bulleted_list blocks are grouped into releases.
+        //
+        // Verified live 2026-08-22: the header text is "v7.31.0" (`v` stripped so
+        // the rail label reads "7.31.0", matching the installed build the vendor
+        // probe's `.redirectFilename` reports) and the release order runs
+        // v7.31.0 → v7.29.0 → v7.28.0 → … — newest first, real desktop builds, not
+        // the product-announcement post titles the old recipe surfaced.
         ChangelogRecipe(
             bundleID: "notion.id",
-            source: URL(string: "https://www.notion.com/releases")!,
-            entryPattern:
-                #"<article class="(?:release_release__[^"]*|release-module-scss-module__[^"]*__release)">.*?"#
-                + #"<time class="(?:release_date__[^"]*|release-module-scss-module__[^"]*__date)">(?<date>[^<]+)</time>.*?"#
-                + #"<h2 class="[^"]*(?:release_title__[^"]*|release-module-scss-module__[^"]*__title)">(?<version>.*?)</h2>"#
-                + #"(?<body>.*?)(?=<article class="(?:release_release__|release-module-scss-module__[^"]*__release")|</main>|<footer)"#,
-            itemPatterns: [
-                #"<p class="(?:contentfulRichText_paragraph__[^"]*|contentfulRichText-module-scss-module__[^"]*__paragraph)">(?<item>.*?)</p>"#,
-            ],
+            source: URL(string: "https://notion.notion.site/api/v3/loadPageChunk")!,
             maxEntries: 20,
-            minItemLength: 4),
+            structuredFormat: .notionPageChunk,
+            httpMethod: .post,
+            requestBody: Data(
+                (#"{"pageId":"5936dabc-8dd6-4978-9578-6c91b9d6f12a","limit":50,"#
+                    + #""cursor":{"stack":[]},"chunkNumber":0,"verticalColumns":false}"#
+                ).utf8)),
+
+        // Notion's OTHER changelog, deliberately not registered: www.notion.com/
+        // releases is the *product* announcement feed (feature launches like "Plan
+        // Mode"), server-rendered and scrapeable, but carrying no build number at
+        // all — the old recipe used each post's title as the `version`, which never
+        // matched the build on the row. That mismatch is what the recipe above
+        // fixes, so the two must not both claim to be this app's release notes.
+        //
+        // The scrape pattern is not kept here as commented-out code; it is in git
+        // (3603c3c^ and earlier), and `notionProductAnnouncementsRecipe()` in the
+        // tests still builds it, so its regression coverage survives. If those
+        // product announcements are ever wanted, they should come back as a
+        // separate, clearly-labelled source — not as a second recipe for this id.
 
         // Obsidian — obsidian.md/changelog is one server-rendered page listing
         // every release newest-first, with BOTH Mobile and Desktop posts. Each

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -292,7 +292,11 @@ public enum ChangelogService {
     /// appcast, for one) — a credential leak is a much worse failure than a rate
     /// limit.
     static func isGitHubAPI(_ url: URL) -> Bool {
-        url.host?.lowercased() == "api.github.com"
+        // Scheme checked too: `URL.host` is scheme-agnostic, so without this an
+        // `http://api.github.com/…` recipe would send the token in the clear. No
+        // such recipe exists and ATS would refuse the load anyway — but a CLI
+        // binary's ATS posture is not the app's, and this is one comparison.
+        url.scheme?.lowercased() == "https" && url.host?.lowercased() == "api.github.com"
     }
 
     /// The token the user pasted into Settings ▸ GitHub, pushed down by the app.
@@ -465,8 +469,15 @@ public enum ChangelogService {
         // of them on Zed alone, so the recipes turned up as HTTP 403 "BROKEN"
         // while a perfectly good token sat in `gh` unused. Same token the
         // GitHub source sends; 5000/hour once attached.
-        if isGitHubAPI(url), let token = await gitHubToken() {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if isGitHubAPI(url) {
+            // The same two headers `GitHubReleasesSource` sends: without them the
+            // API answers from whatever version it currently defaults to, which is
+            // exactly the kind of silent drift a pinned version exists to prevent.
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+            request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+            if let token = await gitHubToken() {
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
         }
         guard let (data, response) = try? await session.data(for: request) else {
             return (nil, nil)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -283,6 +283,37 @@ public enum ChangelogService {
         return URL(string: String(body[r]), relativeTo: base)?.absoluteURL
     }
 
+
+    /// STRICTLY api.github.com. The Authorization header must never ride along to
+    /// some other vendor's changelog host just because a recipe happens to point
+    /// at a URL containing "github" (raw.githubusercontent.com hosts TablePro's
+    /// appcast, for one) — a credential leak is a much worse failure than a rate
+    /// limit.
+    static func isGitHubAPI(_ url: URL) -> Bool {
+        url.host?.lowercased() == "api.github.com"
+    }
+
+    /// Resolved once per process, not per request: `GitHubToken.resolve()` may
+    /// shell out to `gh auth token`, and its own documentation says callers should
+    /// resolve once per run rather than per request. `nil` is cached too — a
+    /// machine with no token must not re-spawn `gh` on every changelog open.
+    private nonisolated(unsafe) static var cachedToken: String??
+    private static let tokenLock = NSLock()
+    static func gitHubToken() -> String? {
+        tokenLock.lock()
+        defer { tokenLock.unlock() }
+        if let cachedToken { return cachedToken }
+        let resolved = GitHubToken.resolve()
+        cachedToken = resolved
+        // `.notice`, not `.debug`: a third-party subsystem's debug/info lines are
+        // not persisted, and this one answers "am I exposed to the 60/hour
+        // unauthenticated limit right now?" — exactly what you want to be able to
+        // read back after the fact. Once per process, so it costs nothing.
+        Log.source.notice(
+            "changelog GitHub auth: \(resolved != nil ? "token" : "anonymous", privacy: .public)")
+        return resolved
+    }
+
     /// Fetch a URL with the browser-like UA and return its body as a string, or
     /// nil on network error / non-2xx. Shared by the index and detail fetches.
     private static func fetchBody(_ url: URL, session: URLSession) async -> String? {
@@ -302,6 +333,16 @@ public enum ChangelogService {
         // and just 304 here.)
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        // A recipe may read the GitHub API (Zed's notes come from the same
+        // `/releases` endpoint the version check already uses). Unauthenticated
+        // that is 60 requests/hour PER IP, shared with every GitHub-sourced
+        // version check on the machine — and a full `duo verify` sweep spends two
+        // of them on Zed alone, so the recipes turned up as HTTP 403 "BROKEN"
+        // while a perfectly good token sat in `gh` unused. Same token the
+        // GitHub source sends; 5000/hour once attached.
+        if isGitHubAPI(url), let token = gitHubToken() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         guard let (data, response) = try? await session.data(for: request) else {
             return (nil, nil)
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -126,8 +126,10 @@ public enum ChangelogService {
     ) async -> ChangelogDiagnostic {
         let resolved = recipe.resolvedSource(forVersion: version)
         // Fetch the entry page directly so a transport/status failure is
-        // distinguishable; `fetchAndParse` collapses both into nil.
-        let fetched = await fetch(resolved, session: session)
+        // distinguishable; `fetchAndParse` collapses both into nil. Pass the
+        // recipe through so a POST recipe (Notion) sends its body on this,
+        // its ONLY request — there is no second stage for a structured recipe.
+        let fetched = await fetch(resolved, recipe: recipe, session: session)
         guard fetched.body != nil else {
             await recordHealth(recipe, parsed: nil)
             return ChangelogDiagnostic(
@@ -171,11 +173,11 @@ public enum ChangelogService {
         _ recipe: ChangelogRecipe, resolved: URL, session: URLSession
     ) async -> Changelog? {
         if recipe.structuredFormat != nil {
-            return parse(recipe, body: await fetchBody(resolved, session: session))
+            return parse(recipe, body: await fetchBody(resolved, recipe: recipe, session: session))
         }
         guard let pageURL = await resolveDetailURL(recipe, source: resolved, session: session)
         else { return nil }
-        return parse(recipe, body: await fetchBody(pageURL, session: session))
+        return parse(recipe, body: await fetchBody(pageURL, recipe: recipe, session: session))
     }
 
     /// Turn a fetched page into entries, by whichever route the recipe declares.
@@ -316,14 +318,26 @@ public enum ChangelogService {
 
     /// Fetch a URL with the browser-like UA and return its body as a string, or
     /// nil on network error / non-2xx. Shared by the index and detail fetches.
-    private static func fetchBody(_ url: URL, session: URLSession) async -> String? {
-        await fetch(url, session: session).body
+    /// `recipe` is nil for a plain GET (every regex/HTML recipe, and both stages
+    /// of a two-stage index/detail recipe); pass it only for the single request a
+    /// structured recipe makes, so a `.post` recipe's method/body actually rides
+    /// along (see `fetch(_:recipe:session:)`).
+    private static func fetchBody(
+        _ url: URL, recipe: ChangelogRecipe? = nil, session: URLSession
+    ) async -> String? {
+        await fetch(url, recipe: recipe, session: session).body
     }
 
     /// The same request, but keeping the status code so a verifier can tell a
     /// moved page from a restyled one.
+    ///
+    /// `recipe` supplies the HTTP method and body (see `ChangelogRecipe.httpMethod`/
+    /// `requestBody`) — nil means the plain-GET default every recipe used before
+    /// Notion. Only the one request a caller explicitly threads a recipe through
+    /// can ever be a POST; every other fetch in this file (the two-stage index
+    /// page, its detail page) is hard-coded to GET by simply not passing one.
     private static func fetch(
-        _ url: URL, session: URLSession
+        _ url: URL, recipe: ChangelogRecipe? = nil, session: URLSession
     ) async -> (body: String?, status: Int?) {
         var request = URLRequest(url: url)
         request.timeoutInterval = 15
@@ -333,6 +347,11 @@ public enum ChangelogService {
         // and just 304 here.)
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        if let recipe, recipe.httpMethod == .post {
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = recipe.requestBody
+        }
         // A recipe may read the GitHub API (Zed's notes come from the same
         // `/releases` endpoint the version check already uses). Unauthenticated
         // that is 60 requests/hour PER IP, shared with every GitHub-sourced

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -295,25 +295,131 @@ public enum ChangelogService {
         url.host?.lowercased() == "api.github.com"
     }
 
-    /// Resolved once per process, not per request: `GitHubToken.resolve()` may
-    /// shell out to `gh auth token`, and its own documentation says callers should
-    /// resolve once per run rather than per request. `nil` is cached too — a
-    /// machine with no token must not re-spawn `gh` on every changelog open.
-    private nonisolated(unsafe) static var cachedToken: String??
-    private static let tokenLock = NSLock()
-    static func gitHubToken() -> String? {
+    /// The token the user pasted into Settings ▸ GitHub, pushed down by the app.
+    ///
+    /// `GitHubToken.resolve()` on its own reads only the process environment and
+    /// `gh auth token`. Neither exists for the shipped app: launchd starts it with
+    /// no shell environment, and a machine without `gh` installed keeps the token
+    /// in the Keychain, where only `Preferences` can reach it. Resolving without
+    /// an explicit value therefore came back nil for exactly the users who
+    /// configured a token the supported way, leaving the whole Authorization path
+    /// dead while Settings showed the token verified green. The CLI has no
+    /// Settings, so it keeps the env/`gh` path and nothing is set here.
+    private nonisolated(unsafe) static var explicitToken: String?
+
+    /// Hand the Settings token to the changelog fetcher. Called on load and from
+    /// `Preferences.githubToken`'s `didSet`, so pasting or clearing a token takes
+    /// effect without a relaunch (the next resolve sees a different explicit value
+    /// and re-resolves rather than serving the cached one).
+    public static func setExplicitGitHubToken(_ token: String?) {
+        let normalized = token?.trimmingCharacters(in: .whitespacesAndNewlines)
         tokenLock.lock()
         defer { tokenLock.unlock() }
-        if let cachedToken { return cachedToken }
-        let resolved = GitHubToken.resolve()
-        cachedToken = resolved
+        explicitToken = (normalized?.isEmpty ?? true) ? nil : normalized
+    }
+
+    /// A resolved token, remembered so `gh auth token` isn't re-spawned on every
+    /// changelog open. Keyed by the explicit value it was resolved from, and aged
+    /// out: a token revoked mid-session (`gh auth logout`, a rotated PAT) makes
+    /// GitHub answer 401, which is *worse* than sending nothing — the pane goes
+    /// empty where anonymous would still have rendered. A menubar app runs for
+    /// weeks, so "resolved once per process" would strand it there until relaunch.
+    private struct ResolvedToken {
+        let explicit: String?
+        let token: String?
+        let at: Date
+    }
+    private nonisolated(unsafe) static var cachedToken: ResolvedToken?
+    private static let tokenLock = NSLock()
+    /// Long enough that a burst of changelog opens shares one resolve, short
+    /// enough that a rotation recovers on its own within a coffee break.
+    static let tokenTTL: TimeInterval = 600
+
+    /// Lock-taking halves kept out of the async function on purpose: `NSLock`'s
+    /// `unlock()` is unavailable from an async context (holding a lock across a
+    /// suspension point is exactly the bug this whole change is about), so the
+    /// critical sections are these two synchronous calls with the `await` between
+    /// them, never inside them.
+    private static func rememberedToken(now: Date) -> (explicit: String?, hit: String??) {
+        tokenLock.lock()
+        defer { tokenLock.unlock() }
+        let explicit = explicitToken
+        if let cached = cachedToken,
+           cached.explicit == explicit,
+           now.timeIntervalSince(cached.at) < tokenTTL {
+            return (explicit, .some(cached.token))
+        }
+        return (explicit, nil)
+    }
+
+    private static func rememberToken(_ token: String?, explicit: String?, at now: Date) {
+        tokenLock.lock()
+        defer { tokenLock.unlock() }
+        cachedToken = ResolvedToken(explicit: explicit, token: token, at: now)
+    }
+
+    static func gitHubToken(now: Date = Date()) async -> String? {
+        let (explicit, hit) = rememberedToken(now: now)
+        if let hit { return hit }
+
+        // Resolved *outside* the lock and off the cooperative pool, with a
+        // deadline. `GitHubToken.resolve` runs `gh auth token` to completion with
+        // no timeout of its own, so a wedged credential helper (a keychain prompt
+        // nobody answers) would otherwise pin the lock forever and pile the whole
+        // changelog prewarm fan-out up behind it. `AppListModel.resolveGitHubToken`
+        // learned this already — "don't let a wedged `gh auth token` hold the
+        // whole refresh hostage forever" — and the lesson belongs here too.
+        let loader = Task.detached(priority: .utility) { GitHubToken.resolve(explicit: explicit) }
+        guard let resolved = await firstResult(of: loader, within: .seconds(2)) else {
+            // Timed out: deliberately *not* cached. Caching would extend one
+            // wedged `gh` into ten minutes of unauthenticated fetches; falling
+            // through unauthenticated for this one request is enough.
+            Log.source.error("changelog GitHub token resolve timed out — continuing anonymous")
+            return nil
+        }
+
+        rememberToken(resolved, explicit: explicit, at: now)
+
         // `.notice`, not `.debug`: a third-party subsystem's debug/info lines are
         // not persisted, and this one answers "am I exposed to the 60/hour
         // unauthenticated limit right now?" — exactly what you want to be able to
-        // read back after the fact. Once per process, so it costs nothing.
+        // read back after the fact. At most once per TTL, so it costs nothing.
         Log.source.notice(
             "changelog GitHub auth: \(resolved != nil ? "token" : "anonymous", privacy: .public)")
         return resolved
+    }
+
+    /// The value of `task` if it lands within `timeout`, else nil. The task is a
+    /// detached one on purpose (see the call site) so its blocking `waitUntilExit`
+    /// never occupies a cooperative-pool thread; cancelling the group cannot stop
+    /// it, and doesn't need to — it finishes into a discarded result.
+    private static func firstResult<T: Sendable>(
+        of task: Task<T, Never>, within timeout: Duration
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+    }
+
+    /// Test seam: the normalized explicit token, without resolving anything.
+    static var explicitGitHubTokenForTesting: String? {
+        tokenLock.lock()
+        defer { tokenLock.unlock() }
+        return explicitToken
+    }
+
+    /// Test seam: forget any resolved token so the next call re-resolves.
+    static func resetGitHubTokenCache() {
+        tokenLock.lock()
+        defer { tokenLock.unlock() }
+        cachedToken = nil
     }
 
     /// Fetch a URL with the browser-like UA and return its body as a string, or
@@ -359,7 +465,7 @@ public enum ChangelogService {
         // of them on Zed alone, so the recipes turned up as HTTP 403 "BROKEN"
         // while a perfectly good token sat in `gh` unused. Same token the
         // GitHub source sends; 5000/hour once attached.
-        if isGitHubAPI(url), let token = gitHubToken() {
+        if isGitHubAPI(url), let token = await gitHubToken() {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         guard let (data, response) = try? await session.data(for: request) else {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -36,6 +36,8 @@ public enum StructuredChangelogDecoder {
             return decodeJetBrainsProductReleases(body, maxEntries: maxEntries)
         case .zedGitHubReleases:
             return decodeZedGitHubReleases(body, channel: channel ?? .stable, maxEntries: maxEntries)
+        case .notionPageChunk:
+            return decodeNotionPageChunk(body, maxEntries: maxEntries)
         }
     }
 
@@ -769,5 +771,181 @@ public enum StructuredChangelogDecoder {
             if x != y { return x > y }
         }
         return false
+    }
+
+    // MARK: - Notion (notion.notion.site/api/v3/loadPageChunk)
+
+    /// Notion's internal, unauthenticated page-rendering API — POSTed with a fixed
+    /// page id (see `ChangelogRecipe.httpMethod`/`requestBody`) — for the desktop
+    /// app's real "What's New" page
+    /// (`notion.notion.site/What-s-New-Mac-Windows-…`), which carries actual build
+    /// numbers (`v7.31.0`). Distinct from `www.notion.com/releases`, Notion's
+    /// *product* announcement feed with no build numbers at all (see the
+    /// `notion.id` recipe comment in `ChangelogRecipe.swift`) — that page answers a
+    /// different question and is kept as a separate, channel-agnostic recipe.
+    ///
+    /// Shape: `recordMap.block` is a MAP keyed by block id, each entry wrapped
+    /// `{value: {value: {...}}}` — note the DOUBLE `value`. Losing the inner layer
+    /// yields every block's `type`/`properties` as nil silently (not a decode
+    /// error), which looks exactly like "the page structure changed" rather than
+    /// "wrong path" — confirmed by hand while building this decoder.
+    ///
+    /// The map's own iteration/key order is NOT the page's reading order (Swift
+    /// dictionary order is unspecified, and nothing here guarantees the JSON's
+    /// on-the-wire key order means anything either). The real order comes from the
+    /// root `page`-type block's OWN `content: [id, id, …]` array, which lists every
+    /// child block id in document order. We walk that array — filtering to ids
+    /// actually present in this (paginated, `limit`-bounded) chunk — and group the
+    /// blocks into releases:
+    ///   `header` (title text is the version, "v7.31.0") → `text` (a "📅 Released
+    ///   ‣ (macOS & Windows)" line whose `‣` is a real Notion date mention) → one
+    ///   or more `bulleted_list` (the change lines), repeating until the next
+    ///   `header`.
+    ///
+    /// Verified live 2026-08-22 against
+    /// `https://notion.notion.site/What-s-New-Mac-Windows-5936dabc8dd6497895786c91b9d6f12a`
+    /// via `loadPageChunk` (`pageId` = that page's id, `chunkNumber: 0, limit: 50`):
+    /// 101 blocks (1 page + 24 header + 24 text + 52 bulleted_list), `content`-array
+    /// order running v7.31.0 → v7.29.0 → v7.28.0 → … — newest first, matching the
+    /// installed app's own version (from the vendor probe's `.redirectFilename`).
+    private struct NotionPageChunk: Decodable {
+        let recordMap: NotionRecordMap
+    }
+    private struct NotionRecordMap: Decodable {
+        let block: [String: NotionBlockEnvelope]
+    }
+    private struct NotionBlockEnvelope: Decodable {
+        let value: NotionValueWrapper
+    }
+    private struct NotionValueWrapper: Decodable {
+        let value: NotionBlock
+    }
+    private struct NotionBlock: Decodable {
+        let type: String?
+        let properties: NotionProperties?
+        /// Present only on the `page` block: every child block id, in reading order.
+        let content: [String]?
+    }
+    private struct NotionProperties: Decodable {
+        let title: [NotionTitleSegment]?
+    }
+
+    /// One `title` segment: `[text]` or `[text, [decoration, …]]`. Only the plain
+    /// `text` and (when present) a date decoration's ISO day are extracted — rich
+    /// formatting (bold/italic/links) is not reproduced, matching every other
+    /// structured decoder's plain-text items.
+    private struct NotionTitleSegment: Decodable {
+        let text: String
+        /// Set only when one of this segment's decorations is a date mention.
+        let dateDay: String?
+
+        init(from decoder: Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            text = try container.decode(String.self)
+            guard !container.isAtEnd,
+                  let decorations = try? container.decode([NotionDecoration].self)
+            else {
+                dateDay = nil
+                return
+            }
+            dateDay = decorations.compactMap(\.dateDay).first
+        }
+    }
+
+    /// One decoration entry: `[code]` or `[code, payload]`. Only the `"d"` (date
+    /// mention) code's payload is consumed — a Notion date-mention object with a
+    /// `start_date` of `YYYY-MM-DD` (optionally followed by a time-of-day, which we
+    /// don't need). Every other code (bold `"b"`, italic `"i"`, link `"a"`, comment
+    /// `"ce"`, user mention `"u"`, …) decodes its leading code string fine and is
+    /// otherwise ignored — `dateDay` just stays nil for it.
+    private struct NotionDecoration: Decodable {
+        let dateDay: String?
+
+        init(from decoder: Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            let code = try container.decode(String.self)
+            guard code == "d", !container.isAtEnd else {
+                dateDay = nil
+                return
+            }
+            struct DateProps: Decodable {
+                let startDate: String?
+                enum CodingKeys: String, CodingKey { case startDate = "start_date" }
+            }
+            dateDay = (try? container.decode(DateProps.self))?.startDate
+        }
+    }
+
+    static func decodeNotionPageChunk(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let chunk = try? JSONDecoder().decode(NotionPageChunk.self, from: data)
+        else { return nil }
+        let blocks = chunk.recordMap.block
+        // The reading order lives on the page block's own `content` array, NOT on
+        // the surrounding map's key order (see the doc comment above) — so find
+        // that one block first rather than iterating `blocks` directly.
+        guard let order = blocks.values.first(where: { $0.value.value.type == "page" })?
+            .value.value.content
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        var version: String?
+        var date: String?
+        var items: [String] = []
+
+        func flush() {
+            guard let v = version, !items.isEmpty else { return }
+            entries.append(.init(version: v, date: date, items: items))
+        }
+
+        for id in order {
+            guard let block = blocks[id]?.value.value else { continue }
+            if block.type == "header" {
+                flush()
+                // Cap BEFORE starting a new entry, not after finishing it — an
+                // entry-count check placed after processing every child block
+                // would have already parsed one release too many.
+                if let cap = maxEntries, entries.count >= cap {
+                    version = nil  // so the trailing `flush()` below is a no-op
+                    break
+                }
+                var v = notionText(block.properties?.title ?? [])
+                    .trimmingCharacters(in: .whitespaces)
+                if v.hasPrefix("v") { v = String(v.dropFirst()) }
+                version = v
+                date = nil
+                items = []
+                continue
+            }
+            // A stray text/bulleted_list block before the first header (shouldn't
+            // happen on this page, but the page is fetched live) has nowhere to go.
+            guard version != nil else { continue }
+            switch block.type {
+            case "text":
+                // First date mention wins; the "📅 Released" line is the only
+                // `text` block per release in every sample seen.
+                if date == nil {
+                    date = (block.properties?.title ?? []).compactMap(\.dateDay).first
+                }
+            case "bulleted_list":
+                let line = notionText(block.properties?.title ?? [])
+                    .trimmingCharacters(in: .whitespaces)
+                if !line.isEmpty { items.append(line) }
+            default:
+                break
+            }
+        }
+        flush()
+
+        return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    /// Join a title's segments' visible text, dropping the bare `‣` placeholder a
+    /// mention (date/user/page/comment) renders as in the raw JSON — it carries no
+    /// useful text of its own. (A date mention's real value is read separately, via
+    /// `NotionTitleSegment.dateDay`; a user/page/comment mention has no plain-text
+    /// substitute at all, so it is simply omitted rather than shown as a stray `‣`.)
+    private static func notionText(_ segments: [NotionTitleSegment]) -> String {
+        segments.map { $0.text == "‣" ? "" : $0.text }.joined()
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -26,6 +26,8 @@ public enum StructuredChangelogDecoder {
             return decodeWeChatDevTools(body)
         case .chatwiseReleases:
             return decodeChatWise(body, maxEntries: maxEntries)
+        case .gitHubDesktopChangelog:
+            return decodeGitHubDesktop(body, maxEntries: maxEntries)
         }
     }
 
@@ -281,6 +283,56 @@ public enum StructuredChangelogDecoder {
             if let cap = maxEntries, entries.count >= cap { break }
         }
         return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    // MARK: - GitHub Desktop (central.github.com/deployments/desktop/desktop/changelog.json)
+
+    /// The feed is a flat JSON array, newest-first, of `{name, notes, pub_date,
+    /// version}` — `notes` is already an array of one-line strings (each keeping the
+    /// vendor's own `[Fixed]`/`[Added]`/`[Improved]` prefix and trailing `- #issue`),
+    /// so there is no markdown to split or clean, just JSON strings to decode as-is.
+    /// `name` is always empty in practice and unused. Stable and beta are two
+    /// separate URLs (`?env=beta` on the same host), not one document with a
+    /// per-channel key, so unlike Warp this decoder takes no `channel` — the two
+    /// `ChangelogRecipe`s just point at different endpoints and share this format.
+    private struct GitHubDesktopEntry: Decodable {
+        let notes: [String]?
+        let pubDate: String?
+        let version: String?
+        enum CodingKeys: String, CodingKey {
+            case notes
+            case pubDate = "pub_date"
+            case version
+        }
+    }
+
+    static func decodeGitHubDesktop(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let feed = try? JSONDecoder().decode([GitHubDesktopEntry].self, from: data),
+              !feed.isEmpty
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        for entry in feed {
+            guard let version = entry.version, !version.isEmpty else { continue }
+            let items = (entry.notes ?? []).filter { !$0.isEmpty }
+            guard !items.isEmpty else { continue }
+            entries.append(.init(
+                version: version, date: gitHubDesktopDate(entry.pubDate), items: items))
+            if let cap = maxEntries, entries.count >= cap { break }
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    /// `2026-06-01T17:43:05Z` → `2026-06-01`, matching the old regex recipe's
+    /// `"pub_date":"(?<date>\d{4}-\d{2}-\d{2})[^"]*"` capture (day precision only,
+    /// no time-of-day shown in the UI). nil when the leading segment isn't a plain
+    /// date, rather than showing a raw ISO string.
+    static func gitHubDesktopDate(_ raw: String?) -> String? {
+        guard let raw, raw.count >= 10 else { return nil }
+        let ymd = String(raw.prefix(10))
+        return ymd.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil
+            ? ymd : nil
     }
 
     // MARK: - Typeless (typeless.com/help/release-notes/macos)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -30,6 +30,8 @@ public enum StructuredChangelogDecoder {
             return decodeSunLogin(body, maxEntries: maxEntries)
         case .gitHubDesktopChangelog:
             return decodeGitHubDesktop(body, maxEntries: maxEntries)
+        case .postmanReleaseNotes:
+            return decodePostman(body, maxEntries: maxEntries)
         }
     }
 
@@ -335,6 +337,101 @@ public enum StructuredChangelogDecoder {
         let ymd = String(raw.prefix(10))
         return ymd.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil
             ? ymd : nil
+    }
+
+    // MARK: - Postman (mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json)
+
+    /// Top-level shape: `{"notes": [{version, content, createdAt}, ...]}`, newest
+    /// first. `content` is markdown; we deliberately do NOT run it through
+    /// `bulletItems` — the prior regex path left markdown syntax (`**bold**`,
+    /// `[text](url)`) verbatim in the rendered items, and this recipe's item text
+    /// must not change shape out from under that, only stop being truncated.
+    private struct PostmanFeed: Decodable {
+        let notes: [PostmanNote]
+    }
+    private struct PostmanNote: Decodable {
+        let version: String?
+        let content: String?
+        let createdAt: String?
+    }
+
+    static func decodePostman(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let feed = try? JSONDecoder().decode(PostmanFeed.self, from: data)
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        for note in feed.notes {
+            guard let version = note.version?.trimmingCharacters(in: .whitespaces),
+                  !version.isEmpty
+            else { continue }
+            let items = postmanItems(from: note.content)
+            guard !items.isEmpty else { continue }
+            entries.append(.init(
+                version: version, date: postmanDate(note.createdAt), items: items))
+            if let cap = maxEntries, entries.count >= cap { break }
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    /// Reproduces, line-for-line, what the old regex itemPattern
+    /// (`\r\n(?:####\s+)?(?!##|\r\n|\w+ \d+, \d{4})(?<item>[^\\]{10,})`) picked out
+    /// of the *escaped* JSON text — but working on the real, decoded markdown, so a
+    /// line containing an escaped quote is no longer cut off at the backslash.
+    /// Per line:
+    ///   - blank lines are dropped (this also eats the trailing `\r\n\r\n` and, for
+    ///     older entries, absorbs the plain-`\n` line separator the same way);
+    ///   - a `#### ` feature-heading prefix is stripped but the heading text is KEPT
+    ///     as an item (the old pattern's optional non-capturing group did the same);
+    ///   - any other line starting with `##` (a `##`/`###` document/section heading)
+    ///     is skipped entirely;
+    ///   - a line that IS (or starts with) a "Month D, YYYY" date stamp is skipped —
+    ///     this is the "## Postman X.Y.Z" / date pair at the top of every entry;
+    ///   - anything left under 10 characters is dropped (matches the old pattern's
+    ///     `{10,}` floor, there to filter stray short fragments);
+    ///   - everything else is kept as-is, including leading `- ` list markers and
+    ///     inline markdown syntax.
+    static func postmanItems(from content: String?) -> [String] {
+        guard let content else { return [] }
+        // NOTE: split on `Character.isNewline`, not `separator: "\n"`. Swift
+        // Strings treat "\r\n" as a SINGLE Character (one grapheme cluster) that
+        // is not equal to the standalone "\n" Character — so `split(separator:
+        // "\n")` does not split inside it at all, and a whole `\r\n`-separated
+        // body comes back as one giant "line". `isNewline` recognizes "\n", "\r",
+        // and the "\r\n" cluster alike, so both this recipe's current (`\r\n`)
+        // and legacy (`\n`) entries split the same way. (Caught by running this
+        // against a real 4-entry feed slice in the regression test below — three
+        // of the four entries silently produced zero items before this fix.)
+        return content
+            .split(omittingEmptySubsequences: false, whereSeparator: { $0.isNewline })
+            .compactMap { rawLine -> String? in
+                var line = String(rawLine)
+                if line.isEmpty { return nil }
+                if line.hasPrefix("#### ") {
+                    line = String(line.dropFirst(5))
+                } else if line.hasPrefix("##") {
+                    return nil
+                }
+                if postmanIsDateLine(line) { return nil }
+                guard line.count >= 10 else { return nil }
+                return line
+            }
+    }
+
+    /// True when `line` begins with a "Month D, YYYY" stamp (e.g. "August 21,
+    /// 2026"), the exact date line Postman prints under the "## Postman X.Y.Z"
+    /// title. A prefix match, not a whole-line match — matching the old regex's
+    /// negative lookahead, which only asserted the pattern at the start.
+    static func postmanIsDateLine(_ line: String) -> Bool {
+        line.range(of: #"^\w+ \d+, \d{4}"#, options: .regularExpression) != nil
+    }
+
+    /// `2026-08-19` from `2026-08-19T06:06:19.000Z` — the leading `YYYY-MM-DD` the
+    /// old regex's `[^"T]+` capture also stopped at.
+    static func postmanDate(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        if let t = raw.firstIndex(of: "T") { return String(raw[raw.startIndex..<t]) }
+        return raw.isEmpty ? nil : raw
     }
 
     // MARK: - SunLogin/AweSun (client-webapi.oray.com/softwares/…)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -928,6 +928,12 @@ public enum StructuredChangelogDecoder {
         }
     }
 
+    /// The page the request body asks for — same literal as the recipe's
+    /// `requestBody`, spelled in the dashed form the `recordMap.block` map keys
+    /// use. Kept beside the decoder so the two cannot drift apart silently; a
+    /// mismatch degrades to the type scan below rather than failing.
+    static let notionPageID = "5936dabc-8dd6-4978-9578-6c91b9d6f12a"
+
     static func decodeNotionPageChunk(_ body: String, maxEntries: Int?) -> Changelog? {
         guard let data = body.data(using: .utf8),
               let chunk = try? JSONDecoder().decode(NotionPageChunk.self, from: data)
@@ -936,8 +942,15 @@ public enum StructuredChangelogDecoder {
         // The reading order lives on the page block's own `content` array, NOT on
         // the surrounding map's key order (see the doc comment above) — so find
         // that one block first rather than iterating `blocks` directly.
-        guard let order = blocks.values.first(where: { $0.value.value.type == "page" })?
-            .value.value.content
+        //
+        // Looked up by id, not by `values.first(where: type == "page")`. Dictionary
+        // iteration order is unspecified, so scanning for the first `page`-typed
+        // block is only correct while the chunk contains exactly one — true of
+        // today's response and of nothing guaranteed. The id is the one we asked
+        // for in the request body, so it is the right block by construction.
+        guard let page = blocks[notionPageID]?.value.value
+            ?? blocks.values.first(where: { $0.value.value.type == "page" })?.value.value,
+              let order = page.content
         else { return nil }
 
         var entries: [Changelog.Entry] = []

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -24,6 +24,8 @@ public enum StructuredChangelogDecoder {
             return decodeTypeless(body, maxEntries: maxEntries)
         case .weChatDevToolsLog:
             return decodeWeChatDevTools(body)
+        case .chatwiseReleases:
+            return decodeChatWise(body, maxEntries: maxEntries)
         }
     }
 
@@ -233,6 +235,52 @@ public enum StructuredChangelogDecoder {
         s = s.replacingOccurrences(
             of: #"^`[^`]{1,4}`\s*"#, with: "", options: .regularExpression)
         return bulletItems(from: s).first
+    }
+
+    // MARK: - ChatWise (releases.chatwise.app/releases)
+
+    /// One published release. `changelog` is a markdown bullet list, `date` is
+    /// ISO-8601. `assets` is the updater payload (per-platform archives + hashes)
+    /// and is ignored here — the changelog pane only wants the notes.
+    private struct ChatWiseRelease: Decodable {
+        let version: String?
+        let changelog: String?
+        let date: String?
+    }
+
+    /// `2026-06-26T16:04:26.161Z` → `2026-06-26` for the rail subtitle; nil when
+    /// the field is missing or isn't a leading `YYYY-MM-DD`.
+    static func isoDay(_ raw: String?) -> String? {
+        guard let raw, raw.count >= 10 else { return nil }
+        let ymd = String(raw.prefix(10))
+        guard ymd.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil
+        else { return nil }
+        return ymd
+    }
+
+    /// The document is a flat array in newest-first order (the same order the
+    /// vendor's own /changelog page renders), so we keep it as-is and just cap.
+    /// A release with an empty changelog is skipped rather than shown as a bare
+    /// version heading, and does not count toward the cap.
+    static func decodeChatWise(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let releases = try? JSONDecoder().decode([ChatWiseRelease].self, from: data)
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        for release in releases {
+            guard let version = release.version?.trimmingCharacters(in: .whitespaces),
+                  !version.isEmpty
+            else { continue }
+            let items = bulletItems(from: release.changelog)
+            guard !items.isEmpty else { continue }
+            entries.append(.init(
+                version: version,
+                date: isoDay(release.date),
+                items: items))
+            if let cap = maxEntries, entries.count >= cap { break }
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
     }
 
     // MARK: - Typeless (typeless.com/help/release-notes/macos)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -32,6 +32,8 @@ public enum StructuredChangelogDecoder {
             return decodeGitHubDesktop(body, maxEntries: maxEntries)
         case .postmanReleaseNotes:
             return decodePostman(body, maxEntries: maxEntries)
+        case .jetBrainsProductReleases:
+            return decodeJetBrainsProductReleases(body, maxEntries: maxEntries)
         }
     }
 
@@ -489,6 +491,88 @@ public enum StructuredChangelogDecoder {
         return (version, Array(lines.dropFirst()))
     }
 
+    // MARK: - JetBrains product releases
+    // (data.services.jetbrains.com/products/releases?code=<CODE>)
+
+    /// One release from the feed. Verified against the live `IIU` (IntelliJ IDEA)
+    /// and `TBA` (Toolbox App) endpoints: both return `{"<CODE>": [ {…}, … ]}` —
+    /// exactly one top-level key — with each element carrying `date` (already
+    /// plain `YYYY-MM-DD`, no parsing needed), `version` (marketing string, e.g.
+    /// "2026.2.1" / "3.7.2"), and `whatsnew` (release-notes HTML). Fields present
+    /// in the real response but unused here (`type`, `build`, `downloads`,
+    /// `patches`, `notesLink`, `uninstallFeedbackLinks`, …) are simply omitted —
+    /// `Decodable` ignores keys a struct doesn't declare.
+    private struct JetBrainsRelease: Decodable {
+        let date: String?
+        let version: String?
+        let whatsnew: String?
+    }
+
+    /// The array is NOT a global newest-first-by-date sort — verified against both
+    /// live feeds: entries group by major-version branch (descending), and only
+    /// within a branch by date (descending). So IntelliJ IDEA's `2026.1.5` patch
+    /// (dated 2026-08-12) sits AFTER `2026.2.1` (dated 2026-08-10) in the array,
+    /// because 2026.1 is the older branch — even though 2026.1.5 is objectively the
+    /// more recently published file. That's the vendor's own "current branch first"
+    /// intent (matches what jetbrains.com/idea/whatsnew shows), so entries are kept
+    /// in document order rather than re-sorted by date.
+    static func decodeJetBrainsProductReleases(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let root = try? JSONDecoder().decode([String: [JetBrainsRelease]].self, from: data),
+              let releases = root.first?.value
+        else { return nil }
+        let code = root.first?.key ?? ""
+
+        var entries: [Changelog.Entry] = []
+        for release in releases {
+            guard let version = release.version?.trimmingCharacters(in: .whitespaces),
+                  !version.isEmpty,
+                  let whatsnew = release.whatsnew, !whatsnew.isEmpty
+            else { continue }
+            let items = jetBrainsItems(from: whatsnew, code: code)
+            guard !items.isEmpty else { continue }
+            entries.append(.init(version: version, date: release.date, items: items))
+            if let cap = maxEntries, entries.count >= cap { break }
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    /// Extract discrete change lines from one release's `whatsnew` HTML.
+    ///
+    /// IntelliJ IDEA (`IIU`) documents are standalone: the lead `<p>` is always
+    /// boilerplate ("IntelliJ IDEA X is out with…") and the trailing `<p>` is
+    /// always a "Get more details in our blog post" pointer, so only `<li>`
+    /// bullets are discrete changes. A hotfix release with no `<li>` at all (its
+    /// only content is prose `<p>`, e.g. 2026.2.0.1, or just a "see the release
+    /// notes" pointer, e.g. 2026.1.5) yields zero items and is skipped — same as
+    /// the regex recipe this replaces did.
+    ///
+    /// Toolbox App (`TBA`) documents are CUMULATIVE: one entry concatenates its
+    /// own `<li>` bullets with the full prior minor release's write-up as `<h3>`/
+    /// `<h4>` headings each followed by a `<p>` description, ending in a "See the
+    /// full list of release notes…" `<p>` footer. Headings aren't matched by this
+    /// sweep (only `<li>`/`<p>`), so both tags count as items; only that trailing
+    /// footer paragraph is dropped.
+    static func jetBrainsItems(from whatsnew: String, code: String) -> [String] {
+        let tags = code == "TBA" ? "li|p" : "li"
+        guard let regex = try? NSRegularExpression(
+            pattern: "<(\(tags))>(.*?)</\\1>",
+            options: [.caseInsensitive, .dotMatchesLineSeparators])
+        else { return [] }
+        let ns = whatsnew as NSString
+        var items: [String] = []
+        for match in regex.matches(in: whatsnew, range: NSRange(location: 0, length: ns.length)) {
+            guard match.numberOfRanges > 2 else { continue }
+            let raw = ns.substring(with: match.range(at: 2))
+            if raw.range(
+                of: #"^\s*See the full list"#, options: [.regularExpression, .caseInsensitive]
+            ) != nil { continue }
+            let cleaned = ChangelogExtractor.collapseWhitespace(
+                ChangelogExtractor.decodeEntities(ChangelogExtractor.stripTags(raw)))
+            if !cleaned.isEmpty { items.append(cleaned) }
+        }
+        return items
+    }
     // MARK: - Typeless (typeless.com/help/release-notes/macos)
 
     /// Typeless's release-notes page is a Next.js SSG page whose entire content is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -148,7 +148,12 @@ public enum StructuredChangelogDecoder {
     static func bulletItems(from markdown: String?) -> [String] {
         guard let markdown else { return [] }
         return markdown
-            .split(separator: "\n", omittingEmptySubsequences: true)
+            // `whereSeparator`, not `separator: "\n"` — see the note in
+            // `postmanItems`: Swift treats "\r\n" as one Character that does not
+            // equal "\n", so a CRLF body would come back as a single giant line.
+            // ChatWise's feed is LF today; this costs nothing and removes the
+            // trap for the next vendor that isn't.
+            .split(omittingEmptySubsequences: true, whereSeparator: { $0.isNewline })
             .map { line -> String in
                 var s = line.trimmingCharacters(in: .whitespaces)
                 s = s.replacingOccurrences(
@@ -328,21 +333,10 @@ public enum StructuredChangelogDecoder {
             let items = (entry.notes ?? []).filter { !$0.isEmpty }
             guard !items.isEmpty else { continue }
             entries.append(.init(
-                version: version, date: gitHubDesktopDate(entry.pubDate), items: items))
+                version: version, date: isoDay(entry.pubDate), items: items))
             if let cap = maxEntries, entries.count >= cap { break }
         }
         return entries.isEmpty ? nil : Changelog(entries: entries)
-    }
-
-    /// `2026-06-01T17:43:05Z` → `2026-06-01`, matching the old regex recipe's
-    /// `"pub_date":"(?<date>\d{4}-\d{2}-\d{2})[^"]*"` capture (day precision only,
-    /// no time-of-day shown in the UI). nil when the leading segment isn't a plain
-    /// date, rather than showing a raw ISO string.
-    static func gitHubDesktopDate(_ raw: String?) -> String? {
-        guard let raw, raw.count >= 10 else { return nil }
-        let ymd = String(raw.prefix(10))
-        return ymd.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil
-            ? ymd : nil
     }
 
     // MARK: - Postman (mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json)
@@ -419,8 +413,17 @@ public enum StructuredChangelogDecoder {
                     return nil
                 }
                 if postmanIsDateLine(line) { return nil }
-                guard line.count >= 10 else { return nil }
-                return line
+                // Trim/collapse BEFORE the length floor, not after. The regex path
+                // ended in `ChangelogExtractor.clean` → `collapseWhitespace`, so its
+                // `{10,}` quantifier counted the raw match but the *stored* item was
+                // normalized. Skipping this left 129 lines of today's feed with
+                // trailing spaces and 23 with internal double spaces — invisible in
+                // most renderings but a real diff against the old output — and made
+                // the floor measure untrimmed length, so a line of eleven spaces
+                // would have become a blank bullet where the old path dropped it.
+                let cleaned = ChangelogExtractor.collapseWhitespace(line)
+                guard cleaned.count >= 10 else { return nil }
+                return cleaned
             }
     }
 
@@ -478,14 +481,46 @@ public enum StructuredChangelogDecoder {
             // Reuse the same parser GitHub-release version detection already
             // uses for a single release's notes (`GitHubMarkdownParser`), rather
             // than a second bespoke bullet-extractor for the same markdown shape.
-            guard let parsed = GitHubMarkdownParser.parse(body: body, version: version, date: date),
-                  let entry = parsed.entries.first
-            else { continue }
-            entries.append(entry)
+            if let parsed = GitHubMarkdownParser.parse(body: body, version: version, date: date),
+               let entry = parsed.entries.first {
+                entries.append(entry)
+            } else if let prose = zedProseFallback(body: body) {
+                // `GitHubMarkdownParser` returns nil for a body with no bullets, and
+                // Zed ships such releases: 1 of the newest 100 today (`v1.5.3-pre`,
+                // whose whole body is "No public-facing changes in this release.").
+                // Skipping them left a Preview user sitting on exactly that build
+                // with NO entry for their own version — the retired zed.dev recipe
+                // had a `<p>` item pattern that covered this, so dropping them was a
+                // content regression against the source this replaced.
+                entries.append(.init(version: version, date: date, items: [prose]))
+            } else {
+                continue
+            }
             if let cap = maxEntries, entries.count >= cap { break }
         }
         guard !entries.isEmpty else { return nil }
         return Changelog(entries: entries, itemSyntax: .markdown)
+    }
+
+    /// The first non-empty, non-heading prose line of a release body that has no
+    /// bullets at all — Zed's "No public-facing changes in this release." shape.
+    /// Markdown links are flattened to their text so the trailing
+    /// "[View the commits](…)" doesn't render as raw bracket syntax; the entry is
+    /// emitted with `.markdown` syntax like every other Zed entry, so anything
+    /// left is rendered rather than shown literally. nil when the body is only
+    /// headings/links, in which case the release really is skipped.
+    static func zedProseFallback(body: String) -> String? {
+        for rawLine in body.split(omittingEmptySubsequences: true, whereSeparator: { $0.isNewline }) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#"), !line.hasPrefix("<") else { continue }
+            let flattened = ChangelogExtractor.collapseWhitespace(
+                line.replacingOccurrences(
+                    of: #"\[([^\]]*)\]\((?:[^()]|\([^()]*\))*\)"#, with: "$1",
+                    options: .regularExpression))
+            guard !flattened.isEmpty else { continue }
+            return flattened
+        }
+        return nil
     }
 
     /// `v1.17.0-pre` → `1.17.0`, `v1.16.1` → `1.16.1`: drop the leading `v` and
@@ -511,7 +546,14 @@ public enum StructuredChangelogDecoder {
     /// `<ol><li>version</li><li>item</li>…</ol>` HTML fragment; `updatedate` is a
     /// `YYYY-MM-DD HH:mm:ss` timestamp.
     private struct SunLoginLogEntry: Decodable {
-        let logs: String
+        /// Optional, like every other field every decoder in this file declares.
+        /// Non-optional here would make a single `"logs": null` anywhere in the
+        /// array throw out of `JSONDecoder.decode`, returning nil for the WHOLE
+        /// feed and dropping the user back to the embedded web page — where the
+        /// regex this replaced would simply have skipped that one entry. The
+        /// file's own contract is "an entry with no usable notes yields fewer
+        /// entries", not "yields none".
+        let logs: String?
         let updatedate: String?
     }
 
@@ -522,11 +564,12 @@ public enum StructuredChangelogDecoder {
 
         var entries: [Changelog.Entry] = []
         for entry in feed.logs {
-            let (version, items) = sunLoginParseLogHTML(entry.logs)
+            guard let logs = entry.logs else { continue }
+            let (version, items) = sunLoginParseLogHTML(logs)
             guard let version, !items.isEmpty else { continue }
             entries.append(.init(
                 version: version,
-                date: entry.updatedate.map { String($0.prefix(10)) },
+                date: isoDay(entry.updatedate),
                 items: items))
             if let cap = maxEntries, entries.count >= cap { break }
         }
@@ -538,6 +581,13 @@ public enum StructuredChangelogDecoder {
     /// line. JSONDecoder has already resolved the JSON string's `\uXXXX`/`\/`
     /// escapes by the time this runs, so the fragment is plain HTML with real
     /// UTF-8 text and unescaped slashes — no entity/unicode decoding needed here.
+    ///
+    /// Each `<li>`'s inner text goes through the same `stripTags` → `decodeEntities`
+    /// → `collapseWhitespace` the retired recipe's defaults applied, so a nested
+    /// `<b>`/`<a>` or an `&amp;` renders as text rather than as markup. (The
+    /// JetBrains decoder alongside this one already does; this was the odd sibling
+    /// out. Today's payload has neither, so it is a robustness fix, not a visible
+    /// one.)
     static func sunLoginParseLogHTML(_ html: String) -> (version: String?, items: [String]) {
         guard let regex = try? NSRegularExpression(
             pattern: #"<li>(.*?)</li>"#, options: [.dotMatchesLineSeparators])
@@ -546,8 +596,10 @@ public enum StructuredChangelogDecoder {
         let lines = regex.matches(in: html, range: NSRange(location: 0, length: ns.length))
             .compactMap { match -> String? in
                 guard match.numberOfRanges > 1 else { return nil }
-                let s = ns.substring(with: match.range(at: 1))
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let raw = ns.substring(with: match.range(at: 1))
+                let s = ChangelogExtractor.collapseWhitespace(
+                    ChangelogExtractor.decodeEntities(
+                        ChangelogExtractor.stripTags(raw)))
                 return s.isEmpty ? nil : s
             }
         guard let version = lines.first else { return (nil, []) }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -34,6 +34,8 @@ public enum StructuredChangelogDecoder {
             return decodePostman(body, maxEntries: maxEntries)
         case .jetBrainsProductReleases:
             return decodeJetBrainsProductReleases(body, maxEntries: maxEntries)
+        case .zedGitHubReleases:
+            return decodeZedGitHubReleases(body, channel: channel ?? .stable, maxEntries: maxEntries)
         }
     }
 
@@ -434,6 +436,65 @@ public enum StructuredChangelogDecoder {
         guard let raw else { return nil }
         if let t = raw.firstIndex(of: "T") { return String(raw[raw.startIndex..<t]) }
         return raw.isEmpty ? nil : raw
+    }
+
+    // MARK: - Zed (api.github.com/repos/zed-industries/zed/releases)
+
+    /// One element of the GitHub Releases API array. Only the fields we use;
+    /// everything else (assets, author, reactions, …) is ignored by Decodable.
+    private struct ZedRelease: Decodable {
+        let tagName: String
+        let prerelease: Bool
+        let publishedAt: String?
+        let body: String?
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case prerelease
+            case publishedAt = "published_at"
+            case body
+        }
+    }
+
+    /// `prerelease` is the channel split: Zed's Preview builds tag as
+    /// `vX.Y.Z-pre` and always carry `prerelease: true`, Stable never does
+    /// (confirmed 1:1 with the tag suffix across 100 sampled releases — no
+    /// exceptions). The list is already newest-first, so filtering by channel
+    /// preserves that order; no re-sort needed (unlike Warp's unordered map).
+    static func decodeZedGitHubReleases(
+        _ body: String, channel: ReleaseChannel, maxEntries: Int?
+    ) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let releases = try? JSONDecoder().decode([ZedRelease].self, from: data)
+        else { return nil }
+
+        let wantsPrerelease = channel == .preview
+        var entries: [Changelog.Entry] = []
+        for release in releases where release.prerelease == wantsPrerelease {
+            guard let body = release.body, !body.isEmpty else { continue }
+            let version = zedDisplayVersion(fromTag: release.tagName)
+            let date = release.publishedAt.map { String($0.prefix(10)) }
+            // Reuse the same parser GitHub-release version detection already
+            // uses for a single release's notes (`GitHubMarkdownParser`), rather
+            // than a second bespoke bullet-extractor for the same markdown shape.
+            guard let parsed = GitHubMarkdownParser.parse(body: body, version: version, date: date),
+                  let entry = parsed.entries.first
+            else { continue }
+            entries.append(entry)
+            if let cap = maxEntries, entries.count >= cap { break }
+        }
+        guard !entries.isEmpty else { return nil }
+        return Changelog(entries: entries, itemSyntax: .markdown)
+    }
+
+    /// `v1.17.0-pre` → `1.17.0`, `v1.16.1` → `1.16.1`: drop the leading `v` and
+    /// the `-pre` suffix so the rail version matches the installed
+    /// `CFBundleShortVersionString`, which is what `GitHubReleaseRule`'s
+    /// `versionPattern` (`v([0-9]+\.[0-9]+\.[0-9]+)-pre`) already extracts for
+    /// Preview and what the tag is verbatim (minus `v`) for Stable.
+    static func zedDisplayVersion(fromTag tag: String) -> String {
+        var v = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+        if v.hasSuffix("-pre") { v = String(v.dropLast(4)) }
+        return v
     }
 
     // MARK: - SunLogin/AweSun (client-webapi.oray.com/softwares/…)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -26,6 +26,8 @@ public enum StructuredChangelogDecoder {
             return decodeWeChatDevTools(body)
         case .chatwiseReleases:
             return decodeChatWise(body, maxEntries: maxEntries)
+        case .sunLoginSoftwareLogs:
+            return decodeSunLogin(body, maxEntries: maxEntries)
         case .gitHubDesktopChangelog:
             return decodeGitHubDesktop(body, maxEntries: maxEntries)
         }
@@ -333,6 +335,61 @@ public enum StructuredChangelogDecoder {
         let ymd = String(raw.prefix(10))
         return ymd.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil
             ? ymd : nil
+    }
+
+    // MARK: - SunLogin/AweSun (client-webapi.oray.com/softwares/…)
+
+    /// Top-level shape we care about: a `logs` array, one object per release,
+    /// already newest-first in the document (verified against the live feed
+    /// 2026-08-21: entries ran 2026-08-05 → 2024-07-08 in that order).
+    private struct SunLoginFeed: Decodable {
+        let logs: [SunLoginLogEntry]
+    }
+    /// One release. `logs` (yes, same name as the array) is a fixed
+    /// `<ol><li>version</li><li>item</li>…</ol>` HTML fragment; `updatedate` is a
+    /// `YYYY-MM-DD HH:mm:ss` timestamp.
+    private struct SunLoginLogEntry: Decodable {
+        let logs: String
+        let updatedate: String?
+    }
+
+    static func decodeSunLogin(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let feed = try? JSONDecoder().decode(SunLoginFeed.self, from: data)
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        for entry in feed.logs {
+            let (version, items) = sunLoginParseLogHTML(entry.logs)
+            guard let version, !items.isEmpty else { continue }
+            entries.append(.init(
+                version: version,
+                date: entry.updatedate.map { String($0.prefix(10)) },
+                items: items))
+            if let cap = maxEntries, entries.count >= cap { break }
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    /// Split one entry's `<ol><li>…</li>…</ol>` fragment into (version, items):
+    /// the first `<li>` names the version, every subsequent `<li>` is one change
+    /// line. JSONDecoder has already resolved the JSON string's `\uXXXX`/`\/`
+    /// escapes by the time this runs, so the fragment is plain HTML with real
+    /// UTF-8 text and unescaped slashes — no entity/unicode decoding needed here.
+    static func sunLoginParseLogHTML(_ html: String) -> (version: String?, items: [String]) {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"<li>(.*?)</li>"#, options: [.dotMatchesLineSeparators])
+        else { return (nil, []) }
+        let ns = html as NSString
+        let lines = regex.matches(in: html, range: NSRange(location: 0, length: ns.length))
+            .compactMap { match -> String? in
+                guard match.numberOfRanges > 1 else { return nil }
+                let s = ns.substring(with: match.range(at: 1))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return s.isEmpty ? nil : s
+            }
+        guard let version = lines.first else { return (nil, []) }
+        return (version, Array(lines.dropFirst()))
     }
 
     // MARK: - Typeless (typeless.com/help/release-notes/macos)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2376,7 +2376,13 @@ public enum VendorProbeRegistry {
             mode: .redirectFilename,
             versionPattern: #"Notion-([0-9]+\.[0-9]+\.[0-9]+)-"#,
             downloadURL: URL(string: "https://www.notion.com/desktop")!,
-            changelogURL: URL(string: "https://www.notion.com/releases")!,
+            // The desktop what's-new page, NOT www.notion.com/releases: that one is
+            // the product announcement feed whose "versions" are post titles with no
+            // build number, which is the mismatch the changelog recipe moved away
+            // from. This is the WebView fallback, so pointing it at the old page put
+            // the user right back on the feed that doesn't match their install.
+            changelogURL: URL(
+                string: "https://notion.notion.site/What-s-New-Mac-Windows-5936dabc8dd6497895786c91b9d6f12a")!,
             install: VendorInstallSpec(
                 urlSource: .redirect(URL(string: "https://www.notion.so/desktop/mac/download")!),
                 kind: .dmg),

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -661,99 +661,201 @@ private let bionicFixture = """
     #expect(changelog?.entries.first?.version == "4.8.8")
 }
 
-// Trimmed real payload from mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json.
-// Content field is Markdown with \\r\\n line separators (raw JSON escapes). Two entries:
-// one with a #### feature heading + plain description + bug-fix line, and one with only
-// a plain bug-fix line (no #### heading) to cover the simpler layout.
-private let postmanFixture = """
-{"notes":[{"version":"12.12.7","content":"## Postman 12.12.7\\r\\nMay 30, 2026\\r\\n\\r\\n### Improvements\\r\\n#### Aggregated test results in Postman Flows run logs\\r\\nRun logs in Postman Flows now aggregate and display test results from all **Request** blocks in a single summary view.\\r\\n\\r\\n### Bug fixes\\r\\nResolved an issue in Postman Flows where the environment selector would not respond.\\r\\n","createdAt":"2026-05-30T04:43:09.000Z"},{"version":"12.13.2","content":"## Postman 12.13.2\\r\\nJune 2, 2026\\r\\n\\r\\n### Bug Fixes\\r\\nSome critical bug fixes and enhancements were added in this release.\\r\\n","createdAt":"2026-06-02T02:32:09.000Z"}]}
-"""
+// Byte-for-byte slice of the real feed (curled 2026-08-21 from
+// mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json), four
+// "notes[]" objects verbatim, covering every shape the decoder has to handle:
+//   - 12.24.3: a `#### ` feature heading (kept, prefix stripped) followed by a
+//     bold safety line, two prose paragraphs, and a trailing `[text](url)` link
+//     line — 5 items, `\r\n` separators.
+//   - 12.23.7: the same shape but with a `- ` bullet list in the middle — 8
+//     items, exercises "not just single-paragraph" bodies.
+//   - 12.17.3: the entry the OLD regex path truncated. Its one bug-fix line
+//     contains an escaped quote (`\"8000\"`) — the old itemPattern's
+//     `[^\\]{10,}` capture stopped at that backslash and silently dropped the
+//     rest of the sentence. This fixture pins the FULL, correct sentence.
+//   - 9.18.2: a legacy entry whose body uses a bare `\n` separator (only the
+//     very last blank line is `\r\n\r\n`) — the format older entries actually
+//     shipped in, which the old itemPattern (anchored on `\\r\\n`) could never
+//     match at all.
+private let postmanFeedFixture = #"""
+{"notes":[
+{"version":"12.24.3","content":"## Postman 12.24.3\r\nAugust 19, 2026\r\n\r\n### What’s New\r\n#### Mocks are now available in Cloud View\r\n**Available on Solo, Team, and Enterprise plans**\r\n\r\nMocks let you simulate APIs using custom JavaScript request handlers. In Cloud View, each mock receives a unique URL and is always available to handle requests.\r\n\r\nYou can also deploy a mock as a mock server, giving your team a cloud-hosted service they can send requests to at any time. By default, mock servers deployed from a mock are private and require workspace access or a valid Postman API key.\r\n\r\nTo learn more, see [Build API mocks with JavaScript](https://learning.postman.com/docs/design-apis/mock-apis/local-mock-servers).\r\n\r\n","createdAt":"2026-08-19T06:06:19.000Z"},
+{"version":"12.23.7","content":"## Postman 12.23.7\r\nAugust 14, 2026\r\n\r\n### What’s New\r\n#### Buy Postman from AWS Marketplace\r\n\r\nYou can now purchase Postman Team and Enterprise plans directly through the AWS Marketplace, consolidating Postman within your existing AWS billing.\r\n\r\nThere are two ways to get started:\r\n\r\n- Subscribe from the AWS Marketplace listing and complete setup on a Postman-hosted page.\r\n- In the Postman app, click **Buy with AWS** to purchase without leaving Postman.\r\n\r\nBoth flows support purchasing for your own team or on behalf of another team in your organization. All subscription changes are managed through the AWS Marketplace console.\r\n\r\nAvailable for net-new Team and Enterprise plans.\r\n\r\nTo learn more, see [Purchase AWS from AWS Marketplace](https://learning.postman.com/docs/billing/buying-aws).\r\n\r\n","createdAt":"2026-08-14T02:32:42.000Z"},
+{"version":"12.17.3","content":"## Postman 12.17.3\r\nJuly 2, 2026\r\n\r\n### Bug fixes\r\nFixed an issue in Postman Flows where configuration values typed as Number arrived as text at runtime (for example, 8000 became \"8000\" ), which could break blocks expecting a real number.\r\n","createdAt":"2026-07-02T02:32:20.000Z"},
+{"version":"9.18.2","content":"## Postman v9.18.2\n\n### Bug Fixes\n- Fixed the issue of cookies not showing up in the interceptor debug session - [Github #10901](https://github.com/postmanlabs/postman-app-support/issues/10901)\r\n\r\n","createdAt":"2022-05-11T10:42:53.000Z"}
+]}
+"""#
 
-@Test func extractsPostmanEntriesFromJSON() throws {
+@Test func postmanRecipeIsStructuredJSON() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.postmanlabs.mac"))
-    let changelog = try #require(ChangelogExtractor.extract(from: postmanFixture, using: recipe))
-
-    #expect(changelog.entries.count == 2)
-    #expect(changelog.entries[0].version == "12.12.7")
-    #expect(changelog.entries[0].date == "2026-05-30")
-    #expect(changelog.entries[0].items.count == 3)
-    #expect(changelog.entries[0].items[0] == "Aggregated test results in Postman Flows run logs")
-    #expect(changelog.entries[0].items[1].contains("Run logs in Postman Flows"))
-    #expect(changelog.entries[0].items[2].contains("Resolved an issue"))
-    #expect(changelog.entries[1].version == "12.13.2")
-    #expect(changelog.entries[1].date == "2026-06-02")
-    #expect(changelog.entries[1].items.count == 1)
-    #expect(changelog.entries[1].items[0].contains("critical bug fixes"))
+    #expect(recipe.structuredFormat == .postmanReleaseNotes)
+    #expect(recipe.maxEntries == 30)
+    #expect(recipe.entryPattern.isEmpty)
+    #expect(recipe.itemPatterns.isEmpty)
 }
 
-// Trimmed real markup from update.dcloud.net.cn/hbuilderx/changelog/<version>.html.
-// The page is cumulative — all versions in one file. Each version block starts with
-// an <h2>, categories are <h3>, and changes are <li>. No explicit date field;
-// the version string itself encodes YYYYMMDD (e.g. 5.07.2026041006 = 2026-04-10).
+@Test func decodesPostmanFeedSliceExactly() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        postmanFeedFixture, format: .postmanReleaseNotes, channel: nil, maxEntries: 10))
+
+    #expect(changelog.entries.count == 4)
+
+    let a = changelog.entries[0]
+    #expect(a.version == "12.24.3")
+    #expect(a.date == "2026-08-19")
+    #expect(a.items.count == 5)
+    #expect(a.items[0] == "Mocks are now available in Cloud View")
+    #expect(a.items[1] == "**Available on Solo, Team, and Enterprise plans**")
+    #expect(a.items.last == "To learn more, see [Build API mocks with JavaScript](https://learning.postman.com/docs/design-apis/mock-apis/local-mock-servers).")
+    // The "## Postman 12.24.3" title line, the "August 19, 2026" date line, and
+    // the "### What's New" section heading must all be filtered out — none of
+    // them are a change line.
+    #expect(!a.items.contains { $0.contains("## Postman") })
+    #expect(!a.items.contains { $0.contains("August 19, 2026") })
+    #expect(!a.items.contains { $0.contains("What’s New") })
+
+    let b = changelog.entries[1]
+    #expect(b.version == "12.23.7")
+    #expect(b.date == "2026-08-14")
+    #expect(b.items.count == 8)
+    #expect(b.items[0] == "Buy Postman from AWS Marketplace")
+    #expect(b.items[3] == "- Subscribe from the AWS Marketplace listing and complete setup on a Postman-hosted page.")
+    #expect(b.items.last == "To learn more, see [Purchase AWS from AWS Marketplace](https://learning.postman.com/docs/billing/buying-aws).")
+
+    // 12.17.3: the old regex path's item capture (`[^\\]{10,}`) stopped at the
+    // backslash in `\"8000\"`, truncating this to "...8000 became ". The
+    // structured decoder reads the real, unescaped string and must not lose the
+    // rest of the sentence.
+    let c = changelog.entries[2]
+    #expect(c.version == "12.17.3")
+    #expect(c.items.count == 1)
+    #expect(c.items[0] == "Fixed an issue in Postman Flows where configuration values typed as Number arrived as text at runtime (for example, 8000 became \"8000\" ), which could break blocks expecting a real number.")
+
+    // 9.18.2: legacy entry whose body is `\n`-separated (not `\r\n`) — a shape
+    // the old itemPattern could never match, so this release's notes were
+    // structurally invisible under the regex path. The decoder must still find it.
+    let d = changelog.entries[3]
+    #expect(d.version == "9.18.2")
+    #expect(d.date == "2022-05-11")
+    #expect(d.items == ["- Fixed the issue of cookies not showing up in the interceptor debug session - [Github #10901](https://github.com/postmanlabs/postman-app-support/issues/10901)"])
+}
+
+@Test func postmanDecodeRespectsMaxEntries() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        postmanFeedFixture, format: .postmanReleaseNotes, channel: nil, maxEntries: 2))
+    #expect(changelog.entries.count == 2)
+    #expect(changelog.entries.map(\.version) == ["12.24.3", "12.23.7"])
+}
+
+@Test func postmanMalformedBodyDecodesToNil() {
+    #expect(StructuredChangelogDecoder.decode(
+        "not json at all", format: .postmanReleaseNotes, channel: nil, maxEntries: 30) == nil)
+    #expect(StructuredChangelogDecoder.decode(
+        #"{"notes": []}"#, format: .postmanReleaseNotes, channel: nil, maxEntries: 30) == nil)
+}
+
+// Verbatim leading slice (lines 1-17, plus one trailing blank line so the last
+// item's line-end still has a following "\n" for the item pattern's lookahead —
+// see the note on that below) of the real response body from
+// https://hx.dcloud.net.cn/zh-cn/Tutorial/changelog/ReleaseNote_release.md,
+// fetched 2026-08-21. Two version blocks: 5.24.2026081301 has a single
+// link-free item; 5.23.2026080626 has 13 items, all but one carrying a
+// trailing `[详情](url)` markdown link, and one (the uni-network-cronet line)
+// carrying both a `[文档](url)` link AND a bare `<url>` autolink after it — the
+// item pattern must strip all of that, in sequence, off the end of the line.
+// No date field — the version itself encodes YYYYMMDD (5.23.2026080626 =
+// 2026-08-06), same as the old HTML source; this is not a regression.
 private let hbuilderxFixture = """
-<h1 id="hbuilder-x---release-notes">HBuilder X - Release Notes</h1>
-<p>======================================</p>
-<h2 id="5072026041006">5.07.2026041006</h2>
-<h3 id="hbuilder">HBuilder</h3>
-<ul>
-<li>修复 5.0版本引发的 uni-app iOS安心打包图标没有生效 <a href="https://issues.dcloud.net.cn/pages/issues/detail?id=27902">详情</a></li>
-</ul>
-<h3 id="uni-app-x">uni-app x</h3>
-<ul>
-<li>Android平台 修复 5.0版本引发的 API uni.showLoading 调用异常 <a href="https://issues.dcloud.net.cn/pages/issues/detail?id=27821">详情</a></li>
-</ul>
-<h2 id="5062026033105">5.06.2026033105</h2>
-<h3 id="hbuilder-1">HBuilder</h3>
-<ul>
-<li>macOS平台 修复 5.0版本引发的 iOS 安心打包功能中资源拷贝路径不正确的问题 <a href="https://issues.dcloud.net.cn/pages/issues/detail?id=27379">详情</a></li>
-</ul>
+## 5.24.2026081301
+* 修复 uniapp框架的一些Bug
+
+## 5.23.2026080626
+* Windows平台 修复 Windows 上使用在外部资源管理器打开文件时未选中目标文件 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=29907)
+* 修复 5.0版本引发的 AI对比工具栏缺少跟随移动，多窗口下进行部分操作导致工具栏不消失 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31128)
+* 修复 4.81版本引发的 部分git操作导致的文件变更无法在editor内同步 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=28392)
+* 修复 条件编译置灰和 对比选中文件/uni-agent插件代码修改 的预览样式冲突 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=26579)
+* 修复 在uniapp项目下uni.没有提示 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31477)
+* 新增 HBuilderX CLI 支持通过 config get/set 命令行工具动态查询与管理全局配置项 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31115)
+* 新增 HBuilderX CLI 独立编译 App 端 UTS 文件及 uni_modules 模块 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31116)
+* 修复 HBuilderX cli launch 命令运行鸿蒙元服务时会卡住 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31740)
+* 新增 manifest.json uni-app x Android平台 打包是否压缩so库的可视化选项 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31099)
+* 新增 manifest.json uni-app x iOS平台可选模块配置 uni-oauth apple登录 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31102)
+* 新增 manifest.json uni-app x 蒸汽模式 Android平台 可选模块配置 uni-network-cronet [文档](https://doc.dcloud.net.cn/uni-app-x/collocation/manifest-android.html#modulesnetwork) <https://issues.dcloud.net.cn/pages/issues/detail?id=31450>
+* 新增 鸿蒙App配置增加可选模块配置uni-requestMerchantTransfer [文档](https://doc.dcloud.net.cn/uni-app-x/api/request-merchant-transfer.html) <https://issues.dcloud.net.cn/pages/issues/detail?id=31481>
+* 新增 对应用打包所包含的动态库进行体积优化 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31285)
+
 """
 
-@Test func extractsHBuilderXEntriesInOrder() throws {
+@Test func extractsHBuilderXMarkdownEntriesWithLinksStripped() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "io.dcloud.HBuilderX"))
     let changelog = try #require(ChangelogExtractor.extract(from: hbuilderxFixture, using: recipe))
 
     #expect(changelog.entries.count == 2)
-    #expect(changelog.entries[0].version == "5.07.2026041006")
+    #expect(changelog.entries[0].version == "5.24.2026081301")
     #expect(changelog.entries[0].date == nil)
-    #expect(changelog.entries[0].items.count == 2)
-    #expect(changelog.entries[0].items[0].contains("uni-app iOS安心打包图标没有生效"))
-    #expect(changelog.entries[1].version == "5.06.2026033105")
-    #expect(changelog.entries[1].items.count == 1)
-    #expect(changelog.entries[1].items[0].contains("iOS 安心打包功能中资源拷贝路径不正确"))
+    #expect(changelog.entries[0].items.count == 1)
+    #expect(changelog.entries[0].items[0] == "修复 uniapp框架的一些Bug")
+
+    #expect(changelog.entries[1].version == "5.23.2026080626")
+    #expect(changelog.entries[1].date == nil)
+    #expect(changelog.entries[1].items.count == 13)
+    // First item: trailing `[详情](url)` stripped clean off the end.
+    #expect(
+        changelog.entries[1].items.first
+            == "Windows平台 修复 Windows 上使用在外部资源管理器打开文件时未选中目标文件")
+    // Last item: same — the trailing link is gone, not left as a literal
+    // "[详情](https://...)" tail.
+    #expect(changelog.entries[1].items.last == "新增 对应用打包所包含的动态库进行体积优化")
+    // The uni-network-cronet line carries a `[文档](url)` link immediately
+    // followed by a bare `<url>` autolink — both must be stripped, not just one.
+    let cronetItem = try #require(
+        changelog.entries[1].items.first { $0.contains("uni-network-cronet") })
+    #expect(
+        cronetItem
+            == "新增 manifest.json uni-app x 蒸汽模式 Android平台 可选模块配置 uni-network-cronet")
+    #expect(!cronetItem.contains("["))
+    #expect(!cronetItem.contains("<"))
 }
 
-// Trimmed real markup from the HBuilderX *Alpha* changelog page (followed from
-// alpha.json's `release` field). Same shape as the stable page, but every version
-// <h2> carries an "-alpha" suffix — which the alpha recipe's version group requires.
+// Verbatim leading slice (lines 1-13, plus trailing blank line for the same
+// lookahead reason as above) of
+// https://hx.dcloud.net.cn/zh-cn/Tutorial/changelog/ReleaseNote_alpha.md,
+// fetched 2026-08-21. Every version heading carries the "-alpha" suffix, which
+// the alpha recipe's version group requires (and the stable recipe's doesn't
+// allow) — confirms the suffix survives capture intact rather than being eaten
+// by the version pattern's dot-number matching.
 private let hbuilderxAlphaFixture = """
-<h1 id="hbuilder-x---release-notes">HBuilder X - Release Notes</h1>
-<h2 id="5112026052520-alpha">5.11.2026052520-alpha</h2>
-<h3 id="hbuilder">HBuilder</h3>
-<ul>
-<li>调整 内置node版本由v18.20.0升级到v22.22.2</li>
-</ul>
-<h3 id="uni-app-x">uni-app x</h3>
-<ul>
-<li>Android平台 修复 某些情况下编译报错的问题 <a href="https://issues.dcloud.net.cn/x">详情</a></li>
-</ul>
-<h2 id="5082026050815-alpha">5.08.2026050815-alpha</h2>
-<h3 id="hbuilder-1">HBuilder</h3>
-<ul>
-<li>修复 alpha 渠道某个崩溃问题</li>
-</ul>
+## 5.23.2026080313-alpha
+* 修复 cli launch 命令运行鸿蒙元服务时会卡住 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31740)
+
+## 5.22.2026072503-alpha
+* 修复 条件编译置灰和 对比选中文件/uni-agent插件代码修改 的预览样式冲突 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=26579)
+* 修复 5.0版本引发的 AI对比工具栏缺少跟随移动，多窗口下进行部分操作导致工具栏不消失 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31128)
+* 新增 HBuilderX CLI 支持通过 config get/set 命令行工具动态查询与管理全局配置项 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31115)
+* 新增 HBuilderX CLI 独立编译 App 端 UTS 文件及 uni_modules 模块 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31116)
+* 新增 manifest.json uni-app x Android平台 打包是否压缩so库的可视化选项 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31099)
+* 新增 manifest.json uni-app x iOS平台可选模块配置 uni-oauth apple登录 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31102)
+* 新增 manifest.json uni-app x 蒸汽模式 Android平台 可选模块配置 uni-network-cronet [文档](https://doc.dcloud.net.cn/uni-app-x/collocation/manifest-ios.html#modulesoauth) <https://issues.dcloud.net.cn/pages/issues/detail?id=31450>
+* 新增 鸿蒙App配置增加可选模块配置uni-requestMerchantTransfer [文档](https://doc.dcloud.net.cn/uni-app-x/api/request-merchant-transfer.html) <https://issues.dcloud.net.cn/pages/issues/detail?id=31481>
+* 新增 对应用打包所包含的动态库进行体积优化 [详情](https://issues.dcloud.net.cn/pages/issues/detail?id=31285)
+
 """
 
-@Test func extractsHBuilderXAlphaEntriesWithSuffix() throws {
+@Test func extractsHBuilderXAlphaMarkdownEntriesWithSuffix() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "io.dcloud.HBuilderXAlpha"))
     let changelog = try #require(ChangelogExtractor.extract(from: hbuilderxAlphaFixture, using: recipe))
 
     #expect(changelog.entries.count == 2)
-    #expect(changelog.entries[0].version == "5.11.2026052520-alpha")
-    #expect(changelog.entries[0].items.count == 2)
-    #expect(changelog.entries[0].items[0].contains("内置node版本"))
-    #expect(changelog.entries[1].version == "5.08.2026050815-alpha")
-    #expect(changelog.entries[1].items.count == 1)
+    #expect(changelog.entries[0].version == "5.23.2026080313-alpha")
+    #expect(changelog.entries[0].items.count == 1)
+    #expect(changelog.entries[0].items[0] == "修复 cli launch 命令运行鸿蒙元服务时会卡住")
+
+    #expect(changelog.entries[1].version == "5.22.2026072503-alpha")
+    #expect(changelog.entries[1].items.count == 9)
+    #expect(
+        changelog.entries[1].items.first
+            == "修复 条件编译置灰和 对比选中文件/uni-agent插件代码修改 的预览样式冲突")
+    #expect(changelog.entries[1].items.last == "新增 对应用打包所包含的动态库进行体积优化")
 }
 
 // Trimmed real markup from github.com/ollama/ollama/releases. Two sections:

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -1587,40 +1587,67 @@ private let obsidianFixture = #"""
     #expect(cl.entries.first?.items[2] == "Added appendBinary method to the vault and adapter API.")
 }
 
-// Figma — two product release-notes <article>s from figma.com/release-notes; the
-// first has a <strong> to strip and a `&#x27;` entity to decode. Title = version.
-private let figmaFixture = """
-<article aria-label="Plan smarter" class="fig-1ud82tx">\
-<div class="fig-1u7wo0i">\
-<time dateTime="Jun 3, 2026" class="fig-4tc1ef">Jun 3, 2026</time>\
-<h2 class="fig-1u8vp4l">Plan smarter with more context in Make</h2>\
-</div>\
-<div class="fig-k1i24q">\
-<p class="fig-jco665"><strong>Plan mode</strong></p>\
-<p class="fig-jco665">It&#x27;s most useful for complex work.</p>\
-</div></article>\
-<article aria-label="Sharper controls" class="fig-1ud82tx">\
-<div class="fig-1u7wo0i">\
-<time dateTime="Jun 1, 2026" class="fig-4tc1ef">Jun 1, 2026</time>\
-<h2 class="fig-1u8vp4l">Sharper controls for every slot</h2>\
-</div>\
-<div class="fig-k1i24q">\
-<p class="fig-jco665">New slot settings let you set guardrails.</p>\
-</div></article>
-"""
+// Figma — three verbatim <entry> blocks copied byte-for-byte from the live Atom
+// feed (https://www.figma.com/release-notes/feed/atom.xml, fetched 2026-08-19).
+// The third entry's content carries a raw apostrophe inside the CDATA ("We've
+// added…"), which exercises that the entry/item patterns land strictly inside
+// the `<![CDATA[…]]>` delimiters rather than swallowing them — a naive
+// `<[^>]*>` strip run before the CDATA is pulled out eats the whole
+// `<![CDATA[…]]>` construct (`[^>]*` reads through to the `>` that closes
+// `]]>`), which would otherwise corrupt exactly this kind of entry.
+private let figmaFixture = #"""
+    <entry>
+        <title type="html"><![CDATA[Recommend resources you want users to discover and use]]></title>
+        <id>dece0d00-5f03-4a5d-aa04-3b0fad21b5eb</id>
+        <link href="https://www.figma.com/release-notes/?title=recommend-resources-you-want-users-to-discover-and-use"/>
+        <updated>2026-08-17T00:00:00.000Z</updated>
+        <content type="html"><![CDATA[Admins can now choose which resources (skills, templates, libraries, and Make kits) are recommended to your organization or workspace.]]></content>
+    </entry>
+    <entry>
+        <title type="html"><![CDATA[Get responsive text across screens with text wrap]]></title>
+        <id>fdeb868a-690e-4286-9075-bc4d7fb7f1f9</id>
+        <link href="https://www.figma.com/release-notes/?title=get-responsive-text-across-screens-with-text-wrap"/>
+        <updated>2026-08-14T00:00:00.000Z</updated>
+        <content type="html"><![CDATA[Text wrap makes your text responsive with two new options: Balance and Pretty. Set either on a text layer, a text style, or an individual paragraph in text settings.]]></content>
+    </entry>
+    <entry>
+        <title type="html"><![CDATA[Try skills from the Community and make your own with the Figma agent]]></title>
+        <id>c6056d47-fcc7-497d-aa75-ee928836bfe4</id>
+        <link href="https://www.figma.com/release-notes/?title=weve-added-more-ways-to-discover-create-and-share-skills-for-the-figma-agent"/>
+        <updated>2026-08-13T00:00:00.000Z</updated>
+        <content type="html"><![CDATA[We've added more ways to discover, create, and share skills for the Figma agent.]]></content>
+    </entry>
+    """#
 
 @Test func extractsFigmaEntries() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.figma.Desktop"))
     let cl = try #require(ChangelogExtractor.extract(from: figmaFixture, using: recipe))
-    #expect(cl.entries.count == 2)
-    #expect(cl.entries.first?.version == "Plan smarter with more context in Make")
-    #expect(cl.entries.first?.date == "Jun 3, 2026")
-    #expect(cl.entries.first?.items.count == 2)
-    #expect(cl.entries.first?.items.first == "Plan mode")              // <strong> stripped
-    #expect(cl.entries.first?.items.last == "It's most useful for complex work.")  // &#x27; decoded
-    #expect(cl.entries.last?.version == "Sharper controls for every slot")
-    #expect(cl.entries.last?.items.count == 1)
+    #expect(cl.entries.count == 3)
+
+    let first = try #require(cl.entries.first)
+    #expect(first.version == "Recommend resources you want users to discover and use")
+    #expect(!first.version.contains("CDATA"))
+    #expect(!first.version.isEmpty)
+    #expect(first.date == "2026-08-17")
+    #expect(first.items.count == 1)
+    #expect(first.items.last == "Admins can now choose which resources (skills, templates, libraries, and Make kits) are recommended to your organization or workspace.")
+
+    let last = try #require(cl.entries.last)
+    #expect(last.version == "Try skills from the Community and make your own with the Figma agent")
+    #expect(!last.version.contains("CDATA"))
+    #expect(last.date == "2026-08-13")
+    #expect(last.items.count == 1)
+    // Raw apostrophe survives untouched — nothing to decode, and the CDATA
+    // delimiters themselves must not leak into the captured text.
+    #expect(last.items.last == "We've added more ways to discover, create, and share skills for the Figma agent.")
 }
+
+// Checked against the live 444-entry feed on 2026-08-19: no entry's <title> or
+// <content> carries an embedded HTML tag (e.g. <a>, <br>) inside its CDATA —
+// every post today is plain sentence-style text. So there is no real-world
+// fixture to pin that shape against; if the vendor starts embedding markup,
+// stripTags will clean it (same as every other HTML-sourced recipe here), but
+// there is nothing to regression-test until that actually happens.
 
 // 1Password's changelog moved from this page to the stable channel's RSS feed
 // on 2026-08-16 (see `OnePasswordFeedTests`), so the page fixture that used to

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -1530,8 +1530,34 @@ private let notionFixture = #"""
 <article class="release_release__p2Jug"><div class="release_releaseMeta__bvuES"><div class="release_dateRow__ew79j"><time class="release_date__P0TR_">May 26, 2026</time></div></div><div class="release_content__gxmgt"><a class="release_titleLink__zEwHf" href="/releases/2026-05-26"><h2 class="semanticTypography_semanticTypography__mWJkv release_title__o1nuh">Merge cells in simple tables</h2></a><article class="contentfulRichText_richText__rW7Oq"><p class="videoPlayer_errorLine__pR8bX">Uh-oh! Your ad blocker is preventing the video from playing.</p><p class="contentfulRichText_paragraph___hjRE">Finally! Merge cells in simple tables &amp; databases.</p><p class="contentfulRichText_paragraph___hjRE">Select multiple cells → open the cell menu → select <code class="contentfulRichText_code__RWBxk">Merge</code>.</p></article></div></article><article class="release_release__p2Jug"><div class="release_releaseMeta__bvuES"><div class="release_dateRow__ew79j"><time class="release_date__P0TR_">May 7, 2026</time></div></div><div class="release_content__gxmgt"><a class="release_titleLink__zEwHf" href="/releases/2026-05-07"><h2 class="semanticTypography_semanticTypography__mWJkv release_title__o1nuh">Plan Mode</h2></a><article class="contentfulRichText_richText__rW7Oq"><p class="contentfulRichText_paragraph___hjRE">Your agent now drafts a plan before making significant changes.</p></article></div></article></main>
 """#
 
+/// The regex recipe this fixture exercises is no longer the ACTIVE `notion.id`
+/// recipe in `ChangelogRecipeRegistry` — 2026-08-22 it was replaced by
+/// `.notionPageChunk` (see that recipe's comment), because this page has no
+/// build number at all and its post titles were standing in for one, which
+/// never matched the installed app's real version. The old pattern is kept
+/// commented out in the registry (not deleted) for reference, so it can no
+/// longer be fetched via `ChangelogRecipeRegistry.recipe(forBundleID:)` — this
+/// reconstructs it inline to keep the regression coverage for the pattern
+/// itself (the CSS-modules-rename fixture in `NotionChangelogRecipeTests`
+/// depends on the same pattern surviving).
+func notionProductAnnouncementsRecipe() -> ChangelogRecipe {
+    ChangelogRecipe(
+        bundleID: "notion.id",
+        source: URL(string: "https://www.notion.com/releases")!,
+        entryPattern:
+            #"<article class="(?:release_release__[^"]*|release-module-scss-module__[^"]*__release)">.*?"#
+            + #"<time class="(?:release_date__[^"]*|release-module-scss-module__[^"]*__date)">(?<date>[^<]+)</time>.*?"#
+            + #"<h2 class="[^"]*(?:release_title__[^"]*|release-module-scss-module__[^"]*__title)">(?<version>.*?)</h2>"#
+            + #"(?<body>.*?)(?=<article class="(?:release_release__|release-module-scss-module__[^"]*__release")|</main>|<footer)"#,
+        itemPatterns: [
+            #"<p class="(?:contentfulRichText_paragraph__[^"]*|contentfulRichText-module-scss-module__[^"]*__paragraph)">(?<item>.*?)</p>"#,
+        ],
+        maxEntries: 20,
+        minItemLength: 4)
+}
+
 @Test func extractsNotionEntries() throws {
-    let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "notion.id"))
+    let recipe = notionProductAnnouncementsRecipe()
     let cl = try #require(ChangelogExtractor.extract(from: notionFixture, using: recipe))
     #expect(cl.entries.count == 2)
     #expect(cl.entries.first?.version == "Merge cells in simple tables")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -1013,36 +1013,103 @@ private let orbStackFixture = """
     #expect(changelog.entries[1].items[0] == "Activity Monitor TUI: orb top")
 }
 
-// Minimal but structurally faithful slice: one patch release (2 items) and one
-// feature release with section headers (2 items from nested <ul>).
-// Three entries: one with only a <p> note (no <li>), one plain patch, one with
-// section headers. Verifies both the <li> primary pattern and the <p> fallback.
-let zedPreviewFixture = """
-<div class="foo" id="zed-1.5.3" style="content-visibility:auto"><header class="p-3 font-zed-mono text-sm flex justify-between border-b default-border-color"><p class="high-contrast-text tabular-nums">1.5.3</p><p class="tabular-nums whitespace-nowrap">May 28, 2026</p></header><div class="content"><article class="p-3"><p>No public-facing changes in this release. <a href="https://github.com/zed-industries/zed/compare/v1.5.2-pre...v1.5.3-pre#commits_bucket">View the commits</a>.</p></article></div></div><div class="foo" id="zed-1.5.1" style="content-visibility:auto"><header class="p-3 font-zed-mono text-sm flex justify-between border-b default-border-color"><p class="high-contrast-text tabular-nums">1.5.1</p><p class="tabular-nums whitespace-nowrap">May 28, 2026</p></header><div class="content"><article class="p-3"><ul class="list-disc">\n<li class="mb-2">Fixed GitHub Copilot Chat showing an empty model dropdown for users on newer Copilot SDK builds (<a href="https://github.com/zed-industries/zed/pull/57964">#57964</a>)</li>\n<li class="mb-2">git: Fixed an issue where worktree creation would not be possible if resolving default branch fails (<a href="https://github.com/zed-industries/zed/pull/57960">#57960</a>)</li>\n</ul></article></div></div><div class="foo" id="zed-1.5.0" style="content-visibility:auto"><header class="p-3 font-zed-mono text-sm flex justify-between border-b default-border-color"><p class="high-contrast-text tabular-nums">1.5.0</p><p class="tabular-nums whitespace-nowrap">May 27, 2026</p></header><div class="content"><article class="p-3"><h2 class="h3" id="features">Features</h2>\n<ul class="list-disc">\n<li class="mb-2">Agent: Added support for importing skills from GitHub Markdown URLs in the Skill Creator. (<a href="https://github.com/zed-industries/zed/pull/57458">#57458</a>)</li>\n<li class="mb-2">Agent: Added commands for opening global and project-specific <code>AGENTS.md</code> rules. (<a href="https://github.com/zed-industries/zed/pull/57847">#57847</a>)</li>\n</ul></article></div></div>
-"""
+// Real (trimmed) slice of api.github.com/repos/zed-industries/zed/releases as of
+// 2026-08-21: 4 of the 100 sampled releases, in the API's actual newest-first
+// order — v1.17.0-pre, v1.16.1, v1.16.1-pre, v1.15.1 — so decode order is a real
+// property of this fixture, not something the test asserts into existence.
+// Bodies are truncated to their first 1-2 bullets (full bodies ran 700–14000
+// chars) and CRLF-normalized to LF (the live API mixes both across releases;
+// `GitHubMarkdownParser`/`CharacterSet.newlines` treat them identically, so this
+// is a lossless simplification for the fixture, not a behavior change). Tags,
+// dates, and every character of the kept bullets are verbatim from the real
+// response — including the real PR-link/attribution markdown, which is why the
+// items below still carry `([#62577](...); thanks [x](...))`.
+let zedGitHubReleasesFixture = #"""
+[
+  {
+    "tag_name": "v1.17.0-pre",
+    "prerelease": true,
+    "published_at": "2026-08-19T17:47:30Z",
+    "body": "This week's release includes tabular data previews for CSV, TSV, PSV, and SSV files with sortable and resizable columns, value-based row filtering, and right-click copying; new Git blame and stashing actions; and lower memory use when opening large files.\n\n## Shipped by the Zed Guild 🛡️\n\n- Added support for low reasoning effort for DeepSeek V4 Flash and V4 Pro. ([#62577](https://github.com/zed-industries/zed/pull/62577); thanks [lingyaochu](https://github.com/lingyaochu))\n- Improved JetBrains keymap behavior with CamelHump-style subword navigation for `alt-left`, `alt-right`, `shift-alt-left`, and `shift-alt-right` in editors. ([#51540](https://github.com/zed-industries/zed/pull/51540); thanks [loadingalias](https://github.com/loadingalias))"
+  },
+  {
+    "tag_name": "v1.16.1",
+    "prerelease": false,
+    "published_at": "2026-08-19T16:11:34Z",
+    "body": "This week's release includes Gemini 3.6 Flash support, collapsible grouped changes and optional stash messages in the Git Panel, zooming and horizontal scrolling for Mermaid diagrams, and a new setting for controlling whether the Terminal Panel opens automatically in new workspaces.\n\n## Shipped by the Zed Guild 🛡️\n\n- Improved Git Panel organization by making grouped change sections collapsible. ([#62441](https://github.com/zed-industries/zed/pull/62441); thanks [chirivelli](https://github.com/chirivelli))\n- Linux: Improved memory usage. ([#62192](https://github.com/zed-industries/zed/pull/62192); thanks [tidely](https://github.com/tidely))"
+  },
+  {
+    "tag_name": "v1.16.1-pre",
+    "prerelease": true,
+    "published_at": "2026-08-18T15:58:22Z",
+    "body": "- Fixed an issue where the Cursor ACP agent would fail to start ([#62826](https://github.com/zed-industries/zed/pull/62826))\n- Added git_gutter_width setting to the Settings UI with default (font-size-scaled) and custom (fixed pixel width) options ([#62813](https://github.com/zed-industries/zed/pull/62813))"
+  },
+  {
+    "tag_name": "v1.15.1",
+    "prerelease": false,
+    "published_at": "2026-08-18T16:05:04Z",
+    "body": "- Fixed an issue where the Cursor ACP agent would fail to start ([#62825](https://github.com/zed-industries/zed/pull/62825))\n- Git: Fixed the GPG passphrase modal appearing on every commit for users whose configured pinentry (e.g. pinentry-mac with the macOS Keychain) can supply the passphrase without Zed's help. Zed now only prompts when gpg cannot obtain the passphrase on its own. ([#62783](https://github.com/zed-industries/zed/pull/62783))"
+  }
+]
+"""#
 
-@Test func extractsZedPreviewEntriesInOrder() throws {
-    let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "dev.zed.Zed-Preview"))
-    let changelog = try #require(ChangelogExtractor.extract(from: zedPreviewFixture, using: recipe))
+@Test func zedRecipesAreStructuredJSONSharingOneURL() throws {
+    let stable = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "dev.zed.Zed"))
+    let preview = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "dev.zed.Zed-Preview"))
+    #expect(stable.structuredFormat == .zedGitHubReleases)
+    #expect(preview.structuredFormat == .zedGitHubReleases)
+    #expect(stable.channel == .stable)
+    #expect(preview.channel == .preview)
+    // Same endpoint for both — the whole reason `channel` exists on the format.
+    #expect(stable.source == preview.source)
+}
 
-    #expect(changelog.entries.count == 3)
-    // 1.5.3: no <li> items — falls back to <p> text
-    #expect(changelog.entries[0].version == "1.5.3")
-    #expect(changelog.entries[0].date == "May 28, 2026")
-    #expect(changelog.entries[0].items.count == 1)
-    #expect(changelog.entries[0].items[0] == "No public-facing changes in this release. View the commits.")
-    // 1.5.1: plain patch with <li> items
-    #expect(changelog.entries[1].version == "1.5.1")
-    #expect(changelog.entries[1].date == "May 28, 2026")
+@Test func decodesZedStableFromGitHubReleases() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        zedGitHubReleasesFixture, format: .zedGitHubReleases, channel: .stable, maxEntries: 15))
+
+    // Only the two non-prerelease entries, in the API's newest-first order.
+    #expect(changelog.entries.count == 2)
+    #expect(changelog.entries[0].version == "1.16.1")
+    #expect(changelog.entries[0].date == "2026-08-19")
+    #expect(changelog.entries[0].items.count == 2)
+    #expect(changelog.entries[0].items[0]
+        == "Improved Git Panel organization by making grouped change sections collapsible. ([#62441](https://github.com/zed-industries/zed/pull/62441); thanks [chirivelli](https://github.com/chirivelli))")
+    #expect(changelog.entries[1].version == "1.15.1")
+    #expect(changelog.entries[1].date == "2026-08-18")
     #expect(changelog.entries[1].items.count == 2)
-    #expect(changelog.entries[1].items[0] == "Fixed GitHub Copilot Chat showing an empty model dropdown for users on newer Copilot SDK builds (#57964)")
-    #expect(changelog.entries[1].items[1] == "git: Fixed an issue where worktree creation would not be possible if resolving default branch fails (#57960)")
-    // 1.5.0: feature release with section headers — <li> wins over <p>
-    #expect(changelog.entries[2].version == "1.5.0")
-    #expect(changelog.entries[2].date == "May 27, 2026")
-    #expect(changelog.entries[2].items.count == 2)
-    #expect(changelog.entries[2].items[0] == "Agent: Added support for importing skills from GitHub Markdown URLs in the Skill Creator. (#57458)")
-    #expect(changelog.entries[2].items[1] == "Agent: Added commands for opening global and project-specific AGENTS.md rules. (#57847)")
+    // Explicitly pin the last item: the version-normalization and the markdown
+    // link both survive to the end of the list, not just the first entry.
+    #expect(changelog.entries[1].items.last
+        == "Git: Fixed the GPG passphrase modal appearing on every commit for users whose configured pinentry (e.g. pinentry-mac with the macOS Keychain) can supply the passphrase without Zed's help. Zed now only prompts when gpg cannot obtain the passphrase on its own. ([#62783](https://github.com/zed-industries/zed/pull/62783))")
+}
+
+@Test func decodesZedPreviewFromGitHubReleasesNormalizingPreSuffix() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        zedGitHubReleasesFixture, format: .zedGitHubReleases, channel: .preview, maxEntries: 15))
+
+    #expect(changelog.entries.count == 2)
+    // "v1.17.0-pre" -> "1.17.0": leading `v` and trailing `-pre` both stripped so
+    // the rail version matches the installed CFBundleShortVersionString.
+    #expect(changelog.entries[0].version == "1.17.0")
+    #expect(changelog.entries[0].date == "2026-08-19")
+    #expect(changelog.entries[1].version == "1.16.1")
+    #expect(changelog.entries[1].date == "2026-08-18")
+    #expect(changelog.entries[1].items.last
+        == "Added git_gutter_width setting to the Settings UI with default (font-size-scaled) and custom (fixed pixel width) options ([#62813](https://github.com/zed-industries/zed/pull/62813))")
+}
+
+@Test func zedChannelsDoNotLeak() throws {
+    // A stable decode must never surface a `-pre`-tagged version, and vice versa
+    // — the whole point of routing both channels through one shared endpoint.
+    let stable = try #require(StructuredChangelogDecoder.decode(
+        zedGitHubReleasesFixture, format: .zedGitHubReleases, channel: .stable, maxEntries: 15))
+    #expect(!stable.entries.contains { $0.version.contains("17.0") })
+    #expect(stable.entries.allSatisfy { !$0.version.hasSuffix("-pre") })
+
+    let preview = try #require(StructuredChangelogDecoder.decode(
+        zedGitHubReleasesFixture, format: .zedGitHubReleases, channel: .preview, maxEntries: 15))
+    #expect(!preview.entries.contains { $0.version == "1.16.1" && $0.date == "2026-08-19" })
 }
 
 @Test func recipeDecodesFromTerseJSON() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -222,44 +222,95 @@ private let codexFixture = """
 </section>
 """
 
-// Trimmed real response from client-webapi.oray.com/softwares/SUNLOGIN_X_MAC_ARM:
+// MARK: - SunLogin/AweSun (client-webapi.oray.com/softwares/… → structured decoder)
+
+// Trimmed real response from client-webapi.oray.com/softwares/SUNLOGIN_X_MAC_ARM
+// (re-verified live 2026-08-21: GET returns 200/~15KB, matching this shape):
 // three entries chosen to cover single-item (V16.5.0.30757), multi-item numbered
 // (v16.0.0.22931), and multi-item unnumbered (V16.3.0.29006). JSON uses \uXXXX
-// for all non-ASCII text and \/ for forward slashes inside HTML attributes — both
-// decoded by ChangelogExtractor.decodeEntities.
-// Fixture uses the raw server encoding: \uXXXX for non-ASCII, \/ for forward
-// slashes inside HTML strings — both must survive the extractor unchanged unless
-// decodeEntities resolves them.
+// for all non-ASCII text and \/ for forward slashes inside HTML strings — both
+// resolved for free by JSONDecoder before the fragment parser ever sees them,
+// which is why the structured decoder needs no entity/unicode-escape pass of
+// its own (unlike the regex path it replaces).
 private let aweSunFixture = #"""
 {"logs":[{"logid":3299,"softwareid":187,"versionid":"3239","lang":"zh","logs":"<ol><li>V16.5.0.30757<\/li><li>1、修复已知bug<\/li><\/ol>","memoen":"V16.5.0.30757\r\n1、修复已知bug","memo":"V16.5.0.30757\r\n1、修复已知bug","updatedate":"2026-05-28 00:00:00","createtime":"2026-05-28 14:41:53"},{"logid":2881,"softwareid":187,"versionid":"2822","lang":"zh","logs":"<ol><li>v16.0.0.22931<\/li><li>1、【优化】功能交互，提升操作体验<\/li><li>2、【修复】已知问题，提升稳定性<\/li><\/ol>","memoen":"v16.0.0.22931 \r\n1、【优化】功能交互，提升操作体验\r\n2、【修复】已知问题，提升稳定性","memo":"v16.0.0.22931 \r\n1、【优化】功能交互，提升操作体验\r\n2、【修复】已知问题，提升稳定性","updatedate":"2025-07-17 00:00:00","createtime":"2025-07-17 14:57:37"},{"logid":3212,"softwareid":187,"versionid":"3153","lang":"zh","logs":"<ol><li>V16.3.0.29006<\/li><li>【新增】向日葵 MCP<\/li><li>【新增】端上支持分组<\/li><li>【新增】网络代理<\/li><li>【新增】跟随被控鼠标自动切换屏幕<\/li><li>【新增】支持设置低 \/ 中 \/ 高码率<\/li><li>【新增】Mac 跨平台文件拖拽<\/li><li>【新增】Mac 主控 HDR 支持<\/li><li>【新增】远程控控支持切换触摸 \/ 鼠标模式<\/li><li>【新增】智能远控硬件线缆状态<\/li><li>【优化】若干操作交互体验<\/li><li>【修复】若干已知问题<\/li><\/ol>","memoen":"V16.3.0.29006\r\n【新增】向日葵 MCP","memo":"V16.3.0.29006\r\n【新增】向日葵 MCP","updatedate":"2026-03-26 00:00:00","createtime":"2026-03-26 16:53:17"}]}
 """#
 
-@Test func extractsAweSunEntriesAndDecodesJSONEscapes() throws {
+// The OLD regex-based recipe this format replaces. Kept only here (deliberately
+// NOT in the registry any more) so the new structured decoder can be
+// cross-checked against it on the exact same fixture below.
+private let aweSunLegacyRegexRecipe = ChangelogRecipe(
+    bundleID: "com.oray.sunlogin.macclient",
+    source: URL(string: "https://client-webapi.oray.com/softwares/SUNLOGIN_X_MAC_ARM?versiontype=stable")!,
+    entryPattern:
+        #""logid":\d+.*?"logs":"<ol><li>(?<version>[^<]+)<\\/li>(?<body>.*?)<\\/ol>".*?"updatedate":"(?<date>\d{4}-\d{2}-\d{2})"#,
+    itemPatterns: [#"<li>(?<item>.*?)<\\/li>"#],
+    mode: .json)
+
+@Test func sunLoginRecipeIsStructuredJSON() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.oray.sunlogin.macclient"))
-    let changelog = try #require(ChangelogExtractor.extract(from: aweSunFixture, using: recipe))
+    #expect(recipe.structuredFormat == .sunLoginSoftwareLogs)
+    #expect(recipe.mode == .json)
+}
+
+@Test func decodesSunLoginEntriesFromLogsArray() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        aweSunFixture, format: .sunLoginSoftwareLogs, channel: nil, maxEntries: 40))
 
     #expect(changelog.entries.count == 3)
 
-    // Entry 0: single item, \uXXXX Chinese text decoded.
+    // Entry 0: single item, \uXXXX Chinese text decoded (by JSONDecoder).
     #expect(changelog.entries[0].version == "V16.5.0.30757")
     #expect(changelog.entries[0].date == "2026-05-28")
-    #expect(changelog.entries[0].items.count == 1)
-    #expect(changelog.entries[0].items[0] == "1、修复已知bug")
+    #expect(changelog.entries[0].items == ["1、修复已知bug"])
 
     // Entry 1: two numbered items.
     #expect(changelog.entries[1].version == "v16.0.0.22931")
     #expect(changelog.entries[1].date == "2025-07-17")
-    #expect(changelog.entries[1].items.count == 2)
-    #expect(changelog.entries[1].items[0] == "1、【优化】功能交互，提升操作体验")
-    #expect(changelog.entries[1].items[1] == "2、【修复】已知问题，提升稳定性")
+    #expect(changelog.entries[1].items == [
+        "1、【优化】功能交互，提升操作体验",
+        "2、【修复】已知问题，提升稳定性",
+    ])
 
-    // Entry 2: eleven unnumbered items; \/ inside text decoded to /.
-    #expect(changelog.entries[2].version == "V16.3.0.29006")
-    #expect(changelog.entries[2].date == "2026-03-26")
-    #expect(changelog.entries[2].items.count == 11)
-    #expect(changelog.entries[2].items[0] == "【新增】向日葵 MCP")
-    #expect(changelog.entries[2].items[4] == "【新增】支持设置低 / 中 / 高码率")
-    #expect(changelog.entries[2].items[10] == "【修复】若干已知问题")
+    // Entry 2: eleven unnumbered items; \/ inside text resolved to a literal /.
+    // The LAST item is pinned explicitly — a regex-based cut is exactly the
+    // kind of thing that silently drops the final bullet (see ChatWise).
+    let entry2 = changelog.entries[2]
+    #expect(entry2.version == "V16.3.0.29006")
+    #expect(entry2.date == "2026-03-26")
+    #expect(entry2.items.count == 11)
+    #expect(entry2.items[0] == "【新增】向日葵 MCP")
+    #expect(entry2.items[4] == "【新增】支持设置低 / 中 / 高码率")
+    #expect(entry2.items.last == "【修复】若干已知问题")
+}
+
+@Test func sunLoginDecodeRespectsMaxEntries() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        aweSunFixture, format: .sunLoginSoftwareLogs, channel: nil, maxEntries: 1))
+    #expect(changelog.entries.count == 1)
+    #expect(changelog.entries[0].version == "V16.5.0.30757")
+}
+
+@Test func sunLoginDecodeDegradesToNilOnGarbage() {
+    #expect(StructuredChangelogDecoder.decode(
+        "not json", format: .sunLoginSoftwareLogs, channel: nil, maxEntries: 40) == nil)
+    #expect(StructuredChangelogDecoder.decode(
+        #"{"logs":[]}"#, format: .sunLoginSoftwareLogs, channel: nil, maxEntries: 40) == nil)
+}
+
+// Old regex path vs new structured decoder, run against the SAME fixture:
+// version/date/item-count/exact-text must match entry for entry.
+@Test func sunLoginOldRegexAndNewDecoderAgree() throws {
+    let legacy = try #require(ChangelogExtractor.extract(from: aweSunFixture, using: aweSunLegacyRegexRecipe))
+    let structured = try #require(StructuredChangelogDecoder.decode(
+        aweSunFixture, format: .sunLoginSoftwareLogs, channel: nil, maxEntries: 40))
+
+    #expect(legacy.entries.count == structured.entries.count)
+    for (old, new) in zip(legacy.entries, structured.entries) {
+        #expect(old.version == new.version)
+        #expect(old.date == new.date)
+        #expect(old.items == new.items)
+    }
 }
 
 @Test func extractsAppCleanerEntriesInOrder() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -1869,28 +1869,38 @@ private let macupdaterFixture = """
     #expect(cl.entries[1].items.count == 1)
 }
 
-// Trimmed real bytes from the JetBrains TBA releases JSON. Raw string so the
-// JSON escapes (\\n between tags, \\" in attrs) stay literal as on the wire. The
-// whatsnew mixes a feature <p>, a <ul><li> bullet list, and the "See the full
-// list…" footer the item pattern must skip.
+// Trimmed real bytes from the live JetBrains TBA releases JSON
+// (data.services.jetbrains.com/products/releases?code=TBA, fetched 2026-08-21).
+// Raw string so the JSON escapes (\\n between tags, \\" in attrs) stay literal as
+// on the wire — `StructuredChangelogDecoder` decodes this with `JSONDecoder`
+// itself (not the regex `ChangelogExtractor`), so the escapes are unescaped by
+// `Decodable`, never by a hand-written item pattern. The whatsnew mixes a
+// feature <p>, a <ul><li> bullet list, and the "See the full list…" footer the
+// decoder must skip. Verified against the real recipe (`ChangelogExtractor` on
+// this same fixture with the pre-migration regex recipe): identical entry count,
+// versions, dates, item counts, and last item per entry.
 private let jbToolboxFixture = #"""
 {"TBA":[{"date":"2026-06-02","type":"release","downloads":{"mac":{"link":"https://x"}},"notesLink":"https://y","version":"3.5","majorVersion":"3.5","build":"3.5.0.84344","whatsnew":"<h3>What's New in Toolbox App 3.5</h3>\n<h4>Zoom controls</h4>\n<p>You can now zoom in and out with Cmd/Ctrl +. <a href=\"https://youtrack.jetbrains.com/issue/TBX-17170/\">TBX-17170</a></p>\n<h4>Bug fixes</h4>\n<ul>\n <li>IDEs no longer randomly disappear from the home view. <a href=\"https://x/TBX-10600/\">TBX-10600</a></li>\n</ul>\n<p>See the full list of release notes <a href=\"https://x\">here</a>.</p>"},{"date":"2026-04-15","type":"release","version":"3.4.3","majorVersion":"3.4","build":"3.4.3.81140","whatsnew":"<h3>Toolbox App 3.4.3</h3>\n<ul>\n <li>Fixed an internal error.</li>\n</ul>"}]}
 """#
 
-@Test func extractsJetBrainsToolboxReleasesFromJSON() throws {
+@Test func decodesJetBrainsToolboxReleases() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.jetbrains.toolbox"))
-    let cl = try #require(ChangelogExtractor.extract(from: jbToolboxFixture, using: recipe))
+    #expect(recipe.structuredFormat == .jetBrainsProductReleases)
+    let cl = try #require(StructuredChangelogDecoder.decode(
+        jbToolboxFixture, format: .jetBrainsProductReleases, channel: nil, maxEntries: nil))
 
     #expect(cl.entries.count == 2)
     #expect(cl.entries[0].version == "3.5")
     #expect(cl.entries[0].date == "2026-06-02")
-    // One feature <p> + one <li>, footer <p> dropped by the negative lookahead.
+    // One feature <p> + one <li>; footer <p> dropped.
     #expect(cl.entries[0].items.count == 2)
     #expect(cl.entries[0].items[0].hasPrefix("You can now zoom in and out with Cmd/Ctrl +."))
     #expect(cl.entries[0].items[1].hasPrefix("IDEs no longer randomly disappear"))
     #expect(!cl.entries[0].items.contains { $0.contains("See the full list") })
+    #expect(cl.entries[0].items.last == "IDEs no longer randomly disappear from the home view. TBX-10600")
     #expect(cl.entries[1].version == "3.4.3")
     #expect(cl.entries[1].items == ["Fixed an internal error."])
+    #expect(cl.entries[1].items.last == "Fixed an internal error.")
 }
 
 // Trimmed real markup from github.com/anomalyco/opencode/releases (GitHub
@@ -1933,15 +1943,23 @@ private let opencodeFixture = """
     #expect(cl.entries[1].items == ["ACP integrations can now send prompts through acp-next."])
 }
 
-// Trimmed real JSON from data.services.jetbrains.com/products/releases?code=IIU&type=release:
-// two stable releases — 2026.1.2 (bug-fix with <li> list) and 2026.1 (major with section headings).
+// Trimmed real bytes from the live JetBrains IIU releases JSON
+// (data.services.jetbrains.com/products/releases?code=IIU&type=release, fetched
+// 2026-08-21): two stable releases — 2026.1.2 (bug-fix with a <li> list, and a
+// boilerplate lead <p> the decoder must NOT count as an item) and 2026.1 (major,
+// same shape). Raw string so the JSON escapes stay literal as on the wire; see
+// `jbToolboxFixture` above for why that matters. Verified against the real
+// recipe (`ChangelogExtractor` on this same fixture with the pre-migration regex
+// recipe): identical entry count, versions, dates, item counts, and last item.
 private let intellijFixture = #"""
 {"IIU":[{"date":"2026-05-15","type":"release","notesLink":"https://youtrack.jetbrains.com/articles/IDEA-A-2100662679","version":"2026.1.2","majorVersion":"2026.1","build":"261.24374.151","whatsnew":"<p>IntelliJ IDEA 2026.1.2 is out with the following improvements:\n <br></p>\n<ul>\n <li>Projects can now be opened correctly via <code>.ipr</code> files. [<a href=\"https://youtrack.jetbrains.com/issue/IJPL-242321\">IJPL-242321</a>]</li>\n <li>The indentation for Java ternary expressions has been fixed. [<a href=\"https://youtrack.jetbrains.com/issue/IDEA-387867\">IDEA-387867</a>]</li>\n</ul>"},{"date":"2026-03-25","type":"release","version":"2026.1","majorVersion":"2026.1","build":"261.23610.47","whatsnew":"<p>IntelliJ IDEA 2026.1 is now out! The highlights include:</p>\n<ul>\n <li>ACP Registry: Browse and install AI agents in one click.</li>\n <li>Git worktrees: Work in parallel branches.</li>\n</ul>"}]}
 """#
 
-@Test func extractsIntelliJIDEAReleasesFromJSON() throws {
+@Test func decodesIntelliJIDEAReleases() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.jetbrains.intellij"))
-    let cl = try #require(ChangelogExtractor.extract(from: intellijFixture, using: recipe))
+    #expect(recipe.structuredFormat == .jetBrainsProductReleases)
+    let cl = try #require(StructuredChangelogDecoder.decode(
+        intellijFixture, format: .jetBrainsProductReleases, channel: nil, maxEntries: nil))
 
     #expect(cl.entries.count == 2)
     #expect(cl.entries[0].version == "2026.1.2")
@@ -1949,10 +1967,13 @@ private let intellijFixture = #"""
     #expect(cl.entries[0].items.count == 2)
     #expect(cl.entries[0].items[0].contains("Projects can now be opened correctly"))
     #expect(cl.entries[0].items[1].contains("ternary expressions"))
+    #expect(cl.entries[0].items.last == "The indentation for Java ternary expressions has been fixed. [IDEA-387867]")
+    #expect(!cl.entries[0].items.contains { $0.contains("is out with the following improvements") })
     #expect(cl.entries[1].version == "2026.1")
     #expect(cl.entries[1].date == "2026-03-25")
     #expect(cl.entries[1].items.count == 2)
     #expect(cl.entries[1].items[0].contains("ACP Registry"))
+    #expect(cl.entries[1].items.last == "Git worktrees: Work in parallel branches.")
 }
 
 // MARK: - Thunderbird (Mozilla) — Stable / ESR / Beta share one page structure

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -128,36 +128,38 @@ private let appCleanerFixture = """
 </div>
 """
 
-// Trimmed fixture from releases.chatwise.app/releases. The real endpoint is JSON,
-// with markdown changelog lines stored as escaped strings.
-private let chatWiseFixture = """
+// Two entries lifted VERBATIM (assets and hashes included) from a real
+// releases.chatwise.app/releases response fetched 2026-08-21, in the order the
+// endpoint emits them. Kept byte-for-byte, and in a raw literal so the `\n`
+// escapes inside `changelog` stay two characters, because the shape that broke
+// us was exactly that escaping: 26.6.0's notes do NOT end in a trailing `\n`,
+// which is what made the old regex item pattern lose its last (here: only)
+// bullet. 26.5.2 is the multi-bullet counterpart.
+private let chatWiseFixture = #"""
 [
-  {
-    "version":"26.5.3",
-    "changelog":"- Add Claude Opus 4.8 and adjust Claude reasoning support\\n",
-    "assets":[],
-    "date":"2026-05-29T07:02:44.116Z"
-  },
-  {
-    "version":"26.5.2",
-    "changelog":"- Add `curl.md` web fetch provider support\\n- Custom provider: add Responses API support for openai-compatible providers\\n- Set user-agent for LLM requests to `ChatWise/$version`\\n",
-    "assets":[],
-    "date":"2026-05-27T06:20:07.532Z"
-  }
+{"version":"26.6.0","changelog":"- new provider: cloudflare workers ai","assets":[{"name":"ChatWise-26.6.0-x64.zip","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0-x64.zip","sha512":"hR0mkg45XrysNVY8TCDaXw3gqVeP+NAAvvYhlF5MYYZrhTTT7Y77FYDIoAHGAT7dEikSsmcuQ5nxXXbdBBGmOA=="},{"name":"ChatWise-26.6.0-arm64.zip","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0-arm64.zip","sha512":"PdsVbVwbQgYdW2HcmR1U5FaKr3zslAGy82eYVb2iRwT875VlYNi9/MHvdZceSDEvRV8979cU2N8Q8sC6IPaA2g=="},{"name":"ChatWise-26.6.0-x64.dmg","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0-x64.dmg","sha512":"iWgVJGPSlye6Ay7uJ08zhkBXY+h8FfD+sPY7C8rKQxO+jImxrWTF+qvbr9Lly9Rqu7Yyt32/04IucEXsmXAmXA=="},{"name":"ChatWise-26.6.0-arm64.dmg","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0-arm64.dmg","sha512":"Ue2BUmAkDB2MfUFo89oQcrWXvOr2q9wlwA0zs4KZYhpvx6kWyZKer1sMFUAHLcuxzsmveRYj4NzWH5dPcUoysw=="},{"name":"ChatWise-26.6.0-setup.exe","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0-setup.exe","sha512":"3PfSmUXs9mtAs/25n3oZUKh6BOwXPYHuDna+mw6uZdfC7R+SzzAgWlDo8mHpEpNWB7//213UvPQArgwezwUqEg=="},{"name":"ChatWise-26.6.0.AppImage","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0.AppImage","sha512":"oDnIZ36PKHbm8ShzIxuHtdl2hHCUmbLm/9TR7+aUqd8XeslcteMS6BNtGgHfDIC1Jhqbg0pdaP/+mia4Bl6MVw=="},{"name":"ChatWise-26.6.0.deb","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0.deb","sha512":"u6eRy6Yx40P+D1GcTXf8e7wA5m71mpf5v3fnBFAEBGfE4dpcivJqxU5E+jVO2vPoIf5E7uEDgza5b5efaq7sGQ=="},{"name":"ChatWise-26.6.0.rpm","url":"https://releases.chatwise.app/26.6.0/ChatWise-26.6.0.rpm","sha512":"US8qTdbIf75Kh5K18g267WXH9BqGD2OOEPyPgel8cUaM5GDmbawqT0GIkOcn2kL5dP8X9xYEQwu5iFR3faN/ow=="}],"date":"2026-06-26T16:04:26.161Z"},
+{"version":"26.5.2","changelog":"- Add `curl.md` web fetch provider support\n- Custom provider: add Responses API support for openai-compatible providers\n- Set user-agent for LLM requests to `ChatWise/$version`\n- Add CJK-friendly remark plugins for better markdown rendering\n","assets":[{"name":"ChatWise-26.5.2-x64.zip","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2-x64.zip","sha512":"O98u9F82JZ6ZSPjt8MHYt+GoEH7gAeyetStz04GVFIlkfQdSaplh0GoM8IxtWo05o0IXmt4jtHeIePYx4AOBzw=="},{"name":"ChatWise-26.5.2-arm64.zip","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2-arm64.zip","sha512":"5thP89IXREnbenfzZRvT3p6amfPFW2zOB6/zFA410lHZBpjIx/PLirqVfhrGUTMLMTbb/YbJ+k8c2c4cDlskNw=="},{"name":"ChatWise-26.5.2-x64.dmg","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2-x64.dmg","sha512":"aCHj9cCyz7i3jLd55WIDTWnVnMxpLNeG6nMRI6HE5CdQkXMOzsEN21o/3AMnNfM+TUgY0y7x/OBeg3bXCQR8Pw=="},{"name":"ChatWise-26.5.2-arm64.dmg","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2-arm64.dmg","sha512":"0XFpaeX4d3skvOBtYkGo3hsMf0gpQxSkkIlFC3wxOVCB7uAGrPHRge6Gan0/B4QISJUuD2RU8LDR1H6dUK9YNw=="},{"name":"ChatWise-26.5.2-setup.exe","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2-setup.exe","sha512":"ybIFl3MghEN3Mx9odKS6hcjESib0IILBiMj6efcNXLxVc9//aMYRryTDjZSyjO4Bj9CHi4x9XqXaW4SzHso+Uw=="},{"name":"ChatWise-26.5.2.AppImage","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2.AppImage","sha512":"VhXtsqJ79aBxz2QiPCN6xuWGmINV//EnnUSqXlVniE21GeH/goL8oZf9HeJjrTEVWkAfQOZFYRoBAV+nM62QcA=="},{"name":"ChatWise-26.5.2.deb","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2.deb","sha512":"TNLNJ6EDdTV/ql3yAEiE1163hflarImlXVcg+6n/hNvucTk4oNo2oM53jFwZdKIjySWrWwNo5f7T7pWqCoKmCA=="},{"name":"ChatWise-26.5.2.rpm","url":"https://releases.chatwise.app/26.5.2/ChatWise-26.5.2.rpm","sha512":"nhaFrSermyq+eXqPddMElQIBKAk2nr2VFOe/Ukqs+bsi7VXeaDaBH930JODI83SAkvkC2tirFkTkDTj2gyVVog=="}],"date":"2026-05-27T06:20:07.532Z"}
 ]
-"""
+"""#
 
-// Trimmed real payloads from central.github.com/deployments/desktop/desktop/
-// changelog.json — the stable feed (bare semver) and the `?env=beta` feed
-// (`-betaN` versions). The beta note includes a JSON `\"` escape to prove the
-// json-mode string unescaper turns it into a real quote.
-private let ghDesktopStableFixture = """
-[{"name":"","notes":["[Fixed] Items in lists such as branches and changed files are properly announced by screen readers on Windows - #22219"],"pub_date":"2026-06-01T17:43:05Z","version":"3.5.12"},{"name":"","notes":["[Fixed] Fix launching custom shells"],"pub_date":"2026-05-26T00:00:00Z","version":"3.5.11"}]
-"""
+// Byte-for-byte slices of two adjacent array elements each, taken from a real
+// `curl` of central.github.com/deployments/desktop/desktop/changelog.json (stable)
+// and the same URL with `?env=beta` appended — captured 2026-08-21. Both feeds
+// are flat JSON arrays, newest-first, of `{name, notes, pub_date, version}` with
+// `notes` already an array of one-line strings — no markdown, nothing to regex.
+//
+// The stable slice's 3.6.3 entry happens to carry a real `\"@null\"` JSON escape
+// (a Git ref name quoted in the note text), so it doubles as the "does the decoder
+// see a literal quote, not a backslash-quote" proof — no constructed case needed.
+private let ghDesktopStableFixture = #"""
+[{"name":"","notes":["[Improved] Update Git for Windows to v2.53.0.windows.4","[Improved] Update Git Credential Manager to 2.9.0"],"pub_date":"2026-08-11T22:07:40Z","version":"3.6.4"},{"name":"","notes":["[Fixed] Resolve error that prevented Copilot-based features from working correctly on Windows - #22509","[Fixed] Keep commit message @-mention autocomplete from surfacing users without a profile name when typing queries like \"@null\" - #22414. Thanks @sukanth!","[Fixed] Resolve a crash where the truncated repository path text could enter an infinite re-render loop - #22458","[Fixed] Fall back to the main worktree so a repository no longer appears as missing when its linked worktree folder was deleted outside Desktop - #22474","[Fixed] Keep files visible in the Changes list after Desktop returns from being backgrounded - #22497","[Fixed] Show an error dialog instead of silently doing nothing when Copilot fails to generate a commit message due to a Git error - #22496","[Fixed] Copilot sessions from generating commit messages or resolving conflicts do not show up in VS Code - #22443","[Fixed] Repository list scrolling no longer gets stuck or jitters when scrolling over tall groups (e.g. large organizations) - #22438. Thanks @peteski22!","[Improved] Clarify the line-ending conversion warning to explain that Git will automatically convert the file's line endings on next checkout, with a link to learn more - #21446. Thanks @Whitebrim!"],"pub_date":"2026-07-14T17:47:41Z","version":"3.6.3"}]
+"""#
 
-private let ghDesktopBetaFixture = """
-[{"name":"","notes":["[Improved] Show \\"No newline at end of file\\" as visible text in the diff view instead of requiring a tooltip hover - #22204","[Fixed] Screen reader now correctly announces added and removed line counts in the pull request preview dialog - #22202"],"pub_date":"2026-05-29T09:38:07Z","version":"3.5.12-beta2"}]
-"""
+// Beta slice: two adjacent 3.6.3-beta entries, the first (beta3) also carrying a
+// real `\"@null\"` escape — same proof as the stable slice, on the beta feed.
+private let ghDesktopBetaFixture = #"""
+[{"name":"","notes":["[Fixed] Resolve error that prevented Copilot-based features from working correctly on Windows - #22509","[Fixed] Keep commit message @-mention autocomplete from surfacing users without a profile name when typing queries like \"@null\" - #22414. Thanks @sukanth!"],"pub_date":"2026-07-08T12:55:09Z","version":"3.6.3-beta3"},{"name":"","notes":["[Fixed] Resolve a crash where the truncated repository path text could enter an infinite re-render loop - #22458","[Fixed] Fall back to the main worktree so a repository no longer appears as missing when its linked worktree folder was deleted outside Desktop - #22474","[Fixed] Keep files visible in the Changes list after Desktop returns from being backgrounded - #22497","[Fixed] Show an error dialog instead of silently doing nothing when Copilot fails to generate a commit message due to a git error - #22496","[Fixed] Copilot sessions from generating commit messages or resolving conflicts do not show up in VS Code - #22443"],"pub_date":"2026-07-07T17:21:05Z","version":"3.6.3-beta2"}]
+"""#
 
 // Trimmed real markup from the latest VS Code updates page (v1_123): one release
 // header and its highlight bullets. Includes the trailing <blockquote> aside

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -277,40 +277,74 @@ private let aweSunFixture = #"""
     #expect(changelog.entries[1].items[0] == "Fixed a bug causing SmartDelete to crash.")
 }
 
-@Test func extractsChatWiseEntriesFromJSON() throws {
+@Test func chatWiseRecipeIsStructuredJSON() throws {
     let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "app.chatwise"))
-    let changelog = try #require(ChangelogExtractor.extract(from: chatWiseFixture, using: recipe))
-
-    #expect(changelog.entries.count == 2)
-    #expect(changelog.entries[0].version == "26.5.3")
-    #expect(changelog.entries[0].date == "2026-05-29T07:02:44.116Z")
-    #expect(changelog.entries[0].items.count == 1)
-    #expect(changelog.entries[0].items[0] == "Add Claude Opus 4.8 and adjust Claude reasoning support")
-    #expect(changelog.entries[1].version == "26.5.2")
-    #expect(changelog.entries[1].items.count == 3)
-    #expect(changelog.entries[1].items[1] == "Custom provider: add Responses API support for openai-compatible providers")
+    #expect(recipe.structuredFormat == .chatwiseReleases)
+    #expect(recipe.source.absoluteString == "https://releases.chatwise.app/releases")
 }
 
-@Test func extractsGitHubDesktopPerChannelFromJSON() throws {
-    // Stable channel → bare semver versions, plain-text notes.
+@Test func decodesChatWiseKeepingTheLastBullet() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        chatWiseFixture, format: .chatwiseReleases, channel: nil, maxEntries: 20))
+
+    #expect(changelog.entries.count == 2)
+
+    // 26.6.0's changelog string has no trailing `\n` escape, so its only bullet
+    // IS its last bullet — the case the previous regex pattern dropped outright.
+    #expect(changelog.entries[0].version == "26.6.0")
+    #expect(changelog.entries[0].date == "2026-06-26")
+    #expect(changelog.entries[0].items == ["new provider: cloudflare workers ai"])
+
+    // Multi-bullet entry: pin the count AND the final item specifically, so a
+    // regression that silently truncates the tail fails here rather than merely
+    // shrinking a count somewhere.
+    let multi = changelog.entries[1]
+    #expect(multi.version == "26.5.2")
+    #expect(multi.date == "2026-05-27")
+    #expect(multi.items.count == 4)
+    #expect(multi.items.first == "Add `curl.md` web fetch provider support")
+    #expect(multi.items.last == "Add CJK-friendly remark plugins for better markdown rendering")
+}
+
+@Test func extractsGitHubDesktopPerChannelFromStructuredJSON() throws {
+    // Stable channel → recipe wiring: bundle id resolves to the .stable recipe,
+    // and it's declared structured (no regex left to exercise).
     let stable = try #require(ChangelogRecipeRegistry.recipe(
         forBundleID: "com.github.GitHubClient", channel: .stable))
-    let scl = try #require(ChangelogExtractor.extract(from: ghDesktopStableFixture, using: stable))
+    #expect(stable.structuredFormat == .gitHubDesktopChangelog)
+    let scl = try #require(StructuredChangelogDecoder.decode(
+        ghDesktopStableFixture, format: stable.structuredFormat!,
+        channel: stable.channel, maxEntries: stable.maxEntries))
     #expect(scl.entries.count == 2)
-    #expect(scl.entries[0].version == "3.5.12")
-    #expect(scl.entries[0].date == "2026-06-01")
-    #expect(scl.entries[0].items.count == 1)
-    #expect(scl.entries[0].items[0] == "[Fixed] Items in lists such as branches and changed files are properly announced by screen readers on Windows - #22219")
-    #expect(scl.entries[1].version == "3.5.11")
+    #expect(scl.entries[0].version == "3.6.4")
+    #expect(scl.entries[0].date == "2026-08-11")
+    #expect(scl.entries[0].items.count == 2)
+    #expect(scl.entries[0].items[0] == "[Improved] Update Git for Windows to v2.53.0.windows.4")
+    #expect(scl.entries[1].version == "3.6.3")
+    #expect(scl.entries[1].date == "2026-07-14")
+    #expect(scl.entries[1].items.count == 9)
+    // A real JSON `\"@null\"` escape inside the entry must decode to a literal
+    // quote, not survive as a backslash-quote.
+    #expect(scl.entries[1].items[1] == "[Fixed] Keep commit message @-mention autocomplete from surfacing users without a profile name when typing queries like \"@null\" - #22414. Thanks @sukanth!")
+    #expect(scl.entries[1].items.last == "[Improved] Clarify the line-ending conversion warning to explain that Git will automatically convert the file's line endings on next checkout, with a link to learn more - #21446. Thanks @Whitebrim!")
 
-    // Beta channel — SAME bundle id, selected by `channel: .beta`: -betaN version,
-    // and the JSON `\"` escape in the first note must decode to a real quote.
+    // Beta channel — SAME bundle id, a DIFFERENT recipe/URL (`?env=beta`),
+    // selected by `channel: .beta`. Same structured format.
     let beta = try #require(ChangelogRecipeRegistry.recipe(
         forBundleID: "com.github.GitHubClient", channel: .beta))
-    let bcl = try #require(ChangelogExtractor.extract(from: ghDesktopBetaFixture, using: beta))
-    #expect(bcl.entries[0].version == "3.5.12-beta2")
+    #expect(beta.structuredFormat == .gitHubDesktopChangelog)
+    let bcl = try #require(StructuredChangelogDecoder.decode(
+        ghDesktopBetaFixture, format: beta.structuredFormat!,
+        channel: beta.channel, maxEntries: beta.maxEntries))
+    #expect(bcl.entries.count == 2)
+    #expect(bcl.entries[0].version == "3.6.3-beta3")
+    #expect(bcl.entries[0].date == "2026-07-08")
     #expect(bcl.entries[0].items.count == 2)
-    #expect(bcl.entries[0].items[0] == "[Improved] Show \"No newline at end of file\" as visible text in the diff view instead of requiring a tooltip hover - #22204")
+    #expect(bcl.entries[0].items[0] == "[Fixed] Resolve error that prevented Copilot-based features from working correctly on Windows - #22509")
+    #expect(bcl.entries[0].items.last == "[Fixed] Keep commit message @-mention autocomplete from surfacing users without a profile name when typing queries like \"@null\" - #22414. Thanks @sukanth!")
+    #expect(bcl.entries[1].version == "3.6.3-beta2")
+    #expect(bcl.entries[1].items.count == 5)
+    #expect(bcl.entries[1].items.last == "[Fixed] Copilot sessions from generating commit messages or resolving conflicts do not show up in VS Code - #22443")
 }
 
 @Test func extractsLatestVSCodeReleaseHighlights() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
@@ -100,3 +100,11 @@ import Foundation
         #expect(await ChangelogService.gitHubToken(now: later) == "fresh")
     }
 }
+
+/// The host gate checks the scheme too. `URL.host` is scheme-agnostic, so a
+/// cleartext URL at the right host would otherwise have put the token on the wire
+/// in the clear.
+@Test func gitHubAuthRequiresHTTPS() {
+    #expect(!ChangelogService.isGitHubAPI(URL(string: "http://api.github.com/repos/x/y")!))
+    #expect(ChangelogService.isGitHubAPI(URL(string: "https://api.github.com/repos/x/y")!))
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
@@ -1,0 +1,23 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The Authorization header may only ever ride to GitHub's API host. A recipe
+/// pointing at any other host — including GitHub's own raw/content hosts, which
+/// serve vendor appcasts (TablePro's lives on raw.githubusercontent.com) — must
+/// stay anonymous, because leaking a token is a far worse failure than a 403.
+@Test func gitHubAuthIsScopedToTheAPIHostOnly() {
+    #expect(ChangelogService.isGitHubAPI(
+        URL(string: "https://api.github.com/repos/zed-industries/zed/releases?per_page=40")!))
+    #expect(ChangelogService.isGitHubAPI(URL(string: "https://API.GitHub.com/repos/x/y")!))
+
+    for other in [
+        "https://raw.githubusercontent.com/TableProApp/TablePro/main/appcast.xml",
+        "https://github.com/ghostty-org/ghostty/releases.atom",
+        "https://central.github.com/deployments/desktop/desktop/changelog.json",
+        "https://api.github.com.evil.example/repos/x/y",
+        "https://notapi.github.com/repos/x/y",
+    ] {
+        #expect(!ChangelogService.isGitHubAPI(URL(string: other)!), "must not authenticate \(other)")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
@@ -21,3 +21,82 @@ import Foundation
         #expect(!ChangelogService.isGitHubAPI(URL(string: other)!), "must not authenticate \(other)")
     }
 }
+
+// MARK: - Reaching the token the user actually configured
+
+/// Serialized, and its own suite: these all drive one piece of process-global
+/// state (`ChangelogService`'s explicit token and its resolved-token cache).
+/// Swift Testing runs tests in parallel by default, so as free functions they
+/// clobbered each other — one test read the token another had just set. That is
+/// a property of the state being global, not of the assertions, so the fix is to
+/// stop them overlapping rather than to weaken what they check.
+@Suite(.serialized) struct ChangelogGitHubTokenResolutionTests {
+
+    /// The shipped GUI has neither a shell environment nor (necessarily) `gh`: it is
+    /// started by launchd, and a user who pasted a token into Settings ▸ GitHub has
+    /// it in the Keychain, which the core package cannot read. Without the explicit
+    /// hand-off, `gitHubToken()` resolved to nil for exactly those users and the
+    /// whole Authorization path stayed dead while Settings showed the token verified.
+    /// The original verification missed this because it ran the CLI from a terminal,
+    /// which inherits the environment and finds `gh`.
+    @Test func explicitTokenFromSettingsReachesTheChangelogFetcher() async {
+        defer {
+            ChangelogService.setExplicitGitHubToken(nil)
+            ChangelogService.resetGitHubTokenCache()
+        }
+        ChangelogService.setExplicitGitHubToken("pasted-in-settings")
+        ChangelogService.resetGitHubTokenCache()
+        #expect(await ChangelogService.gitHubToken() == "pasted-in-settings")
+    }
+
+    /// Whitespace and empty strings mean "no explicit token" — `Preferences` stores
+    /// an empty string for a cleared field, and pushing that must fall back to the
+    /// env/`gh` path rather than sending `Bearer `.
+    @Test func blankExplicitTokenIsTreatedAsAbsent() {
+        defer { ChangelogService.setExplicitGitHubToken(nil) }
+        for blank in ["", "   ", "\n"] {
+            ChangelogService.setExplicitGitHubToken(blank)
+            ChangelogService.resetGitHubTokenCache()
+            // Can't assert the resolved value (the machine may legitimately have a
+            // `gh` token); assert only that the blank did not become the answer.
+            #expect(ChangelogService.explicitGitHubTokenForTesting == nil)
+        }
+    }
+
+    /// A token pasted, then cleared, must take effect without a relaunch. The old
+    /// code resolved once per process and cached `nil` too, so a menubar app running
+    /// for weeks would keep sending a revoked token — and GitHub answers 401 to that,
+    /// which renders an EMPTY pane where anonymous would still have worked.
+    @Test func changingTheExplicitTokenReResolvesRatherThanServingTheCachedOne() async {
+        defer {
+            ChangelogService.setExplicitGitHubToken(nil)
+            ChangelogService.resetGitHubTokenCache()
+        }
+        ChangelogService.setExplicitGitHubToken("first")
+        ChangelogService.resetGitHubTokenCache()
+        #expect(await ChangelogService.gitHubToken() == "first")
+
+        ChangelogService.setExplicitGitHubToken("second")
+        #expect(await ChangelogService.gitHubToken() == "second",
+                "a rotated token must not be masked by the cache")
+    }
+
+    /// And the cache ages out on its own, so a token rotated *outside* the app
+    /// (`gh auth logout`, a PAT revoked on github.com) recovers without a relaunch.
+    @Test func theResolvedTokenCacheExpires() async {
+        defer {
+            ChangelogService.setExplicitGitHubToken(nil)
+            ChangelogService.resetGitHubTokenCache()
+        }
+        ChangelogService.setExplicitGitHubToken("stale")
+        ChangelogService.resetGitHubTokenCache()
+        #expect(await ChangelogService.gitHubToken(now: Date()) == "stale")
+
+        // Same explicit value, but past the TTL: re-resolves rather than serving the
+        // remembered answer. (Here the re-resolve produces the same string; the point
+        // is that the code path runs at all.)
+        let later = Date().addingTimeInterval(ChangelogService.tokenTTL + 1)
+        ChangelogService.setExplicitGitHubToken("fresh")
+        #expect(await ChangelogService.gitHubToken(now: later) == "fresh")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
@@ -1,0 +1,186 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Regressions found reviewing the structured-decoding batch. Each one is pinned
+/// with the *real* bytes that exposed it, because every defect here was invisible
+/// to the tests that shipped with the change: those asserted the shapes the new
+/// code already handled. A fixture written from the implementation cannot catch
+/// the implementation being wrong about the feed.
+
+// MARK: - HBuilderX: Markdown inline code must not reach the user as backticks
+
+/// Verbatim from `https://hx.dcloud.net.cn/zh-cn/Tutorial/changelog/ReleaseNote_release.md`
+/// (fetched 2026-08-22). Four of the nine backticked items in the live top-10
+/// window, plus a plain item and the trailing-link shapes, so this exercises the
+/// interaction between link-consumption and code-span unwrapping rather than
+/// either alone.
+private let hbuilderXCodeSpanFixture = #"""
+## 5.24.2026081301
+* 新增 云打包 通过`CLI pack cancel`取消打包 [文档](https://hx.dcloud.net.cn/cli/pack) <https://issues.dcloud.net.cn/pages/issues/detail?id=30500>
+* 新增 云打包 通过`CLI pack`支持广告等更多参数 [文档](https://hx.dcloud.net.cn/cli/pack) <https://issues.dcloud.net.cn/pages/issues/detail?id=30645>
+* 修复 部分情况下编辑器卡顿的Bug [详情](https://issues.dcloud.net.cn/x)
+* 新增 云打包 通过`CLI pack status`查询打包记录 [文档](https://hx.dcloud.net.cn/cli/pack?id=pack-query)
+
+## 5.23.2026072902
+* 新增 云打包 通过`CLI logcat pack`获取打包控制台日志 [文档](https://hx.dcloud.net.cn/cli/logcat-pack)
+"""#
+
+@Test func hbuilderXUnwrapsInlineCodeInsteadOfShowingBackticks() throws {
+    let recipe = try #require(
+        ChangelogRecipeRegistry.recipe(forBundleID: "io.dcloud.HBuilderX"),
+        "HBuilderX stable recipe must exist")
+    let changelog = try #require(
+        ChangelogExtractor.extract(from: hbuilderXCodeSpanFixture, using: recipe))
+
+    let allItems = changelog.entries.flatMap(\.items)
+    #expect(!allItems.isEmpty)
+    // The whole point: the HTML source this replaced spelled these `<code>…</code>`
+    // and `stripTags` removed the wrapper, so the migration must not start showing
+    // the Markdown equivalent as punctuation.
+    for item in allItems {
+        #expect(!item.contains("`"), "backtick leaked into rendered note: \(item)")
+    }
+    // …while keeping the code TEXT, which is the part that carries the meaning.
+    #expect(allItems.contains("新增 云打包 通过CLI pack cancel取消打包"))
+    #expect(allItems.contains("新增 云打包 通过CLI logcat pack获取打包控制台日志"))
+    // A plain item is untouched, and the trailing links are still consumed.
+    #expect(allItems.contains("修复 部分情况下编辑器卡顿的Bug"))
+}
+
+@Test func markdownUnwrapLeavesUnpairedAndDoubleBackticksAlone() {
+    // A span that never closes is not a span — leave the user's literal character.
+    #expect(ChangelogExtractor.unwrapMarkdownInlineCode("cost is 50`") == "cost is 50`")
+    // Double-backtick spans exist so the code text can itself contain a backtick.
+    #expect(ChangelogExtractor.unwrapMarkdownInlineCode("run ``a `b` c`` now") == "run a `b` c now")
+    // A span may not straddle a line break.
+    #expect(ChangelogExtractor.unwrapMarkdownInlineCode("a`b\nc`d") == "a`b\nc`d")
+}
+
+/// The flag is opt-in: a recipe reading HTML must keep a literal backtick a
+/// vendor typed. Pinning this from the registry rather than a hand-written list
+/// so a future recipe that sets `markdownSource` shows up here.
+@Test func onlyMarkdownSourceRecipesUnwrapCodeSpans() {
+    let flagged = ChangelogRecipeRegistry.recipes.filter(\.markdownSource)
+    #expect(flagged.allSatisfy { $0.source.path.hasSuffix(".md") },
+            "markdownSource belongs on recipes whose body really is Markdown")
+    #expect(!flagged.isEmpty, "HBuilderX stable + alpha should be flagged")
+}
+
+// MARK: - Postman: items keep the whitespace normalization the regex path had
+
+/// Verbatim slice of `https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json`
+/// (fetched 2026-08-22) — the 12.19.0 note whose line carries a trailing space,
+/// which is the exact byte the migration dropped on the floor.
+@Test func postmanItemsAreWhitespaceNormalizedLikeTheRegexPathWas() {
+    let items = StructuredChangelogDecoder.postmanItems(
+        from: "Improved the experience of working with collections, environments, and API specifications. \r\n"
+            + "Fixed  an  issue  where  the  sidebar  flickered.\r\n")
+    #expect(items == [
+        "Improved the experience of working with collections, environments, and API specifications.",
+        "Fixed an issue where the sidebar flickered.",
+    ])
+}
+
+/// The length floor must measure the *normalized* line, as `minItemLength` did
+/// after `clean`. Otherwise a line of nothing but spaces clears a `>= 10` check
+/// and renders as an empty bullet.
+@Test func postmanLengthFloorMeasuresTheTrimmedLine() {
+    #expect(StructuredChangelogDecoder.postmanItems(from: "             \r\nreal content here\r\n")
+            == ["real content here"])
+}
+
+// MARK: - SunLogin: one malformed element must not take the whole feed down
+
+/// Shape check, not a live-feed claim: today's payload is well formed. The point
+/// is the *contract* — the file's own header promises "an entry with no usable
+/// notes yields fewer entries", and a non-optional field turned that into all-or
+/// -nothing, dropping the user back to the embedded web page.
+@Test func sunLoginSkipsAMalformedEntryInsteadOfLosingTheFeed() throws {
+    let body = #"""
+    {"logs":[
+      {"logs":"<ol><li>15.6.1</li><li>Fixed a crash on launch</li></ol>","updatedate":"2026-08-01 10:00:00"},
+      {"logs":null,"updatedate":"2026-07-01 10:00:00"},
+      {"logs":"<ol><li>15.6.0</li><li>Added remote print</li></ol>","updatedate":"2026-06-01 10:00:00"}
+    ]}
+    """#
+    let changelog = try #require(StructuredChangelogDecoder.decodeSunLogin(body, maxEntries: 40))
+    #expect(changelog.entries.map(\.version) == ["15.6.1", "15.6.0"])
+    #expect(changelog.entries.first?.date == "2026-08-01")
+}
+
+/// A junk `updatedate` must not become a junk subtitle — the retired regex
+/// required a `\d{4}-\d{2}-\d{2}` shape and dropped anything else.
+@Test func sunLoginRejectsAMalformedDateRatherThanShowingIt() throws {
+    let body = #"""
+    {"logs":[{"logs":"<ol><li>15.6.1</li><li>Fixed a crash</li></ol>","updatedate":"soon"}]}
+    """#
+    let changelog = try #require(StructuredChangelogDecoder.decodeSunLogin(body, maxEntries: 40))
+    #expect(changelog.entries.first?.date == nil)
+}
+
+/// Inner markup inside an `<li>` gets the same cleaning the retired recipe's
+/// defaults (`stripTags: true, decodeEntities: true`) applied.
+@Test func sunLoginCleansMarkupInsideAnItem() throws {
+    let body = #"""
+    {"logs":[{"logs":"<ol><li>15.6.1</li><li>Fixed <b>copy</b> &amp; paste in the <a href='#'>viewer</a></li></ol>","updatedate":"2026-08-01 10:00:00"}]}
+    """#
+    let changelog = try #require(StructuredChangelogDecoder.decodeSunLogin(body, maxEntries: 40))
+    #expect(changelog.entries.first?.items == ["Fixed copy & paste in the viewer"])
+}
+
+// MARK: - Zed: a release with no bullets still gets an entry
+
+/// `v1.5.3-pre`'s real body, verbatim (1 of the newest 100 releases on
+/// 2026-08-22). `GitHubMarkdownParser` returns nil for it — no bullets — and the
+/// retired zed.dev recipe had a `<p>` item pattern that covered exactly this, so
+/// skipping it meant a Preview user on that build saw no entry for their own
+/// installed version.
+@Test func zedKeepsAReleaseWhoseNotesAreProseNotBullets() throws {
+    let body = #"""
+    {"tag_name":"v1.5.3-pre","prerelease":true,"published_at":"2026-05-14T12:00:00Z",
+     "body":"No public-facing changes in this release. [View the commits](https://github.com/zed-industries/zed/compare/v1.5.2-pre...v1.5.3-pre)"}
+    """#
+    let feed = "[\(body)]"
+    let changelog = try #require(StructuredChangelogDecoder.decodeZedGitHubReleases(feed, channel: .preview, maxEntries: 15))
+    let entry = try #require(changelog.entries.first)
+    #expect(entry.version == "1.5.3")
+    #expect(entry.items == ["No public-facing changes in this release. View the commits"])
+}
+
+/// …but a body with nothing renderable at all is still skipped, rather than
+/// producing a bare version heading with an empty bullet under it.
+@Test func zedStillSkipsAReleaseWithNothingRenderable() {
+    #expect(StructuredChangelogDecoder.zedProseFallback(body: "## Heading only\n\n### Another\n") == nil)
+    #expect(StructuredChangelogDecoder.zedProseFallback(body: "   \n\n  \n") == nil)
+}
+
+// MARK: - ChatWise: CRLF must not fold a whole entry into one line
+
+/// Swift treats "\r\n" as ONE Character that is not equal to "\n", so
+/// `split(separator: "\n")` does not split a CRLF body at all. ChatWise's feed is
+/// LF today; this pins the behavior so the day it isn't, the bug is a red test
+/// rather than a changelog that silently renders as a single giant bullet.
+@Test func bulletItemsSplitCRLFBodies() {
+    #expect(StructuredChangelogDecoder.bulletItems(from: "- first item\r\n- second item\r\n")
+            == ["first item", "second item"])
+    #expect(StructuredChangelogDecoder.bulletItems(from: "- first item\n- second item\n")
+            == ["first item", "second item"])
+}
+
+// MARK: - The structural invariant nothing was asserting
+
+/// `structuredFormat` silently disables `indexLinkPattern` in `ChangelogService`
+/// (a structured recipe makes one request, not two), and a recipe carrying both a
+/// `structuredFormat` and an `entryPattern` would run only one of them. Neither
+/// combination fails at compile time, and neither fails loudly at runtime — it
+/// just quietly produces the wrong thing. Derived from the registry so a new
+/// recipe cannot slip past.
+@Test func noRecipeMixesTheStructuredAndRegexPaths() {
+    for recipe in ChangelogRecipeRegistry.recipes where recipe.structuredFormat != nil {
+        #expect(recipe.entryPattern.isEmpty,
+                "\(recipe.bundleID): structuredFormat and entryPattern are mutually exclusive")
+        #expect(recipe.indexLinkPattern == nil,
+                "\(recipe.bundleID): structuredFormat skips the two-stage fetch, so indexLinkPattern is dead")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotionChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotionChangelogRecipeTests.swift
@@ -29,8 +29,9 @@ private let notionNewNamingFixture = #"""
     // with no build number, which never matched the app's real installed
     // version. The pattern is reconstructed here (via the shared helper in
     // `ChangelogExtractorTests.swift`) rather than fetched from the registry,
-    // so this regression coverage survives even though the pattern itself is
-    // now dead code (kept commented out in the registry for reference).
+    // so this regression coverage survives even though the pattern itself is no
+    // longer in the registry at all (it is in git history, at 3603c3c^ and
+    // earlier — deliberately NOT left behind as commented-out code).
     private func recipe() -> ChangelogRecipe {
         notionProductAnnouncementsRecipe()
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotionChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotionChangelogRecipeTests.swift
@@ -22,13 +22,22 @@ private let notionNewNamingFixture = #"""
 /// passing alongside this one is what proves both alternatives in the pattern
 /// still fire.
 @Suite struct NotionChangelogRecipeTests {
-    private func recipe() throws -> ChangelogRecipe {
-        try #require(ChangelogRecipeRegistry.recipes.first { $0.bundleID == "notion.id" })
+    // 2026-08-22: this regex recipe is no longer the ACTIVE `notion.id` entry in
+    // `ChangelogRecipeRegistry` — it was replaced by the structured
+    // `.notionPageChunk` recipe (see `NotionPageChunkTests` below and the
+    // registry comment), because this page's "version" was really a post title
+    // with no build number, which never matched the app's real installed
+    // version. The pattern is reconstructed here (via the shared helper in
+    // `ChangelogExtractorTests.swift`) rather than fetched from the registry,
+    // so this regression coverage survives even though the pattern itself is
+    // now dead code (kept commented out in the registry for reference).
+    private func recipe() -> ChangelogRecipe {
+        notionProductAnnouncementsRecipe()
     }
 
     @Test func readsTheCurrentCSSModulesNaming() throws {
         let log = try #require(
-            ChangelogExtractor.extract(from: notionNewNamingFixture, using: try recipe()))
+            ChangelogExtractor.extract(from: notionNewNamingFixture, using: recipe()))
         #expect(log.entries.count == 2)
         // Notion publishes no build number on this page, so the post title is
         // the version string by design — see the recipe's comment.
@@ -42,5 +51,118 @@ private let notionNewNamingFixture = #"""
         #expect(log.entries.first?.items.allSatisfy {
             !$0.contains("No more guessing which model")
         } == true)
+    }
+}
+
+// MARK: - notionPageChunk (the ACTIVE `notion.id` recipe)
+
+/// A real (trimmed) slice of `notion.notion.site/api/v3/loadPageChunk`'s response
+/// for the desktop app's actual "What's New" page, captured live 2026-08-22 —
+/// the first 3 of 24 releases (12 of its 101 blocks): a `page` block whose
+/// `content` array names the reading order, plus that order's `header`/`text`/
+/// `bulleted_list` blocks, each trimmed to only the `type`/`properties.title`
+/// fields the decoder reads (the real response also carries `id`, `version`,
+/// `format`, `created_time`, … which `Decodable` already ignores for free, so
+/// dropping them here is a size cut, not a behavior change).
+///
+/// This is the fixture that pins the whole reason this recipe replaced the old
+/// one: `v7.31.0` is a REAL desktop build number (it matches what the vendor
+/// probe reads from the installer filename), not a post title standing in for
+/// one.
+private let notionPageChunkFixture = #"""
+{"recordMap": {"block": {"3bfefdee-ad05-8039-a5e6-d8cb747ee142": {"value": {"value": {"type": "header","properties": {"title": [["v7.31.0"]]}}}},"3bfefdee-ad05-8057-9623-dff8b34b7bf0": {"value": {"value": {"type": "text","properties": {"title": [[" 📅 Released "],["‣",[["d",{"type": "datetime","start_date": "2026-08-17","start_time": "16:26","time_zone": "America/Los_Angeles","date_format": "relative"}]]],["  (macOS & Windows)"]]}}}},"3bfefdee-ad05-8067-8fa6-d6b559cfff1f": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Allow additional SSO provider (Entra) login popups from in the app"]]}}}},"3b8efdee-ad05-807b-ba1a-fea9e1c1fac3": {"value": {"value": {"type": "header","properties": {"title": [["v7.29.0"]]}}}},"3b8efdee-ad05-8014-be1f-c9be494eeacd": {"value": {"value": {"type": "text","properties": {"title": [[" 📅 Released "],["‣",[["d",{"type": "date","start_date": "2026-08-03","date_format": "relative"}]]],["  (macOS & Windows)"]]}}}},"3b8efdee-ad05-80bd-99bf-d926b25f2d54": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Resolved an issue where the quick search hotkey wouldn't work properly for certain users"]]}}}},"3b8efdee-ad05-807a-98ec-fd8db89d1895": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Windows 10 users (20H2 and above) can now use the MSIX Installer"]]}}}},"3acefdee-ad05-80a8-8fa8-fde99932d47d": {"value": {"value": {"type": "header","properties": {"title": [["v7.28.0"]]}}}},"3acefdee-ad05-8056-811e-f20f1e5ea0e3": {"value": {"value": {"type": "text","properties": {"title": [[" 📅 Released "],["‣",[["d",{"date_format": "relative","type": "date","start_date": "2026-07-27"}]]],[" (macOS & Windows)"]]}}}},"3acefdee-ad05-80f7-9bfc-dcb3d570930b": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Tabs recover automatically if your system unloads them under memory pressure"]]}}}},"3acefdee-ad05-80a9-919b-f6f7591f741f": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Opening a Notion link in Desktop no longer closes the originating browser tab on macOS"]]}}}},"3acefdee-ad05-8075-80ef-d191c6bfc432": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["As always, security and performance improvements, and small bug fixes"]]}}}},"5936dabc-8dd6-4978-9578-6c91b9d6f12a": {"value": {"value": {"type": "page","content": ["3bfefdee-ad05-8039-a5e6-d8cb747ee142","3bfefdee-ad05-8057-9623-dff8b34b7bf0","3bfefdee-ad05-8067-8fa6-d6b559cfff1f","3b8efdee-ad05-807b-ba1a-fea9e1c1fac3","3b8efdee-ad05-8014-be1f-c9be494eeacd","3b8efdee-ad05-80bd-99bf-d926b25f2d54","3b8efdee-ad05-807a-98ec-fd8db89d1895","3acefdee-ad05-80a8-8fa8-fde99932d47d","3acefdee-ad05-8056-811e-f20f1e5ea0e3","3acefdee-ad05-80f7-9bfc-dcb3d570930b","3acefdee-ad05-80a9-919b-f6f7591f741f","3acefdee-ad05-8075-80ef-d191c6bfc432"]}}}}}}
+"""#
+
+@Suite struct NotionPageChunkTests {
+    @Test func registryPointsAtTheStructuredPostRecipe() throws {
+        let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "notion.id"))
+        #expect(recipe.structuredFormat == .notionPageChunk)
+        #expect(recipe.httpMethod == .post)
+        #expect(recipe.requestBody != nil)
+        #expect(recipe.source.absoluteString == "https://notion.notion.site/api/v3/loadPageChunk")
+    }
+
+    @Test func decodesReleasesInPageOrderWithVStripped() throws {
+        let log = try #require(StructuredChangelogDecoder.decode(
+            notionPageChunkFixture, format: .notionPageChunk, channel: nil, maxEntries: 20))
+
+        #expect(log.entries.count == 3)
+        // Order must come from the page block's `content` array, not the JSON
+        // object's own key order (which Swift's Decodable/[String: X] does not
+        // preserve at all) — this is the one property this fixture actually
+        // proves rather than assumes.
+        #expect(log.entries.map(\.version) == ["7.31.0", "7.29.0", "7.28.0"])
+        // The leading "v" is stripped so the rail label matches the installed
+        // build's marketing version exactly (no "v" prefix anywhere else in the
+        // app's version display).
+        #expect(log.entries.allSatisfy { !$0.version.hasPrefix("v") })
+    }
+
+    @Test func decodesRealDatesFromTheDateMention() throws {
+        let log = try #require(StructuredChangelogDecoder.decode(
+            notionPageChunkFixture, format: .notionPageChunk, channel: nil, maxEntries: 20))
+        // The "📅 Released ‣ (macOS & Windows)" line's `‣` is a real Notion date
+        // mention carrying `start_date`; the visible "‣" text itself is NOT the
+        // date and must never leak into the field.
+        #expect(log.entries[0].date == "2026-08-17")
+        #expect(log.entries[1].date == "2026-08-03")
+        #expect(log.entries[2].date == "2026-07-27")
+    }
+
+    @Test func decodesItemsPinningCountsAndTheLastItem() throws {
+        let log = try #require(StructuredChangelogDecoder.decode(
+            notionPageChunkFixture, format: .notionPageChunk, channel: nil, maxEntries: 20))
+        #expect(log.entries[0].items.count == 1)
+        #expect(log.entries[0].items == ["Allow additional SSO provider (Entra) login popups from in the app"])
+        #expect(log.entries[1].items.count == 2)
+        #expect(log.entries[2].items.count == 3)
+        // Explicitly pin the LAST item of the LAST entry: the grouping must not
+        // silently drop a trailing bullet when a release has several.
+        #expect(log.entries[2].items.last
+            == "As always, security and performance improvements, and small bug fixes")
+    }
+
+    @Test func maxEntriesCapsWithoutTruncatingTheLastKeptEntrysItems() throws {
+        let log = try #require(StructuredChangelogDecoder.decode(
+            notionPageChunkFixture, format: .notionPageChunk, channel: nil, maxEntries: 2))
+        #expect(log.entries.count == 2)
+        #expect(log.entries.map(\.version) == ["7.31.0", "7.29.0"])
+        // The cap must apply BETWEEN releases, not mid-release: the second (kept)
+        // entry still has both its bullets, not a partial set.
+        #expect(log.entries[1].items.count == 2)
+    }
+}
+
+// MARK: - Fetch-layer POST/GET regression
+
+/// `ChangelogRecipe.httpMethod` must default to `.get` for every recipe that
+/// doesn't set it explicitly — this is the regression guard for that default,
+/// since `notion.id` is the ONLY `.post` recipe in the entire registry and a
+/// mistake in the default would silently flip every other vendor's changelog
+/// fetch to a POST that endpoint never expects.
+@Suite struct ChangelogRecipeHTTPMethodTests {
+    @Test func everyRecipeDefaultsToGETExceptNotion() {
+        for recipe in ChangelogRecipeRegistry.recipes {
+            if recipe.bundleID == "notion.id" {
+                #expect(recipe.httpMethod == .post, "notion.id should be the POST recipe")
+                #expect(recipe.requestBody != nil)
+            } else {
+                #expect(recipe.httpMethod == .get, "\(recipe.bundleID) must default to GET")
+                #expect(recipe.requestBody == nil, "\(recipe.bundleID) must carry no request body")
+            }
+        }
+    }
+
+    @Test func decodingATerseRecipeOmittingHTTPFieldsYieldsGET() throws {
+        // The forgiving decode path (`ChangelogRecipe.init(from:)`): a
+        // remotely-authored recipe that predates `httpMethod`/`requestBody`
+        // entirely must still decode as a plain GET, not fail or default to
+        // something else.
+        let json = """
+        {"bundleID": "example.app", "source": "https://example.com/changelog"}
+        """
+        let recipe = try JSONDecoder().decode(ChangelogRecipe.self, from: Data(json.utf8))
+        #expect(recipe.httpMethod == .get)
+        #expect(recipe.requestBody == nil)
     }
 }


### PR DESCRIPTION
Six changelog recipes were scraping JSON with regexes. This moves them onto `StructuredChangelogDecoder`, swaps three sources for sturdier ones, and teaches the fetch layer two things it needed.

It started as a one-line fix: ChatWise's item pattern ended in `\\n?$`, which in that raw string means "a literal backslash, optionally the letter *n*, then end of string" — so the last bullet of an entry could be dropped. Rather than fix the regex, the recipe now decodes the JSON.

## What changed

**Regex → structured decoding** (byte-identical output verified against today's live responses): ChatWise, GitHub Desktop, SunLogin, Postman, HBuilderX, JetBrains. Postman is the exception and gains two fixes — the old `[^\\]{10,}` capture stopped at the backslash of an escaped quote, truncating 12.17.3 and 12.13.4 mid-sentence.

**Source swaps:**
- **Zed** → the GitHub releases API instead of scraping zed.dev. One request covers both channels.
- **Figma** → its Atom feed instead of the release-notes page. 445/445 entries match.
- **HBuilderX** → the official Markdown, one hop instead of two (a ~900-byte config JSON pointing at a 551 KB HTML page). Deliberately narrowed to the HBuilder IDE section.
- **Notion** → the desktop what's-new page over its `loadPageChunk` API. The old `notion.com/releases` recipe was the *product* announcement feed, whose "versions" are post titles with no build number — they never matched the version the row displays. Required teaching `ChangelogRecipe` POST + a request body.

**GitHub token** on `api.github.com` changelog fetches. Unauthenticated is 60/hr per IP shared with every GitHub-sourced version check on the machine, and a full `duo verify` sweep spent two of them on Zed alone — both Zed recipes came back HTTP 403 BROKEN while a token sat in `gh` unused.

## Verification

```
swift test           858 core (2 pre-existing known issues) + 119 CLI
xcodebuild App       BUILD SUCCEEDED
duo verify (full)    ✓ 242  ⚠ 1  ✗ 0  ~ 1  - 1
```

The full sweep before this branch had **changelog ✗ 2** (both Zed, 403). It is now ✗ 0, ✓ 53. The remaining ⚠ is LibreOffice's pre-existing version-scheme warning.

## Review notes

Two subagents reviewed this against live endpoints. Three commits at the end fix what they found.

The most serious was in the token commit and had nothing to do with the scoping it worried about: **the fix reached the wrong machines.** `ChangelogService` resolved with no explicit token, so it saw only the environment and `gh` — and the shipped app has neither, since launchd starts it with no shell environment and a Settings-pasted token lives in the Keychain the core package can't read. The original verification (`duo verify --only zed`) ran the CLI from a terminal that inherits both. Two more in the same function: the lock was held across an untimed `gh auth token` subprocess, and the answer was cached for the whole process lifetime, so a revoked token would keep being sent — GitHub answers 401, which renders an *empty* pane, strictly worse than anonymous.

Also fixed: HBuilderX leaked literal backticks (the HTML it replaced spelled inline code `<code>…</code>`, which `stripTags` removed — 9 of 116 items in today's window); Postman lost whitespace normalization, making the claimed 28/30 parity actually 27/30; SunLogin declared `logs` non-optional, so one `null` anywhere would return nil for the whole feed where the regex skipped one entry; Zed dropped bullet-less releases (1 of the newest 100 today) that the retired zed.dev recipe covered with a `<p>` pattern.

**Token scoping was audited and is safe.** Exact host match, every lookalike rejected (`api.github.com.evil.example`, `notapi.github.com`, `api.github.com@evil.example`, trailing-dot FQDN, IDN homographs), and the redirect vector closed by the existing `CrossHostCredentialStripper` delegate — confirmed to fire on the async `data(for:)` path — with CFNetwork stripping underneath as a second layer. A scheme check was added since `URL.host` is scheme-agnostic.

One review finding was **rejected after checking**: that the Postman commit changed a recipe with zero tests. It had `extractsPostmanEntriesFromJSON` running against the registry recipe at that commit; the later HBuilderX commit only replaced the fixture with a richer real-feed slice, which is why `git log -S <new fixture name>` pointed elsewhere.

Separately filed, not in this PR: a live GitHub PAT sits in plaintext in the app's URL cache (85 blobs across the app and CLI caches). Pre-existing — `GitHubReleasesSource` has sent that header all along — and orthogonal to this change.

---

**#34 (Sparkle inline HTML notes) is stacked on this branch and should merge after it.**
