### PR TITLE
A locked file must not make a backup undeletable

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
@@ -169,7 +169,7 @@ public enum BackupStore {
         // across a crashed prior attempt.
         try fm.createDirectory(at: root, withIntermediateDirectories: true)
         let staging = root.appendingPathComponent(".staging-\(key)", isDirectory: true)
-        try? fm.removeItem(at: staging)
+        forceRemove(staging)
         try fm.createDirectory(at: staging, withIntermediateDirectories: true)
 
         let name = appPath.lastPathComponent
@@ -183,7 +183,7 @@ public enum BackupStore {
         // nothing worth storing.
         let unreadable = BackupManifest.unreadableFiles(in: appPath)
         guard unreadable.sealed.isEmpty else {
-            try? fm.removeItem(at: staging)
+            forceRemove(staging)
             throw BackupError.payloadUnreadable(unreadable.sealed.first ?? appPath.path)
         }
 
@@ -197,7 +197,7 @@ public enum BackupStore {
             // Without this, a source that does not exist produced an empty copy
             // that passed the omission check and got stored as a backup.
             guard !unreadable.unsealed.isEmpty else {
-                try? fm.removeItem(at: staging)
+                forceRemove(staging)
                 throw BackupError.copyFailed(appPath.path)
             }
             let unexpected = BackupManifest.unexpectedOmissions(
@@ -205,7 +205,7 @@ public enum BackupStore {
             guard unexpected.isEmpty else {
                 Log.install.error(
                     "backup: copy of \(name, privacy: .public) lost \(unexpected.count, privacy: .public) file(s) it should have kept")
-                try? fm.removeItem(at: staging)
+                forceRemove(staging)
                 throw BackupError.copyFailed(appPath.path)
             }
         }
@@ -232,7 +232,7 @@ public enum BackupStore {
         guard let metaData = try? JSONEncoder().encode(meta),
               (try? metaData.write(to: staging.appendingPathComponent("backup.json"),
                                    options: .atomic)) != nil else {
-            try? fm.removeItem(at: staging)
+            forceRemove(staging)
             throw BackupError.copyFailed(appPath.path)
         }
 
@@ -246,7 +246,7 @@ public enum BackupStore {
                 try fm.moveItem(at: staging, to: dir)
             }
         } catch {
-            try? fm.removeItem(at: staging)
+            forceRemove(staging)
             throw BackupError.copyFailed(appPath.path)
         }
         let dest = dir.appendingPathComponent(name)
@@ -292,9 +292,9 @@ public enum BackupStore {
         let fm = FileManager.default
         let scratch = fm.temporaryDirectory
             .appendingPathComponent("DuoUpdater-rollback-\(key)", isDirectory: true)
-        try? fm.removeItem(at: scratch)
+        forceRemove(scratch)
         try fm.createDirectory(at: scratch, withIntermediateDirectories: true)
-        defer { try? fm.removeItem(at: scratch) }
+        defer { forceRemove(scratch) }
 
         let staged = scratch.appendingPathComponent(backup.bundlePath.lastPathComponent)
         guard runDitto(from: backup.bundlePath, to: staged) else {
@@ -383,8 +383,7 @@ public enum BackupStore {
 
     /// Drop the backup for `key` (e.g. the user dismissed it).
     public static func remove(forKey key: String) {
-        try? FileManager.default.removeItem(
-            at: root.appendingPathComponent(key, isDirectory: true))
+        forceRemove(root.appendingPathComponent(key, isDirectory: true))
     }
 
     /// One stored backup, described for a UI that has to let someone choose which
@@ -481,7 +480,7 @@ public enum BackupStore {
             else { continue }
             guard !fm.fileExists(atPath: meta.originalPath) else { continue }
             freed += directorySize(dir)
-            try? fm.removeItem(at: dir)
+            forceRemove(dir)
         }
         return freed
     }
@@ -530,10 +529,62 @@ public enum BackupStore {
         }
     }
 
+    /// Remove something inside our own store, including when a file in it is
+    /// flagged immutable.
+    ///
+    /// `ditto` faithfully copies BSD file flags, which is what we want of a
+    /// backup — and it means a `uchg` file inside an app bundle comes along into
+    /// the store. `removeItem` then fails with EPERM on that one file and, with
+    /// `try?`, fails silently: the backup stays, the space is never reclaimed,
+    /// and the delete sheet reports success while deleting nothing. Found on a
+    /// real machine, where ToDesk's `advInfo.json` had been locked by hand and
+    /// every ToDesk backup had become undeletable.
+    ///
+    /// Clearing the flag is safe **here specifically** because the target is
+    /// always a copy this store made, never the user's own file — and only the
+    /// user-settable flags are touched, since the system ones need root and
+    /// their presence is a genuine reason to stop. A restore is unaffected: it
+    /// copies its own bundle out, flags and all.
+    @discardableResult
+    private static func forceRemove(_ url: URL) -> Bool {
+        let fm = FileManager.default
+        do { try fm.removeItem(at: url); return true } catch {}
+        guard fm.fileExists(atPath: url.path) else { return true }
+
+        clearUserFlags(at: url)
+        do {
+            try fm.removeItem(at: url)
+            return true
+        } catch {
+            Log.install.error(
+                "backup: could not remove \(url.lastPathComponent, privacy: .public) — \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Clear `uchg`/`uappnd` from `url` and everything under it.
+    ///
+    /// `lstat`/`lchflags` rather than the follow-the-link pair: a symlink inside
+    /// a bundle must have its own flags cleared, and following one would let a
+    /// link reach outside the store.
+    private static func clearUserFlags(at url: URL) {
+        let clearable = UInt32(UF_IMMUTABLE) | UInt32(UF_APPEND)
+        func clear(_ path: String) {
+            var info = stat()
+            guard lstat(path, &info) == 0, info.st_flags & clearable != 0 else { return }
+            _ = lchflags(path, info.st_flags & ~clearable)
+        }
+        clear(url.path)
+        guard let walker = FileManager.default.enumerator(
+            at: url, includingPropertiesForKeys: nil, options: [], errorHandler: nil)
+        else { return }
+        for case let child as URL in walker { clear(child.path) }
+    }
+
     /// `ditto src dst`, returning true on success. Faithfully duplicates a bundle
     /// including its code signature, unlike `FileManager.copyItem`.
     private static func runDitto(from src: URL, to dst: URL) -> Bool {
-        try? FileManager.default.removeItem(at: dst)
+        forceRemove(dst)
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
         p.arguments = [src.path, dst.path]

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
@@ -266,6 +266,38 @@ struct BackupStoreTests {
     // MARK: - Orphan cleanup
 
     /// A backup whose original app path no longer exists on disk (uninstalled,
+    /// A locked file inside a bundle must not make its backup undeletable.
+    ///
+    /// `ditto` copies BSD file flags faithfully — correct for a backup — so a
+    /// `uchg` file the user set on an installed app arrives in the store, and
+    /// `removeItem` then refuses the whole tree with EPERM. Every removal here
+    /// used `try?`, so the failure was silent: on a real machine ToDesk's locked
+    /// `advInfo.json` meant its backups accumulated forever while the delete
+    /// sheet reported success.
+    ///
+    /// Asserted through `remove(forKey:)` rather than by deleting a fixture, so
+    /// this fails if the flag handling is dropped from the store's own path.
+    @Test func aBackupHoldingALockedFileCanStillBeRemoved() throws {
+        try withScratchRoot { root in
+            let apps = root.appendingPathComponent("apps")
+            try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "Locked.app", in: apps, marker: "v1")
+            let locked = app.appendingPathComponent("Contents/locked.json")
+            try Data("{}".utf8).write(to: locked)
+            #expect(lchflags(locked.path, UInt32(UF_IMMUTABLE)) == 0, "fixture must be locked")
+            defer { _ = lchflags(locked.path, 0) }
+
+            try BackupStore.save(
+                appPath: app, key: "locked", version: "1.0", bundleID: "com.example.locked")
+            let stored = root.appendingPathComponent("locked", isDirectory: true)
+            #expect(FileManager.default.fileExists(atPath: stored.path))
+
+            BackupStore.remove(forKey: "locked")
+            #expect(!FileManager.default.fileExists(atPath: stored.path),
+                    "a locked file inside the copy must not keep the backup on disk")
+        }
+    }
+
     /// or moved to a new path-scoped key) has nothing left to restore onto —
     /// `pruneOrphans` should reclaim it, and leave backups whose app is still
     /// installed untouched.


### PR DESCRIPTION
`ditto` copies BSD file flags faithfully — correct for a backup — so a `uchg`
file the user set on an installed app arrives in the store along with the
bundle. `removeItem` then fails with `EPERM` on that one file and refuses the
whole tree.

Every removal in `BackupStore` was `try?`, so the failure was silent. The
backup stayed, the space was never reclaimed, and the delete sheet reported
success while deleting nothing.

### How it turned up

On a real machine, ToDesk's `Contents/advInfo.json` had been locked by hand
(there is a `.bak-…-noads` sitting beside it). Every ToDesk backup had become
undeletable, along with a `.staging-` remnant a refused save had left behind.

```
$ ls -lO …/Backups/.staging-com.youqu.todesk…/ToDesk.app/Contents
-rw-r--r--@ 1 bobby admin uchg 340 May 21 17:15 advInfo.json

$ ditto <that directory> /tmp/uchgtest && rm -rf /tmp/uchgtest
rm: uchgtest/ToDesk.app/Contents/advInfo.json: Operation not permitted
rm: uchgtest/ToDesk.app/Contents: Directory not empty
```

### The fix

`forceRemove` tries the plain removal first and only on failure clears the
user-settable flags (`UF_IMMUTABLE`, `UF_APPEND`) and retries. `lstat`/
`lchflags` rather than the follow-the-link pair, so a symlink inside a bundle
has its own flags cleared and a link cannot reach outside the store.

Clearing is safe **here specifically** because the target is always a copy this
store made, never the user's own file. The system flags (`schg`) need root and
their presence is a genuine reason to stop — those still fail, but now they say
so in the log instead of being swallowed.

A restore is unaffected: it copies its own bundle out, flags and all.

### Verification

`aBackupHoldingALockedFileCanStillBeRemoved` goes through the real
`save` → `remove(forKey:)` path rather than deleting a fixture, so it fails if
the flag handling is ever dropped from the store's own path. Confirmed red
before green by commenting out the one `clearUserFlags` call.

```
DuoUpdaterCore  1022 tests / 81 suites passed
CLI              119 tests / 18 suites passed
localizable keys agree — 410 in the catalog, all reachable
```

Verified on the real store afterwards: the `.staging-` remnant that had
survived every previous sweep was removed.
