### PR TITLE
sources: pick the runnable architecture from a dual-arch Sparkle appcast

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -82,20 +82,18 @@ public struct GitHubReleaseRule: Sendable {
         }
         guard !matches.isEmpty else { return nil }
 
-        func has(_ tokens: [String], _ name: String) -> Bool {
-            let lower = name.lowercased()
-            return tokens.contains { lower.contains($0) }
-        }
-
         // 1. An asset explicitly built for this Mac's architecture.
         if let native = matches.first(where: {
-            has(arch.assetTokens, $0.name) && !has(arch.foreignTokens, $0.name)
+            arch.isMarked(inAssetName: $0.name)
+                && !(arch == .arm64 ? HostArch.x86_64 : .arm64).isMarked(inAssetName: $0.name)
         }) { return (native.url, native.size) }
 
         // 2. An arch-neutral asset (a universal build, or a name with no arch
-        //    marker at all) — safe for either machine.
+        //    marker at all) — safe for either machine. A filename that explicitly
+        //    names both architectures is another spelling of universal.
         if let neutral = matches.first(where: {
-            !has(arch.assetTokens, $0.name) && !has(arch.foreignTokens, $0.name)
+            arch.isMarked(inAssetName: $0.name)
+                == (arch == .arm64 ? HostArch.x86_64 : .arm64).isMarked(inAssetName: $0.name)
         }) { return (neutral.url, neutral.size) }
 
         // 3. Everything that matched is built for the OTHER architecture. Offering

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -146,9 +146,14 @@ public struct SparkleAppcastSource: UpdateSource {
     static func bestItem(
         for app: InstalledApp,
         from items: [SparkleAppcastItem],
-        osVersion: String
+        osVersion: String,
+        hostArch: HostArch = .current,
+        allowingIntelTranslation canRunIntel: Bool = HostArch.canRunIntelBuilds
     ) -> SparkleAppcastItem? {
-        usableItems(for: app, from: items, osVersion: osVersion).first
+        usableItems(
+            for: app, from: items, osVersion: osVersion,
+            hostArch: hostArch, allowingIntelTranslation: canRunIntel
+        ).first
     }
 
     /// The runnable, in-channel items for an app, highest version first. The head
@@ -156,7 +161,9 @@ public struct SparkleAppcastSource: UpdateSource {
     static func usableItems(
         for app: InstalledApp,
         from items: [SparkleAppcastItem],
-        osVersion: String
+        osVersion: String,
+        hostArch: HostArch = .current,
+        allowingIntelTranslation canRunIntel: Bool = HostArch.canRunIntelBuilds
     ) -> [SparkleAppcastItem] {
         guard !items.isEmpty else { return [] }
         // Sparkle's real rule: the default (untagged) channel is allowed to
@@ -179,26 +186,75 @@ public struct SparkleAppcastSource: UpdateSource {
             // Default channel ∪ the user's channel — never a higher one.
             guard allowed.contains(normalizeChannel(item.channel)) else { return false }
             // Honor minimum system version when declared.
-            if let minOS = item.minimumSystemVersion, !minOS.isEmpty {
-                return VersionComparator.compare(osVersion, minOS) != .orderedAscending
+            if let minOS = item.minimumSystemVersion, !minOS.isEmpty,
+               VersionComparator.compare(osVersion, minOS) == .orderedAscending {
+                return false
             }
-            return true
+            // A per-architecture twin (TablePro publishes an arm64 and an x86_64
+            // item per release, same version) this Mac cannot run at all — never
+            // offer it, changelog history included. See `archVerdict`.
+            return archVerdict(for: item, hostArch: hostArch, canRunIntel: canRunIntel) != .unrunnable
         }
         // Deterministic tie-break on equal versions. `sorted(by:)` is NOT a stable
-        // sort in Swift, so per-architecture twins (TablePro publishes an arm64 and
-        // an x86_64 item per release) could come back in either order from run to
-        // run — and the changelog dedupe below keeps the FIRST item that yields
-        // notes. Identical bodies make that invisible today; the day a vendor writes
-        // per-arch notes it would silently alternate between them. Falling back to
-        // the enclosure URL is arbitrary but fixed, which is the property that
-        // matters.
+        // sort in Swift, so per-architecture twins could come back in either order
+        // from run to run — and the changelog dedupe below keeps the FIRST item
+        // that yields notes. Rank the twin built for this Mac first; only fall
+        // back to the enclosure URL when architecture doesn't disambiguate
+        // (identical bodies, or neither item names an architecture at all).
         return usable.sorted { (lhs: SparkleAppcastItem, rhs: SparkleAppcastItem) -> Bool in
             switch VersionComparator.compare(lhs.comparisonKey, rhs.comparisonKey) {
             case .orderedDescending: return true
             case .orderedAscending: return false
-            case .orderedSame: return (lhs.enclosureURL?.absoluteString ?? "") < (rhs.enclosureURL?.absoluteString ?? "")
+            case .orderedSame:
+                let lRank = archVerdict(for: lhs, hostArch: hostArch, canRunIntel: canRunIntel)
+                let rRank = archVerdict(for: rhs, hostArch: hostArch, canRunIntel: canRunIntel)
+                if lRank != rRank { return lRank < rRank }
+                return (lhs.enclosureURL?.absoluteString ?? "") < (rhs.enclosureURL?.absoluteString ?? "")
             }
         }
+    }
+
+    /// How well an item's download suits this Mac, cheapest-to-worst. Two
+    /// signals feed it, in priority order:
+    ///
+    ///  1. `<sparkle:hardwareRequirements>` — Sparkle's own structured gate
+    ///     (comma-delimited; today the only value it defines is "arm64").
+    ///     TablePro's real appcast sets it on exactly the arm64-native item of
+    ///     each release pair and leaves the x86_64 twin untagged
+    ///     (fetched 2026-08-24: raw.githubusercontent.com/TableProApp/TablePro/
+    ///     main/appcast.xml). It requires Apple-silicon hardware — never
+    ///     satisfiable on a real Intel Mac, which has no reverse Rosetta — so a
+    ///     tagged item is `.unrunnable` there regardless of anything else.
+    ///     https://sparkle-project.org/documentation/publishing/#minimum-system-version-requirements
+    ///  2. Filename tokens on the enclosure, exactly like
+    ///     `GitHubReleaseRule.installableAsset`: native beats an arch-neutral
+    ///     build beats a foreign-arch one, and a foreign-arch build is only
+    ///     `.foreignButRunnable` (never preferred, but not excluded) while this
+    ///     Mac can still translate it — i.e. only Apple silicon, and only
+    ///     `HostArch.canRunIntelBuilds`. This is the fallback for the vendors
+    ///     that don't set the Sparkle tag at all, and it's also what actually
+    ///     resolves the TablePro pair: only the arm64 item carries the tag, so
+    ///     without this the untagged x86_64 twin would tie with it.
+    private static func archVerdict(
+        for item: SparkleAppcastItem, hostArch: HostArch, canRunIntel: Bool
+    ) -> ArchVerdict {
+        if item.hardwareRequirements.contains("arm64"), hostArch != .arm64 {
+            return .unrunnable
+        }
+        let name = (item.enclosureURL?.lastPathComponent ?? "").lowercased()
+        func has(_ tokens: [String]) -> Bool { tokens.contains { name.contains($0) } }
+        if has(hostArch.assetTokens), !has(hostArch.foreignTokens) { return .native }
+        if !has(hostArch.assetTokens), !has(hostArch.foreignTokens) { return .neutral }
+        // Named for the other architecture. Only Apple silicon can still run an
+        // Intel build (via Rosetta, and only while `canRunIntel` holds) — the
+        // reverse direction has never worked, an arm64 build has never run on
+        // an Intel Mac.
+        return (hostArch == .arm64 && canRunIntel) ? .foreignButRunnable : .unrunnable
+    }
+
+    private enum ArchVerdict: Int, Comparable {
+        case native, neutral, foreignButRunnable, unrunnable
+        static func < (lhs: ArchVerdict, rhs: ArchVerdict) -> Bool { lhs.rawValue < rhs.rawValue }
     }
 
     /// The Sparkle channel the installed build sits on, found by matching the
@@ -278,6 +334,12 @@ struct SparkleAppcastItem {
     /// `<sparkle:channel>` — names a non-default release track (e.g. "beta").
     /// nil/absent means the default (stable) channel, which Sparkle always ships.
     var channel: String?
+    /// `<sparkle:hardwareRequirements>` — a comma-delimited list Sparkle itself
+    /// defines and enforces client-side; today the only value it recognizes is
+    /// "arm64", meaning this item's build requires Apple-silicon hardware.
+    /// Lowercased on parse. Empty for the vast majority of feeds (only vendors
+    /// publishing separate per-architecture items, like TablePro, set it).
+    var hardwareRequirements: Set<String> = []
     /// `<sparkle:minimumAutoupdateVersion>` — the vendor-declared build version
     /// below which this release must never silently auto-install. Sparkle derives
     /// `SUAppcastItem.majorUpgrade` from it, and vendors set it at a paid/license
@@ -414,6 +476,12 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
             current?.minimumSystemVersion = text
         case "sparkle:channel":
             if current?.channel == nil, !text.isEmpty { current?.channel = text }
+        case "sparkle:hardwareRequirements":
+            if !text.isEmpty {
+                current?.hardwareRequirements = Set(
+                    text.lowercased().split(separator: ",")
+                        .map { $0.trimmingCharacters(in: .whitespaces) })
+            }
         case "sparkle:minimumAutoupdateVersion":
             if current?.minimumAutoupdateVersion == nil, !text.isEmpty {
                 current?.minimumAutoupdateVersion = text

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -238,13 +238,20 @@ public struct SparkleAppcastSource: UpdateSource {
     private static func archVerdict(
         for item: SparkleAppcastItem, hostArch: HostArch, canRunIntel: Bool
     ) -> ArchVerdict {
-        if item.hardwareRequirements.contains("arm64"), hostArch != .arm64 {
-            return .unrunnable
+        // Sparkle's structured requirement is authoritative. On Apple silicon it
+        // proves the item is compatible even if an unrelated part of the product
+        // name resembles a filename token (for example, `IntelliJ-…-arm64.zip`).
+        if item.hardwareRequirements.contains("arm64") {
+            return hostArch == .arm64 ? .native : .unrunnable
         }
         let name = (item.enclosureURL?.lastPathComponent ?? "").lowercased()
-        func has(_ tokens: [String]) -> Bool { tokens.contains { name.contains($0) } }
-        if has(hostArch.assetTokens), !has(hostArch.foreignTokens) { return .native }
-        if !has(hostArch.assetTokens), !has(hostArch.foreignTokens) { return .neutral }
+        let native = hostArch.isMarked(inAssetName: name)
+        let foreignArch: HostArch = hostArch == .arm64 ? .x86_64 : .arm64
+        let foreign = foreignArch.isMarked(inAssetName: name)
+        if native && !foreign { return .native }
+        // Neither marker means an ordinary neutral name; both markers explicitly
+        // describe a fat/universal artifact.
+        if native == foreign { return .neutral }
         // Named for the other architecture. Only Apple silicon can still run an
         // Intel build (via Rosetta, and only while `canRunIntel` holds) — the
         // reverse direction has never worked, an arm64 build has never run on

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/HostArch.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/HostArch.swift
@@ -25,7 +25,7 @@ public enum HostArch: Sendable, Equatable {
         return .x86_64
     }
 
-    /// Lowercased substrings that mark an asset *filename* as built for this
+    /// Lowercased markers that identify an asset *filename* as built for this
     /// architecture (e.g. `rustdesk-1.4.6-aarch64.dmg`). Kept conservative — only
     /// tokens that appear as real arch markers in release asset names — so they
     /// don't false-match unrelated words.
@@ -48,6 +48,34 @@ public enum HostArch: Sendable, Equatable {
     /// explicitly for the *other* machine and must not be picked for this one.
     public var foreignTokens: [String] {
         (self == .arm64 ? HostArch.x86_64 : HostArch.arm64).assetTokens
+    }
+
+    /// Whether `name` carries one of this architecture's standalone filename
+    /// markers. Requiring a non-alphanumeric boundary keeps product names such
+    /// as `IntelliJ` from accidentally matching the Intel marker while retaining
+    /// the separators used by real assets (`App-arm64.zip`, `App_x64_mac.dmg`).
+    func isMarked(inAssetName name: String) -> Bool {
+        let lower = name.lowercased()
+        for token in assetTokens {
+            var searchStart = lower.startIndex
+            while searchStart < lower.endIndex,
+                  let range = lower.range(
+                    of: token, range: searchStart..<lower.endIndex) {
+                let startsAtBoundary = range.lowerBound == lower.startIndex
+                    || {
+                        let preceding = lower[lower.index(before: range.lowerBound)]
+                        return !preceding.isLetter && !preceding.isNumber
+                    }()
+                let endsAtBoundary = range.upperBound == lower.endIndex
+                    || {
+                        let following = lower[range.upperBound]
+                        return !following.isLetter && !following.isNumber
+                    }()
+                if startsAtBoundary && endsAtBoundary { return true }
+                searchStart = lower.index(after: range.lowerBound)
+            }
+        }
+        return false
     }
 
     /// Whether an Intel build can still be *run* on this Mac — the one case where

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchSelectionTests.swift
@@ -37,6 +37,24 @@ struct ArchSelectionTests {
         #expect(url?.url.lastPathComponent == "app-1.0-universal.dmg")
     }
 
+    @Test func architectureMarkersRequireFilenameBoundaries() {
+        let a = assets(["IntelliJ-1.0-arm64.dmg"])
+        let url = GitHubReleaseRule.installableAsset(
+            from: a, matching: #"\.dmg$"#, preferring: .arm64,
+            allowingIntelTranslation: false)
+        #expect(url?.url.lastPathComponent == "IntelliJ-1.0-arm64.dmg")
+    }
+
+    @Test func filenameNamingBothArchitecturesIsUniversal() {
+        let a = assets(["app-1.0-arm64-x86_64.dmg"])
+        for arch: HostArch in [.arm64, .x86_64] {
+            let url = GitHubReleaseRule.installableAsset(
+                from: a, matching: #"\.dmg$"#, preferring: arch,
+                allowingIntelTranslation: false)
+            #expect(url?.url.lastPathComponent == "app-1.0-arm64-x86_64.dmg")
+        }
+    }
+
     @Test func fallsBackToForeignArchWhileRosettaCanRunIt() {
         // Only an Intel build exists for this release — better to offer it than
         // nothing, but ONLY while the machine can still run it.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleArchSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleArchSelectionTests.swift
@@ -97,6 +97,19 @@ struct SparkleArchSelectionTests {
         #expect(usable.isEmpty)
     }
 
+    @Test func structuredArmRequirementWinsOverProductNameTokens() {
+        var item = tableProPair().first {
+            $0.hardwareRequirements.contains("arm64")
+        }!
+        // `intel` is a supported Intel marker, but here it is embedded inside
+        // the product name rather than standing alone as an architecture marker.
+        item.enclosureURL = URL(string: "https://example.com/IntelliJ-0.67.1-arm64.zip")
+        let usable = SparkleAppcastSource.usableItems(
+            for: app(), from: [item], osVersion: "28.0.0",
+            hostArch: .arm64, allowingIntelTranslation: false)
+        #expect(usable.count == 1)
+    }
+
     // MARK: - Filename-token fallback (no hardwareRequirements tag at all)
     //
     // Most Sparkle vendors don't use the tag; some still ship a genuine
@@ -179,6 +192,23 @@ struct SparkleArchSelectionTests {
             let best = SparkleAppcastSource.bestItem(
                 for: app(), from: items, osVersion: "14.0.0", hostArch: arch, allowingIntelTranslation: false)
             #expect(best?.enclosureURL?.lastPathComponent == "App.zip")
+        }
+    }
+
+    @Test func explicitDualArchitectureFilenameIsUniversal() {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel><item><sparkle:version>4</sparkle:version><sparkle:shortVersionString>4.0</sparkle:shortVersionString>
+          <enclosure url="https://example.com/App-4.0-arm64-x86_64.zip" sparkle:edSignature="s" length="1" type="application/octet-stream"/></item></channel>
+        </rss>
+        """
+        let items = SparkleAppcastParser.parse(Data(xml.utf8))
+        for arch: HostArch in [.arm64, .x86_64] {
+            let best = SparkleAppcastSource.bestItem(
+                for: app(), from: items, osVersion: "14.0.0",
+                hostArch: arch, allowingIntelTranslation: false)
+            #expect(best?.enclosureURL?.lastPathComponent == "App-4.0-arm64-x86_64.zip")
         }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleArchSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleArchSelectionTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Architecture-aware Sparkle appcast item selection. Mirrors
+/// `ArchSelectionTests` (GitHub releases), but Sparkle vendors that publish
+/// separate per-architecture builds do it as two `<item>`s carrying the SAME
+/// version — a shape GitHub releases never has — so before this, `usableItems`
+/// had no arch signal at all and tie-broke on the enclosure URL string, which
+/// has nothing to do with which one this Mac can run.
+struct SparkleArchSelectionTests {
+
+    private func app() -> InstalledApp {
+        InstalledApp(
+            name: "TablePro", bundleID: "app.tablepro.TablePro",
+            shortVersion: "0.66.0", buildVersion: "110",
+            path: URL(fileURLWithPath: "/Applications/TablePro.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"))
+    }
+
+    /// TablePro's real 0.67.1 item pair, fetched 2026-08-24 from
+    /// raw.githubusercontent.com/TableProApp/TablePro/main/appcast.xml
+    /// (description bodies trimmed; everything else verbatim, including the
+    /// arm64 item appearing first in document order and carrying the only
+    /// `sparkle:hardwareRequirements` tag of the pair). `reversed` swaps the
+    /// item order in the feed, so a test can prove selection depends on
+    /// architecture, not on which item the vendor happened to list first.
+    private func tableProPair(reversed: Bool = false) -> [SparkleAppcastItem] {
+        let arm64Item = """
+        <item>
+          <title>0.67.1</title>
+          <pubDate>Sat, 22 Aug 2026 10:44:28 +0000</pubDate>
+          <sparkle:version>122</sparkle:version>
+          <sparkle:shortVersionString>0.67.1</sparkle:shortVersionString>
+          <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+          <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+          <enclosure url="https://github.com/TableProApp/TablePro/releases/download/v0.67.1/TablePro-0.67.1-arm64.zip"
+                     length="24418655" type="application/octet-stream" sparkle:edSignature="arm-sig"/>
+        </item>
+        """
+        let x86Item = """
+        <item>
+          <title>0.67.1</title>
+          <pubDate>Sat, 22 Aug 2026 10:44:29 +0000</pubDate>
+          <sparkle:version>122</sparkle:version>
+          <sparkle:shortVersionString>0.67.1</sparkle:shortVersionString>
+          <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+          <enclosure url="https://github.com/TableProApp/TablePro/releases/download/v0.67.1/TablePro-0.67.1-x86_64.zip"
+                     length="25966268" type="application/octet-stream" sparkle:edSignature="x86-sig"/>
+        </item>
+        """
+        let body = reversed ? [x86Item, arm64Item] : [arm64Item, x86Item]
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel>\(body.joined())</channel>
+        </rss>
+        """
+        return SparkleAppcastParser.parse(Data(xml.utf8))
+    }
+
+    // MARK: - Real TablePro feed shape
+
+    @Test func parserReadsHardwareRequirements() {
+        let items = tableProPair()
+        let arm = items.first { $0.enclosureURL?.lastPathComponent.contains("arm64") == true }
+        let x86 = items.first { $0.enclosureURL?.lastPathComponent.contains("x86_64") == true }
+        #expect(arm?.hardwareRequirements == ["arm64"])
+        #expect(x86?.hardwareRequirements == [])
+    }
+
+    @Test func arm64HostGetsTheArm64BuildRegardlessOfFeedOrder() {
+        for reversed in [false, true] {
+            let best = SparkleAppcastSource.bestItem(
+                for: app(), from: tableProPair(reversed: reversed), osVersion: "26.6.0",
+                hostArch: .arm64, allowingIntelTranslation: true)
+            #expect(best?.enclosureURL?.lastPathComponent == "TablePro-0.67.1-arm64.zip")
+        }
+    }
+
+    @Test func intelHostGetsTheX86BuildAndNeverTheArm64OneEvenListedFirst() {
+        let best = SparkleAppcastSource.bestItem(
+            for: app(), from: tableProPair(), osVersion: "14.6.0",
+            hostArch: .x86_64, allowingIntelTranslation: false)
+        #expect(best?.enclosureURL?.lastPathComponent == "TablePro-0.67.1-x86_64.zip")
+    }
+
+    @Test func intelHostNeverOffersTheArm64TaggedItemEvenIfItWereTheOnlyOne() {
+        // Isolate the arm64 item only — an Intel Mac can never run it (no
+        // reverse Rosetta), so this must resolve to "nothing usable", not a
+        // fallback pick of an item this host can't run.
+        let armOnly = tableProPair().filter { $0.hardwareRequirements.contains("arm64") }
+        let usable = SparkleAppcastSource.usableItems(
+            for: app(), from: armOnly, osVersion: "14.6.0",
+            hostArch: .x86_64, allowingIntelTranslation: false)
+        #expect(usable.isEmpty)
+    }
+
+    // MARK: - Filename-token fallback (no hardwareRequirements tag at all)
+    //
+    // Most Sparkle vendors don't use the tag; some still ship a genuine
+    // per-arch pair named only by filename (the same shape GitHubReleaseRule
+    // already handles for GitHub releases).
+
+    private func untaggedPair(hostToken: String, otherToken: String) -> [SparkleAppcastItem] {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel>
+          <item><sparkle:version>2</sparkle:version><sparkle:shortVersionString>2.0</sparkle:shortVersionString>
+            <enclosure url="https://example.com/app-2.0-\(otherToken).dmg" sparkle:edSignature="s" length="1" type="application/octet-stream"/></item>
+          <item><sparkle:version>2</sparkle:version><sparkle:shortVersionString>2.0</sparkle:shortVersionString>
+            <enclosure url="https://example.com/app-2.0-\(hostToken).dmg" sparkle:edSignature="s" length="1" type="application/octet-stream"/></item>
+        </channel>
+        </rss>
+        """
+        return SparkleAppcastParser.parse(Data(xml.utf8))
+    }
+
+    @Test func untaggedNativeFilenameWinsOverForeignOnArm64() {
+        let items = untaggedPair(hostToken: "arm64", otherToken: "x86_64")
+        let best = SparkleAppcastSource.bestItem(
+            for: app(), from: items, osVersion: "26.6.0", hostArch: .arm64, allowingIntelTranslation: true)
+        #expect(best?.enclosureURL?.lastPathComponent == "app-2.0-arm64.dmg")
+    }
+
+    @Test func untaggedNativeFilenameWinsOverForeignOnIntel() {
+        let items = untaggedPair(hostToken: "x86_64", otherToken: "arm64")
+        let best = SparkleAppcastSource.bestItem(
+            for: app(), from: items, osVersion: "14.6.0", hostArch: .x86_64, allowingIntelTranslation: false)
+        #expect(best?.enclosureURL?.lastPathComponent == "app-2.0-x86_64.dmg")
+    }
+
+    @Test func untaggedForeignOnlyIsOfferedOnArm64WhileRosettaStillCoversIt() {
+        // No arm64 item exists at all this version — only x86_64, no tag. Still
+        // installable via Rosetta translation, so it must not be dropped.
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel><item><sparkle:version>3</sparkle:version><sparkle:shortVersionString>3.0</sparkle:shortVersionString>
+          <enclosure url="https://example.com/app-3.0-x86_64.dmg" sparkle:edSignature="s" length="1" type="application/octet-stream"/></item></channel>
+        </rss>
+        """
+        let items = SparkleAppcastParser.parse(Data(xml.utf8))
+        let best = SparkleAppcastSource.bestItem(
+            for: app(), from: items, osVersion: "26.6.0", hostArch: .arm64, allowingIntelTranslation: true)
+        #expect(best != nil)
+    }
+
+    @Test func untaggedForeignOnlyIsDroppedOnArm64OnceRosettaIsGone() {
+        // Same feed as above, but macOS 28+ / no Rosetta: nothing this Mac can
+        // run, so it must resolve to "no update", not a doomed download.
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel><item><sparkle:version>3</sparkle:version><sparkle:shortVersionString>3.0</sparkle:shortVersionString>
+          <enclosure url="https://example.com/app-3.0-x86_64.dmg" sparkle:edSignature="s" length="1" type="application/octet-stream"/></item></channel>
+        </rss>
+        """
+        let items = SparkleAppcastParser.parse(Data(xml.utf8))
+        let usable = SparkleAppcastSource.usableItems(
+            for: app(), from: items, osVersion: "28.0.0", hostArch: .arm64, allowingIntelTranslation: false)
+        #expect(usable.isEmpty)
+    }
+
+    @Test func neutralFilenameIsUnaffectedByArchSelection() {
+        // The overwhelming majority of feeds: a single universal build, no arch
+        // marker in the name at all. Must keep working exactly as before.
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+        <channel><item><sparkle:version>1</sparkle:version><sparkle:shortVersionString>1.0</sparkle:shortVersionString>
+          <enclosure url="https://example.com/App.zip" sparkle:edSignature="s" length="1" type="application/octet-stream"/></item></channel>
+        </rss>
+        """
+        let items = SparkleAppcastParser.parse(Data(xml.utf8))
+        for arch: HostArch in [.arm64, .x86_64] {
+            let best = SparkleAppcastSource.bestItem(
+                for: app(), from: items, osVersion: "14.0.0", hostArch: arch, allowingIntelTranslation: false)
+            #expect(best?.enclosureURL?.lastPathComponent == "App.zip")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `SparkleAppcastSource.usableItems`/`bestItem` had no architecture filtering: a vendor publishing separate arm64 and x86_64 `<item>`s at the same version (TablePro is a real, verified example) tied on version, and the tie-break fell back to sorting the enclosure URL string alphabetically — unrelated to which build this Mac can actually run. On a real Intel Mac this could select an arm64-only item.
- Adds arch-aware selection mirroring `GitHubReleaseRule.installableAsset`: prefers Sparkle's own `<sparkle:hardwareRequirements>arm64</...>` tag where present (verified against TablePro's live appcast — only its arm64 item carries the tag), falls back to filename-token matching (native > neutral > foreign) otherwise, and only offers a foreign-arch item while `HostArch.canRunIntelBuilds` holds — an arm64 item is never offered to a real Intel Mac (no reverse Rosetta).
- There's already a second-layer safety net (`SignatureVerifier.verifyRunnableArchitecture`, gate 5) that inspects the downloaded bundle's actual Mach-O architectures before swap, so a wrong pick previously surfaced as an install-time error rather than a bad install — this fix means we no longer pick wrong in the first place.

## Test plan
- [x] `make test` — full `DuoUpdaterCore` (1054 tests, 2 pre-existing known issues unrelated to this change) + CLI (119 tests) suite green.
- [x] New `SparkleArchSelectionTests.swift` covers: the real TablePro `0.67.1` item pair (verbatim, fetched live from `raw.githubusercontent.com/TableProApp/TablePro/main/appcast.xml`) resolving correctly on both arm64 and x86_64 hosts regardless of feed item order; the arm64-tagged item never being offered to an Intel host even if it were the only item; filename-token fallback for vendors that don't set the Sparkle tag; Rosetta-gated foreign-arch fallback; and the untouched single-build (neutral filename) common case.
- [x] Additionally ran the fix against the complete, unmodified live TablePro appcast (139 items, fetched today) via a throwaway test (removed before commit): arm64 host → `TablePro-0.67.1-arm64.zip`, Intel host → `TablePro-0.67.1-x86_64.zip`, arm64 host on macOS 28 without Rosetta → still the arm64 build. Confirms the fix against the real endpoint, not just synthetic fixtures.
- `duo verify --only tablepro` doesn't apply here — TablePro deliberately has no `ChangelogRecipe`/`VendorProbeRecipe` (see the comment in `ChangelogRecipe.swift`); it's detected purely through `SparkleAppcastSource`, which is what this PR changes and what the tests above exercise directly against the real feed.