### PR TITLE
Offer Relaunch for a Sparkle build already in the cache

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
@@ -90,6 +90,21 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
     /// `sparkleFeedURL`, which IS the app's own channel.)
     public let hasSelfUpdater: Bool
 
+    /// True when the bundle embeds Sparkle.
+    ///
+    /// Deliberately NOT folded into `hasSelfUpdater`, even though Sparkle is
+    /// self-updating by any plain reading of the words. That flag decides
+    /// `defersToSelfUpdater` — whether we hand a running app to its own updater
+    /// instead of installing over it — and hundreds of apps here embed Sparkle
+    /// while being updated perfectly well by us. Widening the flag to match its
+    /// name would change install policy for every one of them.
+    ///
+    /// What this is for is narrower: Sparkle stages a downloaded build and applies
+    /// it on the app's next quit, exactly as Squirrel does, and that state has to
+    /// be visible so the row can offer Relaunch instead of re-downloading bytes
+    /// already sitting in the cache. See `SelfUpdaterStaging`.
+    public let hasSparkleUpdater: Bool
+
     /// The release channel this install is on (Stable, Beta, Canary, …),
     /// detected at scan time. A source is only allowed to update this app from a
     /// recipe that targets the SAME channel — so a stable-channel recipe can
@@ -169,6 +184,7 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
         sparkleFeedHeaders: [String: String] = [:],
         sparkleEdPublicKey: String? = nil,
         hasSelfUpdater: Bool = false,
+        hasSparkleUpdater: Bool = false,
         releaseChannel: ReleaseChannel = .stable,
         channelIsAuthoritative: Bool = false,
         toolboxInstalledBuild: String? = nil,
@@ -187,6 +203,7 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
         self.sparkleFeedHeaders = sparkleFeedHeaders
         self.sparkleEdPublicKey = sparkleEdPublicKey
         self.hasSelfUpdater = hasSelfUpdater
+        self.hasSparkleUpdater = hasSparkleUpdater
         self.releaseChannel = releaseChannel
         self.channelIsAuthoritative = channelIsAuthoritative
         self.toolboxInstalledBuild = toolboxInstalledBuild

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -206,6 +206,7 @@ public struct AppScanner: Sendable {
                 sparkleFeedHeaders: app.sparkleFeedHeaders,
                 sparkleEdPublicKey: app.sparkleEdPublicKey,
                 hasSelfUpdater: app.hasSelfUpdater,
+                hasSparkleUpdater: app.hasSparkleUpdater,
                 releaseChannel: app.releaseChannel,
                 channelIsAuthoritative: app.channelIsAuthoritative,
                 toolboxInstalledBuild: app.toolboxInstalledBuild,
@@ -374,6 +375,14 @@ public struct AppScanner: Sendable {
         let squirrel = bundleURL.appendingPathComponent("Contents/Frameworks/Squirrel.framework")
         let hasSelfUpdater = !isiOSAppOnMac && fm.fileExists(atPath: squirrel.path)
 
+        // Sparkle gets its own flag rather than joining the one above: see
+        // `InstalledApp.hasSparkleUpdater` for why widening `hasSelfUpdater`
+        // would change install policy for every Sparkle app on the machine.
+        // Read here, next to Squirrel, because a `fileExists` during a scan that
+        // already stats this bundle is far cheaper than one per app later.
+        let sparkle = bundleURL.appendingPathComponent("Contents/Frameworks/Sparkle.framework")
+        let hasSparkleUpdater = !isiOSAppOnMac && fm.fileExists(atPath: sparkle.path)
+
         // For Toolbox-managed apps, show Toolbox's own `displayVersion`: the
         // on-disk `CFBundleShortVersionString` is either truncated (Android Studio
         // "2025.2" for 2025.2.3) or on a divergent track (Air reports its SHIP
@@ -492,6 +501,7 @@ public struct AppScanner: Sendable {
             sparkleEdPublicKey: (plist["SUPublicEDKey"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
             hasSelfUpdater: hasSelfUpdater,
+            hasSparkleUpdater: hasSparkleUpdater,
             releaseChannel: releaseChannel,
             channelIsAuthoritative: channelIsAuthoritative,
             toolboxInstalledBuild: toolboxTool.flatMap {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
@@ -40,7 +40,7 @@ public enum SelfUpdaterStaging {
     /// own staging layout (Spotify). Keeps `computeSelfUpdateStaging` from
     /// stat-ing every installed app.
     public static func mayHaveStaging(_ app: InstalledApp) -> Bool {
-        app.hasSelfUpdater || app.bundleID == spotifyBundleID
+        app.hasSelfUpdater || app.hasSparkleUpdater || app.bundleID == spotifyBundleID
     }
 
     private static let spotifyBundleID = "com.spotify.client"
@@ -68,7 +68,26 @@ public enum SelfUpdaterStaging {
                 fileManager: fileManager)
         }
 
-        guard app.hasSelfUpdater else { return nil }
+        // Sparkle apps reach the same answer by a different cache layout. Asked
+        // second because an app embeds one framework or the other, never both, so
+        // whichever guard fails costs a single `hasSelfUpdater` read.
+        guard app.hasSelfUpdater else {
+            guard app.hasSparkleUpdater,
+                  let staged = sparkleStagedBundle(
+                    for: app, cachesDirectory: cachesDirectory, fileManager: fileManager)
+            else { return nil }
+            // `sparkleStagedBundle` deliberately returns a staged build of ANY
+            // version, because the restart check needs the ones that are older
+            // (see `RestartStandoff`). This caller wants the opposite question —
+            // "is there an update waiting that a relaunch would apply?" — so the
+            // strictly-newer filter belongs here, matching the two branches below.
+            // Offering Relaunch for an older staged build would be offering a
+            // downgrade, which is exactly the ChatGPT case.
+            let stagedV = staged.buildVersion ?? staged.version
+            guard let installedV = app.buildVersion ?? app.shortVersion,
+                  VersionComparator.isNewer(stagedV, than: installedV) else { return nil }
+            return staged
+        }
 
         // Squirrel writes its staging area to ~/Library/Caches/<bundleID>.ShipIt/.
         let caches = cachesDirectory

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
@@ -149,4 +149,63 @@ struct SparkleStagingTests {
         }
     }
 
+
+    // MARK: - Reaching the shared `staged(for:)` entry point
+
+    /// A Sparkle app with a newer build staged now answers the same question a
+    /// Squirrel one does, which is what turns the row's Update into Relaunch and
+    /// stops us re-downloading bytes already in the cache. TablePlus had 133 MB of
+    /// dmg plus a 382 MB unpacked copy sitting there while we offered to fetch it
+    /// again.
+    @Test func aNewerSparkleStagedBuildIsReportedByStagedFor() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            _ = try stage(in: caches, short: "26.9.11", build: "769")
+            let installed = root.appendingPathComponent("Sparkly.app")
+            try makeApp(at: installed, identifier: bundleID, short: "26.9.9", build: "765")
+
+            let found = SelfUpdaterStaging.staged(
+                for: sparkleApp(at: installed, short: "26.9.9", build: "765"),
+                cachesDirectory: caches)
+
+            #expect(found?.version == "26.9.11")
+        }
+    }
+
+    /// The ChatGPT case must NOT surface here. A staged build older than what is
+    /// installed is not an update waiting to be applied — offering Relaunch for it
+    /// would be offering a downgrade. The restart check still sees it, via
+    /// `sparkleStagedBundle`, because there it is precisely the danger.
+    @Test func anOlderSparkleStagedBuildIsNotReportedAsAnUpdate() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            _ = try stage(in: caches, short: "26.818.41509", build: "6962")
+            let installed = root.appendingPathComponent("Sparkly.app")
+            try makeApp(at: installed, identifier: bundleID, short: "26.818.41705", build: "6971")
+            let app = sparkleApp(at: installed, short: "26.818.41705", build: "6971")
+
+            #expect(SelfUpdaterStaging.staged(for: app, cachesDirectory: caches) == nil)
+            #expect(SelfUpdaterStaging.sparkleStagedBundle(
+                for: app, cachesDirectory: caches)?.version == "26.818.41509")
+        }
+    }
+
+    /// The candidate pre-filter has to let Sparkle apps through, or none of the
+    /// above is ever asked. It must keep saying no to an app with neither.
+    @Test func theCandidateFilterAdmitsSparkleApps() {
+        let path = URL(fileURLWithPath: "/Applications/Sparkly.app")
+        #expect(SelfUpdaterStaging.mayHaveStaging(
+            sparkleApp(at: path, short: "1.0", build: "1")))
+        #expect(!SelfUpdaterStaging.mayHaveStaging(
+            InstalledApp(
+                name: "Plain", bundleID: bundleID, shortVersion: "1.0", buildVersion: "1",
+                path: path, isMASApp: false, sparkleFeedURL: nil)))
+    }
+
+    private func sparkleApp(at path: URL, short: String, build: String) -> InstalledApp {
+        InstalledApp(
+            name: "Sparkly", bundleID: bundleID, shortVersion: short, buildVersion: build,
+            path: path, isMASApp: false, sparkleFeedURL: nil,
+            hasSelfUpdater: false, hasSparkleUpdater: true)
+    }
 }


### PR DESCRIPTION
Squirrel apps have had this since `SelfUpdaterStaging` was written: when the app's own updater has already downloaded its next version and parked it waiting for a quit, the row offers **Relaunch** instead of an Update we would download a second time. Sparkle apps never reached that code.

TablePlus, today: a 133 MB dmg plus a 382 MB unpacked copy of 26.9.11 in its cache, an `Autoupdate` parked since 14:30 — and a row offering to download 26.9.11.

## Why this needed a new flag

The candidate filter keys on `hasSelfUpdater`, which `AppScanner` sets by testing for `Squirrel.framework`. Widening it to mean what its name says was not an option — it also decides `defersToSelfUpdater`, so every Sparkle app on the machine would have started being handed to its own updater instead of installed. `hasSparkleUpdater` is separate, read next to the Squirrel test during a scan that already stats the bundle.

## The two callers want opposite filters

`sparkleStagedBundle` (from #40) returns a staged build of **any** version, because the restart check needs the older ones. This caller applies the strictly-newer filter, matching the Squirrel and Spotify branches:

| staged vs installed | Relaunch offered? | `RestartStandoff` |
|---|---|---|
| newer | yes | proceed if it matches what we installed |
| older (the ChatGPT case) | **no** — that would be a downgrade | hold back |

A test pins both halves of that row.

## Not touched

No App-layer change. The row, the banner and the staged-swap relay already knew what to do with a staged update; they had simply never been shown one from Sparkle.

## Verification

Live, after a clean restart, against a real staged build:

```
self-update staged (relaunch pending): TablePlus→26.9.11
refresh done: 7 updates, 0 need restart
```

TablePlus was counted among the updates before this and is in the actionable-staged tier now. `swift test` 925 passing (2 pre-existing known issues).