### PR TITLE
Reissue 0.3.51 as 0.3.52 with a newer build number

### DIFF
--- a/App/project.yml
+++ b/App/project.yml
@@ -75,8 +75,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.app
-        MARKETING_VERSION: "0.3.51"
-        CURRENT_PROJECT_VERSION: "60"
+        MARKETING_VERSION: "0.3.52"
+        CURRENT_PROJECT_VERSION: "61"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Info.plist
         # Menu-bar-only app: no Dock icon, no main window.
@@ -188,8 +188,8 @@ targets:
         # plist's BundleProgram points at Contents/MacOS/DuoUpdaterHelper. The bundle
         # *identifier* (for signing / XPC pinning) is com.duoupdater.helper.
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.helper
-        MARKETING_VERSION: "0.3.51"
-        CURRENT_PROJECT_VERSION: "60"
+        MARKETING_VERSION: "0.3.52"
+        CURRENT_PROJECT_VERSION: "61"
         SWIFT_VERSION: "6.0"
         # Embed a generated Info.plist into the binary's __TEXT,__info_plist so the
         # helper has a bundle id/version (Bundle.main reads it) without a wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ reads the section matching the version being shipped and embeds it in the GitHub
 release and the Sparkle appcast, so this file is the single source of truth for
 "what's new" — keep each version's prose written for users, not commit-speak.
 
+## 0.3.52
+
+**Same changes as 0.3.51, reissued so it can actually reach you.** 0.3.51 went out carrying the same internal build number as 0.3.50. That number, not the one in the version name, is what an update check compares — so anyone already running 0.3.50 was told they were up to date and never offered it. This release carries the changes below under a build number that is properly newer. If you are reading this on 0.3.51, nothing about the app changed between the two.
+
 ## 0.3.51
 
 **An update that kept coming back.** ChatGPT would offer a new version, install it, restart — and a minute later the same update was waiting again. The install was never the problem: the new version really did land on disk. What happened next is that ChatGPT's own updater put a different one back. There are two lists involved, and Duo Updater was reading the wrong one. The first is everything the vendor has published; the second is what the vendor is actually handing out to your Mac today, which can be an earlier build while a release is still rolling out. Duo Updater was reading the published list — the same address ChatGPT itself is configured with, which is what made it look right — and offering you a build the vendor was still holding back. ChatGPT had meanwhile downloaded the build it *was* being offered and parked it, waiting for the app to close. Restarting to apply our update is what closed it. Duo Updater now asks the same question ChatGPT's own updater asks, so the two agree on what the current version is.


### PR DESCRIPTION
0.3.51 shipped with `CURRENT_PROJECT_VERSION` still at 60 — the same build as 0.3.50. Sparkle compares `CFBundleVersion` (`sparkle:version`) to decide whether an update is newer, so **every install already on 0.3.50 evaluated 0.3.51 as not newer and was never offered it.** Installs on 0.3.49 and earlier (build ≤ 59) were unaffected and did receive it.

It also explains why 0.3.50 disappeared from the appcast: `publish-release.sh` strips any existing item matching the build being published before regenerating, and build 60 matched 0.3.50's entry.

Every release before 0.3.51 bumped both numbers:

| release | marketing | build |
|---|---|---|
| 0.3.49 | 0.3.49 | 59 |
| 0.3.50 | 0.3.50 | 60 |
| 0.3.51 | 0.3.51 | **60** ← |
| 0.3.52 | 0.3.52 | 61 |

No code changes — 0.3.52 is 0.3.51's content under a build number that is properly newer.