### PR TITLE
Stop calling every registration refusal a damaged record

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -16141,43 +16141,84 @@
         }
       }
     },
-    "macOS refused the registration — its record of this background item is damaged. Fixing it needs a system-level reset: run “sudo sfltool resetbtm” in Terminal and restart. That clears background-item approvals for every app, so you'll re-approve the others too.": {
+    "macOS is waiting for your approval. Switch Duo Updater on under “Allow in the Background” in Login Items & Extensions — it's open now.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS hat die Registrierung abgelehnt – der Datensatz zu diesem Hintergrundelement ist beschädigt. Die Behebung erfordert einen systemweiten Reset: Führe „sudo sfltool resetbtm“ im Terminal aus und starte neu. Das löscht die Genehmigungen für Hintergrundelemente aller Apps, sodass du die anderen ebenfalls erneut genehmigen musst."
+            "value": "macOS wartet auf deine Zustimmung. Aktiviere Duo Updater unter „Im Hintergrund erlauben“ in „Anmeldeobjekte & Erweiterungen“ – das Fenster ist jetzt offen."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS rechazó el registro; su registro de este elemento en segundo plano está dañado. Solucionarlo requiere un restablecimiento a nivel de sistema: ejecuta «sudo sfltool resetbtm» en Terminal y reinicia. Esto borra los permisos de elementos en segundo plano de todas las apps, así que tendrás que volver a aprobar las demás."
+            "value": "macOS espera tu aprobación. Activa Duo Updater en «Permitir en segundo plano», dentro de Ítems de inicio y extensiones: ya está abierto."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS a refusé l'enregistrement — son enregistrement de cet élément en arrière-plan est corrompu. La réparation nécessite une réinitialisation au niveau système : exécutez « sudo sfltool resetbtm » dans le Terminal et redémarrez. Cela efface les autorisations d'éléments en arrière-plan pour toutes les applications, vous devrez donc réapprouver les autres aussi."
+            "value": "macOS attend votre approbation. Activez Duo Updater sous « Autoriser en arrière-plan » dans Ouverture et extensions — la fenêtre est déjà ouverte."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOSが登録を拒否しました — このバックグラウンド項目に関する記録が破損しています。修復にはシステムレベルのリセットが必要です。ターミナルで「sudo sfltool resetbtm」を実行して再起動してください。これによりすべてのアプリのバックグラウンド項目の承認がクリアされるため、他のアプリも再承認が必要になります。"
+            "value": "macOSが承認を待っています。「ログイン項目と機能拡張」の「バックグラウンドでの実行を許可」でDuo Updaterをオンにしてください — いま開いています。"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS отклонила регистрацию — её запись об этом фоновом элементе повреждена. Для исправления нужен сброс на уровне системы: выполните «sudo sfltool resetbtm» в Терминале и перезагрузитесь. Это очистит разрешения фоновых элементов для всех приложений, так что остальные придётся одобрить заново."
+            "value": "macOS ждёт вашего подтверждения. Включите Duo Updater в разделе «Разрешить в фоновом режиме» в «Объекты входа и расширения» — он уже открыт."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS 拒绝了注册 — 它关于此后台项目的记录已损坏。修复需要系统级重置：在终端中运行“sudo sfltool resetbtm”并重启。这会清除所有应用的后台项目授权，因此你需要重新批准其他应用。"
+            "value": "macOS 正在等待你批准。请在“登录项与扩展”的“允许在后台”中开启 Duo Updater — 该页面已为你打开。"
+          }
+        }
+      }
+    },
+    "macOS refused the registration. Switch Duo Updater on under “Allow in the Background” in Login Items & Extensions — that alone usually fixes it. If it isn't listed there, or switching it on changes nothing, macOS's record of this background item is damaged and needs a system-level reset: run “sudo sfltool resetbtm” in Terminal and restart. That clears background-item approvals for every app, so you'll re-approve the others too.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS hat die Registrierung abgelehnt. Aktiviere Duo Updater unter „Im Hintergrund erlauben“ in „Anmeldeobjekte & Erweiterungen“ – das allein behebt es meistens. Wird Duo Updater dort nicht aufgeführt oder ändert das Aktivieren nichts, ist der Datensatz von macOS zu diesem Hintergrundelement beschädigt und erfordert einen systemweiten Reset: Führe „sudo sfltool resetbtm“ im Terminal aus und starte neu. Das löscht die Genehmigungen für Hintergrundelemente aller Apps, sodass du die anderen ebenfalls erneut genehmigen musst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS rechazó el registro. Activa Duo Updater en «Permitir en segundo plano», dentro de Ítems de inicio y extensiones: con eso suele bastar. Si Duo Updater no aparece ahí, o activarlo no cambia nada, el registro que macOS tiene de este elemento en segundo plano está dañado y requiere un restablecimiento a nivel de sistema: ejecuta «sudo sfltool resetbtm» en Terminal y reinicia. Esto borra los permisos de elementos en segundo plano de todas las apps, así que tendrás que volver a aprobar las demás."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS a refusé l'enregistrement. Activez Duo Updater sous « Autoriser en arrière-plan » dans Ouverture et extensions — cela suffit le plus souvent. Si Duo Updater n'y figure pas, ou si l'activer ne change rien, l'enregistrement de cet élément en arrière-plan est corrompu et nécessite une réinitialisation au niveau système : exécutez « sudo sfltool resetbtm » dans le Terminal et redémarrez. Cela efface les autorisations d'éléments en arrière-plan pour toutes les applications, vous devrez donc réapprouver les autres aussi."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOSが登録を拒否しました。「ログイン項目と機能拡張」の「バックグラウンドでの実行を許可」でDuo Updaterをオンにしてください — たいていはこれだけで直ります。そこにDuo Updaterが表示されない場合や、オンにしても変わらない場合は、このバックグラウンド項目に関するmacOSの記録が破損しており、システムレベルのリセットが必要です。ターミナルで「sudo sfltool resetbtm」を実行して再起動してください。これによりすべてのアプリのバックグラウンド項目の承認がクリアされるため、他のアプリも再承認が必要になります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS отклонила регистрацию. Включите Duo Updater в разделе «Разрешить в фоновом режиме» в «Объекты входа и расширения» — обычно этого достаточно. Если Duo Updater там нет или включение ничего не меняет, запись macOS об этом фоновом элементе повреждена и нужен сброс на уровне системы: выполните «sudo sfltool resetbtm» в Терминале и перезагрузитесь. Это очистит разрешения фоновых элементов для всех приложений, так что остальные придётся одобрить заново."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 拒绝了注册。请在“登录项与扩展”的“允许在后台”中开启 Duo Updater — 通常这样就能解决。如果那里没有 Duo Updater，或者开启后仍无效，说明 macOS 关于此后台项目的记录已损坏，需要系统级重置：在终端中运行“sudo sfltool resetbtm”并重启。这会清除所有应用的后台项目授权，因此你需要重新批准其他应用。"
           }
         }
       }

--- a/App/Sources/PrivilegedHelperClient.swift
+++ b/App/Sources/PrivilegedHelperClient.swift
@@ -62,26 +62,51 @@ final class PrivilegedHelperClient: ObservableObject {
         do {
             try service.register()
             lastRegisterError = nil
-            log.notice("helper register() ok — status \(self.service.status.rawValue, privacy: .public)")
+            refreshStatus()
+            log.notice("helper register() ok — status \(self.status.rawValue, privacy: .public)")
+            if status == .requiresApproval { openLoginItems() }
+            return
         } catch {
-            lastRegisterError = Self.explain(error)
-            log.error("helper register() failed: \(error.localizedDescription, privacy: .public)")
+            refreshStatus()
+            // Only when it left the helper off. A refusal on an item that is
+            // already switched on changes nothing the user has to act on, and
+            // posting a message would put red type next to the green "Enabled" —
+            // the same contradiction `refreshStatus()` exists to clear.
+            lastRegisterError = status == .enabled ? nil : Self.explain(error, status: status)
+            log.error("helper register() failed: \(error.localizedDescription, privacy: .public) — status \(self.status.rawValue, privacy: .public)")
+            // A refusal is not proof of a damaged record. macOS also refuses while
+            // a background item exists but sits switched OFF, and there the switch
+            // — not a system-wide reset — is the whole cure: reported 2026-08-23,
+            // register() was refused and turning Duo Updater on by hand in Login
+            // Items fixed it outright. `status` does not separate the two cases, so
+            // open the pane for both; on the damaged one that costs a window.
+            if Self.isRefusal(error) || status == .requiresApproval { openLoginItems() }
         }
-        refreshStatus()
-        if status == .requiresApproval { openLoginItems() }
     }
 
-    /// Turn a `SMAppService` failure into something a user can act on. The one worth
-    /// naming is a Background Task Management record macOS can no longer resolve
-    /// (its log line: "fullPath is nil, container=(null)"): registering is refused
-    /// with a bare "Operation not permitted", the Login Items switch has no effect on
-    /// it, and nothing an app is allowed to do will clear it — only a system-level
-    /// reset will.
-    private static func explain(_ error: Error) -> String {
-        let message = error.localizedDescription
-        guard (error as NSError).code == 1 || message.localizedCaseInsensitiveContains("not permitted")
-        else { return message }
-        return String(localized: "macOS refused the registration — its record of this background item is damaged. Fixing it needs a system-level reset: run “sudo sfltool resetbtm” in Terminal and restart. That clears background-item approvals for every app, so you'll re-approve the others too.")
+    /// Whether macOS refused the registration outright — `SMAppService` reports
+    /// this as a bare "Operation not permitted" (code 1) with no indication of
+    /// which of its several causes applies.
+    private static func isRefusal(_ error: Error) -> Bool {
+        (error as NSError).code == 1
+            || error.localizedDescription.localizedCaseInsensitiveContains("not permitted")
+    }
+
+    /// Turn a `SMAppService` failure into something a user can act on.
+    ///
+    /// A refusal has more than one cause and macOS names none of them, so the
+    /// advice leads with the cheap, reversible fix (switch the item on in Login
+    /// Items) and keeps the drastic one (a Background Task Management record macOS
+    /// can no longer resolve — log line "fullPath is nil, container=(null)", curable
+    /// only by `sfltool resetbtm`) as the fallback for when that changed nothing.
+    /// Leading with the reset was wrong: it sent at least one user to reset every
+    /// app's background approvals for a problem one toggle solved.
+    private static func explain(_ error: Error, status: SMAppService.Status) -> String {
+        guard isRefusal(error) else { return error.localizedDescription }
+        if status == .requiresApproval {
+            return String(localized: "macOS is waiting for your approval. Switch Duo Updater on under “Allow in the Background” in Login Items & Extensions — it's open now.")
+        }
+        return String(localized: "macOS refused the registration. Switch Duo Updater on under “Allow in the Background” in Login Items & Extensions — that alone usually fixes it. If it isn't listed there, or switching it on changes nothing, macOS's record of this background item is damaged and needs a system-level reset: run “sudo sfltool resetbtm” in Terminal and restart. That clears background-item approvals for every app, so you'll re-approve the others too.")
     }
 
     func unregister() {

--- a/App/Sources/Settings/DiagnosticsSettingsPage.swift
+++ b/App/Sources/Settings/DiagnosticsSettingsPage.swift
@@ -176,6 +176,11 @@ private struct HelperStatusRow: View {
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
                     .textSelection(.enabled)  // so the reset command can be copied
+                    // Same inset as `settingsRow()` and the reachability line above:
+                    // without it several lines of red type run edge to edge across
+                    // the card while every other row stops 14pt short.
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 6)
             }
         }
     }


### PR DESCRIPTION
## 起因

用户点 Diagnostics 的 “Enable…”，拿到一段红字：BTM 记录损坏，去跑 `sudo sfltool resetbtm` 再重启。他没照做——**手动去 System Settings ▸ Login Items & Extensions 把 Duo Updater 的后台开关打开就好了**。

## 为什么错

`SMAppService.register()` 把拒绝一律报成 `Operation not permitted` (code 1)，而这个码至少有几种成因：plist 已被 launchd 加载、旧 SMJobBless 残留、签名问题、后台项被用户关着——macOS 一个都不说是哪种（[eskimo, forums/707482](https://developer.apple.com/forums/thread/707482)、[forums/756846](https://developer.apple.com/forums/thread/756846)）。我们把最激进的那条当成唯一解释，等于让用户为一个开关能解决的问题清掉**全机所有 app** 的后台授权。

## 改了什么

- 失败后先 `refreshStatus()`，按 `status` 分诊：`.requiresApproval` → 只说「去 Login Items 打开」；其他状态 → 文案**先**给开关这条便宜可逆的路，`resetbtm` 降级成「那里没有它 / 打开也没变化」时的兜底。
- 只要是 refusal 就 `openLoginItems()`，不再只在 `.requiresApproval` 时开——用户那次显然不是这个状态（按钮仍是 “Enable…”，面板也没自动弹）。
- 拒绝但 helper 已经 enabled 时不写消息，免得绿色 “Enabled” 旁边配红字（`refreshStatus()` 本来就是为消除这个矛盾存在的）。
- 红字补上和同卡片其它行一致的 14pt 内缩——原来整段红字贴着卡片边缘跑。
- 6 语翻译同步更新，旧 key 删除。

## 验证

- `make test`：`935 tests in 75 suites passed` + `119 tests in 18 suites passed`（2 个既有 known issue）。
- 本分支单独 `xcodebuild -configuration Release`：`BUILD SUCCEEDED`（compile-only，签名身份不在这个 worktree 里）。
- 合并前在主 checkout 上跑过完整 `make install`，语言检查 `de en es fr ja ru zh-Hans` 全部落盘。

## 没验证的部分

- **红字的 padding 没有截图验证**：要让它出现就得先把 helper 注册弄失败，而在本机动 `unregister()` 是已知会让情况更糟的操作（见 `reregister()` 里那段注释）。改动本身与同卡片里显示正常的 reachability 行是同一组 modifier。
- **用户那次失败具体属于哪种成因，未验证**：本机 4 天内 `smd` / `backgroundtaskmanagementd` / 我们自己 `helper` 分类的日志里没有找到那次记录。能确定的只是原来那条建议对他的情况是错的。