### PR TITLE
Fix what the review found, and gate the release script

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -204,7 +204,21 @@ final class AppListModel {
     /// App ids the user agreed to quit (via the confirm affordance) for an
     /// incremental App Store update — App Store's Continue quits but doesn't reopen,
     /// so we relaunch them ourselves once the new build is in place.
-    @ObservationIgnored private var reopenAfterQuit: Set<String> = []
+    /// Why a row is expecting to be reopened. The distinction is load-bearing:
+    /// only `userAskedToQuit` means a quit was actually requested, and only that
+    /// case may hand an app still running to the terminate observer. Arming from
+    /// the App Store route alone says nothing has closed the app *yet* — treating
+    /// the two alike relaunched apps the user had quit themselves, minutes after
+    /// an install that failed and never closed anything.
+    enum ReopenReason: Sendable, Equatable {
+        /// The user answered a quit-to-install prompt, so a quit is expected.
+        case userAskedToQuit
+        /// An App Store install started with the app running. The store's daemon
+        /// may close it to swap the bundle — or the install may fail and close
+        /// nothing at all.
+        case storeMayCloseIt
+    }
+    @ObservationIgnored private var reopenAfterQuit: [String: ReopenReason] = [:]
     /// id → the build version the running instance launched with, for display.
     private var runningVersionByID: [String: String] = [:]
     /// id → the marketing version the running (pre-self-update) build corresponds to,
@@ -2091,7 +2105,7 @@ final class AppListModel {
                 // the reason the signal is "was it running", not "did they click".
                 if AppStoreQuitPolicy.armsReopen(
                     route: route, wasRunningBeforeInstall: wasRunningBeforeInstall) {
-                    reopenAfterQuit.insert(id)
+                    reopenAfterQuit[id] = .storeMayCloseIt
                 }
                 installing[id] = .downloading(fraction: 0)
                 // Both routes download through the App Store daemon, so we never see
@@ -2108,6 +2122,7 @@ final class AppListModel {
                 guard !Task.isCancelled else {
                     // Cancelled while parked on the permit: nothing started. The
                     // defer above hands it back.
+                    reopenAfterQuit[id] = nil
                     installing[id] = nil
                     return false
                 }
@@ -2121,6 +2136,7 @@ final class AppListModel {
                     // store hasn't surfaced the update into the list yet, the installer
                     // throws `.notInUpdatesList`, shown as a "try again later" hint.
                     guard AppStoreAXInstaller.isTrusted else {
+                        reopenAfterQuit[id] = nil
                         installing[id] = nil
                         installErrors[id] = AppStoreAXInstaller.AXError.notTrusted.errorDescription
                         presentAccessibilityPermissionFlow()
@@ -2162,6 +2178,7 @@ final class AppListModel {
                        await masInstaller.outdatedContains(adamID: adamID) != true {
                         Log.install.notice("App Store: \(result.app.name, privacy: .public) already current (on-disk \(onDisk, privacy: .public) ≥ target \(target, privacy: .public), not outdated per mas) — skipping install before download")
                         await refreshRow(result)
+                        reopenAfterQuit[id] = nil
                         installing[id] = nil
                         return false
                     }
@@ -2200,6 +2217,7 @@ final class AppListModel {
                         // Incremental, no Accessibility, and no mas to fall back to — we
                         // can't update at all. Surface the need and guide to the grant;
                         // the row's retry picks up once access is granted.
+                        reopenAfterQuit[id] = nil
                         installing[id] = nil
                         installErrors[id] = AppStoreAXInstaller.AXError.notTrusted.errorDescription
                         presentAccessibilityPermissionFlow()
@@ -3016,24 +3034,35 @@ final class AppListModel {
         // samples this itself for the quit it completes; this copy is only for the
         // quit it gives up on.
         let wasFrontmost = AppRestarter.isFrontmost(AppRestarter.runningInstances(of: result.app))
+        // A fresh attempt supersedes whatever a previous bail left armed. This has
+        // to happen BEFORE the standoff below can return: a stale marker left by
+        // an earlier bail fires on the very quit the hold-back note asks the user
+        // to perform, relaunching the app straight into the installer we were
+        // trying not to disturb.
+        quitHandoffs[result.id] = nil
         // Is anyone else waiting for this app to quit? Sparkle parks an installer
         // on exactly that signal, so a restart meant to put OUR build into effect
         // can instead apply THEIRS — see `RestartStandoff` for the timeline. Only
         // a staged build that differs from what is on disk is a problem; matching
-        // versions make whoever writes second harmless.
-        let staged = SelfUpdaterStaging.sparkleStagedBundle(for: result.app)
+        // builds make whoever writes second harmless. The `hasSparkleUpdater`
+        // guard keeps every other app off the filesystem work entirely.
+        installNotes[result.id] = nil
+        let staged = result.app.hasSparkleUpdater
+            ? SelfUpdaterStaging.sparkleStagedBundle(for: result.app) : nil
         if case .holdBack(let stagedVersion) = RestartStandoff.decide(
-            stagedVersion: staged?.version,
-            onDiskVersion: Self.readShortVersion(result.app.path)) {
+            staged: staged,
+            onDiskShortVersion: Self.readShortVersion(result.app.path),
+            onDiskBuildVersion: result.app.buildVersion) {
             Log.app.notice(
                 "restart held back: \(result.app.name, privacy: .public) — its own updater has \(stagedVersion, privacy: .public) staged and is waiting for the quit")
+            // Deliberately says "the version on disk" rather than "the version
+            // just installed": this is also reached from the Restart button on a
+            // row that updated itself, where we installed nothing.
             installNotes[result.id] =
                 "\(result.app.name) has its own update (\(stagedVersion)) downloaded and waiting for the app to quit. "
-                + "Restarting from here would install that one over the version just installed, so it wasn't restarted — quit \(result.app.name) yourself when you're ready to take theirs."
+                + "Restarting from here would install that one over the version now on disk, so it wasn't restarted — quit \(result.app.name) yourself when you're ready to take theirs."
             return
         }
-        // A fresh attempt supersedes whatever a previous bail left armed.
-        quitHandoffs[result.id] = nil
         switch await AppRestarter.restart(result.app) {
         case .noBundleID, .notRunning:
             needsRestart.remove(result.id)
@@ -3449,7 +3478,7 @@ final class AppListModel {
         // relaunch it ourselves once the install lands. Show the "Relaunching…"
         // indicator meanwhile (cleared when the install settles in `installApp`).
         if proceed {
-            reopenAfterQuit.insert(id)
+            reopenAfterQuit[id] = .userAskedToQuit
             relaunching.insert(id)
         }
         let cont = quitContinuations.removeValue(forKey: id)
@@ -3479,8 +3508,13 @@ final class AppListModel {
     /// to the terminate observer instead of dropping it (see `QuitHandoff`).
     private func reopenIfQuitForUpdate(_ result: UpdateResult) {
         let id = result.id
-        guard reopenAfterQuit.remove(id) != nil else { return }
+        guard let reason = reopenAfterQuit.removeValue(forKey: id) else { return }
         if !AppRestarter.runningInstances(of: result.app).isEmpty {
+            // Still up, and nobody asked it to quit: the store either never got
+            // that far or the install failed outright. There is nothing to
+            // relay — arming one here is how a cancelled update ended up
+            // relaunching an app the user closed themselves ten minutes later.
+            guard reason == .userAskedToQuit else { return }
             // Only armable against a known pre-install version — that's what tells
             // the relay the store's swap has landed. Without one, fall through to
             // today's behaviour rather than guess at a landing.

--- a/App/project.yml
+++ b/App/project.yml
@@ -75,8 +75,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.app
-        MARKETING_VERSION: "0.3.52"
-        CURRENT_PROJECT_VERSION: "61"
+        MARKETING_VERSION: "0.3.53"
+        CURRENT_PROJECT_VERSION: "62"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Info.plist
         # Menu-bar-only app: no Dock icon, no main window.
@@ -188,8 +188,8 @@ targets:
         # plist's BundleProgram points at Contents/MacOS/DuoUpdaterHelper. The bundle
         # *identifier* (for signing / XPC pinning) is com.duoupdater.helper.
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.helper
-        MARKETING_VERSION: "0.3.52"
-        CURRENT_PROJECT_VERSION: "61"
+        MARKETING_VERSION: "0.3.53"
+        CURRENT_PROJECT_VERSION: "62"
         SWIFT_VERSION: "6.0"
         # Embed a generated Info.plist into the binary's __TEXT,__info_plist so the
         # helper has a bundle id/version (Bundle.main reads it) without a wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ reads the section matching the version being shipped and embeds it in the GitHub
 release and the Sparkle appcast, so this file is the single source of truth for
 "what's new" — keep each version's prose written for users, not commit-speak.
 
+## 0.3.53
+
+**An app that already downloaded its own update is no longer asked to download it again.** Plenty of apps fetch their next version quietly in the background and hold it until you next quit them — that's the "relaunch to update" state you see inside Claude, TablePlus and others. Duo Updater has always recognised that state in Electron apps and offered you Relaunch instead of an Update, because the bytes are already on your disk. Apps built on Sparkle, which is most of the rest, were invisible to it: TablePlus sat there with a 133 MB download and an unpacked 382 MB copy of 26.9.11 in its cache, while its row offered to fetch 26.9.11 for you all over again. Those apps are now recognised too — the row offers Relaunch, and nothing is downloaded twice.
+
+**One thing it deliberately won't do is offer Relaunch for an older build.** An app can be holding a version *behind* the one you have, which happens when a vendor releases to some people before others and Duo Updater installed the newer one first. Relaunching there would quietly move you backwards, so the row doesn't offer it — and Duo Updater won't restart the app for you either, because that restart is the exact signal the app's own installer is waiting for.
+
+**Three ways an update could go wrong that a review caught before you did.** An App Store update that failed, or that you cancelled, could bring the app back to life minutes later — you would quit it yourself and it would reopen, because Duo Updater had noted "this app may need reopening" before anything had actually closed it. It now only reopens an app when a quit was genuinely asked for. Separately, the check added last release to stop an app's own updater undoing ours compared only the version *name*: a vendor that ships several builds under one version number slipped straight past it, which is the same failure it was written to prevent. It now compares the build number too. And an app's own updater is no longer assumed to be waiting just because a downloaded copy is sitting in its cache — Sparkle leaves those behind for ten days after an interrupted install, which could have left a Restart button that did nothing but explain itself.
+
 ## 0.3.52
 
 **Same changes as 0.3.51, reissued so it can actually reach you.** 0.3.51 went out carrying the same internal build number as 0.3.50. That number, not the one in the version name, is what an update check compares — so anyone already running 0.3.50 was told they were up to date and never offered it. This release carries the changes below under a build number that is properly newer. If you are reading this on 0.3.51, nothing about the app changed between the two.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RestartStandoff.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RestartStandoff.swift
@@ -21,7 +21,7 @@ import Foundation
 ///
 /// The decision therefore is not "is another installer armed" — that alone is
 /// harmless — but "is it armed with something OTHER than what we just wrote".
-/// When both sides hold the same version the quit is safe: whichever installer
+/// When both sides hold the same build the quit is safe: whichever installer
 /// runs second writes the same bytes. TablePlus was in exactly that state the
 /// same afternoon, staging 26.9.11 while we were about to install 26.9.11, and
 /// there was nothing to prevent.
@@ -35,18 +35,43 @@ public enum RestartStandoff {
         case holdBack(stagedVersion: String)
     }
 
-    /// `stagedVersion` is what the app's own updater will install on quit (nil if
-    /// nothing is staged); `onDiskVersion` is the bundle as it stands now, i.e.
-    /// what we just installed.
+    /// `staged` is what the app's own updater will install on quit (nil if
+    /// nothing is staged); the two `onDisk` values are the bundle as it stands
+    /// now, i.e. what we just installed.
     ///
-    /// An unreadable `onDiskVersion` holds back rather than proceeding. The whole
-    /// value of this check is knowing the two agree, and "we could not tell" is
-    /// not that — proceeding on it would be guessing with the user's app.
-    public static func decide(stagedVersion: String?, onDiskVersion: String?) -> Decision {
-        guard let staged = stagedVersion else { return .proceed }
-        guard let onDisk = onDiskVersion, staged == onDisk else {
-            return .holdBack(stagedVersion: staged)
+    /// **Every field that both sides carry must match**, not just the marketing
+    /// string. The first version of this compared `CFBundleShortVersionString`
+    /// alone, which is blind to the case it was written for: a vendor that keeps
+    /// the marketing version stable across builds could have 1.4.2 (5104) parked
+    /// while we install 1.4.2 (5120), the strings would agree, the restart would
+    /// be waved through, and 5104 would land on top of ours — the exact failure
+    /// this type exists to prevent, wearing a different version scheme.
+    ///
+    /// The bias is deliberate and one-directional. Holding back costs a manual
+    /// quit; proceeding when the builds differ silently undoes an install the
+    /// user asked for. So anything short of proof that the two agree — an
+    /// unreadable bundle, no field comparable on both sides — holds back.
+    public static func decide(
+        staged: StagedSelfUpdate?,
+        onDiskShortVersion: String?,
+        onDiskBuildVersion: String?
+    ) -> Decision {
+        guard let staged else { return .proceed }
+
+        // Only pairs where BOTH sides carry a value can be compared; a field
+        // missing on either side proves nothing either way.
+        let comparable: [(String, String)] = [
+            (staged.version, onDiskShortVersion),
+            (staged.buildVersion, onDiskBuildVersion),
+        ].compactMap { mine, theirs in
+            guard let theirs else { return nil }
+            guard let mine else { return nil }
+            return (mine, theirs)
         }
+
+        guard !comparable.isEmpty,
+              comparable.allSatisfy({ $0.0 == $0.1 })
+        else { return .holdBack(stagedVersion: staged.version) }
         return .proceed
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
@@ -159,10 +159,12 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
         // `.notice`, not `.debug`: this is the longest and least reliable step in
         // the whole app, and the report it has to answer — "it said it updated and
         // nothing changed" — arrives hours later, when only persisted levels are
-        // still readable. Host only, never the URL: a licensed feed (CleanShot)
-        // carries its key in the query.
-        Log.install.notice(
-            "download start: \(Redactor.host(url), privacy: .public)\(url.path, privacy: .public)")
+        // still readable. Host only, never the path or query: a licensed feed
+        // carries its key in the query (CleanShot), and a signed URL can carry one
+        // in a path segment instead — which is exactly why `Redactor.host` exists.
+        // Which app and which version this is for is already on the
+        // `InstallCoordinator` line above it.
+        Log.install.notice("download start: \(Redactor.host(url), privacy: .public)")
         let started = Date()
 
         var lastError: Error = URLError(.unknown)
@@ -171,7 +173,7 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
                 let result = try await runAttempt(url: url, headers: headers, partial: partial)
                 let secs = Date().timeIntervalSince(started)
                 Log.install.notice(
-                    "download ok: \(self.bytesDownloaded, privacy: .public) bytes in \(Int(secs), privacy: .public)s from \(Redactor.host(url), privacy: .public) (attempt \(attempt + 1, privacy: .public))")
+                    "download ok: \(self.bytesDownloaded, privacy: .public) bytes transferred in \(Int(secs), privacy: .public)s from \(Redactor.host(url), privacy: .public) (attempt \(attempt + 1, privacy: .public))")
                 return result
             } catch {
                 lastError = error
@@ -187,7 +189,7 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
                     throw error
                 }
                 Log.install.notice(
-                    "download retry \(attempt + 1, privacy: .public)/\(self.maxAttempts, privacy: .public): resuming from \(onDisk, privacy: .public) bytes — \(error.localizedDescription, privacy: .public)")
+                    "download retry \(attempt + 1, privacy: .public)/\(self.maxAttempts, privacy: .public): resuming from \(onDisk, privacy: .public) bytes on disk — \(error.localizedDescription, privacy: .public)")
                 // Brief, growing backoff (0.5s, 1.0s, …) so we don't hammer a CDN
                 // that's momentarily resetting connections.
                 try? await Task.sleep(nanoseconds: UInt64(attempt + 1) * 500_000_000)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -143,9 +143,18 @@ public enum InPlaceSwap {
         defer {
             if replaced {
                 Log.install.notice("swap done: \(target.lastPathComponent, privacy: .public)")
-            } else {
+            } else if FileManager.default.fileExists(atPath: target.path) {
                 Log.install.error(
                     "swap did NOT replace \(target.lastPathComponent, privacy: .public) — the app on disk is unchanged")
+            } else {
+                // The privileged path moves the target aside before moving the new
+                // bundle in, and restores it if that fails. If the restore ALSO
+                // fails the app is missing from disk — and this is the one moment
+                // the line is load-bearing, so it must not claim the opposite.
+                // `recoverInterruptedSwaps` promotes the `.duoupdater-old` copy
+                // back on the next launch.
+                Log.install.error(
+                    "swap did NOT complete and \(target.lastPathComponent, privacy: .public) is MISSING from disk — its pre-swap copy should be recovered on next launch")
             }
         }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 /// A Squirrel (Electron) self-update that has been fully downloaded and unpacked
@@ -58,6 +59,7 @@ public enum SelfUpdaterStaging {
         for app: InstalledApp,
         cachesDirectory: URL? = nil,
         applicationSupportDirectory: URL? = nil,
+        parkedInstallerBundleURLs: [URL]? = nil,
         fileManager: FileManager = .default
     ) -> StagedSelfUpdate? {
         guard let bundleID = app.bundleID else { return nil }
@@ -74,7 +76,9 @@ public enum SelfUpdaterStaging {
         guard app.hasSelfUpdater else {
             guard app.hasSparkleUpdater,
                   let staged = sparkleStagedBundle(
-                    for: app, cachesDirectory: cachesDirectory, fileManager: fileManager)
+                    for: app, cachesDirectory: cachesDirectory,
+                    parkedInstallerBundleURLs: parkedInstallerBundleURLs,
+                    fileManager: fileManager)
             else { return nil }
             // `sparkleStagedBundle` deliberately returns a staged build of ANY
             // version, because the restart check needs the ones that are older
@@ -217,24 +221,51 @@ public enum SelfUpdaterStaging {
     /// holds Sparkle's own `Updater.app`, which is not a staged copy of anything;
     /// the bundle-identifier check below independently rejects it.
     ///
-    /// Sparkle apps are NOT covered by `mayHaveStaging`, because `hasSelfUpdater`
-    /// is a Squirrel-only signal (`AppScanner` tests for `Squirrel.framework`) and
-    /// widening it would change `defersToSelfUpdater` for every Sparkle app on the
-    /// machine. So this is called directly, for one app, at the moment the answer
-    /// is needed.
+    /// **An unpacked bundle in the cache is not on its own evidence of anything.**
+    /// The Squirrel branch above demands a `ShipItState.plist` naming this bundle
+    /// as its target — positive proof an installer was armed. Sparkle writes no
+    /// such record, and it only garbage-collects its staging directory for entries
+    /// older than ten days, and then only when a new staging run happens
+    /// (`OLD_ITEM_DELETION_INTERVAL` in Sparkle's `SPULocalCacheDirectory.m`). So
+    /// an extraction abandoned by a reboot, a killed installer or a failed apply
+    /// stays on disk, and treating it as live meant a Restart button that held
+    /// back — pointing at an update that no longer existed — for up to ten days.
+    ///
+    /// The evidence used instead is the thing that actually does the work: an
+    /// installer process parked on this app's termination. Nothing applies on quit
+    /// without one, so where there is no parked installer there is nothing to
+    /// avoid, whatever is lying in the cache.
+    ///
+    /// **Known limitation.** Sparkle's cache is keyed by bundle identifier alone,
+    /// and so is the parked installer's own location, so two copies of one app
+    /// (this project's verification workflow keeps an older one in
+    /// `~/Applications`) share one cache and cannot be told apart here. For the
+    /// restart check that errs safe — both copies hold back. For the Relaunch
+    /// offer it can attribute a staged build to the wrong copy. The installer's
+    /// argv does name its target bundle, which would settle it, but that ordering
+    /// is undocumented and not worth depending on yet.
     public static func sparkleStagedBundle(
         for app: InstalledApp,
         cachesDirectory: URL? = nil,
+        parkedInstallerBundleURLs: [URL]? = nil,
         fileManager: FileManager = .default
     ) -> StagedSelfUpdate? {
         guard let bundleID = app.bundleID else { return nil }
         let caches = cachesDirectory
             ?? fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
         guard let caches else { return nil }
-        let root = caches
+        let sparkleRoot = caches
             .appendingPathComponent(bundleID, isDirectory: true)
             .appendingPathComponent("org.sparkle-project.Sparkle", isDirectory: true)
-            .appendingPathComponent("Installation", isDirectory: true)
+
+        // Cheapest discriminator first: no parked installer, nothing to avoid.
+        let parked = parkedInstallerBundleURLs ?? liveParkedSparkleInstallers()
+        let sparkleRootPath = sparkleRoot.standardizedFileURL.path
+        guard parked.contains(where: {
+            $0.standardizedFileURL.path.hasPrefix(sparkleRootPath + "/")
+        }) else { return nil }
+
+        let root = sparkleRoot.appendingPathComponent("Installation", isDirectory: true)
 
         // The directory itself survives every install — it is empty when nothing
         // is staged, which is why its existence proves nothing and its mtime
@@ -257,6 +288,19 @@ public enum SelfUpdaterStaging {
                 stagedBundlePath: url)
         }
         return nil
+    }
+
+    /// Sparkle's progress agent, which runs out of the staging cache of whichever
+    /// app it is installing — so its own bundle location is what ties a parked
+    /// installer to an app. Observed live: pid 27939 at
+    /// `…/Caches/com.tinyapp.TablePlus/org.sparkle-project.Sparkle/Launcher/<random>/Updater.app`.
+    private static let sparkleInstallerBundleID = "org.sparkle-project.Sparkle.Updater"
+
+    /// Bundle locations of every Sparkle installer currently parked, for any app.
+    private static func liveParkedSparkleInstallers() -> [URL] {
+        NSRunningApplication
+            .runningApplications(withBundleIdentifier: sparkleInstallerBundleID)
+            .compactMap(\.bundleURL)
     }
 
     /// ShipIt stores bundle locations as `file://` URL strings.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Redactor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Redactor.swift
@@ -24,6 +24,12 @@ public enum Redactor {
         "key", "token", "license", "auth", "sig", "signature",
         "access_token", "instance", "api_key", "apikey", "secret",
         "password", "pwd", "session", "credential",
+        // Rollout identifiers. These grant nothing, which is why a recipe may
+        // send one (see `ProbeIdentity`) — but they identify a machine, and the
+        // contract that they never appear in a log, a report or a public issue
+        // rested entirely on the resolved URL never leaving the fetch. That is
+        // one layer with nothing behind it; these put the net back under it.
+        "installation_id", "installationid", "device_id", "deviceid",
     ]
 
     /// Header names dropped whole — the value *is* the secret.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RestartStandoffTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RestartStandoffTests.swift
@@ -1,20 +1,28 @@
+import Foundation
 import Testing
 @testable import DuoUpdaterCore
 
 struct RestartStandoffTests {
 
+    private func staged(_ short: String, _ build: String? = nil) -> StagedSelfUpdate {
+        StagedSelfUpdate(
+            version: short, buildVersion: build,
+            stagedBundlePath: URL(fileURLWithPath: "/tmp/Staged.app"))
+    }
+
     /// The overwhelming common case: nobody else is holding an installer open.
     @Test func nothingStagedProceeds() {
         #expect(RestartStandoff.decide(
-            stagedVersion: nil, onDiskVersion: "1.2.3") == .proceed)
+            staged: nil, onDiskShortVersion: "1.2.3", onDiskBuildVersion: "45") == .proceed)
     }
 
-    /// TablePlus, 2026-08-22: Sparkle had 26.9.11 unpacked and an `Autoupdate`
-    /// parked, and 26.9.11 was also what we were installing. Whoever writes
-    /// second writes the same thing, so there is nothing to hold back for.
+    /// TablePlus, 2026-08-22: Sparkle had 26.9.11 (769) unpacked and an
+    /// `Autoupdate` parked, and 26.9.11 (769) was also what we were installing.
+    /// Whoever writes second writes the same thing.
     @Test func aStagedBuildMatchingDiskProceeds() {
         #expect(RestartStandoff.decide(
-            stagedVersion: "26.9.11", onDiskVersion: "26.9.11") == .proceed)
+            staged: staged("26.9.11", "769"),
+            onDiskShortVersion: "26.9.11", onDiskBuildVersion: "769") == .proceed)
     }
 
     /// Regression, ChatGPT 2026-08-22: we installed 26.818.41705, Sparkle had
@@ -23,7 +31,8 @@ struct RestartStandoffTests {
     /// update pending" would have found nothing to worry about here.
     @Test func anOlderStagedBuildHoldsBack() {
         #expect(RestartStandoff.decide(
-            stagedVersion: "26.818.41509", onDiskVersion: "26.818.41705")
+            staged: staged("26.818.41509", "6962"),
+            onDiskShortVersion: "26.818.41705", onDiskBuildVersion: "6971")
             == .holdBack(stagedVersion: "26.818.41509"))
     }
 
@@ -31,14 +40,45 @@ struct RestartStandoffTests {
     /// installed with something we did not choose.
     @Test func aNewerStagedBuildHoldsBack() {
         #expect(RestartStandoff.decide(
-            stagedVersion: "2.0.0", onDiskVersion: "1.0.0")
+            staged: staged("2.0.0", "200"),
+            onDiskShortVersion: "1.0.0", onDiskBuildVersion: "100")
             == .holdBack(stagedVersion: "2.0.0"))
+    }
+
+    /// Regression for a hole the first version of this had, and which its tests
+    /// could not have caught because every case they used differed in the
+    /// marketing string. A vendor that keeps that string stable across builds —
+    /// and this project already has the build-only bump on record — produces two
+    /// genuinely different bundles whose short versions agree. Comparing only
+    /// that string waves the restart through and the staged build lands over
+    /// ours: the original failure in a different version scheme.
+    @Test func aStagedBuildDifferingOnlyInBuildNumberHoldsBack() {
+        #expect(RestartStandoff.decide(
+            staged: staged("1.4.2", "5104"),
+            onDiskShortVersion: "1.4.2", onDiskBuildVersion: "5120")
+            == .holdBack(stagedVersion: "1.4.2"))
     }
 
     /// "We could not read the bundle" is not "the versions agree".
     @Test func anUnreadableDiskVersionHoldsBack() {
         #expect(RestartStandoff.decide(
-            stagedVersion: "1.0.0", onDiskVersion: nil)
+            staged: staged("1.0.0", "100"),
+            onDiskShortVersion: nil, onDiskBuildVersion: nil)
             == .holdBack(stagedVersion: "1.0.0"))
+    }
+
+    /// A field only one side carries proves nothing, so it is skipped rather than
+    /// counted as a mismatch — but the fields both sides do carry still decide.
+    @Test func fieldsOnlyOneSideCarriesAreSkipped() {
+        #expect(RestartStandoff.decide(
+            staged: staged("1.0.0", nil),
+            onDiskShortVersion: "1.0.0", onDiskBuildVersion: "100") == .proceed)
+        #expect(RestartStandoff.decide(
+            staged: staged("1.0.0", "101"),
+            onDiskShortVersion: "1.0.0", onDiskBuildVersion: nil) == .proceed)
+        #expect(RestartStandoff.decide(
+            staged: staged("1.0.1", nil),
+            onDiskShortVersion: "1.0.0", onDiskBuildVersion: "100")
+            == .holdBack(stagedVersion: "1.0.1"))
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
@@ -53,6 +53,16 @@ struct SparkleStagingTests {
         return staged
     }
 
+    /// Where Sparkle's parked progress agent lives for this app — the evidence
+    /// that an installer is actually waiting on the quit.
+    private func parkedInstaller(in caches: URL) -> URL {
+        caches.appendingPathComponent(bundleID)
+            .appendingPathComponent("org.sparkle-project.Sparkle")
+            .appendingPathComponent("Launcher")
+            .appendingPathComponent("jRGjuao1o")
+            .appendingPathComponent("Updater.app")
+    }
+
     private func withScratch(_ body: (URL) throws -> Void) throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("SparkleStagingTest-\(UUID().uuidString)")
@@ -70,7 +80,8 @@ struct SparkleStagingTests {
 
             let found = SelfUpdaterStaging.sparkleStagedBundle(
                 for: app(at: installed, short: "26.9.9", build: "765"),
-                cachesDirectory: caches)
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)])
 
             #expect(found?.version == "26.9.11")
             #expect(found?.buildVersion == "769")
@@ -90,11 +101,13 @@ struct SparkleStagingTests {
 
             let found = SelfUpdaterStaging.sparkleStagedBundle(
                 for: app(at: installed, short: "26.818.41705", build: "6971"),
-                cachesDirectory: caches)
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)])
 
             #expect(found?.version == "26.818.41509")
             #expect(RestartStandoff.decide(
-                stagedVersion: found?.version, onDiskVersion: "26.818.41705")
+                staged: found,
+                onDiskShortVersion: "26.818.41705", onDiskBuildVersion: "6971")
                 == .holdBack(stagedVersion: "26.818.41509"))
         }
     }
@@ -113,7 +126,8 @@ struct SparkleStagingTests {
 
             #expect(SelfUpdaterStaging.sparkleStagedBundle(
                 for: app(at: installed, short: "1.0", build: "1"),
-                cachesDirectory: caches) == nil)
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)]) == nil)
         }
     }
 
@@ -131,7 +145,8 @@ struct SparkleStagingTests {
 
             #expect(SelfUpdaterStaging.sparkleStagedBundle(
                 for: app(at: installed, short: "1.0", build: "1"),
-                cachesDirectory: caches) == nil)
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)]) == nil)
         }
     }
 
@@ -145,7 +160,8 @@ struct SparkleStagingTests {
 
             #expect(SelfUpdaterStaging.sparkleStagedBundle(
                 for: app(at: installed, short: "1.0", build: "1"),
-                cachesDirectory: caches) == nil)
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)]) == nil)
         }
     }
 
@@ -166,7 +182,8 @@ struct SparkleStagingTests {
 
             let found = SelfUpdaterStaging.staged(
                 for: sparkleApp(at: installed, short: "26.9.9", build: "765"),
-                cachesDirectory: caches)
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)])
 
             #expect(found?.version == "26.9.11")
         }
@@ -184,9 +201,13 @@ struct SparkleStagingTests {
             try makeApp(at: installed, identifier: bundleID, short: "26.818.41705", build: "6971")
             let app = sparkleApp(at: installed, short: "26.818.41705", build: "6971")
 
-            #expect(SelfUpdaterStaging.staged(for: app, cachesDirectory: caches) == nil)
+            let parked = [parkedInstaller(in: caches)]
+            #expect(SelfUpdaterStaging.staged(
+                for: app, cachesDirectory: caches,
+                parkedInstallerBundleURLs: parked) == nil)
             #expect(SelfUpdaterStaging.sparkleStagedBundle(
-                for: app, cachesDirectory: caches)?.version == "26.818.41509")
+                for: app, cachesDirectory: caches,
+                parkedInstallerBundleURLs: parked)?.version == "26.818.41509")
         }
     }
 
@@ -207,5 +228,49 @@ struct SparkleStagingTests {
             name: "Sparkly", bundleID: bundleID, shortVersion: short, buildVersion: build,
             path: path, isMASApp: false, sparkleFeedURL: nil,
             hasSelfUpdater: false, hasSparkleUpdater: true)
+    }
+
+    /// Regression: an unpacked bundle in the cache is not evidence on its own.
+    /// Sparkle keeps abandoned staging for ten days and only sweeps it when a new
+    /// staging run happens, so a reboot or a killed installer leaves one behind.
+    /// Treating that as live gave a Restart button that held back — citing an
+    /// update that no longer existed — for up to ten days, and could quit the
+    /// user's app waiting for a swap nobody was going to perform.
+    @Test func aLeftoverWithNoParkedInstallerIsIgnored() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            _ = try stage(in: caches, short: "26.9.11", build: "769")
+            let installed = root.appendingPathComponent("Sparkly.app")
+            try makeApp(at: installed, identifier: bundleID, short: "26.9.9", build: "765")
+            let app = sparkleApp(at: installed, short: "26.9.9", build: "765")
+
+            #expect(SelfUpdaterStaging.sparkleStagedBundle(
+                for: app, cachesDirectory: caches,
+                parkedInstallerBundleURLs: []) == nil)
+            #expect(SelfUpdaterStaging.staged(
+                for: app, cachesDirectory: caches,
+                parkedInstallerBundleURLs: []) == nil)
+        }
+    }
+
+    /// An installer parked for a DIFFERENT app is not evidence for this one. Every
+    /// Sparkle app's agent shares one bundle identifier, so the location it runs
+    /// from is the only thing that ties it to an app.
+    @Test func anInstallerParkedForAnotherAppIsNotEvidence() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            _ = try stage(in: caches, short: "26.9.11", build: "769")
+            let installed = root.appendingPathComponent("Sparkly.app")
+            try makeApp(at: installed, identifier: bundleID, short: "26.9.9", build: "765")
+            let elsewhere = caches.appendingPathComponent("com.other.app")
+                .appendingPathComponent("org.sparkle-project.Sparkle")
+                .appendingPathComponent("Launcher").appendingPathComponent("x")
+                .appendingPathComponent("Updater.app")
+
+            #expect(SelfUpdaterStaging.sparkleStagedBundle(
+                for: sparkleApp(at: installed, short: "26.9.9", build: "765"),
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [elsewhere]) == nil)
+        }
     }
 }

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -112,14 +112,28 @@ import pathlib
 import re
 import sys
 
+# Drop the item for the version being published, so generate_appcast writes a
+# fresh one rather than a duplicate.
+#
+# Split into whole items FIRST. The obvious single regex --
+# <item>.*?(<sparkle:version>BUILD</sparkle:version>|...).*?</item> with DOTALL --
+# is wrong in a way that only shows up when you republish something that is not
+# the newest entry: the lazy prefix starts at the FIRST <item> in the file and
+# swallows every item before the match. Republishing the newest costs one extra
+# entry, which is how 0.3.50 vanished from the feed on 2026-08-22; republishing
+# an older one empties the appcast completely. Verified against a three-item
+# feed: re-running the old form for the oldest build deleted all three.
 path, build, version = sys.argv[1:4]
 text = pathlib.Path(path).read_text()
-pattern = re.compile(
-    r"<item>.*?(?:<sparkle:version>\s*%s\s*</sparkle:version>|<sparkle:shortVersionString>\s*%s\s*</sparkle:shortVersionString>).*?</item>\s*"
-    % (re.escape(build), re.escape(version)),
-    re.S,
+
+item = re.compile(r"<item>.*?</item>\s*", re.S)
+target = re.compile(
+    r"<sparkle:version>\s*%s\s*</sparkle:version>"
+    r"|<sparkle:shortVersionString>\s*%s\s*</sparkle:shortVersionString>"
+    % (re.escape(build), re.escape(version))
 )
-pathlib.Path(path).write_text(pattern.sub("", text))
+pathlib.Path(path).write_text(
+    item.sub(lambda m: "" if target.search(m.group()) else m.group(), text))
 PY
     fi
 
@@ -130,6 +144,36 @@ PY
         --link "$RELEASE_PAGE_URL" \
         --embed-release-notes \
         "$archives_dir" >/dev/null
+
+    # Nothing may vanish from the feed. At this point `$clone_dir/appcast.xml` is
+    # still the published copy and `$archives_dir/appcast.xml` is the regenerated
+    # one, so they can simply be counted against each other. A shrinking feed is
+    # how the strip step used to fail silently — and a lost entry is not cosmetic:
+    # it is a version nobody can be offered any more.
+    OLD_APPCAST="$clone_dir/appcast.xml" NEW_APPCAST="$archives_dir/appcast.xml" \
+        NEW_VERSION="$version" python3 - <<'PY' || die "appcast sanity check failed"
+import os, pathlib, re, sys
+
+def versions(path):
+    text = pathlib.Path(path).read_text()
+    return re.findall(r"<sparkle:shortVersionString>\s*([^<\s]+)\s*</sparkle:shortVersionString>", text)
+
+old = versions(os.environ["OLD_APPCAST"])
+new = versions(os.environ["NEW_APPCAST"])
+want = os.environ["NEW_VERSION"]
+
+if want not in new:
+    sys.exit(f"the regenerated appcast does not contain {want} — it would publish nothing")
+# One in, at most one out (generate_appcast caps how many it keeps), so the
+# count can never legitimately fall.
+if len(new) < len(old):
+    lost = [v for v in old if v not in new]
+    sys.exit(
+        f"the regenerated appcast lost {len(old) - len(new)} entrie(s): {', '.join(lost) or '?'}\n"
+        f"  before: {', '.join(old)}\n  after:  {', '.join(new)}"
+    )
+print(f"  appcast: {len(old)} -> {len(new)} entries, {want} present")
+PY
 
     cp "$archives_dir/appcast.xml" "$clone_dir/appcast.xml"
 
@@ -143,6 +187,59 @@ PY
     fi
 }
 
+# Refuse to publish a build the updater cannot see as new.
+#
+# Sparkle decides "is this newer" from CFBundleVersion (sparkle:version), not
+# from the version name. 0.3.51 shipped with CURRENT_PROJECT_VERSION left at the
+# previous release's value, so every user already on 0.3.50 was told they were
+# up to date and never offered it; 0.3.52 exists only to correct that. Nothing
+# in this script noticed. It does now, before anything is built.
+#
+# Read the live appcast from git rather than the raw.githubusercontent URL: that
+# CDN lags several minutes and no cache-buster gets through it, so it is exactly
+# blind to the failure "the last push did not land".
+preflight_build_is_newer() {
+    local published
+    git -C "$REPO_ROOT" fetch origin main --quiet 2>/dev/null || true
+    published="$(git -C "$REPO_ROOT" show origin/main:appcast.xml 2>/dev/null || true)"
+    [ -n "$published" ] || { say "No published appcast yet — skipping the build-number check"; return 0; }
+
+    APPCAST_XML="$published" NEW_BUILD="$build" python3 - <<'PY' || die "build number check failed"
+import os, re, sys
+xml = os.environ["APPCAST_XML"]
+new = os.environ["NEW_BUILD"]
+builds = [int(b) for b in re.findall(r"<sparkle:version>\s*(\d+)\s*</sparkle:version>", xml)]
+if not builds:
+    print("  no sparkle:version entries in the published appcast — nothing to compare")
+    sys.exit(0)
+try:
+    mine = int(new)
+except ValueError:
+    sys.exit(f"CURRENT_PROJECT_VERSION {new!r} is not a number; Sparkle compares it numerically")
+top = max(builds)
+if mine <= top:
+    sys.exit(
+        f"CURRENT_PROJECT_VERSION is {mine}, but the published appcast already has {top}.\n"
+        f"  Sparkle compares CFBundleVersion, so every user on build {top} would be told\n"
+        f"  they are up to date and never offered this release. Bump\n"
+        f"  CURRENT_PROJECT_VERSION in App/project.yml (both occurrences)."
+    )
+print(f"  build {mine} > published {top}")
+PY
+}
+
+say "Checking the build number against the published appcast"
+preflight_build_is_newer
+
+# The tests are the only gate this project has — there is no CI on pull
+# requests — and until now `make release` did not run them, so a release could
+# go out over a red suite without anyone being asked.
+if [ "${SKIP_TESTS:-0}" != "1" ]; then
+    say "Running tests before publishing (SKIP_TESTS=1 to override)"
+    ( cd "$REPO_ROOT/DuoUpdaterCore" && swift test ) >/dev/null 2>&1 \
+        || die "swift test failed — refusing to publish. Run 'make test' to see it."
+fi
+
 if [ "$SKIP_NOTARIZE" != "1" ]; then
     say "Building and notarizing release artifact"
     "$REPO_ROOT/scripts/notarize.sh"
@@ -151,6 +248,20 @@ fi
 [ -f "$FINAL_ZIP" ] || die "notarized zip not found: $FINAL_ZIP"
 mkdir -p "$DIST_DIR"
 cp "$FINAL_ZIP" "$ASSET_ZIP"
+
+# The zip must contain the versions we are about to tag. With SKIP_NOTARIZE=1
+# this script reuses whatever `dist/DuoUpdater-notarized.zip` is lying around,
+# which can be the previous build — a silent path to "the tag says A, the
+# binary is B".
+say "Checking the artifact's own version"
+zip_info="$(unzip -Z1 "$ASSET_ZIP" | grep -m1 -E '^[^/]+\.app/Contents/Info\.plist$' || true)"
+[ -n "$zip_info" ] || die "no app Info.plist inside $ASSET_ZIP"
+zip_short="$(unzip -p "$ASSET_ZIP" "$zip_info" | plutil -extract CFBundleShortVersionString raw - 2>/dev/null || true)"
+zip_build="$(unzip -p "$ASSET_ZIP" "$zip_info" | plutil -extract CFBundleVersion raw - 2>/dev/null || true)"
+[ "$zip_short" = "$version" ] \
+    || die "artifact is version $zip_short but this release is $version — stale zip? (rebuild, or unset SKIP_NOTARIZE)"
+[ "$zip_build" = "$build" ] \
+    || die "artifact is build $zip_build but this release is build $build — stale zip? (rebuild, or unset SKIP_NOTARIZE)"
 
 checksum="$(shasum -a 256 "$ASSET_ZIP" | awk '{print $1}')"
 


### PR DESCRIPTION
Three reviews of the 0.3.51/0.3.52 content found ten defects — five already on users' machines — plus a review of the release practice itself. This fixes them and puts gates on the publish path.

## Code fixes (`23db25b`)

The two that matter most:

- **The restart standoff was blind to build numbers.** It compared `CFBundleShortVersionString` alone, so a vendor keeping the marketing string stable across builds defeated it outright: 1.4.2 (5104) staged against 1.4.2 (5120) installed reads as "same version, safe to restart". That is the exact failure it was written to prevent. My tests could not have caught it — all five used versions differing in the marketing string, so the whole build-only class was outside what they described.
- **An App Store install that closed nothing could still relaunch the app.** Arming the reopen at install start was too early. A failed or cancelled install left it armed; the tail then saw the app still running and armed a `QuitHandoff` whose `.appStoreSwap` landing relaunches even with no swap. Quit your own app ten minutes later and it comes back. Arming now records *why*, and only a quit the user asked for may hand a running app to the terminate observer.

Also: four early returns leaked that arming; the hold-back returned before clearing a stale handoff (which then fired on the very quit the note asks for); a staged Sparkle bundle is no longer evidence by itself (Sparkle keeps abandoned staging for ten days — the gate is now an installer process actually parked on this app's termination); `download start` logged `url.path` while its comment claimed host-only; `installation_id`/`device_id` were missing from `Redactor`; `InPlaceSwap` asserted "unchanged" on the one path where the app is actually missing.

Not fixed, documented instead: Sparkle's cache is keyed by bundle id, so two copies of one app cannot be told apart. Safe direction for the restart check; noted as a limitation for the Relaunch offer.

## Release gates (`83d9cef`)

- **Build number must exceed the published one.** Read from `git show origin/main:appcast.xml`, not the raw CDN URL, which lags and is blind to "the push did not land". Checked against today's real feed: 61 refuses, 62 passes.
- **The appcast strip no longer eats its neighbours.** The old single regex's lazy prefix started at the first `<item>` in the file. Republishing the newest cost one extra entry — that is how 0.3.50 vanished today. Republishing an older one empties the feed: verified, three-item feed, all three deleted. Reissues are not hypothetical; 0.3.52 was one.
- **Nothing may vanish from the regenerated feed**, and the new version must be in it.
- **The artifact must be the version being tagged** (`SKIP_NOTARIZE=1` can otherwise reuse a stale zip).
- **Tests run before publishing.** There is no CI on PRs here, so `swift test` is the only gate, and `make release` was not coupled to it at all.

## Verification

`swift test` 929 + 119 passing (2 pre-existing known issues). Live: with a genuinely parked installer on the machine (pid 27939), detection is unchanged — `self-update staged (relaunch pending): TablePlus→26.9.11`. Strip fix proven on the three-item case; build gate proven against the live appcast.

## Correction

An earlier claim that the nightly `recipe-verify` had been dead nine days was wrong — it looks dead in GitHub Actions because it moved to launchd on the mini, where it runs every six hours and was green today at 16:17 (`total ✓ 246 ⚠ 0 ✗ 0`). Its wrapper script does die afterwards on two unrelated bugs (a stale checkout that no longer compiles, and `status` being read-only in zsh), so its reporting tail never completes. Tracked separately.