### PR TITLE
Add multi-language support (ru, zh-Hans, ja, de, fr, es)

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -739,47 +739,6 @@
         }
       }
     },
-    "%@ · checked %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · geprüft %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · comprobado %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · vérifié %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · 確認: %@"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · проверено %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · 检查于 %@"
-          }
-        }
-      }
-    },
     "%@ — click to retry": {
       "extractionState": "manual",
       "localizations": {

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -5276,43 +5276,43 @@
         }
       }
     },
-    "Delete %@ (%@)": {
+    "Delete %lld (%@)": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ löschen (%@)"
+            "value": "%lld löschen (%@)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eliminar %@ (%@)"
+            "value": "Eliminar %lld (%@)"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Supprimer %@ (%@)"
+            "value": "Supprimer %lld (%@)"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 件を削除（%@）"
+            "value": "%lld 件を削除（%@）"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Удалить %@ (%@)"
+            "value": "Удалить %lld (%@)"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除 %@（%@）"
+            "value": "删除 %lld（%@）"
           }
         }
       }
@@ -8310,43 +8310,43 @@
         }
       }
     },
-    "License at activation limit (%@/%@). Key saved — set the instance ID below, or free a slot in Alcove.": {
+    "License at activation limit (%lld/%lld). Key saved — set the instance ID below, or free a slot in Alcove.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lizenz hat das Aktivierungslimit erreicht (%@/%@). Schlüssel gespeichert – Instanz-ID unten festlegen oder einen Platz in Alcove freigeben."
+            "value": "Lizenz hat das Aktivierungslimit erreicht (%lld/%lld). Schlüssel gespeichert – Instanz-ID unten festlegen oder einen Platz in Alcove freigeben."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "La licencia alcanzó el límite de activaciones (%@/%@). Clave guardada; establece el ID de instancia abajo o libera una plaza en Alcove."
+            "value": "La licencia alcanzó el límite de activaciones (%lld/%lld). Clave guardada; establece el ID de instancia abajo o libera una plaza en Alcove."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "La licence a atteint sa limite d'activation (%@/%@). Clé enregistrée — définissez l'ID d'instance ci-dessous, ou libérez un emplacement dans Alcove."
+            "value": "La licence a atteint sa limite d'activation (%lld/%lld). Clé enregistrée — définissez l'ID d'instance ci-dessous, ou libérez un emplacement dans Alcove."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ライセンスがアクティベーション上限（%@/%@）に達しています。キーは保存済みです — 下でインスタンスIDを設定するか、Alcoveでスロットを解放してください。"
+            "value": "ライセンスがアクティベーション上限（%lld/%lld）に達しています。キーは保存済みです — 下でインスタンスIDを設定するか、Alcoveでスロットを解放してください。"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Лицензия достигла лимита активаций (%@/%@). Ключ сохранён — укажите ID экземпляра ниже или освободите слот в Alcove."
+            "value": "Лицензия достигла лимита активаций (%lld/%lld). Ключ сохранён — укажите ID экземпляра ниже или освободите слот в Alcove."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "许可证已达到激活上限（%@/%@）。密钥已保存 — 请在下方设置实例 ID，或在 Alcove 中释放一个名额。"
+            "value": "许可证已达到激活上限（%lld/%lld）。密钥已保存 — 请在下方设置实例 ID，或在 Alcove 中释放一个名额。"
           }
         }
       }
@@ -15403,43 +15403,43 @@
         }
       }
     },
-    "Upgrading… (%@/%@)": {
+    "Upgrading… (%lld/%lld)": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wird aktualisiert … (%@/%@)"
+            "value": "Wird aktualisiert … (%lld/%lld)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Actualizando… (%@/%@)"
+            "value": "Actualizando… (%lld/%lld)"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mise à niveau en cours… (%@/%@)"
+            "value": "Mise à niveau en cours… (%lld/%lld)"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "アップグレード中…（%@/%@）"
+            "value": "アップグレード中…（%lld/%lld）"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Обновление… (%@/%@)"
+            "value": "Обновление… (%lld/%lld)"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在升级…（%@/%@）"
+            "value": "正在升级…（%lld/%lld）"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1,0 +1,16892 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    " · checked %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " · geprüft %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " · comprobado %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " · vérifié %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " · 確認: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " · проверено %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " · 检查于 %@"
+          }
+        }
+      }
+    },
+    " — latest %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " – neueste %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " — última %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " — dernière %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " — 最新 %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " — последняя версия %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " — 最新 %@"
+          }
+        }
+      }
+    },
+    "%@  →  %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@  →  %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@  →  %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@  →  %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@  →  %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@  →  %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@  →  %@"
+          }
+        }
+      }
+    },
+    "%@ %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@"
+          }
+        }
+      }
+    },
+    "%@ %@ → %@ is a major new version. If this is a commercial app, it may need a new license — with an expired subscription the update can drop into a limited/trial mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ → %@ ist eine neue Hauptversion. Falls es sich um eine kommerzielle App handelt, ist möglicherweise eine neue Lizenz nötig – bei abgelaufenem Abo kann das Update in einen eingeschränkten Modus/Testmodus wechseln."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ → %@ es una nueva versión principal. Si es una app comercial, puede necesitar una licencia nueva; con una suscripción caducada, la actualización puede pasar a un modo limitado o de prueba."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ → %@ est une nouvelle version majeure. S'il s'agit d'une application commerciale, une nouvelle licence peut être nécessaire — avec un abonnement expiré, la mise à jour peut basculer en mode limité/essai."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ → %@ は新しいメジャーバージョンです。商用アプリの場合、新しいライセンスが必要になることがあります — サブスクリプションが期限切れの場合、更新後に制限付き/体験モードになる可能性があります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ → %@ — это новая мажорная версия. Если это коммерческое приложение, может потребоваться новая лицензия — при истёкшей подписке обновление может перейти в ограниченный/пробный режим."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ → %@ 是一个重大新版本。如果这是商业应用，可能需要新许可证 — 订阅过期后更新可能会进入受限/试用模式。"
+          }
+        }
+      }
+    },
+    "%@ already downloaded %@ — relaunch to apply it": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hat %@ bereits heruntergeladen – neu starten, um es anzuwenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ya descargó %@; reabre para aplicarlo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ a déjà téléchargé %@ — relancez pour l'appliquer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はすでに %@ をダウンロード済みです — 再起動して適用してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ уже загрузило %@ — перезапустите, чтобы применить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已下载 %@ — 重新启动以应用"
+          }
+        }
+      }
+    },
+    "%@ already downloaded %@ — relaunch to apply it (no extra download; a large app may take a minute to swap & reopen)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hat %@ bereits heruntergeladen – neu starten, um es anzuwenden (kein erneuter Download nötig; bei einer großen App kann der Austausch & Neustart eine Minute dauern)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ya descargó %@; reabre para aplicarlo (sin descarga adicional; en apps grandes el intercambio y la reapertura pueden tardar un minuto)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ a déjà téléchargé %@ — relancez pour l'appliquer (pas de nouveau téléchargement ; pour une grande application, l'échange et la réouverture peuvent prendre une minute)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はすでに %@ をダウンロード済みです — 再起動して適用してください（追加のダウンロードは不要です。大きなアプリは入れ替えと再起動に1分ほどかかる場合があります）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ уже загрузило %@ — перезапустите, чтобы применить (без повторной загрузки; для крупного приложения замена и открытие могут занять минуту)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已下载 %@ — 重新启动以应用（无需再次下载；大型应用替换并重新打开可能需要一分钟）"
+          }
+        }
+      }
+    },
+    "%@ and %@ have updates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für %@ und %@ sind Updates verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay actualizaciones para %@ y %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Des mises à jour sont disponibles pour %@ et %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ と %@ にアップデートがあります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для %@ и %@ доступны обновления."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 和 %@ 有可用更新。"
+          }
+        }
+      }
+    },
+    "%@ doesn’t publish a changelog we can read.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ veröffentlicht kein lesbares Änderungsprotokoll."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ no publica un registro de cambios que podamos leer."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ne publie pas de journal des modifications que nous puissions lire."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ は読み取り可能な更新履歴を公開していません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ не публикует список изменений, который можно прочитать."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 未发布我们可以读取的更新日志。"
+          }
+        }
+      }
+    },
+    "%@ downloaded %@ on its own. Relaunch to apply it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hat %@ selbstständig heruntergeladen. Zum Anwenden neu starten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ descargó %@ por su cuenta. Reabre para aplicarlo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ a téléchargé %@ tout seul. Relancez pour l'appliquer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ が %@ を自動的にダウンロードしました。再起動して適用してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ самостоятельно загрузило %@. Перезапустите, чтобы применить."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已自行下载 %@。重新启动以应用。"
+          }
+        }
+      }
+    },
+    "%@ has an update.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für %@ ist ein Update verfügbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay una actualización para %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une mise à jour est disponible pour %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ にアップデートがあります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для %@ доступно обновление."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 有可用更新。"
+          }
+        }
+      }
+    },
+    "%@ is already downloaded — opens it in macOS's installer (asks for admin). Nothing is downloaded again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wurde bereits heruntergeladen – öffnet es im macOS-Installationsprogramm (erfordert Administratorrechte). Es wird nichts erneut heruntergeladen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ya está descargada; se abre en el instalador de macOS (pide permisos de administrador). No se descarga de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est déjà téléchargée — l'ouvre dans l'installateur macOS (demande les droits admin). Rien n'est téléchargé à nouveau."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はすでにダウンロード済みです — macOSのインストーラーで開きます（管理者権限が必要）。再度ダウンロードされることはありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ уже загружено — открывает его в установщике macOS (потребуются права администратора). Повторная загрузка не выполняется."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已下载 — 会在 macOS 安装程序中打开它（需要管理员权限）。不会再次下载。"
+          }
+        }
+      }
+    },
+    "%@ is an iPhone/iPad app running on Apple Silicon. Its latest version%@ no longer supports Mac, so the App Store won't install it on this device.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist eine iPhone/iPad-App, die auf Apple Silicon läuft. Ihre neueste Version%@ unterstützt Mac nicht mehr, daher installiert der App Store sie nicht auf diesem Gerät."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ es una app de iPhone/iPad que se ejecuta en Apple Silicon. Su última versión%@ ya no admite Mac, por lo que la App Store no la instalará en este dispositivo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est une application iPhone/iPad exécutée sur Apple Silicon. Sa dernière version%@ ne prend plus en charge le Mac, donc l'App Store ne l'installera pas sur cet appareil."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はApple SiliconのMacで動作しているiPhone/iPad用アプリです。その最新バージョン%@ はMacをサポートしなくなったため、App Storeはこのデバイスにインストールしません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — приложение для iPhone/iPad, запущенное на Apple Silicon. Его последняя версия%@ больше не поддерживает Mac, поэтому App Store не установит его на это устройство."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 是运行在 Apple 芯片上的 iPhone/iPad 应用。其最新版本%@ 已不再支持 Mac，因此 App Store 不会在此设备上安装它。"
+          }
+        }
+      }
+    },
+    "%@ is running — open it and let its own updater apply %@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ läuft – öffnen und das integrierte Update-Tool %@ anwenden lassen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ se está ejecutando; ábrela para que su propio actualizador aplique %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est en cours d'exécution — ouvrez-la pour laisser son propre outil appliquer %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ は実行中です — 開いて、独自の更新機能で %@ を適用してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ запущено — откройте его, чтобы его собственный обновитель применил %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 正在运行 — 打开它，让它自己的更新程序应用 %@。"
+          }
+        }
+      }
+    },
+    "%@ is running — open it so its own updater applies the update. Quit it, or pick “Always replace” in Settings, to install directly.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ läuft – öffnen, damit das integrierte Update-Tool das Update anwendet. Zum direkten Installieren die App beenden oder in den Einstellungen „Immer ersetzen“ wählen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ se está ejecutando; ábrela para que su propio actualizador aplique la actualización. Ciérrala, o elige «Reemplazar siempre» en Ajustes, para instalar directamente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est en cours d'exécution — ouvrez-la pour que son propre outil applique la mise à jour. Quittez-la, ou choisissez « Toujours remplacer » dans les Réglages, pour installer directement."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ は実行中です — 開いて独自の更新機能に更新を適用させてください。終了するか、設定で「常に置き換える」を選ぶと直接インストールできます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ запущено — откройте его, чтобы собственный обновитель применил обновление. Закройте его или выберите «Всегда заменять» в настройках, чтобы установить напрямую."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 正在运行 — 打开它以让其自身的更新程序应用更新。退出它，或在设置中选择“始终替换”，即可直接安装。"
+          }
+        }
+      }
+    },
+    "%@ isn’t in your App Store region (%@). It’s listed in %@%@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist in deiner App-Store-Region (%@) nicht verfügbar. Sie ist in %@%@ gelistet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ no está en tu región de la App Store (%@). Está disponible en %@%@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ n'est pas disponible dans votre région de l'App Store (%@). Elle est disponible dans %@%@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はお使いのApp Storeの地域（%@）にはありません。%@%@ で提供されています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ отсутствует в вашем регионе App Store (%@). Оно есть в списке региона %@%@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不在你的 App Store 区域（%@）中。它已在 %@%@ 上架。"
+          }
+        }
+      }
+    },
+    "%@ must quit to finish updating — click to quit it, install, and reopen": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ muss beendet werden, um das Update abzuschließen – zum Beenden, Installieren und erneuten Öffnen klicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ debe cerrarse para terminar de actualizar; haz clic para cerrarla, instalar y volver a abrirla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ doit quitter pour terminer la mise à jour — cliquez pour la quitter, installer, puis la rouvrir"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新を完了するには %@ を終了する必要があります — クリックすると終了・インストール・再度開くを行います"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ должно закрыться, чтобы завершить обновление — нажмите, чтобы закрыть, установить и открыть заново"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 必须退出才能完成更新 — 点击以退出、安装并重新打开"
+          }
+        }
+      }
+    },
+    "%@ updated to %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wurde auf %@ aktualisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ se actualizó a %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ a été mis à jour vers %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ は %@ に更新されました"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ обновлено до %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已更新至 %@"
+          }
+        }
+      }
+    },
+    "%@ · %lld bytes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld Byte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld bytes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld octets"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lldバイト"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld байт"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld 字节"
+          }
+        }
+      }
+    },
+    "%@ — click to retry": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – zum Wiederholen klicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@; haz clic para reintentar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — cliquez pour réessayer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — クリックして再試行"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — нажмите, чтобы повторить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — 点击重试"
+          }
+        }
+      }
+    },
+    "%@ → %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ → %@"
+          }
+        }
+      }
+    },
+    "%@, %@, and %lld more have updates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Für %@, %@ und %lld weitere ist ein Update verfügbar."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Für %@, %@ und %lld weitere sind Updates verfügbar."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%@, %@, and %lld more have an update."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%@, %@, and %lld more have updates."
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Hay actualizaciones para %@, %@ y %lld más."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Hay actualizaciones para %@, %@ y %lld más."
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Des mises à jour sont disponibles pour %@, %@ et %lld autre."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Des mises à jour sont disponibles pour %@, %@ et %lld autres."
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%@、%@、および他 %lld 件にアップデートがあります。"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Для %@, %@ и ещё %lld приложения доступны обновления."
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Для %@, %@ и ещё %lld приложений доступны обновления."
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Для %@, %@ и ещё %lld приложения доступно обновление."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Для %@, %@ и ещё %lld приложения доступны обновления."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%@、%@ 以及另外 %lld 个应用都有可用更新。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%@’s built-in updater": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "das integrierte Update-Tool von %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "el actualizador integrado de %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "le programme de mise à jour intégré de %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の内蔵更新機能"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "встроенный обновитель %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的内置更新程序"
+          }
+        }
+      }
+    },
+    "%lld apps couldn’t be checked — add a token": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App konnte nicht geprüft werden – Token hinzufügen"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps konnten nicht geprüft werden – Token hinzufügen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld app couldn’t be checked — add a token"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld apps couldn’t be checked — add a token"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No se pudo comprobar %lld app; añade un token"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No se pudieron comprobar %lld apps; añade un token"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld application n'a pas pu être vérifiée — ajoutez un jeton"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld applications n'ont pas pu être vérifiées — ajoutez un jeton"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 個のアプリを確認できませんでした — トークンを追加してください"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложения не удалось проверить — добавьте токен"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложений не удалось проверить — добавьте токен"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложение не удалось проверить — добавьте токен"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложения не удалось проверить — добавьте токен"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个应用无法检查 — 请添加令牌"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld apps were updated.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App wurde aktualisiert."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps wurden aktualisiert."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld app was updated."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld apps were updated."
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld app se actualizó."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld apps se actualizaron."
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld application a été mise à jour."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld applications ont été mises à jour."
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 個のアプリを更新しました。"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложения обновлено."
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложений обновлено."
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложение обновлено."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложения обновлено."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "已更新 %lld 个应用。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld apps · up to date": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App · aktuell"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps · aktuell"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld app · up to date"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld apps · up to date"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld app · actualizada"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld apps · actualizadas"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld application · à jour"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld applications · à jour"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 個のアプリ · 最新"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложения · актуально"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложений · актуально"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложение · актуально"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld приложения · актуально"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个应用 · 均为最新"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld brew packages outdated": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Brew-Paket veraltet"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Brew-Pakete veraltet"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld brew package outdated"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld brew packages outdated"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquete de brew desactualizado"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquetes de brew desactualizados"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquet brew obsolète"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquets brew obsolètes"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 件のbrewパッケージが古くなっています"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld пакета brew устарели"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld пакетов brew устарели"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld пакет brew устарел"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld пакета brew устарели"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个 brew 软件包已过期"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld bytes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Byte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld bytes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld octets"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldバイト"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld байт"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 字节"
+          }
+        }
+      }
+    },
+    "%lld releases": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Releases"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld release"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld releases"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld versión"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld versiones"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld version"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld versions"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 件のリリース"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld релиза"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld релизов"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld релиз"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld релиза"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 次发布"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld releases across %lld apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@releases@ auf %#@apps@ verteilt"
+          },
+          "substitutions": {
+            "apps": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld App"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld Apps"
+                    }
+                  }
+                }
+              }
+            },
+            "releases": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld Release"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld Releases"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@releases@ across %#@apps@"
+          },
+          "substitutions": {
+            "apps": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld app"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld apps"
+                    }
+                  }
+                }
+              }
+            },
+            "releases": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld release"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld releases"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@releases@ en %#@apps@"
+          },
+          "substitutions": {
+            "apps": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld app"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld apps"
+                    }
+                  }
+                }
+              }
+            },
+            "releases": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld versión"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld versiones"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@releases@ sur %#@apps@"
+          },
+          "substitutions": {
+            "apps": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld application"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld applications"
+                    }
+                  }
+                }
+              }
+            },
+            "releases": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld version"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld versions"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@apps@にわたる%#@releases@"
+          },
+          "substitutions": {
+            "apps": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld 個のアプリ"
+                    }
+                  }
+                }
+              }
+            },
+            "releases": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld 件のリリース"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@releases@ в %#@apps@"
+          },
+          "substitutions": {
+            "apps": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "few": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld приложениях"
+                    }
+                  },
+                  "many": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld приложениях"
+                    }
+                  },
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld приложении"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld приложении"
+                    }
+                  }
+                }
+              }
+            },
+            "releases": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "few": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld релиза"
+                    }
+                  },
+                  "many": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld релизов"
+                    }
+                  },
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld релиз"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld релиза"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@releases@，涉及 %#@apps@"
+          },
+          "substitutions": {
+            "apps": {
+              "argNum": 2,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld 个应用"
+                    }
+                  }
+                }
+              }
+            },
+            "releases": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld 次发布"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld top-level formulae · all current": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Formel oberster Ebene · alle aktuell"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Formeln oberster Ebene · alle aktuell"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld top-level formula · all current"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld top-level formulae · all current"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld fórmula de nivel superior · todas al día"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld fórmulas de nivel superior · todas al día"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld formule de premier niveau · toutes à jour"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld formules de premier niveau · toutes à jour"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "トップレベルフォーミュラ %lld 件 · すべて最新"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld формулы верхнего уровня · всё актуально"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld формул верхнего уровня · всё актуально"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld формула верхнего уровня · всё актуально"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld формулы верхнего уровня · всё актуально"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个顶层配方 · 均为最新"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld updates available": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Update verfügbar"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Updates verfügbar"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld update available"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld updates available"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld actualización disponible"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld actualizaciones disponibles"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld mise à jour disponible"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld mises à jour disponibles"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 件のアップデートが利用可能"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld обновления доступно"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld обновлений доступно"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld обновление доступно"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld обновления доступно"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个更新可用"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld%%": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld %%"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld %%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
+        }
+      }
+    },
+    "A few quick steps let Duo Updater keep your apps updated without interrupting you. You set these once — they persist across launches.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein paar kurze Schritte, damit Duo Updater deine Apps aktuell hält, ohne dich zu stören. Einmal eingerichtet, bleibt es über Neustarts hinweg erhalten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unos pocos pasos rápidos permiten que Duo Updater mantenga tus apps actualizadas sin molestarte. Se configuran una vez y se mantienen entre aperturas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quelques étapes rapides permettent à Duo Updater de maintenir vos applications à jour sans vous déranger. Réglez-les une fois — elles persistent d'un lancement à l'autre."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "いくつかの簡単な手順で、Duo Updaterが邪魔をせずにアプリを最新の状態に保てるようになります。一度設定すれば、以降の起動でも保持されます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Несколько быстрых шагов позволят Duo Updater обновлять ваши приложения, не отвлекая вас. Настройте один раз — параметры сохранятся между запусками."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "只需几个简单步骤，就能让 Duo Updater 在不打扰你的情况下保持应用更新。设置一次即可，之后每次启动都会保留。"
+          }
+        }
+      }
+    },
+    "A recipe is flagged when it fetched successfully but couldn’t read a version — often a sign the vendor changed their page. Cleared automatically on the next successful check.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Rezept wird markiert, wenn es erfolgreich abgerufen wurde, aber keine Version lesen konnte – oft ein Zeichen, dass der Anbieter seine Seite geändert hat. Wird bei der nächsten erfolgreichen Prüfung automatisch aufgehoben."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una receta se marca cuando se obtuvo correctamente pero no pudo leer una versión; suele indicar que el proveedor cambió su página. Se borra automáticamente en la siguiente comprobación exitosa."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une recette est signalée lorsqu'elle a été récupérée avec succès mais n'a pas pu lire de version — souvent le signe que l'éditeur a modifié sa page. Effacée automatiquement à la prochaine vérification réussie."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正常に取得できたもののバージョンを読み取れなかった場合、そのレシピにはフラグが付きます — これはベンダーがページを変更した兆候であることが多いです。次回の確認が成功すると自動的に解除されます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рецепт помечается, если он успешно получил ответ, но не смог прочитать версию — часто это признак того, что поставщик изменил свою страницу. Снимается автоматически при следующей успешной проверке."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当规则成功获取响应但无法读取版本时会被标记 — 这通常表示厂商更改了其页面。下次成功检查时会自动清除。"
+          }
+        }
+      }
+    },
+    "Accessibility needed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bedienungshilfen erforderlich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se necesita acceso de accesibilidad"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès requis (Accessibilité)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクセシビリティ権限が必要です"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нужен «Универсальный доступ»"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要辅助功能权限"
+          }
+        }
+      }
+    },
+    "Accounts": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuentas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comptes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アカウント"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аккаунты"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "账户"
+          }
+        }
+      }
+    },
+    "Across %lld recorded releases. Times in your local zone.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basierend auf %lld erfasstem Release. Zeiten in deiner Zeitzone."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basierend auf %lld erfassten Releases. Zeiten in deiner Zeitzone."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Across %lld recorded release. Times in your local zone."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Across %lld recorded releases. Times in your local zone."
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basado en %lld versión registrada. Horas en tu zona horaria local."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basado en %lld versiones registradas. Horas en tu zona horaria local."
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basé sur %lld version enregistrée. Heures dans votre fuseau local."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basé sur %lld versions enregistrées. Heures dans votre fuseau local."
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "記録された %lld 件のリリースに基づきます。時刻はお使いのタイムゾーンです。"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированных релизов. Время указано в вашем часовом поясе."
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированных релизов. Время указано в вашем часовом поясе."
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированного релиза. Время указано в вашем часовом поясе."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированного релиза. Время указано в вашем часовом поясе."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "基于已记录的 %lld 次发布。时间为你的本地时区。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Across %lld recorded releases. Times in your local zone. The pattern sharpens as this app ships more.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basierend auf %lld erfasstem Release. Zeiten in deiner Zeitzone. Das Muster wird schärfer, je mehr diese App veröffentlicht."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basierend auf %lld erfassten Releases. Zeiten in deiner Zeitzone. Das Muster wird schärfer, je mehr diese App veröffentlicht."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Across %lld recorded release. Times in your local zone. The pattern sharpens as this app ships more."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Across %lld recorded releases. Times in your local zone. The pattern sharpens as this app ships more."
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basado en %lld versión registrada. Horas en tu zona horaria local. El patrón se afina a medida que esta app publica más versiones."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basado en %lld versiones registradas. Horas en tu zona horaria local. El patrón se afina a medida que esta app publica más versiones."
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basé sur %lld version enregistrée. Heures dans votre fuseau local. La tendance s'affine à mesure que cette application publie davantage."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Basé sur %lld versions enregistrées. Heures dans votre fuseau local. La tendance s'affine à mesure que cette application publie davantage."
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "記録された %lld 件のリリースに基づきます。時刻はお使いのタイムゾーンです。このアプリが今後さらにリリースされるとパターンがより明確になります。"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированных релизов. Время указано в вашем часовом поясе. Закономерность станет чётче по мере новых выпусков."
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированных релизов. Время указано в вашем часовом поясе. Закономерность станет чётче по мере новых выпусков."
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированного релиза. Время указано в вашем часовом поясе. Закономерность станет чётче по мере новых выпусков."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "На основе %lld зафиксированного релиза. Время указано в вашем часовом поясе. Закономерность станет чётче по мере новых выпусков."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "基于已记录的 %lld 次发布。时间为你的本地时区。随着此应用发布更多版本，规律会更加清晰。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Active · instance …%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiv · Instanz …%@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activo · instancia …%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actif · instance …%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効 · インスタンス …%@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активно · экземпляр …%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用 · 实例 …%@"
+          }
+        }
+      }
+    },
+    "Add": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
+          }
+        }
+      }
+    },
+    "Add Folder…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordner hinzufügen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir carpeta…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter un dossier…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを追加…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить папку…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加文件夹…"
+          }
+        }
+      }
+    },
+    "Advanced — set instance ID manually": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erweitert – Instanz-ID manuell festlegen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avanzado: establecer el ID de instancia manualmente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avancé — définir l'ID d'instance manuellement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細設定 — インスタンスIDを手動で設定"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дополнительно — задать ID экземпляра вручную"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级 — 手动设置实例 ID"
+          }
+        }
+      }
+    },
+    "After an update": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach einem Update"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tras una actualización"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Après une mise à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新後"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "После обновления"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新后"
+          }
+        }
+      }
+    },
+    "After updating a running app, restart it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Restart” button.\n\nBackups keep one previous version of each app under Application Support, so an update can be undone. Retention is one backup per app — the previous version is replaced, not accumulated.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach dem Update einer laufenden App wird sie für dich neu gestartet, damit die neue Version wirksam wird – ohne zweiten Klick. Die App wird ganz normal zum Beenden aufgefordert, sodass Hinweise auf ungesicherte Arbeit weiterhin erscheinen; alles, was sich nicht beenden lässt, behält einfach seine Schaltfläche „Neu starten“.\n\nBackups bewahren eine vorherige Version jeder App unter Application Support auf, sodass ein Update rückgängig gemacht werden kann. Es wird ein Backup pro App aufbewahrt – die vorherige Version wird ersetzt, nicht angesammelt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tras actualizar una app en ejecución, se reinicia por ti para que la versión nueva surta efecto, sin un segundo clic. Se le pide a la app que se cierre con normalidad, así que los avisos de trabajo sin guardar siguen apareciendo, y cualquier app que no se cierre simplemente conserva su botón «Reiniciar».\n\nLas copias de seguridad conservan una versión anterior de cada app en Application Support, para poder deshacer una actualización. Se conserva una copia por app; la versión anterior se reemplaza, no se acumula."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Après la mise à jour d'une application en cours d'exécution, elle est redémarrée pour vous afin que la nouvelle version prenne effet — sans second clic. Il est demandé à l'application de quitter normalement, donc les invites de travail non enregistré apparaissent toujours, et tout ce qui ne quitte pas conserve simplement son bouton « Redémarrer ».\n\nLes sauvegardes conservent une version précédente de chaque application sous Application Support, afin qu'une mise à jour puisse être annulée. La rétention est d'une sauvegarde par application — la version précédente est remplacée, pas accumulée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中のアプリを更新した後、新しいバージョンを反映させるために自動的に再起動します — 追加のクリックは不要です。アプリには通常どおり終了が要求されるため、未保存の作業に関するプロンプトは引き続き表示され、終了しないものはその「再起動」ボタンを保持したままになります。\n\nバックアップは各アプリの直前のバージョンをApplication Support配下に1つ保持するため、更新を元に戻せます。保持数はアプリごとに1つで、直前のバージョンが置き換えられ、蓄積はされません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "После обновления запущенного приложения оно перезапускается автоматически, чтобы новая версия вступила в силу — без второго клика. Приложению отправляется обычный запрос на закрытие, поэтому подсказки о несохранённой работе по-прежнему появляются, а всё, что не закрывается, просто сохраняет свою кнопку «Перезапустить».\n\nРезервные копии хранят одну предыдущую версию каждого приложения в Application Support, поэтому обновление можно отменить. Хранится одна копия на приложение — предыдущая версия заменяется, а не накапливается."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新正在运行的应用后，会自动为你重启它，让新版本生效 — 无需再次点击。系统会正常请求该应用退出，因此未保存工作的提示仍会出现，任何拒绝退出的应用只会保留其“重启”按钮。\n\n备份会在“应用程序支持”中保留每个应用的一个先前版本，以便撤销更新。保留策略是每个应用一份备份 — 会替换先前版本，而不是不断累积。"
+          }
+        }
+      }
+    },
+    "Alcove": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove"
+          }
+        }
+      }
+    },
+    "Alcove keeps release notes and installable builds behind its license.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove verbirgt Versionshinweise und installierbare Builds hinter seiner Lizenz."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove mantiene las notas de versión y las compilaciones instalables tras su licencia."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove protège les notes de version et les versions installables derrière sa licence."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcoveはリリースノートとインストール可能なビルドをライセンスの背後に置いています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove скрывает заметки о выпуске и устанавливаемые сборки за лицензией."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove 将发行说明和可安装的版本置于许可证保护之下。"
+          }
+        }
+      }
+    },
+    "Alcove license key": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove-Lizenzschlüssel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clave de licencia de Alcove"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé de licence Alcove"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcoveライセンスキー"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лицензионный ключ Alcove"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove 许可证密钥"
+          }
+        }
+      }
+    },
+    "Alcove publishes release notes and installable builds only to its licensed update channel, so your license key (Alcove → Settings → License) is what unlocks changelogs and one-click updates here. It’s stored in the Keychain, never synced off this Mac, and only ever sent to api.tryalcove.com — the same place Alcove sends it. Without it, DuoUpdater still detects new Alcove versions, but can’t show what changed or install them for you — you’ll be sent to Alcove’s download page (or just let Alcove update itself).": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove veröffentlicht Versionshinweise und installierbare Builds nur in seinem lizenzierten Update-Kanal, daher ist es dein Lizenzschlüssel (Alcove → Settings → License), der hier Änderungsprotokolle und Ein-Klick-Updates freischaltet. Er wird im Schlüsselbund gespeichert, nie über diesen Mac hinaus synchronisiert und ausschließlich an api.tryalcove.com gesendet – denselben Ort, an den Alcove ihn auch sendet. Ohne ihn erkennt DuoUpdater weiterhin neue Alcove-Versionen, kann aber nicht zeigen, was sich geändert hat, oder sie für dich installieren – du wirst zur Download-Seite von Alcove geschickt (oder lässt Alcove sich einfach selbst aktualisieren)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove solo publica notas de versión y compilaciones instalables en su canal de actualización con licencia, así que tu clave de licencia (Alcove → Settings → License) es lo que desbloquea aquí los registros de cambios y las actualizaciones con un clic. Se guarda en el Llavero, nunca se sincroniza fuera de este Mac, y solo se envía a api.tryalcove.com, el mismo lugar al que la envía Alcove. Sin ella, DuoUpdater sigue detectando versiones nuevas de Alcove, pero no puede mostrar qué cambió ni instalarlas por ti; se te enviará a la página de descarga de Alcove (o puedes dejar que Alcove se actualice solo)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove ne publie ses notes de version et ses versions installables que sur son canal de mise à jour sous licence, c'est donc votre clé de licence (Alcove → Settings → License) qui débloque ici les journaux de modifications et les mises à jour en un clic. Elle est stockée dans le Trousseau, jamais synchronisée hors de ce Mac, et n'est envoyée qu'à api.tryalcove.com — le même endroit où Alcove l'envoie lui-même. Sans elle, DuoUpdater détecte toujours les nouvelles versions d'Alcove, mais ne peut pas afficher ce qui a changé ni les installer pour vous — vous serez redirigé vers la page de téléchargement d'Alcove (ou vous pouvez simplement laisser Alcove se mettre à jour lui-même)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcoveはライセンス済みの更新チャンネルにのみリリースノートとインストール可能なビルドを公開するため、ここで更新履歴とワンクリック更新を有効にするのはあなたのライセンスキー（Alcove → Settings → License）です。これはキーチェーンに保存され、このMac以外に同期されることはなく、api.tryalcove.com（Alcove自身が送信するのと同じ場所）にのみ送信されます。それがなくてもDuoUpdaterはAlcoveの新しいバージョンを検出できますが、変更内容の表示やインストールの代行はできません — Alcoveのダウンロードページに案内されるか、Alcove自身に更新させることになります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove публикует заметки о выпуске и устанавливаемые сборки только в своём лицензированном канале обновлений, поэтому именно ваш лицензионный ключ (Alcove → Settings → License) открывает здесь список изменений и одно-кликовые обновления. Он хранится в Keychain, никогда не синхронизируется за пределы этого Mac и отправляется только на api.tryalcove.com — туда же, куда его отправляет сам Alcove. Без него DuoUpdater по-прежнему обнаруживает новые версии Alcove, но не может показать, что изменилось, или установить их за вас — вас направят на страницу загрузки Alcove (или можно просто дать Alcove обновиться самому)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove 仅在其授权的更新渠道中发布发行说明和可安装的版本，因此正是你的许可证密钥（Alcove → Settings → License）解锁了这里的更新日志和一键更新功能。它保存在钥匙串中，绝不会同步到这台 Mac 之外，也只会发送到 api.tryalcove.com — 与 Alcove 本身发送的地址相同。没有它，DuoUpdater 仍能检测到 Alcove 的新版本，但无法显示更改内容或替你安装 — 你会被引导至 Alcove 的下载页面（或者干脆让 Alcove 自行更新）。"
+          }
+        }
+      }
+    },
+    "Alcove rejected this license key.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove hat diesen Lizenzschlüssel abgelehnt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove rechazó esta clave de licencia."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove a rejeté cette clé de licence."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcoveはこのライセンスキーを拒否しました。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove отклонил этот лицензионный ключ."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove 拒绝了此许可证密钥。"
+          }
+        }
+      }
+    },
+    "All apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Apps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les applications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのアプリ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有应用"
+          }
+        }
+      }
+    },
+    "All command-line formulae are current.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Kommandozeilen-Formeln sind aktuell."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todas las fórmulas de línea de comandos están actualizadas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les formules en ligne de commande sont à jour."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのコマンドライン用フォーミュラは最新です。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все формулы командной строки актуальны."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有命令行配方均为最新版本。"
+          }
+        }
+      }
+    },
+    "Always download & replace, then restart": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Immer herunterladen & ersetzen, dann neu starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar y reemplazar siempre, luego reiniciar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toujours télécharger et remplacer, puis redémarrer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常にダウンロードして置き換え、その後再起動する"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всегда загружать и заменять, затем перезапускать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "始终下载并替换，然后重启"
+          }
+        }
+      }
+    },
+    "Always scanned": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird immer gescannt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siempre explorado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toujours analysé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常にスキャン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всегда сканируется"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "始终扫描"
+          }
+        }
+      }
+    },
+    "App": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        }
+      }
+    },
+    "App Management": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Verwaltung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestión de apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestion des applications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appの管理"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Управление приложениями"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用管理"
+          }
+        }
+      }
+    },
+    "App Management lets Duo Updater replace apps updated outside the App Store (Sparkle, Homebrew, direct downloads). macOS can’t grant it programmatically — the button opens System Settings with a panel you drag DuoUpdater into.\n\nGranting through that panel doesn’t trigger the system’s usual “Quit & Reopen”, so a fresh grant may not take effect until DuoUpdater restarts. Use Relaunch below after granting.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„App-Verwaltung“ erlaubt es Duo Updater, Apps zu ersetzen, die außerhalb des App Stores aktualisiert werden (Sparkle, Homebrew, Direktdownloads). macOS kann dies nicht automatisch gewähren – die Schaltfläche öffnet die Systemeinstellungen mit einem Bereich, in den du DuoUpdater ziehst.\n\nDas Erteilen über diesen Bereich löst nicht das übliche „Beenden & erneut öffnen“ des Systems aus, daher wirkt eine neue Berechtigung möglicherweise erst nach einem Neustart von DuoUpdater. Nutze danach unten „Neu starten“."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«Gestión de apps» permite que Duo Updater reemplace apps actualizadas fuera de la App Store (Sparkle, Homebrew, descargas directas). macOS no puede concederlo mediante programación; el botón abre Ajustes del Sistema con un panel al que debes arrastrar DuoUpdater.\n\nConceder el permiso desde ese panel no activa el habitual «Salir y volver a abrir» del sistema, así que un permiso nuevo puede no surtir efecto hasta que reinicies DuoUpdater. Usa «Reabrir» abajo después de concederlo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "« Gestion des applications » permet à Duo Updater de remplacer les applications mises à jour en dehors de l'App Store (Sparkle, Homebrew, téléchargements directs). macOS ne peut pas l'accorder par programmation — le bouton ouvre les Réglages Système avec un panneau où glisser DuoUpdater.\n\nAccorder via ce panneau ne déclenche pas le « Quitter et rouvrir » habituel du système, donc une nouvelle autorisation peut ne prendre effet qu'au redémarrage de DuoUpdater. Utilisez « Relancer » ci-dessous après l'avoir accordée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「Appの管理」により、Duo UpdaterはApp Store以外で更新されるアプリ（Sparkle、Homebrew、直接ダウンロード）を置き換えられるようになります。macOSはこれをプログラムで許可することができません — このボタンをクリックすると、DuoUpdaterをドラッグするパネルとともにシステム設定が開きます。\n\nそのパネルから許可しても、システム通常の「終了して再度開く」はトリガーされないため、新しい許可はDuoUpdaterを再起動するまで反映されない場合があります。許可後は下の「再起動」を使用してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Управление приложениями позволяет Duo Updater заменять приложения, обновляемые вне App Store (Sparkle, Homebrew, прямые загрузки). macOS не может выдать это разрешение программно — кнопка открывает Системные настройки с панелью, куда нужно перетащить DuoUpdater.\n\nПредоставление через эту панель не вызывает обычное системное «Закрыть и открыть заново», поэтому новое разрешение может не вступить в силу до перезапуска DuoUpdater. Используйте «Перезапустить» ниже после предоставления доступа."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“应用管理”权限允许 Duo Updater 替换在 App Store 之外更新的应用（Sparkle、Homebrew、直接下载）。macOS 无法以编程方式授予该权限 — 此按钮会打开系统设置，其中有一个面板，你需要把 DuoUpdater 拖进去。\n\n通过该面板授权不会触发系统通常的“退出并重新打开”，因此新授权可能要等 DuoUpdater 重启后才会生效。授权后请使用下方的“重新启动”。"
+          }
+        }
+      }
+    },
+    "App Store": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store"
+          }
+        }
+      }
+    },
+    "App Store helper": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Store-Helper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asistente de la App Store"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistant App Store"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeヘルパー"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помощник App Store"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store 助理"
+          }
+        }
+      }
+    },
+    "App Store updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Store-Updates"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones de la App Store"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour de l'App Store"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeのアップデート"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновления App Store"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store 更新"
+          }
+        }
+      }
+    },
+    "App Store updates install through a background item that macOS asks you to approve once. Switch DuoUpdater on under Login Items & Extensions, then run the update again — after that it stays on and never asks for your password.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Store-Updates werden über ein Hintergrundelement installiert, das macOS dich einmal zu bestätigen bittet. Schalte DuoUpdater unter „Anmeldeobjekte & Erweiterungen“ ein und führe das Update erneut aus – danach bleibt es aktiviert und fragt nie wieder nach deinem Passwort."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las actualizaciones de la App Store se instalan mediante un elemento en segundo plano que macOS te pide aprobar una vez. Activa DuoUpdater en «Elementos de inicio de sesión y extensiones» y vuelve a ejecutar la actualización; después permanecerá activado y no volverá a pedirte la contraseña."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les mises à jour de l'App Store s'installent via un élément en arrière-plan que macOS vous demande d'approuver une fois. Activez DuoUpdater dans « Éléments de connexion et extensions », puis relancez la mise à jour — il restera ensuite activé et ne redemandera plus votre mot de passe."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeのアップデートは、macOSが一度だけ承認を求めるバックグラウンド項目を通じてインストールされます。「ログイン項目と機能拡張」でDuoUpdaterをオンにしてから、もう一度更新を実行してください — 以降はオンのままになり、パスワードを尋ねられることはありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновления App Store устанавливаются через фоновый элемент, который macOS просит подтвердить один раз. Включите DuoUpdater в разделе «Объекты входа и расширения», затем повторите обновление — после этого он останется включённым и больше не запросит пароль."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store 更新通过一个后台项目安装，macOS 会要求你批准一次。请在“登录项与扩展”中开启 DuoUpdater，然后重新运行更新 — 之后它会保持开启，不再询问密码。"
+          }
+        }
+      }
+    },
+    "App Store updates need it — finish setup": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für App-Store-Updates erforderlich – Einrichtung abschließen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Necesario para las actualizaciones de la App Store: termina la configuración"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nécessaire pour les mises à jour de l'App Store — terminez la configuration"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store のアップデートに必要です — セットアップを完了してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нужен для обновлений App Store — завершите настройку"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store 更新需要它 — 请完成设置"
+          }
+        }
+      }
+    },
+    "Apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        }
+      }
+    },
+    "Apps and versions you've told Duo Updater to leave alone.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps und Versionen, die du Duo Updater in Ruhe zu lassen gebeten hast."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps y versiones que le has pedido a Duo Updater que no toque."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applications et versions que vous avez demandé à Duo Updater de laisser tranquilles."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaterに手を付けないよう指示したアプリとバージョン。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложения и версии, которые вы попросили Duo Updater не трогать."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已告知 Duo Updater 不做处理的应用和版本。"
+          }
+        }
+      }
+    },
+    "As the apps you track publish updates, each release is recorded here. Sparkle, GitHub and Alcove come with an exact publish time; other apps get an estimated “≈” window from when we spot the change. The Patterns view uses only the exact ones.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sobald die verfolgten Apps Updates veröffentlichen, wird jedes Release hier aufgezeichnet. Sparkle, GitHub und Alcove liefern eine genaue Veröffentlichungszeit; bei anderen Apps gibt es ein geschätztes „≈“-Zeitfenster ab dem Moment, in dem wir die Änderung bemerkt haben. Die Muster-Ansicht verwendet nur die genauen Werte."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A medida que las apps que sigues publican actualizaciones, cada versión se registra aquí. Sparkle, GitHub y Alcove incluyen una hora de publicación exacta; el resto de apps recibe una ventana estimada «≈» a partir del momento en que detectamos el cambio. La vista Patrones solo usa los datos exactos."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Au fur et à mesure que les applications suivies publient des mises à jour, chaque version est enregistrée ici. Sparkle, GitHub et Alcove fournissent une heure de publication exacte ; les autres applications reçoivent une fenêtre estimée « ≈ » à partir du moment où le changement a été détecté. La vue Tendances n'utilise que les valeurs exactes."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追跡しているアプリが更新を公開すると、各リリースがここに記録されます。Sparkle、GitHub、Alcoveには正確な公開時刻がありますが、それ以外のアプリでは変更を検知した時点からの推定「≈」の範囲になります。パターンビューでは正確なもののみを使用します。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По мере выхода обновлений отслеживаемых приложений каждый релиз записывается здесь. У Sparkle, GitHub и Alcove есть точное время публикации; для остальных приложений используется оценочное окно «≈» на основе момента обнаружения изменения. Вид «Закономерности» использует только точные данные."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "随着你关注的应用发布更新，每次发布都会记录在这里。Sparkle、GitHub 和 Alcove 会附带确切的发布时间；其他应用则根据我们检测到变化的时间给出估计的“≈”区间。“规律”视图仅使用确切的数据。"
+          }
+        }
+      }
+    },
+    "Ask for administrator access again": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Administratorzugriff erneut anfordern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a solicitar acceso de administrador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redemander l'accès administrateur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理者権限をもう一度要求"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запросить права администратора снова"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新请求管理员权限"
+          }
+        }
+      }
+    },
+    "Ask the helper to answer — tells you whether App Store updates can actually run right now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den Helper zur Antwort auffordern – zeigt, ob App-Store-Updates gerade tatsächlich laufen können"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pedir respuesta al asistente; indica si las actualizaciones de la App Store pueden ejecutarse ahora mismo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demander à l'assistant de répondre — indique si les mises à jour de l'App Store peuvent réellement s'exécuter maintenant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーに応答させます — App Storeのアップデートが実際に今すぐ実行できるかどうかを確認します"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запросить ответ у помощника — покажет, могут ли обновления App Store сейчас действительно выполняться"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请求助理响应 — 用于确认 App Store 更新当前是否真的可以运行"
+          }
+        }
+      }
+    },
+    "Backups are using %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups belegen %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias de seguridad usan %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les sauvegardes utilisent %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップの使用容量: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Резервные копии занимают %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份占用 %@"
+          }
+        }
+      }
+    },
+    "Brew": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brew"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brew"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brew"
+          }
+        }
+      }
+    },
+    "Built-in locations — these are always included and can’t be removed.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integrierte Orte – sind immer enthalten und können nicht entfernt werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicaciones integradas: siempre incluidas y no se pueden quitar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacements intégrés — toujours inclus et impossibles à supprimer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組み込みの場所 — 常に含まれており、削除できません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встроенные расположения — всегда включены и не могут быть удалены."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内置位置 — 始终包含在内，无法移除。"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "Change": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ändern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改"
+          }
+        }
+      }
+    },
+    "Changelog": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungsprotokoll"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro de cambios"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journal des modifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新履歴"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Список изменений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新日志"
+          }
+        }
+      }
+    },
+    "Check": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查"
+          }
+        }
+      }
+    },
+    "Check for DuoUpdater Updates…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach DuoUpdater-Updates suchen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones de DuoUpdater…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des mises à jour de DuoUpdater…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DuoUpdaterのアップデートを確認…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить обновления DuoUpdater…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查 DuoUpdater 更新…"
+          }
+        }
+      }
+    },
+    "Check for Updates…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des mises à jour…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить обновления…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新…"
+          }
+        }
+      }
+    },
+    "Check for updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher les mises à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新を確認"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверять обновления"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        }
+      }
+    },
+    "Check now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jetzt prüfen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobar ahora"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier maintenant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐ確認"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить сейчас"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即检查"
+          }
+        }
+      }
+    },
+    "Check up to %lld apps at once": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Bis zu %lld App gleichzeitig prüfen"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Bis zu %lld Apps gleichzeitig prüfen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Check up to %lld app at once"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Check up to %lld apps at once"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Comprobar hasta %lld app a la vez"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Comprobar hasta %lld apps a la vez"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vérifier jusqu'à %lld application à la fois"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vérifier jusqu'à %lld applications à la fois"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "一度に最大 %lld 個のアプリを確認"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверять до %lld приложений одновременно"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверять до %lld приложений одновременно"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверять до %lld приложения одновременно"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверять до %lld приложения одновременно"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "同时检查最多 %lld 个应用"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Checking": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprüft"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查"
+          }
+        }
+      }
+    },
+    "Checking %lld apps…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld App wird geprüft …"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Apps werden geprüft …"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Checking %lld app…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Checking %lld apps…"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Comprobando %lld app…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Comprobando %lld apps…"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vérification de %lld application…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Vérification de %lld applications…"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 個のアプリを確認中…"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверка %lld приложений…"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверка %lld приложений…"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверка %lld приложения…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Проверка %lld приложения…"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "正在检查 %lld 个应用…"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Checking Homebrew…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew wird geprüft …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando Homebrew…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification de Homebrew…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew を確認中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка Homebrew…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 Homebrew…"
+          }
+        }
+      }
+    },
+    "Checking the gh CLI…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gh CLI wird geprüft …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando gh CLI…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification de gh CLI…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gh CLI を確認中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка gh CLI…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 gh CLI…"
+          }
+        }
+      }
+    },
+    "Checking…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprüft …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查…"
+          }
+        }
+      }
+    },
+    "Choose a folder that contains apps to check for updates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle einen Ordner mit Apps aus, die auf Updates geprüft werden sollen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una carpeta que contenga apps para buscar actualizaciones."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez un dossier contenant des applications à vérifier."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新を確認したいアプリが含まれるフォルダを選択してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите папку с приложениями, которые нужно проверять на обновления."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个包含应用的文件夹以检查更新。"
+          }
+        }
+      }
+    },
+    "Clean Up…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufräumen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyer…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリーンアップ…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理…"
+          }
+        }
+      }
+    },
+    "Cleaning up…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aufgeräumt …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyage en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリーンアップ中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистка…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在清理…"
+          }
+        }
+      }
+    },
+    "Clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消去"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
+          }
+        }
+      }
+    },
+    "Connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続済み"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接"
+          }
+        }
+      }
+    },
+    "Continue only if it’s free or your license covers the new version. Your current version is moved to the Trash, so you can restore it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fahre nur fort, wenn sie kostenlos ist oder deine Lizenz die neue Version abdeckt. Deine aktuelle Version wird in den Papierkorb verschoben, sodass du sie wiederherstellen kannst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continúa solo si es gratis o tu licencia cubre la versión nueva. Tu versión actual se mueve a la Papelera, así que podrás restaurarla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne continuez que si c'est gratuit ou si votre licence couvre la nouvelle version. Votre version actuelle est déplacée vers la Corbeille, vous pourrez donc la restaurer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無料の場合、またはライセンスが新しいバージョンをカバーしている場合のみ続行してください。現在のバージョンはゴミ箱に移動されるため、元に戻すことができます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжайте, только если это бесплатно или ваша лицензия покрывает новую версию. Текущая версия перемещается в Корзину, поэтому вы сможете её восстановить."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅当它是免费的，或你的许可证覆盖新版本时才继续。当前版本会被移到废纸篓，因此你可以还原它。"
+          }
+        }
+      }
+    },
+    "Couldn't load the release notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versionshinweise konnten nicht geladen werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron cargar las notas de la versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de charger les notes de version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リリースノートを読み込めませんでした"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось загрузить заметки о выпуске"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法加载发行说明"
+          }
+        }
+      }
+    },
+    "Couldn’t reach Alcove: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcove konnte nicht erreicht werden: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo conectar con Alcove: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de joindre Alcove : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcoveに接続できませんでした: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось связаться с Alcove: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接到 Alcove：%@"
+          }
+        }
+      }
+    },
+    "Couldn’t verify: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnte nicht geprüft werden: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo verificar: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de vérifier : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証できませんでした: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось проверить: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法验证：%@"
+          }
+        }
+      }
+    },
+    "Defer to the app’s own updater while it’s running": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solange die App läuft, dem eigenen Update-Tool der App den Vortritt lassen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dejar que el propio actualizador de la app actúe mientras se está ejecutando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laisser l'outil de mise à jour propre à l'application faire son travail pendant qu'elle est ouverte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中はアプリ自身の更新機能に任せる"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Полагаться на встроенный обновитель приложения, пока оно запущено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用运行时优先使用其自身的更新程序"
+          }
+        }
+      }
+    },
+    "Delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
+          }
+        }
+      }
+    },
+    "Delete %@ (%@)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ löschen (%@)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar %@ (%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer %@ (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 件を削除（%@）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить %@ (%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 %@（%@）"
+          }
+        }
+      }
+    },
+    "Delete a backup once its app is uninstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup löschen, sobald die zugehörige App deinstalliert wurde"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar la copia de seguridad cuando se desinstale la app"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer une sauvegarde une fois l'application désinstallée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリがアンインストールされたらバックアップを削除する"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалять резервную копию после удаления приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用卸载后删除其备份"
+          }
+        }
+      }
+    },
+    "Delete backups": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar copias de seguridad"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les sauvegardes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップを削除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить резервные копии"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除备份"
+          }
+        }
+      }
+    },
+    "Deselect All": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle abwählen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deseleccionar todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout désélectionner"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての選択を解除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снять выделение со всех"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消全选"
+          }
+        }
+      }
+    },
+    "Detection recipes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erkennungs-Rezepte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recetas de detección"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recettes de détection"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検出レシピ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рецепты обнаружения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测规则"
+          }
+        }
+      }
+    },
+    "Diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostic"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Диагностика"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "诊断"
+          }
+        }
+      }
+    },
+    "Don’t skip %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nicht überspringen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No omitir %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne pas ignorer %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をスキップしない"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не пропускать %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不要跳过 %@"
+          }
+        }
+      }
+    },
+    "Download and install %@ %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ herunterladen und installieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar e instalar %@ %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger et installer %@ %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ をダウンロードしてインストール"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузить и установить %@ %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载并安装 %@ %@"
+          }
+        }
+      }
+    },
+    "Downloading %@ — %lld%%": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wird heruntergeladen – %lld %%"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargando %@: %lld %%"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement de %@ — %lld %%"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をダウンロード中 — %lld%%"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка %@ — %lld%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载 %@ — %lld%%"
+          }
+        }
+      }
+    },
+    "Downloading…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird heruntergeladen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在下载…"
+          }
+        }
+      }
+    },
+    "Downloads the official installer and opens it (asks for admin)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lädt das offizielle Installationsprogramm herunter und öffnet es (erfordert Administratorrechte)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga el instalador oficial y lo abre (pide permisos de administrador)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharge l'installateur officiel et l'ouvre (demande les droits admin)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公式インストーラーをダウンロードして開きます（管理者権限が必要）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загружает официальный установщик и открывает его (потребуются права администратора)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载官方安装程序并打开（需要管理员权限）"
+          }
+        }
+      }
+    },
+    "Duo Updater": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater"
+          }
+        }
+      }
+    },
+    "Duo Updater checks for its own updates hourly on its own. Left off, a new version puts up a prompt and waits for you.\n\nTurned on, it is downloaded and then applied at a quiet moment — no prompt, no clicking. A quiet moment means nothing is being checked or installed, no window of Duo Updater's is open, and you are working in another app; it restarts itself there. Until such a moment comes it simply waits, and installs when you quit Duo Updater anyway.\n\nThe button below forces a check right now either way.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater prüft eigenständig stündlich auf eigene Updates. Ausgeschaltet zeigt eine neue Version eine Aufforderung an und wartet auf dich.\n\nEingeschaltet wird sie heruntergeladen und dann in einem ruhigen Moment angewendet – ohne Aufforderung, ohne Klicken. Ein ruhiger Moment bedeutet: Es wird nichts geprüft oder installiert, kein Fenster von Duo Updater ist geöffnet, und du arbeitest in einer anderen App; dort startet es sich selbst neu. Bis ein solcher Moment kommt, wartet es einfach und installiert ohnehin, wenn du Duo Updater beendest.\n\nDie Schaltfläche unten erzwingt in jedem Fall sofort eine Prüfung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater comprueba sus propias actualizaciones cada hora por su cuenta. Si está desactivado, una versión nueva muestra un aviso y espera tu acción.\n\nSi está activado, se descarga y luego se aplica en un momento tranquilo, sin avisos ni clics. Un momento tranquilo significa que no se está comprobando ni instalando nada, que no hay ninguna ventana de Duo Updater abierta y que estás trabajando en otra app; entonces se reinicia por sí solo. Hasta que llegue ese momento, simplemente espera, e instala de todos modos cuando cierras Duo Updater.\n\nEl botón de abajo fuerza una comprobación ahora mismo en cualquier caso."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater vérifie lui-même ses propres mises à jour toutes les heures. Désactivé, une nouvelle version affiche une invite et attend votre action.\n\nActivé, elle est téléchargée puis appliquée à un moment calme — sans invite, sans clic. Un moment calme signifie que rien n'est en cours de vérification ni d'installation, qu'aucune fenêtre de Duo Updater n'est ouverte, et que vous travaillez dans une autre application ; il se redémarre alors lui-même. Tant qu'un tel moment n'arrive pas, il attend simplement et s'installe de toute façon quand vous quittez Duo Updater.\n\nLe bouton ci-dessous force une vérification immédiate dans tous les cas."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaterは1時間ごとに自身の更新を自動的に確認します。オフの場合、新しいバージョンがあるとプロンプトが表示され、あなたの操作を待ちます。\n\nオンの場合、静かなタイミングでダウンロードされ適用されます — プロンプトもクリックも不要です。静かなタイミングとは、何も確認やインストールが行われておらず、Duo Updaterのウインドウが開かれておらず、あなたが他のアプリで作業していることを意味し、その際に自身を再起動します。そのタイミングが来るまでは単に待機し、いずれにせよDuo Updaterを終了したときにインストールされます。\n\n下のボタンは、いずれの場合も今すぐ確認を強制します。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater самостоятельно проверяет собственные обновления каждый час. Если выключено, новая версия показывает подсказку и ждёт вас.\n\nЕсли включено, обновление загружается и применяется в тихий момент — без подсказок и кликов. Тихий момент означает, что ничего не проверяется и не устанавливается, ни одно окно Duo Updater не открыто, а вы работаете в другом приложении; он перезапускается сам. Пока такой момент не наступит, он просто ждёт и устанавливает обновление, когда вы всё равно закрываете Duo Updater.\n\nКнопка ниже принудительно запускает проверку прямо сейчас в любом случае."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater 会每小时自行检查自身的更新。关闭时，新版本会弹出提示并等待你操作。\n\n开启后，会在安静的时刻下载并应用更新 — 无提示、无需点击。安静的时刻是指没有正在进行的检查或安装、没有打开任何 Duo Updater 窗口，并且你正在其他应用中工作；届时它会自行重启。在这样的时刻到来之前它只会等待，并在你退出 Duo Updater 时顺便安装。\n\n无论如何，下方的按钮都会立即强制检查一次。"
+          }
+        }
+      }
+    },
+    "Duo Updater runs from the menu bar only. The pending-update count moves to the menu-bar icon — the Dock badge needs a Dock icon to sit on.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater läuft nur über die Menüleiste. Die Anzahl ausstehender Updates wandert zum Menüleistensymbol – das Dock-Abzeichen braucht ein Dock-Symbol, auf dem es sitzen kann."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater solo funciona desde la barra de menús. El contador de actualizaciones pendientes pasa al icono de la barra de menús; la insignia del Dock necesita un icono del Dock donde ubicarse."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater fonctionne uniquement depuis la barre de menus. Le nombre de mises à jour en attente se déplace vers l'icône de la barre de menus — le badge du Dock a besoin d'une icône de Dock sur laquelle s'afficher."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaterはメニューバーからのみ動作します。保留中の更新件数はメニューバーアイコンに表示されます — Dockバッジを表示するにはDockアイコンが必要です。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater работает только из строки меню. Счётчик ожидающих обновлений переходит на значок в строке меню — значку в Dock нужен сам значок Dock, на котором отображаться."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater 仅在菜单栏中运行。待处理更新数会显示在菜单栏图标上 — Dock 角标需要有 Dock 图标才能显示。"
+          }
+        }
+      }
+    },
+    "Duo Updater updated itself to %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater hat sich selbst auf %@ aktualisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater se actualizó a %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater s'est mis à jour vers %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater は %@ に自己更新しました"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater обновился до версии %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater 已自我更新至 %@"
+          }
+        }
+      }
+    },
+    "Duo Updater updates itself separately from the managed app list, through Sparkle-signed direct downloads.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater aktualisiert sich getrennt von der verwalteten App-Liste über von Sparkle signierte Direktdownloads."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater se actualiza por separado de la lista de apps gestionadas, mediante descargas directas firmadas con Sparkle."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater se met à jour séparément de la liste des applications gérées, via des téléchargements directs signés par Sparkle."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaterは管理対象アプリの一覧とは別に、Sparkle署名済みの直接ダウンロードによって自身を更新します。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater обновляет себя отдельно от списка управляемых приложений через прямые загрузки, подписанные Sparkle."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater 通过 Sparkle 签名的直接下载来更新自身，与受管理的应用列表分开处理。"
+          }
+        }
+      }
+    },
+    "Duo Updater's own version.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die eigene Version von Duo Updater."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La propia versión de Duo Updater."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La version de Duo Updater lui-même."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater自体のバージョン。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Собственная версия Duo Updater."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater 自身的版本。"
+          }
+        }
+      }
+    },
+    "Each backup lets one update be rolled back. Deleting it frees the space and gives up that option — the app itself is untouched.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jedes Backup ermöglicht das Zurücksetzen eines Updates. Es zu löschen gibt Speicherplatz frei, verzichtet aber auf diese Option – die App selbst bleibt unberührt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada copia de seguridad permite revertir una actualización. Eliminarla libera espacio y renuncia a esa opción; la app en sí no se ve afectada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chaque sauvegarde permet d'annuler une mise à jour. La supprimer libère de l'espace mais fait perdre cette option — l'application elle-même n'est pas touchée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各バックアップにより1回分の更新をロールバックできます。削除すると容量は解放されますがそのオプションは失われます — アプリ自体には影響しません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждая резервная копия позволяет откатить одно обновление. Удаление освобождает место и лишает этой возможности — само приложение не затрагивается."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个备份都可用于回滚一次更新。删除它会释放空间并放弃该选项 — 应用本身不受影响。"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用"
+          }
+        }
+      }
+    },
+    "Enable…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にする…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用…"
+          }
+        }
+      }
+    },
+    "Every 30 minutes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle 30 Minuten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada 30 minutos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les 30 minutes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30分ごと"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждые 30 минут"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每 30 分钟"
+          }
+        }
+      }
+    },
+    "Every 5 minutes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle 5 Minuten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada 5 minutos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les 5 minutes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5分ごと"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждые 5 минут"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每 5 分钟"
+          }
+        }
+      }
+    },
+    "Every 6 hours": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle 6 Stunden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada 6 horas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les 6 heures"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "6時間ごと"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждые 6 часов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每 6 小时"
+          }
+        }
+      }
+    },
+    "Every hour": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jede Stunde"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cada hora"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les heures"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1時間ごと"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждый час"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每小时"
+          }
+        }
+      }
+    },
+    "Everything is up to date": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ist auf dem neuesten Stand"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo está actualizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout est à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて最新の状態です"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё обновлено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有内容均为最新"
+          }
+        }
+      }
+    },
+    "Extracting": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird entpackt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extrayendo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extraction en cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Распаковка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在解压"
+          }
+        }
+      }
+    },
+    "Failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehlgeschlagen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fallo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失敗"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失败"
+          }
+        }
+      }
+    },
+    "Fewer": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weniger"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moins"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "少ない"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Меньше"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "较少"
+          }
+        }
+      }
+    },
+    "Folder not found — it may have moved or been deleted.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordner nicht gefunden – er wurde möglicherweise verschoben oder gelöscht."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la carpeta; puede que se haya movido o eliminado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dossier introuvable — il a peut-être été déplacé ou supprimé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダが見つかりません — 移動または削除された可能性があります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Папка не найдена — возможно, она перемещена или удалена."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到文件夹 — 它可能已被移动或删除。"
+          }
+        }
+      }
+    },
+    "Folders": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordner"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpetas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dossiers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Папки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件夹"
+          }
+        }
+      }
+    },
+    "Folders to scan": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zu durchsuchende Ordner"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carpetas a explorar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dossiers à analyser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキャンするフォルダ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Папки для сканирования"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要扫描的文件夹"
+          }
+        }
+      }
+    },
+    "For apps that ship their own updater (Office, Teams, OneDrive, Edge, Chrome, VS Code, …). “Always replace” — the default — downloads the vendor’s own installer and applies it whether or not the app is running, quitting and relaunching it afterwards. Switch to “Defer while running” if you would rather nothing touched an app while it is open: it then installs only when the app is closed, and offers an Open button instead while it is running, leaving the update to the app itself.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für Apps mit eigenem Update-Tool (Office, Teams, OneDrive, Edge, Chrome, VS Code, …). „Immer ersetzen“ (Standard) lädt das eigene Installationsprogramm des Anbieters herunter und wendet es an, egal ob die App läuft oder nicht, und beendet und startet sie danach neu. Wechsle zu „Zurückstellen, solange geöffnet“, wenn du möchtest, dass eine geöffnete App unangetastet bleibt: Dann wird nur installiert, wenn die App geschlossen ist, und solange sie läuft, wird stattdessen eine Öffnen-Schaltfläche angeboten, sodass das Update der App selbst überlassen bleibt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para apps con su propio actualizador (Office, Teams, OneDrive, Edge, Chrome, VS Code…). «Reemplazar siempre» (predeterminado) descarga el propio instalador del proveedor y lo aplica esté la app en ejecución o no, cerrándola y reabriéndola después. Cambia a «Aplazar mientras se ejecuta» si prefieres que nada toque una app mientras está abierta: entonces solo se instala cuando la app está cerrada, y mientras se ejecuta se ofrece un botón Abrir en su lugar, dejando la actualización a la propia app."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour les applications dotées de leur propre outil de mise à jour (Office, Teams, OneDrive, Edge, Chrome, VS Code…). « Toujours remplacer » (par défaut) télécharge l'installateur propre à l'éditeur et l'applique que l'application soit en cours d'exécution ou non, puis la quitte et la relance ensuite. Passez à « Différer pendant l'exécution » si vous préférez que rien ne touche une application pendant qu'elle est ouverte : elle n'est alors installée que lorsque l'application est fermée, et un bouton Ouvrir est proposé à la place tant qu'elle est en cours d'exécution, laissant la mise à jour à l'application elle-même."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "独自の更新プログラムを備えたアプリ（Office、Teams、OneDrive、Edge、Chrome、VS Codeなど）向けです。「常に置き換える」（デフォルト）は、アプリが実行中かどうかにかかわらずベンダー自身のインストーラーをダウンロードして適用し、その後アプリを終了して再度開きます。アプリが開いている間は何も手を加えたくない場合は「実行中は延期」に切り替えてください。その場合、アプリが閉じられたときにのみインストールされ、実行中は代わりに「開く」ボタンが表示され、更新はアプリ自身に委ねられます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для приложений с собственным обновителем (Office, Teams, OneDrive, Edge, Chrome, VS Code…). «Всегда заменять» (по умолчанию) — загружает собственный установщик поставщика и применяет его независимо от того, запущено ли приложение, после чего закрывает его и открывает заново. Переключитесь на «Отложить, пока запущено», если предпочитаете, чтобы ничего не трогало открытое приложение: тогда установка происходит только после закрытия приложения, а пока оно запущено, предлагается кнопка «Открыть», оставляя обновление самому приложению."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "适用于自带更新程序的应用（Office、Teams、OneDrive、Edge、Chrome、VS Code 等）。“始终替换”（默认）会下载厂商自己的安装程序，无论应用是否在运行都会应用它，之后再退出并重新打开该应用。如果你希望应用打开时不被触碰，请切换为“运行时延后”：这样只会在应用关闭后才安装，运行期间则改为提供“打开”按钮，把更新交给应用自己处理。"
+          }
+        }
+      }
+    },
+    "Full download (no extra permission)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vollständiger Download (keine zusätzliche Berechtigung)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descarga completa (sin permisos adicionales)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléchargement complet (aucune permission supplémentaire)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全ダウンロード（追加の権限は不要）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Полная загрузка (без доп. разрешений)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整下载（无需额外权限）"
+          }
+        }
+      }
+    },
+    "General": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основные"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
+          }
+        }
+      }
+    },
+    "Get Started": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los geht's"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empezar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commencer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "はじめる"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始使用"
+          }
+        }
+      }
+    },
+    "GitHub": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        }
+      }
+    },
+    "GitHub CLI integration": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub-CLI-Integration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integración con GitHub CLI"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intégration GitHub CLI"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI 連携"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Интеграция с GitHub CLI"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI 集成"
+          }
+        }
+      }
+    },
+    "GitHub CLI is authenticated and ready.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI ist angemeldet und einsatzbereit."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI está autenticado y listo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI est authentifié et prêt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLIは認証済みで使用できます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI авторизован и готов к работе."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI 已通过身份验证，可以使用。"
+          }
+        }
+      }
+    },
+    "GitHub CLI is installed but not signed in. Run `gh auth login`, or paste a token below.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI ist installiert, aber nicht angemeldet. Führe `gh auth login` aus oder füge unten ein Token ein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI está instalado pero no has iniciado sesión. Ejecuta `gh auth login` o pega un token abajo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI est installé mais vous n'êtes pas connecté. Exécutez `gh auth login`, ou collez un jeton ci-dessous."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLIはインストール済みですが、サインインしていません。`gh auth login` を実行するか、下にトークンを貼り付けてください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI установлен, но вы не вошли в систему. Выполните `gh auth login` или вставьте токен ниже."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装 GitHub CLI，但尚未登录。请运行 `gh auth login`，或在下方粘贴令牌。"
+          }
+        }
+      }
+    },
+    "GitHub CLI isn’t installed. Paste a personal access token below to lift the rate limit.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI ist nicht installiert. Füge unten ein persönliches Zugriffstoken ein, um das Ratenlimit aufzuheben."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI no está instalado. Pega un token de acceso personal abajo para eliminar el límite de solicitudes."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI n'est pas installé. Collez un jeton d'accès personnel ci-dessous pour lever la limite de requêtes."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLIはインストールされていません。下にパーソナルアクセストークンを貼り付けるとレート制限が解除されます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI не установлен. Вставьте личный токен доступа ниже, чтобы снять ограничение частоты запросов."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未安装 GitHub CLI。请在下方粘贴个人访问令牌以解除请求限制。"
+          }
+        }
+      }
+    },
+    "GitHub access": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub-Zugriff"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso a GitHub"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès à GitHub"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubアクセス"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступ к GitHub"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub 访问权限"
+          }
+        }
+      }
+    },
+    "GitHub answered HTTP %lld.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub antwortete mit HTTP %lld."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub respondió con HTTP %lld."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub a répondu HTTP %lld."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubからHTTP %lldが返されました。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub ответил HTTP %lld."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub 返回了 HTTP %lld。"
+          }
+        }
+      }
+    },
+    "GitHub token — or ": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub-Token – oder "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token de GitHub, o "
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeton GitHub — ou "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubトークン — または "
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Токен GitHub — или "
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub 令牌 — 或 "
+          }
+        }
+      }
+    },
+    "Granted": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erteilt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concedido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "許可済み"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставлено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已授予"
+          }
+        }
+      }
+    },
+    "Grant…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erteilen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conceder…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "許可する…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставить…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予…"
+          }
+        }
+      }
+    },
+    "Hidden from update checks — right-click to stop ignoring": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von Update-Prüfungen ausgeschlossen – Rechtsklick, um das Ignorieren zu beenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculto de las comprobaciones de actualización; clic derecho para dejar de ignorar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masqué des vérifications de mise à jour — clic droit pour arrêter d'ignorer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新チェックから除外されています — 右クリックで無視を解除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыто от проверок обновлений — щёлкните правой кнопкой, чтобы перестать игнорировать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已从更新检查中隐藏 — 右键点击以取消忽略"
+          }
+        }
+      }
+    },
+    "Hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausblenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隠す"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏"
+          }
+        }
+      }
+    },
+    "Hide the Dock icon": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock-Symbol ausblenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar el icono del Dock"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer l'icône du Dock"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dockアイコンを非表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть значок в Dock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏 Dock 图标"
+          }
+        }
+      }
+    },
+    "Hide token": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token ausblenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar token"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer le jeton"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トークンを隠す"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть токен"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏令牌"
+          }
+        }
+      }
+    },
+    "Hitting GitHub’s rate limit": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub-Ratenlimit erreicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se alcanzó el límite de solicitudes de GitHub"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite de requêtes GitHub atteinte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub のレート制限に達しています"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Достигнут лимит запросов GitHub"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已达到 GitHub 的请求限制"
+          }
+        }
+      }
+    },
+    "Homebrew doesn’t publish notes for %@, and it isn’t a GitHub release we can read.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew veröffentlicht keine Hinweise für %@, und es ist kein lesbares GitHub-Release."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew no publica notas para %@, y no es una versión de GitHub que podamos leer."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew ne publie pas de notes pour %@, et ce n'est pas une version GitHub que nous pouvons lire."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrewは %@ のノートを公開しておらず、読み取り可能なGitHubリリースでもありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew не публикует заметки для %@, и это не релиз GitHub, который можно прочитать."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 未发布 %@ 的说明，它也不是我们可以读取的 GitHub 发行版。"
+          }
+        }
+      }
+    },
+    "Homebrew packages up to date": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew-Pakete sind aktuell"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los paquetes de Homebrew están actualizados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paquets Homebrew à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew パッケージは最新です"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пакеты Homebrew обновлены"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew 软件包均为最新"
+          }
+        }
+      }
+    },
+    "How often Duo Updater checks, and what it does when it finds something.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wie oft Duo Updater prüft und was er bei einem Fund tut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Con qué frecuencia comprueba Duo Updater y qué hace cuando encuentra algo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À quelle fréquence Duo Updater vérifie, et ce qu'il fait en cas de trouvaille."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaterが確認する頻度と、見つかった際の動作。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Как часто Duo Updater проверяет обновления и что делает при их обнаружении."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater 检查更新的频率，以及发现更新时的操作。"
+          }
+        }
+      }
+    },
+    "Ignore %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ignorieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorar %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を無視"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорировать %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忽略 %@"
+          }
+        }
+      }
+    },
+    "Ignored": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignoriert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignoradas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無視中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорируемые"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已忽略"
+          }
+        }
+      }
+    },
+    "Ignored apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorierte Apps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps ignoradas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applications ignorées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無視されているアプリ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорируемые приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已忽略的应用"
+          }
+        }
+      }
+    },
+    "In Alcove: menu bar icon → Settings → License. Don’t have it? ": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Alcove: Menüleistensymbol → Settings → License. Hast du keine? "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En Alcove: icono de la barra de menús → Settings → License. ¿No la tienes? "
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dans Alcove : icône de la barre de menus → Settings → License. Vous ne l'avez pas ? "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcoveでは: メニューバーアイコン → Settings → License。お持ちでない場合は "
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В Alcove: значок в строке меню → Settings → License. Нет ключа? "
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Alcove 中：菜单栏图标 → Settings → License。没有密钥？"
+          }
+        }
+      }
+    },
+    "Incremental (needs Accessibility)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inkrementell (benötigt Bedienungshilfen)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incremental (necesita acceso de accesibilidad)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incrémentiel (nécessite l'accès Accessibilité)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "差分更新（アクセシビリティ権限が必要）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инкрементальный (требуется «Универсальный доступ»)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "增量更新（需要辅助功能权限）"
+          }
+        }
+      }
+    },
+    "Install": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装"
+          }
+        }
+      }
+    },
+    "Install Duo Updater's own updates silently": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene Updates von Duo Updater im Hintergrund installieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar en segundo plano las propias actualizaciones de Duo Updater"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer silencieusement les mises à jour de Duo Updater lui-même"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater自体の更新を自動的（無通知）にインストールする"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Устанавливать собственные обновления Duo Updater незаметно"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静默安装 Duo Updater 自身的更新"
+          }
+        }
+      }
+    },
+    "Install every pending update that can be applied automatically": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle ausstehenden Updates installieren, die sich automatisch anwenden lassen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalar todas las actualizaciones pendientes que se puedan aplicar automáticamente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer toutes les mises à jour en attente pouvant être appliquées automatiquement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動的に適用できる保留中の更新をすべてインストールします"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установить все ожидающие обновления, которые можно применить автоматически"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装所有可自动应用的待处理更新"
+          }
+        }
+      }
+    },
+    "Install routing": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installationsweg"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enrutamiento de instalación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Routage d'installation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールの振り分け"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Маршрутизация установки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装路由"
+          }
+        }
+      }
+    },
+    "Installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установлено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
+          }
+        }
+      }
+    },
+    "Installed %@ — waiting for Update All to finish before restarting; click to restart now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ installiert – wartet mit dem Neustart, bis „Alle aktualisieren“ fertig ist; zum sofortigen Neustart klicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ instalado; espera a que termine «Actualizar todo» antes de reiniciar. Haz clic para reiniciar ahora."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ installé — attend la fin de « Tout mettre à jour » avant de redémarrer ; cliquez pour redémarrer maintenant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をインストールしました — 「すべて更新」の完了を待ってから再起動します。クリックすると今すぐ再起動します。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установлено %@ — ожидание завершения «Обновить всё» перед перезапуском; нажмите, чтобы перезапустить сейчас"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装 %@ — 等待“全部更新”完成后再重启；点击立即重启"
+          }
+        }
+      }
+    },
+    "Installing": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird installiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation en cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安装"
+          }
+        }
+      }
+    },
+    "Installing…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird installiert …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installation en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安装…"
+          }
+        }
+      }
+    },
+    "It installs its own updates quietly — see what changed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiert eigene Updates im Hintergrund – Änderungen ansehen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instala sus propias actualizaciones en segundo plano; ver qué cambió"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installe ses propres mises à jour discrètement — voir les changements"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自身のアップデートを静かにインストールします — 変更点を見る"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Устанавливает свои обновления незаметно — посмотреть, что изменилось"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "它会静默安装自身的更新 — 查看更新内容"
+          }
+        }
+      }
+    },
+    "Keep a backup so updates can be rolled back": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup aufbewahren, damit Updates zurückgesetzt werden können"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conservar una copia de seguridad para poder revertir actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conserver une sauvegarde pour pouvoir annuler les mises à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新をロールバックできるようバックアップを保持する"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранить резервную копию для отката обновлений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留备份以便回滚更新"
+          }
+        }
+      }
+    },
+    "Last checked": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt geprüft"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última comprobación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière vérification"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終確認"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последняя проверка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上次检查"
+          }
+        }
+      }
+    },
+    "Launch at login": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Anmelden starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir al iniciar sesión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancer à l'ouverture de session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン時に起動"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запускать при входе в систему"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时启动"
+          }
+        }
+      }
+    },
+    "Layout": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposition"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レイアウト"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Расположение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "布局"
+          }
+        }
+      }
+    },
+    "Lets Duo Updater replace apps updated outside the App Store (Sparkle, Homebrew, direct downloads).": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlaubt Duo Updater, Apps zu ersetzen, die außerhalb des App Stores aktualisiert werden (Sparkle, Homebrew, Direktdownloads)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que Duo Updater reemplace apps actualizadas fuera de la App Store (Sparkle, Homebrew, descargas directas)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permet à Duo Updater de remplacer les applications mises à jour en dehors de l'App Store (Sparkle, Homebrew, téléchargements directs)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store以外で更新されるアプリ（Sparkle、Homebrew、直接ダウンロード）をDuo Updaterが置き換えられるようにします。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позволяет Duo Updater заменять приложения, обновляемые вне App Store (Sparkle, Homebrew, прямые загрузки)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许 Duo Updater 替换在 App Store 之外更新的应用（Sparkle、Homebrew、直接下载）。"
+          }
+        }
+      }
+    },
+    "Lets Duo Updater replace apps updated outside the App Store (Sparkle, Homebrew, direct downloads). macOS isn’t reporting its status on this system — grant it to be safe.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlaubt Duo Updater, Apps zu ersetzen, die außerhalb des App Stores aktualisiert werden (Sparkle, Homebrew, Direktdownloads). macOS meldet den Status auf diesem System nicht – erteile die Berechtigung sicherheitshalber."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permite que Duo Updater reemplace apps actualizadas fuera de la App Store (Sparkle, Homebrew, descargas directas). macOS no informa su estado en este sistema; concédelo para estar seguro."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permet à Duo Updater de remplacer les applications mises à jour en dehors de l'App Store (Sparkle, Homebrew, téléchargements directs). macOS ne signale pas son état sur ce système — autorisez-la par précaution."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store以外で更新されるアプリ（Sparkle、Homebrew、直接ダウンロード）をDuo Updaterが置き換えられるようにします。このシステムではmacOSが状態を報告していません — 念のため許可してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позволяет Duo Updater заменять приложения, обновляемые вне App Store (Sparkle, Homebrew, прямые загрузки). macOS не сообщает его статус в этой системе — предоставьте разрешение на всякий случай."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许 Duo Updater 替换在 App Store 之外更新的应用（Sparkle、Homebrew、直接下载）。macOS 未在此系统上报告其状态 — 为安全起见请授予该权限。"
+          }
+        }
+      }
+    },
+    "Library": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibliothek"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biblioteca"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bibliothèque"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブラリ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Библиотека"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "资料库"
+          }
+        }
+      }
+    },
+    "License at activation limit (%@/%@). Key saved — set the instance ID below, or free a slot in Alcove.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz hat das Aktivierungslimit erreicht (%@/%@). Schlüssel gespeichert – Instanz-ID unten festlegen oder einen Platz in Alcove freigeben."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La licencia alcanzó el límite de activaciones (%@/%@). Clave guardada; establece el ID de instancia abajo o libera una plaza en Alcove."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La licence a atteint sa limite d'activation (%@/%@). Clé enregistrée — définissez l'ID d'instance ci-dessous, ou libérez un emplacement dans Alcove."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライセンスがアクティベーション上限（%@/%@）に達しています。キーは保存済みです — 下でインスタンスIDを設定するか、Alcoveでスロットを解放してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лицензия достигла лимита активаций (%@/%@). Ключ сохранён — укажите ID экземпляра ниже или освободите слот в Alcove."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "许可证已达到激活上限（%@/%@）。密钥已保存 — 请在下方设置实例 ID，或在 Alcove 中释放一个名额。"
+          }
+        }
+      }
+    },
+    "Lift GitHub's anonymous rate limit for apps tracked through Releases.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das anonyme Ratenlimit von GitHub für über Releases verfolgte Apps aufheben."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina el límite de solicitudes anónimas de GitHub para las apps que se siguen mediante Releases."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lever la limite de requêtes anonymes de GitHub pour les applications suivies via Releases."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Releasesで追跡しているアプリに対するGitHubの匿名レート制限を解除します。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снять анонимное ограничение частоты запросов GitHub для приложений, отслеживаемых через Releases."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解除 GitHub 对通过 Releases 追踪的应用的匿名请求限制。"
+          }
+        }
+      }
+    },
+    "Lifts GitHub’s 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. A token is already active — you’re all set.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erhöht das GitHub-Limit von 60 auf 5000 Anfragen pro Stunde, damit häufige Prüfungen von auf GitHub gehosteten Apps (RustDesk, Zed, Stats …) nicht an das Ratenlimit stoßen. Ein Token ist bereits aktiv – alles eingerichtet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumenta el límite de GitHub de 60 a 5000 solicitudes por hora, para que las comprobaciones frecuentes de apps alojadas en GitHub (RustDesk, Zed, Stats…) no den errores de límite. Ya hay un token activo; todo listo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fait passer la limite de GitHub de 60 à 5000 requêtes par heure, afin que les vérifications fréquentes des applications hébergées sur GitHub (RustDesk, Zed, Stats…) n'atteignent pas la limite. Un jeton est déjà actif — tout est prêt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubの1時間あたり60リクエストの制限を5000リクエストに引き上げ、GitHubでホストされているアプリ（RustDesk、Zed、Statsなど）の頻繁な確認がレート制限エラーにならないようにします。トークンはすでに有効です — 準備は完了しています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повышает лимит GitHub с 60 до 5000 запросов в час, чтобы частые проверки приложений на GitHub (RustDesk, Zed, Stats…) не упирались в ограничение. Токен уже активен — всё готово."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 GitHub 每小时 60 次的请求限制提升到 5000 次，让频繁检查 GitHub 托管的应用（RustDesk、Zed、Stats 等）不会触发限速错误。令牌已生效 — 一切就绪。"
+          }
+        }
+      }
+    },
+    "Lifts GitHub’s 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. Optional: sign in with the gh CLI, or paste a token.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erhöht das GitHub-Limit von 60 auf 5000 Anfragen pro Stunde, damit häufige Prüfungen von auf GitHub gehosteten Apps (RustDesk, Zed, Stats …) nicht an das Ratenlimit stoßen. Optional: mit gh CLI anmelden oder ein Token einfügen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumenta el límite de GitHub de 60 a 5000 solicitudes por hora, para que las comprobaciones frecuentes de apps alojadas en GitHub (RustDesk, Zed, Stats…) no den errores de límite. Opcional: inicia sesión con gh CLI o pega un token."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fait passer la limite de GitHub de 60 à 5000 requêtes par heure, afin que les vérifications fréquentes des applications hébergées sur GitHub (RustDesk, Zed, Stats…) n'atteignent pas la limite. Facultatif : connectez-vous avec gh CLI, ou collez un jeton."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubの1時間あたり60リクエストの制限を5000リクエストに引き上げ、GitHubでホストされているアプリ（RustDesk、Zed、Statsなど）の頻繁な確認がレート制限エラーにならないようにします。任意: gh CLIでサインインするか、トークンを貼り付けてください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повышает лимит GitHub с 60 до 5000 запросов в час, чтобы частые проверки приложений на GitHub (RustDesk, Zed, Stats…) не упирались в ограничение. Необязательно: войдите через gh CLI или вставьте токен."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 GitHub 每小时 60 次的请求限制提升到 5000 次，让频繁检查 GitHub 托管的应用（RustDesk、Zed、Stats 等）不会触发限速错误。可选：通过 gh CLI 登录，或粘贴令牌。"
+          }
+        }
+      }
+    },
+    "Lifts GitHub’s anonymous 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. A token is already active — you’re all set.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erhöht das anonyme GitHub-Limit von 60 auf 5000 Anfragen pro Stunde, damit häufige Prüfungen von auf GitHub gehosteten Apps (RustDesk, Zed, Stats …) nicht an das Ratenlimit stoßen. Ein Token ist bereits aktiv – alles eingerichtet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumenta el límite anónimo de GitHub de 60 a 5000 solicitudes por hora, para que las comprobaciones frecuentes de apps alojadas en GitHub (RustDesk, Zed, Stats…) no den errores de límite. Ya hay un token activo; todo listo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fait passer la limite anonyme de GitHub de 60 à 5000 requêtes par heure, afin que les vérifications fréquentes des applications hébergées sur GitHub (RustDesk, Zed, Stats…) n'atteignent pas la limite. Un jeton est déjà actif — tout est prêt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubの1時間あたり60リクエストの匿名制限を5000リクエストに引き上げ、GitHubでホストされているアプリ（RustDesk、Zed、Statsなど）の頻繁な確認がレート制限エラーにならないようにします。トークンはすでに有効です — 準備は完了しています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повышает анонимный лимит GitHub с 60 до 5000 запросов в час, чтобы частые проверки приложений на GitHub (RustDesk, Zed, Stats…) не упирались в ограничение. Токен уже активен — всё готово."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 GitHub 每小时 60 次的匿名请求限制提升到 5000 次，让频繁检查 GitHub 托管的应用（RustDesk、Zed、Stats 等）不会触发限速错误。令牌已生效 — 一切就绪。"
+          }
+        }
+      }
+    },
+    "Lifts GitHub’s anonymous 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. Optional: sign in with the gh CLI, or paste a token.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erhöht das anonyme GitHub-Limit von 60 auf 5000 Anfragen pro Stunde, damit häufige Prüfungen von auf GitHub gehosteten Apps (RustDesk, Zed, Stats …) nicht an das Ratenlimit stoßen. Optional: mit gh CLI anmelden oder ein Token einfügen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumenta el límite anónimo de GitHub de 60 a 5000 solicitudes por hora, para que las comprobaciones frecuentes de apps alojadas en GitHub (RustDesk, Zed, Stats…) no den errores de límite. Opcional: inicia sesión con gh CLI o pega un token."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fait passer la limite anonyme de GitHub de 60 à 5000 requêtes par heure, afin que les vérifications fréquentes des applications hébergées sur GitHub (RustDesk, Zed, Stats…) n'atteignent pas la limite. Facultatif : connectez-vous avec gh CLI, ou collez un jeton."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubの1時間あたり60リクエストの匿名制限を5000リクエストに引き上げ、GitHubでホストされているアプリ（RustDesk、Zed、Statsなど）の頻繁な確認がレート制限エラーにならないようにします。任意: gh CLIでサインインするか、トークンを貼り付けてください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повышает анонимный лимит GitHub с 60 до 5000 запросов в час, чтобы частые проверки приложений на GitHub (RustDesk, Zed, Stats…) не упирались в ограничение. Необязательно: войдите через gh CLI или вставьте токен."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 GitHub 每小时 60 次的匿名请求限制提升到 5000 次，让频繁检查 GitHub 托管的应用（RustDesk、Zed、Stats 等）不会触发限速错误。可选：通过 gh CLI 登录，或粘贴令牌。"
+          }
+        }
+      }
+    },
+    "Lifts the anonymous 60-requests/hour limit to 5000/hour for apps tracked through GitHub Releases. When the gh CLI is signed in this is filled automatically, so the field is optional. A read-only (public-repo) token is enough.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erhöht das anonyme Limit von 60 auf 5000 Anfragen pro Stunde für über GitHub Releases verfolgte Apps. Ist die gh CLI angemeldet, wird dieses Feld automatisch ausgefüllt und ist damit optional. Ein schreibgeschütztes Token (öffentliches Repo) genügt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumenta el límite anónimo de 60 a 5000 solicitudes por hora para las apps que se siguen mediante GitHub Releases. Si gh CLI ha iniciado sesión, este campo se rellena automáticamente y es opcional. Basta con un token de solo lectura (repositorio público)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fait passer la limite anonyme de 60 à 5000 requêtes par heure pour les applications suivies via GitHub Releases. Si gh CLI est connecté, ce champ est rempli automatiquement et devient donc facultatif. Un jeton en lecture seule (dépôt public) suffit."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Releasesで追跡しているアプリの匿名リクエスト制限を、1時間あたり60から5000に引き上げます。gh CLIでサインイン済みの場合はこの項目が自動的に入力されるため、任意項目です。読み取り専用（公開リポジトリ）のトークンで十分です。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повышает анонимный лимит с 60 до 5000 запросов в час для приложений, отслеживаемых через GitHub Releases. Если выполнен вход через gh CLI, это поле заполняется автоматически и необязательно. Достаточно токена только для чтения (публичные репозитории)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将通过 GitHub Releases 追踪的应用的匿名请求限制从每小时 60 次提升到 5000 次。当 gh CLI 已登录时，此字段会自动填充，因此为可选项。只读（公共仓库）令牌即可。"
+          }
+        }
+      }
+    },
+    "Lower this on a slow connection; raise it to check a large library faster.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei einer langsamen Verbindung verringern; erhöhen, um eine große Bibliothek schneller zu prüfen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redúcelo con una conexión lenta; auméntalo para comprobar una biblioteca grande más rápido."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réduisez cette valeur sur une connexion lente ; augmentez-la pour vérifier une grande bibliothèque plus vite."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回線が遅い場合はこの値を下げ、大きなライブラリを速く確認したい場合は上げてください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уменьшите это значение при медленном соединении; увеличьте, чтобы быстрее проверить большую библиотеку."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在网速较慢时调低此值；调高可更快检查庞大的应用库。"
+          }
+        }
+      }
+    },
+    "Mac App Store updates currently use the full-download route via mas. It’s the more predictable option for release builds and doesn’t require Accessibility access.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac-App-Store-Updates verwenden derzeit den vollständigen Download-Weg über mas. Das ist die vorhersehbarere Option für Release-Builds und erfordert keinen Bedienungshilfen-Zugriff."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las actualizaciones de la Mac App Store usan actualmente la vía de descarga completa mediante mas. Es la opción más predecible para compilaciones de publicación y no requiere acceso de accesibilidad."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les mises à jour du Mac App Store utilisent actuellement la voie du téléchargement complet via mas. C'est l'option la plus prévisible pour les versions publiées et elle ne nécessite pas l'accès à l'Accessibilité."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac App Storeのアップデートは現在、mas経由の完全ダウンロード方式を使用しています。これはリリースビルドにとってより予測可能な選択肢であり、アクセシビリティ権限を必要としません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновления Mac App Store сейчас используют путь полной загрузки через mas. Это более предсказуемый вариант для релизных сборок, не требующий «Универсального доступа»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac App Store 更新目前通过 mas 使用完整下载方式。这是发布版更可预测的选项，且不需要辅助功能权限。"
+          }
+        }
+      }
+    },
+    "Major update": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Großes Update"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización importante"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour majeure"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メジャーアップデート"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Крупное обновление"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重大更新"
+          }
+        }
+      }
+    },
+    "Major version upgrade": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade auf eine neue Hauptversion"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización a una versión principal nueva"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à niveau de version majeure"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メジャーバージョンアップグレード"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление до новой мажорной версии"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重大版本升级"
+          }
+        }
+      }
+    },
+    "Major version upgrade — click before updating": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade auf eine neue Hauptversion – vor dem Update anklicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización a una versión principal nueva; haz clic antes de actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à niveau de version majeure — cliquez avant de mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メジャーバージョンアップグレード — 更新前にクリックしてください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление до новой мажорной версии — нажмите перед обновлением"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重大版本升级 — 更新前请点击查看"
+          }
+        }
+      }
+    },
+    "Major version upgrade — review and install it from the menu-bar popover": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upgrade auf eine neue Hauptversion – im Menüleisten-Popover prüfen und installieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización a una versión principal nueva; revísala e instálala desde el menú de la barra de menús"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à niveau de version majeure — à examiner et installer depuis le popover de la barre de menus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メジャーバージョンアップグレード — メニューバーのポップオーバーから確認してインストールしてください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление до новой мажорной версии — просмотрите и установите из всплывающего окна в строке меню"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重大版本升级 — 请从菜单栏弹出窗口查看并安装"
+          }
+        }
+      }
+    },
+    "Managed by JetBrains Toolbox — open Toolbox to update %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird von JetBrains Toolbox verwaltet – Toolbox öffnen, um %@ zu aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionado por JetBrains Toolbox; abre Toolbox para actualizar %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Géré par JetBrains Toolbox — ouvrez Toolbox pour mettre à jour %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JetBrains Toolbox が管理しています — Toolboxを開いて%@を更新してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Управляется JetBrains Toolbox — откройте Toolbox, чтобы обновить %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 JetBrains Toolbox 管理 — 打开 Toolbox 以更新 %@"
+          }
+        }
+      }
+    },
+    "Managed by TestFlight — it handles this beta's updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird von TestFlight verwaltet – kümmert sich um die Updates dieser Beta"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionado por TestFlight; se encarga de las actualizaciones de esta beta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Géré par TestFlight — il gère les mises à jour de cette version bêta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight が管理しています — このベータ版の更新を担当します"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Управляется TestFlight — он занимается обновлениями этой бета-версии"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 TestFlight 管理 — 它负责此测试版的更新"
+          }
+        }
+      }
+    },
+    "Managed by TestFlight — open TestFlight to update %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird von TestFlight verwaltet – TestFlight öffnen, um %@ zu aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionado por TestFlight; abre TestFlight para actualizar %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Géré par TestFlight — ouvrez TestFlight pour mettre à jour %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight が管理しています — TestFlightを開いて%@を更新してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Управляется TestFlight — откройте TestFlight, чтобы обновить %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 TestFlight 管理 — 打开 TestFlight 以更新 %@"
+          }
+        }
+      }
+    },
+    "Managed by the App Store — it handles this app's updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird vom App Store verwaltet – kümmert sich um die Updates dieser App"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestionado por la App Store; se encarga de las actualizaciones de esta app"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Géré par l'App Store — il gère les mises à jour de cette application"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store が管理しています — このアプリの更新を担当します"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Управляется App Store — он занимается обновлениями этого приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 App Store 管理 — 它负责此应用的更新"
+          }
+        }
+      }
+    },
+    "More": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "多い"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Больше"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "较多"
+          }
+        }
+      }
+    },
+    "Most often ships %@, around %@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erscheint am häufigsten %@, gegen %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se publica con más frecuencia el %@, alrededor de las %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort le plus souvent %@, vers %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最も多いのは %@ の %@ 頃のリリースです。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чаще всего выходит %@, около %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最常在 %@ 发布，大约 %@。"
+          }
+        }
+      }
+    },
+    "No GitHub token: checking this often can hit GitHub’s rate limit (60/hour) and show errors on GitHub-sourced apps. Add a token or sign in with the gh CLI under GitHub.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein GitHub-Token: So häufiges Prüfen kann an GitHubs Ratenlimit (60/Stunde) stoßen und bei über GitHub bezogenen Apps Fehler anzeigen. Füge unter GitHub ein Token hinzu oder melde dich mit der gh CLI an."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin token de GitHub: comprobar con esta frecuencia puede alcanzar el límite de GitHub (60/hora) y mostrar errores en las apps de GitHub. Añade un token o inicia sesión con gh CLI en GitHub."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas de jeton GitHub : vérifier aussi souvent peut atteindre la limite de GitHub (60/heure) et afficher des erreurs sur les applications provenant de GitHub. Ajoutez un jeton ou connectez-vous avec gh CLI sous GitHub."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubトークンがありません: この頻度で確認するとGitHubのレート制限（60/時間）に達し、GitHub由来のアプリでエラーが表示されることがあります。「GitHub」でトークンを追加するか、gh CLIでサインインしてください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет токена GitHub: при такой частоте проверок можно упереться в лимит GitHub (60/час) и увидеть ошибки для приложений с GitHub. Добавьте токен или войдите через gh CLI в разделе GitHub."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有 GitHub 令牌：以这个频率检查可能触及 GitHub 的请求限制（60/小时），导致来自 GitHub 的应用出现错误。请在“GitHub”中添加令牌或通过 gh CLI 登录。"
+          }
+        }
+      }
+    },
+    "No apps yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Apps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune application pour l’instant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリはまだありません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет приложений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚无应用"
+          }
+        }
+      }
+    },
+    "No downloads measured": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Downloads erfasst"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se han medido descargas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun téléchargement mesuré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード量は計測されていません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузки не измерялись"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未测量下载量"
+          }
+        }
+      }
+    },
+    "No exact release times recorded yet — the heatmap fills in as Sparkle/GitHub apps ship.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine genauen Release-Zeiten erfasst – die Heatmap füllt sich, sobald Sparkle-/GitHub-Apps veröffentlicht werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no se han registrado horas de publicación exactas; el mapa de calor se irá completando a medida que se publiquen apps de Sparkle/GitHub."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune heure de publication exacte enregistrée pour l'instant — la carte de chaleur se remplit au fil des publications des applications Sparkle/GitHub."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正確なリリース時刻はまだ記録されていません — Sparkle/GitHubのアプリが公開されるにつれてヒートマップが埋まっていきます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет точного времени релизов — тепловая карта заполняется по мере выхода приложений Sparkle/GitHub."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未记录确切的发布时间 — 随着 Sparkle/GitHub 应用发布，热力图会逐渐填充。"
+          }
+        }
+      }
+    },
+    "No extra folders yet.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine zusätzlichen Ordner."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay carpetas adicionales."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun dossier supplémentaire pour l'instant."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加フォルダはまだありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет дополнительных папок."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚无额外文件夹。"
+          }
+        }
+      }
+    },
+    "No ignored apps. Use “Ignore this app” from an app’s menu to hide it from update checks.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine ignorierten Apps. Verwende „Diese App ignorieren“ im Menü einer App, um sie von Update-Prüfungen auszuschließen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay apps ignoradas. Usa «Ignorar esta app» en el menú de una app para ocultarla de las comprobaciones de actualización."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune application ignorée. Utilisez « Ignorer cette application » dans le menu d'une application pour la masquer des vérifications de mise à jour."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無視されているアプリはありません。アプリのメニューから「このアプリを無視」を選ぶと、更新チェックから除外できます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет игнорируемых приложений. Используйте «Игнорировать это приложение» в меню приложения, чтобы скрыть его из проверок обновлений."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有已忽略的应用。可在应用菜单中使用“忽略此应用”将其从更新检查中隐藏。"
+          }
+        }
+      }
+    },
+    "No recipe-backed apps have been checked yet this session.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In dieser Sitzung wurden noch keine Rezept-basierten Apps geprüft."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En esta sesión aún no se ha comprobado ninguna app basada en recetas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune application basée sur une recette n'a encore été vérifiée dans cette session."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このセッションでは、レシピを使用するアプリはまだ確認されていません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В этом сеансе ещё не проверены приложения на основе рецептов."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本次会话中尚未检查任何依赖规则的应用。"
+          }
+        }
+      }
+    },
+    "No release notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Versionshinweise"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin notas de la versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune note de version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リリースノートなし"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет заметок о выпуске"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有发行说明"
+          }
+        }
+      }
+    },
+    "No releases logged yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Releases protokolliert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay versiones registradas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune version consignée pour l'instant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録されたリリースはまだありません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока нет записанных релизов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚无记录的发布"
+          }
+        }
+      }
+    },
+    "No skipped versions.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine übersprungenen Versionen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay versiones omitidas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune version ignorée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキップされたバージョンはありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет пропущенных версий."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有已跳过的版本。"
+          }
+        }
+      }
+    },
+    "Not Now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht jetzt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ahora no"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus tard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今はしない"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не сейчас"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂不"
+          }
+        }
+      }
+    },
+    "Not available in your App Store region — click for details": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In deiner App-Store-Region nicht verfügbar – für Details klicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No disponible en tu región de la App Store; haz clic para más información"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non disponible dans votre région de l'App Store — cliquez pour en savoir plus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お使いのApp Storeの地域では利用できません — クリックして詳細を表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недоступно в вашем регионе App Store — нажмите для подробностей"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在你的 App Store 区域不可用 — 点击查看详情"
+          }
+        }
+      }
+    },
+    "Not supported on this Mac": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf diesem Mac nicht unterstützt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No es compatible con este Mac"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non pris en charge sur ce Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMacではサポートされていません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не поддерживается на этом Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 Mac 不支持"
+          }
+        }
+      }
+    },
+    "Not yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch nicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía no"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未実施"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ещё нет"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未"
+          }
+        }
+      }
+    },
+    "Notify me when updates are found": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigen, wenn Updates gefunden werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avisarme cuando se encuentren actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Me notifier en cas de mise à jour trouvée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新が見つかったら通知する"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уведомлять об обнаруженных обновлениях"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发现更新时通知我"
+          }
+        }
+      }
+    },
+    "Now running %@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es läuft jetzt %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ahora se está ejecutando %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est maintenant en cours d'exécution."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在 %@ を実行中です。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Теперь запущена версия %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "现在运行的是 %@。"
+          }
+        }
+      }
+    },
+    "On the %@ channel — its version can lead or differ from the stable release.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im %@-Kanal – die Version kann der stabilen Version voraus sein oder von ihr abweichen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En el canal %@; su versión puede ir por delante de la versión estable o ser distinta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sur le canal %@ — sa version peut être en avance sur la version stable ou en différer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ チャンネルです — バージョンは安定版より進んでいたり異なったりすることがあります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На канале %@ — версия может опережать стабильный релиз или отличаться от него."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "处于 %@ 渠道 — 其版本可能领先或不同于稳定版。"
+          }
+        }
+      }
+    },
+    "Once a day": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einmal täglich"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una vez al día"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une fois par jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1日1回"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раз в день"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每天一次"
+          }
+        }
+      }
+    },
+    "Only needed if your license is at its activation limit (then the ID can’t be recovered automatically). Capture this Mac’s instance_id from Alcove’s update request, or free an activation slot in Alcove instead.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur nötig, wenn die Lizenz das Aktivierungslimit erreicht hat (dann kann die ID nicht automatisch wiederhergestellt werden). Erfasse die instance_id dieses Macs aus Alcoves Update-Anfrage, oder gib stattdessen einen Aktivierungsplatz in Alcove frei."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo es necesario si tu licencia alcanzó el límite de activaciones (entonces el ID no se puede recuperar automáticamente). Obtén el instance_id de este Mac de la solicitud de actualización de Alcove, o libera una plaza de activación en Alcove."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nécessaire uniquement si votre licence a atteint sa limite d'activation (l'ID ne peut alors pas être récupéré automatiquement). Récupérez l'instance_id de ce Mac depuis la requête de mise à jour d'Alcove, ou libérez plutôt un emplacement d'activation dans Alcove."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライセンスがアクティベーション上限に達している場合のみ必要です（その場合IDは自動的に復元できません）。Alcoveの更新リクエストからこのMacのinstance_idを取得するか、代わりにAlcoveでアクティベーションスロットを解放してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нужно только если лицензия достигла лимита активаций (тогда ID нельзя восстановить автоматически). Получите instance_id этого Mac из запроса обновления Alcove либо освободите слот активации в Alcove."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅当许可证达到激活上限时才需要（此时无法自动恢复 ID）。请从 Alcove 的更新请求中获取此 Mac 的 instance_id，或改为在 Alcove 中释放一个激活名额。"
+          }
+        }
+      }
+    },
+    "Only when I check": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur wenn ich manuell prüfe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo cuando yo compruebe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uniquement quand je vérifie"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認したときのみ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Только вручную"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅在我检查时"
+          }
+        }
+      }
+    },
+    "Open": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开"
+          }
+        }
+      }
+    },
+    "Open %@’s built-in updater (it updates itself)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das integrierte Update-Tool von %@ öffnen (aktualisiert sich selbst)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir el actualizador integrado de %@ (se actualiza a sí misma)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le programme de mise à jour intégré de %@ (il se met à jour lui-même)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に内蔵の更新機能を開きます（自身で更新されます）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть встроенный обновитель %@ (обновляется самостоятельно)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 %@ 的内置更新程序（它会自行更新）"
+          }
+        }
+      }
+    },
+    "Open App Store": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir la App Store"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir l'App Store"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeを開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть App Store"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 App Store"
+          }
+        }
+      }
+    },
+    "Open App Store anyway": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Store trotzdem öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir la App Store de todos modos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir quand même l'App Store"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "それでもApp Storeを開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё равно открыть App Store"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仍然打开 App Store"
+          }
+        }
+      }
+    },
+    "Open Login Items": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anmeldeobjekte öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir elementos de inicio de sesión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les éléments de connexion"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン項目を開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть объекты входа"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开登录项"
+          }
+        }
+      }
+    },
+    "Open TestFlight": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir TestFlight"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir TestFlight"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlightを開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть TestFlight"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 TestFlight"
+          }
+        }
+      }
+    },
+    "Open Window": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenster öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir la fenêtre"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウインドウを開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть окно"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开窗口"
+          }
+        }
+      }
+    },
+    "Open download page": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download-Seite öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir la página de descarga"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir la page de téléchargement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードページを開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть страницу загрузки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开下载页面"
+          }
+        }
+      }
+    },
+    "Open in App Store": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im App Store öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir en la App Store"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir dans l'App Store"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeで開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть в App Store"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 App Store 中打开"
+          }
+        }
+      }
+    },
+    "Open on GitHub": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf GitHub öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir en GitHub"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir sur GitHub"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubで開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть на GitHub"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开"
+          }
+        }
+      }
+    },
+    "Open page": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seite öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir página"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir la page"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ページを開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть страницу"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开页面"
+          }
+        }
+      }
+    },
+    "Open the official download page": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offizielle Download-Seite öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir la página de descarga oficial"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir la page de téléchargement officielle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公式ダウンロードページを開く"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть официальную страницу загрузки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开官方下载页面"
+          }
+        }
+      }
+    },
+    "Opens %@ in the App Store. Turn on the background helper in Settings to install App Store updates in one click.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet %@ im App Store. Aktiviere den Hintergrund-Helper in den Einstellungen, um App-Store-Updates mit einem Klick zu installieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre %@ en la App Store. Activa el asistente en segundo plano en Ajustes para instalar las actualizaciones de la App Store con un clic."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre %@ dans l'App Store. Activez l'assistant en arrière-plan dans les Réglages pour installer les mises à jour de l'App Store en un clic."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeで%@を開きます。設定でバックグラウンドヘルパーを有効にすると、App Storeの更新をワンクリックでインストールできます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открывает %@ в App Store. Включите фоновый помощник в настройках, чтобы устанавливать обновления App Store в один клик."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 App Store 中打开 %@。请在设置中启用后台助理，以便一键安装 App Store 更新。"
+          }
+        }
+      }
+    },
+    "Paste from clipboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus Zwischenablage einfügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pegar desde el portapapeles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coller depuis le presse-papiers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボードから貼り付け"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставить из буфера обмена"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从剪贴板粘贴"
+          }
+        }
+      }
+    },
+    "Paste license key": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenzschlüssel einfügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pegar clave de licencia"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coller la clé de licence"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライセンスキーを貼り付け"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставить лицензионный ключ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴许可证密钥"
+          }
+        }
+      }
+    },
+    "Paste token": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token einfügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pegar token"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coller le jeton"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トークンを貼り付け"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставить токен"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴令牌"
+          }
+        }
+      }
+    },
+    "Patterns": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muster"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Patrones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendances"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パターン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закономерности"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "规律"
+          }
+        }
+      }
+    },
+    "Permissions": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechtigungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisations"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
+          }
+        }
+      }
+    },
+    "Permissions, last check, and the health of each detection recipe.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechtigungen, letzte Prüfung und der Zustand jedes Erkennungs-Rezepts."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos, última comprobación y el estado de cada receta de detección."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisations, dernière vérification et état de chaque recette de détection."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限、最終確認時刻、および各検出レシピの状態。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешения, время последней проверки и состояние каждого рецепта обнаружения."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限、上次检查时间，以及每个检测规则的健康状况。"
+          }
+        }
+      }
+    },
+    "Pick a folder that contains apps (or pick an app — its folder is added). Apps there are checked for updates just like the ones in your Applications folder.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle einen Ordner mit Apps aus (oder eine App – dann wird ihr Ordner hinzugefügt). Apps dort werden genauso auf Updates geprüft wie die im Programme-Ordner."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una carpeta que contenga apps (o una app; se añadirá su carpeta). Las apps allí se comprueban igual que las de tu carpeta Aplicaciones."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez un dossier contenant des applications (ou une application — son dossier sera ajouté). Les applications qui s'y trouvent sont vérifiées comme celles de votre dossier Applications."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリが含まれるフォルダを選択してください（またはアプリ自体を選択すると、そのフォルダが追加されます）。そこにあるアプリは、Applicationsフォルダのアプリと同様に更新が確認されます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите папку с приложениями (или само приложение — будет добавлена его папка). Приложения там проверяются так же, как в папке «Программы»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个包含应用的文件夹（或选择某个应用 — 会添加其所在文件夹）。其中的应用会像“应用程序”文件夹里的应用一样被检查更新。"
+          }
+        }
+      }
+    },
+    "Pick an app to read its changelog.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle eine App aus, um ihr Änderungsprotokoll zu lesen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una app para leer su registro de cambios."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez une application pour lire son journal des modifications."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新履歴を読むアプリを選択してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите приложение, чтобы прочитать список изменений."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个应用以查看其更新日志。"
+          }
+        }
+      }
+    },
+    "Pick an app to see its download history.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle eine App aus, um ihren Download-Verlauf zu sehen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una app para ver su historial de descargas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez une application pour voir son historique de téléchargements."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード履歴を見るアプリを選択してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите приложение, чтобы увидеть историю загрузок."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个应用以查看其下载历史。"
+          }
+        }
+      }
+    },
+    "Published %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veröffentlicht %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publicado %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publié %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公開日: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опубликовано %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布于 %@"
+          }
+        }
+      }
+    },
+    "Queued": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En cola"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待機中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В очереди"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排队中"
+          }
+        }
+      }
+    },
+    "Quit": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выйти"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
+          }
+        }
+      }
+    },
+    "Quit %@ — waiting for it to swap in the new version and reopen": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ beenden – wartet darauf, auf die neue Version umzustellen und erneut zu öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar %@; esperando a que se reemplace por la nueva versión y se reabra"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter %@ — en attente du remplacement par la nouvelle version puis de la réouverture"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を終了 — 新しいバージョンに入れ替えて再度開くのを待っています"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрыть %@ — ожидание подмены на новую версию и повторного открытия"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 %@ — 等待替换为新版本并重新打开"
+          }
+        }
+      }
+    },
+    "Quit the app to finish installing the update, then reopen it": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App beenden, um die Update-Installation abzuschließen, dann erneut öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cierra la app para terminar de instalar la actualización y vuelve a abrirla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quittez l'application pour terminer l'installation de la mise à jour, puis rouvrez-la"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを終了して更新のインストールを完了し、再度開いてください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закройте приложение, чтобы завершить установку обновления, затем откройте его снова"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出该应用以完成更新安装，然后重新打开"
+          }
+        }
+      }
+    },
+    "Rate-limited": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ratenlimit erreicht"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Límite de solicitudes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limité en requêtes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レート制限中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ограничение частоты запросов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已限速"
+          }
+        }
+      }
+    },
+    "Reading outdated formulae": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veraltete Formeln werden gelesen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyendo fórmulas desactualizadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture des formules obsolètes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いフォーミュラを読み込み中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтение устаревших формул"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在读取过期配方"
+          }
+        }
+      }
+    },
+    "Reading recipe health…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zustand der Rezepte wird gelesen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyendo el estado de las recetas…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecture de l'état des recettes…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レシピの状態を読み込み中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка состояния рецептов…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在读取规则健康状态…"
+          }
+        }
+      }
+    },
+    "Recover it by email": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per E-Mail wiederherstellen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recuperarla por correo electrónico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La récupérer par e-mail"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メールで復元する"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановить по электронной почте"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过电子邮件找回"
+          }
+        }
+      }
+    },
+    "Region-locked": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regional gesperrt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bloqueado por región"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verrouillé par région"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地域制限あり"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Региональная блокировка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "区域限制"
+          }
+        }
+      }
+    },
+    "Rejected by GitHub — check it’s correct and not expired.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von GitHub abgelehnt – prüfe, ob es korrekt und nicht abgelaufen ist."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechazado por GitHub; comprueba que sea correcto y no haya caducado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rejeté par GitHub — vérifiez qu'il est correct et non expiré."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHubに拒否されました — 正しいか、期限切れでないか確認してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклонён GitHub — проверьте, что он верен и не истёк."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "被 GitHub 拒绝 — 请检查是否正确且未过期。"
+          }
+        }
+      }
+    },
+    "Relaunch": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neu starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reabrir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relancer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再起動"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动"
+          }
+        }
+      }
+    },
+    "Relaunch DuoUpdater": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DuoUpdater neu starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reabrir DuoUpdater"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relancer DuoUpdater"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DuoUpdaterを再起動"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить DuoUpdater"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动 DuoUpdater"
+          }
+        }
+      }
+    },
+    "Relaunching…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird neu gestartet …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reabriendo…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relance en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再起動中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапуск…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在重新启动…"
+          }
+        }
+      }
+    },
+    "Release Log": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release-Protokoll"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro de versiones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journal des versions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リリースログ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Журнал релизов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布日志"
+          }
+        }
+      }
+    },
+    "Release Log — when the apps you track shipped each version": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release-Protokoll – wann die verfolgten Apps welche Version veröffentlicht haben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro de versiones: cuándo publicó cada versión cada app que sigues"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journal des versions — quand les applications suivies ont publié chaque version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リリースログ — 追跡中のアプリが各バージョンを公開した時期"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Журнал релизов — когда отслеживаемые приложения выпускали каждую версию"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布日志 — 你关注的应用各版本的发布时间"
+          }
+        }
+      }
+    },
+    "Release Notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versionshinweise"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notas de la versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes de version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リリースノート"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заметки о выпуске"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发行说明"
+          }
+        }
+      }
+    },
+    "Release notes, traffic, and settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versionshinweise, Datenverkehr und Einstellungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notas de versión, tráfico y ajustes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes de version, trafic et réglages"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リリースノート、トラフィック、設定"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заметки о выпуске, трафик и настройки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发行说明、流量与设置"
+          }
+        }
+      }
+    },
+    "Released sometime between %@ and %@ — estimated from when we detected the change, not a vendor date.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Irgendwann zwischen %@ und %@ veröffentlicht – geschätzt ab dem Zeitpunkt, an dem wir die Änderung bemerkt haben, nicht das Datum des Anbieters."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se publicó entre %@ y %@; es una estimación basada en cuándo detectamos el cambio, no una fecha del proveedor."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publiée entre %@ et %@ — estimation basée sur le moment où le changement a été détecté, pas une date de l'éditeur."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ から %@ の間にリリースされたと推定されます — これはベンダーの公開日ではなく、変更を検知した時点からの推定です。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выпущено где-то между %@ и %@ — оценка на основе момента обнаружения изменения, а не даты поставщика."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布时间在 %@ 到 %@ 之间 — 根据我们检测到变化的时间估算，而非厂商公布的日期。"
+          }
+        }
+      }
+    },
+    "Releases appear here as the apps you track ship them": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Releases erscheinen hier, sobald die verfolgten Apps sie veröffentlichen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las versiones aparecen aquí a medida que las apps que sigues las publican"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les versions apparaissent ici au fur et à mesure que les applications suivies les publient"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追跡しているアプリがリリースされると、ここに表示されます"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Релизы появляются здесь по мере выхода отслеживаемых приложений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "随着你关注的应用发布新版本，发布记录会显示在这里"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        }
+      }
+    },
+    "Rescan and check for updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut scannen und nach Updates suchen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a escanear y buscar actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rebalayer et rechercher des mises à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再スキャンして更新を確認"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пересканировать и проверить обновления"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新扫描并检查更新"
+          }
+        }
+      }
+    },
+    "Responding — App Store updates will work": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antwortet – App-Store-Updates funktionieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responde: las actualizaciones de la App Store funcionarán"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Répond — les mises à jour de l'App Store fonctionneront"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "応答あり — App Storeのアップデートは動作します"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отвечает — обновления App Store будут работать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有响应 — App Store 更新可正常工作"
+          }
+        }
+      }
+    },
+    "Restart": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neu starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再起動"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动"
+          }
+        }
+      }
+    },
+    "Restart Helper…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper neu starten …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar el asistente…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer l'assistant…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーを再起動…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить помощника…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重启助理进程…"
+          }
+        }
+      }
+    },
+    "Restart now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jetzt neu starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar ahora"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer maintenant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐ再起動"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить сейчас"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即重启"
+          }
+        }
+      }
+    },
+    "Restart the background helper — use this if App Store updates fail saying the helper isn’t answering. Asks for an administrator password.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Den Hintergrund-Helper neu starten – nutze dies, wenn App-Store-Updates fehlschlagen, weil der Helper nicht antwortet. Erfordert ein Administratorpasswort."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reinicia el asistente en segundo plano; úsalo si las actualizaciones de la App Store fallan indicando que el asistente no responde. Pide una contraseña de administrador."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarre l'assistant en arrière-plan — utilisez cette option si les mises à jour de l'App Store échouent en indiquant que l'assistant ne répond pas. Demande un mot de passe administrateur."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックグラウンドヘルパーを再起動します — App Storeの更新が「ヘルパーが応答していません」というエラーで失敗する場合に使用してください。管理者パスワードが必要です。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить фонового помощника — используйте, если обновления App Store завершаются ошибкой «помощник не отвечает». Потребует пароль администратора."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重启后台助理 — 如果 App Store 更新失败并提示助理无响应，请使用此选项。需要输入管理员密码。"
+          }
+        }
+      }
+    },
+    "Restart updated apps automatically": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisierte Apps automatisch neu starten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar automáticamente las apps actualizadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer automatiquement les applications mises à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新したアプリを自動的に再起動する"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматически перезапускать обновлённые приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动重启已更新的应用"
+          }
+        }
+      }
+    },
+    "Restarted on the new version.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit der neuen Version neu gestartet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se reinició con la versión nueva."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarré avec la nouvelle version."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいバージョンで再起動しました。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапущено на новой версии."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已在新版本上重新启动。"
+          }
+        }
+      }
+    },
+    "Restarting…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird neu gestartet …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrage en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再起動中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапуск…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在重启…"
+          }
+        }
+      }
+    },
+    "Restore %@ %@ from the backup taken before its last update": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ %@ aus dem Backup wiederherstellen, das vor dem letzten Update erstellt wurde"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar %@ %@ desde la copia de seguridad hecha antes de su última actualización"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurer %@ %@ à partir de la sauvegarde effectuée avant sa dernière mise à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回の更新前に作成したバックアップから %@ %@ を復元します"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановить %@ %@ из резервной копии, сделанной перед последним обновлением"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从上次更新前的备份中恢复 %@ %@"
+          }
+        }
+      }
+    },
+    "Reveal": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示"
+          }
+        }
+      }
+    },
+    "Reveal in Finder": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Finder anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar en el Finder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher dans le Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderで表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать в Finder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中显示"
+          }
+        }
+      }
+    },
+    "Roll back": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revertir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revenir en arrière"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロールバック"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откатить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回滚"
+          }
+        }
+      }
+    },
+    "Roll back to %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf %@ zurücksetzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revertir a %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revenir à %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ にロールバック"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откатить до %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回滚到 %@"
+          }
+        }
+      }
+    },
+    "Rollback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reversión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restauration"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロールバック"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откат"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回滚"
+          }
+        }
+      }
+    },
+    "Run Setup Again…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einrichtung erneut ausführen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver a ejecutar la configuración…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relancer la configuration…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップをもう一度実行…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустить настройку заново…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新运行设置…"
+          }
+        }
+      }
+    },
+    "Running": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En ejecución"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En cours d'exécution"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запущено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行中"
+          }
+        }
+      }
+    },
+    "Running %@ but %@ is installed — restart to apply it": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ läuft, aber %@ ist installiert – neu starten, um es anzuwenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se está ejecutando %@, pero está instalado %@; reinicia para aplicarlo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est en cours d'exécution mais %@ est installé — redémarrez pour l'appliquer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を実行中ですが %@ がインストールされています — 再起動して適用してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запущена версия %@, но установлена %@ — перезапустите, чтобы применить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在运行 %@，但已安装 %@ — 重启以应用"
+          }
+        }
+      }
+    },
+    "Running an older build — restart to apply the installed update": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es läuft ein älterer Build – neu starten, um das installierte Update anzuwenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se está ejecutando una compilación anterior; reinicia para aplicar la actualización instalada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une ancienne version est en cours d'exécution — redémarrez pour appliquer la mise à jour installée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いビルドが実行中です — 再起動してインストール済みの更新を適用してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запущена более старая сборка — перезапустите, чтобы применить установленное обновление"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在运行较旧的版本 — 重启以应用已安装的更新"
+          }
+        }
+      }
+    },
+    "Running brew upgrade…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew upgrade wird ausgeführt …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutando brew upgrade…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécution de brew upgrade…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brew upgrade を実行中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняется brew upgrade…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在运行 brew upgrade…"
+          }
+        }
+      }
+    },
+    "Running now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft gerade"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En ejecución"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En cours d'exécution"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сейчас запущено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在运行"
+          }
+        }
+      }
+    },
+    "Runs `brew upgrade --formula` — upgrades every outdated CLI formula at once. Casks are managed per-row above.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führt `brew upgrade --formula` aus – aktualisiert alle veralteten CLI-Formeln auf einmal. Casks werden oben zeilenweise verwaltet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta `brew upgrade --formula`; actualiza de una vez todas las fórmulas de CLI desactualizadas. Los casks se gestionan fila por fila arriba."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécute `brew upgrade --formula` — met à niveau toutes les formules CLI obsolètes en une fois. Les casks sont gérés ligne par ligne ci-dessus."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`brew upgrade --formula` を実行し、古いCLIフォーミュラをまとめてアップグレードします。Caskは上の各行で個別に管理されます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняет `brew upgrade --formula` — обновляет сразу все устаревшие формулы командной строки. Casks управляются построчно выше."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行 `brew upgrade --formula` — 一次性升级所有过期的命令行配方。Cask 在上方逐行管理。"
+          }
+        }
+      }
+    },
+    "Runs `brew upgrade --formula`, then upgrades any listed cask by name. Covers command-line formulae plus casks that install no app (CLIs, fonts) — those have no row of their own. GUI casks are managed per-app above and are never touched. The count reads your local tap; brew refreshes itself during the upgrade, so it still lands the latest.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Führt `brew upgrade --formula` aus und aktualisiert anschließend jeden aufgeführten Cask namentlich. Umfasst Kommandozeilen-Formeln sowie Casks, die keine App installieren (CLIs, Schriften) – diese haben keine eigene Zeile. GUI-Casks werden oben pro App verwaltet und nie berührt. Die Anzahl liest deinen lokalen Tap; brew aktualisiert sich während des Upgrades selbst, sodass trotzdem die neueste Version landet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecuta `brew upgrade --formula` y luego actualiza por nombre cada cask listado. Cubre las fórmulas de línea de comandos y los casks que no instalan ninguna app (CLI, fuentes), que no tienen fila propia. Los casks GUI se gestionan por app arriba y nunca se tocan aquí. El recuento lee tu tap local; brew se actualiza a sí mismo durante el proceso, así que igualmente obtiene la última versión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécute `brew upgrade --formula`, puis met à niveau chaque cask listé par son nom. Couvre les formules en ligne de commande ainsi que les casks qui n'installent aucune application (CLI, polices) — ceux-ci n'ont pas de ligne propre. Les casks GUI sont gérés par application ci-dessus et ne sont jamais touchés. Le nombre lit votre tap local ; brew se rafraîchit lui-même pendant la mise à niveau, donc la dernière version est quand même obtenue."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`brew upgrade --formula` を実行し、その後リストにある各Caskを名前で個別にアップグレードします。CLIフォーミュラと、アプリをインストールしないCask（CLI、フォントなど、専用の行がないもの）が対象です。GUI Caskは上の各アプリ行で管理され、ここでは決して操作されません。件数はローカルのtapを参照します。アップグレード中にbrew自体も更新されるため、常に最新の状態が反映されます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняет `brew upgrade --formula`, затем обновляет по имени каждый указанный cask. Охватывает формулы командной строки и casks, не устанавливающие приложение (CLI, шрифты) — у них нет отдельной строки. GUI-casks управляются построчно выше и никогда не затрагиваются. Счётчик читает ваш локальный tap; brew обновляется сам в процессе, так что всё равно устанавливается последняя версия."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行 `brew upgrade --formula`，然后按名称升级所有列出的 cask。涵盖命令行配方以及不安装应用的 cask（CLI、字体）— 它们没有自己的行。GUI cask 在上方按应用逐个管理，绝不会被触及。计数读取你本地的 tap；brew 会在升级过程中自我刷新，因此仍会获取最新版本。"
+          }
+        }
+      }
+    },
+    "Save": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Save key + instance ID": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlüssel + Instanz-ID speichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar clave e ID de instancia"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer la clé et l'ID d'instance"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーとインスタンスIDを保存"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить ключ и ID экземпляра"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存密钥和实例 ID"
+          }
+        }
+      }
+    },
+    "Saved": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gespeichert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済み"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存"
+          }
+        }
+      }
+    },
+    "Saved · belongs to %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gespeichert · gehört zu %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado · pertenece a %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistré · appartient à %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済み · %@ のもの"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранено · принадлежит %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存 · 属于 %@"
+          }
+        }
+      }
+    },
+    "Saved — precise detection enabled.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gespeichert – präzise Erkennung aktiviert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado; detección precisa activada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistré — détection précise activée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済み — 高精度検出が有効になりました。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранено — точное определение включено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存 — 已启用精确检测。"
+          }
+        }
+      }
+    },
+    "Saved — using a new activation for this Mac.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gespeichert – neue Aktivierung für diesen Mac wird verwendet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado; se está usando una activación nueva para este Mac."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistré — utilise une nouvelle activation pour ce Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済み — このMac用に新しいアクティベーションを使用しています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранено — используется новая активация для этого Mac."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存 — 正在为此 Mac 使用新的激活。"
+          }
+        }
+      }
+    },
+    "Scanning…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird gescannt …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキャン中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сканирование…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在扫描…"
+          }
+        }
+      }
+    },
+    "Search": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suchen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поиск"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索"
+          }
+        }
+      }
+    },
+    "Search apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps suchen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des applications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを検索"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поиск приложений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索应用"
+          }
+        }
+      }
+    },
+    "Select All": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle auswählen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout sélectionner"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて選択"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрать все"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全选"
+          }
+        }
+      }
+    },
+    "Select an app": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App auswählen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona una app"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner une application"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリを選択"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите приложение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择一个应用"
+          }
+        }
+      }
+    },
+    "Self-updating apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selbstaktualisierende Apps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apps que se actualizan solas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applications à mise à jour automatique"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自己更新するアプリ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Самообновляющиеся приложения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自更新应用"
+          }
+        }
+      }
+    },
+    "Set Up…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einrichten …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurer…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップ…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настроить…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        }
+      }
+    },
+    "Settings…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
+          }
+        }
+      }
+    },
+    "Show all": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout afficher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать все"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示全部"
+          }
+        }
+      }
+    },
+    "Show token": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar token"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le jeton"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トークンを表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать токен"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示令牌"
+          }
+        }
+      }
+    },
+    "Signed in as %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angemeldet als %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesión iniciada como %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecté en tant que %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ としてサインイン中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы вошли как %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已登录为 %@"
+          }
+        }
+      }
+    },
+    "Skip %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ überspringen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をスキップ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропустить %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过 %@"
+          }
+        }
+      }
+    },
+    "Skipped": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersprungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignoré (version)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキップ済み"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропущено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已跳过"
+          }
+        }
+      }
+    },
+    "Skipped versions": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersprungene Versionen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versiones omitidas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versions ignorées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキップされたバージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропущенные версии"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已跳过的版本"
+          }
+        }
+      }
+    },
+    "Sparkle": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle"
+          }
+        }
+      }
+    },
+    "Starting…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird gestartet …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrage…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начало…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在开始…"
+          }
+        }
+      }
+    },
+    "Still running %@ — restart pending from an earlier update": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es läuft noch %@ – Neustart aus einem früheren Update steht noch aus"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún se está ejecutando %@; queda pendiente un reinicio de una actualización anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ est toujours en cours d'exécution — redémarrage en attente d'une mise à jour précédente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだ %@ が実行中です — 以前の更新による再起動が保留中です"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё ещё запущена версия %@ — ожидается перезапуск после предыдущего обновления"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仍在运行 %@ — 等待此前更新的重启"
+          }
+        }
+      }
+    },
+    "Stop ignoring %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ nicht mehr ignorieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dejar de ignorar %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne plus ignorer %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の無視を解除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перестать игнорировать %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止忽略 %@"
+          }
+        }
+      }
+    },
+    "Switch between side-by-side and long-scroll layouts": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischen nebeneinander angeordnetem Layout und Langbildlauf wechseln"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar entre el diseño en paralelo y el de desplazamiento largo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basculer entre la disposition côte à côte et le défilement long"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左右分割とロングスクロールのレイアウトを切り替えます"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключение между расположением бок о бок и длинной прокруткой"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在并排布局和长滚动布局之间切换"
+          }
+        }
+      }
+    },
+    "Switched on but not responding — use Restart Helper": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeschaltet, antwortet aber nicht – „Helper neu starten“ verwenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado pero sin respuesta; usa «Reiniciar el asistente»"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activé mais ne répond pas — utilisez « Redémarrer l'assistant »"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効ですが応答がありません — 「ヘルパーを再起動」を使用してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включён, но не отвечает — используйте «Перезапустить помощник»"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已开启但无响应 — 请使用“重启助理”"
+          }
+        }
+      }
+    },
+    "TestFlight": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TestFlight"
+          }
+        }
+      }
+    },
+    "That folder is already covered.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Ordner wird bereits erfasst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esa carpeta ya está incluida."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce dossier est déjà couvert."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "そのフォルダはすでに対象になっています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта папка уже отслеживается."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该文件夹已被覆盖。"
+          }
+        }
+      }
+    },
+    "The file loaded but carried no release sections.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Datei wurde geladen, enthielt aber keine Versionsabschnitte."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El archivo se cargó pero no contenía ninguna sección de versión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier a été chargé mais ne contenait aucune section de version."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルは読み込まれましたが、リリースに関する項目が含まれていませんでした。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл загружен, но не содержит разделов о выпуске."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件已加载，但不包含任何发行说明部分。"
+          }
+        }
+      }
+    },
+    "The install finished without an error, but %@ on disk is still %@ — what was downloaded wasn't %@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Installation wurde ohne Fehler abgeschlossen, aber %@ ist auf der Festplatte weiterhin %@ – was heruntergeladen wurde, war nicht %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La instalación terminó sin errores, pero %@ en el disco sigue en %@; lo descargado no era %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'installation s'est terminée sans erreur, mais %@ sur le disque est toujours en %@ — ce qui a été téléchargé n'était pas %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールはエラーなく完了しましたが、ディスク上の %@ はまだ %@ のままです — ダウンロードされたものは %@ ではありませんでした。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установка завершилась без ошибок, но %@ на диске всё ещё %@ — то, что было загружено, не является %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装未报告错误，但磁盘上的 %@ 仍为 %@ — 下载的内容并非 %@。"
+          }
+        }
+      }
+    },
+    "The latest version no longer supports this Mac — click for details": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die neueste Version unterstützt diesen Mac nicht mehr – für Details klicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La última versión ya no admite este Mac; haz clic para más información"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La dernière version ne prend plus en charge ce Mac — cliquez pour en savoir plus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新バージョンはこのMacをサポートしなくなりました — クリックして詳細を表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последняя версия больше не поддерживает этот Mac — нажмите для подробностей"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新版本已不再支持此 Mac — 点击查看详情"
+          }
+        }
+      }
+    },
+    "The update is downloaded. Relaunch %@ to finish installing it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Update wurde heruntergeladen. %@ neu starten, um die Installation abzuschließen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La actualización está descargada. Reabre %@ para terminar de instalarla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La mise à jour est téléchargée. Relancez %@ pour terminer l'installation."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新はダウンロード済みです。%@ を再起動してインストールを完了してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление загружено. Перезапустите %@, чтобы завершить установку."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新已下载。重新启动 %@ 以完成安装。"
+          }
+        }
+      }
+    },
+    "The update is installed; Update All is waiting to restart apps until the batch finishes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Update ist installiert; „Alle aktualisieren“ wartet mit dem Neustart der Apps, bis der Stapel abgeschlossen ist"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La actualización está instalada; «Actualizar todo» esperará a que termine el lote antes de reiniciar las apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La mise à jour est installée ; « Tout mettre à jour » attend la fin du lot avant de redémarrer les applications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新はインストール済みです。「すべて更新」はこのバッチが完了するまでアプリの再起動を待機します。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление установлено; «Обновить всё» отложит перезапуск приложений до завершения пакета"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新已安装；“全部更新”会等到本批次完成后再重启应用"
+          }
+        }
+      }
+    },
+    "The vendor's latest is %@ — older than your %@. You're ahead, so there's nothing to do. Usually a beta channel, a pulled release, or a lagging check.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die neueste Version des Anbieters ist %@ – älter als deine %@. Du bist voraus, es ist also nichts zu tun. Meist liegt das an einem Beta-Kanal, einer zurückgezogenen Version oder einer verzögerten Prüfung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La última versión del proveedor es %@, anterior a tu %@. Vas por delante, así que no hay nada que hacer. Suele deberse a un canal beta, una versión retirada o una comprobación desfasada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La dernière version de l'éditeur est %@ — plus ancienne que votre %@. Vous avez de l'avance, rien à faire. Cela vient généralement d'un canal bêta, d'une version retirée ou d'une vérification en retard."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ベンダーの最新版は %@ で、お使いの %@ より古いバージョンです。先行しているため何もする必要はありません。通常はベータチャンネル、取り下げられたリリース、または確認の遅延が原因です。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последняя версия от поставщика — %@, она старше вашей %@. Вы впереди, поэтому делать ничего не нужно. Обычно это бета-канал, отозванный релиз или отстающая проверка."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "厂商的最新版本为 %@ — 比你的 %@ 更旧。你领先了，无需操作。通常是测试版渠道、已撤回的版本或检查滞后所致。"
+          }
+        }
+      }
+    },
+    "The version you're running": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Version, die du gerade nutzt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La versión que estás usando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La version que vous utilisez"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在使用中のバージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия, которую вы используете"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你正在运行的版本"
+          }
+        }
+      }
+    },
+    "This app reports versions but no exact release time, so there's no habit heatmap — only the estimated windows below.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese App meldet Versionen, aber keine genaue Release-Zeit, daher gibt es keine Gewohnheits-Heatmap – nur die geschätzten Zeitfenster unten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta app informa las versiones pero no una hora de publicación exacta, así que no hay mapa de calor de hábitos; solo las ventanas estimadas de abajo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette application indique les versions mais pas d'heure de publication exacte, il n'y a donc pas de carte de chaleur des habitudes — seulement les fenêtres estimées ci-dessous."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このアプリはバージョンを報告しますが、正確なリリース時刻はないため、習慣ヒートマップはありません — 以下は推定される範囲のみです。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это приложение сообщает версии, но не точное время релиза, поэтому тепловая карта привычек недоступна — только оценочные окна ниже."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此应用会报告版本，但没有确切的发布时间，因此没有习惯热力图 — 仅有下方的估计区间。"
+          }
+        }
+      }
+    },
+    "This source": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Quelle"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta fuente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このソース"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот источник"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此来源"
+          }
+        }
+      }
+    },
+    "Timeline": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitachse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cronología"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chronologie"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムライン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хронология"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时间线"
+          }
+        }
+      }
+    },
+    "Toggle “Show all” to see every app.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviere „Alle anzeigen“, um jede App zu sehen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa «Mostrar todo» para ver todas las apps."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez « Tout afficher » pour voir toutes les applications."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「すべて表示」を有効にするとすべてのアプリが表示されます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите «Показать все», чтобы увидеть все приложения."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开“显示全部”即可查看所有应用。"
+          }
+        }
+      }
+    },
+    "Toolbox": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toolbox"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toolbox"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toolbox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toolbox"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toolbox"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toolbox"
+          }
+        }
+      }
+    },
+    "Total downloaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insgesamt heruntergeladen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total descargado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total téléchargé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "合計ダウンロード量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всего загружено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "总下载量"
+          }
+        }
+      }
+    },
+    "Traffic": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenverkehr"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tráfico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trafic"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トラフィック"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Трафик"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "流量"
+          }
+        }
+      }
+    },
+    "Traffic appears here after an update we download ourselves (Sparkle, a vendor site, GitHub, or a pkg). Homebrew, the App Store, and apps that update through their own built-in updater aren’t measured.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenverkehr erscheint hier nach einem Update, das wir selbst heruntergeladen haben (Sparkle, eine Anbieter-Website, GitHub oder ein Pkg). Homebrew, der App Store und Apps, die über ihr eigenes integriertes Update-Tool aktualisieren, werden nicht erfasst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El tráfico aparece aquí tras una actualización que descargamos nosotros mismos (Sparkle, el sitio de un proveedor, GitHub o un pkg). Homebrew, la App Store y las apps que se actualizan mediante su propio actualizador integrado no se miden."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le trafic apparaît ici après une mise à jour que nous téléchargeons nous-mêmes (Sparkle, le site d'un éditeur, GitHub ou un pkg). Homebrew, l'App Store et les applications qui se mettent à jour via leur propre outil intégré ne sont pas mesurés."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkle、ベンダーサイト、GitHub、pkgなど、こちらが自分でダウンロードした更新の後にトラフィックがここに表示されます。Homebrew、App Store、および独自の内蔵アップデーターで更新するアプリは計測されません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Трафик появляется здесь после обновления, загруженного нами самостоятельно (Sparkle, сайт поставщика, GitHub или pkg). Homebrew, App Store и приложения, обновляющиеся через встроенный обновитель, не учитываются."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当我们自行下载更新（Sparkle、厂商网站、GitHub 或 pkg）后，流量会显示在此处。Homebrew、App Store 以及通过自身内置更新程序更新的应用不会被统计。"
+          }
+        }
+      }
+    },
+    "Try Again": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut versuchen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réessayer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повторить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试"
+          }
+        }
+      }
+    },
+    "Turn On Helper…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper einschalten …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar el asistente…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer l'assistant…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーを有効にする…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить помощника…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用助理…"
+          }
+        }
+      }
+    },
+    "Turn on DuoUpdater's background helper": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaters Hintergrund-Helper einschalten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa el asistente en segundo plano de DuoUpdater"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez l'assistant en arrière-plan de DuoUpdater"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DuoUpdaterのバックグラウンドヘルパーをオンにする"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите фонового помощника DuoUpdater"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开启 DuoUpdater 的后台助理"
+          }
+        }
+      }
+    },
+    "Unignore": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht mehr ignorieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dejar de ignorar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ne plus ignorer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無視を解除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перестать игнорировать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消忽略"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconocido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inconnu"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неизвестно"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
+        }
+      }
+    },
+    "Update": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Update %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を更新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新 %@"
+          }
+        }
+      }
+    },
+    "Update %@ in the App Store": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ im App Store aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar %@ en la App Store"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour %@ dans l'App Store"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeで%@を更新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить %@ в App Store"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 App Store 中更新 %@"
+          }
+        }
+      }
+    },
+    "Update %@ in the App Store — iPhone/iPad apps can’t be updated from here": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ im App Store aktualisieren – iPhone/iPad-Apps können hier nicht aktualisiert werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar %@ en la App Store; las apps de iPhone/iPad no se pueden actualizar aquí"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour %@ dans l'App Store — les applications iPhone/iPad ne peuvent pas être mises à jour ici"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Storeで%@を更新 — iPhone/iPad用アプリはここから更新できません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить %@ в App Store — приложения для iPhone/iPad нельзя обновить отсюда"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 App Store 中更新 %@ — 无法在此处更新 iPhone/iPad 应用"
+          }
+        }
+      }
+    },
+    "Update All": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar todo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout mettre à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて更新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить всё"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部更新"
+          }
+        }
+      }
+    },
+    "Update anyway": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trotzdem aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar de todos modos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour quand même"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "それでも更新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё равно обновить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仍然更新"
+          }
+        }
+      }
+    },
+    "Update check failed — click to retry": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update-Prüfung fehlgeschlagen – zum Wiederholen klicken"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fallo al comprobar actualizaciones; haz clic para reintentar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la vérification des mises à jour — cliquez pour réessayer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新の確認に失敗しました — クリックして再試行"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось проверить обновления — нажмите, чтобы повторить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新检查失败 — 点击重试"
+          }
+        }
+      }
+    },
+    "Update in background": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Hintergrund aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar en segundo plano"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à jour en arrière-plan"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックグラウンドで更新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить в фоновом режиме"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在后台更新"
+          }
+        }
+      }
+    },
+    "Update is ready. Restart to apply it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update ist bereit. Zum Anwenden neu starten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La actualización está lista. Reinicia para aplicarla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La mise à jour est prête. Redémarrez pour l'appliquer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新の準備ができました。再起動して適用してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление готово. Перезапустите, чтобы применить."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新已就绪。重启以应用。"
+          }
+        }
+      }
+    },
+    "Update to %@ is ready. Restart to apply it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update auf %@ ist bereit. Zum Anwenden neu starten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La actualización a %@ está lista. Reinicia para aplicarla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La mise à jour vers %@ est prête. Redémarrez pour l'appliquer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ への更新の準備ができました。再起動して適用してください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление до %@ готово. Перезапустите, чтобы применить."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新到 %@ 已就绪。重启以应用。"
+          }
+        }
+      }
+    },
+    "Updated": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新済み"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновлено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已更新"
+          }
+        }
+      }
+    },
+    "Updated to %@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf %@ aktualisiert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizado a %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis à jour vers %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に更新しました。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновлено до %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已更新至 %@。"
+          }
+        }
+      }
+    },
+    "Updated.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisiert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis à jour."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新しました。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновлено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已更新。"
+          }
+        }
+      }
+    },
+    "Updates": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデート"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновления"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Updates installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates installiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones instaladas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour installées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートをインストールしました"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновления установлены"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新已安装"
+          }
+        }
+      }
+    },
+    "Updating…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aktualisiert …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour en cours…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新…"
+          }
+        }
+      }
+    },
+    "Upgrade": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mettre à niveau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップグレード"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "升级"
+          }
+        }
+      }
+    },
+    "Upgrade All": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Formeln aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar fórmulas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout mettre à niveau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてアップグレード"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить формулы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部升级"
+          }
+        }
+      }
+    },
+    "Upgrading Homebrew formulae": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew-Formeln werden aktualisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando fórmulas de Homebrew"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à niveau des formules Homebrew"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homebrew フォーミュラをアップグレード中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление формул Homebrew"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在升级 Homebrew 配方"
+          }
+        }
+      }
+    },
+    "Upgrading… (%@/%@)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird aktualisiert … (%@/%@)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando… (%@/%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à niveau en cours… (%@/%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップグレード中…（%@/%@）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление… (%@/%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在升级…（%@/%@）"
+          }
+        }
+      }
+    },
+    "Usually ships %@, around %@.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erscheint gewöhnlich %@, gegen %@."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suele publicarse el %@, alrededor de las %@."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort généralement %@, vers %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通常は %@ の %@ 頃にリリースされます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обычно выходит %@, около %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通常在 %@ 发布，大约 %@。"
+          }
+        }
+      }
+    },
+    "Valid — belongs to **%@**": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gültig – gehört zu **%@**"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Válido; pertenece a **%@**"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valide — appartient à **%@**"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効 — **%@** のもの"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Действителен — принадлежит **%@**"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有效 — 属于 **%@**"
+          }
+        }
+      }
+    },
+    "Verify & Save": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen & Speichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar y guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier et enregistrer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証して保存"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить и сохранить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证并保存"
+          }
+        }
+      }
+    },
+    "Verifying": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird verifiziert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification en cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка целостности"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在校验"
+          }
+        }
+      }
+    },
+    "Versions": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versionen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versiones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версии"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本"
+          }
+        }
+      }
+    },
+    "View": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看"
+          }
+        }
+      }
+    },
+    "Welcome to Duo Updater": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Willkommen bei Duo Updater"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenido a Duo Updater"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bienvenue dans Duo Updater"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaterへようこそ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добро пожаловать в Duo Updater"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "欢迎使用 Duo Updater"
+          }
+        }
+      }
+    },
+    "What's New": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuigkeiten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novedades"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveautés"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新機能について"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что нового"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新功能"
+          }
+        }
+      }
+    },
+    "What's New — Duo Updater's own release notes": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuigkeiten – die eigenen Versionshinweise von Duo Updater"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novedades: notas de la versión del propio Duo Updater"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveautés — notes de version de Duo Updater lui-même"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新機能について — Duo Updater 自体のリリースノート"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что нового — заметки о выпуске самого Duo Updater"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新功能 — Duo Updater 自身的发行说明"
+          }
+        }
+      }
+    },
+    "Where Duo Updater looks for installed apps.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wo Duo Updater nach installierten Apps sucht."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dónde busca Duo Updater las apps instaladas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Où Duo Updater recherche les applications installées."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updaterがインストール済みアプリを探す場所。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Где Duo Updater ищет установленные приложения."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duo Updater 在哪里查找已安装的应用。"
+          }
+        }
+      }
+    },
+    "You already have it installed, so it can still be updated — DuoUpdater drives the App Store’s Updates list in the background (a fresh install would need a %@ account). It only works once the App Store has listed this update; if it hasn’t yet, try again later.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du hast die App bereits installiert, daher kann sie trotzdem aktualisiert werden – DuoUpdater steuert die Updates-Liste des App Stores im Hintergrund (für eine Neuinstallation wäre ein %@-Account nötig). Das funktioniert erst, sobald der App Store dieses Update gelistet hat; falls noch nicht, versuche es später erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya la tienes instalada, así que aún se puede actualizar: DuoUpdater controla la lista de actualizaciones de la App Store en segundo plano (una instalación nueva necesitaría una cuenta de %@). Solo funciona una vez que la App Store haya publicado esta actualización; si aún no lo ha hecho, inténtalo más tarde."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous l'avez déjà installée, elle peut donc quand même être mise à jour — DuoUpdater pilote la liste des mises à jour de l'App Store en arrière-plan (une nouvelle installation nécessiterait un compte %@). Cela ne fonctionne qu'une fois que l'App Store a listé cette mise à jour ; si ce n'est pas encore le cas, réessayez plus tard."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すでにインストール済みなので、引き続き更新できます — DuoUpdaterがバックグラウンドでApp Storeの「アップデート」リストを操作します（新規インストールには%@のアカウントが必要です）。これはApp Storeがこの更新をリストに掲載した後にのみ機能します。まだ掲載されていない場合は、後でもう一度お試しください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У вас уже установлено это приложение, поэтому обновление всё же возможно — DuoUpdater управляет списком обновлений App Store в фоновом режиме (для новой установки понадобится учётная запись региона %@). Это работает только после того, как App Store добавит обновление в список; если этого ещё не произошло, попробуйте позже."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已经安装了它，所以仍然可以更新 — DuoUpdater 会在后台驱动 App Store 的“更新”列表（全新安装则需要 %@ 地区的账户）。这仅在 App Store 已将此更新列出后才有效；如果尚未列出，请稍后再试。"
+          }
+        }
+      }
+    },
+    "You can keep using the installed version (%@). Updating isn't possible until the developer ships a Mac-compatible build again — it's the vendor's choice, not a refresh problem.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du kannst die installierte Version (%@) weiter nutzen. Ein Update ist erst möglich, wenn der Entwickler wieder eine Mac-kompatible Version veröffentlicht – das ist die Entscheidung des Anbieters, kein Prüfproblem."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puedes seguir usando la versión instalada (%@). No podrás actualizar hasta que el desarrollador publique de nuevo una compilación compatible con Mac; es decisión del proveedor, no un problema de comprobación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous pouvez continuer à utiliser la version installée (%@). La mise à jour ne sera possible que lorsque le développeur publiera à nouveau une version compatible Mac — c'est un choix de l'éditeur, pas un problème de vérification."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済みのバージョン（%@）はそのまま使用できます。開発元がMac対応ビルドを再度提供するまで更新はできません — これは確認の問題ではなく、開発元の判断によるものです。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы можете продолжать использовать установленную версию (%@). Обновление невозможно, пока разработчик снова не выпустит сборку, совместимую с Mac — это решение поставщика, а не проблема проверки."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你可以继续使用已安装的版本（%@）。在开发者再次发布兼容 Mac 的版本之前，无法更新 — 这是厂商的选择，而非检测问题。"
+          }
+        }
+      }
+    },
+    "You skipped this version — right-click to un-skip": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Version wurde übersprungen – Rechtsklick, um das rückgängig zu machen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitiste esta versión; clic derecho para dejar de omitirla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous avez ignoré cette version — clic droit pour annuler"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このバージョンはスキップされています — 右クリックでスキップを解除"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы пропустили эту версию — щёлкните правой кнопкой, чтобы отменить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已跳过此版本 — 右键点击以取消跳过"
+          }
+        }
+      }
+    },
+    "You’re running an older version — restart to finish updating": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du nutzt eine ältere Version – neu starten, um das Update abzuschließen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estás usando una versión anterior; reinicia para terminar de actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous utilisez une ancienne version — redémarrez pour terminer la mise à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いバージョンを実行中です — 再起動して更新を完了してください"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы используете более старую версию — перезапустите, чтобы завершить обновление"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你正在运行较旧版本 — 重启以完成更新"
+          }
+        }
+      }
+    },
+    "create a personal access token": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ein persönliches Zugriffstoken erstellen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "crea un token de acceso personal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "créer un jeton d'accès personnel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パーソナルアクセストークンを作成"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "создать личный токен доступа"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建个人访问令牌"
+          }
+        }
+      }
+    },
+    "current": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aktuell"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "actual"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "actuelle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のバージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "текущей"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前版本"
+          }
+        }
+      }
+    },
+    "instance_id (UUID)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "instance_id (UUID)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "instance_id (UUID)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "instance_id (UUID)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "instance_id（UUID）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "instance_id (UUID)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "instance_id（UUID）"
+          }
+        }
+      }
+    },
+    "just now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gerade eben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "justo ahora"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "à l'instant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "たった今"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "только что"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刚刚"
+          }
+        }
+      }
+    },
+    "macOS refused the registration — its record of this background item is damaged. Fixing it needs a system-level reset: run “sudo sfltool resetbtm” in Terminal and restart. That clears background-item approvals for every app, so you'll re-approve the others too.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS hat die Registrierung abgelehnt – der Datensatz zu diesem Hintergrundelement ist beschädigt. Die Behebung erfordert einen systemweiten Reset: Führe „sudo sfltool resetbtm“ im Terminal aus und starte neu. Das löscht die Genehmigungen für Hintergrundelemente aller Apps, sodass du die anderen ebenfalls erneut genehmigen musst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS rechazó el registro; su registro de este elemento en segundo plano está dañado. Solucionarlo requiere un restablecimiento a nivel de sistema: ejecuta «sudo sfltool resetbtm» en Terminal y reinicia. Esto borra los permisos de elementos en segundo plano de todas las apps, así que tendrás que volver a aprobar las demás."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS a refusé l'enregistrement — son enregistrement de cet élément en arrière-plan est corrompu. La réparation nécessite une réinitialisation au niveau système : exécutez « sudo sfltool resetbtm » dans le Terminal et redémarrez. Cela efface les autorisations d'éléments en arrière-plan pour toutes les applications, vous devrez donc réapprouver les autres aussi."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOSが登録を拒否しました — このバックグラウンド項目に関する記録が破損しています。修復にはシステムレベルのリセットが必要です。ターミナルで「sudo sfltool resetbtm」を実行して再起動してください。これによりすべてのアプリのバックグラウンド項目の承認がクリアされるため、他のアプリも再承認が必要になります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS отклонила регистрацию — её запись об этом фоновом элементе повреждена. Для исправления нужен сброс на уровне системы: выполните «sudo sfltool resetbtm» в Терминале и перезагрузитесь. Это очистит разрешения фоновых элементов для всех приложений, так что остальные придётся одобрить заново."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 拒绝了注册 — 它关于此后台项目的记录已损坏。修复需要系统级重置：在终端中运行“sudo sfltool resetbtm”并重启。这会清除所有应用的后台项目授权，因此你需要重新批准其他应用。"
+          }
+        }
+      }
+    },
+    "previous version": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vorherige Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "versión anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "version précédente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以前のバージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "предыдущая версия"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "先前版本"
+          }
+        }
+      }
+    },
+    "the latest version": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "die neueste Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "la última versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "la dernière version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新バージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "последняя версия"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新版本"
+          }
+        }
+      }
+    },
+    "the new version": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "die neue Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "la nueva versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "la nouvelle version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいバージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "новая версия"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新版本"
+          }
+        }
+      }
+    },
+    "the update": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "das Update"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "la actualización"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "la mise à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この更新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "обновление"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此更新"
+          }
+        }
+      }
+    },
+    "this version": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "diese Version"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "esta versión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cette version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このバージョン"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "эта версия"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此版本"
+          }
+        }
+      }
+    },
+    "v%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@"
+          }
+        }
+      }
+    },
+    "v%@ · up to date": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ · aktuell"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ · actualizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ · à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ · 最新"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ · актуально"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ · 已是最新"
+          }
+        }
+      }
+    },
+    "v%@ → %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ → %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ → %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ → %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ → %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ → %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "v%@ → %@"
+          }
+        }
+      }
+    },
+    "validation request failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfanfrage fehlgeschlagen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falló la solicitud de validación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La demande de validation a échoué"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証リクエストに失敗しました"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "запрос на проверку не выполнен"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证请求失败"
+          }
+        }
+      }
+    },
+    "your region": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "deine Region"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tu región"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "votre région"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お使いの地域"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ваш регион"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的地区"
+          }
+        }
+      }
+    },
+    "· app no longer installed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· App nicht mehr installiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· la app ya no está instalada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· application désinstallée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· アプリはインストールされていません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· приложение больше не установлено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· 应用已不再安装"
+          }
+        }
+      }
+    },
+    "· unusable, its record is missing": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· unbrauchbar, Datensatz fehlt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· inutilizable, falta el registro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· inutilisable, l'enregistrement est manquant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· 使用不可、記録がありません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· неработоспособна, отсутствует запись"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· 不可用，记录缺失"
+          }
+        }
+      }
+    },
+    "≈ %@–%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "≈ %@–%@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "≈ %@–%@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "≈ %@–%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "≈ %@–%@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "≈ %@–%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "≈ %@–%@"
+          }
+        }
+      }
+    },
+    "≈ within %lldd": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ innerhalb von %lld Tag"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ innerhalb von %lld Tagen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ within %lldd"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ within %lldd"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ en un plazo de %lld día"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ en un plazo de %lld días"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ dans un délai de %lld j"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ dans un délai de %lld j"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ %lld日以内"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ в пределах %lldд"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ в пределах %lldд"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ в пределах %lldд"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ в пределах %lldд"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "≈ %lld 天内"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1,47 +1,6 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    " · checked %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " · geprüft %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " · comprobado %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " · vérifié %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " · 確認: %@"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " · проверено %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " · 检查于 %@"
-          }
-        }
-      }
-    },
     " — latest %@": {
       "extractionState": "manual",
       "localizations": {
@@ -776,6 +735,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ · %lld 字节"
+          }
+        }
+      }
+    },
+    "%@ · checked %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · geprüft %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · comprobado %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · vérifié %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · 確認: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · проверено %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · 检查于 %@"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -534,43 +534,43 @@
         }
       }
     },
-    "%@ is running — open it and let its own updater apply %@.": {
+    "%@ is running — open it and let its own updater apply %@. Quit it, or pick “Always replace” in Settings, to install directly.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ läuft – öffnen und das integrierte Update-Tool %@ anwenden lassen."
+            "value": "%@ läuft – öffnen und das integrierte Update-Tool %@ anwenden lassen. Zum direkten Installieren die App beenden oder in den Einstellungen „Immer ersetzen“ wählen."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ se está ejecutando; ábrela para que su propio actualizador aplique %@."
+            "value": "%@ se está ejecutando; ábrela para que su propio actualizador aplique %@. Ciérrala, o elige «Reemplazar siempre» en Ajustes, para instalar directamente."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ est en cours d'exécution — ouvrez-la pour laisser son propre outil appliquer %@."
+            "value": "%@ est en cours d'exécution — ouvrez-la pour laisser son propre outil appliquer %@. Quittez-la, ou choisissez « Toujours remplacer » dans les Réglages, pour installer directement."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ は実行中です — 開いて、独自の更新機能で %@ を適用してください。"
+            "value": "%@ は実行中です — 開いて、独自の更新機能で %@ を適用してください。終了するか、設定で「常に置き換える」を選ぶと直接インストールできます。"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ запущено — откройте его, чтобы его собственный обновитель применил %@."
+            "value": "%@ запущено — откройте его, чтобы его собственный обновитель применил %@. Закройте его или выберите «Всегда заменять» в настройках, чтобы установить напрямую."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 正在运行 — 打开它，让它自己的更新程序应用 %@。"
+            "value": "%@ 正在运行 — 打开它，让它自己的更新程序应用 %@。退出它，或在设置中选择“始终替换”，即可直接安装。"
           }
         }
       }
@@ -989,47 +989,6 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "%@’s built-in updater": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "das integrierte Update-Tool von %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "el actualizador integrado de %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "le programme de mise à jour intégré de %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ の内蔵更新機能"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "встроенный обновитель %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 的内置更新程序"
           }
         }
       }
@@ -2452,6 +2411,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "当规则成功获取响应但无法读取版本时会被标记 — 这通常表示厂商更改了其页面。下次成功检查时会自动清除。"
+          }
+        }
+      }
+    },
+    "AM": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AM"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a. m."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AM"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AM"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AM"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AM"
           }
         }
       }
@@ -8392,88 +8392,6 @@
         }
       }
     },
-    "Lifts GitHub’s 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. A token is already active — you’re all set.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erhöht das GitHub-Limit von 60 auf 5000 Anfragen pro Stunde, damit häufige Prüfungen von auf GitHub gehosteten Apps (RustDesk, Zed, Stats …) nicht an das Ratenlimit stoßen. Ein Token ist bereits aktiv – alles eingerichtet."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aumenta el límite de GitHub de 60 a 5000 solicitudes por hora, para que las comprobaciones frecuentes de apps alojadas en GitHub (RustDesk, Zed, Stats…) no den errores de límite. Ya hay un token activo; todo listo."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fait passer la limite de GitHub de 60 à 5000 requêtes par heure, afin que les vérifications fréquentes des applications hébergées sur GitHub (RustDesk, Zed, Stats…) n'atteignent pas la limite. Un jeton est déjà actif — tout est prêt."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GitHubの1時間あたり60リクエストの制限を5000リクエストに引き上げ、GitHubでホストされているアプリ（RustDesk、Zed、Statsなど）の頻繁な確認がレート制限エラーにならないようにします。トークンはすでに有効です — 準備は完了しています。"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Повышает лимит GitHub с 60 до 5000 запросов в час, чтобы частые проверки приложений на GitHub (RustDesk, Zed, Stats…) не упирались в ограничение. Токен уже активен — всё готово."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "将 GitHub 每小时 60 次的请求限制提升到 5000 次，让频繁检查 GitHub 托管的应用（RustDesk、Zed、Stats 等）不会触发限速错误。令牌已生效 — 一切就绪。"
-          }
-        }
-      }
-    },
-    "Lifts GitHub’s 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. Optional: sign in with the gh CLI, or paste a token.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erhöht das GitHub-Limit von 60 auf 5000 Anfragen pro Stunde, damit häufige Prüfungen von auf GitHub gehosteten Apps (RustDesk, Zed, Stats …) nicht an das Ratenlimit stoßen. Optional: mit gh CLI anmelden oder ein Token einfügen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aumenta el límite de GitHub de 60 a 5000 solicitudes por hora, para que las comprobaciones frecuentes de apps alojadas en GitHub (RustDesk, Zed, Stats…) no den errores de límite. Opcional: inicia sesión con gh CLI o pega un token."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fait passer la limite de GitHub de 60 à 5000 requêtes par heure, afin que les vérifications fréquentes des applications hébergées sur GitHub (RustDesk, Zed, Stats…) n'atteignent pas la limite. Facultatif : connectez-vous avec gh CLI, ou collez un jeton."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GitHubの1時間あたり60リクエストの制限を5000リクエストに引き上げ、GitHubでホストされているアプリ（RustDesk、Zed、Statsなど）の頻繁な確認がレート制限エラーにならないようにします。任意: gh CLIでサインインするか、トークンを貼り付けてください。"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Повышает лимит GitHub с 60 до 5000 запросов в час, чтобы частые проверки приложений на GitHub (RustDesk, Zed, Stats…) не упирались в ограничение. Необязательно: войдите через gh CLI или вставьте токен."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "将 GitHub 每小时 60 次的请求限制提升到 5000 次，让频繁检查 GitHub 托管的应用（RustDesk、Zed、Stats 等）不会触发限速错误。可选：通过 gh CLI 登录，或粘贴令牌。"
-          }
-        }
-      }
-    },
     "Lifts GitHub’s anonymous 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. A token is already active — you’re all set.": {
       "extractionState": "manual",
       "localizations": {
@@ -10438,6 +10356,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "在 App Store 中打开 %@。请在设置中启用后台助理，以便一键安装 App Store 更新。"
+          }
+        }
+      }
+    },
+    "PM": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PM"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p. m."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PM"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PM"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PM"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PM"
           }
         }
       }
@@ -16018,6 +15977,47 @@
         }
       }
     },
+    "a": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "a"
+          }
+        }
+      }
+    },
     "create a personal access token": {
       "extractionState": "manual",
       "localizations": {
@@ -16219,6 +16219,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS 拒绝了注册 — 它关于此后台项目的记录已损坏。修复需要系统级重置：在终端中运行“sudo sfltool resetbtm”并重启。这会清除所有应用的后台项目授权，因此你需要重新批准其他应用。"
+          }
+        }
+      }
+    },
+    "p": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "p"
           }
         }
       }

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1620,7 +1620,7 @@ final class AppListModel {
         guard upgradingFormulae.isEmpty else { return }
         brewUpgrading = true
         brewUpgradeError = nil
-        brewUpgradeNote = "Starting…"
+        brewUpgradeNote = String(localized: "Starting…")
         // Snapshot the target set so dependency formulae brew pulls in (which also
         // emit a 🍺 line) don't inflate the count past the user-visible total.
         let targets = Set(brewOutdatedFormulae.map(\.name))
@@ -1671,7 +1671,7 @@ final class AppListModel {
         guard !upgradingFormulae.contains(name) else { return }
         upgradingFormulae.insert(name)
         formulaUpgradeErrors[name] = nil
-        formulaUpgradeNotes[name] = "Starting…"
+        formulaUpgradeNotes[name] = String(localized: "Starting…")
         defer {
             upgradingFormulae.remove(name)
             formulaUpgradeNotes[name] = nil
@@ -1696,9 +1696,9 @@ final class AppListModel {
     /// available — the phase is the stable signal.
     nonisolated static func brewUpgradePhase(from line: String) -> String? {
         let l = line.lowercased()
-        if l.contains("pouring") || l.contains("installing") { return "Installing…" }
-        if l.contains("downloading") || l.contains("fetching") || l.contains("bottle") { return "Downloading…" }
-        if l.contains("cleaning") || l.contains("cleanup") { return "Cleaning up…" }
+        if l.contains("pouring") || l.contains("installing") { return String(localized: "Installing…") }
+        if l.contains("downloading") || l.contains("fetching") || l.contains("bottle") { return String(localized: "Downloading…") }
+        if l.contains("cleaning") || l.contains("cleanup") { return String(localized: "Cleaning up…") }
         return nil
     }
 
@@ -1707,7 +1707,7 @@ final class AppListModel {
     var brewBulkProgressText: String? {
         guard brewUpgrading, brewUpgradeTotal > 0 else { return nil }
         let current = min(brewUpgradeDone + 1, brewUpgradeTotal)
-        return "Upgrading… (\(current)/\(brewUpgradeTotal))"
+        return String(localized: "Upgrading… (\(current)/\(brewUpgradeTotal))")
     }
 
     /// Fetch a formula's release notes once, on first selection. Idempotent: a
@@ -2255,7 +2255,7 @@ final class AppListModel {
                 let onDisk = updated.app.shortVersion ?? updated.app.buildVersion ?? "?"
                 let target = result.remote?.displayVersion ?? result.remote?.shortVersion ?? "?"
                 Log.install.error("install applied nothing: \(updated.app.name, privacy: .public) still \(onDisk, privacy: .public) on disk after installing \(target, privacy: .public)")
-                installErrors[id] = "The install finished without an error, but \(updated.app.name) on disk is still \(onDisk) — what was downloaded wasn't \(target)."
+                installErrors[id] = String(localized: "The install finished without an error, but \(updated.app.name) on disk is still \(onDisk) — what was downloaded wasn't \(target).")
                 reopenIfQuitForUpdate(result)
                 installing[id] = nil
                 relaunching.remove(id)
@@ -3320,14 +3320,14 @@ final class AppListModel {
             return
         }
         let alert = NSAlert()
-        alert.messageText = "Turn on DuoUpdater's background helper"
-        alert.informativeText = """
+        alert.messageText = String(localized: "Turn on DuoUpdater's background helper")
+        alert.informativeText = String(localized: """
             App Store updates install through a background item that macOS asks you to \
             approve once. Switch DuoUpdater on under Login Items & Extensions, then run \
             the update again — after that it stays on and never asks for your password.
-            """
-        alert.addButton(withTitle: "Open Login Items")
-        alert.addButton(withTitle: "Not Now")
+            """)
+        alert.addButton(withTitle: String(localized: "Open Login Items"))
+        alert.addButton(withTitle: String(localized: "Not Now"))
         NSApp.activate(ignoringOtherApps: true)
         if alert.runModal() == .alertFirstButtonReturn {
             helperClient.openLoginItems()

--- a/App/Sources/AppSearchField.swift
+++ b/App/Sources/AppSearchField.swift
@@ -8,7 +8,7 @@ import AppKit
 /// the standard rounded search-field appearance, magnifier, and built-in clear button.
 struct AppSearchField: NSViewRepresentable {
     @Binding var text: String
-    var prompt: String = "Search apps"
+    var prompt: String = String(localized: "Search apps")
 
     func makeNSView(context: Context) -> NSSearchField {
         let field = NSSearchField()

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -312,18 +312,18 @@ struct MenuContentView: View {
         HStack(spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Duo Updater").font(.headline)
-                // Wraps to a second line rather than shrinking or clipping. The
-                // slot this gets is what's left after the Update All button, and
-                // a translated button is wider: Russian leaves 167pt for a line
-                // that wants 250. Scaling it to fit made it unreadable, and
-                // truncating drops the timestamp — the half most worth reading.
-                // Two lines cost the header 12pt in the languages that need it
-                // and nothing in the ones that don't.
+                // One line, at full size, truncating when it must. The slot is
+                // whatever the Update All button leaves, and a translated button
+                // is wider — Russian gets 167pt for a sentence that wants 247.
+                // Shrinking it to fit was unreadable and a second line unbalanced
+                // the header, so the tail gets cut and the tooltip carries the
+                // whole thing. Explicit, because without a limit the same
+                // sentence wrapped in one state and truncated in another.
                 Text(statusLine)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(1)
+                    .help(Text(statusLine))
             }
             Spacer()
             if model.canUpdateAll {
@@ -366,17 +366,19 @@ struct MenuContentView: View {
         let base = updates == 0
             ? String(localized: "\(model.results.count) apps · up to date")
             : String(localized: "\(updates) updates available")
-        // One key with both halves in it, rather than appending a " · checked …"
-        // fragment: a leading-space fragment is a string no translator can move,
-        // and languages that want the timestamp first — or a different separator —
-        // have nowhere to say so.
+        // The timestamp joins on with a separator and no verb. "checked" was a
+        // word the relative time already implies, and it cost more room than the
+        // header has: translated, the line ran 247pt against the 167pt left over
+        // once "Обновить всё" had taken its width, so the half that says *when*
+        // was the half being cut off. Nothing to translate in " · ", so this is
+        // plain interpolation rather than a key with no words in it.
         if let last = model.lastCheck {
-            return String(localized: "\(base) · checked \(Self.checkedAgo(last))")
+            return "\(base) · \(Self.checkedAgo(last))"
         }
         return base
     }
 
-    /// "checked just now" / "checked 2m ago". Guards the just-finished case: the
+    /// "just now" / "2m ago". Guards the just-finished case: the
     /// relative formatter rounds a sub-second (or microscopically future, from
     /// clock jitter) interval to "in 0 seconds", which read as a wrong-tense
     /// "checked in 0s" right after a refresh. Anything within a few seconds is

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -312,9 +312,18 @@ struct MenuContentView: View {
         HStack(spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Duo Updater").font(.headline)
+                // Wraps to a second line rather than shrinking or clipping. The
+                // slot this gets is what's left after the Update All button, and
+                // a translated button is wider: Russian leaves 167pt for a line
+                // that wants 250. Scaling it to fit made it unreadable, and
+                // truncating drops the timestamp — the half most worth reading.
+                // Two lines cost the header 12pt in the languages that need it
+                // and nothing in the ones that don't.
                 Text(statusLine)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
             if model.canUpdateAll {
@@ -357,8 +366,12 @@ struct MenuContentView: View {
         let base = updates == 0
             ? String(localized: "\(model.results.count) apps · up to date")
             : String(localized: "\(updates) updates available")
+        // One key with both halves in it, rather than appending a " · checked …"
+        // fragment: a leading-space fragment is a string no translator can move,
+        // and languages that want the timestamp first — or a different separator —
+        // have nowhere to say so.
         if let last = model.lastCheck {
-            return base + String(localized: " · checked \(Self.checkedAgo(last))")
+            return String(localized: "\(base) · checked \(Self.checkedAgo(last))")
         }
         return base
     }
@@ -370,12 +383,28 @@ struct MenuContentView: View {
     /// "just now"; older falls back to the relative formatter.
     private static func checkedAgo(_ date: Date) -> String {
         if date.timeIntervalSinceNow > -5 { return String(localized: "just now") }
-        return relative.localizedString(for: date, relativeTo: .now)
+        let abbreviated = relative.localizedString(for: date, relativeTo: .now)
+        // CLDR spells the narrow past form as a signed number in some locales:
+        // Russian renders "7 seconds ago" as "-7 с" and French as "-7 s", where
+        // English gets "7s ago". Dropped into "checked …" that reads as a
+        // negative count, so those locales fall through to the next style up,
+        // which spells the direction out ("7 сек. назад", "il y a 7 s"). Every
+        // locale whose narrow form already reads as elapsed time keeps it —
+        // English, German, Spanish, Chinese and Japanese are untouched.
+        guard abbreviated.hasPrefix("-") || abbreviated.hasPrefix("\u{2212}") else { return abbreviated }
+        return spelledOut.localizedString(for: date, relativeTo: .now)
     }
 
     private static let relative: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
         f.unitsStyle = .abbreviated
+        return f
+    }()
+
+    /// The fallback for locales whose abbreviated form comes out signed.
+    private static let spelledOut: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .short
         return f
     }()
 

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -159,8 +159,11 @@ struct MenuContentView: View {
     @ViewBuilder
     private var content: some View {
         if model.results.isEmpty {
+            let emptyTitle = model.isScanning
+                ? String(localized: "Scanning…")
+                : String(localized: "No apps yet")
             ContentUnavailableView(
-                model.isScanning ? "Scanning…" : "No apps yet",
+                emptyTitle,
                 systemImage: "magnifyingglass"
             )
             .frame(height: 200)
@@ -316,6 +319,8 @@ struct MenuContentView: View {
             Spacer()
             if model.canUpdateAll {
                 Button("Update All") { Task { await model.installAll() } }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
                     .controlSize(.small)
                     .buttonStyle(.borderedProminent)
                     .help("Install every pending update that can be applied automatically")
@@ -345,13 +350,15 @@ struct MenuContentView: View {
     }
 
     private var statusLine: String {
-        if model.isChecking { return "Checking \(model.results.count) apps…" }
+        if model.isChecking {
+            return String(localized: "Checking \(model.results.count) apps…")
+        }
         let updates = model.updateCount
         let base = updates == 0
-            ? "\(model.results.count) apps · up to date"
-            : "\(updates) update\(updates == 1 ? "" : "s") available"
+            ? String(localized: "\(model.results.count) apps · up to date")
+            : String(localized: "\(updates) updates available")
         if let last = model.lastCheck {
-            return base + " · checked \(Self.checkedAgo(last))"
+            return base + String(localized: " · checked \(Self.checkedAgo(last))")
         }
         return base
     }
@@ -362,7 +369,7 @@ struct MenuContentView: View {
     /// "checked in 0s" right after a refresh. Anything within a few seconds is
     /// "just now"; older falls back to the relative formatter.
     private static func checkedAgo(_ date: Date) -> String {
-        if date.timeIntervalSinceNow > -5 { return "just now" }
+        if date.timeIntervalSinceNow > -5 { return String(localized: "just now") }
         return relative.localizedString(for: date, relativeTo: .now)
     }
 
@@ -402,10 +409,14 @@ struct MenuContentView: View {
             }
             .buttonStyle(.borderless)
             .font(.caption)
+            .lineLimit(1)
+            .minimumScaleFactor(0.85)
             .help("Release notes, traffic, and settings")
             Button("Quit") { NSApp.terminate(nil) }
                 .buttonStyle(.borderless)
                 .font(.caption)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -436,7 +447,7 @@ struct MenuContentView: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Upgrading Homebrew formulae")
                         .font(.caption).fontWeight(.medium)
-                    Text(model.brewBulkProgressText ?? "Running brew upgrade…")
+                    Text(model.brewBulkProgressText ?? String(localized: "Running brew upgrade…"))
                         .font(.caption2).foregroundStyle(.secondary)
                         .lineLimit(1).truncationMode(.middle)
                         .monospacedDigit()
@@ -489,7 +500,7 @@ struct MenuContentView: View {
                 VStack(alignment: .leading, spacing: 1) {
                     // "package", not "formula": this surface also carries casks that
                     // install no app (CLIs, fonts), which have no per-app row.
-                    Text("\(count) brew package\(count == 1 ? "" : "s") outdated")
+                    Text("\(count) brew packages outdated")
                         .font(.caption).fontWeight(.medium)
                     if let error = model.brewUpgradeError {
                         Text(error).font(.caption2).foregroundStyle(.red).lineLimit(1)
@@ -500,6 +511,8 @@ struct MenuContentView: View {
                 }
                 Spacer()
                 Button("Upgrade") { Task { await model.upgradeBrewFormulae() } }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
                     .controlSize(.small)
                     .buttonStyle(.borderedProminent)
                     .help("Runs `brew upgrade --formula`, then upgrades any listed cask by name. Covers command-line formulae plus casks that install no app (CLIs, fonts) — those have no row of their own. GUI casks are managed per-app above and are never touched. The count reads your local tap; brew refreshes itself during the upgrade, so it still lands the latest.")
@@ -521,8 +534,8 @@ struct MenuContentView: View {
     /// line when the leaf count isn't available yet.
     private var brewUpToDateSummary: String {
         let n = model.brewFormulae.count
-        guard n > 0 else { return "All command-line formulae are current." }
-        return "\(n) top-level formula\(n == 1 ? "" : "e") · all current"
+        guard n > 0 else { return String(localized: "All command-line formulae are current.") }
+        return String(localized: "\(n) top-level formulae · all current")
     }
 }
 
@@ -721,7 +734,10 @@ private struct AppRow: View {
                             .buttonStyle(.link)
                     }
                     if model.showsHelperRestartFallback(result.id) {
-                        Button(model.restartingHelper ? "Restarting…" : "Restart Helper…") {
+                        let restartHelperLabel = model.restartingHelper
+                            ? String(localized: "Restarting…")
+                            : String(localized: "Restart Helper…")
+                        Button(restartHelperLabel) {
                             Task { await model.restartAppStoreHelper(result.id) }
                         }
                         .font(.caption2)
@@ -753,16 +769,17 @@ private struct AppRow: View {
         Button("Changelog") { openChangelog() }
         Divider()
         if result.hasUpdate {
-            let offered = result.remote?.displayVersion ?? "this version"
+            let offered = result.remote?.displayVersion ?? String(localized: "this version")
             if model.prefs.isVersionSkipped(result.app, version: result.remote?.displayVersion) {
                 Button("Don’t skip \(offered)") { model.prefs.clearSkip(result.app) }
             } else {
                 Button("Skip \(offered)") { model.skipThisVersion(result) }
             }
         }
-        Button(model.prefs.isIgnored(result.app)
-            ? "Stop ignoring \(result.app.name)"
-            : "Ignore \(result.app.name)") {
+        let ignoreLabel = model.prefs.isIgnored(result.app)
+            ? String(localized: "Stop ignoring \(result.app.name)")
+            : String(localized: "Ignore \(result.app.name)")
+        Button(ignoreLabel) {
             model.toggleIgnore(result)
         }
         // The way back out of a dismissed administrator prompt. Shown only while
@@ -857,7 +874,7 @@ private struct AppRow: View {
             // instead, where it can be read in full, and the line keeps to the one
             // comparison that decides the click: what you have vs what is offered.
             .help(model.restartFromVersion(result.id).map {
-                "Still running \($0) — restart pending from an earlier update"
+                String(localized: "Still running \($0) — restart pending from an earlier update")
             } ?? "")
             // Long date-style versions (Warp) would otherwise wrap mid-number;
             // keep it one line and shrink slightly instead.
@@ -1123,32 +1140,34 @@ private struct AppRow: View {
 
     private func stageLabel(_ stage: InstallStage) -> String {
         switch stage {
-        case .queued: return "Queued"
-        case .checking: return "Checking"
-        case .downloading(let f): return "\(Int(f * 100))%"
-        case .verifyingSignature, .verifyingCodeSignature: return "Verifying"
-        case .extracting: return "Extracting"
-        case .installing: return "Installing"
-        case .runningCommand: return "Installing"
-        case .done: return "Installed"
+        case .queued: return String(localized: "Queued")
+        case .checking: return String(localized: "Checking")
+        case .downloading(let f): return String(localized: "\(Int(f * 100))%")
+        case .verifyingSignature, .verifyingCodeSignature: return String(localized: "Verifying")
+        case .extracting: return String(localized: "Extracting")
+        case .installing: return String(localized: "Installing")
+        case .runningCommand: return String(localized: "Installing")
+        case .done: return String(localized: "Installed")
         }
     }
 
     private var autoUpdateButton: some View {
         Button("Update") { Task { await model.install(result) } }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
             .controlSize(.small)
             .buttonStyle(.borderedProminent)
     }
 
     /// Muted tag for an app the user has chosen to ignore — right-click to manage.
     private var ignoredTag: some View {
-        Text("Ignored").font(.caption2).foregroundStyle(.tertiary)
+        Text("Ignored").font(.caption2).foregroundStyle(.tertiary).lineLimit(1).minimumScaleFactor(0.7)
             .help("Hidden from update checks — right-click to stop ignoring")
     }
 
     /// Muted tag for an update whose offered version the user skipped.
     private var skippedTag: some View {
-        Text("Skipped").font(.caption2).foregroundStyle(.tertiary)
+        Text("Skipped").font(.caption2).foregroundStyle(.tertiary).lineLimit(1).minimumScaleFactor(0.7)
             .help("You skipped this version — right-click to un-skip")
     }
 
@@ -1156,6 +1175,8 @@ private struct AppRow: View {
     /// relaunch so the update actually takes effect.
     private var restartButton: some View {
         Button("Restart") { Task { await model.restart(result) } }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
             .controlSize(.small)
             .buttonStyle(.bordered)
             .tint(.orange)
@@ -1167,10 +1188,12 @@ private struct AppRow: View {
     /// a slow unrelated installer never makes this completed download look lost.
     private var pendingBatchRestartButton: some View {
         Button("Restart now") { Task { await model.restart(result) } }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
             .controlSize(.small)
             .buttonStyle(.bordered)
             .tint(.orange)
-            .help("Installed \(result.app.shortVersion ?? "the new version") — waiting for Update All to finish before restarting; click to restart now")
+            .help("Installed \(result.app.shortVersion ?? String(localized: "the new version")) — waiting for Update All to finish before restarting; click to restart now")
     }
 
     /// The app self-downloaded a newer build (Squirrel/ShipIt staged it); a
@@ -1180,6 +1203,8 @@ private struct AppRow: View {
     /// — the bytes are already staged on disk.
     private func relaunchToUpdateButton(_ staged: StagedSelfUpdate) -> some View {
         Button("Relaunch") { Task { await model.relaunchStagedUpdate(result) } }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
             .controlSize(.small)
             .buttonStyle(.bordered)
             .tint(.orange)
@@ -1192,6 +1217,8 @@ private struct AppRow: View {
     /// and we reopen it. Labelled "Relaunch" to match the other quit-to-apply action.
     private func quitToFinishButton(_ appName: String) -> some View {
         Button("Relaunch") { model.confirmQuit(result.id, proceed: true) }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
             .controlSize(.small)
             .buttonStyle(.bordered)
             .tint(.orange)
@@ -1218,15 +1245,15 @@ private struct AppRow: View {
                 .font(.caption2).foregroundStyle(.secondary).lineLimit(1)
         }
         .frame(minWidth: 64, alignment: .center)
-        .help("\(result.app.name) updated to \(result.app.shortVersion ?? "the latest version")")
+        .help("\(result.app.name) updated to \(result.app.shortVersion ?? String(localized: "the latest version"))")
     }
 
     private var restartHelp: String {
-        let disk = result.app.shortVersion ?? "the new version"
+        let disk = result.app.shortVersion ?? String(localized: "the new version")
         if let running = model.runningVersion(result.id) {
-            return "Running \(running) but \(disk) is installed — restart to apply it"
+            return String(localized: "Running \(running) but \(disk) is installed — restart to apply it")
         }
-        return "You’re running an older version — restart to finish updating"
+        return String(localized: "You’re running an older version — restart to finish updating")
     }
 
     /// pkg cask: download the official installer and open it (system installer
@@ -1239,11 +1266,15 @@ private struct AppRow: View {
             // make the user pull hundreds of megabytes down a second time because
             // they dismissed it.
             Button("Install") { Task { await model.openStagedPackage(result) } }
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
                 .controlSize(.small)
                 .buttonStyle(.borderedProminent)
                 .help("\(staged.url.lastPathComponent) is already downloaded — opens it in macOS's installer (asks for admin). Nothing is downloaded again.")
         } else {
             Button("Update") { Task { await model.install(result) } }
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
                 .controlSize(.small)
                 .buttonStyle(.bordered)
                 .help("Downloads the official installer and opens it (asks for admin)")
@@ -1301,7 +1332,7 @@ private struct AppRow: View {
         Button("Open") { model.openSelfUpdater(result) }
             .controlSize(.small)
             .buttonStyle(.bordered)
-            .help("\(result.app.name) is running — open it and let its own updater apply \(result.remote?.displayVersion ?? "the update"). Quit it, or pick “Always replace” in Settings, to install directly.")
+            .help("\(result.app.name) is running — open it and let its own updater apply \(result.remote?.displayVersion ?? String(localized: "the update")). Quit it, or pick “Always replace” in Settings, to install directly.")
     }
 
     private func openAction() {
@@ -1355,11 +1386,11 @@ private struct AppRow: View {
     }
 
     private var openHelp: String {
-        guard let url = result.remote?.pageURL else { return "Reveal in Finder" }
+        guard let url = result.remote?.pageURL else { return String(localized: "Reveal in Finder") }
         if let scheme = url.scheme, scheme != "http", scheme != "https" {
-            return "Open \(result.app.name)’s built-in updater (it updates itself)"
+            return String(localized: "Open \(result.app.name)’s built-in updater (it updates itself)")
         }
-        return "Open the official download page"
+        return String(localized: "Open the official download page")
     }
 
     /// App Store apps: when the app is in the signed-in region, a Get button
@@ -1419,9 +1450,9 @@ private struct AppRow: View {
     /// decline to do, with nothing to act on.
     private var appStoreRedirectHelp: String {
         if !model.helperEnabled {
-            return "Opens \(result.app.name) in the App Store. Turn on the background helper in Settings to install App Store updates in one click."
+            return String(localized: "Opens \(result.app.name) in the App Store. Turn on the background helper in Settings to install App Store updates in one click.")
         }
-        return "Update \(result.app.name) in the App Store"
+        return String(localized: "Update \(result.app.name) in the App Store")
     }
 
     private func openInAppStore(_ info: AppStoreAvailability) {
@@ -1431,12 +1462,12 @@ private struct AppRow: View {
     }
 
     private func regionHintPopover(_ info: AppStoreAvailability) -> some View {
-        let here = info.homeRegion.map(Self.regionName) ?? "your region"
+        let here = info.homeRegion.map(Self.regionName) ?? String(localized: "your region")
         let there = Self.regionName(info.availableRegion)
         return VStack(alignment: .leading, spacing: 8) {
             Label("Region-locked", systemImage: "globe.badge.chevron.backward")
                 .font(.headline)
-            Text("\(result.app.name) isn’t in your App Store region (\(here)). It’s listed in \(there)\(result.remote?.displayVersion.map { " — latest \($0)" } ?? "").")
+            Text("\(result.app.name) isn’t in your App Store region (\(here)). It’s listed in \(there)\(result.remote?.displayVersion.map { String(localized: " — latest \($0)") } ?? "").")
                 .font(.callout)
             // The region lock blocks a *fresh install* (the product page is "App Not
             // Available" under a \(here) account), but it does NOT block updating an
@@ -1468,7 +1499,7 @@ private struct AppRow: View {
                 .font(.headline)
             Text("\(result.app.name) is an iPhone/iPad app running on Apple Silicon. Its latest version\(result.remote?.displayVersion.map { " (\($0))" } ?? "") no longer supports Mac, so the App Store won't install it on this device.")
                 .font(.callout)
-            Text("You can keep using the installed version (\(result.app.shortVersion ?? "current")). Updating isn't possible until the developer ships a Mac-compatible build again — it's the vendor's choice, not a refresh problem.")
+            Text("You can keep using the installed version (\(result.app.shortVersion ?? String(localized: "current"))). Updating isn't possible until the developer ships a Mac-compatible build again — it's the vendor's choice, not a refresh problem.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Button("Open App Store anyway") { openInAppStore(info) }
@@ -1508,8 +1539,13 @@ private struct AppRow: View {
             // Name the failure inline so a wall of orange retry buttons isn't
             // indistinguishable — a rate-limit (the common no-token case) reads
             // differently from a one-off network error without needing a hover.
-            Text(result.status.isRateLimitError ? "Rate-limited" : "Failed")
+            let statusLabel = result.status.isRateLimitError
+                ? String(localized: "Rate-limited")
+                : String(localized: "Failed")
+            Text(statusLabel)
                 .font(.caption2)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
                 .foregroundStyle(result.status.isRateLimitError ? Color.orange : Color.secondary)
             Button { Task { await model.retry(result) } } label: {
                 Image(systemName: "arrow.clockwise")
@@ -1518,8 +1554,8 @@ private struct AppRow: View {
             .buttonStyle(.bordered)
             .tint(.orange)
             .help(errorText.isEmpty
-                ? "Update check failed — click to retry"
-                : "\(errorText) — click to retry")
+                ? String(localized: "Update check failed — click to retry")
+                : String(localized: "\(errorText) — click to retry"))
         }
     }
 
@@ -1529,8 +1565,8 @@ private struct AppRow: View {
     }
 
     private var sourceHint: String {
-        if result.app.isMASApp { return "App Store" }
-        if result.app.sparkleFeedURL != nil { return "Sparkle" }
+        if result.app.isMASApp { return String(localized: "App Store") }
+        if result.app.sparkleFeedURL != nil { return String(localized: "Sparkle") }
         return "—"
     }
 }

--- a/App/Sources/NotificationController.swift
+++ b/App/Sources/NotificationController.swift
@@ -55,9 +55,9 @@ final class NotificationController: NSObject, UNUserNotificationCenterDelegate, 
         center.delegate = self
 
         let installAll = UNNotificationAction(
-            identifier: ID.installAll, title: "Update All", options: [])
+            identifier: ID.installAll, title: String(localized: "Update All"), options: [])
         let view = UNNotificationAction(
-            identifier: ID.view, title: "View", options: [.foreground])
+            identifier: ID.view, title: String(localized: "View"), options: [.foreground])
         let category = UNNotificationCategory(
             identifier: ID.updatesCategory,
             actions: [installAll, view],
@@ -68,7 +68,7 @@ final class NotificationController: NSObject, UNUserNotificationCenterDelegate, 
         // No `.foreground`: the restart runs headless via NSWorkspace; we don't pull
         // DuoUpdater forward for it.
         let relaunch = UNNotificationAction(
-            identifier: ID.relaunch, title: "Relaunch", options: [])
+            identifier: ID.relaunch, title: String(localized: "Relaunch"), options: [])
         let selfUpdate = UNNotificationCategory(
             identifier: ID.selfUpdateCategory,
             actions: [relaunch],
@@ -79,7 +79,7 @@ final class NotificationController: NSObject, UNUserNotificationCenterDelegate, 
         // without opening the menu. No `.foreground`: the installer takes it from
         // there; there's nothing for the user to look at in DuoUpdater.
         let confirmQuit = UNNotificationAction(
-            identifier: ID.confirmQuit, title: "Relaunch", options: [])
+            identifier: ID.confirmQuit, title: String(localized: "Relaunch"), options: [])
         let quitToInstall = UNNotificationCategory(
             identifier: ID.quitConfirmCategory,
             actions: [confirmQuit],

--- a/App/Sources/Preferences.swift
+++ b/App/Sources/Preferences.swift
@@ -28,12 +28,12 @@ final class Preferences {
 
         var label: String {
             switch self {
-            case .manual:      return "Only when I check"
-            case .every5Min:   return "Every 5 minutes"
-            case .every30Min:  return "Every 30 minutes"
-            case .hourly:      return "Every hour"
-            case .every6Hours: return "Every 6 hours"
-            case .daily:       return "Once a day"
+            case .manual:      return String(localized: "Only when I check")
+            case .every5Min:   return String(localized: "Every 5 minutes")
+            case .every30Min:  return String(localized: "Every 30 minutes")
+            case .hourly:      return String(localized: "Every hour")
+            case .every6Hours: return String(localized: "Every 6 hours")
+            case .daily:       return String(localized: "Once a day")
             }
         }
 

--- a/App/Sources/PrivilegedHelperClient.swift
+++ b/App/Sources/PrivilegedHelperClient.swift
@@ -81,10 +81,7 @@ final class PrivilegedHelperClient: ObservableObject {
         let message = error.localizedDescription
         guard (error as NSError).code == 1 || message.localizedCaseInsensitiveContains("not permitted")
         else { return message }
-        return "macOS refused the registration — its record of this background item "
-            + "is damaged. Fixing it needs a system-level reset: run "
-            + "“sudo sfltool resetbtm” in Terminal and restart. That clears background-item "
-            + "approvals for every app, so you'll re-approve the others too."
+        return String(localized: "macOS refused the registration — its record of this background item is damaged. Fixing it needs a system-level reset: run “sudo sfltool resetbtm” in Terminal and restart. That clears background-item approvals for every app, so you'll re-approve the others too.")
     }
 
     func unregister() {

--- a/App/Sources/ReleaseLogView.swift
+++ b/App/Sources/ReleaseLogView.swift
@@ -21,6 +21,15 @@ struct ReleaseLogView: View {
         case timeline = "Timeline"
         case patterns = "Patterns"
         var id: String { rawValue }
+
+        /// User-facing label. Kept separate from `rawValue` (which stays a stable,
+        /// English identifier) so the segmented control can be translated.
+        var displayName: String {
+            switch self {
+            case .timeline: return String(localized: "Timeline")
+            case .patterns: return String(localized: "Patterns")
+            }
+        }
     }
     @State private var mode: Mode = .timeline
 
@@ -51,7 +60,7 @@ struct ReleaseLogView: View {
             Spacer()
             if !events.isEmpty {
                 Picker("", selection: $mode) {
-                    ForEach(Mode.allCases) { Text($0.rawValue).tag($0) }
+                    ForEach(Mode.allCases) { Text($0.displayName).tag($0) }
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
@@ -65,8 +74,8 @@ struct ReleaseLogView: View {
     private var summary: String {
         let releases = events.count
         let apps = Set(events.map(\.appID)).count
-        guard releases > 0 else { return "Releases appear here as the apps you track ship them" }
-        return "\(releases) release\(releases == 1 ? "" : "s") across \(apps) app\(apps == 1 ? "" : "s")"
+        guard releases > 0 else { return String(localized: "Releases appear here as the apps you track ship them") }
+        return String(localized: "\(releases) releases across \(apps) apps")
     }
 
     // MARK: - Feed
@@ -202,16 +211,16 @@ enum ReleaseTiming {
         if range.duration <= 36 * 3600 {
             let from = range.start.formatted(date: .omitted, time: .shortened)
             let to = range.end.formatted(date: .omitted, time: .shortened)
-            return "≈ \(from)–\(to)"
+            return String(localized: "≈ \(from)–\(to)")
         }
         let days = max(1, Int((range.duration / 86_400).rounded()))
-        return "≈ within \(days)d"
+        return String(localized: "≈ within \(days)d")
     }
 
     static func approxHelp(_ range: DateInterval) -> String {
         let from = range.start.formatted(date: .abbreviated, time: .shortened)
         let to = range.end.formatted(date: .abbreviated, time: .shortened)
-        return "Released sometime between \(from) and \(to) — estimated from when we detected the change, not a vendor date."
+        return String(localized: "Released sometime between \(from) and \(to) — estimated from when we detected the change, not a vendor date.")
     }
 }
 
@@ -284,8 +293,8 @@ private struct ReleasePatternsView: View {
         HStack(spacing: 8) {
             Image(systemName: "clock.badge.questionmark").foregroundStyle(.secondary)
             Text(selectedAppID == nil
-                 ? "No exact release times recorded yet — the heatmap fills in as Sparkle/GitHub apps ship."
-                 : "This app reports versions but no exact release time, so there's no habit heatmap — only the estimated windows below.")
+                 ? String(localized: "No exact release times recorded yet — the heatmap fills in as Sparkle/GitHub apps ship.")
+                 : String(localized: "This app reports versions but no exact release time, so there's no habit heatmap — only the estimated windows below."))
                 .font(.callout).foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -321,19 +330,22 @@ private struct ReleasePatternsView: View {
     }
 
     private var subtitle: String {
-        let base = "Across \(stats.total) recorded release\(stats.total == 1 ? "" : "s"). Times in your local zone."
         // A single-app pattern only means something with a handful of releases; say
-        // so plainly rather than over-reading one or two points.
+        // so plainly rather than over-reading one or two points. Each branch is a
+        // full sentence (rather than a concatenation) so it translates cleanly.
         if selectedAppID != nil && stats.total < 5 {
-            return base + " The pattern sharpens as this app ships more."
+            return String(localized: "Across \(stats.total) recorded releases. Times in your local zone. The pattern sharpens as this app ships more.")
         }
-        return base
+        return String(localized: "Across \(stats.total) recorded releases. Times in your local zone.")
     }
 
     private func peakSentence(_ peak: (weekday: Int, hour: Int, count: Int)) -> String {
         let day = Calendar.current.standaloneWeekdaySymbols[peak.weekday]
-        let lead = selectedAppID == nil ? "Most often ships" : "Usually ships"
-        return "\(lead) \(day), around \(hourLabel(peak.hour, long: true))."
+        let time = hourLabel(peak.hour, long: true)
+        if selectedAppID == nil {
+            return String(localized: "Most often ships \(day), around \(time).")
+        }
+        return String(localized: "Usually ships \(day), around \(time).")
     }
 
     // MARK: Per-app version list
@@ -396,7 +408,7 @@ private struct ReleasePatternsView: View {
         RoundedRectangle(cornerRadius: 2)
             .fill(cellColor(count: count, maxCount: maxCount))
             .frame(width: cellSize, height: cellSize)
-            .help(count > 0 ? "\(count) release\(count == 1 ? "" : "s")" : "")
+            .help(count > 0 ? String(localized: "\(count) releases") : "")
     }
 
     private func cellColor(count: Int, maxCount: Int) -> Color {
@@ -432,10 +444,11 @@ private struct ReleasePatternsView: View {
     /// readability regardless of locale's 24h preference.
     private func hourLabel(_ hour: Int, long: Bool) -> String {
         let h12 = hour % 12 == 0 ? 12 : hour % 12
-        let ampm = hour < 12 ? "a" : "p"
         if long {
-            return "\(h12) \(hour < 12 ? "AM" : "PM")"
+            let meridiem = hour < 12 ? String(localized: "AM") : String(localized: "PM")
+            return "\(h12) \(meridiem)"
         }
+        let ampm = hour < 12 ? String(localized: "a") : String(localized: "p")
         return "\(h12)\(ampm)"
     }
 }

--- a/App/Sources/SelfChangelogView.swift
+++ b/App/Sources/SelfChangelogView.swift
@@ -102,12 +102,12 @@ struct SelfChangelogView: View {
         do {
             let (data, response) = try await URLSession.updates.data(for: request)
             if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
-                state = .failed("GitHub answered HTTP \(http.statusCode).")
+                state = .failed(String(localized: "GitHub answered HTTP \(http.statusCode)."))
                 return
             }
             let text = String(decoding: data, as: UTF8.self)
             guard let changelog = SelfChangelogParser.parse(text) else {
-                state = .failed("The file loaded but carried no release sections.")
+                state = .failed(String(localized: "The file loaded but carried no release sections."))
                 return
             }
             state = .loaded(changelog)

--- a/App/Sources/Settings/AlcoveSettingsPage.swift
+++ b/App/Sources/Settings/AlcoveSettingsPage.swift
@@ -100,7 +100,7 @@ struct AlcoveSettingsPage: View {
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.borderless)
-            .help(revealKey ? "Hide" : "Reveal")
+            .help(revealKey ? String(localized: "Hide") : String(localized: "Reveal"))
         }
         .settingsRow()
 
@@ -170,8 +170,8 @@ struct AlcoveSettingsPage: View {
         case .idle, .resolving:
             EmptyView()
         case .ok(let consumed):
-            Label(consumed ? "Saved — using a new activation for this Mac."
-                           : "Saved — precise detection enabled.",
+            Label(consumed ? String(localized: "Saved — using a new activation for this Mac.")
+                           : String(localized: "Saved — precise detection enabled."),
                   systemImage: "checkmark.circle.fill")
                 .foregroundStyle(.green).font(.callout).lineLimit(2)
         case .atLimit(let usage, let limit):
@@ -196,8 +196,8 @@ struct AlcoveSettingsPage: View {
                 Text(maskSecret(prefs.alcoveLicenseKey))
                     .font(.system(.body, design: .monospaced))
                 Text(prefs.alcoveInstanceID.isEmpty
-                     ? "Saved"
-                     : "Active · instance …\(prefs.alcoveInstanceID.suffix(4))")
+                     ? String(localized: "Saved")
+                     : String(localized: "Active · instance …\(prefs.alcoveInstanceID.suffix(4))"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -238,7 +238,7 @@ struct AlcoveSettingsPage: View {
         status = .resolving
         let service = AlcoveLicenseService()
         guard let info = await service.validate(licenseKey: trimmedKey) else {
-            status = .failed("validation request failed"); return
+            status = .failed(String(localized: "validation request failed")); return
         }
         guard info.active else { status = .invalid; return }
         prefs.alcoveLicenseKey = trimmedKey

--- a/App/Sources/Settings/BackupsSheet.swift
+++ b/App/Sources/Settings/BackupsSheet.swift
@@ -163,15 +163,16 @@ struct BackupsSheet: View {
 
     private var footer: some View {
         HStack(spacing: 12) {
-            Button(allSelected ? "Deselect All" : "Select All") {
+            Button(allSelected ? String(localized: "Deselect All") : String(localized: "Select All")) {
                 selected = allSelected ? [] : Set(backups.map(\.key))
             }
             Spacer(minLength: 0)
             Button("Cancel") { dismiss() }
                 .keyboardShortcut(.cancelAction)
-            Button(selected.isEmpty
-                   ? "Delete"
-                   : "Delete \(selected.count) (\(ByteCountFormatter.string(fromByteCount: selectedBytes, countStyle: .file)))") {
+            let deleteLabel = selected.isEmpty
+                ? String(localized: "Delete")
+                : String(localized: "Delete \(selected.count) (\(ByteCountFormatter.string(fromByteCount: selectedBytes, countStyle: .file)))")
+            Button(deleteLabel) {
                 onDelete(Array(selected))
                 dismiss()
             }

--- a/App/Sources/Settings/DiagnosticsSettingsPage.swift
+++ b/App/Sources/Settings/DiagnosticsSettingsPage.swift
@@ -80,7 +80,7 @@ struct DiagnosticsSettingsPage: View {
     private var lastCheckCard: some View {
         SettingsCard {
             SettingsField(title: "Last checked") {
-                Text(model.lastCheck.map { $0.formatted(date: .abbreviated, time: .shortened) } ?? "Not yet")
+                Text(model.lastCheck.map { $0.formatted(date: .abbreviated, time: .shortened) } ?? String(localized: "Not yet"))
                     .foregroundStyle(.secondary)
             }
         }
@@ -194,10 +194,10 @@ private struct HelperStatusRow: View {
             if checking || answering != nil {
                 statusIcon
                 Text(checking && answering == nil
-                     ? "Checking…"
+                     ? String(localized: "Checking…")
                      : (answering == true
-                        ? "Responding — App Store updates will work"
-                        : "Switched on but not responding — use Restart Helper"))
+                        ? String(localized: "Responding — App Store updates will work")
+                        : String(localized: "Switched on but not responding — use Restart Helper")))
                     .foregroundStyle(checking ? Color.secondary
                                      : (answering == true ? Color.green : Color.orange))
             }
@@ -270,7 +270,7 @@ private struct HelperStatusRow: View {
                 checkButton
                 // Disabled while the authorization panel is up: pressing again
                 // would stack a second prompt on the first and kickstart twice.
-                Button(restarting ? "Restarting…" : "Restart Helper…") {
+                Button(restarting ? String(localized: "Restarting…") : String(localized: "Restart Helper…")) {
                     guard !restarting else { return }
                     restarting = true
                     Task {

--- a/App/Sources/Settings/FoldersSettingsPage.swift
+++ b/App/Sources/Settings/FoldersSettingsPage.swift
@@ -115,8 +115,8 @@ struct FoldersSettingsPage: View {
         panel.canChooseFiles = true
         panel.allowedContentTypes = [.application]
         panel.allowsMultipleSelection = true
-        panel.prompt = "Add"
-        panel.message = "Choose a folder that contains apps to check for updates."
+        panel.prompt = String(localized: "Add")
+        panel.message = String(localized: "Choose a folder that contains apps to check for updates.")
 
         guard panel.runModal() == .OK else { return }
         var added = false

--- a/App/Sources/Settings/GeneralSettingsPage.swift
+++ b/App/Sources/Settings/GeneralSettingsPage.swift
@@ -142,10 +142,15 @@ struct GeneralSettingsPage: View {
                 header: "Install routing",
                 footer: "Mac App Store updates currently use the full-download route via mas. It’s the more predictable option for release builds and doesn’t require Accessibility access."
             ) {
-                Picker("App Store updates", selection: $prefs.appStoreUpdateStrategy) {
-                    ForEach(Preferences.AppStoreUpdateStrategy.availableCases) { strategy in
-                        Text(strategy.label).tag(strategy)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("App Store updates").font(.callout)
+                    Picker("App Store updates", selection: $prefs.appStoreUpdateStrategy) {
+                        ForEach(Preferences.AppStoreUpdateStrategy.availableCases) { strategy in
+                            Text(strategy.label).tag(strategy)
+                        }
                     }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
                 }
                 .settingsRow()
             }
@@ -153,10 +158,15 @@ struct GeneralSettingsPage: View {
             SettingsCard(
                 footer: "For apps that ship their own updater (Office, Teams, OneDrive, Edge, Chrome, VS Code, …). “Always replace” — the default — downloads the vendor’s own installer and applies it whether or not the app is running, quitting and relaunching it afterwards. Switch to “Defer while running” if you would rather nothing touched an app while it is open: it then installs only when the app is closed, and offers an Open button instead while it is running, leaving the update to the app itself."
             ) {
-                Picker("Self-updating apps", selection: $prefs.vendorInstallPolicy) {
-                    ForEach(Preferences.VendorInstallPolicy.allCases) { policy in
-                        Text(policy.label).tag(policy)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Self-updating apps").font(.callout)
+                    Picker("Self-updating apps", selection: $prefs.vendorInstallPolicy) {
+                        ForEach(Preferences.VendorInstallPolicy.allCases) { policy in
+                            Text(policy.label).tag(policy)
+                        }
                     }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
                 }
                 .settingsRow()
             }

--- a/App/Sources/Settings/GitHubSettingsPage.swift
+++ b/App/Sources/Settings/GitHubSettingsPage.swift
@@ -86,10 +86,10 @@ struct GitHubSettingsPage: View {
 
     private var statusHeadline: String {
         switch cliStatus {
-        case .none:          return "Checking the gh CLI…"
-        case .authenticated: return "GitHub CLI is authenticated and ready."
-        case .notLoggedIn:   return "GitHub CLI is installed but not signed in. Run `gh auth login`, or paste a token below."
-        case .notInstalled:  return "GitHub CLI isn’t installed. Paste a personal access token below to lift the rate limit."
+        case .none:          return String(localized: "Checking the gh CLI…")
+        case .authenticated: return String(localized: "GitHub CLI is authenticated and ready.")
+        case .notLoggedIn:   return String(localized: "GitHub CLI is installed but not signed in. Run `gh auth login`, or paste a token below.")
+        case .notInstalled:  return String(localized: "GitHub CLI isn’t installed. Paste a personal access token below to lift the rate limit.")
         }
     }
 
@@ -153,7 +153,7 @@ struct GitHubSettingsPage: View {
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.borderless)
-            .help(revealToken ? "Hide token" : "Show token")
+            .help(revealToken ? String(localized: "Hide token") : String(localized: "Show token"))
         }
     }
 
@@ -189,8 +189,8 @@ struct GitHubSettingsPage: View {
                 Text(maskSecret(prefs.githubToken))
                     .font(.system(.body, design: .monospaced))
                 Text(prefs.githubTokenAccount.isEmpty
-                     ? "Saved"
-                     : "Saved · belongs to \(prefs.githubTokenAccount)")
+                     ? String(localized: "Saved")
+                     : String(localized: "Saved · belongs to \(prefs.githubTokenAccount)"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -219,11 +219,13 @@ struct GitHubSettingsPage: View {
                 .foregroundStyle(.red)
                 .font(.callout)
                 .lineLimit(1)
+                .minimumScaleFactor(0.85)
         case .failed(let message):
             Label("Couldn’t verify: \(message)", systemImage: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
                 .font(.callout)
                 .lineLimit(1)
+                .minimumScaleFactor(0.85)
         case .none:
             EmptyView()
         }

--- a/App/Sources/Settings/IgnoredSettingsPage.swift
+++ b/App/Sources/Settings/IgnoredSettingsPage.swift
@@ -64,7 +64,7 @@ struct IgnoredSettingsPage: View {
         }
     }
 
-    private func emptyRow(_ text: String) -> some View {
+    private func emptyRow(_ text: LocalizedStringKey) -> some View {
         Text(text)
             .font(.callout)
             .foregroundStyle(.secondary)

--- a/App/Sources/Settings/SettingsChrome.swift
+++ b/App/Sources/Settings/SettingsChrome.swift
@@ -72,22 +72,22 @@ struct SettingsPage<Content: View>: View {
 /// `header` sits above the slab, `footer` below it, both outside it so long
 /// explanatory text reads as text.
 struct SettingsCard<Content: View>: View {
-    var header: String?
-    var footer: String?
+    var header: LocalizedStringKey?
+    var footer: LocalizedStringKey?
     @ViewBuilder var content: Content
 
     /// Footer as a view, for the rare case that needs a `Label` or a live warning
     /// rather than a static string.
     private var footerView: AnyView?
 
-    init(header: String? = nil, footer: String? = nil, @ViewBuilder content: () -> Content) {
+    init(header: LocalizedStringKey? = nil, footer: LocalizedStringKey? = nil, @ViewBuilder content: () -> Content) {
         self.header = header
         self.footer = footer
         self.footerView = nil
         self.content = content()
     }
 
-    init(header: String? = nil, @ViewBuilder content: () -> Content, @ViewBuilder footer: () -> some View) {
+    init(header: LocalizedStringKey? = nil, @ViewBuilder content: () -> Content, @ViewBuilder footer: () -> some View) {
         self.header = header
         self.footer = nil
         self.footerView = AnyView(footer())
@@ -122,8 +122,8 @@ struct SettingsCard<Content: View>: View {
 /// Explanatory text under a card. Panes use this directly when a footnote needs
 /// to sit outside any card.
 struct SettingsFootnote: View {
-    private let text: String
-    init(_ text: String) { self.text = text }
+    private let text: LocalizedStringKey
+    init(_ text: LocalizedStringKey) { self.text = text }
 
     var body: some View {
         Text(text)
@@ -243,8 +243,8 @@ struct SettingsIconTile: View {
 /// A label/value row: title on the left, arbitrary trailing content on the right.
 /// `LabeledContent` in a non-`Form` context loses its alignment, so panes use this.
 struct SettingsField<Trailing: View>: View {
-    let title: String
-    var detail: String?
+    let title: LocalizedStringKey
+    var detail: LocalizedStringKey?
     @ViewBuilder var trailing: Trailing
 
     var body: some View {

--- a/App/Sources/Settings/SettingsSection.swift
+++ b/App/Sources/Settings/SettingsSection.swift
@@ -20,6 +20,16 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case accounts = "Accounts"
         case library = "Library"
         var id: String { rawValue }
+
+        /// Localized sidebar group header. `rawValue` stays a plain internal
+        /// identifier — this is the only form actually shown to the user.
+        var displayName: String {
+            switch self {
+            case .app:      return String(localized: "App")
+            case .accounts: return String(localized: "Accounts")
+            case .library:  return String(localized: "Library")
+            }
+        }
     }
 
     var group: Group {
@@ -32,13 +42,13 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
-        case .general:     return "General"
-        case .folders:     return "Folders"
-        case .updates:     return "Updates"
-        case .github:      return "GitHub"
-        case .alcove:      return "Alcove"
-        case .ignored:     return "Ignored"
-        case .diagnostics: return "Diagnostics"
+        case .general:     return String(localized: "General")
+        case .folders:     return String(localized: "Folders")
+        case .updates:     return String(localized: "Updates")
+        case .github:      return String(localized: "GitHub")
+        case .alcove:      return String(localized: "Alcove")
+        case .ignored:     return String(localized: "Ignored")
+        case .diagnostics: return String(localized: "Diagnostics")
         }
     }
 
@@ -69,13 +79,13 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     /// Short line under the page title.
     var subtitle: String {
         switch self {
-        case .general:     return "How often Duo Updater checks, and what it does when it finds something."
-        case .folders:     return "Where Duo Updater looks for installed apps."
-        case .updates:     return "Duo Updater's own version."
-        case .github:      return "Lift GitHub's anonymous rate limit for apps tracked through Releases."
-        case .alcove:      return "Alcove keeps release notes and installable builds behind its license."
-        case .ignored:     return "Apps and versions you've told Duo Updater to leave alone."
-        case .diagnostics: return "Permissions, last check, and the health of each detection recipe."
+        case .general:     return String(localized: "How often Duo Updater checks, and what it does when it finds something.")
+        case .folders:     return String(localized: "Where Duo Updater looks for installed apps.")
+        case .updates:     return String(localized: "Duo Updater's own version.")
+        case .github:      return String(localized: "Lift GitHub's anonymous rate limit for apps tracked through Releases.")
+        case .alcove:      return String(localized: "Alcove keeps release notes and installable builds behind its license.")
+        case .ignored:     return String(localized: "Apps and versions you've told Duo Updater to leave alone.")
+        case .diagnostics: return String(localized: "Permissions, last check, and the health of each detection recipe.")
         }
     }
 

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -94,7 +94,7 @@ private struct SettingsSidebar: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            AppSearchField(text: $query, prompt: "Search")
+            AppSearchField(text: $query, prompt: String(localized: "Search"))
                 .frame(height: 24)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 8)
@@ -106,7 +106,7 @@ private struct SettingsSidebar: View {
             } else {
                 List(selection: $selection) {
                     ForEach(groups, id: \.group.id) { entry in
-                        SwiftUI.Section(entry.group.rawValue) {
+                        SwiftUI.Section(entry.group.displayName) {
                             ForEach(entry.sections) { section in
                                 row(section).tag(section)
                             }

--- a/App/Sources/Settings/UpdatesSettingsPage.swift
+++ b/App/Sources/Settings/UpdatesSettingsPage.swift
@@ -24,7 +24,7 @@ struct UpdatesSettingsPage: View {
         case let (_, build?) where !build.isEmpty:
             return build
         default:
-            return "Unknown"
+            return String(localized: "Unknown")
         }
     }
 

--- a/App/Sources/UpdateNotifier.swift
+++ b/App/Sources/UpdateNotifier.swift
@@ -14,27 +14,27 @@ enum UpdateNotifier {
     /// `NotificationController`). `total` is the full pending count; `newApps`
     /// names the ones that newly appeared since the last check.
     static func updatesAvailable(total: Int, newApps: [String]) {
-        let title = total == 1 ? "1 update available" : "\(total) updates available"
+        let title = String(localized: "\(total) updates available")
         let body: String
         switch newApps.count {
         case 0:  return  // nothing newly appeared — don't nag
-        case 1:  body = "\(newApps[0]) has an update."
-        case 2:  body = "\(newApps[0]) and \(newApps[1]) have updates."
-        default: body = "\(newApps[0]), \(newApps[1]), and \(newApps.count - 2) more have updates."
+        case 1:  body = String(localized: "\(newApps[0]) has an update.")
+        case 2:  body = String(localized: "\(newApps[0]) and \(newApps[1]) have updates.")
+        default: body = String(localized: "\(newApps[0]), \(newApps[1]), and \(newApps.count - 2) more have updates.")
         }
         post(title: title, body: body, categoryID: NotificationController.ID.updatesCategory)
     }
 
     /// A not-running app was updated in place — there's nothing left to do.
     static func updated(app: String, version: String?) {
-        post(title: app, body: version.map { "Updated to \($0)." } ?? "Updated.")
+        post(title: app, body: version.map { String(localized: "Updated to \($0).") } ?? String(localized: "Updated."))
     }
 
     /// "Update All" finished — one summary instead of a banner per app. Apps that
     /// were running show a Restart badge in the menu, so we don't enumerate them.
     static func batchUpdated(count: Int) {
-        post(title: "Updates installed",
-             body: count == 1 ? "1 app was updated." : "\(count) apps were updated.")
+        post(title: String(localized: "Updates installed"),
+             body: String(localized: "\(count) apps were updated."))
     }
 
     /// A running app was updated on disk, but its live process is still on the
@@ -43,8 +43,9 @@ enum UpdateNotifier {
     /// this banner in place once the new version is live, instead of leaving a
     /// stale "Restart to apply it" stacked under the "Now running" confirmation.
     static func readyToRestart(app: String, version: String?, appID: String?) {
-        let lead = version.map { "Update to \($0) is ready." } ?? "Update is ready."
-        post(title: app, body: lead + " Restart to apply it.",
+        let body = version.map { String(localized: "Update to \($0) is ready. Restart to apply it.") }
+            ?? String(localized: "Update is ready. Restart to apply it.")
+        post(title: app, body: body,
              identifier: appID.map { "restart:\($0)" })
     }
 
@@ -55,7 +56,7 @@ enum UpdateNotifier {
     /// previous banner in Notification Center rather than stacking copies.
     static func selfDownloaded(app: String, version: String, appID: String) {
         post(title: app,
-             body: "\(app) downloaded \(version) on its own. Relaunch to apply it.",
+             body: String(localized: "\(app) downloaded \(version) on its own. Relaunch to apply it."),
              categoryID: NotificationController.ID.selfUpdateCategory,
              identifier: "selfupdate:\(appID)",
              userInfo: [NotificationController.ID.appIDKey: appID])
@@ -71,7 +72,7 @@ enum UpdateNotifier {
     /// new, it's the app asking a question it can't proceed without.
     static func needsQuitConfirmation(app: String, rowID: String) {
         post(title: app,
-             body: "The update is downloaded. Relaunch \(app) to finish installing it.",
+             body: String(localized: "The update is downloaded. Relaunch \(app) to finish installing it."),
              categoryID: NotificationController.ID.quitConfirmCategory,
              identifier: "quitconfirm:\(rowID)",
              userInfo: [NotificationController.ID.appIDKey: rowID])
@@ -102,7 +103,7 @@ enum UpdateNotifier {
     /// "Restart to apply it" banner in Notification Center rather than stacking a
     /// second copy beneath it — one banner per app lifecycle, not two.
     static func restarted(app: String, version: String?, appID: String?) {
-        post(title: app, body: version.map { "Now running \($0)." } ?? "Restarted on the new version.",
+        post(title: app, body: version.map { String(localized: "Now running \($0).") } ?? String(localized: "Restarted on the new version."),
              identifier: appID.map { "restart:\($0)" })
     }
 

--- a/App/Sources/WelcomeView.swift
+++ b/App/Sources/WelcomeView.swift
@@ -34,18 +34,25 @@ struct WelcomeView: View {
             auroraBackground
 
             VStack(spacing: 0) {
-                hero
-                    .padding(.top, 46)
-                    .padding(.horizontal, 36)
+                // A plain ScrollView here costs nothing when content fits (which is
+                // the common case, English included) — it just top-aligns like a
+                // VStack would. It's the safety net for languages whose permission-
+                // card text runs longer than English: this window is fixed-size and
+                // non-resizable, so without it, overflow would silently clip instead
+                // of scrolling.
+                ScrollView {
+                    hero
+                        .padding(.top, 46)
+                        .padding(.horizontal, 36)
 
-                cards
-                    .padding(.top, 30)
-                    .padding(.horizontal, 30)
-
-                Spacer(minLength: 20)
+                    cards
+                        .padding(.top, 30)
+                        .padding(.horizontal, 30)
+                }
 
                 footer
                     .padding(.horizontal, 24)
+                    .padding(.top, 20)
                     .padding(.bottom, 26)
             }
         }
@@ -131,18 +138,18 @@ struct WelcomeView: View {
         let stack = VStack(spacing: 14) {
             PermissionCard(
                 systemImage: "shippingbox",
-                title: "App Management",
+                title: String(localized: "App Management"),
                 detail: appManagementDetail,
                 status: appManagementCardStatus,
                 action: { model.presentAppManagementPermissionFlow() }
             )
             PermissionCard(
                 systemImage: "key",
-                title: "GitHub access",
+                title: String(localized: "GitHub access"),
                 detail: githubDetail,
                 status: githubCardStatus,
-                actionLabel: "Set Up…",
-                grantedLabel: "Connected",
+                actionLabel: String(localized: "Set Up…"),
+                grantedLabel: String(localized: "Connected"),
                 action: { openGitHubSetup() }
             )
         }
@@ -213,11 +220,10 @@ struct WelcomeView: View {
     }
 
     private var appManagementDetail: String {
-        let base = "Lets Duo Updater replace apps updated outside the App Store (Sparkle, Homebrew, direct downloads)."
         if model.appManagementStatus == .unknown {
-            return base + " macOS isn’t reporting its status on this system — grant it to be safe."
+            return String(localized: "Lets Duo Updater replace apps updated outside the App Store (Sparkle, Homebrew, direct downloads). macOS isn’t reporting its status on this system — grant it to be safe.")
         }
-        return base
+        return String(localized: "Lets Duo Updater replace apps updated outside the App Store (Sparkle, Homebrew, direct downloads).")
     }
 
     // MARK: - GitHub access (optional)
@@ -231,11 +237,10 @@ struct WelcomeView: View {
     }
 
     private var githubDetail: String {
-        let base = "Lifts GitHub’s anonymous 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors."
         if githubConnected == true {
-            return base + " A token is already active — you’re all set."
+            return String(localized: "Lifts GitHub’s anonymous 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. A token is already active — you’re all set.")
         }
-        return base + " Optional: sign in with the gh CLI, or paste a token."
+        return String(localized: "Lifts GitHub’s anonymous 60-requests/hour limit to 5000/hour, so frequent checks of GitHub-hosted apps (RustDesk, Zed, Stats…) don’t hit rate-limit errors. Optional: sign in with the gh CLI, or paste a token.")
     }
 
     /// Deep-link straight to Settings → GitHub so the user lands on the token UI
@@ -265,9 +270,9 @@ private struct PermissionCard: View {
     let status: Status
     /// Label for the action button. Defaults to the permission wording; the
     /// optional GitHub card overrides it ("Set Up…").
-    var actionLabel: String = "Grant…"
+    var actionLabel: String = String(localized: "Grant…")
     /// Label for the satisfied state. Defaults to "Granted"; GitHub uses "Connected".
-    var grantedLabel: String = "Granted"
+    var grantedLabel: String = String(localized: "Granted")
     let action: () -> Void
 
     var body: some View {

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -22,8 +22,8 @@ struct WorkbenchWindowView: View {
         var id: String { rawValue }
         var label: String {
             switch self {
-            case .releaseNotes: return "Release Notes"
-            case .traffic:      return "Traffic"
+            case .releaseNotes: return String(localized: "Release Notes")
+            case .traffic:      return String(localized: "Traffic")
             }
         }
     }
@@ -188,8 +188,8 @@ struct WorkbenchWindowView: View {
                     "Select an app",
                     systemImage: "sidebar.left",
                     description: Text(mode == .releaseNotes
-                        ? "Pick an app to read its changelog."
-                        : "Pick an app to see its download history."))
+                        ? String(localized: "Pick an app to read its changelog.")
+                        : String(localized: "Pick an app to see its download history.")))
             }
         }
         .navigationTitle("Duo Updater")
@@ -404,19 +404,19 @@ struct WorkbenchWindowView: View {
     }
 
     private var appsHeader: some View {
-        sectionHeader("Apps", systemImage: "square.grid.2x2.fill",
+        sectionHeader(String(localized: "Apps"), systemImage: "square.grid.2x2.fill",
                       count: filteredApps.count, expanded: $appsExpanded)
     }
 
     private var brewHeader: some View {
-        sectionHeader("Brew", systemImage: "mug.fill",
+        sectionHeader(String(localized: "Brew"), systemImage: "mug.fill",
                       count: brewItemCount, expanded: $brewExpanded) {
             brewBulkUpgrade
         }
     }
 
     private var rollbackHeader: some View {
-        sectionHeader("Rollback", systemImage: "arrow.uturn.backward",
+        sectionHeader(String(localized: "Rollback"), systemImage: "arrow.uturn.backward",
                       count: rollbackableApps.count, expanded: $rollbackExpanded)
     }
 
@@ -666,12 +666,12 @@ private struct WorkbenchActionView: View {
             // one-click. A Mac App Store app lands here when the privileged helper
             // isn't approved yet — still an installed app with a pending update, so
             // it says **Update** (what the store calls it), never "Get".
-            Button(result.app.isiOSAppOnMac ? "App Store" : "Update") {
+            Button(result.app.isiOSAppOnMac ? String(localized: "App Store") : String(localized: "Update")) {
                 if let url = info.deepLink ?? result.remote?.pageURL { NSWorkspace.shared.open(url) }
             }
             .buttonStyle(.bordered)
             .help(result.app.isiOSAppOnMac
-                  ? "Update \(result.app.name) in the App Store — iPhone/iPad apps can’t be updated from here"
+                  ? String(localized: "Update \(result.app.name) in the App Store — iPhone/iPad apps can’t be updated from here")
                   : appStoreRedirectHelp)
         } else if let url = result.remote?.pageURL {
             Button("Open page") { NSWorkspace.shared.open(url) }
@@ -685,9 +685,9 @@ private struct WorkbenchActionView: View {
     /// user has, so say so when that's what's missing.
     private var appStoreRedirectHelp: String {
         if !model.helperEnabled {
-            return "Opens \(result.app.name) in the App Store. Turn on the background helper in Settings to install App Store updates in one click."
+            return String(localized: "Opens \(result.app.name) in the App Store. Turn on the background helper in Settings to install App Store updates in one click.")
         }
-        return "Update \(result.app.name) in the App Store"
+        return String(localized: "Update \(result.app.name) in the App Store")
     }
 
     @ViewBuilder
@@ -707,14 +707,14 @@ private struct WorkbenchActionView: View {
 
     private func stageLabel(_ stage: InstallStage) -> String {
         switch stage {
-        case .queued: return "Queued"
-        case .checking: return "Checking"
-        case .downloading(let f): return "\(Int(f * 100))%"
-        case .verifyingSignature, .verifyingCodeSignature: return "Verifying"
-        case .extracting: return "Extracting"
-        case .installing: return "Installing"
-        case .runningCommand: return "Installing"
-        case .done: return "Installed"
+        case .queued: return String(localized: "Queued")
+        case .checking: return String(localized: "Checking")
+        case .downloading(let f): return String(localized: "\(Int(f * 100))%")
+        case .verifyingSignature, .verifyingCodeSignature: return String(localized: "Verifying")
+        case .extracting: return String(localized: "Extracting")
+        case .installing: return String(localized: "Installing")
+        case .runningCommand: return String(localized: "Installing")
+        case .done: return String(localized: "Installed")
         }
     }
 }
@@ -876,7 +876,7 @@ private struct WorkbenchRollbackRow: View {
 
     private var inFlight: Bool { model.installing[result.id] != nil }
     private var error: String? { model.installErrors[result.id] }
-    private var targetLabel: String { target == "previous" ? "previous version" : "v\(target)" }
+    private var targetLabel: String { target == "previous" ? String(localized: "previous version") : String(localized: "v\(target)") }
 
     var body: some View {
         HStack(spacing: 8) {
@@ -1011,7 +1011,7 @@ private struct FormulaDetailPane: View {
             if upgrading {
                 HStack(spacing: 7) {
                     ProgressView().controlSize(.small)
-                    Text(model.formulaUpgradeNotes[formula.name] ?? "Updating…")
+                    Text(model.formulaUpgradeNotes[formula.name] ?? String(localized: "Updating…"))
                         .font(.callout).foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
@@ -1109,7 +1109,7 @@ private struct DetailHeader: View {
                         .buttonStyle(.link)
                 }
                 if model.showsHelperRestartFallback(result.id) {
-                    Button(model.restartingHelper ? "Restarting…" : "Restart Helper…") {
+                    Button(model.restartingHelper ? String(localized: "Restarting…") : String(localized: "Restart Helper…")) {
                         Task { await model.restartAppStoreHelper(result.id) }
                     }
                     .font(.caption)
@@ -1553,10 +1553,10 @@ private struct TrafficPane: View {
 
     private func versionTransition(_ event: TrafficEvent) -> String {
         switch (event.fromVersion, event.toVersion) {
-        case let (from?, to?): return "\(from) → \(to)"
+        case let (from?, to?): return String(localized: "\(from) → \(to)")
         case let (nil, to?): return to
         case let (from?, nil): return from
-        case (nil, nil): return "Update"
+        case (nil, nil): return String(localized: "Update")
         }
     }
 }

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1224,7 +1224,7 @@ private struct ReleaseNotesPane: View {
         ContentUnavailableView {
             Label("No release notes", systemImage: "doc.text.magnifyingglass")
         } description: {
-            Text("\(result.remote?.sourceName ?? "This source") doesn’t publish a changelog we can read.")
+            Text("\(result.remote?.sourceName ?? String(localized: "This source")) doesn’t publish a changelog we can read.")
         } actions: {
             if let dl = result.remote?.pageURL {
                 Link("Open download page", destination: dl)

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -345,12 +345,23 @@ struct WorkbenchWindowView: View {
                     Image(systemName: systemImage)
                         .font(.callout)
                         .foregroundStyle(.secondary)
+                    // Holds its size instead of compressing: the accessory beside it
+                    // is a translated button, and "Обновить формулы" is wide enough
+                    // to squeeze this to nothing — at which point a four-letter
+                    // section name wraps to "Bre / w". The button truncates instead.
                     Text(title)
                         .font(.headline)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                     Spacer(minLength: 8)
                     Text("\(count)")
                         .font(.caption.weight(.semibold)).monospacedDigit()
                         .foregroundStyle(.secondary)
+                        // Same reason as the title: with the title pinned, the
+                        // squeeze lands here next, and "52" came out stacked as
+                        // "5 / 2" inside the capsule.
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                         .padding(.horizontal, 7).padding(.vertical, 1)
                         .background(.quaternary, in: Capsule())
                 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateSettings.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateSettings.swift
@@ -24,8 +24,8 @@ public enum AppStoreUpdateStrategy: String, CaseIterable, Identifiable, Sendable
 
     public var label: String {
         switch self {
-        case .full:        return "Full download (no extra permission)"
-        case .incremental: return "Incremental (needs Accessibility)"
+        case .full:        return String(localized: "Full download (no extra permission)")
+        case .incremental: return String(localized: "Incremental (needs Accessibility)")
         }
     }
 }
@@ -73,8 +73,8 @@ public enum VendorInstallPolicy: String, CaseIterable, Identifiable, Sendable {
 
     public var label: String {
         switch self {
-        case .deferWhenRunning: return "Defer to the app’s own updater while it’s running"
-        case .alwaysOverwrite:  return "Always download & replace, then restart"
+        case .deferWhenRunning: return String(localized: "Defer to the app’s own updater while it’s running")
+        case .alwaysOverwrite:  return String(localized: "Always download & replace, then restart")
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 test:
 	cd DuoUpdaterCore && swift test
 	swift test --package-path CLI
+	python3 scripts/check_localizable_keys.py
 
 # The notarytool keychain profile both targets below need. Not a secret — the
 # credentials it names live in the keychain; this is only which of them to use.

--- a/scripts/check_localizable_keys.py
+++ b/scripts/check_localizable_keys.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Hold Localizable.xcstrings and the source it serves to the same set of keys.
+
+A localizable key is a string the compiler builds from the literal *and* the
+format specifier of every interpolated value: an `Int` becomes `%lld`, a
+`String` becomes `%@`. Miss that by one character and the lookup finds nothing
+and quietly renders the English source — inside a window where everything
+around it is translated. That is exactly how the German Backups sheet came to
+offer "Delete 49 (21.04 GB)" next to "Alle abwählen": the catalog said
+`Delete %@ (%@)` where the runtime asks for `Delete %lld (%@)`.
+
+Nothing else catches it. The build succeeds, `swift test` passes, and the
+catalog reports every language "translated" — the key it translated is simply
+one nobody asks for. So this compares the two sets directly:
+
+  * a key the source asks for but the catalog lacks  -> renders English
+  * a key the catalog carries but no source asks for -> dead weight, and
+    indistinguishable from the first case to the next person reading the file
+
+The source side is not guessed. `SWIFT_EMIT_LOC_STRINGS=YES` makes the Swift
+compiler write a .stringsdata file per source file containing the exact keys it
+emitted, with the file and line each came from — the same data Xcode's own
+"Export Localizations" is built on, minus the XLIFF round-trip that rewrites
+`%lld` back to `%@`.
+
+The build runs into its own derived-data directory so it never invalidates the
+one `make install` uses (the extra build setting would otherwise force a full
+rebuild on every switch). The first run is a full build; later runs are
+incremental.
+
+Usage:  python3 scripts/check_localizable_keys.py [--derived-data DIR]
+Exit:   0 when both sets agree, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+CATALOG = REPO / "App" / "Resources" / "Localizable.xcstrings"
+PROJECT = REPO / "App" / "DuoUpdater.xcodeproj"
+TABLE = "Localizable"
+
+# Keys the catalog is expected to carry without a source site. Keep this list
+# empty unless there is a real reason: every entry here is a key that no test
+# can prove still works.
+ALLOWED_UNREACHABLE: set[str] = set()
+
+# `Text("\(a) · \(b)")` is a localizable key as far as the compiler is
+# concerned, but "%@ · %@" holds no words — there is nothing for a translator
+# to do with it, and demanding a catalog entry would be busywork that hides the
+# keys that matter. Anything with a letter left after the specifiers are
+# removed is real copy and must be in the catalog.
+SPECIFIER = re.compile(r"%(?:\d+\$)?(?:lld|ld|l?[dfsu@]|%)")
+
+
+def has_words(key: str) -> bool:
+    return any(ch.isalpha() for ch in SPECIFIER.sub("", key))
+
+
+def build(derived_data: pathlib.Path) -> None:
+    """Compile the app with loc-string emission on. Signing is off — this only
+    needs the compiler's string metadata, so a fork without the Developer ID
+    team can run the check too."""
+    if not PROJECT.exists():
+        sys.exit(
+            f"✗ {PROJECT} is missing — run `xcodegen generate` in App/ first "
+            "(scripts/install.sh does it for you)."
+        )
+    result = subprocess.run(
+        [
+            "xcodebuild",
+            "-project", str(PROJECT),
+            "-scheme", "DuoUpdater",
+            "-configuration", "Release",
+            "-derivedDataPath", str(derived_data),
+            "SWIFT_EMIT_LOC_STRINGS=YES",
+            "CODE_SIGNING_ALLOWED=NO",
+            "CODE_SIGNING_REQUIRED=NO",
+            "build",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        tail = "\n".join(result.stdout.splitlines()[-25:])
+        sys.exit(f"✗ the extraction build failed:\n{tail}\n{result.stderr[-2000:]}")
+
+
+def keys_from_source(derived_data: pathlib.Path) -> dict[str, str]:
+    """Every key the compiler emitted, mapped to the `file:line` it came from."""
+    found: dict[str, str] = {}
+    for path in derived_data.rglob("*.stringsdata"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        source = data.get("source", "")
+        try:
+            source = str(pathlib.Path(source).relative_to(REPO))
+        except ValueError:
+            pass
+        for entry in data.get("tables", {}).get(TABLE, []):
+            key = entry.get("key")
+            if key is None:
+                continue
+            line = entry.get("location", {}).get("startingLine")
+            found.setdefault(key, f"{source}:{line}" if line else source)
+    return found
+
+
+def report(title: str, detail: str, rows: list[str]) -> None:
+    print(f"\n✗ {title}")
+    print(f"  {detail}")
+    for row in rows:
+        print(f"    {row}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--derived-data",
+        default="/tmp/duo-loc-check",
+        help="where to build (kept separate from the install build's cache)",
+    )
+    args = parser.parse_args()
+    derived_data = pathlib.Path(args.derived_data)
+
+    build(derived_data)
+    source = keys_from_source(derived_data)
+    if not source:
+        sys.exit(
+            f"✗ no .stringsdata under {derived_data} — the build emitted no "
+            "localizable keys at all, which means this check is testing nothing."
+        )
+
+    catalog = set(json.loads(CATALOG.read_text(encoding="utf-8"))["strings"])
+
+    missing = sorted(k for k in set(source) - catalog if has_words(k))
+    unreachable = sorted(catalog - set(source) - ALLOWED_UNREACHABLE)
+
+    if missing:
+        report(
+            f"{len(missing)} key(s) the source asks for are not in the catalog",
+            "These render their English source in every language.",
+            [f"{source[key]}  {key!r}" for key in missing],
+        )
+    if unreachable:
+        report(
+            f"{len(unreachable)} key(s) in the catalog no source site asks for",
+            "Translated, never shown. Usually a specifier that does not match "
+            "the call site — an Int argument spelled %@ instead of %lld.",
+            [repr(key) for key in unreachable],
+        )
+    if missing or unreachable:
+        return 1
+
+    print(f"✓ localizable keys agree — {len(catalog)} in the catalog, all reachable")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Fixes #39 (Russian support), and adds Simplified Chinese, Japanese, German, French, and Spanish alongside it.
- Adds `App/Resources/Localizable.xcstrings` (Apple String Catalog) and converts every user-facing string — SwiftUI views, notifications, AppKit alerts, and two shared `DuoUpdaterCore` labels — to route through it. A lot of the app's copy is built from computed properties, ternaries, and custom view types (`SettingsCard`, `SettingsFootnote`, `DisclosureGroup`) that silently render verbatim in English unless wrapped in `String(localized:)` — those traps are fixed throughout.
- Proper CLDR plural handling, including Russian's four categories and a compound substitution for "N releases across M apps".
- A handful of SwiftUI layout tweaks (menu-bar popover buttons, two Settings pickers, the Welcome window) so longer German/Russian translations don't overflow or clip.
- `duo` CLI and the vendored `PermissionFlow` onboarding panel stay English-only (out of scope — CLI is terminal-only, PermissionFlow already documents itself as deliberately English-pending-a-resource-bundle-rework).

## Test plan
- [x] `xcodebuild` succeeds (clean derived-data build)
- [x] `make test` — 119/119 passing
- [x] Inspected compiled `.strings`/`.stringsdict` for all 7 languages inside the built app bundle — correct translated text and plural tables land where expected
- [x] `make install` deploys and runs correctly
- [x] Manually verified on a second Mac (macOS 26.6) via `-AppleLanguages` override across multiple languages
- [x] Six-agent QA pass: translation accuracy (per language pair), independent coverage sweep, and static overflow-risk analysis — findings fixed (grammar bugs in reachable plural counts, cross-reference mismatches, a Japanese untranslated string, a Spanish button collision, coverage gaps, and the flagged overflow risks)