### PR TITLE
engine: stop waiting on a launch that never comes back

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -116,16 +116,90 @@ public enum AppRestarter {
     /// foreground state instead (see `isFrontmost`), so an app that was in the
     /// background comes back in the background.
     @discardableResult
-    public static func launchApp(_ bundle: URL, activates: Bool = true) async -> Bool {
-        let config = NSWorkspace.OpenConfiguration()
-        config.activates = activates
-        do {
-            _ = try await NSWorkspace.shared.openApplication(at: bundle, configuration: config)
-            return true
-        } catch {
+    public static func launchApp(
+        _ bundle: URL, activates: Bool = true, timeout: Duration = launchTimeout
+    ) async -> Bool {
+        return await firstToFinish(timeout: timeout, fallback: false) {
             Log.install.error(
-                "app-restarter: launch failed: \(bundle.lastPathComponent, privacy: .public) — \(error.localizedDescription, privacy: .public)")
-            return false
+                "app-restarter: launch timed out: \(bundle.lastPathComponent, privacy: .public) — LaunchServices never came back")
+        } operation: {
+            // Built inside the operation, not captured: `OpenConfiguration` is a
+            // non-Sendable class, and the operation has to cross an isolation
+            // boundary to race the timer.
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = activates
+            do {
+                _ = try await NSWorkspace.shared.openApplication(at: bundle, configuration: config)
+                return true
+            } catch {
+                Log.install.error(
+                    "app-restarter: launch failed: \(bundle.lastPathComponent, privacy: .public) — \(error.localizedDescription, privacy: .public)")
+                return false
+            }
         }
+    }
+
+    /// How long `launchApp` gives LaunchServices before it stops waiting.
+    ///
+    /// `openApplication` has no timeout of its own, and a launch that never comes
+    /// back is not a local failure. `restart(_:)` never returns either, so its
+    /// caller's `defer` never runs and the row stays on "Relaunching…"
+    /// indefinitely: its Restart button is dead behind the re-entry guard, and the
+    /// self-update idle probe — which refuses to fire while anything is still
+    /// waiting to be relaunched — keeps Duo Updater from updating *itself* until
+    /// it is quit. Giving up does not get the app open, but it stops one wedged
+    /// launch from taking the rest of the app down with it.
+    ///
+    /// A minute is deliberately far past a normal launch. The slow case we know
+    /// of is a bundle we just replaced: nothing of it is in the page cache and
+    /// Gatekeeper re-validates the whole thing, which is seconds even at WeChat's
+    /// half a gigabyte.
+    public static let launchTimeout: Duration = .seconds(60)
+
+    /// Await `operation`, or answer `fallback` once `timeout` elapses — **without
+    /// waiting for the abandoned operation to finish**.
+    ///
+    /// That last part is the whole point, and it is why this is not a
+    /// `withTaskGroup`: a group awaits every child before it returns, so a child
+    /// wedged in a system call that ignores cancellation would hold the group open
+    /// and the timeout would be decorative. Here whichever side finishes first
+    /// resumes the continuation and the loser runs on unobserved.
+    static func firstToFinish<T: Sendable>(
+        timeout: Duration,
+        fallback: T,
+        onTimeout: @Sendable @escaping () -> Void = {},
+        operation: @Sendable @escaping () async -> T
+    ) async -> T {
+        let once = Once()
+        return await withCheckedContinuation { (continuation: CheckedContinuation<T, Never>) in
+            let timer = Task {
+                try? await Task.sleep(for: timeout)
+                guard !Task.isCancelled, once.claim() else { return }
+                onTimeout()
+                continuation.resume(returning: fallback)
+            }
+            Task {
+                let value = await operation()
+                guard once.claim() else { return }
+                timer.cancel()
+                continuation.resume(returning: value)
+            }
+        }
+    }
+}
+
+/// One-shot latch: the first caller to `claim()` gets true, every later one gets
+/// false. Guards a `CheckedContinuation` that two racing tasks can reach, where a
+/// second `resume` would trap.
+final class Once: @unchecked Sendable {
+    private let lock = NSLock()
+    private var taken = false
+
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if taken { return false }
+        taken = true
+        return true
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
@@ -62,4 +62,52 @@ import Foundation
         let outcome = await AppRestarter.restart(app())
         #expect(outcome == .notRunning)
     }
+
+    // MARK: - The launch timeout
+
+    /// The ordinary case: the work finishes well inside the budget, so its own
+    /// answer stands and the timeout never enters into it.
+    @Test func anOperationThatFinishesInTimeKeepsItsAnswer() async {
+        let value = await AppRestarter.firstToFinish(timeout: .seconds(10), fallback: false) {
+            true
+        }
+        #expect(value)
+    }
+
+    /// Past the budget the caller gets `fallback` instead of waiting forever.
+    @Test func anOperationPastTheBudgetAnswersWithTheFallback() async {
+        let value = await AppRestarter.firstToFinish(timeout: .milliseconds(50), fallback: false) {
+            try? await Task.sleep(for: .seconds(30))
+            return true
+        }
+        #expect(!value)
+    }
+
+    /// The property the whole thing exists for, and the one a `withTaskGroup`
+    /// would quietly fail: giving up must not mean *waiting* for the abandoned
+    /// operation. If this regressed, the call would take the operation's 30s
+    /// rather than the timeout's 50ms — which is exactly the wedged-launch
+    /// behaviour the timeout was added to prevent.
+    @Test func givingUpDoesNotWaitForTheAbandonedOperation() async {
+        let started = ContinuousClock.now
+        _ = await AppRestarter.firstToFinish(timeout: .milliseconds(50), fallback: false) {
+            try? await Task.sleep(for: .seconds(30))
+            return true
+        }
+        #expect(ContinuousClock.now - started < .seconds(5))
+    }
+
+    /// `onTimeout` is the log line, so it must fire only when the budget really
+    /// ran out — an operation that answered in time must not be reported as a
+    /// timed-out launch.
+    @Test func onTimeoutFiresOnlyWhenTheBudgetActuallyRanOut() async {
+        let timedOut = Once()
+        _ = await AppRestarter.firstToFinish(
+            timeout: .seconds(10), fallback: false, onTimeout: { _ = timedOut.claim() }
+        ) {
+            true
+        }
+        // Still unclaimed, so `onTimeout` never ran.
+        #expect(timedOut.claim())
+    }
 }


### PR DESCRIPTION
## 起因

排查一例用户反馈：微信更新后行永久停在 "Relaunching…"，app 没被拉起来。截图能读出三件事同时成立——盘上已是新版（`v` 前缀单版本只出自 `installedDisplay`）、没有绿点（`isRunning` 为假，进程全退了）、行仍在 `relaunching` 集合里。

`relaunching` 只由 `AppListModel` 那个 `defer` 清除，所以这个组合只能是 `restart(_:)` 没有返回。而 `restart(_:)` 里唯一的无界等待就是 `launchApp` 的 `NSWorkspace.openApplication`——退出循环有 30s 上限，它没有。

**说明：这个根因没有被复现证实。** 本机把检测、未运行 swap、运行中 swap、GUI 全流程、以及用 v0.3.57 构造的安装器对撞都跑过一遍，四条路径全绿，`openApplication` 每次都秒回。所以这条是从代码约束反推的。

即便如此这个改动仍然值得做，理由与根因无关：**卡住的影响不是局部的**。

## 卡住会连累什么

- `DuoUpdaterApp.swift` 的自更新 idle probe 是 `guard model.canRefresh, model.relaunching.isEmpty else { return false }`。只要有一行永久卡在 `relaunching`，**Duo Updater 自己的静默自更新就再也不会触发**，直到用户退出重开。
- `AppListModel` 的重入保护 `guard !relaunching.contains(result.id) else { return }` 让那一行的 Restart 按钮从此点不动，且没有任何反馈。

所以无论 LaunchServices 因为什么卡住（刚替换的大 bundle、Gatekeeper 重新校验、别的进程正在改写同一个 bundle），代价都是整个 app 的自更新能力。

## 改动

`launchApp` 与一个 60s 预算竞速，预算赢了就答 `false`，让 `defer` 得以执行。这**不会**让 app 启动起来——这里没有任何东西能做到——它只是把损害限制在这一行，并让用户可以重试。

`firstToFinish` 刻意不用 `withTaskGroup`：group 在返回前会等待每个子任务，一个卡在不响应取消的系统调用里的子任务会把 group 一直held住，超时就成了摆设。这里由先完成的一方 resume continuation，输的一方继续跑但无人观察。

## 验证

```
make test exit=0
core:  1025 tests / 81 suites passed (2 known issues — GitHubReleaseRule 既有的)
CLI:    119 tests / 18 suites passed
l10n:  ✓ localizable keys agree — 410 in the catalog, all reachable
```

判据有效性单独验过（红→绿）。把实现临时换成无超时的 `return await operation()` 后：

```
✘ anOperationPastTheBudgetAnswersWithTheFallback  failed after 31.996 seconds
✘ givingUpDoesNotWaitForTheAbandonedOperation     failed after 31.997 seconds
```

两个都跑满 operation 的 30s 才失败，正是"没有超时"的症状。恢复实现后 10/10 通过，其中 `givingUpDoesNotWaitForTheAbandonedOperation` 用时 0.050s。