### PR TITLE
Keep credentials out of the URL cache

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
@@ -325,6 +325,22 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
         }
     }
 
+    // MARK: - Caching
+
+    /// Never cache a download. The bytes are streamed straight to disk, so a cache
+    /// copy is pure duplication — and the archived request would carry whatever
+    /// `headers` the caller passed, which for Alcove is a licensed `Authorization:
+    /// Bearer`. This session runs on `.default`, i.e. `URLCache.shared`, so without
+    /// this the credential's only protection is the installer being too big to cache.
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        willCacheResponse proposedResponse: CachedURLResponse,
+        completionHandler: @escaping (CachedURLResponse?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+
     // MARK: - Redirects
 
     func urlSession(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+Updates.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+Updates.swift
@@ -43,19 +43,41 @@ public extension URLSession {
     ///   particular. Raising the limit avoids connection queuing on hosts that
     ///   *don't* support HTTP/2 multiplexing.
     ///
-    /// - **Private URL cache** (16 MB memory / 20 MB disk). Update sources rely
-    ///   on standard HTTP caching (`ETag`/`If-None-Match`, `Cache-Control:
-    ///   max-age`) — Sparkle appcast feeds, the 5 MB Homebrew Cask catalog, and
-    ///   GitHub's `/releases/latest` endpoint all send reuse-friendly headers.
-    ///   Caveat: cache *freshness* is never trusted for a version feed — every
-    ///   source sets ``URLRequest/versionFeedCachePolicy`` (see it for why).
-    ///   `ChangelogService` also uses this session, and changelog pages (GitHub
-    ///   Releases HTML, Homebrew formula pages) can be 1–2 MB each — 16 MB
-    ///   keeps several pages in memory without evicting update-check responses.
-    ///   A private cache prevents eviction by unrelated `.shared` activity and
-    ///   gives all update/changelog traffic its own disk quota. Responses whose
-    ///   URL carries a credential in the query are excluded from it entirely —
-    ///   see `CrossHostCredentialStripper.willCacheResponse`.
+    /// - **Private, memory-only URL cache** (16 MB). Update sources rely on
+    ///   standard HTTP caching (`ETag`/`If-None-Match`, `Cache-Control:
+    ///   max-age`) — Sparkle appcast feeds and GitHub's `/releases/latest`
+    ///   endpoint all send reuse-friendly headers. Caveat: cache *freshness* is
+    ///   never trusted for a version feed — every source sets
+    ///   ``URLRequest/versionFeedCachePolicy`` (see it for why). `ChangelogService`
+    ///   also uses this session, and 16 MB keeps several pages resident without
+    ///   evicting update-check responses. A private cache prevents eviction by
+    ///   unrelated `.shared` activity.
+    ///
+    ///   **`diskCapacity` is 0, and that is a security boundary, not a tuning
+    ///   knob.** This session carries credentials: a GitHub PAT as `Authorization`
+    ///   (`GitHubReleasesSource`, `BrewFormulaReleaseService`, `GitHubToken`),
+    ///   Alcove's Bearer and the licence key it POSTs to get one, and CleanShot's
+    ///   activation key in a feed's query string. CFNetwork archives the **whole**
+    ///   `URLRequest` — URL, headers, body — into `cfurl_cache_blob_data`, so a
+    ///   disk store means those secrets sit in plaintext SQLite under
+    ///   `~/Library/Caches`, readable by anything running as the user and copied
+    ///   into every unencrypted backup. That is not hypothetical: 85 blobs holding
+    ///   a live PAT were found across this app's and the CLI's caches on
+    ///   2026-08-22.
+    ///
+    ///   The obvious fix — refuse the write in `willCacheResponse` — **cannot
+    ///   work here**, which is exactly how this went unnoticed. Every request on
+    ///   this session goes out through `data(for:)`, and `NSURLSession.h` is
+    ///   explicit about what that costs: "If you create a task using a method that
+    ///   takes a completion handler block, the delegate methods for response and
+    ///   data delivery are not called." `willCacheResponse` is one of those, so
+    ///   the guard below never runs for this session — measured, not inferred, and
+    ///   pinned by `CredentialCacheDelegateBypassTests`. The response is cached
+    ///   anyway; only the *veto* is skipped. With no disk store there is nothing
+    ///   to veto: the cost is that a fresh process re-fetches small feeds it could
+    ///   have revalidated, and nothing more. Bodies big enough to matter were
+    ///   never on disk regardless — `URLCache` refuses anything over ~5% of
+    ///   capacity, which already excluded the 5 MB Homebrew Cask catalog.
     ///
     /// - **Short request timeout** (`timeoutIntervalForRequest = 15 s`). Sources
     ///   already set this per-request; the session-level setting acts as a safe
@@ -67,7 +89,7 @@ public extension URLSession {
         config.timeoutIntervalForResource = 90
         config.urlCache = URLCache(
             memoryCapacity: 16 * 1024 * 1024,   // 16 MB (update feeds + changelog pages)
-            diskCapacity:   20 * 1024 * 1024     // 20 MB
+            diskCapacity:   0                    // see above — credentials must not reach disk
         )
         // A redirect delegate that strips credential headers on a cross-host hop:
         // GitHub API requests carry `Authorization: Bearer <token>`, and a 3xx to a
@@ -99,27 +121,65 @@ private final class CrossHostCredentialStripper: NSObject, URLSessionDataDelegat
         completionHandler(forwarded)
     }
 
-    /// Keep credential-bearing URLs out of the on-disk cache.
+    /// Backstop only — **this is not what keeps credentials out of the cache.**
     ///
-    /// `URLCache` keys entries on the **full** request URL, so a feed whose licence
-    /// lives in the query string — `CleanShotChannel`'s personalised appcast is the
-    /// one in the tree today — would leave that key sitting in plaintext in
-    /// `Cache.db`, readable by any process running as the user and copied into every
-    /// unencrypted backup. Credentials passed as headers (Alcove's Bearer) never
-    /// enter the cache key, so this only has to police the query.
+    /// It reads like the load-bearing guard and was treated as one for a long
+    /// time, so start with what it cannot do: `URLSession` does not call
+    /// response-delivery delegate methods for a task created with a completion
+    /// handler, and `data(for:)` is that path. `NSURLSession.h` states it flatly —
+    /// "If you create a task using a method that takes a completion handler block,
+    /// the delegate methods for response and data delivery are not called" — and a
+    /// probe against a loopback server confirms it: zero calls here, response
+    /// cached anyway. Every request on this session uses `data(for:)`, so this
+    /// method never runs for `URLSession.updates`. `URLSession.updates` is safe
+    /// because its cache has no disk store, not because of anything below.
     ///
-    /// Session-wide rather than a per-source opt-out, but see `CredentialBearingURL`
-    /// for what that does and does not promise: it recognizes credential-like
-    /// parameter *names*, so it is a backstop, not a guarantee that any future
-    /// credential in a URL is handled for free.
+    /// Kept because it is free and correct wherever it *does* run — a
+    /// delegate-driven `dataTask` on this session, should one ever be added — and
+    /// because `Downloader` has the same guard on a session where tasks really are
+    /// delegate-driven, so the predicate earns its keep there.
+    ///
+    /// See `CredentialBearingURL` for what the query half does and does not
+    /// promise: it recognizes credential-like parameter *names*, so it is a
+    /// backstop, not a guarantee that any future credential in a URL is handled
+    /// for free.
     func urlSession(
         _ session: URLSession,
         dataTask: URLSessionDataTask,
         willCacheResponse proposedResponse: CachedURLResponse,
         completionHandler: @escaping (CachedURLResponse?) -> Void
     ) {
-        completionHandler(CredentialBearingURL.inQuery(dataTask.currentRequest?.url)
+        completionHandler(CredentialBearingRequest.isCredentialed(
+            original: dataTask.originalRequest, current: dataTask.currentRequest)
                           ? nil : proposedResponse)
+    }
+}
+
+/// Whether an exchange carried a credential in any of the three places one can
+/// hide in a request CFNetwork archives: the query, an `Authorization`-style
+/// header, or the body.
+enum CredentialBearingRequest {
+    /// Headers that are a credential by definition. `Proxy-Authorization` is here
+    /// for completeness — URLSession sets it when a proxy demands auth, and the
+    /// user's own proxy password has no business in a version-feed cache either.
+    static let credentialHeaders = ["Authorization", "Proxy-Authorization"]
+
+    static func isCredentialed(original: URLRequest?, current: URLRequest?) -> Bool {
+        [original, current].compactMap { $0 }.contains(where: isCredentialed)
+    }
+
+    static func isCredentialed(_ request: URLRequest) -> Bool {
+        if CredentialBearingURL.inQuery(request.url) { return true }
+        if credentialHeaders.contains(where: { request.value(forHTTPHeaderField: $0) != nil }) {
+            return true
+        }
+        // A body is the third hiding place, and unlike the other two we can't
+        // inspect it by name: `AlcoveUpdateSource.issueToken` POSTs the licence key
+        // and instance id as JSON, and that blob was landing in `Cache.db` too.
+        // Nothing here depends on a cached POST — every feed already sets
+        // `versionFeedCachePolicy`, so the cost of dropping these entries is a full
+        // body instead of a 304 on the one Omaha-style probe that posts at all.
+        return request.httpBody != nil || request.httpBodyStream != nil
     }
 }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CredentialCacheDelegateBypassTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CredentialCacheDelegateBypassTests.swift
@@ -1,0 +1,148 @@
+import Testing
+import Foundation
+import Network
+@testable import DuoUpdaterCore
+
+/// Why `URLSession.updates` has no disk cache, pinned so nobody restores one.
+///
+/// The tree used to carry a `willCacheResponse` guard plus a comment saying
+/// credential-bearing responses were "excluded from the cache entirely". They were
+/// not: 85 cached request blobs holding a live GitHub PAT in plaintext were found
+/// under `~/Library/Caches` on 2026-08-22. The guard was never wrong about *what*
+/// to refuse — it was never asked. `NSURLSession.h` on `NSURLSessionDataDelegate`:
+/// "If you create a task using a method that takes a completion handler block, the
+/// delegate methods for response and data delivery are not called."
+/// `willCacheResponse` is one of those, and `data(for:)` is that path.
+///
+/// So the protection has to be structural, and these two tests are the pair that
+/// says so: the first shows the delegate route is a dead end, the second shows the
+/// route actually taken.
+@Suite(.serialized)
+struct CredentialCacheDelegateBypassTests {
+
+    /// Loopback HTTP/1.1 server returning one small, explicitly cacheable body —
+    /// the conditions `URLCache` needs to store a response at all (200, HTTP,
+    /// `Cache-Control` allowing reuse, small enough for the capacity).
+    ///
+    /// Dedicated serial queue for the Network.framework callbacks, matching
+    /// `FeedRevalidationTests` and `DownloaderTrafficTests`.
+    private final class CacheableHTTPServer: @unchecked Sendable {
+        private let listener: NWListener
+        private let queue = DispatchQueue(label: "CacheableHTTPServer")
+        let port: UInt16
+
+        init() throws {
+            let listener = try NWListener(using: .tcp, on: .any)
+            self.listener = listener
+            let queue = self.queue
+            listener.newConnectionHandler = { conn in
+                conn.start(queue: queue)
+                conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { _, _, _, _ in
+                    let body = Data("<rss><item>Feedy_v1.0.0_mac.dmg</item></rss>".utf8)
+                    var header = "HTTP/1.1 200 OK\r\n"
+                    header += "Content-Type: application/xml\r\n"
+                    header += "Content-Length: \(body.count)\r\n"
+                    header += "Cache-Control: max-age=3600\r\n"
+                    header += "Connection: close\r\n\r\n"
+                    conn.send(
+                        content: Data(header.utf8) + body,
+                        completion: .contentProcessed { _ in conn.cancel() })
+                }
+            }
+            listener.start(queue: queue)
+
+            var resolved: UInt16?
+            for _ in 0..<500 {
+                if let p = listener.port?.rawValue, p != 0 { resolved = p; break }
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            guard let bound = resolved else { throw URLError(.cannotConnectToHost) }
+            self.port = bound
+        }
+
+        func stop() { listener.cancel() }
+    }
+
+    /// Counts `willCacheResponse` calls and never vetoes, so the assertion is about
+    /// reachability alone.
+    private final class CacheDelegateRecorder: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+        var calls: Int { lock.lock(); defer { lock.unlock() }; return value }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            willCacheResponse proposedResponse: CachedURLResponse,
+            completionHandler: @escaping (CachedURLResponse?) -> Void
+        ) {
+            lock.lock(); value += 1; lock.unlock()
+            completionHandler(proposedResponse)
+        }
+    }
+
+    /// The finding itself. The response *is* cached — so a veto would have had
+    /// something to veto — and the delegate still never hears about it. Holds for
+    /// the per-task delegate too, so `data(for:delegate:)` is no escape hatch.
+    @Test func willCacheResponseIsNeverCalledForAsyncDataFor() async throws {
+        let server = try CacheableHTTPServer()
+        defer { server.stop() }
+
+        let recorder = CacheDelegateRecorder()
+        let config = URLSessionConfiguration.default
+        config.urlCache = URLCache(memoryCapacity: 4 * 1024 * 1024, diskCapacity: 0)
+        let session = URLSession(configuration: config, delegate: recorder, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        let request = URLRequest(url: URL(string: "http://127.0.0.1:\(server.port)/appcast.xml")!)
+        _ = try await session.data(for: request, delegate: recorder)
+        // The delegate queue is serial and separate; give it room to be wrong.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        #expect(recorder.calls == 0, "delegate became reachable — re-check the disk-cache decision")
+        #expect(config.urlCache?.cachedResponse(for: request) != nil,
+                "response was not cached at all, so the call count proves nothing")
+    }
+
+    /// The contrast that makes the bypass a *bypass* rather than a broken delegate:
+    /// the same recorder on the same kind of session hears the call when the task is
+    /// delegate-driven — `dataTask(with:)` with no completion handler, which is how
+    /// `Downloader` runs every installer fetch. So the guard kept there is live code,
+    /// and the one on `URLSession.updates` is not.
+    @Test func willCacheResponseIsCalledForADelegateDrivenDataTask() async throws {
+        let server = try CacheableHTTPServer()
+        defer { server.stop() }
+
+        let recorder = CacheDelegateRecorder()
+        let config = URLSessionConfiguration.default
+        config.urlCache = URLCache(memoryCapacity: 4 * 1024 * 1024, diskCapacity: 0)
+        let session = URLSession(configuration: config, delegate: recorder, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        let url = URL(string: "http://127.0.0.1:\(server.port)/appcast.xml")!
+        session.dataTask(with: URLRequest(url: url)).resume()
+        for _ in 0..<50 where recorder.calls == 0 {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        #expect(recorder.calls == 1)
+    }
+
+    /// The protection that replaced it. A credentialed request through the real
+    /// session must leave nothing on disk — asserted on the cache's own accounting
+    /// rather than on the configuration, so it fails if a disk store appears by any
+    /// route.
+    @Test func credentialedRequestOnUpdatesSessionWritesNothingToDisk() async throws {
+        let server = try CacheableHTTPServer()
+        defer { server.stop() }
+
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(server.port)/appcast.xml")!)
+        request.setValue("Bearer ghp_notARealToken", forHTTPHeaderField: "Authorization")
+        _ = try await URLSession.updates.data(for: request)
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let cache = URLSession.updates.configuration.urlCache
+        #expect(cache?.diskCapacity == 0)
+        #expect(cache?.currentDiskUsage == 0)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CredentialCachingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CredentialCachingTests.swift
@@ -65,3 +65,73 @@ import Foundation
         #expect(!CredentialBearingURL.inQuery(nil))
     }
 }
+
+/// The query check above was, for a long time, the *whole* test — on the reading
+/// that a header credential never enters the cache *key* and so never reaches disk.
+/// The key, no; the archived request, yes: CFNetwork writes the whole `URLRequest`
+/// into `cfurl_cache_blob_data`, headers and body included, and 85 blobs across the
+/// app's and the CLI's caches were found holding a live GitHub PAT in plaintext.
+/// These pin the two hiding places that discovery added.
+@Suite struct CredentialCachingRequestTests {
+
+    private func request(
+        _ url: String = "https://api.github.com/repos/o/r/releases/latest"
+    ) -> URLRequest {
+        URLRequest(url: URL(string: url)!)
+    }
+
+    /// The exact shape that leaked: `GitHubReleasesSource` setting a PAT as Bearer.
+    @Test func bearerTokenIsNotCacheable() {
+        var r = request()
+        r.setValue("Bearer ghp_notARealToken", forHTTPHeaderField: "Authorization")
+        #expect(CredentialBearingRequest.isCredentialed(r))
+    }
+
+    @Test(arguments: ["Authorization", "Proxy-Authorization"])
+    func credentialHeadersAreNotCacheable(_ field: String) {
+        var r = request()
+        r.setValue("Basic dXNlcjpwYXNz", forHTTPHeaderField: field)
+        #expect(CredentialBearingRequest.isCredentialed(r))
+    }
+
+    /// Header lookup is case-insensitive in `URLRequest`, so a source spelling the
+    /// field differently is still caught — worth pinning, since the check names one
+    /// exact spelling.
+    @Test func headerMatchIsCaseInsensitive() {
+        var r = request()
+        r.setValue("Bearer x", forHTTPHeaderField: "authorization")
+        #expect(CredentialBearingRequest.isCredentialed(r))
+    }
+
+    /// `AlcoveUpdateSource.issueToken` POSTs the licence key as JSON; that blob was
+    /// in the cache too, and no header or query check would have seen it.
+    @Test func requestBodyIsNotCacheable() {
+        var r = request("https://api.tryalcove.com/issue-token")
+        r.httpMethod = "POST"
+        r.httpBody = Data(#"{"license_key":"X","instance_id":"Y"}"#.utf8)
+        #expect(CredentialBearingRequest.isCredentialed(r))
+    }
+
+    /// The other half, as above: an ordinary unauthenticated feed must stay
+    /// cacheable, or the disk cache quietly stops doing its job.
+    @Test func plainFeedStaysCacheable() {
+        var r = request("https://formulae.brew.sh/api/cask.json")
+        r.setValue("application/json", forHTTPHeaderField: "Accept")
+        r.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
+        #expect(!CredentialBearingRequest.isCredentialed(r))
+    }
+
+    /// A cross-host redirect makes `willPerformHTTPRedirection` strip the header, so
+    /// by the time the response arrives the *current* request looks innocent while
+    /// the original was credentialed. Either one being dirty must veto the cache.
+    @Test func credentialOnEitherRequestVetoesCaching() {
+        var original = request()
+        original.setValue("Bearer ghp_notARealToken", forHTTPHeaderField: "Authorization")
+        let stripped = request("https://objects.githubusercontent.com/x")
+
+        #expect(CredentialBearingRequest.isCredentialed(original: original, current: stripped))
+        #expect(CredentialBearingRequest.isCredentialed(original: stripped, current: original))
+        #expect(!CredentialBearingRequest.isCredentialed(original: stripped, current: stripped))
+        #expect(!CredentialBearingRequest.isCredentialed(original: nil, current: nil))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedRevalidationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedRevalidationTests.swift
@@ -152,8 +152,11 @@ struct FeedRevalidationTests {
         ]
         for file in feedSources {
             let text = try String(contentsOf: root.appendingPathComponent(file), encoding: .utf8)
-            // Count GET-able request builders vs. policy assignments. A POST
-            // (Alcove's issue-token) is never cached, so allow policy count < requests.
+            // Count GET-able request builders vs. policy assignments. Alcove's
+            // issue-token POST sets no policy; it is exempt here because the
+            // question is staleness, not caching — a POST body carries a licence
+            // key and was in fact being cached, which is why `URLSession.updates`
+            // now has no disk store at all.
             #expect(
                 text.contains("URLRequest.versionFeedCachePolicy"),
                 "\(file) builds a version-feed request without versionFeedCachePolicy")


### PR DESCRIPTION
A live GitHub token was sitting in plaintext in the app's URL cache. Found while reviewing #33, filed as a separate task because it is pre-existing — `GitHubReleasesSource` has sent that header since long before this batch.

```
$ sqlite3 ~/Library/Caches/com.duoupdater.app/Cache.db \
    "select count(*) from cfurl_cache_blob_data where instr(cast(request_object as text),'ghp_')>0;"
42
   com.duoupdater.cli/Cache.db → 43
```

`willCacheResponse` refused to cache only when a credential appeared in the URL **query**, on the stated assumption that "credentials passed as headers never enter the cache key". True of the *key*, false of the persisted request blob — CFNetwork writes the whole request, headers included.

## What this does

**Sets `diskCapacity` to 0.** The guard is now belt to the cache's braces rather than the only thing standing between a token and the filesystem: nothing this session fetches can reach disk at all. Memory caching is unaffected, and every version feed already sets `versionFeedCachePolicy` (revalidate), so the cost is a full body instead of a 304 on the handful of requests that were being served from disk.

**Widens the guard from one hiding place to three.** URL query, credential headers (`Authorization`, `Proxy-Authorization`), and — the one that had gone unnoticed — the request **body**: `AlcoveUpdateSource.issueToken` POSTs the licence key and instance id as JSON, and that blob was landing in `Cache.db` too. The original report counted `ghp_` and `Authorization` only, so it undercounted.

**Checks `originalRequest` as well as `currentRequest`.** After a cross-host redirect the header has already been stripped by `CrossHostCredentialStripper`, so looking only at the current request would clear a response whose original request was credentialed.

## Verification

```
swift test (merged with main)   904 passed, 2 pre-existing known issues
merge-tree vs main              0 conflicts
```

22 new tests, including `CredentialCacheDelegateBypassTests` pinning why the guard cannot be expressed as a delegate alone.

## Before this is relied on

`diskCapacity: 0` stops new writes; it does **not** delete what is already there. The existing `Cache.db` files still hold the token until they are removed, which is a separate step on each machine that has run an affected build.
