### PR TITLE
Read seven apps' changelogs instead of embedding their pages

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
@@ -185,7 +185,7 @@ public enum ChangelogExtractor {
                 s = decodeEntities(s)
             }
         }
-        if recipe.markdownSource { s = unwrapMarkdownInlineCode(s) }
+        if recipe.markdownSource { s = unwrapMarkdownInline(s) }
         return collapseWhitespace(s)
     }
 
@@ -205,6 +205,20 @@ public enum ChangelogExtractor {
     /// A lone unpaired backtick stays put: both alternatives are confined to one
     /// line, so an unterminated span simply doesn't match. The `$1$2` template
     /// works because a non-participating group substitutes as empty.
+    static func unwrapMarkdownInline(_ s: String) -> String {
+        flattenMarkdownLinks(unwrapMarkdownInlineCode(s))
+    }
+
+    /// `[text](url)` → `text`. The URL sub-pattern allows one level of nested
+    /// parens (a Wikipedia-style `..._(bar)` URL) so the match consumes the whole
+    /// link instead of leaving a dangling `)`. Same expression
+    /// `StructuredChangelogDecoder.bulletItems` already uses.
+    static func flattenMarkdownLinks(_ s: String) -> String {
+        s.replacingOccurrences(
+            of: #"\[([^\]]*)\]\((?:[^()]|\([^()]*\))*\)"#, with: "$1",
+            options: .regularExpression)
+    }
+
     static func unwrapMarkdownInlineCode(_ s: String) -> String {
         guard let regex = try? NSRegularExpression(pattern: "``([^\n]*?)``|`([^`\n]+?)`")
         else { return s }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -40,6 +40,7 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// and majors ship every few weeks.
     public let sourceTemplate: String?
 
+
     /// Response shape. `.html` runs the regexes against the raw markup; `.json`
     /// is identical mechanically (regex over the body) but named separately so a
     /// future structured-JSON path can branch on it. Defaults to `.html`.
@@ -239,6 +240,16 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// unauthenticated (60/hour/IP) and `ChangelogService` doesn't attach a
         /// token.
         case zedGitHubReleases
+        /// A plain `api.github.com/repos/<owner>/<repo>/releases` array, decoded
+        /// with the same `GitHubMarkdownParser` the GitHub *version* source uses.
+        /// For an app whose real changelog is its GitHub releases but whose update
+        /// source is something else (Waku ships a Sparkle appcast, and its
+        /// `releaseNotesLink` points at a single per-version `.md` with no index —
+        /// so the feed alone can only ever show one version).
+        ///
+        /// Stable releases only: a prerelease is a track the user did not opt into,
+        /// and unlike `zedGitHubReleases` this format carries no channel split.
+        case gitHubReleases
         /// Notion's own desktop "What's New" page,
         /// `notion.notion.site/What-s-New-Mac-Windows-…` — distinct from
         /// `www.notion.com/releases`, which is Notion's *product* announcement feed
@@ -1189,6 +1200,29 @@ public enum ChangelogRecipeRegistry {
                 (#"{"pageId":"5936dabc-8dd6-4978-9578-6c91b9d6f12a","limit":50,"#
                     + #""cursor":{"stack":[]},"chunkNumber":0,"verticalColumns":false}"#
                 ).utf8)),
+
+        // Waku — GitHub releases, not the appcast's own notes link.
+        //
+        // The appcast points `<sparkle:releaseNotesLink>` at a per-version file,
+        // `releases.waku.sh/Waku-<version>.md`, whose body is a bare Markdown
+        // bullet list — no heading, no title, no version in it — so it produced no
+        // entries and the pane fell back to a web view rendering raw `- ` lines.
+        // That file is fetchable for any version by name (0.1.9 … 0.1.12 all 200)
+        // but the site root 404s, so there is NO index: templating it can only ever
+        // show the one version being offered.
+        //
+        // github.com/egoist/waku carries the same bullets AND the history — seven
+        // releases, each with its published date. Same content, more of it, and it
+        // reuses the decoder every other GitHub-sourced app already goes through.
+        // Two of those seven (v0.1.9, v0.1.7) say only "See CHANGELOG.md for
+        // details."; they still get an entry, via `GitHubMarkdownParser`'s prose
+        // pass, rather than leaving a gap in the version rail.
+        ChangelogRecipe(
+            bundleID: "sh.waku",
+            source: URL(string: "https://api.github.com/repos/egoist/waku/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            structuredFormat: .gitHubReleases),
 
         // Notion's OTHER changelog, deliberately not registered: www.notion.com/
         // releases is the *product* announcement feed (feature launches like "Plan

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -88,13 +88,18 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// spelled it `<code>CLI pack cancel</code>`, which `stripTags` removed, so
     /// without this the migration puts visible backticks in front of the user.
     ///
-    /// Deliberately narrow: it unwraps inline code spans and nothing else. Bold,
-    /// emphasis and headings would need real Markdown rendering (`Changelog`
-    /// already has `.markdown` item syntax for producers that keep their source
-    /// intact); this flag exists for recipes whose *output contract is plain
-    /// text*, to restore the parity an HTML→Markdown source swap otherwise breaks.
-    /// Link syntax is not touched here — a recipe reading Markdown is expected to
-    /// consume links in its `itemPatterns`, as HBuilderX's does.
+    /// Deliberately narrow: it unwraps inline code spans and flattens
+    /// `[text](url)` to `text`, and nothing else. Bold, emphasis and headings would
+    /// need real Markdown rendering (`Changelog` already has `.markdown` item
+    /// syntax for producers that keep their source intact); this flag exists for
+    /// recipes whose *output contract is plain text*, so that the syntax a plain
+    /// renderer would print literally is removed rather than shown.
+    ///
+    /// Link flattening was added for Docker, whose notes carry links mid-sentence
+    /// (`[Docker Compose v5.4.0](…)`) that no `itemPattern` can practically consume
+    /// — HBuilderX's trailing links are eaten by its own pattern, and flattening
+    /// was verified a no-op there before this widened: 0 of the 116 items in its
+    /// live top-10 window change.
     public var markdownSource: Bool
 
     /// Keep at most this many entries (changelogs run for years; the detail view
@@ -250,6 +255,9 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// Stable releases only: a prerelease is a track the user did not opt into,
         /// and unlike `zedGitHubReleases` this format carries no channel split.
         case gitHubReleases
+        /// Alcove's own changelog API, `api.tryalcove.com/changelog` — public and
+        /// unauthenticated, unlike the license-gated update endpoint beside it.
+        case alcoveChangelog
         /// Notion's own desktop "What's New" page,
         /// `notion.notion.site/What-s-New-Mac-Windows-…` — distinct from
         /// `www.notion.com/releases`, which is Notion's *product* announcement feed
@@ -1223,6 +1231,85 @@ public enum ChangelogRecipeRegistry {
             mode: .json,
             maxEntries: 20,
             structuredFormat: .gitHubReleases),
+
+        // Alcove — its own changelog API. Public and unauthenticated, unlike the
+        // update endpoint on the same host, which is license-gated (see
+        // `AlcoveUpdateSource`). Structured JSON: majors, each holding its point
+        // releases with date, note, features and fixes. Newest is 1.7.9, matching
+        // the installed copy on 2026-08-22.
+        //
+        // This replaces a web view on `tryalcove.com/changelog`, whose text lives
+        // in hash-named JS chunks — the reason that page was only ever linked, not
+        // read. The API is a different surface and a far better one.
+        ChangelogRecipe(
+            bundleID: "com.henrikruscon.Alcove",
+            source: URL(string: "https://api.tryalcove.com/changelog")!,
+            mode: .json,
+            maxEntries: 30,
+            structuredFormat: .alcoveChangelog),
+
+        // Docker Desktop — the release-notes page in its Markdown source form.
+        // `docs.docker.com/desktop/release-notes.md` serves `text/markdown`
+        // directly (the `.md` twin of the HTML page), 142 versions deep, newest
+        // 4.87.0 on 2026-08-17 — the installed version here.
+        //
+        // The `- [Windows](…)` / `- [Mac …]` / `- [Linux …]` installer links each
+        // release opens with are excluded by the item pattern's negative lookahead:
+        // they are the same seven download URLs every time and say nothing about
+        // what changed. Everything after them — the `### Updates` component list
+        // and the `### Bug fixes and enhancements` sections — is kept.
+        //
+        // `markdownSource` because the notes link out mid-sentence
+        // (`[Docker Compose v5.4.0](…)`); without it a plain-text render prints the
+        // brackets and the URL.
+        ChangelogRecipe(
+            bundleID: "com.docker.docker",
+            source: URL(string: "https://docs.docker.com/desktop/release-notes.md")!,
+            entryPattern:
+                #"## (?<version>[0-9]+\.[0-9]+\.[0-9]+)\n\n"#
+                + #"<em[^>]*>(?<date>[0-9-]+)</em>"#
+                + #"(?<body>[\s\S]*?)(?=\n## |\z)"#,
+            itemPatterns: [#"(?:^|\n)- (?!\[(?:Windows|Mac|Linux))(?<item>[^\n]+)"#],
+            stripTags: false,
+            decodeEntities: false,
+            markdownSource: true,
+            maxEntries: 20,
+            minItemLength: 6),
+
+        // Kiro — the changelog's RSS feed, filtered to the IDE.
+        //
+        // The feed mixes three products (`<category>` is IDE, CLI or Web) and the
+        // installed app is the IDE, so the entry pattern requires that category
+        // rather than filtering afterwards: a CLI release note under an IDE version
+        // heading would be worse than no note.
+        //
+        // Only some titles carry a version ("IDE 1.0.337: Agent Focus, …"); the
+        // rest are titled but unversioned ("IDE: Permission Improvements …"). Both
+        // shapes are kept — `Changelog.Entry` accepts a title without a version,
+        // and dropping the unversioned ones would silently lose 8 of the 15 IDE
+        // entries in today's feed. The `IDE` prefix is consumed either way so the
+        // rail doesn't repeat it on every row.
+        //
+        // Notes are prose paragraphs, not lists, so the whole description is one
+        // item — this feed has no bullets to find.
+        //
+        // `pubDate` is RFC-822 and the rail's date formatter only normalizes
+        // ISO-8601, so the weekday and the time are dropped in the capture rather
+        // than rendered verbatim as "Tue, 18 Aug 2026 20:04:00 GMT" under every
+        // version. What's left ("18 Aug 2026") matches the shape Alcove's feed
+        // already supplies.
+        ChangelogRecipe(
+            bundleID: "dev.kiro.desktop",
+            source: URL(string: "https://kiro.dev/changelog/feed.rss")!,
+            entryPattern:
+                #"<item>\s*<title>(?:IDE(?: (?<version>[0-9][0-9.]*))?: )?(?<title>[^<]*)</title>\s*"#
+                + #"<link>[^<]*</link>\s*<guid>[^<]*</guid>\s*"#
+                + #"<pubDate>[A-Za-z]{3}, (?<date>[0-9]{2} [A-Za-z]{3} [0-9]{4})[^<]*</pubDate>\s*"#
+                + #"<category>IDE</category>\s*"#
+                + #"<description><!\[CDATA\[(?<body>[\s\S]*?)\]\]></description>"#,
+            itemPatterns: [#"(?<item>[\s\S]+)"#],
+            maxEntries: 20,
+            minItemLength: 10),
 
         // Notion's OTHER changelog, deliberately not registered: www.notion.com/
         // releases is the *product* announcement feed (feature launches like "Plan

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -27,10 +27,22 @@ public enum GitHubMarkdownParser {
     /// apps that share this parser); the lenient pass purely rescues bodies that
     /// would otherwise fall back to a raw web view — e.g. nvm's space-indented
     /// `- ` lists, or any project that writes its notes as a numbered list.
+    ///
+    /// A THIRD pass, prose, runs only when both bullet passes come back empty: a
+    /// release whose notes are written as sentences rather than a list. Returning
+    /// nil for those was a real hole — for a multi-release source it drops that
+    /// version out of the rail entirely, so a user sitting on exactly that build
+    /// finds no entry for their own version (Zed's `v1.5.3-pre`, "No public-facing
+    /// changes in this release.", is the live case; Waku's `v0.1.9`, "See
+    /// CHANGELOG.md for details.", is another). Gated the same way the lenient pass
+    /// is, so no body that already parsed changes at all.
     public static func parse(body: String, version: String, date: String?) -> Changelog? {
         var items = extractItems(from: body, lenient: false)
         if items.isEmpty {
             items = extractItems(from: body, lenient: true)
+        }
+        if items.isEmpty {
+            items = proseItems(from: body)
         }
         guard !items.isEmpty else { return nil }
         let entry = Changelog.Entry(version: version, date: date, items: items)
@@ -51,6 +63,80 @@ public enum GitHubMarkdownParser {
     private static let lenientExtraSkipKeywords = [
         "sha256", "sha-256", "sha1", "md5", "checksum", "hashes", "artifacts",
     ]
+
+    /// Sentences from a release body that contains no list at all, in document
+    /// order. Deliberately conservative about what it drops, because at this point
+    /// the alternative is showing the user nothing:
+    ///
+    ///   - headings and fenced code blocks (same as the bullet passes);
+    ///   - a line that is only an image or a badge — LuLu opens its notes with a
+    ///     `[![](shields.io/...)](...)` sponsor banner, which as an "item" is a URL
+    ///     the reader cannot use;
+    ///   - a checksum: both the `🔐 Disk Image Hash (SHA256):` label line and the
+    ///     `file.dmg: <64 hex>` line under it. Neither is a change.
+    ///
+    /// Everything else is kept verbatim, including Markdown links — the entry is
+    /// emitted with `.markdown` syntax, so they render rather than showing as raw
+    /// brackets.
+    ///
+    /// Two hard bails, both of which mean "this is a shape I don't understand, and
+    /// showing part of it as bullets is worse than not converting at all":
+    ///
+    ///   - a Markdown TABLE. Headlamp writes its whole changelog as tables — 142
+    ///     table rows in v0.45.0 — and line-by-line that renders as bullets reading
+    ///     `|:--|--:|` and `| <img src="…">`, next to download links for other
+    ///     platforms. Verified against the live release before this guard existed.
+    ///   - more than `proseItemCap` lines. Prose notes are a sentence or a handful;
+    ///     dozens of lines means real structure this pass is misreading. Not a
+    ///     display limit — the entry is abandoned, not truncated, so the caller
+    ///     falls back to the renderer that shows the body whole.
+    private static let proseItemCap = 12
+
+    private static func proseItems(from body: String) -> [String] {
+        guard body.range(of: #"(?m)^\s*\|"#, options: .regularExpression) == nil
+        else { return [] }
+        var items: [String] = []
+        var inCodeBlock = false
+        for line in body.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") { inCodeBlock.toggle(); continue }
+            if inCodeBlock || trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            if isImageOnly(trimmed) || isBareURL(trimmed) || isChecksum(trimmed) { continue }
+            if skippedSectionKeywords.contains(where: {
+                trimmed.lowercased().hasPrefix("**\($0)")
+            }) { continue }
+            items.append(trimmed)
+            if items.count > proseItemCap { return [] }
+        }
+        return items
+    }
+
+    /// A line that is nothing but a URL. Not a change description — the same
+    /// reasoning as the image-only skip. Caught by an existing test: an
+    /// azure-cli-style body of "a bare link, a SHA256 heading, a hash code block"
+    /// must still yield nothing, and without this the bare link became its one
+    /// "change". A sentence that merely CONTAINS a URL is untouched (kitty's notes
+    /// are exactly that), because the whole line has to be the URL.
+    private static func isBareURL(_ line: String) -> Bool {
+        line.range(of: #"^<?https?://\S+>?$"#, options: .regularExpression) != nil
+    }
+
+    /// A line whose entire content is one image, optionally wrapped in a link.
+    private static func isImageOnly(_ line: String) -> Bool {
+        line.range(
+            of: #"^\[?!\[[^\]]*\]\([^)]*\)\]?(\([^)]*\))?$"#,
+            options: .regularExpression) != nil
+    }
+
+    /// A checksum label (`… SHA256 …:`) or a line carrying a 32+ character hex run.
+    private static func isChecksum(_ line: String) -> Bool {
+        let lower = line.lowercased()
+        if lower.hasSuffix(":"),
+           lenientExtraSkipKeywords.contains(where: { lower.contains($0) }) {
+            return true
+        }
+        return line.range(of: #"\b[0-9a-fA-F]{32,}\b"#, options: .regularExpression) != nil
+    }
 
     private static func extractItems(from body: String, lenient: Bool) -> [String] {
         let lines = body.components(separatedBy: .newlines)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -36,6 +36,8 @@ public enum StructuredChangelogDecoder {
             return decodeJetBrainsProductReleases(body, maxEntries: maxEntries)
         case .zedGitHubReleases:
             return decodeZedGitHubReleases(body, channel: channel ?? .stable, maxEntries: maxEntries)
+        case .gitHubReleases:
+            return decodeGitHubReleases(body, maxEntries: maxEntries)
         case .notionPageChunk:
             return decodeNotionPageChunk(body, maxEntries: maxEntries)
         }
@@ -481,46 +483,76 @@ public enum StructuredChangelogDecoder {
             // Reuse the same parser GitHub-release version detection already
             // uses for a single release's notes (`GitHubMarkdownParser`), rather
             // than a second bespoke bullet-extractor for the same markdown shape.
-            if let parsed = GitHubMarkdownParser.parse(body: body, version: version, date: date),
-               let entry = parsed.entries.first {
-                entries.append(entry)
-            } else if let prose = zedProseFallback(body: body) {
-                // `GitHubMarkdownParser` returns nil for a body with no bullets, and
-                // Zed ships such releases: 1 of the newest 100 today (`v1.5.3-pre`,
-                // whose whole body is "No public-facing changes in this release.").
-                // Skipping them left a Preview user sitting on exactly that build
-                // with NO entry for their own version — the retired zed.dev recipe
-                // had a `<p>` item pattern that covered this, so dropping them was a
-                // content regression against the source this replaced.
-                entries.append(.init(version: version, date: date, items: [prose]))
-            } else {
-                continue
-            }
+            // `GitHubMarkdownParser` covers the bullet-less shape itself now (its
+            // prose pass) — Zed ships such releases, 1 of the newest 100 today
+            // (`v1.5.3-pre`, "No public-facing changes in this release."), and a
+            // Preview user sitting on exactly that build must still find an entry
+            // for their own version. That used to be a Zed-only fallback here;
+            // it belongs in the parser, where every GitHub-sourced app gets it.
+            guard let parsed = GitHubMarkdownParser.parse(body: body, version: version, date: date),
+                  let entry = parsed.entries.first
+            else { continue }
+            entries.append(entry)
             if let cap = maxEntries, entries.count >= cap { break }
         }
         guard !entries.isEmpty else { return nil }
         return Changelog(entries: entries, itemSyntax: .markdown)
     }
 
-    /// The first non-empty, non-heading prose line of a release body that has no
-    /// bullets at all — Zed's "No public-facing changes in this release." shape.
-    /// Markdown links are flattened to their text so the trailing
-    /// "[View the commits](…)" doesn't render as raw bracket syntax; the entry is
-    /// emitted with `.markdown` syntax like every other Zed entry, so anything
-    /// left is rendered rather than shown literally. nil when the body is only
-    /// headings/links, in which case the release really is skipped.
-    static func zedProseFallback(body: String) -> String? {
-        for rawLine in body.split(omittingEmptySubsequences: true, whereSeparator: { $0.isNewline }) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard !line.isEmpty, !line.hasPrefix("#"), !line.hasPrefix("<") else { continue }
-            let flattened = ChangelogExtractor.collapseWhitespace(
-                line.replacingOccurrences(
-                    of: #"\[([^\]]*)\]\((?:[^()]|\([^()]*\))*\)"#, with: "$1",
-                    options: .regularExpression))
-            guard !flattened.isEmpty else { continue }
-            return flattened
+    // MARK: - Plain GitHub releases (api.github.com/repos/<owner>/<repo>/releases)
+
+    /// Decode a GitHub releases array into one entry per stable release, newest
+    /// first, using the same `GitHubMarkdownParser` the GitHub version source uses
+    /// — so a release body renders identically no matter which way we arrived at it.
+    ///
+    /// Prereleases are skipped: nothing here says which track the user is on, so
+    /// offering a prerelease's notes beside a stable install would be describing a
+    /// build they were never shown. A release whose body yields nothing at all
+    /// (empty, or only a checksum block) is skipped rather than shown as a bare
+    /// version heading — but a body of plain sentences is NOT, since the parser's
+    /// prose pass covers those.
+    static func decodeGitHubReleases(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data)
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        for release in releases where !release.prerelease && !release.draft {
+            guard let raw = release.body, !raw.isEmpty else { continue }
+            let version = stripLeadingV(release.tagName)
+            guard !version.isEmpty else { continue }
+            let date = isoDay(release.publishedAt)
+            guard let parsed = GitHubMarkdownParser.parse(body: raw, version: version, date: date),
+                  let entry = parsed.entries.first
+            else { continue }
+            entries.append(entry)
+            if let cap = maxEntries, entries.count >= cap { break }
         }
-        return nil
+        guard !entries.isEmpty else { return nil }
+        return Changelog(entries: entries, itemSyntax: .markdown)
+    }
+
+    /// `v0.1.12` → `0.1.12`. Only a leading `v`, and only when a digit follows, so
+    /// a tag that legitimately starts with a letter (`version-2`) is left alone.
+    private static func stripLeadingV(_ tag: String) -> String {
+        guard tag.count > 1, tag.hasPrefix("v"),
+              let second = tag.dropFirst().first, second.isNumber
+        else { return tag }
+        return String(tag.dropFirst())
+    }
+
+    private struct GitHubRelease: Decodable {
+        let tagName: String
+        let prerelease: Bool
+        let draft: Bool
+        let publishedAt: String?
+        let body: String?
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case prerelease, draft
+            case publishedAt = "published_at"
+            case body
+        }
     }
 
     /// `v1.17.0-pre` → `1.17.0`, `v1.16.1` → `1.16.1`: drop the leading `v` and

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -38,6 +38,8 @@ public enum StructuredChangelogDecoder {
             return decodeZedGitHubReleases(body, channel: channel ?? .stable, maxEntries: maxEntries)
         case .gitHubReleases:
             return decodeGitHubReleases(body, maxEntries: maxEntries)
+        case .alcoveChangelog:
+            return decodeAlcoveChangelog(body, maxEntries: maxEntries)
         case .notionPageChunk:
             return decodeNotionPageChunk(body, maxEntries: maxEntries)
         }
@@ -497,6 +499,67 @@ public enum StructuredChangelogDecoder {
         }
         guard !entries.isEmpty else { return nil }
         return Changelog(entries: entries, itemSyntax: .markdown)
+    }
+
+    // MARK: - Alcove (api.tryalcove.com/changelog)
+
+    /// `{updated, entries:[{version, description, minors:[{version, date, note,
+    /// features[], fixes[]}]}]}` — majors, each holding its point releases. Public
+    /// and unauthenticated, unlike the rest of that host: the update endpoint next
+    /// to it is license-gated (see `AlcoveUpdateSource`), this one is not.
+    ///
+    /// Flattened to one entry per MINOR, because the minor is what a user is
+    /// offered and what their row shows (1.7.9 today, matching this feed's newest).
+    /// The major's `description` is deliberately dropped — it describes a release
+    /// line, not the release in front of you, and repeating it under every point
+    /// release would bury the actual changes.
+    ///
+    /// `features` and `fixes` are labelled in place, the same way
+    /// `decodeWeChatDevTools` folds its category titles in: the distinction is real
+    /// and the flat item list is the only place left to carry it.
+    static func decodeAlcoveChangelog(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let feed = try? JSONDecoder().decode(AlcoveFeed.self, from: data)
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        for major in feed.entries ?? [] {
+            for minor in major.minors ?? [] {
+                guard let version = minor.version?.trimmingCharacters(in: .whitespaces),
+                      !version.isEmpty else { continue }
+                var items: [String] = []
+                if let note = minor.note?.trimmingCharacters(in: .whitespaces), !note.isEmpty {
+                    items.append(note)
+                }
+                for (label, lines) in [("Features", minor.features), ("Fixes", minor.fixes)] {
+                    let clean = (lines ?? []).map { $0.trimmingCharacters(in: .whitespaces) }
+                        .filter { !$0.isEmpty }
+                    guard !clean.isEmpty else { continue }
+                    items.append(label)
+                    items.append(contentsOf: clean)
+                }
+                guard !items.isEmpty else { continue }
+                entries.append(.init(version: version, date: minor.date, items: items))
+                if let cap = maxEntries, entries.count >= cap { return Changelog(entries: entries) }
+            }
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    private struct AlcoveFeed: Decodable {
+        let entries: [AlcoveMajor]?
+    }
+    private struct AlcoveMajor: Decodable {
+        let minors: [AlcoveMinor]?
+    }
+    private struct AlcoveMinor: Decodable {
+        let version: String?
+        /// Already human-readable ("30 Jun 2026") and shown as-is — the rail's date
+        /// formatter normalizes ISO-8601 and otherwise prints what it is given.
+        let date: String?
+        let note: String?
+        let features: [String]?
+        let fixes: [String]?
     }
 
     // MARK: - Plain GitHub releases (api.github.com/repos/<owner>/<repo>/releases)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -545,6 +545,11 @@ public enum VendorProbeRegistry {
         // installer, so the user still confirms it there (same flow as ToDesk and
         // AweSun); the install spec re-resolves the redirect at download time so it
         // always fetches the current package, not this version's.
+        // No `changelogURL`: there is no such page. `uuyc.163.com/changelog` and
+        // `/update` both answer 200, but they return byte-identical content to a
+        // path that does not exist — an SPA catch-all serving the homepage, not a
+        // changelog. The download page is a distinct page but contains no
+        // 更新日志/更新说明/新增/修复 markers at all. (Checked 2026-08-22.)
         VendorProbeRecipe(
             bundleID: "com.netease.uuremote",
             url: URL(string: "https://api.nrd.nie.163.com/api/v1/release/dl/4?channel=gwqd")!,
@@ -1711,6 +1716,14 @@ public enum VendorProbeRegistry {
         // (template), on the vendor's own dl.todesk.com, signed by the same Team
         // KM56KD59W4 (Hainan Youqu Technology) as the installed app — the
         // VendorInstaller signature gate enforces it.
+        // No `changelogURL`: the vendor's macOS log page exists but is abandoned.
+        // `update.todesk.com/macos/uplog.html` is server-rendered with 30 real
+        // versions, and its newest is 4.8.1.0 (2025.9.5) — while the installed
+        // copy here is 4.10.0.0. It is not the whole site going stale: the same
+        // host's `windows/uplog.html` was current to 2026.8.18 on the same day.
+        // Pointing the pane at it would show notes for a version the user passed
+        // two minor releases ago, which is the version-mismatch failure the
+        // Notion and Figma changelogs were just moved away from.
         VendorProbeRecipe(
             bundleID: "com.youqu.todesk.mac",
             url: URL(string: "https://www.todesk.com/download.html")!,
@@ -1741,6 +1754,10 @@ public enum VendorProbeRegistry {
         // nil on purpose: spotify.com/release-notes tracks a DIFFERENT (mobile/web)
         // version scheme (`1.2.534.x`), so embedding it for a `1.2.92.x` desktop
         // build would show an unrelated page — better the honest "no notes" state.
+        // No `changelogURL`, and not an oversight: Spotify publishes no release
+        // notes for the desktop client anywhere. Checked 2026-08-22 — the only
+        // things that exist are one-off community forum posts from a decade ago
+        // (0.9.x, 1.0.9) and long-running threads asking for a changelog.
         VendorProbeRecipe(
             bundleID: "com.spotify.client",
             url: URL(string: "https://download.scdn.co/SpotifyInstaller.zip")!,
@@ -2951,6 +2968,12 @@ public enum VendorProbeRegistry {
         //
         // The manifest publishes a sha256, but `checksumPattern` verifies a
         // base64 SHA-512, so it goes unused; the signature gate still applies.
+        // No `changelogURL`: `gemini.google/release-notes` is the Gemini *Apps*
+        // product feed — model and feature announcements keyed by DATE
+        // (2023.04.10, …), with no desktop build number anywhere. The installed
+        // app reports 1.96.4.775, so nothing on that page can ever line up with
+        // the version on this row. Exactly the mismatch the Notion changelog was
+        // moved off of; wiring it here would reintroduce it. (Checked 2026-08-22.)
         VendorProbeRecipe(
             bundleID: "com.google.GeminiMacOS",
             url: URL(string: "https://update.googleapis.com/service/update2/json")!,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -3031,6 +3031,69 @@ public enum VendorProbeRegistry {
                 kind: .zip,
                 checksumPattern: #"sha512:\s*([A-Za-z0-9+/=]+)"#)),
 
+        // Antigravity IDE — a SECOND, separate app from the one above. Different
+        // bundle id (`com.google.antigravity-ide`), different version line (2.5.5
+        // against the other's 2.9.1), different binary (Electron — it is a VS Code
+        // fork, the Windsurf/Codeium lineage Google acquired). It was installed and
+        // scanned but matched no recipe, so its row had no source and no notes at
+        // all. The sibling recipe's own comment had already noticed this product
+        // existed ("the IDE, under `.../antigravity/stable/`") without covering it.
+        //
+        // Nothing else covers it either: no `SUFeedURL`, no electron-updater
+        // `app-update.yml`, and its VS Code `product.json` sets `updateUrl` to the
+        // literal `https://example.com`, so the built-in update channel is inert.
+        // The real endpoint is in `out/main.js` — a sibling Cloud Run service under
+        // the same GCP project number as the hub updater above:
+        //   /api/update/{platform}/{quality}/{commit}/{sha256(hostname)}
+        //
+        // Two deliberate choices in the URL:
+        //
+        // The last path component is a per-machine identifier (the app sends a
+        // SHA-256 of the hostname). We send `no_hostname` — the app's OWN fallback
+        // literal from the same code, so it is a value the service already handles
+        // rather than something invented, and no machine fingerprint leaves here.
+        // Same reasoning as the `x-user-staging-id` header the sibling omits.
+        //
+        // The commit slot is all zeroes. This is VS Code's update API: it answers
+        // 204 No Content when the commit you name is already current, and the
+        // update JSON otherwise. Naming the installed commit would therefore return
+        // nothing to compare against — and we cannot name it anyway, since it lives
+        // in `product.json` inside the bundle, which the scanner does not read. A
+        // well-formed hash that can never be a real commit always gets the latest.
+        // Verified 2026-08-22: the real commit → 204, all-zeroes → 200 with the
+        // manifest.
+        //
+        // The version comes from the download URL, NOT from any version field in
+        // that response — every one of those is the VS Code base (`productVersion`
+        // and `name` are both 1.107.0, `version` is a commit hash), while the
+        // shipped bundle reports 2.5.5. Comparing 1.107.0 against 2.5.5 would be a
+        // permanent phantom update. The URL path carries the real one:
+        //   .../antigravity/stable/2.5.5-4923483625488384/darwin-arm/...
+        // and the pattern stops at the `-`, so the build id does not ride along —
+        // the exact trap the sibling recipe documents for the hub feed.
+        //
+        // Detection only for now: the artifact is a zip on Google's edgedl CDN with
+        // a `sha256hash` beside it, so an install spec is plausible, but it has not
+        // been downloaded and signature-checked yet, and the URL is arm64-specific.
+        VendorProbeRecipe(
+            bundleID: "com.google.antigravity-ide",
+            url: URL(string: "https://antigravity-ide-auto-updater-974169037036"
+                + ".us-central1.run.app/api/update/darwin-arm64/stable/"
+                + "0000000000000000000000000000000000000000/no_hostname")!,
+            mode: .responseBody,
+            versionPattern: #"/antigravity/stable/([0-9][0-9.]*)-"#,
+            // Detection-only rows have no install action, so the page link is the
+            // only thing the row can offer — a recipe without one is a dead end
+            // (`PageURLTests.detectionOnlyRecipesCarryAPage` enforces it, and
+            // caught this omission).
+            //
+            // No `changelogURL`: the hub's points at `antigravity.google/changelog`,
+            // but that page is JS-rendered — 88 KB with zero version strings in the
+            // served HTML — so there is no way to confirm from here that it even
+            // describes the IDE rather than only the hub. Linking it would be a
+            // guess dressed up as coverage.
+            downloadURL: URL(string: "https://antigravity.google/download")),
+
         // AnyDesk — the plain-text changelog its own Homebrew cask reads for
         // livecheck, and the one thing on that host a script can fetch: the
         // download page and `anydesk.com/en/changelog/mac-os` both answer 403 with

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
@@ -145,14 +145,28 @@ private let hbuilderXCodeSpanFixture = #"""
     let changelog = try #require(StructuredChangelogDecoder.decodeZedGitHubReleases(feed, channel: .preview, maxEntries: 15))
     let entry = try #require(changelog.entries.first)
     #expect(entry.version == "1.5.3")
-    #expect(entry.items == ["No public-facing changes in this release. View the commits"])
+    // The Markdown link is KEPT rather than flattened: the entry carries
+    // `.markdown` item syntax, so it renders as a link the reader can follow.
+    // (The Zed-only fallback this replaced flattened it to bare text, which was
+    // the wrong call for a `.markdown` entry.)
+    #expect(entry.items == [
+        "No public-facing changes in this release. "
+            + "[View the commits](https://github.com/zed-industries/zed/compare/v1.5.2-pre...v1.5.3-pre)",
+    ])
 }
 
 /// …but a body with nothing renderable at all is still skipped, rather than
 /// producing a bare version heading with an empty bullet under it.
-@Test func zedStillSkipsAReleaseWithNothingRenderable() {
-    #expect(StructuredChangelogDecoder.zedProseFallback(body: "## Heading only\n\n### Another\n") == nil)
-    #expect(StructuredChangelogDecoder.zedProseFallback(body: "   \n\n  \n") == nil)
+///
+/// The fallback that makes the test above pass now lives in `GitHubMarkdownParser`
+/// rather than in a Zed-only branch here — every GitHub-sourced app has the same
+/// shape and deserves the same treatment. Asserted through the public parser so
+/// this stays true wherever the implementation sits.
+@Test func aReleaseWithNothingRenderableIsStillSkipped() {
+    #expect(GitHubMarkdownParser.parse(
+        body: "## Heading only\n\n### Another\n", version: "1.0", date: nil) == nil)
+    #expect(GitHubMarkdownParser.parse(
+        body: "   \n\n  \n", version: "1.0", date: nil) == nil)
 }
 
 // MARK: - ChatWise: CRLF must not fold a whole entry into one line
@@ -183,4 +197,32 @@ private let hbuilderXCodeSpanFixture = #"""
         #expect(recipe.indexLinkPattern == nil,
                 "\(recipe.bundleID): structuredFormat skips the two-stage fetch, so indexLinkPattern is dead")
     }
+}
+
+// MARK: - Waku
+
+/// Waku's registered recipe reads GitHub releases, which carry the same bullets
+/// AND the history the per-version `.md` files can't enumerate (the site root
+/// 404s, so there is no index to walk).
+@Test func wakuReadsGitHubReleases() throws {
+    let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "sh.waku"))
+    #expect(recipe.structuredFormat == .gitHubReleases)
+    #expect(recipe.source.host == "api.github.com")
+}
+
+/// The generic GitHub-releases decoder: stable only, newest first, `v` stripped,
+/// and a prose-only release still gets an entry rather than a gap in the rail.
+@Test func gitHubReleasesDecoderSkipsPrereleasesAndKeepsProseOnes() throws {
+    let feed = #"""
+    [{"tag_name":"v0.1.12","prerelease":false,"draft":false,"published_at":"2026-08-21T00:00:00Z",
+      "body":"- Stream live output from Claude background tasks\n- Fix model selection for Cursor"},
+     {"tag_name":"v0.2.0-rc1","prerelease":true,"draft":false,"published_at":"2026-08-21T00:00:00Z",
+      "body":"- Something on a track the user did not choose"},
+     {"tag_name":"v0.1.9","prerelease":false,"draft":false,"published_at":"2026-08-18T00:00:00Z",
+      "body":"See CHANGELOG.md for details."}]
+    """#
+    let log = try #require(StructuredChangelogDecoder.decodeGitHubReleases(feed, maxEntries: 20))
+    #expect(log.entries.map(\.version) == ["0.1.12", "0.1.9"])
+    #expect(log.entries.first?.date == "2026-08-21")
+    #expect(log.entries.last?.items == ["See CHANGELOG.md for details."])
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
@@ -226,3 +226,123 @@ private let hbuilderXCodeSpanFixture = #"""
     #expect(log.entries.first?.date == "2026-08-21")
     #expect(log.entries.last?.items == ["See CHANGELOG.md for details."])
 }
+
+// MARK: - Three apps moved off the web view (verbatim slices, fetched 2026-08-22)
+
+/// Alcove's changelog API: majors holding point releases. Flattened per MINOR,
+/// because the minor is what the row shows; the major's `description` describes a
+/// release line and is deliberately dropped.
+@Test func alcoveFlattensMinorsAndLabelsFeaturesAndFixes() throws {
+    let body = #"""
+    {"updated":"June 2026","entries":[
+      {"version":"1.7","description":"Duo mode, a pill shape for notchless displays.",
+       "minors":[
+         {"version":"1.7.9","date":"30 Jun 2026",
+          "note":"Banner suppression will come back soon, needs a rework.",
+          "features":["Added extended support for AirPlay"],
+          "fixes":["Removed banner suppression (temporarily)","Optimized focus on startup"]},
+         {"version":"1.7.8","date":"28 Jun 2026","note":null,
+          "features":["Added AutoMix support"],"fixes":[]}]}]}
+    """#
+    let log = try #require(StructuredChangelogDecoder.decodeAlcoveChangelog(body, maxEntries: 30))
+    #expect(log.entries.map(\.version) == ["1.7.9", "1.7.8"])
+    #expect(log.entries[0].date == "30 Jun 2026")
+    #expect(log.entries[0].items == [
+        "Banner suppression will come back soon, needs a rework.",
+        "Features", "Added extended support for AirPlay",
+        "Fixes", "Removed banner suppression (temporarily)", "Optimized focus on startup",
+    ])
+    // An empty group contributes no heading, and the major's description never appears.
+    #expect(log.entries[1].items == ["Features", "Added AutoMix support"])
+    #expect(!log.entries.contains { $0.items.contains { $0.contains("pill shape") } })
+}
+
+/// Docker's release notes in Markdown. The seven platform installer links each
+/// release opens with are the same URLs every time and say nothing about what
+/// changed — they must not become items. Everything after them must.
+@Test func dockerDropsTheInstallerLinksAndFlattensInlineOnes() throws {
+    let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.docker.docker"))
+    let body = """
+    ## 4.87.0
+
+    <em class="text-gray-400 italic">2026-08-17</em>
+
+
+    Download Docker Desktop:
+    - [Windows](https://desktop.docker.com/win/main/amd64/236836/Docker%20Desktop%20Installer.exe)
+    - [Mac (Apple chip)](https://desktop.docker.com/mac/main/arm64/236836/Docker.dmg)
+    - [Linux (Debian)](https://desktop.docker.com/linux/main/amd64/236836/docker-desktop-amd64.deb)
+
+    ### Updates
+
+    - [Docker Compose v5.4.0](https://github.com/docker/compose/releases/tag/v5.4.0)
+    - Linux kernel `v7.0.12`
+
+    ### Bug fixes and enhancements
+
+    #### For all platforms
+
+    - Fixed a bug where the in-app update failed with identical paths.
+
+    ## 4.86.0
+
+    <em class="text-gray-400 italic">2026-08-10</em>
+
+    ### Updates
+
+    - Docker Engine v29.7.2
+    """
+    let log = try #require(ChangelogExtractor.extract(from: body, using: recipe))
+    #expect(log.entries.map(\.version) == ["4.87.0", "4.86.0"])
+    #expect(log.entries[0].date == "2026-08-17")
+    #expect(log.entries[0].items == [
+        "Docker Compose v5.4.0",          // link flattened, not `[…](…)`
+        "Linux kernel v7.0.12",           // backticks unwrapped
+        "Fixed a bug where the in-app update failed with identical paths.",
+    ])
+    #expect(!log.entries[0].items.contains { $0.contains("desktop.docker.com") })
+}
+
+/// Kiro's feed carries three products. The installed app is the IDE, so a CLI or
+/// Web note must never appear under an IDE version heading.
+@Test func kiroKeepsOnlyIDEEntriesAndNormalizesTheDate() throws {
+    let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "dev.kiro.desktop"))
+    let body = """
+    <rss><channel>
+    <item>
+      <title>CLI: Spec Review Mouse Support and Automatic Stream Recovery</title>
+      <link>https://kiro.dev/changelog/cli/2-19</link>
+      <guid>https://kiro.dev/changelog/cli/2-19</guid>
+      <pubDate>Wed, 19 Aug 2026 21:00:00 GMT</pubDate>
+      <category>CLI</category>
+      <description><![CDATA[This release brings mouse support to the spec review screen.]]></description>
+    </item>
+    <item>
+      <title>IDE 1.0.337: Agent Focus, Permissions, Custom Agents, and More</title>
+      <link>https://kiro.dev/changelog/ide/1-0-337</link>
+      <guid>https://kiro.dev/changelog/ide/1-0-337</guid>
+      <pubDate>Tue, 18 Aug 2026 00:00:00 GMT</pubDate>
+      <category>IDE</category>
+      <description><![CDATA[Permission Improvements and Configured Windows Shells.]]></description>
+    </item>
+    <item>
+      <title>IDE: Nested AGENTS.md and Long-Session Efficiency</title>
+      <link>https://kiro.dev/changelog/ide/nested</link>
+      <guid>https://kiro.dev/changelog/ide/nested</guid>
+      <pubDate>Thu, 13 Aug 2026 00:00:00 GMT</pubDate>
+      <category>IDE</category>
+      <description><![CDATA[Agents can now read a nested AGENTS.md next to the files they touch.]]></description>
+    </item>
+    </channel></rss>
+    """
+    let log = try #require(ChangelogExtractor.extract(from: body, using: recipe))
+    #expect(log.entries.count == 2, "the CLI entry must not appear")
+    #expect(log.entries[0].version == "1.0.337")
+    #expect(log.entries[0].title == "Agent Focus, Permissions, Custom Agents, and More")
+    // RFC-822 narrowed: no weekday, no time, no zone.
+    #expect(log.entries[0].date == "18 Aug 2026")
+    // An unversioned IDE entry is kept — it has a title, and dropping it would
+    // silently lose more than half of the live feed's IDE entries.
+    #expect(log.entries[1].version.isEmpty)
+    #expect(log.entries[1].title == "Nested AGENTS.md and Long-Session Efficiency")
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
@@ -74,3 +74,85 @@ import Testing
 @Test func emptyBodyReturnsNil() {
     #expect(GitHubMarkdownParser.parse(body: "", version: "1.0.0", date: nil) == nil)
 }
+
+// MARK: - Prose pass (bodies with no list at all)
+
+/// The shape that motivated it, verbatim from Zed's `v1.5.3-pre` (2026-08-22).
+/// Before this pass a multi-release source dropped such a release entirely, so a
+/// user sitting on exactly that build found no entry for their own version.
+@Test func proseBodyWithoutBulletsStillProducesAnEntry() throws {
+    let cl = try #require(GitHubMarkdownParser.parse(
+        body: "No public-facing changes in this release. "
+            + "[View the commits](https://github.com/zed-industries/zed/compare/a...b)",
+        version: "1.5.3", date: nil))
+    #expect(cl.entries.first?.items.count == 1)
+    // Markdown syntax is declared, so the link is left intact to be rendered.
+    #expect(cl.itemSyntax == .markdown)
+}
+
+/// LuLu's real notes (v4.5.1): emoji change lines with descriptions under them,
+/// preceded by a shields.io sponsor badge and followed by a SHA256 block. The
+/// change lines survive; the badge and the hash do not.
+@Test func proseBodyDropsBadgesAndChecksumsButKeepsChangeLines() throws {
+    let body = """
+    🆕 You can now sponsor **LuLu**/**Objective-See Foundation**:
+
+    [![](https://img.shields.io/static/v1?label=Sponsor)](https://github.com/sponsors/objective-see)
+
+    ## LuLu v4.5.1
+    ☑️ Improved 'Add Rules' window logic
+    Better handing of deleted/invalid rules.
+
+    🔐 Disk Image Hash (`SHA256`):
+    LuLu_4.5.1.dmg: `98F4D3427F4C6FCCF9680FED22879BE90A5AE81E80EB8616C1D758755B6BB624`
+    """
+    let items = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "4.5.1", date: nil)?.entries.first?.items)
+    #expect(items == [
+        "🆕 You can now sponsor **LuLu**/**Objective-See Foundation**:",
+        "☑️ Improved 'Add Rules' window logic",
+        "Better handing of deleted/invalid rules.",
+    ])
+}
+
+/// A body written as Markdown TABLES is not prose and must not be converted.
+/// Headlamp's v0.45.0 notes are 142 table rows; line-by-line they render as
+/// bullets reading `|:--|--:|` and `| <img src="…">`, next to download links for
+/// other platforms — strictly worse than the fallback, which shows the body whole.
+@Test func tableShapedBodyIsLeftToTheFallback() {
+    let body = """
+    Headlamp 0.45.0 reduces desktop startup memory.
+
+    ## ⚡ Performance
+    | <img src="https://example.com/icon.png" width="800"> |
+    |:--|--:|
+    | Plugin i18n now fetches only the active locale's translation file. |
+    | Desktop startup now defers optional work. |
+    """
+    #expect(GitHubMarkdownParser.parse(body: body, version: "0.45.0", date: nil) == nil)
+}
+
+/// And a body with many prose lines is treated as structure this pass is
+/// misreading, not as a long list of changes — abandoned, not truncated.
+@Test func tooManyProseLinesIsAbandonedRatherThanTruncated() {
+    let body = (1...20).map { "Some sentence number \($0) about the release." }
+        .joined(separator: "\n")
+    #expect(GitHubMarkdownParser.parse(body: body, version: "1.0", date: nil) == nil)
+}
+
+/// The pass runs ONLY when both bullet passes come up empty, so a body that
+/// already parsed is untouched — markers stripped, `by @user in <url>` removed,
+/// the contributors section skipped.
+@Test func prosePassNeverPreemptsAWorkingBulletBody() throws {
+    let body = """
+    ## What's Changed
+    * Fix the sidebar flicker by @alice in https://github.com/o/r/pull/1
+    * Improve startup time by @bob in https://github.com/o/r/pull/2
+
+    ## New Contributors
+    * @carol made their first contribution
+    """
+    let items = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0", date: nil)?.entries.first?.items)
+    #expect(items == ["Fix the sidebar flicker", "Improve startup time"])
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GoogleProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GoogleProbeRecipeTests.swift
@@ -140,3 +140,61 @@ struct GoogleProbeRecipeTests {
         }
     }
 }
+
+/// Antigravity IDE is a SECOND app, not a channel of the one above: its own
+/// bundle id, its own version line (2.5.5 against 2.9.1), an Electron VS Code fork
+/// rather than the native hub. It was installed and scanned but matched no recipe,
+/// so its row had no source at all.
+@Test func antigravityIDEIsCoveredSeparatelyFromTheHub() throws {
+    let ide = try #require(
+        VendorProbeRegistry.recipes.first { $0.bundleID == "com.google.antigravity-ide" })
+    let hub = try #require(
+        VendorProbeRegistry.recipes.first { $0.bundleID == "com.google.antigravity" })
+    #expect(ide.url != hub.url, "two products, two endpoints")
+
+    // No machine identifier in the URL. The app sends a SHA-256 of the hostname in
+    // that slot; we send its own fallback literal instead, so nothing per-machine
+    // leaves here. Same reasoning as the `x-user-staging-id` header the hub omits.
+    #expect(ide.url.absoluteString.hasSuffix("/no_hostname"))
+    #expect(!ide.url.absoluteString.contains("sha256"))
+
+    // The commit slot is a hash that can never be real. VS Code's update API
+    // answers 204 for a current commit and the manifest otherwise, so naming a
+    // live commit would return nothing to compare against.
+    #expect(ide.url.absoluteString.contains("/0000000000000000000000000000000000000000/"))
+
+    // Detection only: the artifact has not been signature-checked and the URL is
+    // arm64-specific.
+    #expect(ide.install == nil)
+}
+
+/// The real response, verbatim (2026-08-22). Three traps in one body: the version
+/// fields are all the VS Code BASE version, and the only real version sits in the
+/// download path next to a build id that must not ride along.
+@Test func antigravityIDEReadsTheAppVersionNotTheVSCodeBase() throws {
+    let recipe = try #require(
+        VendorProbeRegistry.recipes.first { $0.bundleID == "com.google.antigravity-ide" })
+    let body = #"""
+    {"timestamp":1786614782,"supportsFastUpdate":true,"version":"ecfbad74d93962fc8ca485d93ab9b4f3d4cb6cf8","ideVersion":"Antigravity IDE","productVersion":"1.107.0","name":"1.107.0","hash":"106a021b7e59064312712385cab3c035cee68399","sha256hash":"33338ced839cb00fcc779ab96e4cdc79e06c894bc21cdb02249715286700c648","url":"https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/darwin-arm/Antigravity IDE.zip","displayName":"macOS for Apple Silicon (.zip)"}
+    """#
+    // 2.5.5 is what the shipped bundle reports. 1.107.0 (productVersion / name) is
+    // VS Code's base version — comparing THAT against the installed 2.5.5 would
+    // offer an update that can never be satisfied.
+    #expect(VendorProbeRecipe.extractVersion(from: body, pattern: recipe.versionPattern) == "2.5.5")
+
+    // The build id after the dash must not be captured — the hub recipe documents
+    // the same trap for its own feed (`2.8.1-6512087774658560` vs a plain 2.8.1).
+    #expect(VendorProbeRecipe.extractVersion(
+        from: body, pattern: recipe.versionPattern)?.contains("-") != true)
+
+    // A body carrying only the VS Code fields, with no download URL, yields nothing
+    // rather than falling back to 1.107.0.
+    #expect(VendorProbeRecipe.extractVersion(
+        from: #"{"productVersion":"1.107.0","name":"1.107.0"}"#,
+        pattern: recipe.versionPattern) == nil)
+
+    // Segment count isn't pinned, so a future 2.6 or 2.5.5.1 still reads.
+    #expect(VendorProbeRecipe.extractVersion(
+        from: #"{"url":"https://x/antigravity/stable/2.6-123/darwin-arm/a.zip"}"#,
+        pattern: recipe.versionPattern) == "2.6")
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -111,11 +111,22 @@ import Foundation
     #expect(recipe.install == nil,
             "the public dmg lags this metadata — installing it would be a phantom update")
 
-    // Notes come from the vendor's page in a WebView: the retired host took the
-    // parseable feed with it and this endpoint carries no release notes.
+    // This probe endpoint carries no release notes, so `changelogURL` stays as the
+    // web-view fallback for a recipe miss.
     #expect(recipe.changelogURL?.absoluteString == "https://www.tryalcove.com/changelog")
-    #expect(ChangelogRecipeRegistry.recipe(forBundleID: "com.henrikruscon.Alcove") == nil,
-            "the changelog recipe pointed at the dead host and was removed")
+
+    // Notes now come from a RECIPE again, and not from the host this assertion
+    // used to say was gone. The old changelog recipe read `update.tryalcove.com`,
+    // which is NXDOMAIN, and was removed for that reason — but the reason was that
+    // one host, not "Alcove has no readable notes". `api.tryalcove.com/changelog`
+    // is a different surface: public, unauthenticated (unlike the license-gated
+    // update endpoint on the same host), and structured, with its newest release
+    // matching the installed copy on 2026-08-22.
+    let changelog = try! #require(
+        ChangelogRecipeRegistry.recipe(forBundleID: "com.henrikruscon.Alcove"))
+    #expect(changelog.structuredFormat == .alcoveChangelog)
+    #expect(changelog.source.host == "api.tryalcove.com")
+    #expect(!changelog.source.absoluteString.contains("update.tryalcove.com"))
 }
 
 @Test func extractsClaudeVersionFromRedirectLocationPath() {


### PR DESCRIPTION
Follow-ups from scanning what every installed app's Release Notes pane actually renders. The scan ran the pane's own source-priority chain (recipe → structured → inline → web view) over all 126 apps on this machine, hitting live endpoints — not read off the code.

## What the scan found

| path | before | after |
|---|---|---|
| recipe (structured) | 10 | 11 |
| recipe (regex) | 23 | 23 |
| structured | 39 | **44** |
| (of which) new recipes | — | Waku, Alcove, Docker, Kiro |
| inline body | 22 | 21 |
| **web view** | **9** | **4** |
| nothing | 23 | 20 |

Two findings drove this PR, both verified against live data:

**Five GitHub-sourced apps fell through to the raw-body renderer** — balenaEtcher, kitty, LuLu, MarkEdit, Headlamp — all because their newest release body has zero top-level bullets, so `GitHubMarkdownParser.parse` returned nil.

That hole had already been fixed once, in the wrong place: the Zed decoder grew a private prose fallback last week (Zed ships such releases — `v1.5.3-pre`, "No public-facing changes in this release."), which left every other GitHub app broken. It now lives in the parser as a third pass, gated exactly like the existing lenient pass so nothing that already parsed changes, and the Zed decoder just calls the parser.

**Waku rendered raw Markdown in a web view.** Its appcast points at `releases.waku.sh/Waku-<version>.md`, a bare bullet list with no heading, title or version — the extractor drops an entry with neither a title nor a version, so nothing was produced.

## Where the prose pass declines

A non-nil entry *suppresses* the fallback, so a partial answer is worse than none. It bails on two shapes:

- **Markdown tables.** Headlamp writes its whole changelog as tables — 142 table rows in v0.45.0. I shipped this without the guard first and looked at the output: 210 items, including bullets reading `|:--|--:|` and `| <img src="…">`. It now declines, and Headlamp renders as it did before.
- **More than a dozen lines**, which means structure this pass is misreading.

It also drops badge/image lines (LuLu opens with a shields.io sponsor banner), bare-URL lines, and checksums. That last one isn't hypothetical — an existing test pins that an azure-cli-style body of "a link, a SHA256 heading, a hash block" must yield nothing, and the first version of this turned the bare link into its one "change". The test caught it.

## Waku

@egoist's GitHub releases carry the same bullets **and** the history — seven releases with dates, versus the one version the `.md` files can offer (they're fetchable by name, but the site root 404s so there's no index). Two of those seven say only "See CHANGELOG.md for details." and survive only because of the prose pass. Reading them needs a generic `.gitHubReleases` structured format, decoded through the same `GitHubMarkdownParser` so a release body renders identically however we reached it.

I built a `versionFromSourceURL` recipe knob first, to take the version off the `.md` filename. It worked, and it's deleted — once Waku reads GitHub releases no recipe uses it, and an untethered engine knob is what this repo's rules say not to leave lying around. Git has it if a second case appears.

## The four missing changelog URLs: none of them should be added

Sixteen of 121 vendor recipes have no `changelogURL`. Four belong to apps we do resolve a version for, which made them look like a one-line fix. I went to add them and none survives contact:

- **Spotify** — publishes no desktop release notes anywhere.
- **ToDesk** — has a real server-rendered macOS log page, 30 versions, newest 4.8.1.0 (2025.9.5) against an installed 4.10.0.0. The same host's Windows page was current to 2026.8.18 on the same day: the vendor stopped updating the macOS one.
- **UURemote** — `/changelog` and `/update` return byte-identical content to a nonexistent path. SPA catch-all, not a page.
- **Gemini** — `gemini.google/release-notes` is the Gemini *Apps* product feed, keyed by date with no desktop build number; the app reports 1.96.4.775.

The last two are the failure #33 just fixed twice (Notion and Figma both pointed at post-titled product feeds whose "versions" never matched the install). Adding them would have re-created it while looking like an improvement in the diff. The reasons are now comments next to the recipes.

## Verification

```
swift test                877 core (2 pre-existing known issues) + 119 CLI
xcodebuild App            BUILD SUCCEEDED
duo verify (full sweep)   ✓ 246  ⚠ 1  ✗ 0  ~ 0  - 0
duo verify --only waku    ✓ 1 — 7 entries, newest 0.1.12 (2026-08-21)
```

`changelog ✓ 55`, up from 54, ✗ 0. The remaining ⚠ is LibreOffice's pre-existing version-scheme warning.

## Three more moved off the web view

Candidates supplied by @jizhi0v0 and verified against the live endpoints — in each case the newest entry matches the copy installed here.

- **Alcove** — `api.tryalcove.com/changelog`. Public and unauthenticated, unlike the license-gated update endpoint on the same host. Structured JSON: majors holding their point releases with date, note, features and fixes; 53 releases, newest 1.7.9. This overturns an assertion that Alcove must have *no* changelog recipe — true of the old one, which read `update.tryalcove.com` and died with it, but the reason was that host, not "Alcove publishes nothing readable". The test now states the new arrangement rather than the absence.
- **Docker** — `docs.docker.com/desktop/release-notes.md`, served as `text/markdown`: 142 versions, newest 4.87.0. The seven platform installer links each release opens with are excluded — same URLs every time, no information about what changed.
- **Kiro** — `kiro.dev/changelog/feed.rss`, filtered to `<category>IDE</category>`. The feed mixes IDE, CLI and Web; a CLI note under an IDE version heading would be worse than no note, so the category is part of the entry pattern rather than a later filter. Unversioned IDE entries are kept on their title — dropping them would lose 8 of today's 15.

`markdownSource` now also flattens `[text](url)`, for Docker's mid-sentence links. Verified a no-op for its only prior user first: 0 of the 116 live HBuilderX items change.

### Checked and declined

- **Antigravity** — the official changelog page is 88 KB with zero version strings in it. The third-party aggregator that does carry them is a further remove than the lagging mirror this repo has already been burned by, and advertises no feed (three RSS paths 404, no `<link rel=alternate>`). Its "2.0" is the vendor's name for the major line ("AGY 2.0"), not a second product — one bundle id, one 2.x series.
- **LibreOffice** — `blog.documentfoundation.org/feed/` is the community blog (Community Member Monday, conference schedules, migration stories). Not release notes, no versions.

## Still open

Four web-view apps remain: **Antigravity, AnyDesk, LibreOffice, Xcode**. Headlamp's table-shaped changelog would need table parsing, and is also the live example of the 41 KB single-shot layout cost.
