### PR TITLE
Ask ChatGPT's appcast which rollout track this account is on

### DIFF
--- a/CLI/Sources/DuoKit/Finding.swift
+++ b/CLI/Sources/DuoKit/Finding.swift
@@ -69,6 +69,17 @@ public struct Finding: Codable, Sendable {
     /// Every string here is scrubbed at construction rather than at the point of
     /// output, so there is no path from a sweep to a report, an issue body or a
     /// model prompt that skips redaction.
+    /// Warnings minus machine notes — the subset that may be published.
+    ///
+    /// A note names this machine's state (a file it could not read), and a
+    /// GitHub issue about a vendor's recipe is exactly the wrong audience for
+    /// it. `Report` prints the full set and `report.json` keeps it; everything
+    /// that writes vendor-facing text uses this instead. See
+    /// `Finding.machineNotePrefix`.
+    public var publicWarnings: [String] {
+        warnings.filter { !$0.hasPrefix(Finding.machineNotePrefix) }
+    }
+
     public init(        recipeID: String, registry: Registry, bundleID: String, channel: String,
         status: FindingStatus, version: String? = nil,
         failureKind: String? = nil, failureDetail: String? = nil,

--- a/CLI/Sources/DuoKit/Reconcile.swift
+++ b/CLI/Sources/DuoKit/Reconcile.swift
@@ -259,7 +259,7 @@ public enum Reconcile {
     /// sloppy in a title you'll scan a list of.
     static func reason(for finding: Finding) -> String {
         if let kind = finding.failureKind { return kind }
-        guard let first = finding.warnings.first else { return "degraded" }
+        guard let first = finding.publicWarnings.first else { return "degraded" }
         // Warnings are written as "<claim> — <explanation>"; the claim is the
         // headline, and it is already a complete thought.
         let claim = first.components(separatedBy: " — ").first ?? first
@@ -297,9 +297,9 @@ public enum Reconcile {
         }
         out += "| consecutive sweeps | \(entry.consecutiveActionable) |\n"
 
-        if !finding.warnings.isEmpty {
+        if !finding.publicWarnings.isEmpty {
             out += "\n**Warnings**\n\n"
-            for warning in finding.warnings { out += "- \(warning)\n" }
+            for warning in finding.publicWarnings { out += "- \(warning)\n" }
         }
         if let sample = finding.bodySample {
             out += "\n<details><summary>Captured response (redacted, truncated)</summary>\n\n"

--- a/CLI/Sources/DuoKit/Report.swift
+++ b/CLI/Sources/DuoKit/Report.swift
@@ -46,7 +46,8 @@ public enum Report {
             if let version = finding.version {
                 print("      resolved  \(version)")
             }
-            for warning in finding.warnings {
+            for warning in finding.warnings
+            where !warning.hasPrefix(Finding.machineNotePrefix) {
                 print("      warning   \(warning)")
             }
             if showSamples, let sample = finding.bodySample {
@@ -54,6 +55,23 @@ public enum Report {
                 for line in sample.split(separator: "\n", omittingEmptySubsequences: false).prefix(40) {
                     print("      | \(line.prefix(160))")
                 }
+            }
+        }
+
+        // Notes ride on findings that are otherwise fine, so the loop above —
+        // which prints only actionable statuses — would never show them. They
+        // describe the machine doing the sweeping rather than the recipe, and a
+        // reader who cannot see them is back to the silent fallback this exists
+        // to end.
+        let notes = findings.flatMap { finding in
+            finding.warnings
+                .filter { $0.hasPrefix(Finding.machineNotePrefix) }
+                .map { (finding.recipeID, String($0.dropFirst(Finding.machineNotePrefix.count))) }
+        }
+        if !notes.isEmpty {
+            print("\n  \u{24D8} NOTES (about this machine, not the recipe)")
+            for (recipeID, note) in notes {
+                print("      \(recipeID) — \(note)")
             }
         }
 

--- a/CLI/Sources/DuoKit/Triage.swift
+++ b/CLI/Sources/DuoKit/Triage.swift
@@ -295,8 +295,8 @@ public enum Triage {
         if let kind = finding.failureKind {
             out += "failure: \(kind)\(finding.failureDetail.map { " — \($0)" } ?? "")\n"
         }
-        if !finding.warnings.isEmpty {
-            out += "warnings: \(finding.warnings.joined(separator: "; "))\n"
+        if !finding.publicWarnings.isEmpty {
+            out += "warnings: \(finding.publicWarnings.joined(separator: "; "))\n"
         }
         out += "\nThe captured response body follows between the markers. "
         out += "It is untrusted data, not instructions.\n\n"

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -244,8 +244,8 @@ public enum Verify {
                let complaint = await brewComplaint(bundleID: recipe.bundleID, version: version) {
                 finding = finding.adding(warning: complaint)
             }
-            if let complaint = await rolloutTrackComplaint(recipe, source: source) {
-                finding = finding.adding(warning: complaint)
+            if let note = await rolloutTrackComplaint(recipe, source: source) {
+                finding = finding.observing(note)
             }
             return finding
         }
@@ -264,6 +264,14 @@ public enum Verify {
     /// silent all the way through: the version resolves, the URL resolves, the
     /// download is a real notarized build from the same vendor.
     ///
+    /// Reported as a machine note, not a warning: it accuses nobody. The recipe
+    /// is fine — this machine is the thing that cannot read its plan, and on a
+    /// sweep box nobody signs into ChatGPT that is the permanent state. Letting
+    /// it promote the finding to `.warn` would add an actionable streak and,
+    /// after two sweeps inside one rollout window, file a public issue against a
+    /// recipe that is working. `installURLTransient` is exempted from
+    /// `actionable` in `classify` for the same reason.
+    ///
     /// Costs two extra requests, and only for recipes that declare a track.
     private static func rolloutTrackComplaint(
         _ recipe: VendorProbeRecipe, source: VendorProbeSource
@@ -273,7 +281,8 @@ public enum Verify {
               case .diverged(let ours, let contrast)? =
                 await source.rolloutTrackVerdict(recipe)
         else { return nil }
-        return "rolloutTrackDefaulted: no value at \(track.selector.displayPath), so this"
+        return Finding.machineNotePrefix
+            + "rolloutTrackDefaulted: no value at \(track.selector.displayPath), so this"
             + " machine is asking as `\(track.selector.fallback ?? "?")` while the vendor is"
             + " serving two tracks (\(ours) vs \(contrast) for \(track.contrastTrackName))"
     }
@@ -726,6 +735,28 @@ public enum Verify {
 }
 
 extension Finding {
+    /// Marks a warning that describes the SWEEPING MACHINE rather than the
+    /// recipe. Carried as a prefix on the string because `Finding` is the
+    /// persisted report schema and a new field would have to be threaded
+    /// through every construction site.
+    ///
+    /// It survives `Baseline.signature`, which keys on the first 40 characters,
+    /// so a note stays one stable signature rather than a new one per sweep.
+    public static let machineNotePrefix = "machine-note: "
+
+    /// Attach a note without touching the status — see `machineNotePrefix`. A
+    /// finding that accuses nobody must not accumulate an actionable streak, so
+    /// this deliberately does NOT promote `ok` to `warn`; `Report` surfaces
+    /// notes in their own section instead.
+    public func observing(_ note: String) -> Finding {
+        Finding(
+            recipeID: recipeID, registry: registry, bundleID: bundleID, channel: channel,
+            status: status, version: version,
+            failureKind: failureKind, failureDetail: failureDetail,
+            warnings: warnings + [note], endpointHost: endpointHost, pattern: pattern,
+            attempts: attempts, elapsedMs: elapsedMs, bodySample: bodySample)
+    }
+
     /// Attach a warning discovered after the fact (the baseline's history checks
     /// run once every finding exists), promoting `ok` to `warn`.
     public func adding(warning: String) -> Finding {

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -244,8 +244,38 @@ public enum Verify {
                let complaint = await brewComplaint(bundleID: recipe.bundleID, version: version) {
                 finding = finding.adding(warning: complaint)
             }
+            if let complaint = await rolloutTrackComplaint(recipe, source: source) {
+                finding = finding.adding(warning: complaint)
+            }
             return finding
         }
+    }
+
+    /// The one question a normal probe cannot answer for a recipe whose track is
+    /// picked by a value on disk: did we actually read that value, and is it
+    /// still deciding anything?
+    ///
+    /// Only the combination is worth reporting. Falling back while the vendor's
+    /// tracks are converged costs nothing — every value gets the same answer.
+    /// Falling back while they have SPLIT means we are on the cautious track by
+    /// accident, offering whatever that track holds to a machine whose own
+    /// updater may well be on the other one. That is the failure
+    /// `ChannelArtifactProof` describes for channel recipes, and it is otherwise
+    /// silent all the way through: the version resolves, the URL resolves, the
+    /// download is a real notarized build from the same vendor.
+    ///
+    /// Costs two extra requests, and only for recipes that declare a track.
+    private static func rolloutTrackComplaint(
+        _ recipe: VendorProbeRecipe, source: VendorProbeSource
+    ) async -> String? {
+        guard let track = recipe.track,
+              source.trackProvenance(recipe) == .fallback,
+              case .diverged(let ours, let contrast)? =
+                await source.rolloutTrackVerdict(recipe)
+        else { return nil }
+        return "rolloutTrackDefaulted: no value at \(track.selector.displayPath), so this"
+            + " machine is asking as `\(track.selector.fallback ?? "?")` while the vendor is"
+            + " serving two tracks (\(ours) vs \(contrast) for \(track.contrastTrackName))"
     }
 
     // MARK: - GitHub rules

--- a/CLI/Tests/DuoKitTests/MachineNoteTests.swift
+++ b/CLI/Tests/DuoKitTests/MachineNoteTests.swift
@@ -55,6 +55,22 @@ struct MachineNoteTests {
         #expect(baseline.isReportable(warned.recipeID))
     }
 
+    /// A note must not reach anything vendor-facing. It says this machine could
+    /// not read a file; a GitHub issue about OpenAI's appcast recipe is the
+    /// wrong audience, and the sweep publishes those bodies verbatim.
+    @Test func aNoteIsKeptOutOfPublishedText() {
+        let mixed = finding()
+            .adding(warning: "remote is BEHIND the installed copy — check the scheme")
+            .observing(note)
+        #expect(mixed.warnings.count == 2)
+        #expect(mixed.publicWarnings.count == 1)
+        #expect(mixed.publicWarnings.first?.contains("BEHIND") == true)
+
+        let body = Reconcile.body(for: mixed, entry: Baseline.Entry())
+        #expect(!body.contains("rolloutTrackDefaulted"))
+        #expect(body.contains("BEHIND"))
+    }
+
     /// The note survives `Finding`'s redactor intact — it names a path, and a
     /// note nobody can read is the silence this was built to end.
     @Test func theNoteSurvivesRedaction() {

--- a/CLI/Tests/DuoKitTests/MachineNoteTests.swift
+++ b/CLI/Tests/DuoKitTests/MachineNoteTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import DuoKit
+
+/// A sweep finding accuses a recipe. Some things it discovers accuse nobody —
+/// they describe the machine doing the sweeping — and the difference matters,
+/// because an accusation that repeats twice becomes a public GitHub comment.
+///
+/// The rollout-track note is the case: on a sweep box nobody signs into ChatGPT,
+/// "this machine could not read its plan" is the permanent, correct state of a
+/// perfectly healthy recipe. `installURLTransient` was split out of
+/// `installURLUnresolved` for the same reason.
+struct MachineNoteTests {
+
+    private func finding(status: FindingStatus = .ok) -> Finding {
+        Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable",
+            status: status, version: "1.2.3",
+            warnings: [], endpointHost: "example.invalid", pattern: "([0-9.]+)")
+    }
+
+    private let note = Finding.machineNotePrefix
+        + "rolloutTrackDefaulted: no value at ~/.codex/auth.json, so this machine is"
+        + " asking as `unknown` while the vendor is serving two tracks (2.0 vs 1.0)"
+
+    /// The whole point of the split: a note is carried, and the finding stays ok.
+    @Test func aNoteIsCarriedWithoutPromotingTheStatus() {
+        let observed = finding().observing(note)
+        #expect(observed.status == .ok)
+        #expect(observed.warnings.contains(note))
+    }
+
+    /// And so it never accumulates a streak. Two sweeps is the threshold at which
+    /// a real complaint becomes a public comment.
+    @Test func aNoteNeverMakesARecipeReportable() {
+        var baseline = Baseline()
+        let observed = finding().observing(note)
+        baseline.reconcile(observed)
+        baseline.reconcile(observed)
+        #expect(!baseline.isReportable(observed.recipeID))
+        #expect(baseline.streak(observed.recipeID) == 0)
+    }
+
+    /// The contrast, so this is a real distinction rather than a spelling: the
+    /// same text attached as a warning DOES promote and DOES accumulate. This is
+    /// what the note would have done before the split.
+    @Test func anOrdinaryWarningStillPromotesAndAccumulates() {
+        var baseline = Baseline()
+        let warned = finding().adding(warning: "something the recipe got wrong")
+        #expect(warned.status == .warn)
+        baseline.reconcile(warned)
+        baseline.reconcile(warned)
+        #expect(baseline.isReportable(warned.recipeID))
+    }
+
+    /// The note survives `Finding`'s redactor intact — it names a path, and a
+    /// note nobody can read is the silence this was built to end.
+    @Test func theNoteSurvivesRedaction() {
+        let observed = finding().observing(note)
+        #expect(observed.warnings.first?.contains("~/.codex/auth.json") == true)
+        #expect(observed.warnings.first?.contains("rolloutTrackDefaulted") == true)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ProbeIdentity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ProbeIdentity.swift
@@ -283,6 +283,30 @@ public struct ProbeIdentity: Sendable {
         homeDirectory: URL? = nil,
         fileManager: FileManager = .default
     ) -> URL? {
+        resolved(
+            url, applicationSupportDirectory: applicationSupportDirectory,
+            homeDirectory: homeDirectory, fileManager: fileManager)?.url
+    }
+
+    /// Where a substituted value came from.
+    ///
+    /// Invisible in the finished URL and worth keeping anyway: a value that was
+    /// READ describes this machine, and a value that FELL BACK describes only
+    /// our own ignorance. For a rollout track those are different situations —
+    /// see `RolloutTrack`, which files a finding for the second one and says
+    /// nothing about the first.
+    public enum Provenance: Sendable, Equatable {
+        case read
+        case fallback
+    }
+
+    /// `resolve`, plus where the value came from.
+    public func resolved(
+        _ url: URL,
+        applicationSupportDirectory: URL? = nil,
+        homeDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> (url: URL, provenance: Provenance)? {
         let text = url.absoluteString
         guard text.contains(placeholder) else { return nil }
         let read = value(
@@ -290,9 +314,28 @@ public struct ProbeIdentity: Sendable {
             homeDirectory: homeDirectory, fileManager: fileManager)
         // A fallback stands in for an unreadable value, but is held to the same
         // gate — a recipe author's typo must not reach the wire either.
+        let provenance: Provenance = read == nil ? .fallback : .read
         guard let value = read
             ?? fallback.flatMap({ Self.accept($0, matching: validationPattern) })
         else { return nil }
-        return URL(string: text.replacingOccurrences(of: placeholder, with: value))
+        guard let substituted = URL(
+            string: text.replacingOccurrences(of: placeholder, with: value))
+        else { return nil }
+        return (substituted, provenance)
+    }
+
+    /// `url` with `placeholder` replaced by a literal instead of by whatever
+    /// this machine holds — how a verification sweep asks the endpoint what a
+    /// *different* value would be told (see `RolloutTrack.contrastValue`).
+    ///
+    /// Held to the same pattern and character gate as a read value: a recipe
+    /// author's typo must not reach the wire just because it was typed rather
+    /// than read.
+    public func resolve(_ url: URL, substituting value: String) -> URL? {
+        let text = url.absoluteString
+        guard text.contains(placeholder),
+              let accepted = Self.accept(value, matching: validationPattern)
+        else { return nil }
+        return URL(string: text.replacingOccurrences(of: placeholder, with: accepted))
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ProbeIdentity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ProbeIdentity.swift
@@ -161,6 +161,24 @@ public struct ProbeIdentity: Sendable {
         }
     }
 
+    /// What this reaches INSIDE the file, written as a path. Pairs with
+    /// `displayPath` so `RegistrySecurity` can allow-list a specific read out of
+    /// a file that also holds credentials, rather than the whole file — the
+    /// distinction that matters when the file is `~/.codex/auth.json`.
+    ///
+    /// Only ever compared against a literal in that allow-list, so the exact
+    /// spelling is arbitrary; what it must be is *distinct* — two different
+    /// reads must never render alike.
+    public var readPath: String {
+        switch encoding {
+        case .plain: return "<whole file>"
+        case .base64: return "<whole file, base64>"
+        case .jsonKey(let key): return key
+        case .jwtClaim(let tokenPath, let claimPath):
+            return tokenPath.joined(separator: ".") + " → " + claimPath.joined(separator: ".")
+        }
+    }
+
     /// The characters a value may contain, regardless of what
     /// `validationPattern` allows. These are URL-unreserved, so substituting the
     /// value into a query needs no escaping and cannot smuggle in a second

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ProbeIdentity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ProbeIdentity.swift
@@ -13,14 +13,24 @@ import Foundation
 /// both: the answer is, by construction, the answer the app itself would get.
 ///
 /// So this is not a general "put a variable in the URL" hook. It exists for the
-/// narrow case of *the machine's own identity*, and it carries the rules that
-/// make sending that identity safe:
+/// narrow case of *what the vendor's rollout keys on*, and it carries the rules
+/// that make sending that safe:
 ///
 ///   - **Never a credential.** An id that also authenticates (a license key, a
 ///     bearer token) must not come through here — those apps stay out of the
 ///     swept registries entirely (`RegistrySecurity`, and the Alcove/CleanShot
-///     precedent). This is for identifiers that select a rollout bucket and
-///     grant nothing.
+///     precedent). This is for values that select a rollout bucket and grant
+///     nothing.
+///
+///     Reading a non-credential value *out of* a file that also holds
+///     credentials is the one nearby case this allows, and only under
+///     `.jwtClaim`, which can reach exactly one claim by an explicit path and
+///     can return nothing else. ChatGPT's `plan_type` is the instance: it lives
+///     in `~/.codex/auth.json` beside real tokens, but the claim itself
+///     authenticates nothing — it names a rollout track. The tokens in that file
+///     are never parsed, never held beyond the read, and cannot be what
+///     `.jwtClaim` yields. See `VendorProbeRegistry`'s Codex recipe for why the
+///     value is needed at all.
 ///   - **Never recorded.** The value is substituted into the request URL inside
 ///     the fetch and nowhere else: it is not stored on the recipe, not on
 ///     `ProbeOutcome`, and not logged. Everything the verify sweep persists —
@@ -31,6 +41,12 @@ import Foundation
 ///     yields nil, which the source reports as `.notApplicable` — "this recipe
 ///     doesn't cover this machine", the same status as a channel mismatch. A
 ///     sweep on a machine without the app skips it instead of filing a bug.
+///
+///     A `fallback` changes that answer for values where the vendor defines a
+///     "don't know" of its own: absence then substitutes that literal rather
+///     than skipping the recipe. Only for values the endpoint *tolerates* being
+///     wrong — a machine id has no such value (a made-up one picks a stranger's
+///     bucket), so identity recipes leave `fallback` nil and keep skipping.
 public struct ProbeIdentity: Sendable {
 
     /// How the identifier is stored in the file. Apps rarely write a bare value.
@@ -47,10 +63,32 @@ public struct ProbeIdentity: Sendable {
         /// value, a missing key, or anything that isn't an object yields nil —
         /// the same "doesn't look like itself" answer the other cases give.
         case jsonKey(String)
+        /// The contents are a JSON object holding a JWT; walk `tokenPath` to the
+        /// token string, decode its payload, then walk `claimPath` to the claim.
+        /// ChatGPT's plan lives two levels down in a namespaced claim:
+        /// `tokens.access_token` → `"https://api.openai.com/auth"` →
+        /// `chatgpt_plan_type`.
+        ///
+        /// Deliberately narrow: both paths are literal, so this reaches exactly
+        /// the one claim a recipe names and can yield nothing else — no
+        /// enumeration, no wildcard, and no way to return the token it decoded.
+        /// Signature is not verified because nothing here trusts the claim: it
+        /// is a hint about which rollout track to *ask* about, and the answer
+        /// comes from the vendor either way.
+        case jwtClaim(tokenPath: [String], claimPath: [String])
     }
 
-    /// Path to the file, relative to `~/Library/Application Support`.
-    public let applicationSupportPath: String
+    /// Where the file lives. Most apps keep their id under Application Support;
+    /// ChatGPT keeps its account state in a dotfile under the home directory.
+    public enum Location: Sendable {
+        /// Path relative to `~/Library/Application Support`.
+        case applicationSupport(String)
+        /// Path relative to the user's home directory.
+        case home(String)
+    }
+
+    /// Where to read the value from.
+    public let location: Location
 
     /// How to turn the file's bytes into the value.
     public let encoding: Encoding
@@ -68,22 +106,60 @@ public struct ProbeIdentity: Sendable {
     /// default is built from unreserved characters only.
     public let placeholder: String
 
+    /// Literal to substitute when the file is missing or doesn't parse, instead
+    /// of failing the probe. Nil (the default) keeps the strict behaviour: an
+    /// unreadable value skips the recipe. Must satisfy the same character
+    /// backstop and pattern as a read value — it goes on the wire identically.
+    public let fallback: String?
+
+    /// Cap on this file. The default suits an identity file, which is tens of
+    /// bytes; a recipe reading a claim out of a larger document raises it
+    /// deliberately. Above the cap we stop rather than parse (let alone
+    /// transmit) something we're evidently pointed at by mistake.
+    public let maxBytes: Int
+
+    public init(
+        location: Location,
+        encoding: Encoding,
+        validationPattern: String,
+        placeholder: String = "__IDENTITY__",
+        fallback: String? = nil,
+        maxBytes: Int = ProbeIdentity.maxFileBytes
+    ) {
+        self.location = location
+        self.encoding = encoding
+        self.validationPattern = validationPattern
+        self.placeholder = placeholder
+        self.fallback = fallback
+        self.maxBytes = maxBytes
+    }
+
+    /// Convenience for the common case: a file under Application Support.
     public init(
         applicationSupportPath: String,
         encoding: Encoding,
         validationPattern: String,
-        placeholder: String = "__IDENTITY__"
+        placeholder: String = "__IDENTITY__",
+        fallback: String? = nil,
+        maxBytes: Int = ProbeIdentity.maxFileBytes
     ) {
-        self.applicationSupportPath = applicationSupportPath
-        self.encoding = encoding
-        self.validationPattern = validationPattern
-        self.placeholder = placeholder
+        self.init(
+            location: .applicationSupport(applicationSupportPath), encoding: encoding,
+            validationPattern: validationPattern, placeholder: placeholder,
+            fallback: fallback, maxBytes: maxBytes)
     }
 
-    /// Cap on the file we'll read. An identity file is tens of bytes; anything
-    /// larger means we're pointed at the wrong file and should not try to parse
-    /// (let alone transmit) it.
-    static let maxFileBytes = 4096
+    /// Default cap on the file we'll read. An identity file is tens of bytes.
+    public static let maxFileBytes = 4096
+
+    /// Where the file is, written the way a person would say it — for the
+    /// `.notApplicable` message, which must name a path but never a value.
+    public var displayPath: String {
+        switch location {
+        case .applicationSupport(let path): return "~/Library/Application Support/\(path)"
+        case .home(let path): return "~/\(path)"
+        }
+    }
 
     /// The characters a value may contain, regardless of what
     /// `validationPattern` allows. These are URL-unreserved, so substituting the
@@ -98,15 +174,23 @@ public struct ProbeIdentity: Sendable {
     /// oversized, or malformed file yields nil, never a throw.
     public func value(
         applicationSupportDirectory: URL? = nil,
+        homeDirectory: URL? = nil,
         fileManager: FileManager = .default
     ) -> String? {
-        let appSupport = applicationSupportDirectory
-            ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        guard let appSupport else { return nil }
-        let fileURL = appSupport.appendingPathComponent(applicationSupportPath, isDirectory: false)
+        let fileURL: URL
+        switch location {
+        case .applicationSupport(let path):
+            let appSupport = applicationSupportDirectory
+                ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            guard let appSupport else { return nil }
+            fileURL = appSupport.appendingPathComponent(path, isDirectory: false)
+        case .home(let path):
+            let home = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
+            fileURL = home.appendingPathComponent(path, isDirectory: false)
+        }
 
         guard let data = try? Data(contentsOf: fileURL),
-              data.count <= Self.maxFileBytes else { return nil }
+              data.count <= maxBytes else { return nil }
 
         let raw = String(decoding: data, as: UTF8.self)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -123,12 +207,51 @@ public struct ProbeIdentity: Sendable {
                   let fields = object as? [String: Any],
                   let value = fields[key] as? String else { return nil }
             decoded = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        case .jwtClaim(let tokenPath, let claimPath):
+            guard let object = try? JSONSerialization.jsonObject(with: data),
+                  let token = Self.string(at: tokenPath, in: object),
+                  let payload = Self.jwtPayload(token),
+                  let value = Self.string(at: claimPath, in: payload) else { return nil }
+            decoded = value.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        guard !decoded.isEmpty,
-              decoded.unicodeScalars.allSatisfy(Self.allowedCharacters.contains),
-              decoded.range(of: "^(?:\(validationPattern))$", options: .regularExpression) != nil
+        return Self.accept(decoded, matching: validationPattern)
+    }
+
+    /// The shared gate every value passes, whether read or fallen back to.
+    private static func accept(_ value: String, matching pattern: String) -> String? {
+        guard !value.isEmpty,
+              value.unicodeScalars.allSatisfy(allowedCharacters.contains),
+              value.range(of: "^(?:\(pattern))$", options: .regularExpression) != nil
         else { return nil }
-        return decoded
+        return value
+    }
+
+    /// Walk a literal key path through nested JSON objects to a string leaf.
+    /// Anything that isn't an object at a step, a missing key, or a non-string
+    /// leaf yields nil.
+    private static func string(at path: [String], in object: Any) -> String? {
+        guard !path.isEmpty else { return nil }
+        var current = object
+        for key in path {
+            guard let fields = current as? [String: Any], let next = fields[key] else { return nil }
+            current = next
+        }
+        return current as? String
+    }
+
+    /// A JWT's payload, decoded as JSON. Base64url (the `-`/`_` alphabet, padding
+    /// omitted) is what JWT uses and what `Data(base64Encoded:)` does not accept,
+    /// so translate before decoding. The signature is neither read nor checked —
+    /// see `.jwtClaim` for why nothing here needs to trust the payload.
+    private static func jwtPayload(_ token: String) -> Any? {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3 else { return nil }
+        var base64 = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+        guard let bytes = Data(base64Encoded: base64) else { return nil }
+        return try? JSONSerialization.jsonObject(with: bytes)
     }
 
     /// `url` with `placeholder` replaced by the machine's identifier, or nil when
@@ -139,13 +262,18 @@ public struct ProbeIdentity: Sendable {
     public func resolve(
         _ url: URL,
         applicationSupportDirectory: URL? = nil,
+        homeDirectory: URL? = nil,
         fileManager: FileManager = .default
     ) -> URL? {
         let text = url.absoluteString
-        guard text.contains(placeholder),
-              let value = value(
-                applicationSupportDirectory: applicationSupportDirectory,
-                fileManager: fileManager)
+        guard text.contains(placeholder) else { return nil }
+        let read = value(
+            applicationSupportDirectory: applicationSupportDirectory,
+            homeDirectory: homeDirectory, fileManager: fileManager)
+        // A fallback stands in for an unreadable value, but is held to the same
+        // gate — a recipe author's typo must not reach the wire either.
+        guard let value = read
+            ?? fallback.flatMap({ Self.accept($0, matching: validationPattern) })
         else { return nil }
         return URL(string: text.replacingOccurrences(of: placeholder, with: value))
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RegistrySecurity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RegistrySecurity.swift
@@ -76,9 +76,12 @@ public enum RegistrySecurity {
     /// to one claim and can return nothing else.
     ///
     /// So this allow-lists the READ, not the file. Keyed by
-    /// `ProbeIdentity.displayPath`, valued by `ProbeIdentity.readPath`; a probe
-    /// identity pointing into one of these files must name a read listed here,
-    /// which `RegistrySecurityTests` asserts against the registry as it stands.
+    /// `ProbeIdentity.displayPath`, valued by `ProbeIdentity.readPath`; every
+    /// read in `VendorProbeRecipe.localReads` that points into one of these files
+    /// must be listed here, which `RegistrySecurityTests` asserts against the
+    /// registry as it stands. Derived from `localReads` rather than from
+    /// `identities` on purpose — the day the plan moved from one to the other,
+    /// an enumerated guard would have gone quiet instead of red.
     public static let credentialBearingFileReads: [String: Set<String>] = [
         "~/.codex/auth.json": [
             // The rollout track ChatGPT's appcast keys on. Authenticates

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RegistrySecurity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RegistrySecurity.swift
@@ -20,6 +20,12 @@ import Foundation
 ///    `com.henrikruscon.Alcove` entry that *is* in `VendorProbeRegistry` is the
 ///    public, unauthenticated CDN mirror.)
 ///
+/// A second dimension arrived with the Codex recipe: an app that is perfectly
+/// safe to sweep, reading one non-credential value out of a file that also holds
+/// tokens. That is not "this app carries a secret", it is "this read must stay
+/// exactly the read it is", so it is allow-listed separately below in
+/// `credentialBearingFileReads`.
+///
 /// So this type is a guard against future drift, not a filter for the present —
 /// which is exactly when a guard is cheap to add.
 public enum RegistrySecurity {
@@ -52,4 +58,33 @@ public enum RegistrySecurity {
     public static func isCredentialBearing(bundleID: String) -> Bool {
         credentialBearingBundleIDs.contains(bundleID)
     }
+
+    /// Local files that hold real credentials but also hold one value a recipe
+    /// legitimately needs, mapped to the exact reads allowed out of each.
+    ///
+    /// `credentialBearingBundleIDs` answers "may this app be swept at all".
+    /// This answers a narrower question the same class of mistake hides behind:
+    /// the app is fine to sweep, the endpoint keys on a value that lives in a
+    /// file which ALSO holds tokens, and nothing in `ProbeIdentity`'s types
+    /// stops a later recipe from reaching for a different key in that same file.
+    ///
+    /// `~/.codex/auth.json` is the instance and it is not a hypothetical hazard:
+    /// `OPENAI_API_KEY` sits at its TOP LEVEL, so `.jsonKey("OPENAI_API_KEY")`
+    /// would read it, and the character backstop would wave it through — an
+    /// `sk-` key is URL-unreserved end to end. What makes the one allowed read
+    /// safe is not the file, it is the path: `.jwtClaim` walks two literal paths
+    /// to one claim and can return nothing else.
+    ///
+    /// So this allow-lists the READ, not the file. Keyed by
+    /// `ProbeIdentity.displayPath`, valued by `ProbeIdentity.readPath`; a probe
+    /// identity pointing into one of these files must name a read listed here,
+    /// which `RegistrySecurityTests` asserts against the registry as it stands.
+    public static let credentialBearingFileReads: [String: Set<String>] = [
+        "~/.codex/auth.json": [
+            // The rollout track ChatGPT's appcast keys on. Authenticates
+            // nothing; see the Codex recipe in `VendorProbeRegistry` for why it
+            // is needed and what it can and cannot tell us.
+            "tokens.access_token → https://api.openai.com/auth.chatgpt_plan_type",
+        ],
+    ]
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RolloutTrack.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RolloutTrack.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// A release track the VENDOR puts an account on, selected by a value the
+/// request carries.
+///
+/// Three types in this codebase now answer "which build does this machine get",
+/// and telling them apart is the whole reason this one exists:
+///
+///   * `ReleaseChannel` / `ChannelBinding` — the channel a user **chose**. Its
+///     resolvers read a preference the user flipped, and its safety rule is
+///     "never fall back to a higher channel", because the wrong answer means
+///     pushing a prerelease at someone who didn't ask for one.
+///   * `ProbeIdentity` — the machine's own **identity**: an id that selects a
+///     rollout BUCKET inside one track and grants nothing. Fabricating one
+///     lands you in a stranger's bucket, so it has no fallback and an
+///     unreadable value skips the recipe.
+///   * `RolloutTrack` (this) — a **track** the vendor assigns. Nobody chose it,
+///     it identifies no machine, and the vendor defines a "don't know" value
+///     for it, so unlike an identity it *can* fall back.
+///
+/// Structurally it is `TablePlusChannel` with a query parameter where that has a
+/// header: ONE endpoint, ONE request-borne value, and the server decides which
+/// builds come back. ChatGPT's `plan_type` is the instance — see the Codex
+/// recipe in `VendorProbeRegistry` for what it selects and what it costs to get
+/// wrong.
+///
+/// Getting it wrong is expensive in a specific, quiet way that
+/// `ChannelArtifactProof` already describes for channel recipes: the version
+/// resolves, the URL resolves, the download is a real notarized build from the
+/// same vendor with the same Team ID, so every gate we have passes — and the
+/// machine's own updater refuses the build, stages the one it wanted, and
+/// applies it at the next quit. Our restart is that quit. Nothing in a normal
+/// probe can see this, which is why `contrastValue` is part of the type.
+public struct RolloutTrack: Sendable {
+
+    /// How this machine's value is read, and the placeholder it replaces.
+    ///
+    /// Deliberately reuses `ProbeIdentity`: the mechanics are identical — one
+    /// value out of one local file, held to a pattern and a character backstop,
+    /// substituted inside the fetch and recorded nowhere. What differs is what
+    /// the value MEANS, and that is what this type carries.
+    public let selector: ProbeIdentity
+
+    /// A value known to select a DIFFERENT track from this vendor.
+    ///
+    /// Not decoration — it is the only way to answer "is this parameter doing
+    /// anything right now". Vendor tracks converge once a rollout finishes, and
+    /// while they are converged our value and any other give the same answer.
+    /// A check that looks only at our own answer therefore cannot distinguish
+    /// "we picked the right track" from "it did not matter today", and will
+    /// report healthy right up until the next rollout window opens.
+    public let contrastValue: String
+
+    /// What to call the track `contrastValue` selects, in a finding a human
+    /// reads. ("the enterprise track", "the beta track".)
+    public let contrastTrackName: String
+
+    public init(selector: ProbeIdentity, contrastValue: String, contrastTrackName: String) {
+        self.selector = selector
+        self.contrastValue = contrastValue
+        self.contrastTrackName = contrastTrackName
+    }
+}
+
+/// What asking the endpoint twice — once with this machine's value, once with
+/// `RolloutTrack.contrastValue` — established.
+///
+/// Deliberately a verification-time answer, not a runtime one. It costs an extra
+/// request per check, which is fine inside a sweep that already makes ~150 and
+/// wrong inside the app's periodic check.
+public enum RolloutTrackVerdict: Sendable, Equatable {
+
+    /// The two values resolved to different targets: the vendor is running two
+    /// tracks *right now*, so which one we ask for decides what we offer.
+    case diverged(ours: String, contrast: String)
+
+    /// Both resolved alike. Either the rollout completed and the tracks merged,
+    /// or the parameter stopped mattering. Indistinguishable from here, and in
+    /// both cases nothing we send today can be wrong.
+    case converged(String)
+
+    /// A request failed, so nothing was established. Not a finding: the vendor
+    /// being unreachable is not the recipe being wrong.
+    case indeterminate
+
+    public var name: String {
+        switch self {
+        case .diverged: return "diverged"
+        case .converged: return "converged"
+        case .indeterminate: return "indeterminate"
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -171,10 +171,12 @@ public struct VendorProbeRecipe: Sendable {
     /// keeps the machine's identifier out of them.
     public let url: URL
 
-    /// Set when the endpoint only answers for a specific machine and the app
-    /// keeps that machine's id on disk. See `ProbeIdentity` for why a synthesized
-    /// id is not an acceptable substitute, and for the handling rules.
-    public let identity: ProbeIdentity?
+    /// Set when the endpoint only answers for a specific machine — or a specific
+    /// rollout track — and the app keeps what it keys on, on disk. Each entry
+    /// substitutes its own placeholder, and all are applied before the request.
+    /// See `ProbeIdentity` for why a synthesized value is not an acceptable
+    /// substitute, and for the handling rules.
+    public let identities: [ProbeIdentity]
 
     /// How to recover the version from the endpoint's response.
     public let mode: Mode
@@ -316,13 +318,13 @@ public struct VendorProbeRecipe: Sendable {
         requestHeaders: [String: String] = [:],
         followRedirects: Bool = true,
         channel: ReleaseChannel = .stable,
-        identity: ProbeIdentity? = nil,
+        identities: [ProbeIdentity] = [],
         variant: String? = nil
     ) {
         self.bundleID = bundleID
         self.channel = channel
         self.url = url
-        self.identity = identity
+        self.identities = identities
         self.variant = variant
         self.mode = mode
         self.versionPattern = versionPattern
@@ -1938,10 +1940,10 @@ public enum VendorProbeRegistry {
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(#"(https://downloads\.claude\.ai/releases/darwin/universal/[0-9.]+/Claude-[0-9a-f]+\.zip)"#),
                 kind: .zip),
-            identity: ProbeIdentity(
+            identities: [ProbeIdentity(
                 applicationSupportPath: "Claude/ant-did",
                 encoding: .base64,
-                validationPattern: #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"#),
+                validationPattern: #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"#)],
             variant: "rollout"),
 
         // VLC — official Sparkle appcast. Lists releases ascending, so
@@ -1988,9 +1990,41 @@ public enum VendorProbeRegistry {
         // to answer plausibly and wrongly. `installation_id` selects the rollout
         // bucket and grants nothing; see `ProbeIdentity` for why it never reaches
         // a log, a report, or the recipe's own recorded URL.
+        //
+        // `plan_type` is the second thing the endpoint keys on, and unlike
+        // `app_version` it decides the answer. Measured 2026-08-24, same
+        // installation_id, only this parameter varying:
+        //
+        //     free | go | plus | pro | team   → appcast-26.818.61809.xml
+        //     business | enterprise | ent26   → appcast-26.818.41509.xml
+        //     unknown | omitted | nonsense    → appcast-26.818.41509.xml
+        //
+        // Two rollout tracks, not per-tier builds: the five consumer values
+        // return byte-identical XML, as do the three enterprise ones. The
+        // enterprise feed does not merely sort 61809 lower — it has no such
+        // item. This is the "enterprise-plan recognition" of openai/codex
+        // 0.146.0 (PRs #35238, #35537): business tiers roll out behind consumer
+        // ones so IT can qualify a build.
+        //
+        // So omitting it is not neutral — it silently books this machine onto
+        // the enterprise track. That is what made `duo verify` report "remote is
+        // BEHIND the installed copy" while ChatGPT itself was installing 61809.
+        // And hardcoding a consumer value is worse than omitting: on an actual
+        // business account we would offer a build that account's own updater
+        // refuses, which is precisely the fight described above — its Sparkle
+        // stages the older build, waits for a quit, and our restart is the quit.
+        //
+        // Hence reading the real value. It is an account attribute rather than a
+        // machine id, so it lives with the account state in `~/.codex/auth.json`
+        // (ChatGPT.app and the `codex` CLI are one product and share that file);
+        // `ProbeIdentity.jwtClaim` reaches that one claim and nothing else.
+        // Absent — never signed in, or the file moved — falls back to "unknown",
+        // which is what OpenAI's own `codex doctor` hardcodes
+        // (codex-rs/cli/src/doctor/updates.rs) and which lands on the cautious
+        // track: the same answer we gave before this parameter existed.
         VendorProbeRecipe(
             bundleID: "com.openai.codex",
-            url: URL(string: "https://chatgpt.com/backend-api/wham/app/appcast?installation_id=__IDENTITY__&arch=arm64&beta=false&app_version=0.0.0")!,
+            url: URL(string: "https://chatgpt.com/backend-api/wham/app/appcast?installation_id=__IDENTITY__&arch=arm64&beta=false&app_version=0.0.0&plan_type=__PLANTYPE__")!,
             mode: .responseBody,
             versionPattern: #"<sparkle:shortVersionString>([0-9][^<]*)</sparkle:shortVersionString>"#,
             // Required of any identity recipe: without it `.responseBody` falls back
@@ -2014,10 +2048,26 @@ public enum VendorProbeRegistry {
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(#"url="([^"]+\.zip)""#),
                 kind: .zip),
-            identity: ProbeIdentity(
-                applicationSupportPath: "com.openai.codex/production-appcast-bootstrap.json",
-                encoding: .jsonKey("installationId"),
-                validationPattern: #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"#)),
+            identities: [
+                ProbeIdentity(
+                    applicationSupportPath: "com.openai.codex/production-appcast-bootstrap.json",
+                    encoding: .jsonKey("installationId"),
+                    validationPattern: #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"#),
+                // Deliberately permissive: we are a passthrough, not an authority
+                // on OpenAI's tier names. A slug we have never seen is forwarded
+                // as-is and the vendor decides; only something that isn't a slug
+                // at all falls back. `maxBytes` is raised because this file holds
+                // JWTs — see `.jwtClaim` for what is and isn't read out of it.
+                ProbeIdentity(
+                    location: .home(".codex/auth.json"),
+                    encoding: .jwtClaim(
+                        tokenPath: ["tokens", "access_token"],
+                        claimPath: ["https://api.openai.com/auth", "chatgpt_plan_type"]),
+                    validationPattern: #"[a-z0-9_]{1,32}"#,
+                    placeholder: "__PLANTYPE__",
+                    fallback: "unknown",
+                    maxBytes: 32768),
+            ]),
 
         // ChatWise — Squirrel releases endpoint; array of versions, take highest.
         VendorProbeRecipe(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -171,12 +171,36 @@ public struct VendorProbeRecipe: Sendable {
     /// keeps the machine's identifier out of them.
     public let url: URL
 
-    /// Set when the endpoint only answers for a specific machine — or a specific
-    /// rollout track — and the app keeps what it keys on, on disk. Each entry
-    /// substitutes its own placeholder, and all are applied before the request.
-    /// See `ProbeIdentity` for why a synthesized value is not an acceptable
-    /// substitute, and for the handling rules.
+    /// Set when the endpoint only answers for a specific machine, and the app
+    /// keeps the identifier it keys on, on disk. Each entry substitutes its own
+    /// placeholder, and all are applied before the request. See `ProbeIdentity`
+    /// for why a synthesized value is not an acceptable substitute, and for the
+    /// handling rules.
+    ///
+    /// Identities only. A value that selects which BUILDS come back rather than
+    /// which bucket this machine is in belongs in `track` — the two look alike
+    /// in the URL and behave nothing alike when they are wrong.
     public let identities: [ProbeIdentity]
+
+    /// Set when the endpoint serves several tracks off one URL and a
+    /// request-borne value picks between them. Substituted exactly like an
+    /// identity; kept apart from one because it is not a machine identifier and
+    /// because it carries what a verification sweep needs to tell whether it is
+    /// doing anything. See `RolloutTrack`.
+    public let track: RolloutTrack?
+
+    /// Every local value this recipe substitutes into its URL: its identities,
+    /// plus its track's selector if it has one.
+    ///
+    /// Exists so the rules that apply to "a value read off this machine and put
+    /// on the wire" — distinct placeholders, a fallback that survives its own
+    /// validation, nothing baked into `recipe.url`, no unreviewed read out of a
+    /// credential file — are checked against ONE derived list. Splitting the
+    /// plan out of `identities` broke two such guards the day it happened, which
+    /// is the argument for deriving rather than enumerating.
+    public var localReads: [ProbeIdentity] {
+        identities + (track.map { [$0.selector] } ?? [])
+    }
 
     /// How to recover the version from the endpoint's response.
     public let mode: Mode
@@ -319,12 +343,14 @@ public struct VendorProbeRecipe: Sendable {
         followRedirects: Bool = true,
         channel: ReleaseChannel = .stable,
         identities: [ProbeIdentity] = [],
+        track: RolloutTrack? = nil,
         variant: String? = nil
     ) {
         self.bundleID = bundleID
         self.channel = channel
         self.url = url
         self.identities = identities
+        self.track = track
         self.variant = variant
         self.mode = mode
         self.versionPattern = versionPattern
@@ -2082,6 +2108,12 @@ public enum VendorProbeRegistry {
         // All four fail toward "unknown" or a stale consumer value, never toward
         // claiming enterprise on a consumer account, so the blast radius is the
         // cautious track — where omitting the parameter put everyone anyway.
+        //
+        // The first of the four is no longer silent, at least in a sweep: this
+        // rides in `track` rather than `identities`, and `duo verify` reports a
+        // machine that fell back WHILE the vendor's two tracks are actually
+        // apart. See `RolloutTrack` for why that combination is the only one
+        // worth a finding.
         VendorProbeRecipe(
             bundleID: "com.openai.codex",
             url: URL(string: "https://chatgpt.com/backend-api/wham/app/appcast?installation_id=__IDENTITY__&arch=arm64&beta=false&app_version=0.0.0&plan_type=__PLANTYPE__")!,
@@ -2113,12 +2145,23 @@ public enum VendorProbeRegistry {
                     applicationSupportPath: "com.openai.codex/production-appcast-bootstrap.json",
                     encoding: .jsonKey("installationId"),
                     validationPattern: #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"#),
-                // Deliberately permissive: we are a passthrough, not an authority
-                // on OpenAI's tier names. A slug we have never seen is forwarded
-                // as-is and the vendor decides; only something that isn't a slug
-                // at all falls back. `maxBytes` is raised because this file holds
-                // JWTs — see `.jwtClaim` for what is and isn't read out of it.
-                ProbeIdentity(
+            ],
+            // The plan is NOT an identity — it names which builds come back, not
+            // which bucket this machine is in — so it rides here, where the
+            // sweep can also check whether it is still deciding anything.
+            //
+            // `business` is the contrast because it is the value the two-track
+            // split is actually about; when the endpoint answers it the same way
+            // it answers ours, the rollout has merged and today's value cannot be
+            // wrong. `validationPattern` is deliberately permissive: we are a
+            // passthrough, not an authority on OpenAI's tier names. A slug we
+            // have never seen is forwarded as-is and the vendor decides; only
+            // something that isn't a slug at all falls back. `maxBytes` is raised
+            // because this file holds JWTs — see `.jwtClaim` for what is and is
+            // not read out of it, and `RegistrySecurity` for the allow-list that
+            // keeps it that way.
+            track: RolloutTrack(
+                selector: ProbeIdentity(
                     location: .home(".codex/auth.json"),
                     encoding: .jwtClaim(
                         tokenPath: ["tokens", "access_token"],
@@ -2127,7 +2170,8 @@ public enum VendorProbeRegistry {
                     placeholder: "__PLANTYPE__",
                     fallback: "unknown",
                     maxBytes: 32768),
-            ]),
+                contrastValue: "business",
+                contrastTrackName: "the enterprise track")),
 
         // ChatWise — Squirrel releases endpoint; array of versions, take highest.
         VendorProbeRecipe(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -1987,9 +1987,15 @@ public enum VendorProbeRegistry {
         // version, and 99.999.99999 all resolved to the same target. A sentinel is
         // deliberate — if OpenAI ever does step upgrades, 0.0.0 is the value most
         // likely to be rejected outright, which `duo verify` reports, rather than
-        // to answer plausibly and wrongly. `installation_id` selects the rollout
-        // bucket and grants nothing; see `ProbeIdentity` for why it never reaches
-        // a log, a report, or the recipe's own recorded URL.
+        // to answer plausibly and wrongly. The app also sends `os-version` and a
+        // `codex_cache_bust` counter; neither changes the redirect target
+        // (measured 2026-08-24: os-version 13.0.0 / 26.0.0 / 27.0.0 / omitted
+        // resolve alike, and the counter is not stable even across the app's own
+        // checks — 8, then 2, then 4), so this URL stays as short as it can be.
+        //
+        // `installation_id` selects the rollout bucket and grants nothing; see
+        // `ProbeIdentity` for why it never reaches a log, a report, or the
+        // recipe's own recorded URL.
         //
         // `plan_type` is the second thing the endpoint keys on, and unlike
         // `app_version` it decides the answer. Measured 2026-08-24, same
@@ -2006,6 +2012,14 @@ public enum VendorProbeRegistry {
         // 0.146.0 (PRs #35238, #35537): business tiers roll out behind consumer
         // ones so IT can qualify a build.
         //
+        // The split is a WINDOW, not a standing structure: by 15:29Z the same
+        // day every value above — `business`, `enterprise` and omitted included
+        // — resolved to 26.818.61809. So nothing can assert on the split, and
+        // `duo verify` cannot tell whether this parameter is doing anything:
+        // outside the window both answers agree. It earns its place only inside
+        // the window, which is exactly when getting it wrong starts the fight
+        // described below.
+        //
         // So omitting it is not neutral — it silently books this machine onto
         // the enterprise track. That is what made `duo verify` report "remote is
         // BEHIND the installed copy" while ChatGPT itself was installing 61809.
@@ -2016,12 +2030,58 @@ public enum VendorProbeRegistry {
         //
         // Hence reading the real value. It is an account attribute rather than a
         // machine id, so it lives with the account state in `~/.codex/auth.json`
-        // (ChatGPT.app and the `codex` CLI are one product and share that file);
-        // `ProbeIdentity.jwtClaim` reaches that one claim and nothing else.
-        // Absent — never signed in, or the file moved — falls back to "unknown",
-        // which is what OpenAI's own `codex doctor` hardcodes
+        // — ChatGPT.app bundles the `codex` CLI at `Contents/Resources/codex`
+        // and both resolve `CODEX_HOME ?? ~/.codex`, so it is one file for one
+        // product. `ProbeIdentity.jwtClaim` reaches that one claim and nothing
+        // else. Absent — never signed in, or the file moved — falls back to
+        // "unknown", which is what OpenAI's own `codex doctor` hardcodes
         // (codex-rs/cli/src/doctor/updates.rs) and which lands on the cautious
         // track: the same answer we gave before this parameter existed.
+        //
+        // What is shared is the FILE and the LOGIN EVENTS. The VALUE is not.
+        // Measured on one machine, 2026-08-24:
+        //
+        //   * signing out of ChatGPT.app DELETES `~/.codex/auth.json`, after
+        //     which `codex login status` reports "Not logged in" — the app
+        //     drives that file;
+        //   * signing in again through `codex` recreates it, and the app returns
+        //     to a signed-in state on its own;
+        //   * but with the file holding a `team` token while the app's session
+        //     was `free`, the app sent `plan_type=free` and never touched the
+        //     file (mtime unchanged). It does not consult this file to answer.
+        //
+        // The app builds its value from the live session of the ACTIVE account
+        // (`setSparkleQueryParams({beta, planType})`, fed from the account
+        // object; default `unknown`), and that plan is not persisted anywhere we
+        // can read — `~/Library/Application Support/com.openai.codex/` holds
+        // only the bootstrap json above and a web session directory. So this
+        // claim is the best local source that exists, not the app's own value.
+        //
+        // Ours is right whenever the login is the one the app is using — the
+        // ordinary case, and strictly better than omitting the parameter (which
+        // books every machine onto the enterprise track) or hardcoding one
+        // (wrong in the dangerous direction on a business account). But four
+        // things drift it, all silently:
+        //
+        //   * `codex login --with-api-key` — auth_mode becomes apikey and the
+        //     token carries no `chatgpt_plan_type` at all, so we send "unknown"
+        //     while the app sends the account's real plan;
+        //   * a plan change between token refreshes leaves the claim stale;
+        //   * switching the active workspace inside the app is not a re-login,
+        //     so the minted claim need not follow it. UNVERIFIED: the account on
+        //     hand belonged to no workspace, so no switcher appeared;
+        //   * `CODEX_HOME` moves the file, and this path is hardcoded. Real
+        //     setups do it — openai/codex#35817 is an XDG-style
+        //     `CODEX_HOME=$HOME/.local/share/codex` on macOS whose `~/.codex`
+        //     holds nothing but a stray Desktop sqlite dir. Those machines get
+        //     the pre-fix behaviour. Reading the variable is NOT the fix: the
+        //     GUI app is launched by launchd and does not inherit the user's
+        //     shell environment, so `duo verify` (which does) would go green
+        //     over a machine where the app still falls back.
+        //
+        // All four fail toward "unknown" or a stale consumer value, never toward
+        // claiming enterprise on a consumer account, so the blast radius is the
+        // cautious track — where omitting the parameter put everyone anyway.
         VendorProbeRecipe(
             bundleID: "com.openai.codex",
             url: URL(string: "https://chatgpt.com/backend-api/wham/app/appcast?installation_id=__IDENTITY__&arch=arm64&beta=false&app_version=0.0.0&plan_type=__PLANTYPE__")!,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -308,11 +308,14 @@ public struct VendorProbeSource: UpdateSource {
         // account is not a defect.
         guard mine.url != contrast.url else { return .indeterminate }
 
-        async let mineVersion = trackVersion(recipe, at: mine.url)
-        async let contrastVersion = trackVersion(recipe, at: contrast.url)
-        guard let ours = await mineVersion, let theirs = await contrastVersion else {
-            return .indeterminate
-        }
+        // Sequential on purpose. `Verify.byHost` walks one host's recipes one at
+        // a time with a delay and jitter so "a host serving several recipes
+        // doesn't see a metronome"; firing these two together would make the one
+        // endpoint we ask about a track also the one endpoint we burst. The cost
+        // is a single extra round trip on a path that only runs in a sweep.
+        guard let ours = await trackVersion(recipe, at: mine.url),
+              let theirs = await trackVersion(recipe, at: contrast.url)
+        else { return .indeterminate }
         return ours == theirs
             ? .converged(ours)
             : .diverged(ours: ours, contrast: theirs)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -274,6 +274,62 @@ public struct VendorProbeSource: UpdateSource {
         await probeOutcome(recipe, allowInstall: true)
     }
 
+    /// Where this machine's track value came from — read off disk, or the
+    /// recipe's declared fallback. Nil when the recipe has no track, or when the
+    /// expansion fails outright.
+    ///
+    /// Deliberately narrow. The expanded URL stays inside this type, so a caller
+    /// that wants to know "are we on the cautious track by default?" gets that
+    /// answer and not a string with the machine's identifier in it.
+    public func trackProvenance(_ recipe: VendorProbeRecipe) -> ProbeIdentity.Provenance? {
+        guard recipe.track != nil, case .success(let resolved) = resolveEndpoint(recipe)
+        else { return nil }
+        return resolved.trackProvenance
+    }
+
+    /// Ask one recipe's endpoint twice — once as this machine, once as
+    /// `RolloutTrack.contrastValue` — and report whether the vendor is serving
+    /// two different answers right now. Nil for a recipe with no track.
+    ///
+    /// **Verification-time only.** It doubles the requests for the recipe, which
+    /// is nothing inside a sweep that already makes ~150 and wrong inside the
+    /// app's periodic check. It is also the only thing that can tell a healthy
+    /// track selection from an irrelevant one: while a vendor's tracks are
+    /// converged, every value gives the same answer, so our own answer looking
+    /// right proves nothing about whether we chose right.
+    public func rolloutTrackVerdict(_ recipe: VendorProbeRecipe) async -> RolloutTrackVerdict? {
+        guard let track = recipe.track else { return nil }
+        guard case .success(let mine) = resolveEndpoint(recipe),
+              case .success(let contrast) = resolveEndpoint(
+                recipe, trackOverride: track.contrastValue)
+        else { return .indeterminate }
+        // This machine already sits on the contrast track, so asking again as
+        // the contrast establishes nothing. Not a finding — being an enterprise
+        // account is not a defect.
+        guard mine.url != contrast.url else { return .indeterminate }
+
+        async let mineVersion = trackVersion(recipe, at: mine.url)
+        async let contrastVersion = trackVersion(recipe, at: contrast.url)
+        guard let ours = await mineVersion, let theirs = await contrastVersion else {
+            return .indeterminate
+        }
+        return ours == theirs
+            ? .converged(ours)
+            : .diverged(ours: ours, contrast: theirs)
+    }
+
+    /// The version one already-expanded endpoint reports, by the same extractor
+    /// a real probe uses — so a divergence means the tracks differ, not that two
+    /// code paths read the body differently.
+    private func trackVersion(_ recipe: VendorProbeRecipe, at endpoint: URL) async -> String? {
+        guard case .success(let body) = await fetchBody(recipe, endpoint: endpoint)
+        else { return nil }
+        let extractor = recipe.selectHighest
+            ? VendorProbeRecipe.highestVersion
+            : VendorProbeRecipe.extractVersion
+        return extractor(body.text, recipe.versionPattern)
+    }
+
     /// What a mode's fetch step yields on success: the text the version pattern
     /// runs against, the download URL that text resolved to, and the status code.
     private struct FetchedBody {
@@ -413,13 +469,26 @@ public struct VendorProbeSource: UpdateSource {
             httpStatus: body.status, bodySample: sample, elapsedMs: elapsed())
     }
 
-    /// The per-mode fetch half of a probe, with each `return nil` in the original
-    /// replaced by the specific reason it happened.
-    private func fetchBody(_ recipe: VendorProbeRecipe) async -> Result<FetchedBody, ProbeFailure> {
-        // The one place a `ProbeIdentity` is expanded. `endpoint` stays local to
-        // this function so the machine's identifier reaches the request and
-        // nothing else — `recipe.url` (the placeholder) is what every log line,
-        // finding and outcome keeps carrying.
+    /// What a recipe's placeholders expand to, and where the track value came
+    /// from. `trackProvenance` is nil for a recipe with no `track`.
+    struct ResolvedEndpoint {
+        let url: URL
+        let trackProvenance: ProbeIdentity.Provenance?
+    }
+
+    /// The one place a `ProbeIdentity` or a `RolloutTrack` is expanded. The
+    /// result stays local to the caller so the machine's identifier reaches the
+    /// request and nothing else — `recipe.url` (the placeholders) is what every
+    /// log line, finding and outcome keeps carrying.
+    ///
+    /// `trackOverride` substitutes a literal for the track's own value instead
+    /// of reading it, which is how the verification sweep asks the endpoint what
+    /// a *different* track would be told. It is held to the same pattern and
+    /// character gate as a read value; a recipe author's typo must not reach the
+    /// wire either.
+    func resolveEndpoint(
+        _ recipe: VendorProbeRecipe, trackOverride: String? = nil
+    ) -> Result<ResolvedEndpoint, ProbeFailure> {
         var endpoint = recipe.url
         for identity in recipe.identities {
             guard let resolved = identity.resolve(endpoint) else {
@@ -428,6 +497,41 @@ public struct VendorProbeSource: UpdateSource {
             endpoint = resolved
         }
 
+        var provenance: ProbeIdentity.Provenance?
+        if let track = recipe.track {
+            if let override = trackOverride {
+                guard let resolved = track.selector.resolve(endpoint, substituting: override)
+                else {
+                    return .failure(.notApplicable(
+                        "'\(override)' is not a value \(recipe.bundleID)'s track accepts"))
+                }
+                endpoint = resolved
+                provenance = nil
+            } else {
+                guard let resolved = track.selector.resolved(endpoint) else {
+                    return .failure(.notApplicable(
+                        "no rollout track at \(track.selector.displayPath)"))
+                }
+                endpoint = resolved.url
+                provenance = resolved.provenance
+            }
+        }
+        return .success(ResolvedEndpoint(url: endpoint, trackProvenance: provenance))
+    }
+
+    /// The per-mode fetch half of a probe, with each `return nil` in the original
+    /// replaced by the specific reason it happened.
+    private func fetchBody(_ recipe: VendorProbeRecipe) async -> Result<FetchedBody, ProbeFailure> {
+        switch resolveEndpoint(recipe) {
+        case .failure(let failure): return .failure(failure)
+        case .success(let resolved): return await fetchBody(recipe, endpoint: resolved.url)
+        }
+    }
+
+    /// `fetchBody` against an endpoint whose placeholders are already expanded.
+    private func fetchBody(
+        _ recipe: VendorProbeRecipe, endpoint: URL
+    ) async -> Result<FetchedBody, ProbeFailure> {
         switch recipe.mode {
         case .redirectFilename:
             var request = URLRequest(url: endpoint)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -420,15 +420,12 @@ public struct VendorProbeSource: UpdateSource {
         // this function so the machine's identifier reaches the request and
         // nothing else — `recipe.url` (the placeholder) is what every log line,
         // finding and outcome keeps carrying.
-        let endpoint: URL
-        if let identity = recipe.identity {
-            guard let resolved = identity.resolve(recipe.url) else {
-                return .failure(.notApplicable(
-                    "no device identity at ~/Library/Application Support/\(identity.applicationSupportPath)"))
+        var endpoint = recipe.url
+        for identity in recipe.identities {
+            guard let resolved = identity.resolve(endpoint) else {
+                return .failure(.notApplicable("no device identity at \(identity.displayPath)"))
             }
             endpoint = resolved
-        } else {
-            endpoint = recipe.url
         }
 
         switch recipe.mode {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GoogleProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GoogleProbeRecipeTests.swift
@@ -125,7 +125,7 @@ struct GoogleProbeRecipeTests {
     /// that header is a per-machine identifier.
     @Test func antigravitySendsNoMachineIdentifier() throws {
         let recipe = try #require(googleRecipe("com.google.antigravity"))
-        #expect(recipe.identity == nil)
+        #expect(recipe.identities.isEmpty)
         #expect(recipe.requestBody == nil)
         #expect(!recipe.url.absoluteString.contains("staging"))
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MultiEndpointChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MultiEndpointChannelTests.swift
@@ -132,14 +132,14 @@ import Testing
     /// `ant-did` we can't read, and the reason the pair degrades gracefully.
     @Test func theGAEndpointNeedsNoIdentity() throws {
         let ga = try #require(recipes.first { $0.variant == "ga" })
-        #expect(ga.identity == nil)
+        #expect(ga.identities.isEmpty)
         #expect(!ga.url.absoluteString.contains("device_id"))
     }
 
     @Test func theRolloutEndpointReadsClaudesOwnDeviceID() throws {
         let rollout = try #require(recipes.first { $0.variant == "rollout" })
-        let identity = try #require(rollout.identity)
-        #expect(identity.applicationSupportPath == "Claude/ant-did")
+        let identity = try #require(rollout.identities.first)
+        #expect(identity.displayPath == "~/Library/Application Support/Claude/ant-did")
         #expect(rollout.url.absoluteString.contains("device_id=\(identity.placeholder)"))
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeIdentityTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeIdentityTests.swift
@@ -364,14 +364,14 @@ import Testing
 @Suite struct ProbeIdentityRedactionTests {
 
     private var identityRecipes: [VendorProbeRecipe] {
-        VendorProbeRegistry.recipes.filter { !$0.identities.isEmpty }
+        VendorProbeRegistry.recipes.filter { !$0.localReads.isEmpty }
     }
 
     /// `recipe.url` is what `Verify` reads the endpoint host from and what the
     /// log lines carry. It must still hold the placeholder, never a value.
     @Test func theRegistryHoldsPlaceholdersNotValues() throws {
         for recipe in identityRecipes {
-            for identity in recipe.identities {
+            for identity in recipe.localReads {
                 #expect(
                     recipe.url.absoluteString.contains(identity.placeholder),
                     "\(recipe.recipeID) declares an identity its URL never uses")
@@ -388,7 +388,7 @@ import Testing
     /// placeholder and fail the whole probe.
     @Test func placeholdersAreDistinctWithinARecipe() throws {
         for recipe in identityRecipes {
-            let placeholders = recipe.identities.map(\.placeholder)
+            let placeholders = recipe.localReads.map(\.placeholder)
             #expect(
                 Set(placeholders).count == placeholders.count,
                 "\(recipe.recipeID) reuses a placeholder across identities")
@@ -407,7 +407,7 @@ import Testing
         try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
 
         for recipe in identityRecipes {
-            for identity in recipe.identities {
+            for identity in recipe.localReads {
                 guard let fallback = identity.fallback else { continue }
                 let resolved = identity.resolve(
                     URL(string: "https://example.com/?x=\(identity.placeholder)")!,
@@ -419,8 +419,8 @@ import Testing
         }
     }
 
-    /// The asymmetry that makes the two Codex identities safe, pinned so a later
-    /// edit cannot quietly swap it. The machine id must keep skipping when it is
+    /// The asymmetry that makes the two Codex reads safe, pinned so a later edit
+    /// cannot quietly swap it. The machine id must keep skipping when it is
     /// unreadable — a synthesized one picks a stranger's rollout bucket. The plan
     /// must keep falling back — without it, a signed-out machine would lose
     /// ChatGPT coverage entirely rather than land on the cautious track.
@@ -428,7 +428,7 @@ import Testing
         let codex = try #require(
             VendorProbeRegistry.recipes.first { $0.bundleID == "com.openai.codex" })
         let byPlaceholder = Dictionary(
-            uniqueKeysWithValues: codex.identities.map { ($0.placeholder, $0) })
+            uniqueKeysWithValues: codex.localReads.map { ($0.placeholder, $0) })
 
         let machineID = try #require(byPlaceholder["__IDENTITY__"])
         #expect(machineID.fallback == nil, "a fabricated installation_id must never be sent")
@@ -437,6 +437,19 @@ import Testing
         #expect(
             plan.fallback == "unknown",
             "an unreadable plan must fall back to the value OpenAI's own doctor sends")
+    }
+
+    /// And the two must stay in different slots. `installation_id` names a
+    /// rollout BUCKET inside one track; `plan_type` names the TRACK. They look
+    /// alike in the URL and behave nothing alike when wrong, and only the second
+    /// gets the sweep's divergence check.
+    @Test func theCodexPlanIsATrackAndTheIDIsNot() throws {
+        let codex = try #require(
+            VendorProbeRegistry.recipes.first { $0.bundleID == "com.openai.codex" })
+        #expect(codex.identities.map(\.placeholder) == ["__IDENTITY__"])
+        let track = try #require(codex.track)
+        #expect(track.selector.placeholder == "__PLANTYPE__")
+        #expect(track.contrastValue == "business")
     }
 
     /// An identity recipe must not use a mode that routes the fetched URL into

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeIdentityTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeIdentityTests.swift
@@ -172,6 +172,146 @@ import Testing
         #expect(Self.codexIdentity.value(applicationSupportDirectory: root) == nil)
     }
 
+    // MARK: - ChatGPT's plan: a claim inside a JWT, under the home directory
+
+    /// The rollout track the endpoint keys on. Omitting it books the machine onto
+    /// the enterprise track, so it is read rather than guessed — see the Codex
+    /// recipe in `VendorProbeRegistry`.
+    private static let planIdentity = ProbeIdentity(
+        location: .home(".codex/auth.json"),
+        encoding: .jwtClaim(
+            tokenPath: ["tokens", "access_token"],
+            claimPath: ["https://api.openai.com/auth", "chatgpt_plan_type"]),
+        validationPattern: #"[a-z0-9_]{1,32}"#,
+        placeholder: "__PLANTYPE__",
+        fallback: "unknown",
+        maxBytes: 32768)
+
+    /// Build a JWT whose payload is `claims`. Signature is a fixed stand-in: the
+    /// decoder never reads it, which is itself part of the contract.
+    private func jwt(claims: [String: Any]) throws -> String {
+        let payload = try JSONSerialization.data(withJSONObject: claims)
+        let encoded = payload.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "eyJhbGciOiJSUzI1NiJ9.\(encoded).c2lnbmF0dXJl"
+    }
+
+    /// Write `contents` to `<tmp>/.codex/auth.json` and hand back the tmp root to
+    /// pass as the home directory.
+    private func home(withAuth contents: String?) throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("probe-identity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(".codex"), withIntermediateDirectories: true)
+        if let contents {
+            try Data(contents.utf8).write(to: root.appendingPathComponent(".codex/auth.json"))
+        }
+        return root
+    }
+
+    /// The file as the app actually writes it: the claim is namespaced, and the
+    /// token sits beside a refresh token this must never touch.
+    private func authJSON(plan: String) throws -> String {
+        let token = try jwt(claims: [
+            "https://api.openai.com/auth": ["chatgpt_plan_type": plan],
+        ])
+        return """
+            {"auth_mode":"chatgpt","tokens":{"access_token":"\(token)",\
+            "refresh_token":"rt-must-not-be-read","account_id":"acct"}}
+            """
+    }
+
+    @Test func readsThePlanClaimOutOfTheAccessToken() throws {
+        let root = try home(withAuth: authJSON(plan: "team"))
+        #expect(Self.planIdentity.value(homeDirectory: root) == "team")
+    }
+
+    /// Every tier we measured on 2026-08-24 must survive the pattern — the two
+    /// tracks are only meaningful if both sides can actually be sent.
+    @Test func everyKnownTierPassesValidation() throws {
+        for plan in ["free", "go", "plus", "pro", "team", "business", "enterprise", "ent26"] {
+            let root = try home(withAuth: authJSON(plan: plan))
+            #expect(Self.planIdentity.value(homeDirectory: root) == plan)
+        }
+    }
+
+    /// Never signed in, or the file moved. The probe must still run — falling
+    /// back to the cautious track rather than skipping ChatGPT entirely.
+    @Test func aMissingAuthFileFallsBackToUnknown() throws {
+        let root = try home(withAuth: nil)
+        #expect(Self.planIdentity.value(homeDirectory: root) == nil)
+        let resolved = Self.planIdentity.resolve(
+            URL(string: "https://example.com/?plan_type=__PLANTYPE__")!, homeDirectory: root)
+        #expect(resolved?.absoluteString == "https://example.com/?plan_type=unknown")
+    }
+
+    /// A tier name we have never seen is forwarded verbatim: the vendor decides
+    /// what its own slugs mean, and downgrading a new consumer tier to "unknown"
+    /// would silently park those users on the enterprise track.
+    @Test func anUnrecognizedTierIsForwardedRatherThanFlattened() throws {
+        let root = try home(withAuth: authJSON(plan: "pro_max_2027"))
+        #expect(Self.planIdentity.value(homeDirectory: root) == "pro_max_2027")
+    }
+
+    /// The claim is namespaced; a payload that puts it at the top level is not
+    /// the shape this recipe declared.
+    @Test func aClaimAtTheWrongPathYieldsNil() throws {
+        let token = try jwt(claims: ["chatgpt_plan_type": "team"])
+        let root = try home(withAuth: #"{"tokens":{"access_token":"\#(token)"}}"#)
+        #expect(Self.planIdentity.value(homeDirectory: root) == nil)
+    }
+
+    /// Not a JWT at all — three dot-separated parts are the whole structural
+    /// check, and a bare string fails it rather than being base64-decoded blind.
+    @Test func aTokenThatIsNotAJWTYieldsNil() throws {
+        let root = try home(withAuth: #"{"tokens":{"access_token":"not-a-jwt"}}"#)
+        #expect(Self.planIdentity.value(homeDirectory: root) == nil)
+    }
+
+    /// The claim holds the wrong type. Coercing it would put `true` on the wire.
+    @Test func aNonStringClaimYieldsNil() throws {
+        let token = try jwt(claims: ["https://api.openai.com/auth": ["chatgpt_plan_type": true]])
+        let root = try home(withAuth: #"{"tokens":{"access_token":"\#(token)"}}"#)
+        #expect(Self.planIdentity.value(homeDirectory: root) == nil)
+    }
+
+    /// The structural backstop applies here too: a claim rewritten into something
+    /// URL-significant must not reach the query, pattern or no pattern.
+    @Test func aHostileClaimIsRefused() throws {
+        for hostile in ["team&admin=1", "team/../x", "TEAM", "a b"] {
+            let root = try home(withAuth: authJSON(plan: hostile))
+            #expect(
+                Self.planIdentity.value(homeDirectory: root) == nil,
+                "'\(hostile)' must not reach a request URL")
+        }
+    }
+
+    /// Pointed at something far larger than an auth file, we stop before parsing.
+    @Test func anOversizedAuthFileFallsBackRatherThanParsing() throws {
+        let padding = String(repeating: "p", count: 40000)
+        let root = try home(withAuth: #"{"pad":"\#(padding)","tokens":{}}"#)
+        #expect(Self.planIdentity.value(homeDirectory: root) == nil)
+    }
+
+    /// The one rule that makes reading this file acceptable: `.jwtClaim` reaches
+    /// the claim a recipe names and can return nothing else — least of all a
+    /// credential sitting beside it.
+    @Test func aRecipeCannotReachTheRefreshToken() throws {
+        let root = try home(withAuth: authJSON(plan: "team"))
+        let reachingForTheToken = ProbeIdentity(
+            location: .home(".codex/auth.json"),
+            encoding: .jsonKey("refresh_token"),
+            validationPattern: ".+",
+            maxBytes: 32768)
+        #expect(reachingForTheToken.value(homeDirectory: root) == nil)
+        // And what the real identity yields is the plan, never the token.
+        let value = try #require(Self.planIdentity.value(homeDirectory: root))
+        #expect(value == "team")
+        #expect(!value.contains("rt-must-not-be-read"))
+    }
+
 }
 
 /// The identity must not escape the fetch. Everything the verify sweep persists —
@@ -180,22 +320,79 @@ import Testing
 @Suite struct ProbeIdentityRedactionTests {
 
     private var identityRecipes: [VendorProbeRecipe] {
-        VendorProbeRegistry.recipes.filter { $0.identity != nil }
+        VendorProbeRegistry.recipes.filter { !$0.identities.isEmpty }
     }
 
     /// `recipe.url` is what `Verify` reads the endpoint host from and what the
     /// log lines carry. It must still hold the placeholder, never a value.
     @Test func theRegistryHoldsPlaceholdersNotValues() throws {
         for recipe in identityRecipes {
-            let identity = try #require(recipe.identity)
-            #expect(
-                recipe.url.absoluteString.contains(identity.placeholder),
-                "\(recipe.recipeID) declares an identity its URL never uses")
-            // The real value, if this machine has one, must not be baked in.
-            if let value = identity.value() {
-                #expect(!recipe.url.absoluteString.contains(value))
+            for identity in recipe.identities {
+                #expect(
+                    recipe.url.absoluteString.contains(identity.placeholder),
+                    "\(recipe.recipeID) declares an identity its URL never uses")
+                // The real value, if this machine has one, must not be baked in.
+                if let value = identity.value() {
+                    #expect(!recipe.url.absoluteString.contains(value))
+                }
             }
         }
+    }
+
+    /// Two identities on one recipe must not share a placeholder: the first
+    /// substitution would consume both slots and the second would then find no
+    /// placeholder and fail the whole probe.
+    @Test func placeholdersAreDistinctWithinARecipe() throws {
+        for recipe in identityRecipes {
+            let placeholders = recipe.identities.map(\.placeholder)
+            #expect(
+                Set(placeholders).count == placeholders.count,
+                "\(recipe.recipeID) reuses a placeholder across identities")
+        }
+    }
+
+    /// A declared fallback must survive its own recipe's validation. It is only
+    /// checked at substitution time, so a typo would otherwise sit in the
+    /// registry looking fine and turn into a skipped probe the day the file it
+    /// stands in for goes missing — the one day it was supposed to help.
+    @Test func everyDeclaredFallbackWouldActuallySubstitute() throws {
+        // A directory with nothing in it: every read fails, so what comes out is
+        // the fallback or nothing.
+        let empty = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("probe-identity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+
+        for recipe in identityRecipes {
+            for identity in recipe.identities {
+                guard let fallback = identity.fallback else { continue }
+                let resolved = identity.resolve(
+                    URL(string: "https://example.com/?x=\(identity.placeholder)")!,
+                    applicationSupportDirectory: empty, homeDirectory: empty)
+                #expect(
+                    resolved?.absoluteString == "https://example.com/?x=\(fallback)",
+                    "\(recipe.recipeID)'s fallback '\(fallback)' fails its own validation")
+            }
+        }
+    }
+
+    /// The asymmetry that makes the two Codex identities safe, pinned so a later
+    /// edit cannot quietly swap it. The machine id must keep skipping when it is
+    /// unreadable — a synthesized one picks a stranger's rollout bucket. The plan
+    /// must keep falling back — without it, a signed-out machine would lose
+    /// ChatGPT coverage entirely rather than land on the cautious track.
+    @Test func codexKeepsTheIDStrictAndThePlanForgiving() throws {
+        let codex = try #require(
+            VendorProbeRegistry.recipes.first { $0.bundleID == "com.openai.codex" })
+        let byPlaceholder = Dictionary(
+            uniqueKeysWithValues: codex.identities.map { ($0.placeholder, $0) })
+
+        let machineID = try #require(byPlaceholder["__IDENTITY__"])
+        #expect(machineID.fallback == nil, "a fabricated installation_id must never be sent")
+
+        let plan = try #require(byPlaceholder["__PLANTYPE__"])
+        #expect(
+            plan.fallback == "unknown",
+            "an unreadable plan must fall back to the value OpenAI's own doctor sends")
     }
 
     /// An identity recipe must not use a mode that routes the fetched URL into

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeIdentityTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeIdentityTests.swift
@@ -211,14 +211,24 @@ import Testing
         return root
     }
 
-    /// The file as the app actually writes it: the claim is namespaced, and the
-    /// token sits beside a refresh token this must never touch.
+    /// The file as the app actually writes it, mirrored from a real
+    /// `~/.codex/auth.json` (read 2026-08-24): the claim is namespaced two
+    /// levels down inside the access token, and it shares the file with an id
+    /// token, a refresh token, and `OPENAI_API_KEY` at the TOP LEVEL.
+    ///
+    /// That last one is why this fixture is worth keeping honest. The previous
+    /// version put only nested secrets in the file, which made a test asserting
+    /// "a recipe cannot reach the refresh token" pass for the wrong reason —
+    /// `.jsonKey` reads top-level keys, so it missed on the PATH, not on any
+    /// protection.
     private func authJSON(plan: String) throws -> String {
         let token = try jwt(claims: [
             "https://api.openai.com/auth": ["chatgpt_plan_type": plan],
         ])
         return """
-            {"auth_mode":"chatgpt","tokens":{"access_token":"\(token)",\
+            {"OPENAI_API_KEY":"sk-must-not-be-read","auth_mode":"chatgpt",\
+            "last_refresh":"2026-08-24T15:26:45Z",\
+            "tokens":{"access_token":"\(token)","id_token":"\(token)",\
             "refresh_token":"rt-must-not-be-read","account_id":"acct"}}
             """
     }
@@ -295,21 +305,55 @@ import Testing
         #expect(Self.planIdentity.value(homeDirectory: root) == nil)
     }
 
-    /// The one rule that makes reading this file acceptable: `.jwtClaim` reaches
-    /// the claim a recipe names and can return nothing else — least of all a
-    /// credential sitting beside it.
-    @Test func aRecipeCannotReachTheRefreshToken() throws {
+    /// What `.jwtClaim` actually guarantees: it walks to the claim a recipe
+    /// names and can return nothing else — not the token it decoded, not a
+    /// sibling of that token.
+    @Test func theClaimEncodingCannotReturnTheTokenItDecoded() throws {
         let root = try home(withAuth: authJSON(plan: "team"))
+        let value = try #require(Self.planIdentity.value(homeDirectory: root))
+        #expect(value == "team")
+
+        // Aimed at the token itself rather than at a claim inside it: there is
+        // no claim path to walk, so there is no answer to give.
         let reachingForTheToken = ProbeIdentity(
             location: .home(".codex/auth.json"),
-            encoding: .jsonKey("refresh_token"),
+            encoding: .jwtClaim(tokenPath: ["tokens", "access_token"], claimPath: []),
             validationPattern: ".+",
             maxBytes: 32768)
         #expect(reachingForTheToken.value(homeDirectory: root) == nil)
-        // And what the real identity yields is the plan, never the token.
-        let value = try #require(Self.planIdentity.value(homeDirectory: root))
-        #expect(value == "team")
-        #expect(!value.contains("rt-must-not-be-read"))
+
+        // A sibling that is not a JWT decodes to nothing either.
+        let reachingForTheRefreshToken = ProbeIdentity(
+            location: .home(".codex/auth.json"),
+            encoding: .jwtClaim(
+                tokenPath: ["tokens", "refresh_token"], claimPath: ["anything"]),
+            validationPattern: ".+",
+            maxBytes: 32768)
+        #expect(reachingForTheRefreshToken.value(homeDirectory: root) == nil)
+    }
+
+    /// The hazard the allow-list exists for, written as a test rather than left
+    /// as a comment: a DIFFERENT encoding aimed at this same file reaches the
+    /// API key at its top level, and the character backstop waves it through
+    /// (an `sk-` key is URL-unreserved end to end).
+    ///
+    /// Nothing in `ProbeIdentity`'s types prevents this, which is the point —
+    /// what prevents it is `RegistrySecurity.credentialBearingFileReads` plus
+    /// the registry-derived check in `RegistrySecurityTests`. If this test ever
+    /// goes red the hazard moved, and that guard needs re-reading before it is
+    /// trusted again.
+    @Test func anotherEncodingWouldReachTheAPIKeyBesideTheClaim() throws {
+        let root = try home(withAuth: authJSON(plan: "team"))
+        let reachingForTheKey = ProbeIdentity(
+            location: .home(".codex/auth.json"),
+            encoding: .jsonKey("OPENAI_API_KEY"),
+            validationPattern: ".+",
+            maxBytes: 32768)
+        #expect(reachingForTheKey.value(homeDirectory: root) == "sk-must-not-be-read")
+        #expect(
+            RegistrySecurity.credentialBearingFileReads["~/.codex/auth.json"]?
+                .contains(reachingForTheKey.readPath) != true,
+            "this read must never appear in the allow-list")
     }
 
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RedactionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RedactionTests.swift
@@ -139,4 +139,39 @@ import Foundation
             }
         }
     }
+
+    /// A recipe may read out of a file that also holds credentials only at a
+    /// path somebody has looked at. `ProbeIdentity`'s types cannot express that
+    /// rule — `.jsonKey` reaches any top-level key, and `~/.codex/auth.json`
+    /// keeps `OPENAI_API_KEY` at its top level — so the registry is checked
+    /// against the allow-list directly.
+    @Test func noRecipeReadsAnUnreviewedPathOutOfACredentialFile() {
+        for recipe in VendorProbeRegistry.recipes {
+            for identity in recipe.identities {
+                guard let allowed =
+                    RegistrySecurity.credentialBearingFileReads[identity.displayPath]
+                else { continue }
+                #expect(
+                    allowed.contains(identity.readPath),
+                    "\(recipe.bundleID) reads '\(identity.readPath)' out of \(identity.displayPath); confirm it is not a credential, then allow-list it")
+            }
+        }
+    }
+
+    /// And the allow-list must describe the registry rather than outlive it. An
+    /// entry no recipe performs is a standing permission for a read nobody
+    /// makes, which the next reader would take as "this was decided to be fine".
+    @Test func everyAllowedCredentialFileReadIsActuallyPerformed() {
+        let performed = Set(
+            VendorProbeRegistry.recipes
+                .flatMap(\.identities)
+                .map { "\($0.displayPath)|\($0.readPath)" })
+        for (file, reads) in RegistrySecurity.credentialBearingFileReads {
+            for read in reads {
+                #expect(
+                    performed.contains("\(file)|\(read)"),
+                    "the allow-list permits '\(read)' out of \(file), but no recipe reads it; drop the entry")
+            }
+        }
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RedactionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RedactionTests.swift
@@ -147,7 +147,7 @@ import Foundation
     /// against the allow-list directly.
     @Test func noRecipeReadsAnUnreviewedPathOutOfACredentialFile() {
         for recipe in VendorProbeRegistry.recipes {
-            for identity in recipe.identities {
+            for identity in recipe.localReads {
                 guard let allowed =
                     RegistrySecurity.credentialBearingFileReads[identity.displayPath]
                 else { continue }
@@ -164,7 +164,7 @@ import Foundation
     @Test func everyAllowedCredentialFileReadIsActuallyPerformed() {
         let performed = Set(
             VendorProbeRegistry.recipes
-                .flatMap(\.identities)
+                .flatMap(\.localReads)
                 .map { "\($0.displayPath)|\($0.readPath)" })
         for (file, reads) in RegistrySecurity.credentialBearingFileReads {
             for read in reads {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RolloutTrackTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RolloutTrackTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// A rollout track is only worth carrying if the sweep can tell whether it is
+/// still deciding anything. These cover that question — the two-request verdict
+/// — and the registry invariants that keep the verdict from dying silently.
+@Suite(.serialized)
+struct RolloutTrackTests {
+
+    /// Answers each request with the version its `plan_type` maps to, so a test
+    /// can put the vendor into "two tracks" or "merged" and see what we make of
+    /// it. An unmapped value fails the request, which is how the unreachable
+    /// case is staged.
+    private final class PlanRouter: URLProtocol, @unchecked Sendable {
+        private static let lock = NSLock()
+        nonisolated(unsafe) private static var versions: [String: String] = [:]
+
+        static func serve(_ versions: [String: String]) {
+            lock.lock(); defer { lock.unlock() }
+            Self.versions = versions
+        }
+
+        private static func version(for plan: String?) -> String? {
+            lock.lock(); defer { lock.unlock() }
+            return plan.flatMap { versions[$0] }
+        }
+
+        static func session() -> URLSession {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [PlanRouter.self]
+            return URLSession(configuration: configuration)
+        }
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            let plan = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first { $0.name == "plan_type" }?.value
+            guard let version = Self.version(for: plan) else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data("<version>\(version)</version>".utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    /// A recipe whose track can never be read — the path does not exist — so the
+    /// value on the wire is always the fallback. That is the state the finding
+    /// exists for, and it makes these tests independent of whatever this machine
+    /// happens to be signed into.
+    private static func recipe(fallback: String, contrast: String) -> VendorProbeRecipe {
+        VendorProbeRecipe(
+            bundleID: "com.example.tracked",
+            url: URL(string: "https://tracks.example/appcast?plan_type=__PLANTYPE__")!,
+            mode: .responseBody,
+            versionPattern: #"<version>([0-9.]+)</version>"#,
+            track: RolloutTrack(
+                selector: ProbeIdentity(
+                    location: .home(".duo-updater-absent-by-design/auth.json"),
+                    encoding: .plain,
+                    validationPattern: #"[a-z0-9_]{1,32}"#,
+                    placeholder: "__PLANTYPE__",
+                    fallback: fallback),
+                contrastValue: contrast,
+                contrastTrackName: "the contrast track"))
+    }
+
+    private func verdict(fallback: String, contrast: String) async -> RolloutTrackVerdict? {
+        await VendorProbeSource(recipes: [], session: PlanRouter.session())
+            .rolloutTrackVerdict(Self.recipe(fallback: fallback, contrast: contrast))
+    }
+
+    /// The vendor is running two tracks: which value we send decides what we are
+    /// offered, so sending the wrong one has a cost right now.
+    @Test func twoAnswersAreReportedAsDiverged() async {
+        PlanRouter.serve(["free": "2.0", "business": "1.0"])
+        #expect(
+            await verdict(fallback: "free", contrast: "business")
+                == .diverged(ours: "2.0", contrast: "1.0"))
+    }
+
+    /// The rollout finished and the tracks merged. Nothing we send today can be
+    /// wrong, so there is nothing to report — and, crucially, nothing that
+    /// proves we would have chosen right had they still been split.
+    @Test func oneAnswerIsReportedAsConverged() async {
+        PlanRouter.serve(["free": "2.0", "business": "2.0"])
+        #expect(await verdict(fallback: "free", contrast: "business") == .converged("2.0"))
+    }
+
+    /// The vendor being unreachable is not the recipe being wrong.
+    @Test func anUnreachableEndpointIsIndeterminate() async {
+        PlanRouter.serve([:])
+        #expect(await verdict(fallback: "free", contrast: "business") == .indeterminate)
+    }
+
+    /// The silent death this exists to prevent: a contrast equal to the value we
+    /// would send anyway asks the same question twice, so the check can never
+    /// find anything. Pinned here, and forbidden across the registry below.
+    @Test func aContrastEqualToOurOwnValueEstablishesNothing() async {
+        PlanRouter.serve(["free": "2.0", "business": "1.0"])
+        #expect(await verdict(fallback: "free", contrast: "free") == .indeterminate)
+    }
+
+    /// A track whose value cannot be read reports itself as defaulted. That is
+    /// the cheap half of the finding's precondition — it costs no request, which
+    /// is why the sweep checks it first and only then pays for a verdict.
+    @Test func anUnreadableTrackReportsAsFallback() {
+        let source = VendorProbeSource(recipes: [], session: PlanRouter.session())
+        #expect(
+            source.trackProvenance(Self.recipe(fallback: "free", contrast: "business"))
+                == .fallback)
+    }
+
+    /// A recipe with no track is asked nothing.
+    @Test func aRecipeWithoutATrackHasNoVerdict() async {
+        let plain = VendorProbeRecipe(
+            bundleID: "com.example.plain",
+            url: URL(string: "https://tracks.example/appcast")!,
+            mode: .responseBody,
+            versionPattern: #"<version>([0-9.]+)</version>"#)
+        #expect(
+            await VendorProbeSource(recipes: [], session: PlanRouter.session())
+                .rolloutTrackVerdict(plain) == nil)
+    }
+}
+
+/// The registry's own tracks, checked against the rules that keep the verdict
+/// meaningful. Both failures below would leave a track that looks configured and
+/// reports healthy forever.
+@Suite struct RolloutTrackRegistryTests {
+
+    private var tracked: [VendorProbeRecipe] {
+        VendorProbeRegistry.recipes.filter { $0.track != nil }
+    }
+
+    /// The contrast goes on the wire through the same gate as a read value, so a
+    /// contrast its own selector rejects turns every verdict into
+    /// `.indeterminate` — silently, and only in the window where it mattered.
+    @Test func everyContrastSurvivesItsOwnSelectorsValidation() throws {
+        for recipe in tracked {
+            let track = try #require(recipe.track)
+            #expect(
+                track.selector.resolve(recipe.url, substituting: track.contrastValue) != nil,
+                "\(recipe.recipeID)'s contrast '\(track.contrastValue)' fails its own validation")
+        }
+    }
+
+    /// And it must differ from the fallback. The finding only fires when we ARE
+    /// on the fallback; a contrast equal to it compares that value against
+    /// itself, and the one check that can catch a defaulted track never fires.
+    @Test func noContrastEqualsItsOwnFallback() throws {
+        for recipe in tracked {
+            let track = try #require(recipe.track)
+            #expect(
+                track.contrastValue != track.selector.fallback,
+                "\(recipe.recipeID)'s contrast is its own fallback, so the divergence check is dead")
+        }
+    }
+}


### PR DESCRIPTION
## What was wrong

`chatgpt.com/backend-api/wham/app/appcast` serves **two feeds**, and `plan_type` picks which one. Measured 2026-08-24 against a single `installation_id`, varying only that parameter:

| `plan_type` | redirects to | top version |
|---|---|---|
| `free` `go` `plus` `pro` `team` | `appcast-26.818.61809.xml` | 26.818.61809 |
| `business` `enterprise` `ent26` | `appcast-26.818.41509.xml` | 26.818.41509 |
| `unknown`, omitted, nonsense | `appcast-26.818.41509.xml` | 26.818.41509 |

**We never sent the parameter, and that is not neutral — it books every machine onto the enterprise track.** That is why `duo verify` reported `remote is BEHIND the installed copy (41509 < 61809)` while ChatGPT itself was installing 61809.

Business tiers trail so IT can qualify a build first (openai/codex 0.146.0, "enterprise-plan recognition", #35238/#35537).

## The split is a window, not a structure

Measured again at **15:29Z the same day**: every value — `business`, `enterprise` and omitted included — resolved to `26.818.61809`. The enterprise track had caught up.

This matters more than it sounds. It means:

- no test can assert on the split, and
- **`duo verify` cannot tell whether this parameter is doing anything.** Outside the rollout window every value gives the same answer, so our own answer looking right proves nothing about whether we chose right.

The parameter earns its place only inside the window — which is exactly when getting it wrong starts a fight the app wins: its Sparkle stages the build it wanted, waits for a quit, and our restart is the quit.

## Reading the value, and what that value actually is

`plan_type` is read from `~/.codex/auth.json` — ChatGPT.app bundles the `codex` CLI and both resolve `CODEX_HOME ?? ~/.codex`.

The first draft of this PR claimed the app and the CLI "are one product and share that file". Half right, and the wrong half was load-bearing. Measured:

| experiment | result |
|---|---|
| sign out of ChatGPT.app | `~/.codex/auth.json` is **deleted**; `codex login status` → "Not logged in" |
| sign in through `codex` | the file is recreated and the app returns to a signed-in state |
| **put a `team` token in the file while the app's session is `free`** | **the app sends `plan_type=free` and never touches the file** |

So the file and the login *events* are shared; the **value is not**. The app builds its own from the live session of the active account and persists that plan nowhere we can read (`~/Library/Application Support/com.openai.codex/` holds the bootstrap json and a web session directory, nothing else). The claim is the best local source that exists — not the app's own value.

Reading it is still strictly better than omitting the parameter (everyone onto the enterprise track) or hardcoding one (wrong in the dangerous direction on a business account), and there is no third option.

## What this does

### It is a track, not an identity

Two different things had ended up in one type. `installation_id` names the rollout **bucket** this machine falls in inside a track; `plan_type` names the **track**. They look alike in the URL and behave nothing alike when wrong — a fabricated id lands you in a stranger's bucket, a wrong track offers a build the machine's own updater refuses.

`RolloutTrack` names the second. Structurally it is `TablePlusChannel` with a query parameter where that has a header — one endpoint, one request-borne value, the server picking the builds — and deliberately not a `ReleaseChannel`, because that type means "the channel a user chose" and nobody chose their subscription tier.

### And the track carries its own discriminator

Because the tracks converge, a check that looks only at our own answer reports healthy right up until the next window opens. So `RolloutTrack` carries a `contrastValue`, `VendorProbeSource.rolloutTrackVerdict` asks the endpoint twice, and `duo verify` reports the one combination that costs something: **we fell back AND the vendor's tracks are currently apart.** Verification-time only — two extra requests are nothing in a sweep that makes ~150 and wrong in the app's periodic check.

It is reported as a *machine note*, not a warning: the condition describes the machine running the sweep, not the recipe. Letting it promote a finding to `.warn` would accumulate an actionable streak and, after two sweeps inside one rollout window, file a public issue against a recipe that is working. (Same reasoning as `installURLTransient`'s exemption.) Notes stay out of issue titles, issue bodies and triage prompts.

### Reading one claim out of a file full of credentials

`ProbeIdentity` gains `.jwtClaim(tokenPath:claimPath:)` — two literal paths to one claim, no enumeration, no way to return the token it decoded — plus `Location.home`, per-recipe `maxBytes`, and `fallback`.

That is not enough on its own. `~/.codex/auth.json` keeps `OPENAI_API_KEY` at its **top level**, where `.jsonKey` looks, and the character backstop would pass an `sk-` key end to end. So `RegistrySecurity.credentialBearingFileReads` allow-lists the **read**, not the file, and a registry-derived test fails any identity reading an unlisted path out of a credential-bearing file. Verified red: adding `.jsonKey("OPENAI_API_KEY")` to this recipe produces

```
com.openai.codex reads 'OPENAI_API_KEY' out of ~/.codex/auth.json;
confirm it is not a credential, then allow-list it
```

The asymmetry between the two reads is deliberate and pinned by tests: the machine id has **no fallback** (a fabricated one picks a stranger's bucket, so an unreadable id skips the recipe), the plan falls back to `unknown` — what OpenAI's own `codex doctor` hardcodes, and what ChatGPT.app itself defaults to when signed out.

## Known gaps

The value we read can disagree with the app's, silently, four ways:

1. `codex login --with-api-key` — the token carries no `chatgpt_plan_type` at all, so we send `unknown` while the app sends the real plan;
2. a plan change between token refreshes leaves the claim stale;
3. switching the active workspace inside the app is not a re-login, so the minted claim need not follow it (**unverified** — the account on hand belonged to no workspace, so no switcher appeared);
4. `CODEX_HOME` moves the file and this path is hardcoded. Real setups do it — openai/codex#35817 is an XDG-style `CODEX_HOME=$HOME/.local/share/codex` on macOS whose `~/.codex` holds nothing but a stray Desktop sqlite dir.

All four fail toward `unknown` or a stale consumer value, never toward claiming enterprise on a consumer account, so the blast radius is the cautious track — where omitting the parameter put everyone anyway. The first is no longer silent in a sweep.

Reading `CODEX_HOME` is **not** the fix: the GUI app is launched by launchd and does not inherit the user's shell environment, so `duo verify` (which does) would go green over a machine where the app still falls back.

## Verification

```
make test
Ran 41 tests in 0.004s / OK
━ Test run with 1046 tests in 83 suites passed after 88.741 seconds with 2 known issues.
✔ Test run with 124 tests in 19 suites passed after 0.046 seconds.
✓ localizable keys agree — 410 in the catalog, all reachable
```
(the 2 known issues pre-date this branch)

```
duo verify --only codex
  vendor probe  ✓ 1  ⚠ 0  ✗ 0        # was ⚠ 1
```

Full sweep, since this changes the shared fetch path:

```
vendor probe  ✓ 124  ⚠ 1  ✗ 0
GitHub rule   ✓ 68   ⚠ 0  ✗ 0
changelog     ✓ 56   ⚠ 1  ✗ 1
```
The three findings are pre-existing (LibreOffice's version scheme, Figma's and Ghostty's changelog patterns) — the LibreOffice one reproduces on a `duo` built before this branch.

Live check of the new verdict path against the real endpoint: provenance `.read`, verdict `.converged("26.818.61809")` — matching the tracks having merged.

The report still carries only the placeholder URL and the endpoint host; grepping it for the claim value or the real `installation_id` returns nothing.

## Follow-up

#58 — nothing here is blocked on it; it tracks whether the divergence check should grow into the full `ChannelArtifactProof` treatment.

## Not included

No CHANGELOG entry — the file is organised by released version with no Unreleased section, so an entry needs the next version number, which is a release decision.
