### PR TITLE
Keep the rollback backups on another disk

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -3117,6 +3117,47 @@
         }
       }
     },
+    "A different disk is mounted here": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hier ist eine andere Festplatte eingebunden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aquí hay montado otro disco"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un autre disque est monté ici"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のディスクがマウントされています"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Здесь подключён другой диск"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此处挂载的是另一块磁盘"
+          }
+        }
+      }
+    },
     "A few quick steps let Duo Updater keep your apps updated without interrupting you. You set these once — they persist across launches.": {
       "extractionState": "manual",
       "localizations": {
@@ -3789,43 +3830,43 @@
         }
       }
     },
-    "After updating a running app, restart it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Restart” button.\n\nBackups keep one previous version of each app under Application Support, so an update can be undone. Retention is one backup per app — the previous version is replaced, not accumulated.": {
+    "After updating a running app, restart it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Restart” button.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nach dem Update einer laufenden App wird sie für dich neu gestartet, damit die neue Version wirksam wird – ohne zweiten Klick. Die App wird ganz normal zum Beenden aufgefordert, sodass Hinweise auf ungesicherte Arbeit weiterhin erscheinen; alles, was sich nicht beenden lässt, behält einfach seine Schaltfläche „Neu starten“.\n\nBackups bewahren eine vorherige Version jeder App unter Application Support auf, sodass ein Update rückgängig gemacht werden kann. Es wird ein Backup pro App aufbewahrt – die vorherige Version wird ersetzt, nicht angesammelt."
+            "value": "Nach dem Update einer laufenden App wird sie für dich neu gestartet, damit die neue Version wirksam wird – ohne zweiten Klick. Die App wird normal zum Beenden aufgefordert, sodass Rückfragen zu ungesicherten Änderungen weiterhin erscheinen; was sich nicht beenden lässt, behält einfach seinen Knopf „Neu starten“."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tras actualizar una app en ejecución, se reinicia por ti para que la versión nueva surta efecto, sin un segundo clic. Se le pide a la app que se cierre con normalidad, así que los avisos de trabajo sin guardar siguen apareciendo, y cualquier app que no se cierre simplemente conserva su botón «Reiniciar».\n\nLas copias de seguridad conservan una versión anterior de cada app en Application Support, para poder deshacer una actualización. Se conserva una copia por app; la versión anterior se reemplaza, no se acumula."
+            "value": "Tras actualizar una app en ejecución, se reinicia por ti para que la nueva versión surta efecto, sin un segundo clic. Se le pide salir con normalidad, así que los avisos de trabajo sin guardar siguen apareciendo y lo que no pueda salir conserva su botón «Reiniciar»."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Après la mise à jour d'une application en cours d'exécution, elle est redémarrée pour vous afin que la nouvelle version prenne effet — sans second clic. Il est demandé à l'application de quitter normalement, donc les invites de travail non enregistré apparaissent toujours, et tout ce qui ne quitte pas conserve simplement son bouton « Redémarrer ».\n\nLes sauvegardes conservent une version précédente de chaque application sous Application Support, afin qu'une mise à jour puisse être annulée. La rétention est d'une sauvegarde par application — la version précédente est remplacée, pas accumulée."
+            "value": "Après la mise à jour d’une app en cours d’exécution, elle est redémarrée pour vous afin que la nouvelle version prenne effet — sans second clic. L’app reçoit une demande de fermeture normale, donc les alertes de travail non enregistré s’affichent toujours, et ce qui refuse de quitter conserve son bouton « Redémarrer »."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "実行中のアプリを更新した後、新しいバージョンを反映させるために自動的に再起動します — 追加のクリックは不要です。アプリには通常どおり終了が要求されるため、未保存の作業に関するプロンプトは引き続き表示され、終了しないものはその「再起動」ボタンを保持したままになります。\n\nバックアップは各アプリの直前のバージョンをApplication Support配下に1つ保持するため、更新を元に戻せます。保持数はアプリごとに1つで、直前のバージョンが置き換えられ、蓄積はされません。"
+            "value": "起動中の App を更新した後、新しいバージョンを有効にするために自動で再起動します（2 回目のクリックは不要）。App には通常の終了を要求するため、保存していない作業の確認は従来どおり表示され、終了しない App には「再起動」ボタンが残ります。"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "После обновления запущенного приложения оно перезапускается автоматически, чтобы новая версия вступила в силу — без второго клика. Приложению отправляется обычный запрос на закрытие, поэтому подсказки о несохранённой работе по-прежнему появляются, а всё, что не закрывается, просто сохраняет свою кнопку «Перезапустить».\n\nРезервные копии хранят одну предыдущую версию каждого приложения в Application Support, поэтому обновление можно отменить. Хранится одна копия на приложение — предыдущая версия заменяется, а не накапливается."
+            "value": "После обновления запущенной программы она перезапускается автоматически, чтобы новая версия вступила в силу, — без второго щелчка. Программе отправляется обычный запрос на завершение, поэтому запросы о несохранённой работе по-прежнему появляются, а то, что не закрывается, сохраняет кнопку «Перезапустить»."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "更新正在运行的应用后，会自动为你重启它，让新版本生效 — 无需再次点击。系统会正常请求该应用退出，因此未保存工作的提示仍会出现，任何拒绝退出的应用只会保留其“重启”按钮。\n\n备份会在“应用程序支持”中保留每个应用的一个先前版本，以便撤销更新。保留策略是每个应用一份备份 — 会替换先前版本，而不是不断累积。"
+            "value": "更新正在运行的 App 后自动为你重启它，让新版本生效——不用点第二次。App 会收到正常的退出请求，因此未保存内容的提示照常出现；拒绝退出的 App 会保留「重新启动」按钮。"
           }
         }
       }
@@ -4814,43 +4855,289 @@
         }
       }
     },
-    "Backups are using %@": {
+    "Backups": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Backups belegen %@"
+            "value": "Backups"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Las copias de seguridad usan %@"
+            "value": "Copias de seguridad"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Les sauvegardes utilisent %@"
+            "value": "Sauvegardes"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "バックアップの使用容量: %@"
+            "value": "バックアップ"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Резервные копии занимают %@"
+            "value": "Резервные копии"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "备份占用 %@"
+            "value": "备份"
+          }
+        }
+      }
+    },
+    "Backups are copied here in the background, after an update is installed, so nothing waits on the disk.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups werden nach der Installation eines Updates im Hintergrund hierher kopiert, sodass nichts auf die Festplatte wartet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias se copian aquí en segundo plano, después de instalar una actualización, así que nada espera al disco."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les sauvegardes sont copiées ici en arrière-plan, après l’installation d’une mise à jour, donc rien n’attend le disque."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップは更新のインストール後にバックグラウンドでここへコピーされるため、ディスクを待つ処理はありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копии переносятся сюда в фоне, уже после установки обновления, поэтому ничего не ждёт диск."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份在更新安装完成后于后台复制到这里，因此不会有任何操作等待磁盘。"
+          }
+        }
+      }
+    },
+    "Backups are copies of whole apps, so they are large. Keeping them on an external disk or a network share frees that space on this Mac without giving up the ability to undo an update.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups sind Kopien vollständiger Apps und entsprechend groß. Wenn du sie auf einer externen Festplatte oder einem Netzlaufwerk aufbewahrst, wird dieser Speicherplatz auf diesem Mac frei, ohne dass du auf das Rückgängigmachen von Updates verzichten musst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias son copias de apps completas, así que ocupan mucho. Guardarlas en un disco externo o en un recurso de red libera ese espacio en este Mac sin renunciar a poder deshacer una actualización."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les sauvegardes sont des copies d’apps entières, donc volumineuses. Les conserver sur un disque externe ou un partage réseau libère cet espace sur ce Mac sans renoncer à la possibilité d’annuler une mise à jour."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップは App 全体のコピーなので容量が大きくなります。外付けディスクやネットワーク共有に置けば、更新を取り消せる機能はそのままに、この Mac の容量を空けられます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Резервные копии — это копии программ целиком, поэтому они большие. Хранение их на внешнем диске или в сетевой папке освобождает это место на Mac, не лишая возможности отменить обновление."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份是整个 App 的完整副本，因此很占地方。把它们放到外接磁盘或网络共享上，可以在不放弃撤销更新能力的前提下腾出这台 Mac 的空间。"
+          }
+        }
+      }
+    },
+    "Backups are kept on this Mac": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups werden auf diesem Mac aufbewahrt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias se guardan en este Mac"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les sauvegardes sont conservées sur ce Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップはこの Mac に保存されます"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копии хранятся на этом Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份保存在这台 Mac 上"
+          }
+        }
+      }
+    },
+    "Backups keep one previous version of each app, so an update can be undone. Retention is one per app — the previous version is replaced, not accumulated.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups bewahren je App eine vorherige Version auf, sodass ein Update rückgängig gemacht werden kann. Aufbewahrt wird genau eine pro App – die vorherige Version wird ersetzt, nicht angesammelt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias conservan una versión anterior de cada app, de modo que una actualización pueda deshacerse. Se conserva una por app: la versión anterior se sustituye, no se acumula."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les sauvegardes conservent une version précédente de chaque app, afin qu’une mise à jour puisse être annulée. Une seule par app est conservée : la version précédente est remplacée, non accumulée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップは各 App の以前のバージョンを 1 つ保持し、更新を取り消せるようにします。保持数は App ごとに 1 つで、以前のバージョンは蓄積されず置き換えられます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Резервные копии хранят одну предыдущую версию каждой программы, чтобы обновление можно было отменить. Хранится по одной на программу: предыдущая версия заменяется, а не накапливается."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份为每个 App 保留一个此前的版本，以便撤销更新。每个 App 只留一份——旧版本会被替换，不会累积。"
+          }
+        }
+      }
+    },
+    "Backups on another disk are stored as a single compressed archive. That is what lets a disk formatted for Windows, or a network share, hold one at all — and it is usually less than half the size of the app.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups auf einer anderen Festplatte werden als einzelnes komprimiertes Archiv abgelegt. Genau dadurch kann eine für Windows formatierte Festplatte oder ein Netzlaufwerk überhaupt eines aufnehmen – und es ist meist weniger als halb so groß wie die App."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias en otro disco se guardan como un único archivo comprimido. Eso es lo que permite que un disco formateado para Windows, o un recurso de red, pueda alojarlas, y suele ocupar menos de la mitad que la app."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les sauvegardes sur un autre disque sont stockées sous forme d’une seule archive compressée. C’est ce qui permet à un disque formaté pour Windows, ou à un partage réseau, d’en contenir une — et elle fait généralement moins de la moitié de la taille de l’app."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のディスク上のバックアップは、単一の圧縮アーカイブとして保存されます。Windows 用にフォーマットされたディスクやネットワーク共有でも保存できるのはこのためで、サイズは通常 App の半分未満になります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копии на другом диске хранятся в виде одного сжатого архива. Именно поэтому их может принять диск, отформатированный для Windows, или сетевая папка, — и обычно архив занимает меньше половины размера программы."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存放在另一块磁盘上的备份是单个压缩归档。正因如此，为 Windows 格式化的磁盘或网络共享才能存得下它——而且通常不到 App 体积的一半。"
+          }
+        }
+      }
+    },
+    "Backups on “%@” aren’t available right now — showing only what’s on this Mac.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backups auf „%@“ sind derzeit nicht verfügbar — es wird nur gezeigt, was auf diesem Mac liegt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias en «%@» no están disponibles ahora mismo; solo se muestra lo que hay en este Mac."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les sauvegardes sur « %@ » sont indisponibles pour le moment ; seul ce qui se trouve sur ce Mac est affiché."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」のバックアップは現在利用できません。この Mac にあるものだけを表示しています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Резервные копии на «%@» сейчас недоступны — показано только то, что есть на этом Mac."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@”上的备份现在读不到 —— 只显示这台 Mac 上的。"
           }
         }
       }
@@ -5056,6 +5343,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "更新日志"
+          }
+        }
+      }
+    },
+    "Change…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ändern …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改…"
           }
         }
       }
@@ -5697,6 +6025,47 @@
         }
       }
     },
+    "Choose a folder on an external disk or a network share. Backups are kept inside it, and moving them there is what frees space on this Mac.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle einen Ordner auf einer externen Festplatte oder einem Netzlaufwerk. Die Backups werden darin aufbewahrt, und genau dieses Verschieben schafft Speicherplatz auf diesem Mac."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige una carpeta en un disco externo o en un recurso de red. Las copias se guardan dentro de ella, y es ese traslado lo que libera espacio en este Mac."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez un dossier sur un disque externe ou un partage réseau. Les sauvegardes y sont conservées, et c’est ce déplacement qui libère de l’espace sur ce Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外付けディスクまたはネットワーク共有上のフォルダを選んでください。バックアップはその中に保存され、そこへ移すことでこの Mac の容量が空きます。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите папку на внешнем диске или в сетевой папке. Копии хранятся внутри неё, и именно этот перенос освобождает место на этом Mac."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择外接磁盘或网络共享上的文件夹。备份会存放在其中，正是这次搬移才腾出这台 Mac 的空间。"
+          }
+        }
+      }
+    },
     "Choose a folder that contains apps to check for updates.": {
       "extractionState": "manual",
       "localizations": {
@@ -5861,6 +6230,47 @@
         }
       }
     },
+    "Compression": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komprimierung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compresión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compression"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圧縮"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сжатие"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "压缩"
+          }
+        }
+      }
+    },
     "Connected": {
       "extractionState": "manual",
       "localizations": {
@@ -5939,6 +6349,88 @@
           "stringUnit": {
             "state": "translated",
             "value": "仅当它是免费的，或你的许可证覆盖新版本时才继续。当前版本会被移到废纸篓，因此你可以还原它。"
+          }
+        }
+      }
+    },
+    "Copy Now": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jetzt kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar ahora"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier maintenant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐコピー"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать сейчас"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即复制"
+          }
+        }
+      }
+    },
+    "Copying %@…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wird kopiert …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiando %@…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copie de %@…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ をコピー中…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копирование %@…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在复制 %@…"
           }
         }
       }
@@ -7496,6 +7988,47 @@
         }
       }
     },
+    "Everything is on the backup disk": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles liegt auf der Backup-Festplatte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo está en el disco de copias"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout est sur le disque de sauvegarde"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてバックアップディスク上にあります"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё находится на диске для копий"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部已在备份磁盘上"
+          }
+        }
+      }
+    },
     "Everything is up to date": {
       "extractionState": "manual",
       "localizations": {
@@ -7615,6 +8148,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "失败"
+          }
+        }
+      }
+    },
+    "Faster": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schneller"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más rápida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus rapide"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高速"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Быстрее"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更快"
           }
         }
       }
@@ -9300,6 +9874,47 @@
         }
       }
     },
+    "Keep a copy of the previous version so an update can be undone — here or on another disk.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Kopie der vorherigen Version aufbewahren, damit ein Update rückgängig gemacht werden kann – hier oder auf einer anderen Festplatte."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guarda una copia de la versión anterior para poder deshacer una actualización, aquí o en otro disco."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conserver une copie de la version précédente pour pouvoir annuler une mise à jour — ici ou sur un autre disque."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新を取り消せるように、以前のバージョンのコピーを保持します（この Mac または別のディスク）。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранить копию предыдущей версии, чтобы обновление можно было отменить — здесь или на другом диске."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留上一个版本的副本，以便撤销更新——存在本机或另一块磁盘上。"
+          }
+        }
+      }
+    },
     "Last checked": {
       "extractionState": "manual",
       "localizations": {
@@ -10161,6 +10776,47 @@
         }
       }
     },
+    "Measured at about %@/s. Backups are copied here in the background, after an update is installed, so nothing waits on the disk.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemessen bei etwa %@/s. Backups werden nach der Installation eines Updates im Hintergrund hierher kopiert, sodass nichts auf die Festplatte wartet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medido en unos %@/s. Las copias se copian aquí en segundo plano, después de instalar una actualización, así que nada espera al disco."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mesuré à environ %@/s. Les sauvegardes sont copiées ici en arrière-plan, après l’installation d’une mise à jour, donc rien n’attend le disque."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実測で約 %@/秒。バックアップは更新のインストール後にバックグラウンドでここへコピーされるため、ディスクを待つ処理はありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Измерено около %@/с. Копии переносятся сюда в фоне, уже после установки обновления, поэтому ничего не ждёт диск."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实测约 %@/秒。备份在更新安装完成后于后台复制到这里，因此不会有任何操作等待磁盘。"
+          }
+        }
+      }
+    },
     "More": {
       "extractionState": "manual",
       "localizations": {
@@ -10198,6 +10854,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "较多"
+          }
+        }
+      }
+    },
+    "New backups stay on this Mac until the disk is back, then move on their own. If this Mac runs low on space while the disk is away, updates are installed without a rollback point rather than filling the startup disk.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neue Backups bleiben auf diesem Mac, bis die Festplatte wieder da ist, und wandern dann von selbst weiter. Wird der Speicherplatz auf diesem Mac knapp, während die Festplatte fehlt, werden Updates ohne Wiederherstellungspunkt installiert, statt das Startvolume zu füllen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las copias nuevas se quedan en este Mac hasta que vuelva el disco y luego se trasladan solas. Si a este Mac le queda poco espacio mientras el disco no está, las actualizaciones se instalan sin punto de reversión en lugar de llenar el disco de arranque."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les nouvelles sauvegardes restent sur ce Mac jusqu’au retour du disque, puis migrent d’elles-mêmes. Si l’espace vient à manquer sur ce Mac pendant l’absence du disque, les mises à jour sont installées sans point de restauration plutôt que de remplir le disque de démarrage."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいバックアップは、ディスクが戻るまでこの Mac に残り、その後は自動的に移動します。ディスクがない間にこの Mac の空き容量が少なくなった場合は、起動ディスクを埋めるのではなく、巻き戻しポイントなしで更新をインストールします。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новые копии остаются на этом Mac, пока диск не вернётся, а затем переносятся сами. Если места на этом Mac станет мало, пока диска нет, обновления будут устанавливаться без точки отката, вместо того чтобы заполнять загрузочный диск."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新的备份会先留在这台 Mac 上，等磁盘回来后自动搬走。如果磁盘不在期间本机空间告急，更新会在没有回滚点的情况下安装，而不是把启动磁盘塞满。"
           }
         }
       }
@@ -10612,6 +11309,47 @@
         }
       }
     },
+    "No rollback point: the backup disk isn’t connected and this Mac is low on space.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein Wiederherstellungspunkt: Die Backup-Festplatte ist nicht angeschlossen und auf diesem Mac ist wenig Speicherplatz frei."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin punto de reversión: el disco de copias no está conectado y a este Mac le queda poco espacio."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun point de restauration : le disque de sauvegarde n’est pas connecté et l’espace disponible sur ce Mac est faible."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "巻き戻しポイントはありません: バックアップディスクが接続されておらず、この Mac の空き容量も少なくなっています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Точки отката нет: диск для копий не подключён, а на этом Mac мало свободного места."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有回滚点：备份磁盘未连接，且这台 Mac 剩余空间不足。"
+          }
+        }
+      }
+    },
     "No skipped versions.": {
       "extractionState": "manual",
       "localizations": {
@@ -10946,6 +11684,47 @@
         }
       }
     },
+    "On another disk": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf einer anderen Festplatte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En otro disco"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sur un autre disque"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のディスク上"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На другом диске"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在另一块磁盘上"
+          }
+        }
+      }
+    },
     "On the %@ channel — its version can lead or differ from the stable release.": {
       "extractionState": "manual",
       "localizations": {
@@ -10983,6 +11762,129 @@
           "stringUnit": {
             "state": "translated",
             "value": "处于 %@ 渠道 — 其版本可能领先或不同于稳定版。"
+          }
+        }
+      }
+    },
+    "On the backup disk": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf der Backup-Festplatte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En el disco de copias"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sur le disque de sauvegarde"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップディスク上"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На диске для копий"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在备份磁盘上"
+          }
+        }
+      }
+    },
+    "On this Mac": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf diesem Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En este Mac"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sur ce Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac 上"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На этом Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在这台 Mac 上"
+          }
+        }
+      }
+    },
+    "On “%@”": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf „%@“"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En «%@»"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sur « %@ »"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」上"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На «%@»"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在「%@」上"
           }
         }
       }
@@ -13676,6 +14578,47 @@
         }
       }
     },
+    "Rollback points": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederherstellungspunkte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puntos de reversión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Points de restauration"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "巻き戻しポイント"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Точки отката"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回滚点"
+          }
+        }
+      }
+    },
     "Run Setup Again…": {
       "extractionState": "manual",
       "localizations": {
@@ -14912,6 +15855,47 @@
         }
       }
     },
+    "Smaller": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kleiner"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más pequeña"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus petite"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小容量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Меньше"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更小"
+          }
+        }
+      }
+    },
     "Some apps could not be checked — see above.": {
       "extractionState": "manual",
       "localizations": {
@@ -15170,6 +16154,47 @@
         }
       }
     },
+    "Storage": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherplatz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stockage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранилище"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储占用"
+          }
+        }
+      }
+    },
     "Switch between side-by-side and long-scroll layouts": {
       "extractionState": "manual",
       "localizations": {
@@ -15330,6 +16355,129 @@
           "stringUnit": {
             "state": "translated",
             "value": "该文件夹已被覆盖。"
+          }
+        }
+      }
+    },
+    "That folder wasn’t used: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Ordner wurde nicht verwendet: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esa carpeta no se ha usado: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce dossier n’a pas été utilisé : %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダは使用されませんでした: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта папка не была использована: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该文件夹未被使用：%@"
+          }
+        }
+      }
+    },
+    "The backup disk isn’t connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Backup-Festplatte ist nicht angeschlossen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El disco de copias no está conectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le disque de sauvegarde n’est pas connecté"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップディスクが接続されていません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Диск для резервных копий не подключён"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份磁盘未连接"
+          }
+        }
+      }
+    },
+    "The disk mounted at this path isn’t the one the backups were set up on. Nothing has been written to it. Reconnect the original disk, or choose this one to start using it instead.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die unter diesem Pfad eingebundene Festplatte ist nicht die, auf der die Backups eingerichtet wurden. Es wurde nichts darauf geschrieben. Schließe die ursprüngliche Festplatte wieder an oder wähle diese aus, um künftig sie zu verwenden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El disco montado en esta ruta no es aquel en el que se configuraron las copias. No se ha escrito nada en él. Vuelve a conectar el disco original o elige este para empezar a usarlo en su lugar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le disque monté à cet emplacement n’est pas celui sur lequel les sauvegardes ont été configurées. Rien n’y a été écrit. Reconnectez le disque d’origine, ou choisissez celui-ci pour l’utiliser à la place."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このパスにマウントされているディスクは、バックアップを設定したディスクではありません。何も書き込まれていません。元のディスクを接続し直すか、こちらを選んで今後はこのディスクを使ってください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Диск, подключённый по этому пути, — не тот, на котором настраивались копии. На него ничего не записано. Подключите исходный диск или выберите этот, чтобы использовать его вместо прежнего."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "挂载在此路径的磁盘不是当初设置备份的那一块。我们没有往它上面写入任何内容。请重新接上原来的磁盘，或者选择这一块以改用它。"
           }
         }
       }
@@ -15658,6 +16806,170 @@
           "stringUnit": {
             "state": "translated",
             "value": "此应用会报告版本，但没有确切的发布时间，因此没有习惯热力图 — 仅有下方的估计区间。"
+          }
+        }
+      }
+    },
+    "This disk’s format caps a single file at %@, so a very large app may not fit. Reformatting it as APFS or Mac OS Extended removes that limit.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Format dieser Festplatte begrenzt eine einzelne Datei auf %@, sodass eine sehr große App möglicherweise nicht hineinpasst. Ein Neuformatieren als APFS oder Mac OS Extended hebt diese Grenze auf."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El formato de este disco limita cada archivo a %@, así que una app muy grande puede no caber. Reformatearlo como APFS o Mac OS Plus elimina ese límite."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le format de ce disque limite un fichier à %@, si bien qu’une app très volumineuse risque de ne pas tenir. Le reformater en APFS ou Mac OS étendu supprime cette limite."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このディスクのフォーマットは 1 ファイルあたり %@ が上限のため、非常に大きな App は収まらないことがあります。APFS または Mac OS 拡張でフォーマットし直すと、この制限はなくなります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Формат этого диска ограничивает размер одного файла значением %@, поэтому очень большая программа может не поместиться. Переформатирование в APFS или Mac OS Extended снимает это ограничение."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这块磁盘的格式把单个文件限制在 %@，因此非常大的 App 可能放不下。重新格式化为 APFS 或 Mac OS 扩展可解除该限制。"
+          }
+        }
+      }
+    },
+    "This folder can’t be written to": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In diesen Ordner kann nicht geschrieben werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede escribir en esta carpeta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d’écrire dans ce dossier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダには書き込めません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В эту папку нельзя записывать"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法写入此文件夹"
+          }
+        }
+      }
+    },
+    "This folder is on the same disk as this Mac, so it frees no space. Backups there are only stored compressed, at roughly half the size. To move them off this Mac, choose a folder on an external disk or a network share.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Ordner liegt auf derselben Festplatte wie dieser Mac und schafft daher keinen Speicherplatz. Backups werden dort lediglich komprimiert abgelegt, mit etwa halber Größe. Wähle einen Ordner auf einer externen Festplatte oder einem Netzlaufwerk, um sie von diesem Mac wegzubewegen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta carpeta está en el mismo disco que este Mac, así que no libera espacio. Allí las copias solo se guardan comprimidas, con aproximadamente la mitad del tamaño. Para sacarlas de este Mac, elige una carpeta en un disco externo o en un recurso de red."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce dossier se trouve sur le même disque que ce Mac : il ne libère donc aucun espace. Les sauvegardes y sont seulement stockées compressées, pour environ la moitié de la taille. Pour les sortir de ce Mac, choisissez un dossier sur un disque externe ou un partage réseau."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダはこの Mac と同じディスク上にあるため、容量は空きません。そこではバックアップが圧縮して保存されるだけで、サイズはおよそ半分になります。この Mac の外へ移すには、外付けディスクまたはネットワーク共有上のフォルダを選んでください。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта папка находится на том же диске, что и сам Mac, поэтому места она не освобождает. Копии там лишь хранятся в сжатом виде, примерно вдвое меньшего размера. Чтобы вынести их за пределы этого Mac, выберите папку на внешнем диске или в сетевой папке."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此文件夹和这台 Mac 在同一块磁盘上，因此不会腾出任何空间。备份在那里只是被压缩存放，体积约为一半。要把它们移出这台 Mac，请选择外接磁盘或网络共享上的文件夹。"
+          }
+        }
+      }
+    },
+    "This folder is on this Mac’s disk": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Ordner liegt auf der Festplatte dieses Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta carpeta está en el disco de este Mac"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce dossier se trouve sur le disque de ce Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダはこの Mac のディスク上にあります"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта папка находится на диске этого Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此文件夹位于这台 Mac 的磁盘上"
           }
         }
       }
@@ -16939,6 +18251,47 @@
         }
       }
     },
+    "Use This Folder": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diesen Ordner verwenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar esta carpeta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser ce dossier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダを使用"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использовать эту папку"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用此文件夹"
+          }
+        }
+      }
+    },
     "Valid — belongs to **%@**": {
       "extractionState": "manual",
       "localizations": {
@@ -17144,6 +18497,47 @@
         }
       }
     },
+    "Waiting to be copied: %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warten auf Kopieren: %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendientes de copiar: %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente de copie : %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー待ち: %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидают копирования: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待复制：%lld"
+          }
+        }
+      }
+    },
     "Welcome to Duo Updater": {
       "extractionState": "manual",
       "localizations": {
@@ -17304,6 +18698,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "Duo Updater 在哪里查找已安装的应用。"
+          }
+        }
+      }
+    },
+    "Where backups are kept": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherort der Backups"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dónde se guardan las copias"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacement des sauvegardes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップの保存先"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Где хранятся копии"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份存放位置"
           }
         }
       }
@@ -17513,6 +18948,47 @@
         }
       }
     },
+    "backup, rollback, roll back, undo, restore, previous version, external disk, drive, nas, archive, storage, space": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "backup, sicherung, wiederherstellen, zurücksetzen, rückgängig, vorherige version, externe festplatte, laufwerk, nas, archiv, speicherplatz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "copia de seguridad, respaldo, revertir, deshacer, restaurar, versión anterior, disco externo, unidad, nas, archivo, almacenamiento, espacio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sauvegarde, restauration, revenir, annuler, version précédente, disque externe, lecteur, nas, archive, stockage, espace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップ, 巻き戻し, 復元, 取り消し, 以前のバージョン, 外付けディスク, ドライブ, nas, アーカイブ, ストレージ, 空き容量"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "резервная копия, откат, откатить, отменить, восстановить, предыдущая версия, внешний диск, накопитель, nas, архив, хранилище, место"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份, 回滚, 撤销, 还原, 恢复, 上一版本, 外接磁盘, 硬盘, 移动硬盘, nas, 归档, 存储, 空间"
+          }
+        }
+      }
+    },
     "create a personal access token": {
       "extractionState": "manual",
       "localizations": {
@@ -17718,43 +19194,43 @@
         }
       }
     },
-    "launch, login, frequency, notify, restart, backup, rollback, concurrency, app store, self-updating, vendor": {
+    "launch, login, frequency, notify, restart, concurrency, app store, self-updating, vendor": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start, Anmeldung, Häufigkeit, Benachrichtigung, Neustart, Backup, Zurücksetzen, Parallelität, App Store, Selbstaktualisierung, Anbieter"
+            "value": "starten, anmeldung, häufigkeit, intervall, benachrichtigung, neustart, parallel, app store, selbstaktualisierend, hersteller"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "inicio, sesión, frecuencia, notificar, reiniciar, copia de seguridad, revertir, concurrencia, App Store, autoactualización, proveedor"
+            "value": "inicio, sesión, frecuencia, intervalo, notificación, reinicio, simultáneo, app store, autoactualizable, fabricante"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "démarrage, connexion, fréquence, notification, redémarrer, sauvegarde, restauration, simultanéité, App Store, mise à jour automatique, éditeur"
+            "value": "démarrage, connexion, fréquence, intervalle, notification, redémarrage, simultané, app store, auto-mise à jour, éditeur"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "起動, ログイン, 頻度, 通知, 再起動, バックアップ, ロールバック, 同時実行, App Store, 自動更新, 提供元"
+            "value": "起動, ログイン, 頻度, 間隔, 通知, 再起動, 同時実行, app store, 自動更新, ベンダー"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "запуск, вход, частота, уведомления, перезапуск, резервная копия, откат, параллельность, App Store, самообновление, разработчик"
+            "value": "запуск, вход, частота, интервал, уведомление, перезапуск, параллельно, app store, самообновление, поставщик"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "启动, 登录, 频率, 通知, 重启, 备份, 回滚, 并发, App Store, 自更新, 厂商"
+            "value": "启动, 登录, 频率, 间隔, 通知, 重启, 并发, app store, 自更新, 厂商"
           }
         }
       }
@@ -18669,6 +20145,88 @@
           "stringUnit": {
             "state": "translated",
             "value": "· 不可用，记录缺失"
+          }
+        }
+      }
+    },
+    "“%@” is connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„%@“ ist angeschlossen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«%@» está conectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "« %@ » est connecté"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」が接続されています"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«%@» подключён"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」已连接"
+          }
+        }
+      }
+    },
+    "“%@” isn’t connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„%@“ ist nicht angeschlossen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«%@» no está conectado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "« %@ » n’est pas connecté"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」が接続されていません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«%@» не подключён"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」未连接"
           }
         }
       }

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -339,6 +339,16 @@ final class AppListModel {
     /// result.id → the version we have a rollback backup for, refreshed from the
     /// on-disk backup store whenever the list changes.
     private(set) var backupVersions: [String: String] = [:]
+    /// The name of the backup disk we are configured for but cannot see right now,
+    /// or nil when the store is fully readable.
+    ///
+    /// Exists because an unreachable disk degrades the read paths to "show what is
+    /// on this Mac" — the right behaviour, but indistinguishable on screen from
+    /// having no backups. A user who moved fifty rollback points to a stick and
+    /// then unplugged it sees the Rollback section shrink to whatever was taken
+    /// since, with nothing saying why. Naming the disk turns a vanished list into
+    /// a plugged-out cable.
+    private(set) var offlineBackupDisk: String?
     /// Bundle *paths* of apps with at least one live process right now. Kept current
     /// by `NSWorkspace`'s launch/terminate notifications, so a row's running dot
     /// lights up/clears the moment the user opens or quits the app — no refresh
@@ -1482,6 +1492,16 @@ final class AppListModel {
         if prefs.pruneOrphanBackups {
             await Task.detached(priority: .utility) { BackupStore.pruneOrphans() }.value
         }
+        // Not behind `pruneOrphanBackups`, deliberately. That setting governs
+        // retention — whether a backup whose app is gone is still worth keeping —
+        // and this removes things that are not backups at all: a `.staging-` dir
+        // from a save that was cut off, and key directories with no sidecar,
+        // which no read path can see and no other cleanup would ever touch. There
+        // is no rollback point to lose here, only bytes nobody can spend.
+        let inFlight = await BackupTransferQueue.shared.protectedKeys
+        await Task.detached(priority: .utility) {
+            BackupStore.sweepStaleScratch(excluding: inFlight)
+        }.value
         await refreshBackupIndex()
         isChecking = false
         recordCheckOutcomes(checked)
@@ -3871,7 +3891,31 @@ final class AppListModel {
     /// so the update can be undone. Best-effort: a failed backup logs and proceeds
     /// (the user opted into the update; a missing safety net mustn't block it).
     private func backupCurrent(_ result: UpdateResult, route: InstallCoordinator.Route) async {
+        // With the store pointed at a disk that is not here, a backup still gets
+        // taken — it just waits locally for the disk to come back. That is the
+        // agreed degradation, and it is the right one until the boot volume is
+        // the thing under pressure, which is usually the very reason the store
+        // was moved. Past that point the honest answer is to skip, and say so.
+        let diskIsHere: Bool
+        if case .ready = BackupStore.availability() { diskIsHere = true } else { diskIsHere = false }
+        if prefs.backupDestination.kind == .external, !diskIsHere, isBootVolumeTight {
+            Log.install.notice(
+                "backup skipped: \(result.app.name, privacy: .public) — backup disk away and this Mac is low on space")
+            installNotes[result.id] = String(
+                localized: "No rollback point: the backup disk isn’t connected and this Mac is low on space.")
+            return
+        }
+
         let outcome = await InstallCoordinator.backUp(result.app, route: route)
+        // Anything that landed is owed to the disk. Draining reads what is owed
+        // from the sidecars rather than from this call, so a backup taken while
+        // the disk was away is picked up here too.
+        if outcome != .failed, prefs.backupDestination.kind == .external {
+            Task.detached(priority: .utility) {
+                await BackupTransferQueue.shared.resumePending()
+                await BackupTransferQueue.shared.drain()
+            }
+        }
         if case .savedWithoutRuntimeState(let omitted) = outcome {
             Log.install.notice("backup: \(result.app.name, privacy: .public) stored without \(omitted, privacy: .public) runtime file(s)")
         }
@@ -3893,6 +3937,84 @@ final class AppListModel {
     /// auto-prune preference, and refreshes the on-screen backup index so any
     /// rollback affordance that pointed at a just-removed orphan disappears.
     /// Returns the bytes freed, for the confirmation the button shows.
+    /// Free space on the boot volume below which we stop adding to the local
+    /// outbox. A backup that fills the startup disk is not a safety net.
+    private static let bootVolumeFloorBytes: Int64 = 10 << 30
+
+    private var isBootVolumeTight: Bool {
+        let free = (try? URL(fileURLWithPath: NSHomeDirectory())
+            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]))?
+            .volumeAvailableCapacityForImportantUsage
+        guard let free else { return false }
+        return free < Self.bootVolumeFloorBytes
+    }
+
+    // MARK: - Backup destination
+
+    /// Whether the configured backup disk can be written to right now.
+    func backupAvailability() -> BackupStore.Availability { BackupStore.availability() }
+
+    /// Sizes of the two stores, for the Settings page. Walks both, so off-main.
+    func backupStoreSizes() async -> (outbox: Int64, destination: Int64) {
+        await Task.detached(priority: .utility) { BackupStore.storeSizes() }.value
+    }
+
+    /// How many backups are still waiting to move.
+    func pendingBackupTransfers() async -> Int {
+        await Task.detached(priority: .utility) { BackupStore.pendingTransferKeys().count }.value
+    }
+
+    /// Adopt `url` as the backup disk: probe it, mark it, persist it, and start
+    /// moving anything already owed. Throws so the page can show why a folder
+    /// was refused rather than silently doing nothing.
+    func useBackupDisk(at url: URL) async throws -> BackupDestinationProbe.Report {
+        let (destination, report) = try await Task.detached(priority: .userInitiated) {
+            try BackupDestinationProbe.adopt(directory: url)
+        }.value
+        prefs.backupDestination = destination
+        await syncBackupsNow()
+        await refreshBackupIndex()
+        return report
+    }
+
+    /// Switch back to a disk already adopted once. No probe and no marker write:
+    /// it was verified when it was chosen, and re-verifying would mean failing
+    /// here for a disk that is merely unplugged — which is a state this feature
+    /// is built to sit in, not an error.
+    func useBackupDisk(_ destination: BackupDestination) async {
+        prefs.backupDestination = destination
+        await syncBackupsNow()
+        await refreshBackupIndex()
+    }
+
+    /// Go back to keeping backups on this Mac. Copies already on the disk are
+    /// left where they are — they are still perfectly good rollback points, and
+    /// deleting someone's backups because they changed a setting would be its own
+    /// kind of wrong.
+    func useLocalBackups() async {
+        prefs.backupDestination = .local
+        await refreshBackupIndex()
+    }
+
+    /// What the transfer queue is doing right now, for a progress line.
+    func backupTransferState() async -> BackupTransferQueue.State {
+        await BackupTransferQueue.shared.state
+    }
+
+    /// Move everything that is owed, now. Also the launch path, which is why it
+    /// sweeps: a run that was killed mid-transfer left its scratch behind, and
+    /// the next launch is the first moment anything can be sure that work is not
+    /// still going on somewhere.
+    func syncBackupsNow() async {
+        let inFlight = await BackupTransferQueue.shared.protectedKeys
+        await Task.detached(priority: .utility) {
+            BackupStore.sweepStaleScratch(excluding: inFlight)
+        }.value
+        await BackupTransferQueue.shared.resumePending()
+        await BackupTransferQueue.shared.drain()
+        await refreshBackupIndex()
+    }
+
     /// Every stored backup, measured, for the delete sheet. Off the main actor:
     /// sizing walks each bundle.
     func backupListing() async -> [BackupStore.Listing] {
@@ -3913,7 +4035,14 @@ final class AppListModel {
     /// Re-read which apps have a rollback backup on disk (one directory scan),
     /// mapping it onto the current rows.
     func refreshBackupIndex() async {
-        let map = await Task.detached(priority: .utility) { BackupStore.allBackups() }.value
+        let scan = await Task.detached(priority: .utility) {
+            // Both in the same hop off the main actor: they read the same two
+            // directories, and asking separately would let the list and the
+            // "disk isn't there" note disagree about a disk unplugged between them.
+            (map: BackupStore.allBackups(), state: BackupStore.availability())
+        }.value
+        let map = scan.map
+        offlineBackupDisk = scan.state.unreachableDiskName
         var byID: [String: String] = [:]
         for result in results {
             for key in BackupStore.keyCandidates(

--- a/App/Sources/BackupVolumeWatcher.swift
+++ b/App/Sources/BackupVolumeWatcher.swift
@@ -1,0 +1,106 @@
+import AppKit
+import DuoUpdaterCore
+import Foundation
+
+/// Starts moving backups when the backup disk appears, and stops when it is
+/// about to go away.
+///
+/// The queue can already recover on its own — an interrupted transfer leaves the
+/// local copy untouched, and the next drain redoes it — so nothing here is
+/// load-bearing for correctness. What it buys is timing: without it, a disk
+/// plugged in at lunchtime would sit idle until the next update happened to
+/// trigger a drain, and a transfer running when the user reaches for Eject would
+/// hold the volume busy long enough to be told the disk is in use.
+///
+/// Lives in the app rather than the core package because `NSWorkspace`'s mount
+/// notifications are AppKit, and `duo` is a short-lived process that transfers
+/// synchronously and has nothing to watch for.
+@MainActor
+final class BackupVolumeWatcher {
+
+    private var observers: [NSObjectProtocol] = []
+
+    func start() {
+        guard observers.isEmpty else { return }
+        let center = NSWorkspace.shared.notificationCenter
+
+        observers.append(center.addObserver(
+            forName: NSWorkspace.didMountNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.diskAppeared()
+        })
+
+        // `willUnmount`, not `didUnmount`: the point is to stop before the volume
+        // goes, so the copy is not the reason the eject fails. It is best effort —
+        // the notification may not arrive early enough to interrupt a write in
+        // progress — which is why the recovery path does not depend on it.
+        observers.append(center.addObserver(
+            forName: NSWorkspace.willUnmountNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.diskLeaving()
+        })
+
+        observers.append(center.addObserver(
+            forName: NSWorkspace.willSleepNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.diskLeaving()
+        })
+
+        observers.append(center.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.diskAppeared()
+        })
+
+        // Quitting must take the archive subprocess down with us. `aa` is a
+        // child process and macOS does not reap it on our exit, so an orphan
+        // would keep writing, finish, and rename a complete archive into place
+        // that no sidecar records — bytes no read path can see. Nothing is lost
+        // by stopping mid-archive: the local copy is only removed once the
+        // destination copy is complete, so the work is simply owed again.
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification, object: nil, queue: .main
+        ) { _ in
+            BundleArchive.terminateInFlight()
+        })
+    }
+
+    func stop() {
+        let center = NSWorkspace.shared.notificationCenter
+        for observer in observers {
+            center.removeObserver(observer)
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observers.removeAll()
+    }
+
+    // No `deinit` unregistering: the observers are main-actor state and `deinit`
+    // is not isolated, so it cannot reach them. That is fine here rather than
+    // merely tolerable — this watcher is created once, at launch, and lives as
+    // long as the app does, so there is no moment where it is deallocated with
+    // observers still attached. `stop()` exists for a caller that wants to.
+
+    /// Any volume appearing is enough of a hint to look — the notification does
+    /// not say which disk we care about, and asking the store is cheap next to
+    /// getting this wrong.
+    private func diskAppeared() {
+        Task.detached(priority: .utility) {
+            guard case .ready = BackupStore.availability() else { return }
+            // Sweep before draining, not after: a disk that has just come back is
+            // the one place an interrupted transfer's leftovers are — a `.partial`
+            // the yank cut off, or a key directory whose archive landed but whose
+            // sidecar never did. Clearing them first means the drain is not
+            // writing beside dead bytes it will then have to work around.
+            let inFlight = await BackupTransferQueue.shared.protectedKeys
+            BackupStore.sweepStaleScratch(excluding: inFlight)
+            await BackupTransferQueue.shared.resumePending()
+            await BackupTransferQueue.shared.drain()
+        }
+    }
+
+    private func diskLeaving() {
+        Task.detached(priority: .utility) {
+            await BackupTransferQueue.shared.suspend()
+        }
+    }
+}

--- a/App/Sources/DuoUpdaterApp.swift
+++ b/App/Sources/DuoUpdaterApp.swift
@@ -90,6 +90,9 @@ struct DuoUpdaterApp: App {
 /// gets: the label View renders as soon as the status item appears (before any popover
 /// opens), so its `.task` is where we trigger first-run onboarding.
 private struct MenuBarLabel: View {
+    /// Held here so the notification observers outlive the `.task` that starts them.
+    @State private var backupVolumeWatcher = BackupVolumeWatcher()
+
     @Bindable var model: AppListModel
     @Environment(\.openWindow) private var openWindow
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
@@ -112,6 +115,14 @@ private struct MenuBarLabel: View {
             // badge, and `sync` checks the policy this sets.
             DockIcon.apply(hidden: model.prefs.hideDockIcon)
             AppDockBadge.syncSoon(count: model.badgeCount)
+            // Start moving backups when the backup disk shows up, and get out of
+            // the way when it is about to leave. Also drains anything a previous
+            // run left owed — the common case being backups taken while the disk
+            // was elsewhere.
+            backupVolumeWatcher.start()
+            if model.prefs.backupDestination.kind == .external {
+                Task { await model.syncBackupsNow() }
+            }
             if let front = SilentSelfUpdateRelaunch.consume() { handTheFrontBack(to: front) }
             // What "a safe moment to replace ourselves" means, for the silent
             // self-update path.

--- a/App/Sources/Preferences.swift
+++ b/App/Sources/Preferences.swift
@@ -75,6 +75,7 @@ final class Preferences {
         static let maxConcurrency = "MaxConcurrency"
         static let keepBackups = "KeepBackups"
         static let pruneOrphanBackups = "PruneOrphanBackups"
+        static let backupCompression = UpdateSettings.backupCompressionKey
         static let notifyOnUpdates = "NotifyOnUpdates"
         static let autoRestartAfterUpdate = "AutoRestartAfterUpdate"
         static let hideDockIcon = "HideDockIcon"
@@ -177,6 +178,34 @@ final class Preferences {
     /// left behind by an uninstall or move are the only unbounded growth.
     var pruneOrphanBackups: Bool {
         didSet { defaults.set(pruneOrphanBackups, forKey: Key.pruneOrphanBackups) }
+    }
+
+    /// Where backups are kept. `.local` means the boot volume, as it always has.
+    ///
+    /// Setting this reconfigures the store immediately rather than at the next
+    /// launch: the alternative is a window where the settings window says one
+    /// thing and the next install does another.
+    var backupDestination: BackupDestination {
+        didSet {
+            backupDestination.save(into: defaults)
+            BackupStore.configure(backupDestination)
+        }
+    }
+
+    /// The disk last chosen, even while backups are being kept on this Mac.
+    /// Lets the switch go back on without a second trip through a file picker.
+    var rememberedBackupDisk: BackupDestination? {
+        BackupDestination.remembered(from: defaults)
+    }
+
+    /// How hard to compress a backup on its way to the external disk.
+    ///
+    /// Measured on an 802 MB Electron bundle: `.fast` (lzfse) took 1.8 s for
+    /// 330 MB, `.smallest` (lzma) 22 s for 242 MB. Fast is the default because
+    /// twelve times the CPU for a further 27% is a trade only worth making
+    /// deliberately, on a small or slow disk.
+    var backupCompression: BundleArchive.Compression {
+        didSet { defaults.set(backupCompression.rawValue, forKey: Key.backupCompression) }
     }
 
     /// Post a notification when a background check finds updates.
@@ -363,6 +392,10 @@ final class Preferences {
         // Default ON for these — all opt-out conveniences.
         self.keepBackups = defaults.object(forKey: Key.keepBackups) as? Bool ?? true
         self.pruneOrphanBackups = defaults.object(forKey: Key.pruneOrphanBackups) as? Bool ?? true
+        self.backupDestination = BackupDestination.load(from: defaults)
+        self.backupCompression = BundleArchive.Compression(
+            rawValue: defaults.string(forKey: Key.backupCompression) ?? "")
+            ?? UpdateSettings.backupCompressionDefault
         self.notifyOnUpdates = defaults.object(forKey: Key.notifyOnUpdates) as? Bool ?? true
         self.autoRestartAfterUpdate = defaults.object(forKey: Key.autoRestartAfterUpdate) as? Bool ?? true
         self.hideDockIcon = defaults.object(forKey: Key.hideDockIcon) as? Bool ?? true
@@ -391,6 +424,10 @@ final class Preferences {
         // package — the launch path is precisely the one that has no environment
         // and no `gh` to fall back on.
         ChangelogService.setExplicitGitHubToken(self.githubToken)
+        // Same reason as the line above: `didSet` does not fire inside `init`,
+        // so without this the store would stay pointed at the boot volume for
+        // the whole session no matter what the user configured.
+        BackupStore.configure(self.backupDestination)
     }
 
     // MARK: - Cross-process changes

--- a/App/Sources/Settings/BackupsSettingsPage.swift
+++ b/App/Sources/Settings/BackupsSettingsPage.swift
@@ -1,0 +1,382 @@
+import AppKit
+import DuoUpdaterCore
+import SwiftUI
+
+/// Rollback points: whether to keep them, where they live, and what they cost.
+///
+/// Split out of General once "where" became a real question. A backup is a full
+/// second copy of an app, so on a machine that is short of space the usual
+/// response is to turn the safety net off — and pointing the store at an
+/// external disk is the way to keep both.
+struct BackupsSettingsPage: View {
+    @Bindable var prefs: Preferences
+    let model: AppListModel
+
+    @State private var outboxBytes: Int64?
+    @State private var destinationBytes: Int64?
+    @State private var pendingCount = 0
+    @State private var transferState: BackupTransferQueue.State = .idle
+    @State private var availability: BackupStore.Availability = .localOnly(BackupStore.outboxRoot)
+    @State private var lastReport: BackupDestinationProbe.Report?
+    @State private var pickError: String?
+    @State private var isWorking = false
+    /// True when the chosen folder lives on the same volume as the local
+    /// store, which makes every word of the "another disk" promise untrue.
+    @State private var isOnThisMacsDisk = false
+
+    @State private var showingBackups = false
+    @State private var backupListing: [BackupStore.Listing] = []
+    @State private var isCleaningBackups = false
+
+    var body: some View {
+        SettingsPage(section: .backups) {
+            rollbackCard
+            locationCard
+            storageCard
+        }
+        .task {
+            await refresh()
+            // The page would otherwise show whatever was true when it opened: a
+            // transfer finishing in the background is exactly the thing someone
+            // has this page open to watch, and it reported "Zero KB" for a
+            // backup that had already landed. Sizes walk both stores, so they
+            // are re-read only when the amount of owed work actually changes.
+            var tick = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                // Two cadences on purpose. The queue's state lives in memory and
+                // is free to read, so the progress line stays live; counting what
+                // is owed reads a sidecar per backup and re-measuring sizes walks
+                // both stores, so those happen half as often and only when the
+                // amount of owed work has actually moved.
+                transferState = await model.backupTransferState()
+                tick += 1
+                if tick % 2 == 0 {
+                    let owed = await model.pendingBackupTransfers()
+                    if owed != pendingCount { await refresh() }
+                }
+            }
+        }
+        .sheet(isPresented: $showingBackups) {
+            BackupsSheet(backups: backupListing) { keys in
+                Task {
+                    await model.deleteBackups(keys: keys)
+                    await refresh()
+                }
+            }
+        }
+    }
+
+    // MARK: - Cards
+
+    private var rollbackCard: some View {
+        SettingsCard(
+            header: "Rollback points",
+            footer: "Backups keep one previous version of each app, so an update can be undone. Retention is one per app — the previous version is replaced, not accumulated."
+        ) {
+            Toggle("Keep a backup so updates can be rolled back", isOn: $prefs.keepBackups)
+                .settingsRow()
+            SettingsDivider()
+            Toggle("Delete a backup once its app is uninstalled", isOn: $prefs.pruneOrphanBackups)
+                .settingsRow()
+        }
+    }
+
+    private var locationCard: some View {
+        SettingsCard(header: "Where backups are kept") {
+            Picker("Where backups are kept", selection: locationBinding) {
+                Text("On this Mac").tag(false)
+                Text("On another disk").tag(true)
+            }
+            .pickerStyle(.radioGroup)
+            .labelsHidden()
+            .settingsRow()
+
+            if prefs.backupDestination.kind == .external {
+                SettingsDivider()
+                diskRow.settingsRow()
+            }
+        } footer: {
+            if let pickError {
+                // Named as the folder that was *rejected*, because the row above
+                // still shows the destination in use — without this the warning
+                // reads as being about that one.
+                Label(pickError, systemImage: "exclamationmark.triangle")
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if prefs.backupDestination.kind == .external {
+                Text(destinationFooter)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("Backups are copies of whole apps, so they are large. Keeping them on an external disk or a network share frees that space on this Mac without giving up the ability to undo an update.")
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var diskRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: statusIcon)
+                .foregroundStyle(statusTint)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(statusTitle)
+                if let path = prefs.backupDestination.path {
+                    Text(path)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                }
+            }
+            Spacer(minLength: 12)
+            Button("Change…") { chooseDisk() }
+                .controlSize(.small)
+                .disabled(isWorking)
+        }
+    }
+
+    private var storageCard: some View {
+        SettingsCard(header: "Storage") {
+            HStack {
+                Text("On this Mac")
+                Spacer()
+                Text(format(outboxBytes)).foregroundStyle(.secondary)
+            }
+            .settingsRow()
+
+            if prefs.backupDestination.kind == .external {
+                SettingsDivider()
+                HStack {
+                    Text(prefs.backupDestination.volumeName.map { "On “\($0)”" } ?? "On the backup disk")
+                    Spacer()
+                    Text(format(destinationBytes)).foregroundStyle(.secondary)
+                }
+                .settingsRow()
+
+                if case .copying(let name, let completed, let total) = transferState {
+                    SettingsDivider()
+                    // A bare count reads as stalled on a slow disk — a single
+                    // large app can hold the number still for a minute. Naming
+                    // what is moving, and how far along the run is, is the
+                    // difference between "working" and "stuck".
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text("Copying \(name)…")
+                            Spacer()
+                            Text("\(completed + 1)/\(max(total, completed + 1))")
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                        ProgressView(
+                            value: Double(completed),
+                            total: Double(max(total, completed + 1)))
+                    }
+                    .settingsRow()
+                } else if pendingCount > 0 {
+                    SettingsDivider()
+                    HStack {
+                        // Colon form rather than "%lld backups waiting": it needs no
+                        // plural agreement in any language, which keeps this out of
+                        // four-way Russian plural variations for a settings row.
+                        Text("Waiting to be copied: \(pendingCount)")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Copy Now") { Task { await work { await model.syncBackupsNow() } } }
+                            .controlSize(.small)
+                            .disabled(isWorking)
+                    }
+                    .settingsRow()
+                } else if case .ready = availability {
+                    SettingsDivider()
+                    // Say "finished" rather than letting the row disappear. A
+                    // control that vanishes when its work is done reads the same
+                    // as one that broke: there is nothing left to tell you
+                    // whether everything moved or the feature stopped trying.
+                    Label("Everything is on the backup disk", systemImage: "checkmark.circle")
+                        .foregroundStyle(.secondary)
+                        .settingsRow()
+                }
+            }
+
+            SettingsDivider()
+            AdaptiveCompressionRow(selection: $prefs.backupCompression)
+                .settingsRow()
+
+            SettingsDivider()
+            HStack {
+                Spacer()
+                Button("Clean Up…") {
+                    guard !isCleaningBackups else { return }
+                    isCleaningBackups = true
+                    Task {
+                        backupListing = await model.backupListing()
+                        isCleaningBackups = false
+                        showingBackups = !backupListing.isEmpty
+                    }
+                }
+                .disabled(isCleaningBackups)
+            }
+            .settingsRow()
+        } footer: {
+            Text("Backups on another disk are stored as a single compressed archive. That is what lets a disk formatted for Windows, or a network share, hold one at all — and it is usually less than half the size of the app.")
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Status wording
+
+    private var statusIcon: String {
+        if isOnThisMacsDisk { return "internaldrive.fill" }
+        switch availability {
+        case .ready:             return "externaldrive.fill.badge.checkmark"
+        case .volumeNotMounted:  return "externaldrive.badge.xmark"
+        case .identityMismatch:  return "externaldrive.badge.questionmark"
+        case .notWritable:       return "lock.fill"
+        case .localOnly:         return "internaldrive.fill"
+        }
+    }
+
+    private var statusTint: Color {
+        if isOnThisMacsDisk { return .orange }
+        if case .ready = availability { return .accentColor }
+        if case .localOnly = availability { return .secondary }
+        return .orange
+    }
+
+    private var statusTitle: String {
+        let name = prefs.backupDestination.volumeName
+        switch availability {
+        case .ready:
+            if isOnThisMacsDisk { return String(localized: "This folder is on this Mac’s disk") }
+            return name.map { String(localized: "“\($0)” is connected") }
+                ?? String(localized: "Connected")
+        case .volumeNotMounted:
+            return name.map { String(localized: "“\($0)” isn’t connected") }
+                ?? String(localized: "The backup disk isn’t connected")
+        case .identityMismatch:
+            return String(localized: "A different disk is mounted here")
+        case .notWritable:
+            return String(localized: "This folder can’t be written to")
+        case .localOnly:
+            return String(localized: "Backups are kept on this Mac")
+        }
+    }
+
+    private var destinationFooter: String {
+        if isOnThisMacsDisk {
+            return String(localized: "This folder is on the same disk as this Mac, so it frees no space. Backups there are only stored compressed, at roughly half the size. To move them off this Mac, choose a folder on an external disk or a network share.")
+        }
+        switch availability {
+        case .ready:
+            if let report = lastReport, let speed = report.writeBytesPerSecond {
+                let rate = ByteCountFormatter.string(fromByteCount: Int64(speed), countStyle: .file)
+                return String(localized: "Measured at about \(rate)/s. Backups are copied here in the background, after an update is installed, so nothing waits on the disk.")
+            }
+            return String(localized: "Backups are copied here in the background, after an update is installed, so nothing waits on the disk.")
+        case .volumeNotMounted, .notWritable:
+            return String(localized: "New backups stay on this Mac until the disk is back, then move on their own. If this Mac runs low on space while the disk is away, updates are installed without a rollback point rather than filling the startup disk.")
+        case .identityMismatch:
+            return String(localized: "The disk mounted at this path isn’t the one the backups were set up on. Nothing has been written to it. Reconnect the original disk, or choose this one to start using it instead.")
+        case .localOnly:
+            return ""
+        }
+    }
+
+    /// Warns only when the ceiling is one a backup could plausibly hit — FAT32's
+    /// 4 GB cap. Reported by the filesystem, not guessed from its name.
+    private var sizeCeilingWarning: String? {
+        guard let max = lastReport?.maxFileBytes, max < (8 << 30) else { return nil }
+        let limit = ByteCountFormatter.string(fromByteCount: max, countStyle: .file)
+        return String(localized: "This disk’s format caps a single file at \(limit), so a very large app may not fit. Reformatting it as APFS or Mac OS Extended removes that limit.")
+    }
+
+    // MARK: - Actions
+
+    private var locationBinding: Binding<Bool> {
+        Binding(
+            get: { prefs.backupDestination.kind == .external },
+            set: { wantsExternal in
+                guard wantsExternal else {
+                    Task { await work { await model.useLocalBackups() } }
+                    return
+                }
+                // Turning the disk back on is a switch, not a decision to make
+                // again. Only ask for a folder when there is none to return to —
+                // and note that "remembered but not plugged in right now" is not
+                // one of those cases: the status row says so, and backups wait on
+                // this Mac until it is back, which is the designed behaviour.
+                if let remembered = prefs.rememberedBackupDisk {
+                    Task { await work { await model.useBackupDisk(remembered) } }
+                } else {
+                    chooseDisk()
+                }
+            })
+    }
+
+    private func chooseDisk() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.prompt = String(localized: "Use This Folder")
+        panel.message = String(localized: "Choose a folder on an external disk or a network share. Backups are kept inside it, and moving them there is what frees space on this Mac.")
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task {
+            await work {
+                do {
+                    lastReport = try await model.useBackupDisk(at: url)
+                    pickError = sizeCeilingWarning
+                } catch {
+                    pickError = String(
+                        localized: "That folder wasn’t used: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    /// Runs `body` with the busy flag held and the page refreshed afterwards, so
+    /// every button that changes something leaves the numbers honest.
+    private func work(_ body: () async -> Void) async {
+        isWorking = true
+        await body()
+        isWorking = false
+        await refresh()
+    }
+
+    private func refresh() async {
+        availability = model.backupAvailability()
+        let sizes = await model.backupStoreSizes()
+        outboxBytes = sizes.outbox
+        destinationBytes = sizes.destination
+        pendingCount = await model.pendingBackupTransfers()
+        transferState = await model.backupTransferState()
+        isOnThisMacsDisk = prefs.backupDestination.directory.map {
+            BackupDestinationProbe.isOnSameVolume($0, as: BackupStore.outboxRoot)
+        } ?? false
+    }
+
+    private func format(_ bytes: Int64?) -> String {
+        guard let bytes else { return "…" }
+        return ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}
+
+/// The compression choice, laid out the way the other settings pickers are.
+private struct AdaptiveCompressionRow: View {
+    @Binding var selection: BundleArchive.Compression
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text("Compression").font(.callout)
+            Spacer(minLength: 12)
+            Picker("Compression", selection: $selection) {
+                Text("Faster").tag(BundleArchive.Compression.fast)
+                Text("Smaller").tag(BundleArchive.Compression.smallest)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .fixedSize()
+        }
+    }
+}

--- a/App/Sources/Settings/GeneralSettingsPage.swift
+++ b/App/Sources/Settings/GeneralSettingsPage.swift
@@ -11,11 +11,6 @@ struct GeneralSettingsPage: View {
     /// rate-limit caution — a developer with `gh` authenticated never sees it.
     @State private var hasGitHubToken: Bool?
 
-    /// Total on-disk size of the backup store, refreshed on appear and after
-    /// every cleanup so the footer stays truthful without polling.
-    @State private var backupBytes: Int64?
-    @State private var isCleaningBackups = false
-
     var body: some View {
         SettingsPage(section: .general) {
             scheduleCard
@@ -31,29 +26,6 @@ struct GeneralSettingsPage: View {
                 GitHubToken.resolve(explicit: explicit) != nil
             }.value
         }
-        .task {
-            backupBytes = await Task.detached(priority: .utility) { BackupStore.totalSize() }.value
-        }
-        .sheet(isPresented: $showingBackups) {
-            BackupsSheet(backups: backupListing) { keys in
-                Task {
-                    await model.deleteBackups(keys: keys)
-                    backupBytes = await Task.detached(priority: .utility) {
-                        BackupStore.totalSize()
-                    }.value
-                }
-            }
-        }
-    }
-
-    /// Presented by "Clean Up…", loaded on demand because measuring every backup
-    /// walks the disk.
-    @State private var showingBackups = false
-    @State private var backupListing: [BackupStore.Listing] = []
-
-    private var backupSizeLabel: String {
-        guard let backupBytes else { return "…" }
-        return ByteCountFormatter.string(fromByteCount: backupBytes, countStyle: .file)
     }
 
     private var scheduleCard: some View {
@@ -89,39 +61,13 @@ struct GeneralSettingsPage: View {
     private var afterUpdateCard: some View {
         SettingsCard(
             header: "After an update",
-            footer: "After updating a running app, restart it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Restart” button.\n\nBackups keep one previous version of each app under Application Support, so an update can be undone. Retention is one backup per app — the previous version is replaced, not accumulated."
+            footer: "After updating a running app, restart it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Restart” button."
         ) {
             Toggle("Notify me when updates are found", isOn: $prefs.notifyOnUpdates)
                 .settingsRow()
             SettingsDivider()
             Toggle("Restart updated apps automatically", isOn: $prefs.autoRestartAfterUpdate)
                 .settingsRow()
-            SettingsDivider()
-            Toggle("Keep a backup so updates can be rolled back", isOn: $prefs.keepBackups)
-                .settingsRow()
-            SettingsDivider()
-            Toggle("Delete a backup once its app is uninstalled", isOn: $prefs.pruneOrphanBackups)
-                .settingsRow()
-            SettingsDivider()
-            HStack {
-                Text("Backups are using \(backupSizeLabel)")
-                    .foregroundStyle(.secondary)
-                Spacer()
-                // Opens the list rather than acting immediately: every backup is
-                // somebody's rollback, and the old behaviour (prune orphans only)
-                // usually deleted nothing and said nothing, which read as broken.
-                Button("Clean Up…") {
-                    guard !isCleaningBackups else { return }
-                    isCleaningBackups = true
-                    Task {
-                        backupListing = await model.backupListing()
-                        isCleaningBackups = false
-                        showingBackups = !backupListing.isEmpty
-                    }
-                }
-                .disabled(isCleaningBackups || backupBytes == 0)
-            }
-            .settingsRow()
         }
     }
 

--- a/App/Sources/Settings/SettingsSection.swift
+++ b/App/Sources/Settings/SettingsSection.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// sidebar search beyond the visible label, so "token" finds GitHub and
 /// "rollback" finds General.
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case general, folders, updates
+    case general, backups, folders, updates
     case github, alcove
     case ignored, diagnostics
 
@@ -35,7 +35,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
     var group: Group {
         switch self {
-        case .general, .folders, .updates: return .app
+        case .general, .backups, .folders, .updates: return .app
         case .github, .alcove:             return .accounts
         case .ignored, .diagnostics:       return .library
         }
@@ -44,6 +44,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .general:     return String(localized: "General")
+        case .backups:     return String(localized: "Backups")
         case .folders:     return String(localized: "Folders")
         case .updates:     return String(localized: "Updates")
         case .github:      return String(localized: "GitHub")
@@ -56,6 +57,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .general:     return "gearshape.fill"
+        case .backups:     return "clock.arrow.circlepath"
         case .folders:     return "folder.fill"
         case .updates:     return "arrow.triangle.2.circlepath"
         case .github:      return "key.fill"
@@ -68,6 +70,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var tint: Color {
         switch self {
         case .general:     return .gray
+        case .backups:     return .indigo
         case .folders:     return .blue
         case .updates:     return .green
         case .github:      return .purple
@@ -81,6 +84,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var subtitle: String {
         switch self {
         case .general:     return String(localized: "How often Duo Updater checks, and what it does when it finds something.")
+        case .backups:     return String(localized: "Keep a copy of the previous version so an update can be undone — here or on another disk.")
         case .folders:     return String(localized: "Where Duo Updater looks for installed apps.")
         case .updates:     return String(localized: "Duo Updater's own version.")
         case .github:      return String(localized: "Lift GitHub's anonymous rate limit for apps tracked through Releases.")
@@ -106,7 +110,8 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     private var localizedKeywords: [String] {
         let list: String
         switch self {
-        case .general:     list = String(localized: "launch, login, frequency, notify, restart, backup, rollback, concurrency, app store, self-updating, vendor", comment: "Comma-separated extra search terms for the General settings page")
+        case .general:     list = String(localized: "launch, login, frequency, notify, restart, concurrency, app store, self-updating, vendor", comment: "Comma-separated extra search terms for the General settings page")
+        case .backups:     list = String(localized: "backup, rollback, roll back, undo, restore, previous version, external disk, drive, nas, archive, storage, space", comment: "Comma-separated extra search terms for the Backups settings page")
         case .folders:     list = String(localized: "scan, locations, applications, path, directory", comment: "Comma-separated extra search terms for the Folders settings page")
         case .updates:     list = String(localized: "version, about, self", comment: "Comma-separated extra search terms for the Updates settings page")
         case .github:      list = String(localized: "token, personal access token, rate limit", comment: "Comma-separated extra search terms for the GitHub settings page")
@@ -136,7 +141,8 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     /// before still finds it, and the localized terms are new ground.
     private var englishAliases: [String] {
         switch self {
-        case .general:     return ["launch", "login", "frequency", "notify", "restart", "backup", "rollback", "concurrency", "app store", "mas", "self-updating", "vendor"]
+        case .general:     return ["launch", "login", "frequency", "notify", "restart", "concurrency", "app store", "mas", "self-updating", "vendor"]
+        case .backups:     return ["backup", "rollback", "roll back", "undo", "restore", "previous version", "external disk", "drive", "nas", "archive", "storage", "space"]
         case .folders:     return ["scan", "locations", "applications", "path", "directory"]
         case .updates:     return ["version", "sparkle", "about", "self"]
         case .github:      return ["token", "personal access token", "pat", "gh", "cli", "rate limit"]

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -56,6 +56,7 @@ struct SettingsView: View {
     private func page(for section: SettingsSection) -> some View {
         switch section {
         case .general:     GeneralSettingsPage(prefs: prefs, model: model)
+        case .backups:     BackupsSettingsPage(prefs: prefs, model: model)
         case .folders:     FoldersSettingsPage(prefs: prefs, model: model)
         case .updates:     UpdatesSettingsPage()
         case .github:      GitHubSettingsPage(prefs: prefs)

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -385,10 +385,16 @@ struct WorkbenchWindowView: View {
             // disturbs that draggable divider). Only shown when something is
             // restorable; the always-visible header is the discovery surface for
             // apps that have already updated and dropped out of the lists above.
-            if hasRollback {
+            // Shown when the backup disk is away even with nothing restorable
+            // locally: that is precisely the case where the section would
+            // otherwise vanish along with every rollback point on the disk.
+            if hasRollback || model.offlineBackupDisk != nil {
                 Divider()
                 rollbackHeader
-                if rollbackExpanded { rollbackListView }
+                if rollbackExpanded {
+                    if let disk = model.offlineBackupDisk { offlineBackupNotice(disk) }
+                    if hasRollback { rollbackListView }
+                }
             }
         }
     }
@@ -408,6 +414,22 @@ struct WorkbenchWindowView: View {
     private var rollbackHeader: some View {
         sectionHeader(String(localized: "Rollback"), systemImage: "arrow.uturn.backward",
                       count: rollbackableApps.count, expanded: $rollbackExpanded)
+    }
+
+    /// Says why this list is shorter than the store. Without it an unplugged disk
+    /// and an empty store look the same on screen — and the second reading is the
+    /// one that makes a user think their backups are gone.
+    private func offlineBackupNotice(_ disk: String) -> some View {
+        Label {
+            Text("Backups on “\(disk)” aren’t available right now — showing only what’s on this Mac.")
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: "externaldrive.badge.xmark")
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 14)
+        .padding(.bottom, hasRollback ? 2 : 8)
     }
 
     /// The Rollback list: every app with a backup we can restore, each with an inline

--- a/CLI/Sources/DuoKit/Backups.swift
+++ b/CLI/Sources/DuoKit/Backups.swift
@@ -26,6 +26,12 @@ public enum Backups {
             /// path, then bundle id, then name prefix — but must land on
             /// exactly one install, since a restore needs a single target.
             case restore(app: String)
+            /// Move everything still sitting on this Mac onto the backup disk.
+            case sync
+            /// Re-check stored backups against what was recorded for them.
+            case verify(deep: Bool)
+            /// Ask whether a folder could hold the store, without adopting it.
+            case probe(path: String)
         }
         public var operation: Operation
         public var json = false
@@ -39,6 +45,12 @@ public enum Backups {
             return await list(json: options.json)
         case .restore(let query):
             return await restore(query, assumeYes: options.assumeYes, json: options.json)
+        case .sync:
+            return sync(json: options.json)
+        case .verify(let deep):
+            return verify(deep: deep, json: options.json)
+        case .probe(let path):
+            return probe(path: path, json: options.json)
         }
     }
 
@@ -58,8 +70,36 @@ public enum Backups {
         let settings = Settings.load()
         let installed = await Inventory.scan(settings)
         let rows = rows(installed: installed, backups: BackupStore.allBackups())
+        // Said before the rows, and on stderr so it cannot corrupt `--json`.
+        // Without it a store that lives on a disk in someone's bag prints "No
+        // backups stored.", which is a sentence about their data rather than
+        // about a cable, and is the difference between reaching for the disk and
+        // concluding the backups are gone.
+        note(unreachableDestination())
         json ? emitJSON(rows) : emitText(rows)
         return 0
+    }
+
+    /// A line explaining why the listing may be short, or nil when it is whole.
+    static func unreachableDestination() -> String? {
+        switch BackupStore.availability() {
+        case .localOnly, .ready:
+            return nil
+        case .volumeNotMounted(let name, _):
+            return "the backup disk \u{201C}\(name ?? "?")\u{201D} isn't connected — "
+                + "showing only what is on this Mac"
+        case .identityMismatch(_, _, let path):
+            return "a different disk is mounted at \u{201C}\(path)\u{201D} — "
+                + "showing only what is on this Mac"
+        case .notWritable(let path):
+            return "\u{201C}\(path)\u{201D} can't be written to — "
+                + "showing only what is on this Mac"
+        }
+    }
+
+    static func note(_ message: String?) {
+        guard let message else { return }
+        FileHandle.standardError.write(Data("duo: \(message)\n".utf8))
     }
 
     /// Pair every backup on disk with the installed app it belongs to, the same
@@ -96,7 +136,17 @@ public enum Backups {
 
     /// `BackupStore.totalSize()` only sums every backup at once; there is no
     /// public per-backup size, so this walks the one bundle the same way.
+    ///
+    /// A backup on the external destination is a single archive file, not a
+    /// directory, and a directory enumerator over a file yields nothing — so
+    /// without the branch every such backup would be reported as 0 bytes, which
+    /// looks like an empty backup rather than a compressed one.
     static func backupSize(_ backup: BackupStore.Backup) -> Int64 {
+        if backup.location == .destination {
+            let size = try? FileManager.default.attributesOfItem(
+                atPath: backup.bundlePath.path)[.size] as? Int64
+            return size.flatMap { $0 } ?? 0
+        }
         guard let enumerator = FileManager.default.enumerator(
             at: backup.bundlePath, includingPropertiesForKeys: [.fileSizeKey],
             options: [], errorHandler: nil)
@@ -259,6 +309,232 @@ public enum Backups {
     static func resolveKey(for app: InstalledApp) -> String? {
         BackupStore.keyCandidates(bundleID: app.bundleID, path: app.path)
             .first { BackupStore.backup(forKey: $0) != nil }
+    }
+
+    // MARK: - Sync
+
+    /// Move every backup still sitting on this Mac onto the backup disk, now.
+    ///
+    /// Synchronous and in this process, not handed to `BackupTransferQueue`.
+    /// The queue's whole job — running in the background, holding an App Nap
+    /// assertion, backing off around a cable that comes and goes — is only
+    /// meaningful for a process that stays alive, and `duo` exits. So this walks
+    /// what is owed and reports each move as it lands, which is what a command
+    /// line can actually offer: a line per app and an exit code.
+    ///
+    /// The menu-bar app's queue may be moving the same backups at the same
+    /// time. A key that disappears from the outbox mid-run is therefore reported
+    /// as already moved rather than as a failure — the outcome is the one that
+    /// was asked for, whoever produced it.
+    static func sync(json: Bool) -> Int32 {
+        // Sweep before asking about the disk, so this is worth running even with
+        // no disk configured: a save that was cut off leaves its scratch in the
+        // outbox whether or not the store was ever moved, and this is the only
+        // command a machine without the menu-bar app running can use to clear it.
+        //
+        // Without an `excluding` set — this process knows of no transfer in
+        // flight, and cannot ask the app's queue — so the age gate is the only
+        // guard. The cost of getting that wrong is bounded: a `.partial` removed
+        // out from under a live transfer makes that one transfer fail and be
+        // redone, never a backup lost.
+        BackupStore.sweepStaleScratch()
+
+        switch BackupStore.availability() {
+        case .localOnly:
+            note("no backup disk is configured — backups stay on this Mac")
+            return 0
+        case .ready:
+            break
+        case .volumeNotMounted, .identityMismatch, .notWritable:
+            note(unreachableDestination())
+            return 1
+        }
+
+        let keys = BackupStore.pendingTransferKeys()
+        let compression = Settings.backupCompression()
+        if json { NDJSON.begin("backups sync") }
+        guard !keys.isEmpty else {
+            if !json { print("Nothing to move — every backup is already on the disk.") }
+            return 0
+        }
+
+        var moved = 0
+        var movedBytes: Int64 = 0
+        var failures = 0
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        for key in keys {
+            let name = BackupStore.displayName(forKey: key) ?? key
+            do {
+                let backup = try BackupStore.transferToDestination(
+                    forKey: key, compression: compression)
+                let bytes = (try? FileManager.default.attributesOfItem(
+                    atPath: backup.bundlePath.path)[.size] as? Int64).flatMap { $0 } ?? 0
+                moved += 1
+                movedBytes += bytes
+                if json {
+                    NDJSON.emit(["app": name, "key": key, "moved": true, "bytes": bytes])
+                } else {
+                    print("  \(name)  →  \(formatter.string(fromByteCount: bytes))")
+                }
+            } catch {
+                // Gone from the outbox means somebody else moved it, which is the
+                // result this command wanted. Anything else is a real failure.
+                if BackupStore.backup(forKey: key)?.location == .destination {
+                    if json { NDJSON.emit(["app": name, "key": key, "moved": true, "byOther": true]) }
+                    continue
+                }
+                failures += 1
+                let message = (error as? LocalizedError)?.errorDescription
+                    ?? error.localizedDescription
+                if json {
+                    NDJSON.emit(["app": name, "key": key, "moved": false, "error": message])
+                } else {
+                    FileHandle.standardError.write(Data("  \(name): \(message)\n".utf8))
+                }
+            }
+        }
+        if !json {
+            print("\n  \(moved) moved, \(formatter.string(fromByteCount: movedBytes)) on the disk"
+                + (failures == 0 ? "." : ", \(failures) failed."))
+        }
+        return failures == 0 ? 0 : 1
+    }
+
+    // MARK: - Verify
+
+    /// Re-check every stored backup against what was recorded when it was
+    /// stored, and say plainly which ones could not be checked at all.
+    ///
+    /// Exits 1 only for a backup that is damaged or unreadable. One that predates
+    /// fingerprints is reported and does not fail the run: it is not evidence of
+    /// a problem, and making it an error would train anyone scripting this to
+    /// ignore the exit code.
+    static func verify(deep: Bool, json: Bool) -> Int32 {
+        note(unreachableDestination())
+        let outcomes = BackupStore.verify(deep: deep)
+        if json {
+            NDJSON.begin("backups verify")
+            for outcome in outcomes { NDJSON.emit(payload(outcome)) }
+        } else {
+            emitVerifyText(outcomes)
+        }
+        return outcomes.contains { $0.result.isFailure } ? 1 : 0
+    }
+
+    static func payload(_ outcome: BackupStore.VerifyOutcome) -> [String: Any] {
+        var row: [String: Any] = [
+            "app": outcome.name,
+            "key": outcome.key,
+            "where": outcome.location == .outbox ? "this Mac" : "backup disk",
+            "status": status(outcome.result),
+        ]
+        if let version = outcome.version { row["version"] = version }
+        if let detail = detail(outcome.result) { row["detail"] = detail }
+        return row
+    }
+
+    static func status(_ result: BackupStore.VerifyOutcome.Result) -> String {
+        switch result {
+        case .ok:           return "ok"
+        case .mismatch:     return "mismatch"
+        case .unverifiable: return "unverifiable"
+        case .unreadable:   return "unreadable"
+        }
+    }
+
+    static func detail(_ result: BackupStore.VerifyOutcome.Result) -> String? {
+        switch result {
+        case .ok: return nil
+        case .mismatch(let why), .unverifiable(let why), .unreadable(let why): return why
+        }
+    }
+
+    static func emitVerifyText(_ outcomes: [BackupStore.VerifyOutcome]) {
+        guard !outcomes.isEmpty else {
+            print("No backups stored.")
+            return
+        }
+        let width = min(38, outcomes.map(\.name.count).max() ?? 10)
+        for outcome in outcomes.sorted(by: {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }) {
+            let name = outcome.name.count > width
+                ? String(outcome.name.prefix(width - 1)) + "\u{2026}"
+                : outcome.name.padding(toLength: width, withPad: " ", startingAt: 0)
+            let mark: String
+            switch outcome.result {
+            case .ok:           mark = "ok"
+            case .mismatch:     mark = "DAMAGED"
+            case .unverifiable: mark = "not checkable"
+            case .unreadable:   mark = "UNREADABLE"
+            }
+            let place = outcome.location == .outbox ? "this Mac" : "backup disk"
+            print("  \(name)  \(mark)  (\(place))"
+                + (detail(outcome.result).map { " — \($0)" } ?? ""))
+        }
+        let damaged = outcomes.filter { $0.result.isFailure }.count
+        let unchecked = outcomes.filter {
+            if case .unverifiable = $0.result { return true }
+            return false
+        }.count
+        print("\n  \(outcomes.count) checked, \(damaged) damaged"
+            + (unchecked == 0 ? "." : ", \(unchecked) with nothing to check against."))
+    }
+
+    // MARK: - Probe
+
+    /// Report what a folder could do as a backup store, without claiming it.
+    ///
+    /// Deliberately does not adopt: no marker is written and no preference
+    /// changes, so this is safe to point at a share you are only considering.
+    /// It is also the honest answer to "will this work on my NAS?" — SMB and NFS
+    /// cannot be faked in a test, so the project ships the measurement rather
+    /// than a claim.
+    static func probe(path: String, json: Bool) -> Int32 {
+        let directory = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+            .standardizedFileURL
+        let report: BackupDestinationProbe.Report
+        do {
+            report = try BackupDestinationProbe.run(at: directory)
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+            FileHandle.standardError.write(Data("duo: \(message)\n".utf8))
+            return 1
+        }
+
+        if json {
+            NDJSON.begin("backups probe")
+            var row: [String: Any] = ["path": directory.path]
+            if let free = report.freeBytes { row["freeBytes"] = free }
+            if let max = report.maxFileBytes { row["maxFileBytes"] = max }
+            if let speed = report.writeBytesPerSecond { row["writeBytesPerSecond"] = speed }
+            if let fs = report.filesystem { row["filesystem"] = fs }
+            if let removable = report.isRemovable { row["isRemovable"] = removable }
+            if let local = report.isLocal { row["isLocal"] = local }
+            NDJSON.emit(row)
+            return 0
+        }
+
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        print("  \(directory.path)")
+        print("  filesystem       \(report.filesystem ?? "?")"
+            + (report.isLocal == false ? "  (network)" : "")
+            + (report.isRemovable == true ? "  (removable)" : ""))
+        print("  free             "
+            + (report.freeBytes.map { formatter.string(fromByteCount: $0) } ?? "?"))
+        // Stated as the number, not as a verdict. Whether it is enough depends on
+        // the largest app being backed up, which this command has no way to know.
+        print("  largest file     "
+            + (report.maxFileBytes.map { formatter.string(fromByteCount: $0) }
+               ?? "no declared limit"))
+        print("  write speed      "
+            + (report.writeBytesPerSecond
+                .map { "\(formatter.string(fromByteCount: Int64($0)))/s" }
+               ?? "too fast to measure"))
+        return 0
     }
 
     /// Ask before overwriting the installed bundle. Mirrors `Install.confirm`:

--- a/CLI/Sources/DuoKit/Settings.swift
+++ b/CLI/Sources/DuoKit/Settings.swift
@@ -33,6 +33,29 @@ public struct Settings: Sendable {
         defaults.set(Array(keys).sorted(), forKey: UpdateSettings.declinedElevationKeysKey)
     }
 
+    /// Point `BackupStore` at whatever disk the user configured in the app.
+    ///
+    /// Separate from ``load()`` and called once from `main`, before any command
+    /// runs, because forgetting it does not fail — it quietly reads a different
+    /// store than the app writes. `duo backups list` would then report "No
+    /// backups stored." for a machine whose backups are all sitting on an
+    /// external disk, which reads as data loss rather than as a missing call.
+    public static func configureBackupStore() {
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        BackupStore.configure(BackupDestination.load(from: defaults))
+    }
+
+    /// How hard to squeeze a bundle on its way to the backup disk, as the app
+    /// has it set. Read here rather than passed in so `duo backups sync` writes
+    /// archives the app would have written — a CLI that quietly used a different
+    /// algorithm would leave a store whose sizes nobody could explain.
+    public static func backupCompression() -> BundleArchive.Compression {
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        return defaults.string(forKey: UpdateSettings.backupCompressionKey)
+            .flatMap(BundleArchive.Compression.init(rawValue:))
+            ?? UpdateSettings.backupCompressionDefault
+    }
+
     public var updateSettings: UpdateSettings
     public var ignoredKeys: Set<String>
     /// App preference key → the version the user chose to skip.

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -18,7 +18,8 @@ commands:
   restart       Quit and relaunch apps whose running copy is stale.
   ignore        Hide an app from update checks. unignore undoes it.
   skip          Hide the version currently offered. unskip undoes it.
-  backups       List the rollback points, or put one back.
+  backups       List the rollback points, put one back, move them to the
+                backup disk, or check that they are still intact.
   doctor        Whether this machine can actually install anything, and what
                 is missing if not.
   verify        Sweep the recipes against their live endpoints and report the
@@ -87,6 +88,15 @@ ignore / unignore / skip / unskip options:
 backups options:
   list                Every stored rollback point: app, version, when, size.
   restore <app>       Put a backed-up bundle back over the installed one.
+  sync                Move backups still on this Mac onto the backup disk.
+  verify              Re-check every stored backup against what was recorded
+                      for it. Exits 1 if any is damaged.
+  probe <path>        What a folder could do as a backup store — filesystem,
+                      free space, largest file it can hold, write speed.
+                      Writes nothing and changes no setting.
+  --deep              verify only: unpack each archive on the disk and compare
+                      the whole bundle, not just the archive's digest. As slow
+                      as a rollback, and needs room for one.
   --yes               Don't ask before overwriting.
   --json              Machine-readable form.
 
@@ -95,6 +105,9 @@ backups options:
   rollback, it does not refuse when the target is running; it restores and tells
   you to restart. A shared bundle id (Android Studio's channels, Thunderbird
   stable/esr) is ambiguous for a restore and is refused rather than guessed.
+
+  When the backup disk isn't connected, list and verify say so on stderr and
+  report what is on this Mac, rather than reporting nothing.
 
 doctor options:
   --json              Machine-readable form of the same report.
@@ -157,6 +170,10 @@ exit codes:
   2  usage error
 """
 
+// Before anything parses an argument: the backup store has to be pointed at the
+// disk the user chose in the app, and this is the one place no command can skip.
+Settings.configureBackupStore()
+
 guard let args = Args(CommandLine.arguments) else {
     print(usage)
     exit(2)
@@ -217,8 +234,18 @@ case "backups":
             die("backups restore needs exactly one app\n\n\(usage)", code: 2)
         }
         operation = .restore(app: args.operands[1])
+    case "sync":
+        operation = .sync
+    case "verify":
+        operation = .verify(deep: args.has("deep"))
+    case "probe":
+        guard args.operands.count == 2 else {
+            die("backups probe needs exactly one folder\n\n\(usage)", code: 2)
+        }
+        operation = .probe(path: args.operands[1])
     case let other?:
-        die("unknown backups operation '\(other)'; expected list or restore", code: 2)
+        die("unknown backups operation '\(other)'; expected "
+            + "list, restore, sync, verify or probe", code: 2)
     }
     var options = Backups.Options(operation: operation)
     options.json = args.has("json")

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateSettings.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateSettings.swift
@@ -121,6 +121,39 @@ public struct UpdateSettings: Sendable {
     /// user already refused in the menu bar.
     public static let declinedElevationKeysKey = "DeclinedElevatedInstalls"
 
+    /// Where rollback backups are kept, and how they are packed. See
+    /// ``BackupDestination`` and ``BundleArchive/Compression``.
+    ///
+    /// Shared for a sharper reason than the keys above. `duo backups` reads and
+    /// writes the same store the menu bar does, so a drifted name here would not
+    /// read as "unset and therefore local" in any visible way — the CLI would
+    /// keep writing backups to the boot volume while the app wrote them to the
+    /// external disk, each product listing a store the other cannot see. The
+    /// first symptom would be a rollback offered in one place and missing in the
+    /// other, long after the divergence started.
+    /// Renamed from `BackupDestinationPath`, which stored the folder the user
+    /// picked rather than the store directory inside it. Any value under the old
+    /// name points at somewhere that belongs to the user, so it is ignored
+    /// outright instead of migrated — re-picking is one click, and silently
+    /// repointing a store at someone's Documents folder is not a risk worth
+    /// taking to save it.
+    public static let backupDestinationPathKey = "BackupDestinationFolder"
+    public static let backupDestinationIdentityKey = "BackupDestinationIdentity"
+    public static let backupDestinationVolumeNameKey = "BackupDestinationVolumeName"
+    /// Whether backups currently go to that folder.
+    ///
+    /// Separate from the folder itself so switching back to "on this Mac" is a
+    /// switch and not an erasure: the disk stays remembered, and turning it on
+    /// again does not mean finding it in a file picker a second time.
+    public static let backupDestinationEnabledKey = "BackupsGoToAnotherDisk"
+    public static let backupCompressionKey = "BackupCompression"
+
+    /// What the compression setting resolves to when its key is absent.
+    /// Shared for the same reason ``vendorInstallPolicyDefault`` is: the app and
+    /// the CLI resolve it independently, and a default that drifted would mean
+    /// the same update archived two different ways depending on who ran it.
+    public static let backupCompressionDefault: BundleArchive.Compression = .fast
+
     public init(
         appStoreUpdateStrategy: AppStoreUpdateStrategy,
         vendorInstallPolicy: VendorInstallPolicy,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupDestination.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupDestination.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Where rollback backups are kept.
+///
+/// The default — and, until someone points it somewhere else, the only case —
+/// is `local`: `~/Library/Application Support/DuoUpdater/Backups`, on the boot
+/// volume, holding a plain copy of each replaced bundle. That copy is a real
+/// second copy, so a 1.5 GB app costs 1.5 GB, and on a machine that is short of
+/// space the usual response is to turn backups off entirely — trading the
+/// rollback safety net for disk. Pointing the store at an external disk is the
+/// way to keep both.
+///
+/// An external destination is identified by **two** things, and the second is
+/// what makes it trustworthy. A path alone is not an identity: `/Volumes/Archive`
+/// is whatever happens to be mounted there, which may be a different disk, or —
+/// when nothing is mounted — a plain directory on the boot volume that something
+/// created. So a configured destination also carries an `identity`, matched
+/// against a marker file we wrote inside it (see ``BackupVolumeMarker``).
+public struct BackupDestination: Sendable, Equatable {
+
+    public enum Kind: String, Sendable {
+        case local, external
+    }
+
+    public var kind: Kind
+    /// Absolute, standardized path of the chosen directory. Nil for `.local`.
+    public var path: String?
+    /// The `identity` we expect ``BackupVolumeMarker`` at `path` to carry.
+    /// Nil for `.local`, and nil for an external destination configured before
+    /// the marker was written (which reads as "not yet verified", not "matches").
+    public var identity: String?
+    /// The volume's name when it was chosen, for UI copy only ("“Archive” isn't
+    /// connected"). Never a matching criterion — volumes get renamed.
+    public var volumeName: String?
+
+    public static let local = BackupDestination(kind: .local)
+
+    /// The directory we create inside the folder the user picks, and the only
+    /// one we ever read, write, measure or delete within.
+    ///
+    /// Never treat the picked folder itself as the store. A folder picker hands
+    /// back somewhere that belongs to the user and is usually full of their
+    /// things — `~/Documents` here had seventy-five subdirectories — and a store
+    /// rooted there would count every one of them as a backup: their size
+    /// reported as ours, their names listed in the clean-up sheet, and one
+    /// confirmation away from `removeItem`. Owning a subdirectory makes that
+    /// impossible by construction rather than by remembering to filter.
+    public static let storeFolderName = "DuoUpdater Backups"
+
+    public init(
+        kind: Kind, path: String? = nil, identity: String? = nil, volumeName: String? = nil
+    ) {
+        self.kind = kind
+        self.path = path
+        self.identity = identity
+        self.volumeName = volumeName
+    }
+
+    /// The configured directory, or nil when backups stay local. Does **not**
+    /// check whether it exists — that is ``BackupStore``'s job, and conflating
+    /// "configured" with "reachable" is how a detached disk turns into a
+    /// directory created on the boot volume.
+    public var directory: URL? {
+        guard kind == .external, let path, !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    // MARK: - Persistence
+
+    /// Read the destination the app persisted.
+    ///
+    /// Lives here rather than in each product because the app and `duo` resolve
+    /// it independently. A key name — or a default — that drifted between them
+    /// would not fail loudly: the CLI would quietly write backups to the boot
+    /// volume while the menu bar wrote them to the external disk, and both
+    /// answers look individually correct.
+    public static func load(from defaults: UserDefaults) -> BackupDestination {
+        guard let remembered = remembered(from: defaults) else { return .local }
+        // Absent means "on, if a folder was ever chosen". Reading a missing key
+        // as `false` would have switched off the disk of everyone who configured
+        // one before this flag existed — silently, since a store that has quietly
+        // gone local looks exactly like one that was never moved.
+        let enabled = defaults.object(forKey: UpdateSettings.backupDestinationEnabledKey)
+            as? Bool ?? true
+        return enabled ? remembered : .local
+    }
+
+    /// The folder last chosen, whether or not backups are going there now.
+    ///
+    /// Kept so that turning the disk back on is a switch rather than a second
+    /// trip through a file picker — and so the settings page can name the disk
+    /// it would return to.
+    public static func remembered(from defaults: UserDefaults) -> BackupDestination? {
+        guard let path = defaults.string(forKey: UpdateSettings.backupDestinationPathKey),
+              !path.isEmpty
+        else { return nil }
+        return BackupDestination(
+            kind: .external,
+            path: path,
+            identity: defaults.string(forKey: UpdateSettings.backupDestinationIdentityKey),
+            volumeName: defaults.string(forKey: UpdateSettings.backupDestinationVolumeNameKey))
+    }
+
+    /// Persist this destination.
+    ///
+    /// Going local flips the switch and **keeps** the folder: erasing it would
+    /// mean that changing your mind twice costs you the disk, and a stale
+    /// location is harmless — nothing reads it while the switch is off, and
+    /// picking a different folder overwrites it.
+    public func save(into defaults: UserDefaults) {
+        guard kind == .external, let path, !path.isEmpty else {
+            defaults.set(false, forKey: UpdateSettings.backupDestinationEnabledKey)
+            return
+        }
+        defaults.set(true, forKey: UpdateSettings.backupDestinationEnabledKey)
+        defaults.set(path, forKey: UpdateSettings.backupDestinationPathKey)
+        defaults.set(identity, forKey: UpdateSettings.backupDestinationIdentityKey)
+        defaults.set(volumeName, forKey: UpdateSettings.backupDestinationVolumeNameKey)
+    }
+}
+
+/// The file that proves a directory is the backup destination we were configured
+/// for, written at the destination root as `.duo-backup-volume.json`.
+///
+/// `identity` is a UUID **we** generate, not anything the system reports, and
+/// that is the point:
+///
+///   • every filesystem can store it — `volumeUUIDStringKey` is not guaranteed
+///     on exFAT or an SMB share, so a check built on it would be unavailable
+///     exactly where it is most needed;
+///   • it distinguishes "my disk is mounted here" from "some other disk is
+///     mounted at the same path", which a path check cannot;
+///   • reformatting the volume destroys the marker along with the backups, so
+///     the mismatch is detected instead of being silently written over.
+///
+/// The observed values below are diagnostics — better wording for "this looks
+/// like a different disk", and something to put in a log. They are deliberately
+/// **not** matching criteria: volumes get renamed, and a volume UUID that is
+/// absent on one filesystem would otherwise read as a mismatch.
+public struct BackupVolumeMarker: Codable, Sendable, Equatable {
+    public static let fileName = ".duo-backup-volume.json"
+
+    public let identity: String
+    public let createdAt: Date
+    public var volumeName: String?
+    public var volumeUUID: String?
+    /// `statfs` `f_fstypename`, purely descriptive. Never a gate: which
+    /// filesystems can hold a backup is settled by the archive format, not by
+    /// this string.
+    public var filesystem: String?
+
+    public init(
+        identity: String = UUID().uuidString,
+        createdAt: Date = Date(),
+        volumeName: String? = nil,
+        volumeUUID: String? = nil,
+        filesystem: String? = nil
+    ) {
+        self.identity = identity
+        self.createdAt = createdAt
+        self.volumeName = volumeName
+        self.volumeUUID = volumeUUID
+        self.filesystem = filesystem
+    }
+
+    /// Read the marker at a destination root, or nil when there is none to read.
+    public static func read(at directory: URL) -> BackupVolumeMarker? {
+        guard let data = try? Data(
+            contentsOf: directory.appendingPathComponent(fileName)) else { return nil }
+        return try? JSONDecoder().decode(BackupVolumeMarker.self, from: data)
+    }
+
+    public func write(to directory: URL) throws {
+        try JSONEncoder().encode(self).write(
+            to: directory.appendingPathComponent(Self.fileName), options: .atomic)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupDestinationProbe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupDestinationProbe.swift
@@ -1,0 +1,244 @@
+import Foundation
+
+/// Checks whether a directory the user picked can actually serve as the backup
+/// store, at the moment they pick it — rather than at the moment they need a
+/// rollback.
+///
+/// It is much smaller than it would have to be if backups were stored as bundles.
+/// The hard question there would be "can this filesystem faithfully hold a `.app`,
+/// with its extended attributes, symlinks and permissions?" — a question that has
+/// a different answer on exFAT, on SMB, and on whatever a given NAS presents, and
+/// one that can only be answered by round-tripping a real bundle. Storing an
+/// archive removes it: the destination holds one opaque file, and any filesystem
+/// can do that. See ``BundleArchive``.
+///
+/// What is left is four cheap questions about the volume itself.
+public enum BackupDestinationProbe {
+
+    public struct Report: Sendable, Codable, Equatable {
+        /// Space available for something the user would mind losing.
+        public let freeBytes: Int64?
+        /// Largest single file this filesystem can hold, or nil when it declares
+        /// no representable ceiling.
+        ///
+        /// Reported as the factual number rather than filtered through some
+        /// notion of "large enough not to matter" — the useful question is
+        /// whether *this* archive fits, so the caller compares against the size
+        /// it actually has, and there is no threshold here to get wrong. On this
+        /// machine: FAT32 4 GiB − 1, APFS ~36 PB, HFS+ and exFAT no ceiling.
+        ///
+        /// The case that matters is FAT32. A very large app can archive past
+        /// 4 GiB, and finding out at transfer time would mean discovering it on
+        /// the first update after the disk was set up. Read from
+        /// `pathconf(_PC_FILESIZEBITS)` rather than inferred from the
+        /// filesystem's name, and without writing anything: a probe that tested
+        /// the limit by creating a 4 GiB file would, on FAT, actually allocate
+        /// 4 GiB, because FAT has no sparse files.
+        public let maxFileBytes: Int64?
+        /// Measured throughput, for deciding whether to copy in the background
+        /// and for telling the user roughly how long an update will take to
+        /// stow. Nil when the sample was too quick to time meaningfully — which
+        /// is itself the answer "fast enough not to care".
+        public let writeBytesPerSecond: Double?
+        /// `statfs`'s `f_fstypename`. Descriptive only — nothing here gates on
+        /// it, because the archive format is what settles which filesystems can
+        /// hold a backup.
+        public let filesystem: String?
+        public let isRemovable: Bool?
+        /// False for a network volume. Worth surfacing because it changes the
+        /// character of the failures the user should expect: a share drops
+        /// mid-copy far more often than a cable falls out.
+        public let isLocal: Bool?
+        public let probedAt: Date
+    }
+
+    public enum ProbeFailure: LocalizedError {
+        case notADirectory(String)
+        case notWritable(String)
+        case tooSmall(needBytes: Int64, freeBytes: Int64)
+
+        public var errorDescription: String? {
+            switch self {
+            case .notADirectory(let path):
+                return "“\(path)” isn’t a folder."
+            case .notWritable(let path):
+                return "“\(path)” can’t be written to."
+            case .tooSmall(let need, let free):
+                let f = ByteCountFormatter()
+                f.countStyle = .file
+                return "Not enough room: \(f.string(fromByteCount: free)) available, "
+                    + "\(f.string(fromByteCount: need)) needed."
+            }
+        }
+    }
+
+    /// Bytes written to measure throughput. Big enough to time a slow share
+    /// honestly, small enough that picking a folder does not feel like a task.
+    private static let sampleBytes = 4 << 20
+
+    public static func run(at directory: URL, minimumFreeBytes: Int64 = 0) throws -> Report {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw ProbeFailure.notADirectory(directory.path)
+        }
+
+        let values = try? directory.resourceValues(forKeys: [
+            .volumeAvailableCapacityForImportantUsageKey,
+            .volumeIsRemovableKey, .volumeIsLocalKey,
+        ])
+        // Already `Int64?`; the outer optional is `resourceValues` having failed.
+        let free = values?.volumeAvailableCapacityForImportantUsage ?? nil
+        if minimumFreeBytes > 0, let free, free < minimumFreeBytes {
+            throw ProbeFailure.tooSmall(needBytes: minimumFreeBytes, freeBytes: free)
+        }
+
+        // Writability is established by writing, not by asking. `isWritableFile`
+        // answers from the permission bits, which say nothing about a read-only
+        // mount or a share whose credentials have lapsed.
+        let speed = try measureWrite(in: directory)
+
+        return Report(
+            freeBytes: free,
+            maxFileBytes: maxFileSize(at: directory),
+            writeBytesPerSecond: speed,
+            filesystem: filesystemName(at: directory),
+            isRemovable: values?.volumeIsRemovable,
+            isLocal: values?.volumeIsLocal,
+            probedAt: Date())
+    }
+
+    /// Probe a directory and, if it can serve, mark it as ours and return the
+    /// destination to persist.
+    ///
+    /// An existing marker's identity is **kept**, never regenerated. Re-picking
+    /// a folder that already holds backups is the ordinary way someone
+    /// reconnects a disk after reinstalling, and minting a fresh identity there
+    /// would make every backup already on it read as belonging to a different
+    /// disk.
+    public static func adopt(
+        directory: URL, minimumFreeBytes: Int64 = 0
+    ) throws -> (destination: BackupDestination, report: Report) {
+        let report = try run(at: directory, minimumFreeBytes: minimumFreeBytes)
+
+        // Our own subdirectory, never the folder the user handed us. See
+        // `BackupDestination.storeFolderName` for what rooting the store in
+        // someone's Documents folder would have cost.
+        //
+        // Unless they handed us the store itself — which is the ordinary thing
+        // to do, because the settings page shows that path and picking what is
+        // shown is how anyone re-selects a disk. Adopting must therefore be
+        // idempotent: without this, each re-pick nested another
+        // `DuoUpdater Backups` inside the last one, and the newly empty folder
+        // became the destination while every existing backup sat one level up,
+        // invisible.
+        let alreadyOurs = BackupVolumeMarker.read(at: directory) != nil
+            || directory.lastPathComponent == BackupDestination.storeFolderName
+        let store = alreadyOurs
+            ? directory
+            : directory.appendingPathComponent(
+                BackupDestination.storeFolderName, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(
+                at: store, withIntermediateDirectories: true)
+        } catch {
+            throw ProbeFailure.notWritable(directory.path)
+        }
+
+        let existing = BackupVolumeMarker.read(at: store)
+        let volumeName = (try? directory.resourceValues(forKeys: [.volumeNameKey]))?.volumeName
+        let marker = BackupVolumeMarker(
+            identity: existing?.identity ?? UUID().uuidString,
+            createdAt: existing?.createdAt ?? Date(),
+            volumeName: volumeName,
+            volumeUUID: (try? directory.resourceValues(forKeys: [.volumeUUIDStringKey]))?
+                .volumeUUIDString,
+            filesystem: report.filesystem)
+        try marker.write(to: store)
+
+        return (
+            BackupDestination(
+                kind: .external, path: store.standardizedFileURL.path,
+                identity: marker.identity, volumeName: volumeName),
+            report
+        )
+    }
+
+    /// Whether two paths sit on the same mounted volume right now.
+    ///
+    /// The point of moving the store is to get the bytes off this Mac's disk,
+    /// and a folder picker cannot express that on its own — `~/Documents/Backups`
+    /// is a perfectly valid folder that defeats the entire purpose. Comparing
+    /// volumes is what tells the two apart.
+    ///
+    /// Compared by mount point rather than by `volumeIdentifierKey`. Both answer
+    /// the question, and the identifier is an opaque existential that reads
+    /// worse at the call site; neither is suitable to **store**, which is why
+    /// ``BackupVolumeMarker`` identifies a disk with a UUID of our own — a mount
+    /// token changes when the disk is replugged, so a persisted copy would
+    /// report a mismatch every time.
+    public static func isOnSameVolume(_ one: URL, as other: URL) -> Bool {
+        func mountPoint(_ url: URL) -> URL? {
+            (try? url.resourceValues(forKeys: [.volumeURLKey]))?.volume
+        }
+        guard let a = mountPoint(one), let b = mountPoint(other) else { return false }
+        return a.standardizedFileURL == b.standardizedFileURL
+    }
+
+    // MARK: - Pieces
+
+    /// Writes and deletes a sample, returning bytes per second.
+    ///
+    /// The payload is random rather than zeroes: a run of zeroes can be stored
+    /// as a hole on a filesystem that supports them, which would time the
+    /// bookkeeping instead of the disk and report a share as faster than the
+    /// cable it runs over.
+    private static func measureWrite(in directory: URL) throws -> Double? {
+        let file = directory.appendingPathComponent(".duo-write-check-\(UUID().uuidString)")
+        var payload = Data(count: sampleBytes)
+        payload.withUnsafeMutableBytes { buffer in
+            guard let base = buffer.bindMemory(to: UInt8.self).baseAddress else { return }
+            arc4random_buf(base, buffer.count)
+        }
+
+        let started = DispatchTime.now().uptimeNanoseconds
+        do {
+            // `.atomic` would write to a neighbouring temporary and rename, which
+            // is a different — and on a network share, much slower — operation
+            // than the streaming write a transfer actually performs.
+            try payload.write(to: file)
+        } catch {
+            throw ProbeFailure.notWritable(directory.path)
+        }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - started
+        try? FileManager.default.removeItem(at: file)
+
+        guard elapsed > 1_000_000 else { return nil }  // under a millisecond: unmeasurable
+        return Double(sampleBytes) / (Double(elapsed) / 1_000_000_000)
+    }
+
+    /// Max regular-file size, from `pathconf`.
+    ///
+    /// POSIX defines `_PC_FILESIZEBITS` as the minimum number of bits needed to
+    /// represent the maximum file size **as a signed integer**, so the limit is
+    /// `2^(bits-1) - 1`: FAT32 reports 33, giving 4 GiB − 1, which is exactly its
+    /// documented cap. Measured on this machine: msdos 33, HFS+ 64, APFS 56.
+    /// Anything at or above 63 is reported as no limit — there is nothing useful
+    /// to say about a ceiling of 4 exabytes.
+    private static func maxFileSize(at directory: URL) -> Int64? {
+        let bits = pathconf(directory.path, _PC_FILESIZEBITS)
+        guard bits > 0, bits < 63 else { return nil }
+        return (Int64(1) << (Int64(bits) - 1)) - 1
+    }
+
+    private static func filesystemName(at directory: URL) -> String? {
+        var buffer = statfs()
+        guard statfs(directory.path, &buffer) == 0 else { return nil }
+        return withUnsafePointer(to: buffer.f_fstypename) { pointer in
+            pointer.withMemoryRebound(
+                to: CChar.self, capacity: Int(MFSTYPENAMELEN)
+            ) { String(cString: $0) }
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
@@ -32,17 +32,185 @@ public enum BackupStore {
     /// they interleave. Production never binds it and always gets nil.
     @TaskLocal public static var rootOverride: URL?
 
-    public static var root: URL {
+    /// Test seam for the *destination*, bound the same way and for the same
+    /// reason as `rootOverride`. Production never binds it and reads
+    /// ``configure(_:)``'s value instead.
+    @TaskLocal public static var destinationOverride: BackupDestination?
+
+    /// Where backups are written first, always on the boot volume.
+    ///
+    /// This is the store as it has always been — the name changed, the meaning
+    /// did not. When no external destination is configured it is also where they
+    /// stay; when one is configured it is the staging area a transfer drains.
+    /// Keeping it as the first stop is what lets an unreachable disk degrade to
+    /// "the rollback point is on this Mac for now" rather than "there is no
+    /// rollback point", and it keeps every existing backup exactly where it is.
+    public static var outboxRoot: URL {
         if let rootOverride { return rootOverride }
         return DuoStateDirectory.base
             .appendingPathComponent("DuoUpdater/Backups", isDirectory: true)
     }
 
-    /// A stored backup: the bundle on disk plus the metadata we show in the UI.
+    /// Former name of ``outboxRoot``, kept so existing callers and tests read
+    /// unchanged.
+    public static var root: URL { outboxRoot }
+
+    // MARK: - Destination
+
+    private nonisolated(unsafe) static var configuredDestination: BackupDestination = .local
+    private static let destinationLock = NSLock()
+
+    /// Point the store at a destination. Called once per process — the app at
+    /// launch, `duo` in `main` — so no command can forget and silently use a
+    /// different store than the one the user configured.
+    public static func configure(_ destination: BackupDestination) {
+        destinationLock.lock()
+        defer { destinationLock.unlock() }
+        configuredDestination = destination
+    }
+
+    public static var destination: BackupDestination {
+        if let destinationOverride { return destinationOverride }
+        destinationLock.lock()
+        defer { destinationLock.unlock() }
+        return configuredDestination
+    }
+
+    /// Whether the configured destination can be written to right now.
+    ///
+    /// Every case is reported rather than collapsed into a bool because the
+    /// difference matters to the user: a disk that is merely unplugged will come
+    /// back on its own, one holding a different volume needs a decision, and a
+    /// read-only mount needs a different fix again. Collapsing them is how a UI
+    /// ends up saying "no backups" when the truthful answer is "your backup disk
+    /// isn't connected".
+    public enum Availability: Sendable, Equatable {
+        /// No external destination configured; the outbox is the store.
+        case localOnly(URL)
+        case ready(URL)
+        case volumeNotMounted(volumeName: String?, path: String)
+        case identityMismatch(expected: String?, found: String?, path: String)
+        case notWritable(path: String)
+
+        /// The disk's name when its copies cannot be read right now, else nil.
+        ///
+        /// One accessor for all three unreachable cases on purpose. They differ
+        /// in what the user has to do about it — which the Backups settings page
+        /// spells out — but they are identical in the fact a list somewhere else
+        /// is now shorter than the store, and that is the only thing the rollback
+        /// surface needs to say.
+        public var unreachableDiskName: String? {
+            switch self {
+            case .localOnly, .ready:
+                return nil
+            case .volumeNotMounted(let name, let path):
+                return name ?? Self.diskName(fromPath: path)
+            case .identityMismatch(_, _, let path), .notWritable(let path):
+                return Self.diskName(fromPath: path)
+            }
+        }
+
+        /// "Archive" out of "/Volumes/Archive/DuoUpdater Backups". Falls back to
+        /// the whole path rather than inventing a name, since a destination need
+        /// not live under `/Volumes` at all.
+        private static func diskName(fromPath path: String) -> String {
+            let parts = URL(fileURLWithPath: path).pathComponents
+            guard let volumes = parts.firstIndex(of: "Volumes"),
+                  parts.indices.contains(volumes + 1) else { return path }
+            return parts[volumes + 1]
+        }
+    }
+
+    /// Resolve the destination's state **without creating anything**.
+    ///
+    /// The order is deliberate: existence is checked before any thought of
+    /// writing. `save` used to reach the destination through
+    /// `createDirectory(withIntermediateDirectories: true)`, which on a detached
+    /// disk does not fail — it happily builds the whole path on the boot volume.
+    /// That is worse than losing the backup: the directory now squats the mount
+    /// point, so when the real disk is plugged in macOS mounts it beside the
+    /// decoy as `Archive 1`, and the user's backups are split across two places
+    /// that each look correct.
+    public static func availability(
+        _ destination: BackupDestination = BackupStore.destination
+    ) -> Availability {
+        guard let directory = destination.directory else {
+            return .localOnly(outboxRoot)
+        }
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return .volumeNotMounted(
+                volumeName: destination.volumeName, path: directory.path)
+        }
+
+        // A marker we cannot read means this is not the place we configured —
+        // most often nothing is mounted and something else made the directory.
+        // Treating that as "not mounted" rather than "corrupt" is the reading
+        // that matches what the user has to do about it: plug the disk in.
+        let marker = BackupVolumeMarker.read(at: directory)
+        if let expected = destination.identity {
+            guard let marker else {
+                return .volumeNotMounted(
+                    volumeName: destination.volumeName, path: directory.path)
+            }
+            guard marker.identity == expected else {
+                return .identityMismatch(
+                    expected: expected, found: marker.identity, path: directory.path)
+            }
+        }
+
+        guard fm.isWritableFile(atPath: directory.path) else {
+            return .notWritable(path: directory.path)
+        }
+        return .ready(directory)
+    }
+
+    /// The destination directory, or nil when backups are local-only.
+    /// Throws when one is configured but unreachable — never a URL that merely
+    /// looks usable.
+    static func destinationRoot() throws -> URL? {
+        switch availability() {
+        case .localOnly:
+            return nil
+        case .ready(let url):
+            return url
+        case .volumeNotMounted(let name, let path):
+            throw BackupError.destinationUnavailable(name ?? path)
+        case .identityMismatch(_, _, let path):
+            throw BackupError.destinationIsADifferentDisk(path)
+        case .notWritable(let path):
+            throw BackupError.destinationNotWritable(path)
+        }
+    }
+
+    /// The destination directory when it happens to be reachable, else nil.
+    /// For read paths, which must degrade to "show what is on this Mac" rather
+    /// than fail.
+    static var reachableDestinationRoot: URL? {
+        if case .ready(let url) = availability() { return url }
+        return nil
+    }
+
+    /// A stored backup: what is on disk plus the metadata we show in the UI.
     public struct Backup: Sendable, Equatable {
+        /// Which of the two stores this copy came out of.
+        public enum Location: Sendable, Equatable {
+            /// A plain `.app` directory on the boot volume.
+            case outbox
+            /// A `.aar` archive on the configured external destination.
+            case destination
+        }
+
         public let key: String
         public let version: String?
+        /// Where the stored copy lives: the `.app` directory for an outbox
+        /// backup, the archive file for one on the destination. Read `location`
+        /// before assuming which — a destination copy is a single file, so
+        /// walking it as a directory yields nothing rather than failing.
         public let bundlePath: URL
+        public let location: Location
         public let savedAt: Date
         /// Whether the update this backup was taken for was applied by a `.pkg`
         /// through the system installer.
@@ -53,6 +221,18 @@ public enum BackupStore {
         /// which is worth saying out loud rather than presenting as a clean
         /// rollback. Nil for backups written before this was recorded.
         public let fromPackageInstall: Bool?
+
+        public init(
+            key: String, version: String?, bundlePath: URL,
+            location: Location = .outbox, savedAt: Date, fromPackageInstall: Bool?
+        ) {
+            self.key = key
+            self.version = version
+            self.bundlePath = bundlePath
+            self.location = location
+            self.savedAt = savedAt
+            self.fromPackageInstall = fromPackageInstall
+        }
     }
 
     /// JSON sidecar persisted next to a backed-up bundle.
@@ -77,6 +257,26 @@ public enum BackupStore {
         /// vendor-signature gate at restore, which is the best that can be said
         /// about a copy we never fingerprinted.
         var manifest: BackupManifest?
+        /// Name of the archive holding this backup at the destination, e.g.
+        /// `Slack-4.35.121.aar`. Optional for the same reason as the fields
+        /// above — an outbox-only backup has none, and neither does one written
+        /// before there were destinations.
+        var archiveName: String?
+        /// SHA-256 of that archive as written.
+        ///
+        /// This is the integrity gate for the copy on the destination, and it is
+        /// deliberately a different question from `manifest`. One digest over one
+        /// file is something no filesystem can disagree about, which is the whole
+        /// reason a backup can live on a volume that could never hold the bundle
+        /// itself. `manifest` still guards the restore, but it is computed on the
+        /// unpacked tree — on APFS, both times.
+        var archiveSHA256: String?
+        /// Size of the archive on disk, so the UI can show what the move bought.
+        var archiveBytes: Int64?
+        /// True while a copy still exists only in the outbox and is waiting to be
+        /// moved to the destination. Absent means "not waiting", which is the
+        /// right reading for every backup written before transfers existed.
+        var pendingTransfer: Bool?
     }
 
     /// A filesystem-safe directory name for one installed copy of an app. It keeps
@@ -159,7 +359,11 @@ public enum BackupStore {
         fromPackageInstall: Bool = false
     ) throws -> Backup {
         let fm = FileManager.default
-        let dir = root.appendingPathComponent(key, isDirectory: true)
+        // Always the outbox, never the destination — even when one is configured.
+        // Writing here first is what makes an unplugged disk a delay rather than a
+        // missing rollback point, and it keeps the manifest recorded below computed
+        // on APFS, which is what lets the same manifest gate a restore later.
+        let dir = outboxRoot.appendingPathComponent(key, isDirectory: true)
         // Build the new backup in a hidden staging dir FIRST, then swap it into place
         // atomically. Retention = 1 must not delete the prior rollback point until the
         // new copy is fully written — otherwise a failed/interrupted re-backup (disk
@@ -167,8 +371,8 @@ public enum BackupStore {
         // about to change versions. The staging name is hidden (`.`-prefixed, so it's
         // skipped by `allBackups`' directory scan) and keyed per app, so it self-cleans
         // across a crashed prior attempt.
-        try fm.createDirectory(at: root, withIntermediateDirectories: true)
-        let staging = root.appendingPathComponent(".staging-\(key)", isDirectory: true)
+        try fm.createDirectory(at: outboxRoot, withIntermediateDirectories: true)
+        let staging = outboxRoot.appendingPathComponent(".staging-\(key)", isDirectory: true)
         forceRemove(staging)
         try fm.createDirectory(at: staging, withIntermediateDirectories: true)
 
@@ -225,7 +429,12 @@ public enum BackupStore {
             originalPath: appPath.path, bundleName: name, savedAt: savedAt,
             fromPackageInstall: fromPackageInstall,
             omittedFiles: unreadable.unsealed.isEmpty ? nil : unreadable.unsealed,
-            manifest: manifest)
+            manifest: manifest,
+            // Marked from the destination *setting*, not from whether the disk
+            // happens to be plugged in: the copy is owed either way, and a backup
+            // taken while the disk was out would otherwise never be picked up when
+            // it came back.
+            pendingTransfer: destination.kind == .external ? true : nil)
         // The sidecar is what EVERY read path keys off (`backup(forKey:)` returns nil
         // without it), so a backup whose sidecar didn't write is unusable. Fail the
         // save (leaving the prior backup intact) rather than leave an invisible bundle.
@@ -262,19 +471,218 @@ public enum BackupStore {
             fromPackageInstall: fromPackageInstall)
     }
 
+    // MARK: - Transfer
+
+    /// Keys whose backup is still sitting in the outbox owing a copy to the
+    /// destination — what a drain works through.
+    ///
+    /// **Everything in the outbox**, once a destination is configured, not only
+    /// what was saved since. The outbox is a staging area by definition, so
+    /// anything left in it is owed. Filtering on the `pendingTransfer` flag
+    /// written at save time looked tidier and was wrong in the case that matters:
+    /// backups taken before the disk was ever chosen would never move, which on a
+    /// real machine meant the 23.87 GB the user was trying to reclaim was exactly
+    /// the part that stayed put. The flag remains in the sidecar of the copy on
+    /// the disk, where it records that the move is settled.
+    ///
+    /// A directory only counts when it is actually a backup — a readable sidecar
+    /// and the bundle it names. Skipping that check to save the reads was a false
+    /// economy: `save` leaves a directory behind when it refuses a bundle it
+    /// cannot fully read (ToDesk and VSCodium both do this, keeping root-owned
+    /// state inside their own bundles), and those remnants went into the queue as
+    /// work that could never succeed.
+    public static func pendingTransferKeys() -> [String] {
+        guard destination.kind == .external else { return [] }
+        return storedKeys(in: outboxRoot).filter { key in
+            let dir = outboxRoot.appendingPathComponent(key, isDirectory: true)
+            guard let meta = readMeta(in: dir) else { return false }
+            return FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent(meta.bundleName).path)
+        }
+    }
+
+    /// The app's name for a key, for a progress line someone can read.
+    /// `com.pais.handy-1551b69e…` is an identity, not a name.
+    public static func displayName(forKey key: String) -> String? {
+        for root in [outboxRoot, reachableDestinationRoot].compactMap({ $0 }) {
+            if let meta = readMeta(in: root.appendingPathComponent(key, isDirectory: true)) {
+                return (meta.bundleName as NSString).deletingPathExtension
+            }
+        }
+        return nil
+    }
+
+    /// Archive the outbox copy of `key` onto the destination and drop the local
+    /// one. Throws — without touching either copy — when the disk is not there.
+    ///
+    /// The order is the whole of the safety argument, so it is worth stating
+    /// plainly: the archive lands, then its digest is read back **from the
+    /// destination**, then the sidecar is written, and only then is the local
+    /// copy removed. At every point before that last step there is a complete,
+    /// restorable backup somewhere. Reversing any two of them would open a
+    /// window where a yanked cable leaves the user with no rollback point for an
+    /// app that has just been updated — which is the one outcome this whole
+    /// feature exists to avoid.
+    ///
+    /// The digest is deliberately computed by reading the file back off the
+    /// destination rather than from the bytes we just had in hand. It costs one
+    /// sequential read and it is the only thing here that actually proves the
+    /// write arrived; hashing the source would certify something we did not
+    /// store, which is the same mistake `save` explicitly avoids.
+    @discardableResult
+    public static func transferToDestination(
+        forKey key: String,
+        compression: BundleArchive.Compression = UpdateSettings.backupCompressionDefault
+    ) throws -> Backup {
+        guard let root = try destinationRoot() else {
+            throw BackupError.destinationUnavailable(destination.volumeName ?? "backup disk")
+        }
+        let fm = FileManager.default
+        let outboxDir = outboxRoot.appendingPathComponent(key, isDirectory: true)
+        guard let meta = readMeta(in: outboxDir) else { throw BackupError.noBackup(key) }
+        let bundle = outboxDir.appendingPathComponent(meta.bundleName)
+        guard fm.fileExists(atPath: bundle.path) else { throw BackupError.noBackup(key) }
+
+        // Safe to create: `destinationRoot()` has already established that the
+        // root exists and carries our marker, so this cannot conjure a path on
+        // the boot volume.
+        let targetDir = root.appendingPathComponent(key, isDirectory: true)
+        try fm.createDirectory(at: targetDir, withIntermediateDirectories: true)
+
+        let archiveName = (meta.bundleName as NSString).deletingPathExtension + ".aar"
+        let archive = targetDir.appendingPathComponent(archiveName)
+        // Straight to the destination rather than via a local staging file:
+        // `BundleArchive` already writes a `.partial` beside the target and
+        // renames it, so the atomicity is the same, and streaming the compressed
+        // output over means a transfer never needs a second bundle-sized hole on
+        // the boot volume — which is usually the reason the store was moved.
+        try BundleArchive.archive(bundle: bundle, to: archive, compression: compression)
+
+        let digest = try BundleArchive.sha256(of: archive)
+        let bytes = (try? fm.attributesOfItem(atPath: archive.path)[.size] as? Int64) ?? nil
+
+        var moved = meta
+        moved.archiveName = archiveName
+        moved.archiveSHA256 = digest
+        moved.archiveBytes = bytes
+        moved.pendingTransfer = false
+        guard let data = try? JSONEncoder().encode(moved),
+              (try? data.write(to: targetDir.appendingPathComponent("backup.json"),
+                               options: .atomic)) != nil else {
+            // No sidecar means no readable backup, so leave nothing half-made.
+            forceRemove(targetDir)
+            throw BackupError.copyFailed(archive.path)
+        }
+
+        forceRemove(outboxDir)
+        Log.install.info(
+            "backup: moved \(key, privacy: .public) to the backup disk (\(bytes ?? 0, privacy: .public) bytes)")
+        return Backup(
+            key: key, version: meta.version, bundlePath: archive, location: .destination,
+            savedAt: meta.savedAt, fromPackageInstall: meta.fromPackageInstall)
+    }
+
+    // MARK: - Cleanup of interrupted work
+
+    /// Remove scratch left behind by a transfer that was cut off — a yanked
+    /// disk, a crash, a sleep the copy did not survive.
+    ///
+    /// Age is the only usable signal across processes, but a network volume's
+    /// timestamps come from the server's clock and can be skewed, so this is the
+    /// backstop and not the guard: `excluding` carries the keys a queue knows
+    /// are in flight right now, and those are skipped regardless of what their
+    /// mtime claims.
+    public static func sweepStaleScratch(
+        olderThan age: TimeInterval = 24 * 60 * 60, excluding inFlight: Set<String> = []
+    ) {
+        sweepStaleScratch(in: outboxRoot, age: age, inFlight: inFlight)
+        if let destination = reachableDestinationRoot {
+            sweepStaleScratch(in: destination, age: age, inFlight: inFlight)
+        }
+    }
+
+    private static func sweepStaleScratch(in root: URL, age: TimeInterval, inFlight: Set<String>) {
+        let fm = FileManager.default
+        let cutoff = Date().addingTimeInterval(-age)
+        let keys: [URLResourceKey] = [.contentModificationDateKey]
+
+        func isStale(_ url: URL) -> Bool {
+            guard let modified = (try? url.resourceValues(forKeys: Set(keys)))?
+                .contentModificationDate else { return false }
+            return modified < cutoff
+        }
+
+        guard let entries = try? fm.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: keys, options: []) else { return }
+        for entry in entries {
+            let name = entry.lastPathComponent
+            // A save that never finished: `.staging-<key>` at the store root.
+            if name.hasPrefix(".staging-") {
+                let key = String(name.dropFirst(".staging-".count))
+                if !inFlight.contains(key), isStale(entry) { forceRemove(entry) }
+                continue
+            }
+            // A transfer that never finished: the archive's `.partial` lives one
+            // level down, inside the key's own directory, because that is where
+            // it has to be for the rename into place to stay on one volume.
+            guard !name.hasPrefix("."), !inFlight.contains(name) else { continue }
+            guard let inner = try? fm.contentsOfDirectory(
+                at: entry, includingPropertiesForKeys: keys, options: []) else { continue }
+            for file in inner where file.lastPathComponent.hasSuffix(".partial") {
+                if isStale(file) { forceRemove(file) }
+            }
+            // A key directory with no sidecar is not a backup — no read path can
+            // see it and no other sweep would ever remove it. It is what an
+            // interrupted transfer leaves when the archive landed but the sidecar
+            // never did: dead bytes that would sit on the disk forever. Only ever
+            // true inside our own store root, which is why the store owns a
+            // subdirectory rather than the folder the user picked.
+            if readMeta(in: entry) == nil, isStale(entry) {
+                forceRemove(entry)
+            }
+        }
+    }
+
     // MARK: - Query
 
-    /// The current backup for `key`, or nil if none exists.
-    public static func backup(forKey key: String) -> Backup? {
+    private static func readMeta(in dir: URL) -> Meta? {
+        guard let data = try? Data(contentsOf: dir.appendingPathComponent("backup.json"))
+        else { return nil }
+        return try? JSONDecoder().decode(Meta.self, from: data)
+    }
+
+    /// The backup for `key` held under a specific root.
+    private static func backup(
+        forKey key: String, in root: URL, location: Backup.Location
+    ) -> Backup? {
         let dir = root.appendingPathComponent(key, isDirectory: true)
-        let metaURL = dir.appendingPathComponent("backup.json")
-        guard let data = try? Data(contentsOf: metaURL),
-              let meta = try? JSONDecoder().decode(Meta.self, from: data) else { return nil }
-        let bundle = dir.appendingPathComponent(meta.bundleName)
-        guard FileManager.default.fileExists(atPath: bundle.path) else { return nil }
+        guard let meta = readMeta(in: dir) else { return nil }
+        let payload: URL
+        switch location {
+        case .outbox:
+            payload = dir.appendingPathComponent(meta.bundleName)
+        case .destination:
+            // No archive name means the sidecar was copied but the archive was
+            // not — nothing to restore from, so this is not a backup.
+            guard let archiveName = meta.archiveName else { return nil }
+            payload = dir.appendingPathComponent(archiveName)
+        }
+        guard FileManager.default.fileExists(atPath: payload.path) else { return nil }
         return Backup(
-            key: key, version: meta.version, bundlePath: bundle, savedAt: meta.savedAt,
-            fromPackageInstall: meta.fromPackageInstall)
+            key: key, version: meta.version, bundlePath: payload, location: location,
+            savedAt: meta.savedAt, fromPackageInstall: meta.fromPackageInstall)
+    }
+
+    /// The current backup for `key`, or nil if none exists.
+    ///
+    /// The outbox wins when a key exists in both. It is the newer copy by
+    /// construction — a transfer only clears it after the destination copy is
+    /// complete — and restoring from it is a local directory copy rather than
+    /// unpacking an archive across a cable.
+    public static func backup(forKey key: String) -> Backup? {
+        if let local = backup(forKey: key, in: outboxRoot, location: .outbox) { return local }
+        guard let destination = reachableDestinationRoot else { return nil }
+        return backup(forKey: key, in: destination, location: .destination)
     }
 
     // MARK: - Restore
@@ -290,15 +698,27 @@ public enum BackupStore {
             throw BackupError.noBackup(key)
         }
         let fm = FileManager.default
+        // Per-invocation, not per-key. Keying the scratch directory on the app
+        // alone meant two restores of the same key shared one working directory,
+        // and since each one deletes it on the way in and again on the way out,
+        // the second would pull the tree out from under the first mid-copy. The
+        // `defer` below then removes only this run's directory, so a concurrent
+        // restore is no longer able to destroy it.
         let scratch = fm.temporaryDirectory
-            .appendingPathComponent("DuoUpdater-rollback-\(key)", isDirectory: true)
-        forceRemove(scratch)
+            .appendingPathComponent(
+                "DuoUpdater-rollback-\(key)-\(UUID().uuidString)", isDirectory: true)
         try fm.createDirectory(at: scratch, withIntermediateDirectories: true)
         defer { forceRemove(scratch) }
 
-        let staged = scratch.appendingPathComponent(backup.bundlePath.lastPathComponent)
-        guard runDitto(from: backup.bundlePath, to: staged) else {
-            throw BackupError.copyFailed(backup.bundlePath.path)
+        let staged: URL
+        switch backup.location {
+        case .outbox:
+            staged = scratch.appendingPathComponent(backup.bundlePath.lastPathComponent)
+            guard runDitto(from: backup.bundlePath, to: staged) else {
+                throw BackupError.copyFailed(backup.bundlePath.path)
+            }
+        case .destination:
+            staged = try unpackFromDestination(backup, key: key, into: scratch)
         }
         // Integrity gate before swapping a backup over the live app: a stored copy
         // that has changed since we wrote it has been corrupted or tampered with,
@@ -306,11 +726,175 @@ public enum BackupStore {
         // restore it — a rollback that knowingly installs a damaged bundle is worse
         // than leaving the (working) current app in place. See `integrityHolds` for
         // why this asks about our own copy rather than the vendor's signature.
-        guard integrityHolds(for: key, staged: staged) else {
+        let metaRoot = backup.location == .outbox
+            ? outboxRoot : backup.bundlePath.deletingLastPathComponent().deletingLastPathComponent()
+        guard integrityHolds(for: key, in: metaRoot, staged: staged) else {
             throw BackupError.backupCorrupted(backup.bundlePath.lastPathComponent)
         }
         try InPlaceSwap.replace(newApp: staged, over: target)
         return backup.version
+    }
+
+    /// Unpack a destination archive into `scratch`, returning the bundle.
+    ///
+    /// The digest is checked **before** unpacking rather than after. It is the
+    /// only integrity question that can be asked about bytes sitting on a
+    /// foreign filesystem, it costs one sequential read of a file we are about
+    /// to read anyway, and failing here means the manifest gate downstream never
+    /// has to explain a difference that a truncated transfer already accounts for.
+    private static func unpackFromDestination(
+        _ backup: Backup, key: String, into scratch: URL
+    ) throws -> URL {
+        let dir = backup.bundlePath.deletingLastPathComponent()
+        guard let meta = readMeta(in: dir) else { throw BackupError.noBackup(key) }
+
+        if let expected = meta.archiveSHA256 {
+            let actual = try BundleArchive.sha256(of: backup.bundlePath)
+            guard actual == expected else {
+                Log.install.error(
+                    "rollback: the archive for \(key, privacy: .public) on the backup disk does not match what was written — refusing to restore")
+                throw BackupError.backupCorrupted(backup.bundlePath.lastPathComponent)
+            }
+        }
+
+        let staged = scratch.appendingPathComponent(meta.bundleName)
+        try BundleArchive.extract(archive: backup.bundlePath, into: staged)
+        return staged
+    }
+
+    // MARK: - Verification
+
+    /// What a stored backup would do if it were needed right now.
+    ///
+    /// The distinction between the cases is the whole point. "Not verifiable" is
+    /// not a pass and not a failure — a backup written before fingerprints were
+    /// recorded genuinely cannot be checked, and reporting it as fine would be a
+    /// reassurance nobody earned. Only ``mismatch`` means the bytes changed.
+    public struct VerifyOutcome: Sendable, Equatable {
+        public enum Result: Sendable, Equatable {
+            case ok
+            /// The stored copy is not what was stored.
+            case mismatch(String)
+            /// Nothing to compare against.
+            case unverifiable(String)
+            /// The copy could not be read at all.
+            case unreadable(String)
+
+            public var isFailure: Bool {
+                if case .mismatch = self { return true }
+                if case .unreadable = self { return true }
+                return false
+            }
+        }
+        public let key: String
+        public let name: String
+        public let version: String?
+        public let location: Backup.Location
+        public let result: Result
+    }
+
+    /// Check every stored backup without restoring anything.
+    ///
+    /// Each store is asked the strongest question that is cheap there. An outbox
+    /// copy is a bundle on APFS, so its recorded manifest is recomputed in place —
+    /// the same comparison a rollback would make, at the same fidelity, for the
+    /// cost of a tree walk. A destination copy is one archive on a filesystem we
+    /// deliberately assume nothing about, so the digest recorded when it was
+    /// written is recomputed: that proves the bytes on the disk are the bytes we
+    /// sent, which is the only question those bytes can answer without unpacking.
+    ///
+    /// `deep` closes the remaining gap on the destination by extracting the
+    /// archive to a scratch directory and comparing the manifest — exactly what a
+    /// restore does, without the swap. It needs room for a full bundle and takes
+    /// as long as a rollback would, which is why it is not the default.
+    public static func verify(deep: Bool = false) -> [VerifyOutcome] {
+        var out = verify(in: outboxRoot, location: .outbox, deep: deep)
+        if let destination = reachableDestinationRoot {
+            out += verify(in: destination, location: .destination, deep: deep)
+        }
+        return out
+    }
+
+    private static func verify(
+        in root: URL, location: Backup.Location, deep: Bool
+    ) -> [VerifyOutcome] {
+        let fm = FileManager.default
+        return storedKeys(in: root).compactMap { key -> VerifyOutcome? in
+            let dir = root.appendingPathComponent(key, isDirectory: true)
+            // No sidecar is not a damaged backup, it is not a backup — the sweeper
+            // deals with those, and reporting them here would put remnants in a
+            // list whose every other row is something the user can act on.
+            guard let meta = readMeta(in: dir) else { return nil }
+            func outcome(_ result: VerifyOutcome.Result) -> VerifyOutcome {
+                VerifyOutcome(
+                    key: key, name: (meta.bundleName as NSString).deletingPathExtension,
+                    version: meta.version, location: location, result: result)
+            }
+
+            switch location {
+            case .outbox:
+                let bundle = dir.appendingPathComponent(meta.bundleName)
+                guard fm.fileExists(atPath: bundle.path) else {
+                    return outcome(.unreadable("the stored bundle is gone"))
+                }
+                guard let recorded = meta.manifest else {
+                    return outcome(.unverifiable("taken before fingerprints were recorded"))
+                }
+                guard let current = BackupManifest.compute(for: bundle) else {
+                    return outcome(.unreadable("the stored bundle could not be fingerprinted"))
+                }
+                guard current == recorded else {
+                    return outcome(.mismatch(
+                        "\(current.fileCount) files now, \(recorded.fileCount) when it was stored"))
+                }
+                return outcome(.ok)
+
+            case .destination:
+                guard let archiveName = meta.archiveName else {
+                    return outcome(.unreadable("the sidecar names no archive"))
+                }
+                let archive = dir.appendingPathComponent(archiveName)
+                guard fm.fileExists(atPath: archive.path) else {
+                    return outcome(.unreadable("the archive is gone"))
+                }
+                guard let expected = meta.archiveSHA256 else {
+                    return outcome(.unverifiable("moved before digests were recorded"))
+                }
+                guard let actual = try? BundleArchive.sha256(of: archive) else {
+                    return outcome(.unreadable("the archive could not be read"))
+                }
+                guard actual == expected else {
+                    return outcome(.mismatch("the archive is not the one that was written"))
+                }
+                guard deep else { return outcome(.ok) }
+                return outcome(deepCheck(archive: archive, meta: meta))
+            }
+        }
+    }
+
+    private static func deepCheck(archive: URL, meta: Meta) -> VerifyOutcome.Result {
+        guard let recorded = meta.manifest else {
+            return .unverifiable("taken before fingerprints were recorded")
+        }
+        let fm = FileManager.default
+        let scratch = fm.temporaryDirectory.appendingPathComponent(
+            "DuoUpdater-verify-\(UUID().uuidString)", isDirectory: true)
+        defer { forceRemove(scratch) }
+        let staged = scratch.appendingPathComponent(meta.bundleName)
+        do {
+            try BundleArchive.extract(archive: archive, into: staged)
+        } catch {
+            return .unreadable("the archive would not unpack — "
+                + ((error as? LocalizedError)?.errorDescription ?? error.localizedDescription))
+        }
+        guard let current = BackupManifest.compute(for: staged) else {
+            return .unreadable("the unpacked bundle could not be fingerprinted")
+        }
+        guard current == recorded else {
+            return .mismatch(
+                "\(current.fileCount) files unpacked, \(recorded.fileCount) when it was stored")
+        }
+        return .ok
     }
 
     /// Whether the staged copy is still what we stored.
@@ -321,11 +905,14 @@ public enum BackupStore {
     /// apps which break their own seal by writing state inside their bundle
     /// (ToDesk, EasyConnect), so a faithful copy of what the user was running
     /// was rejected as "corrupted".
-    private static func integrityHolds(for key: String, staged: URL) -> Bool {
-        let metaURL = root.appendingPathComponent(key, isDirectory: true)
-            .appendingPathComponent("backup.json")
-        let recorded = (try? Data(contentsOf: metaURL))
-            .flatMap { try? JSONDecoder().decode(Meta.self, from: $0) }?.manifest
+    /// `root` is whichever store the backup came out of. The recorded manifest
+    /// and the recomputation are both taken on APFS — the sidecar's was computed
+    /// on the outbox copy, and `staged` is in the temporary directory — so this
+    /// comparison never straddles two filesystems no matter where the bytes were
+    /// parked in between. That is what keeps a backup on an exFAT stick or an SMB
+    /// share restorable rather than only apparently stored.
+    private static func integrityHolds(for key: String, in root: URL, staged: URL) -> Bool {
+        let recorded = readMeta(in: root.appendingPathComponent(key, isDirectory: true))?.manifest
 
         if let recorded {
             guard let current = BackupManifest.compute(for: staged) else {
@@ -363,27 +950,53 @@ public enum BackupStore {
         }
     }
 
-    /// Every current backup, keyed by app key — one scan of the backups root.
-    /// Lets the UI light up rollback affordances without a stat per app.
-    public static func allBackups() -> [String: Backup] {
-        let fm = FileManager.default
-        guard let dirs = try? fm.contentsOfDirectory(
+    /// Keys that have a directory under `root`, hidden entries skipped so the
+    /// `.staging-` scratch and the volume marker never read as backups.
+    private static func storedKeys(in root: URL) -> [String] {
+        guard let dirs = try? FileManager.default.contentsOfDirectory(
             at: root, includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]) else { return [:] }
+            options: [.skipsHiddenFiles]) else { return [] }
+        return dirs.filter {
+            (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+        }.map(\.lastPathComponent)
+    }
+
+    /// Every current backup, keyed by app key — one scan of each store.
+    /// Lets the UI light up rollback affordances without a stat per app.
+    ///
+    /// The union matters more than it looks. A read path that saw only the
+    /// destination would report "no backups" whenever the disk was detached,
+    /// which is indistinguishable, on screen, from having none — and the copies
+    /// waiting in the outbox to be transferred would be invisible precisely
+    /// while they were the only ones present.
+    public static func allBackups() -> [String: Backup] {
         var out: [String: Backup] = [:]
-        for dir in dirs {
-            guard (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            else { continue }
-            if let backup = backup(forKey: dir.lastPathComponent) {
-                out[dir.lastPathComponent] = backup
+        if let destination = reachableDestinationRoot {
+            for key in storedKeys(in: destination) {
+                out[key] = backup(forKey: key, in: destination, location: .destination)
             }
         }
-        return out
+        // Outbox second so it wins a collision: it is the newer copy, and
+        // restoring from it does not go over the cable.
+        for key in storedKeys(in: outboxRoot) {
+            if let local = backup(forKey: key, in: outboxRoot, location: .outbox) {
+                out[key] = local
+            }
+        }
+        return out.compactMapValues { $0 }
     }
 
     /// Drop the backup for `key` (e.g. the user dismissed it).
+    ///
+    /// Removes it from both stores. Dropping only one would leave the other to
+    /// reappear at the next refresh, which reads as the deletion having silently
+    /// failed.
     public static func remove(forKey key: String) {
-        forceRemove(root.appendingPathComponent(key, isDirectory: true))
+        let fm = FileManager.default
+        forceRemove(outboxRoot.appendingPathComponent(key, isDirectory: true))
+        if let destination = reachableDestinationRoot {
+            forceRemove(destination.appendingPathComponent(key, isDirectory: true))
+        }
     }
 
     /// One stored backup, described for a UI that has to let someone choose which
@@ -412,6 +1025,26 @@ public enum BackupStore {
         /// the point — they are invisible to every other surface, which is how one
         /// grew to 272 MB unnoticed, counted in the total but impossible to remove.
         public let isRestorable: Bool
+        /// Which store this row came out of, so a sheet about reclaiming space
+        /// can say *whose* space — the boot volume's or the backup disk's.
+        public let location: Backup.Location
+
+        public init(
+            key: String, name: String, version: String?, currentVersion: String?,
+            savedAt: Date?, sizeBytes: Int64, bundlePath: URL?, appStillInstalled: Bool,
+            isRestorable: Bool, location: Backup.Location = .outbox
+        ) {
+            self.key = key
+            self.name = name
+            self.version = version
+            self.currentVersion = currentVersion
+            self.savedAt = savedAt
+            self.sizeBytes = sizeBytes
+            self.bundlePath = bundlePath
+            self.appStillInstalled = appStillInstalled
+            self.isRestorable = isRestorable
+            self.location = location
+        }
     }
 
     /// `CFBundleShortVersionString` of the app currently at `path`, or nil if it
@@ -427,33 +1060,47 @@ public enum BackupStore {
 
     /// Every stored backup with its size, newest first. Walks each directory to
     /// measure it, so call it off the main thread.
+    ///
+    /// Both stores are listed, and a key present in both appears **twice** — one
+    /// row per copy. That is deliberate for a sheet whose job is reclaiming
+    /// space: a backup mid-transfer really is occupying both disks, and merging
+    /// the rows would hide half of what deleting it would free.
     public static func listing() -> [Listing] {
-        let fm = FileManager.default
-        guard let dirs = try? fm.contentsOfDirectory(
-            at: root, includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]) else { return [] }
-        var out: [Listing] = []
-        for dir in dirs {
-            guard (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            else { continue }
-            let bundle = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil))?
-                .first { $0.pathExtension == "app" }
-            let meta = (try? Data(contentsOf: dir.appendingPathComponent("backup.json")))
-                .flatMap { try? JSONDecoder().decode(Meta.self, from: $0) }
-            out.append(Listing(
-                key: dir.lastPathComponent,
-                name: meta?.bundleName ?? bundle?.lastPathComponent ?? dir.lastPathComponent,
-                version: meta?.version,
-                currentVersion: meta.flatMap { installedShortVersion(atPath: $0.originalPath) },
-                savedAt: meta?.savedAt,
-                sizeBytes: directorySize(dir),
-                bundlePath: bundle,
-                appStillInstalled: meta.map { fm.fileExists(atPath: $0.originalPath) } ?? false,
-                isRestorable: meta != nil))
+        var out = listing(in: outboxRoot, location: .outbox)
+        if let destination = reachableDestinationRoot {
+            out += listing(in: destination, location: .destination)
         }
         // Undated (sidecar-less) entries sort last: they are the ones to clear out,
         // not the ones to reason about.
         return out.sorted { ($0.savedAt ?? .distantPast) > ($1.savedAt ?? .distantPast) }
+    }
+
+    private static func listing(in root: URL, location: Backup.Location) -> [Listing] {
+        let fm = FileManager.default
+        var out: [Listing] = []
+        for key in storedKeys(in: root) {
+            let dir = root.appendingPathComponent(key, isDirectory: true)
+            let meta = readMeta(in: dir)
+            // The payload is a directory in the outbox and a single file on the
+            // destination, so what stands in for "the bundle" differs; on the
+            // destination there is no `.app` to take an icon from.
+            let payload: URL? = location == .outbox
+                ? (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil))?
+                    .first { $0.pathExtension == "app" }
+                : meta?.archiveName.map { dir.appendingPathComponent($0) }
+            out.append(Listing(
+                key: key,
+                name: meta?.bundleName ?? payload?.lastPathComponent ?? key,
+                version: meta?.version,
+                currentVersion: meta.flatMap { installedShortVersion(atPath: $0.originalPath) },
+                savedAt: meta?.savedAt,
+                sizeBytes: directorySize(dir),
+                bundlePath: payload,
+                appStillInstalled: meta.map { fm.fileExists(atPath: $0.originalPath) } ?? false,
+                isRestorable: meta != nil,
+                location: location))
+        }
+        return out
     }
 
     // MARK: - Cleanup
@@ -464,20 +1111,30 @@ public enum BackupStore {
     /// the only unbounded growth left is these orphans: nothing ever revisits a
     /// key once its app is gone, and a large app bundle backup left behind is
     /// pure disk waste with no path left to restore onto. Returns the bytes freed.
+    /// Prunes both stores, and simply skips the destination when the disk is not
+    /// connected — a detached disk is not an orphan, and deleting on the strength
+    /// of "I could not see it" is how a backup disk gets emptied by being left at
+    /// the office.
+    ///
+    /// Note that "nothing to prune" and "could not look at the destination" both
+    /// return zero. Nothing distinguishes them today because nothing asks; the
+    /// caller discards this value entirely. Give this a richer return type when
+    /// a surface exists that would say something different about the two.
     @discardableResult
     public static func pruneOrphans() -> Int64 {
+        var freed = pruneOrphans(in: outboxRoot)
+        if let destination = reachableDestinationRoot {
+            freed += pruneOrphans(in: destination)
+        }
+        return freed
+    }
+
+    private static func pruneOrphans(in root: URL) -> Int64 {
         let fm = FileManager.default
-        guard let dirs = try? fm.contentsOfDirectory(
-            at: root, includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]) else { return 0 }
         var freed: Int64 = 0
-        for dir in dirs {
-            guard (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            else { continue }
-            let metaURL = dir.appendingPathComponent("backup.json")
-            guard let data = try? Data(contentsOf: metaURL),
-                  let meta = try? JSONDecoder().decode(Meta.self, from: data)
-            else { continue }
+        for key in storedKeys(in: root) {
+            let dir = root.appendingPathComponent(key, isDirectory: true)
+            guard let meta = readMeta(in: dir) else { continue }
             guard !fm.fileExists(atPath: meta.originalPath) else { continue }
             freed += directorySize(dir)
             forceRemove(dir)
@@ -486,9 +1143,25 @@ public enum BackupStore {
     }
 
     /// Total on-disk size of every stored backup, for display in Settings.
+    ///
+    /// Both stores together. Settings shows them apart — the point of moving the
+    /// store is to watch one number shrink — but the sum is what the existing
+    /// callers ask for, so ``storeSizes()`` answers the split question.
     public static func totalSize() -> Int64 {
-        let fm = FileManager.default
-        guard let dirs = try? fm.contentsOfDirectory(
+        let sizes = storeSizes()
+        return sizes.outbox + sizes.destination
+    }
+
+    /// On-disk size of each store separately. `destination` is zero when the
+    /// disk is not connected, which is indistinguishable from "empty" and should
+    /// be presented alongside ``availability()`` rather than on its own.
+    public static func storeSizes() -> (outbox: Int64, destination: Int64) {
+        (storeSize(of: outboxRoot),
+         reachableDestinationRoot.map(storeSize(of:)) ?? 0)
+    }
+
+    private static func storeSize(of root: URL) -> Int64 {
+        guard let dirs = try? FileManager.default.contentsOfDirectory(
             at: root, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
         else { return 0 }
         return dirs.reduce(into: 0) { $0 += directorySize($1) }
@@ -513,9 +1186,18 @@ public enum BackupStore {
         case noBackup(String)
         case backupCorrupted(String)
         case payloadUnreadable(String)
+        case destinationUnavailable(String)
+        case destinationIsADifferentDisk(String)
+        case destinationNotWritable(String)
 
         public var errorDescription: String? {
             switch self {
+            case .destinationUnavailable(let name):
+                return "The backup disk “\(name)” isn’t connected."
+            case .destinationIsADifferentDisk(let path):
+                return "A different disk is mounted at “\(path)”, so it was left alone."
+            case .destinationNotWritable(let path):
+                return "“\(path)” can’t be written to."
             case .copyFailed(let path):
                 return "Could not copy the app bundle at “\(path)”."
             case .noBackup(let key):
@@ -535,16 +1217,16 @@ public enum BackupStore {
     /// `ditto` faithfully copies BSD file flags, which is what we want of a
     /// backup — and it means a `uchg` file inside an app bundle comes along into
     /// the store. `removeItem` then fails with EPERM on that one file and, with
-    /// `try?`, fails silently: the backup stays, the space is never reclaimed,
-    /// and the delete sheet reports success while deleting nothing. Found on a
-    /// real machine, where ToDesk's `advInfo.json` had been locked by hand and
-    /// every ToDesk backup had become undeletable.
+    /// `try?`, fails silently: the backup stays, the sweeper appears to run, the
+    /// space is never reclaimed, and Clean Up reports success while deleting
+    /// nothing. Found on a real machine, where ToDesk's `advInfo.json` had been
+    /// locked by hand and every ToDesk backup had become undeletable.
     ///
     /// Clearing the flag is safe **here specifically** because the target is
     /// always a copy this store made, never the user's own file — and only the
     /// user-settable flags are touched, since the system ones need root and
     /// their presence is a genuine reason to stop. A restore is unaffected: it
-    /// copies its own bundle out, flags and all.
+    /// unpacks its own copy, flags and all.
     @discardableResult
     private static func forceRemove(_ url: URL) -> Bool {
         let fm = FileManager.default

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupTransferQueue.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupTransferQueue.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// Moves backups from the local outbox onto the configured external disk, one at
+/// a time, in the background.
+///
+/// The queue exists so that an install never waits on a cable. `BackupStore.save`
+/// always writes to the boot volume — fast, local, and the same operation it has
+/// always been — and the copy to the external disk happens afterwards, out of the
+/// install's way. What the user sees is unchanged install latency; what they get
+/// is the boot volume reclaimed a minute later.
+///
+/// **One at a time, deliberately.** The destination is a single slow pipe, so
+/// running two copies concurrently makes both slower and neither finish sooner;
+/// and compression is CPU-bound, so parallel transfers would compete there too.
+///
+/// **An absent disk is not a failure.** Every attempt re-asks
+/// `BackupStore.availability()` first, and an unreachable destination suspends
+/// the queue rather than consuming a retry: a disk that is in a bag is going to
+/// stay in a bag for longer than five exponential backoffs, and burning the
+/// budget on it would mean the transfer had permanently "failed" by the time it
+/// was plugged back in. Retries are for the transfer genuinely going wrong while
+/// the disk is right there.
+public actor BackupTransferQueue {
+
+    public static let shared = BackupTransferQueue()
+
+    public enum State: Sendable, Equatable {
+        case idle
+        /// `completed` and `total` count backups, not bytes. Bytes would be the
+        /// truer bar, but knowing them means walking every bundle in the outbox
+        /// before starting — minutes of stat calls on a big store, spent to
+        /// improve a bar rather than to move anything.
+        case copying(name: String, completed: Int, total: Int)
+        /// Work is owed but the destination is not reachable.
+        case waitingForDisk(pending: Int)
+        case failed(name: String, message: String, pending: Int)
+    }
+
+    public private(set) var state: State = .idle
+
+    /// Keys owed a copy, in the order they were asked for. An array rather than
+    /// a set because the oldest backup is the one most likely to be wanted back.
+    private var pending: [String] = []
+    /// The key being copied right now. `BackupStore.sweepStaleScratch` must skip
+    /// it: its `.partial` is minutes old by design on a slow disk, and mtime
+    /// alone cannot tell that apart from abandoned scratch.
+    private var inFlight: String?
+    private var draining = false
+    private var napAssertion: NSObjectProtocol?
+
+    /// Matches `Downloader`'s shape — `(attempt + 1) * 500ms`, five attempts.
+    /// Injectable so tests do not actually sleep, the way `MASInstaller` does it.
+    private let maxAttempts: Int
+    private let backoffUnitNanos: UInt64
+
+    public init(maxAttempts: Int = 5, backoffUnitNanos: UInt64 = 500_000_000) {
+        self.maxAttempts = maxAttempts
+        self.backoffUnitNanos = backoffUnitNanos
+    }
+
+    /// Keys the sweeper must leave alone.
+    public var protectedKeys: Set<String> { inFlight.map { [$0] } ?? [] }
+
+    /// How much is still owed, from the queue's own memory. The settings page
+    /// polls this rather than rescanning the store every second.
+    public var pendingCount: Int { pending.count + (inFlight == nil ? 0 : 1) }
+
+    // MARK: - Enqueuing
+
+    public func enqueue(_ key: String) {
+        guard !pending.contains(key), inFlight != key else { return }
+        pending.append(key)
+    }
+
+    /// Pick up everything the store says is still owed — at launch, and whenever
+    /// a disk appears.
+    ///
+    /// Reads from the sidecars rather than from memory on purpose: the backup
+    /// that most needs collecting is the one taken in a previous run, while the
+    /// disk was elsewhere, and an in-memory queue would have forgotten it.
+    public func resumePending() {
+        for key in BackupStore.pendingTransferKeys() { enqueue(key) }
+    }
+
+    // MARK: - Draining
+
+    /// Work the queue until it is empty or the disk goes away. Returns when
+    /// there is nothing further it can do right now.
+    public func drain() async {
+        guard !draining else { return }
+        draining = true
+        defer {
+            draining = false
+            endActivity()
+        }
+
+        var completed = 0
+        var failures: [(name: String, message: String)] = []
+        while !pending.isEmpty {
+            if Task.isCancelled { break }
+            // Ask before every item, not once per drain: a disk can be unplugged
+            // between two transfers, and the next one must suspend rather than
+            // fail.
+            guard case .ready = BackupStore.availability() else {
+                state = .waitingForDisk(pending: pending.count)
+                return
+            }
+            beginActivity()
+            let total = completed + pending.count
+            let key = pending.removeFirst()
+            inFlight = key
+            state = .copying(
+                name: BackupStore.displayName(forKey: key) ?? key,
+                completed: completed, total: total)
+            let outcome = await attempt(key)
+            inFlight = nil
+
+            switch outcome {
+            case .done:
+                completed += 1
+                continue
+            case .diskGone:
+                // Put it back at the front — it is still owed, and it was next.
+                pending.insert(key, at: 0)
+                state = .waitingForDisk(pending: pending.count)
+                return
+            case .failed(let message):
+                // Skip it and keep going. Stopping the run for one item meant a
+                // single backup that could never transfer — a remnant `save`
+                // left behind, say — held every remaining backup on the boot
+                // volume indefinitely, which is the opposite of what moving the
+                // store is for. The failure is reported once the rest are done.
+                failures.append((BackupStore.displayName(forKey: key) ?? key, message))
+                continue
+            }
+        }
+        if let first = failures.first {
+            state = .failed(
+                name: first.name, message: first.message, pending: failures.count)
+        } else {
+            state = .idle
+        }
+    }
+
+    private enum Outcome {
+        case done
+        case diskGone
+        case failed(String)
+    }
+
+    private func attempt(_ key: String) async -> Outcome {
+        var lastMessage = ""
+        for attempt in 0..<maxAttempts {
+            if Task.isCancelled { return .diskGone }
+            do {
+                try BackupStore.transferToDestination(forKey: key)
+                return .done
+            } catch {
+                // A destination that has gone away is not a transfer failure and
+                // must not spend an attempt; re-asking the store is what tells
+                // the two apart, since the tool underneath reports only an exit
+                // code and cannot.
+                if case .ready = BackupStore.availability() {
+                    lastMessage = error.localizedDescription
+                    Log.install.error(
+                        "backup transfer: \(key, privacy: .public) failed (attempt \(attempt + 1, privacy: .public)) — \(lastMessage, privacy: .public)")
+                } else {
+                    return .diskGone
+                }
+            }
+            if attempt + 1 < maxAttempts {
+                try? await Task.sleep(nanoseconds: UInt64(attempt + 1) * backoffUnitNanos)
+            }
+        }
+        return .failed(lastMessage)
+    }
+
+    // MARK: - Interruptions
+
+    /// Drop everything queued, for a disk that is about to be unmounted or a
+    /// machine about to sleep. Nothing on disk is undone: an interrupted
+    /// transfer leaves the local copy intact — it is only removed after the
+    /// destination copy is complete — so the work is simply owed again.
+    public func suspend() {
+        state = pending.isEmpty ? .idle : .waitingForDisk(pending: pending.count)
+    }
+
+    // MARK: - App Nap
+
+    /// Held only while a transfer is actually running. A copy to a slow disk can
+    /// outlast the idle timer, and letting the system nap mid-transfer is how a
+    /// `.partial` ends up sitting on the destination until the next sweep.
+    private func beginActivity() {
+        guard napAssertion == nil else { return }
+        napAssertion = ProcessInfo.processInfo.beginActivity(
+            options: .userInitiatedAllowingIdleSystemSleep,
+            reason: "Copying rollback backups to the backup disk")
+    }
+
+    private func endActivity() {
+        if let napAssertion { ProcessInfo.processInfo.endActivity(napAssertion) }
+        napAssertion = nil
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BundleArchive.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BundleArchive.swift
@@ -1,0 +1,257 @@
+import CryptoKit
+import Foundation
+
+/// Packs an app bundle into a single Apple Archive (`.aar`) and back out again.
+///
+/// It exists so a backup can be stored somewhere that is **not** a Mac-native
+/// filesystem. A `.app` is a directory whose meaning lives as much in its metadata
+/// as in its bytes — extended attributes, symlinks, permissions, hard links — and
+/// an exFAT stick or an SMB share stores those approximately at best. Writing the
+/// tree there and reading it back is not the same tree, which matters twice over:
+/// the restored app's code signature breaks, and `BackupManifest` (computed on the
+/// stored copy, rechecked on the way out) sees a different tree and refuses the
+/// rollback. Both failures surface on the day the user actually needs the backup.
+///
+/// An archive moves that problem out of the destination filesystem's hands: the
+/// metadata is encoded *inside* the byte stream, so the destination only has to
+/// hold one opaque file, which even FAT can do. It is also the right shape for
+/// this payload — we write a backup once and read it back whole, so none of the
+/// random-write machinery of a disk image (`hdiutil` sparse bundles, band files,
+/// the `F_FULLFSYNC` caveat on network servers) buys us anything.
+///
+/// Measured on Claude.app — 802 MB across 3421 files:
+///
+/// | algorithm | archive | time |
+/// |---|---|---|
+/// | `lzfse` (default) | 330 MB (41%) | 1.8 s |
+/// | `lzma` | 242 MB (30%) | 22 s |
+/// | extract (`lzfse`) | — | 1.1 s |
+///
+/// Two things that table understates. Compression is nearly free next to the
+/// transfer it feeds, so the default costs essentially nothing. And 3421 files
+/// becoming one is the larger win on a network share, where per-file round trips —
+/// not bandwidth — are usually what makes a NAS backup slow.
+///
+/// Round-tripping is verified to preserve the vendor code signature, not merely
+/// the file contents: AppCleaner, TestFlight, Pearcleaner and Claude all come back
+/// `codesign --verify --deep --strict` clean. That check is separate from a
+/// manifest comparison on purpose — `BackupManifest` does not hash extended
+/// attributes, so a tree can match byte-for-byte and still restore an app whose
+/// seal is broken.
+public enum BundleArchive {
+
+    /// Which way to trade time for size.
+    ///
+    /// `fast` is `lzfse`, Apple's own default, and is what a background transfer
+    /// should use: on the measurement above it costs under two seconds for a
+    /// 2.4× reduction. `smallest` is `lzma`, which buys a further 27% for twelve
+    /// times the CPU — worth offering for a slow or small destination, not worth
+    /// making the default.
+    public enum Compression: String, Sendable, CaseIterable, Codable {
+        case fast, smallest
+
+        var algorithm: String {
+            switch self {
+            case .fast:     return "lzfse"
+            case .smallest: return "lzma"
+            }
+        }
+    }
+
+    public enum ArchiveError: LocalizedError {
+        case toolMissing
+        case archiveFailed(code: Int32, message: String)
+        case extractFailed(code: Int32, message: String)
+        case producedNothing
+        case unreadable(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .toolMissing:
+                return "The system archive tool (/usr/bin/aa) is missing."
+            case .archiveFailed(let code, let message):
+                let detail = message.isEmpty ? "" : " — \(message)"
+                return "Could not pack the app into a backup archive (exit \(code))\(detail)."
+            case .extractFailed(let code, let message):
+                let detail = message.isEmpty ? "" : " — \(message)"
+                return "Could not unpack the backup archive (exit \(code))\(detail)."
+            case .producedNothing:
+                return "Packing the app produced no archive."
+            case .unreadable(let path):
+                return "Could not read “\(path)”."
+            }
+        }
+    }
+
+    /// Apple Archive ships with the OS; there is no fallback and no vendored copy.
+    static let tool = URL(fileURLWithPath: "/usr/bin/aa")
+
+    public static var isAvailable: Bool {
+        FileManager.default.isExecutableFile(atPath: tool.path)
+    }
+
+    /// The fields we require the archive to carry.
+    ///
+    /// `aa`'s default set already includes these — the round-trip tests pass
+    /// without the flag — but naming them makes the dependency explicit rather
+    /// than inherited from an undocumented default that a future macOS is free to
+    /// change. `attr` is `aa`'s own alias for `uid,gid,mod,flg,mtm,btm,ctm`.
+    /// Adding to the field set is additive, so this cannot subtract anything.
+    private static let requiredFields = "xat,acl,attr"
+
+    // MARK: - Pack
+
+    /// Pack `bundle` into a single archive at `file`.
+    ///
+    /// Writes to a sibling temporary name and renames into place, so an
+    /// interrupted run (drive yanked, share dropped) can leave a `.partial`
+    /// behind but never a truncated file under the real name. The caller sweeps
+    /// those; a half-written archive that looked complete would be a backup that
+    /// fails only at restore time.
+    public static func archive(
+        bundle: URL, to file: URL, compression: Compression = .fast
+    ) throws {
+        guard isAvailable else { throw ArchiveError.toolMissing }
+        guard FileManager.default.fileExists(atPath: bundle.path) else {
+            throw ArchiveError.unreadable(bundle.path)
+        }
+
+        let partial = file.deletingLastPathComponent()
+            .appendingPathComponent(".\(file.lastPathComponent).partial")
+        try? FileManager.default.removeItem(at: partial)
+
+        // `-d bundle` archives the bundle's *contents*; the directory's own name is
+        // not recorded. That is deliberate — the app's name lives in the sidecar
+        // (`Meta.bundleName`), which every read path already requires, and keeping
+        // it out of the archive means renaming a backup can never disagree with it.
+        let result = run([
+            "archive",
+            "-d", bundle.path,
+            "-o", partial.path,
+            "-a", compression.algorithm,
+            "-include-field", requiredFields,
+            "-no-ignore-eperm",
+        ])
+
+        guard result.status == 0 else {
+            try? FileManager.default.removeItem(at: partial)
+            throw ArchiveError.archiveFailed(code: result.status, message: result.message)
+        }
+        guard FileManager.default.fileExists(atPath: partial.path) else {
+            throw ArchiveError.producedNothing
+        }
+
+        try? FileManager.default.removeItem(at: file)
+        do {
+            try FileManager.default.moveItem(at: partial, to: file)
+        } catch {
+            try? FileManager.default.removeItem(at: partial)
+            throw error
+        }
+    }
+
+    // MARK: - Unpack
+
+    /// Unpack `archive` into `directory`, which becomes the restored bundle.
+    ///
+    /// `directory` must already exist and should be empty; `aa` writes the
+    /// bundle's contents directly into it.
+    ///
+    /// Runs with `-no-ignore-eperm`, which is **not** `aa`'s default. Left at the
+    /// default, a failure to set an attribute is swallowed and the extract still
+    /// reports success — and a bundle whose extended attributes did not come back
+    /// is a bundle whose code signature is broken, restored silently. That is
+    /// precisely the failure this whole path exists to prevent, so it is worth
+    /// the stricter reading: the cost is that a bundle carrying files this user
+    /// cannot chown (a `.pkg` install that left root-owned payload) now refuses to
+    /// unpack rather than unpacking wrong.
+    public static func extract(archive: URL, into directory: URL) throws {
+        guard isAvailable else { throw ArchiveError.toolMissing }
+        guard FileManager.default.fileExists(atPath: archive.path) else {
+            throw ArchiveError.unreadable(archive.path)
+        }
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+
+        let result = run([
+            "extract",
+            "-i", archive.path,
+            "-d", directory.path,
+            "-no-ignore-eperm",
+        ])
+        guard result.status == 0 else {
+            throw ArchiveError.extractFailed(code: result.status, message: result.message)
+        }
+    }
+
+    // MARK: - Digest
+
+    /// SHA-256 of a single file, streamed.
+    ///
+    /// This is the integrity gate for the copy that lives on the destination: one
+    /// digest over one file, which no filesystem can disagree about. It replaces —
+    /// for that copy — the tree-walking comparison `BackupManifest` has to do,
+    /// and it is the reason the destination's filesystem stops mattering.
+    ///
+    /// Chunked for the same reason `BackupManifest.compute` is: an app archive
+    /// runs to hundreds of megabytes, and reading one whole into memory to hash it
+    /// is how a backup of a large app turns into a memory spike.
+    public static func sha256(of file: URL) throws -> String {
+        guard let handle = try? FileHandle(forReadingFrom: file) else {
+            throw ArchiveError.unreadable(file.path)
+        }
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let chunk = try handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Process
+
+    /// The subprocess running right now, so a quitting app can stop it instead of
+    /// orphaning it.
+    ///
+    /// `aa` is a child process, and macOS does not take it down when we exit — an
+    /// orphan would keep writing, finish, and rename a complete archive into
+    /// place that nothing then records in a sidecar. The bytes would be invisible
+    /// to every read path and swept by none of them, because the sweeper looks
+    /// for `.partial` and this is not one.
+    private nonisolated(unsafe) static var inFlight: Process?
+    private static let inFlightLock = NSLock()
+
+    /// Stop the running archive/extract, if any. Safe to call when nothing runs.
+    public static func terminateInFlight() {
+        inFlightLock.lock()
+        let process = inFlight
+        inFlightLock.unlock()
+        process?.terminate()
+    }
+
+    private static func run(_ arguments: [String]) -> (status: Int32, message: String) {
+        let process = Process()
+        process.executableURL = tool
+        process.arguments = arguments
+        let errPipe = Pipe()
+        let outPipe = Pipe()
+        process.standardError = errPipe
+        process.standardOutput = outPipe
+
+        do { try process.run() } catch {
+            return (-1, error.localizedDescription)
+        }
+        inFlightLock.lock(); inFlight = process; inFlightLock.unlock()
+        defer { inFlightLock.lock(); inFlight = nil; inFlightLock.unlock() }
+        // Drained before `waitUntilExit` so a verbose failure cannot fill the pipe
+        // buffer and deadlock the tool against a reader that never runs.
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        _ = outPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        let message = String(decoding: errData, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\n").last.map(String.init) ?? ""
+        return (process.terminationStatus, message)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupDestinationProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupDestinationProbeTests.swift
@@ -1,0 +1,376 @@
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// Probing a candidate backup folder, and — the part that carries the design —
+/// proving a backup survives a full round trip on filesystems that could never
+/// hold an app bundle directly.
+///
+/// The filesystem cases run against real volumes made with `hdiutil`: sparse
+/// images cost nothing until written, need no administrator rights, and can be
+/// formatted as anything Disk Utility offers. They assert an **invariant, not a
+/// table**: save → transfer → restore must work on *every* format. That is the
+/// claim storing archives makes, and it is worth asserting directly rather than
+/// hedging behind "the probe said it was fine".
+///
+/// SMB and NFS cannot be conjured this way and are deliberately not faked. The
+/// honest answer there is a probe the user can run against a real share.
+@Suite struct BackupDestinationProbeTests {
+
+    private static let hdiutilAvailable =
+        FileManager.default.isExecutableFile(atPath: "/usr/bin/hdiutil")
+        && ProcessInfo.processInfo.environment["DUO_FS_TESTS"] != "0"
+
+    // MARK: - Basics, on whatever $TMPDIR is
+
+    private func scratch() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoProbeTest-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func withScratch(_ body: (URL) throws -> Void) throws {
+        let dir = scratch()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try body(dir)
+    }
+
+    @Test func aProbeDescribesTheVolume() throws {
+        try withScratch { dir in
+            let report = try BackupDestinationProbe.run(at: dir)
+            #expect(report.freeBytes ?? 0 > 0)
+            #expect(report.filesystem != nil)
+            // Whatever $TMPDIR is, its ceiling must not be one a backup could
+            // ever hit. Asserted as a bound rather than an exact value so this
+            // does not encode which filesystem the boot volume happens to use.
+            #expect(report.maxFileBytes == nil || (report.maxFileBytes ?? 0) > (1 << 40))
+        }
+    }
+
+    @Test func aProbeLeavesNothingBehind() throws {
+        try withScratch { dir in
+            _ = try BackupDestinationProbe.run(at: dir)
+            let leftovers = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            #expect(leftovers.isEmpty, "unexpected leftovers: \(leftovers)")
+        }
+    }
+
+    @Test func aFileIsNotAFolder() throws {
+        try withScratch { dir in
+            let file = dir.appendingPathComponent("f")
+            try Data("x".utf8).write(to: file)
+            #expect(throws: BackupDestinationProbe.ProbeFailure.self) {
+                _ = try BackupDestinationProbe.run(at: file)
+            }
+        }
+    }
+
+    @Test func aVolumeWithoutRoomIsRefused() throws {
+        try withScratch { dir in
+            #expect(throws: BackupDestinationProbe.ProbeFailure.self) {
+                // More than any disk has.
+                _ = try BackupDestinationProbe.run(
+                    at: dir, minimumFreeBytes: Int64.max - 1)
+            }
+        }
+    }
+
+    // MARK: - Adoption
+
+    @Test func adoptingAFolderMarksItAndDescribesIt() throws {
+        try withScratch { dir in
+            let (destination, _) = try BackupDestinationProbe.adopt(directory: dir)
+            #expect(destination.kind == .external)
+            // The store is our subdirectory inside what was picked, never the
+            // picked folder itself.
+            #expect(destination.path
+                == dir.appendingPathComponent(BackupDestination.storeFolderName)
+                    .standardizedFileURL.path)
+            let store = try #require(destination.directory)
+            let marker = try #require(BackupVolumeMarker.read(at: store))
+            #expect(destination.identity == marker.identity)
+            // The freshly adopted folder is immediately usable as a destination.
+            try BackupStore.$destinationOverride.withValue(destination) {
+                #expect(BackupStore.availability() == .ready(destination.directory!))
+            }
+        }
+    }
+
+    /// **The one that matters.** A folder picker hands back somewhere that
+    /// belongs to the user. Rooting the store there made every one of their
+    /// subdirectories look like a backup: counted in the storage total, listed in
+    /// the clean-up sheet, and one confirmation away from `removeItem`. Measured
+    /// on a real machine, `~/Documents` had 75 of them and 31 GB of the user's
+    /// files reported as backup storage.
+    @Test func adoptingNeverTakesOverTheFolderTheUserPicked() throws {
+        try withScratch { picked in
+            let fm = FileManager.default
+            // Stand in for someone's Documents folder.
+            for name in ["2026-03-03", "Taxes", "Screenshots"] {
+                let dir = picked.appendingPathComponent(name, isDirectory: true)
+                try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+                try Data(repeating: 0xAB, count: 4096)
+                    .write(to: dir.appendingPathComponent("theirs.bin"))
+            }
+
+            let (destination, _) = try BackupDestinationProbe.adopt(directory: picked)
+            let store = try #require(destination.directory)
+
+            #expect(store.lastPathComponent == BackupDestination.storeFolderName)
+            #expect(store.deletingLastPathComponent().standardizedFileURL
+                == picked.standardizedFileURL)
+            // Nothing of ours is left loose in the folder they chose.
+            #expect(BackupVolumeMarker.read(at: picked) == nil,
+                    "the marker must go inside our own directory, not theirs")
+            #expect(BackupVolumeMarker.read(at: store) != nil)
+
+            try BackupStore.$rootOverride.withValue(
+                picked.appendingPathComponent("outbox", isDirectory: true)
+            ) {
+                try BackupStore.$destinationOverride.withValue(destination) {
+                    // Their folders are not backups, are not listed, and are not
+                    // counted — so nothing can offer to delete them.
+                    #expect(BackupStore.listing().isEmpty)
+                    #expect(BackupStore.allBackups().isEmpty)
+                    #expect(BackupStore.storeSizes().destination == 0)
+                }
+            }
+            // And they are all still there.
+            for name in ["2026-03-03", "Taxes", "Screenshots"] {
+                #expect(fm.fileExists(
+                    atPath: picked.appendingPathComponent("\(name)/theirs.bin").path))
+            }
+        }
+    }
+
+    /// Picking the store itself must not nest another one inside it. The
+    /// settings page shows the store path, so picking what is shown is the
+    /// ordinary way anyone re-selects a disk — and each re-pick used to bury the
+    /// real backups one level further up, out of sight, while an empty folder
+    /// became the destination.
+    @Test func rePickingTheStoreItselfDoesNotNestAnother() throws {
+        try withScratch { picked in
+            let first = try BackupDestinationProbe.adopt(directory: picked).destination
+            let store = try #require(first.directory)
+
+            // The user copies the path out of Settings and picks that.
+            let second = try BackupDestinationProbe.adopt(directory: store).destination
+
+            #expect(second.path == first.path, "adoption must be idempotent")
+            #expect(second.identity == first.identity, "and must keep the disk's identity")
+            #expect(!FileManager.default.fileExists(
+                atPath: store.appendingPathComponent(
+                    BackupDestination.storeFolderName).path),
+                "no store nested inside the store")
+        }
+    }
+
+    /// A third pick is still the same place — the guard cannot depend on how
+    /// many times it has run.
+    @Test func adoptingTheStoreRepeatedlyStaysPut() throws {
+        try withScratch { picked in
+            var destination = try BackupDestinationProbe.adopt(directory: picked).destination
+            let expected = destination.path
+            for _ in 0..<3 {
+                destination = try BackupDestinationProbe
+                    .adopt(directory: try #require(destination.directory)).destination
+                #expect(destination.path == expected)
+            }
+        }
+    }
+
+    /// Re-picking a folder that already holds backups is how someone reconnects
+    /// a disk after reinstalling. Minting a fresh identity there would make every
+    /// backup already on it read as belonging to a different disk.
+    @Test func adoptingTheSameFolderTwiceKeepsTheIdentity() throws {
+        try withScratch { dir in
+            let first = try BackupDestinationProbe.adopt(directory: dir).destination
+            let second = try BackupDestinationProbe.adopt(directory: dir).destination
+            #expect(first.identity == second.identity)
+        }
+    }
+
+    // MARK: - Real filesystems
+
+    /// Create, attach, and guarantee detach of a sparse image.
+    private func withVolume(
+        format: String, sizeMB: Int = 256, _ body: (URL) throws -> Void
+    ) throws {
+        let fm = FileManager.default
+        let id = UUID().uuidString
+        let image = fm.temporaryDirectory.appendingPathComponent("duo-\(id).sparseimage")
+        let mount = fm.temporaryDirectory.appendingPathComponent("duo-mnt-\(id)", isDirectory: true)
+        // exFAT volume labels cap at 11 characters, so the name cannot carry a
+        // UUID. Uniqueness lives in the mount point instead, which also keeps
+        // concurrent runs from colliding on `/Volumes/Name 1`.
+        let volname = "duo\(id.prefix(5))"
+
+        func run(_ arguments: [String]) -> Int32 {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+            process.arguments = arguments
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            guard (try? process.run()) != nil else { return -1 }
+            process.waitUntilExit()
+            return process.terminationStatus
+        }
+
+        try #require(run([
+            "create", "-size", "\(sizeMB)m", "-type", "SPARSE",
+            "-fs", format, "-volname", volname, image.path,
+        ]) == 0, "could not create a \(format) image")
+        defer { try? fm.removeItem(at: image) }
+
+        try fm.createDirectory(at: mount, withIntermediateDirectories: true)
+        try #require(run([
+            "attach", "-nobrowse", "-mountpoint", mount.path, image.path,
+        ]) == 0, "could not attach the \(format) image")
+        defer {
+            // A leaked mount poisons the next run, so a stuck one is forced.
+            if run(["detach", mount.path]) != 0 { _ = run(["detach", "-force", mount.path]) }
+            try? fm.removeItem(at: mount)
+        }
+
+        try body(mount)
+    }
+
+    @discardableResult
+    private func makeApp(named name: String, in dir: URL, marker: String) throws -> URL {
+        let fm = FileManager.default
+        let app = dir.appendingPathComponent(name)
+        let contents = app.appendingPathComponent("Contents")
+        try? fm.removeItem(at: app)
+        try fm.createDirectory(at: contents, withIntermediateDirectories: true)
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+          <key>CFBundleExecutable</key><string>App</string>
+          <key>CFBundleIdentifier</key><string>com.example.testapp</string>
+          <key>CFBundleName</key><string>App</string>
+          <key>CFBundlePackageType</key><string>APPL</string>
+        </dict></plist>
+        """
+        try Data(plist.utf8).write(to: contents.appendingPathComponent("Info.plist"))
+        try Data(marker.utf8).write(to: contents.appendingPathComponent("marker.txt"))
+        // A symlink and an extended attribute: the two things a bundle carries
+        // that FAT and SMB cannot represent, and the reason the payload is an
+        // archive rather than a directory.
+        try fm.createSymbolicLink(
+            atPath: contents.appendingPathComponent("Current").path,
+            withDestinationPath: "MacOS")
+        let data = Data("0081;0;Safari;".utf8)
+        _ = data.withUnsafeBytes { buffer in
+            setxattr(contents.appendingPathComponent("marker.txt").path,
+                     "com.apple.quarantine", buffer.baseAddress, buffer.count, 0, 0)
+        }
+        return app
+    }
+
+    private func marker(of app: URL) -> String? {
+        try? String(contentsOf: app.appendingPathComponent("Contents/marker.txt"), encoding: .utf8)
+    }
+
+    /// **The claim the whole approach rests on.** A backup taken on APFS, stored
+    /// on a volume that could not hold the bundle itself, and restored — on every
+    /// format, with no per-format special casing anywhere in the code.
+    @Test(
+        .enabled(if: BackupDestinationProbeTests.hdiutilAvailable),
+        arguments: ["MS-DOS", "ExFAT", "HFS+", "APFS", "Case-sensitive APFS"]
+    )
+    func aBackupRoundTripsOnAnyFilesystem(_ format: String) throws {
+        try withVolume(format: format) { volume in
+            let fm = FileManager.default
+            let local = fm.temporaryDirectory
+                .appendingPathComponent("DuoFS-\(UUID().uuidString)", isDirectory: true)
+            let outbox = local.appendingPathComponent("outbox", isDirectory: true)
+            let apps = local.appendingPathComponent("apps", isDirectory: true)
+            defer { try? fm.removeItem(at: local) }
+            try fm.createDirectory(at: outbox, withIntermediateDirectories: true)
+            try fm.createDirectory(at: apps, withIntermediateDirectories: true)
+
+            let (destination, report) = try BackupDestinationProbe.adopt(directory: volume)
+            #expect(report.filesystem != nil, "\(format): no filesystem name")
+
+            try BackupStore.$rootOverride.withValue(outbox) {
+                try BackupStore.$destinationOverride.withValue(destination) {
+                    let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+                    try BackupStore.save(
+                        appPath: app, key: "k", version: "1.0",
+                        bundleID: "com.example.testapp")
+
+                    let moved = try BackupStore.transferToDestination(forKey: "k")
+                    #expect(moved.location == .destination, "\(format): transfer did not land")
+                    #expect(!fm.fileExists(atPath: outbox.appendingPathComponent("k").path),
+                            "\(format): local copy should be gone")
+
+                    try makeApp(named: "App.app", in: apps, marker: "v2")
+                    let version = try BackupStore.restore(forKey: "k", over: app)
+                    #expect(version == "1.0", "\(format): wrong version restored")
+                    #expect(marker(of: app) == "v1", "\(format): contents did not come back")
+                    // The symlink is the thing that would have been flattened had
+                    // the bundle been copied onto this volume directly.
+                    let link = app.appendingPathComponent("Contents/Current")
+                    #expect(try fm.destinationOfSymbolicLink(atPath: link.path) == "MacOS",
+                            "\(format): symlink did not survive")
+                }
+            }
+        }
+    }
+
+    /// FAT32 caps a single file at 4 GiB − 1, and the probe reads that off the
+    /// filesystem rather than guessing from its name. The others report either no
+    /// ceiling at all (HFS+, exFAT) or one — APFS's ~36 PB — that no backup can
+    /// reach; both are fine, and neither is worth hard-coding, so they are
+    /// asserted as "not a limit anything could hit".
+    @Test(
+        .enabled(if: BackupDestinationProbeTests.hdiutilAvailable),
+        arguments: ["MS-DOS", "ExFAT", "HFS+", "APFS"]
+    )
+    func theFileSizeCeilingIsReadFromTheFilesystem(_ format: String) throws {
+        try withVolume(format: format) { volume in
+            let report = try BackupDestinationProbe.run(at: volume)
+            if format == "MS-DOS" {
+                #expect(report.maxFileBytes == (1 << 32) - 1,
+                        "FAT should report a 4 GiB ceiling, got \(String(describing: report.maxFileBytes))")
+            } else {
+                #expect(report.maxFileBytes == nil || (report.maxFileBytes ?? 0) > (1 << 40),
+                        "\(format) should report no reachable ceiling, got \(String(describing: report.maxFileBytes))")
+            }
+        }
+    }
+
+    /// A folder picker cannot express "another disk" on its own —
+    /// `~/Documents/Backups` is a perfectly valid folder that frees nothing.
+    /// This is what tells the two apart, so the page can say so instead of
+    /// promising space it will not reclaim.
+    @Test func twoFoldersOnTheBootVolumeAreTheSameVolume() throws {
+        try withScratch { a in
+            try withScratch { b in
+                #expect(BackupDestinationProbe.isOnSameVolume(a, as: b))
+            }
+        }
+    }
+
+    @Test(.enabled(if: BackupDestinationProbeTests.hdiutilAvailable))
+    func amountedDiskIsADifferentVolumeFromTheBootDisk() throws {
+        try withVolume(format: "APFS") { volume in
+            try withScratch { local in
+                #expect(!BackupDestinationProbe.isOnSameVolume(volume, as: local))
+                // And it agrees with itself, so the check is not just "always false".
+                #expect(BackupDestinationProbe.isOnSameVolume(volume, as: volume))
+            }
+        }
+    }
+
+    @Test(.enabled(if: BackupDestinationProbeTests.hdiutilAvailable))
+    func aDiskImageIsSeenAsRemovableAndLocal() throws {
+        try withVolume(format: "APFS") { volume in
+            let report = try BackupDestinationProbe.run(at: volume)
+            #expect(report.isLocal == true, "an attached image is not a network volume")
+            #expect(report.writeBytesPerSecond ?? 0 > 0)
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupDestinationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupDestinationTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// How a configured backup destination survives a trip through UserDefaults, and
+/// how a destination proves which disk it is.
+///
+/// Worth testing at this level because both products resolve this independently:
+/// the menu bar app and `duo backups` read the same keys out of the same suite,
+/// and a disagreement between them would not surface as an error. Each would
+/// simply use a different store, and the first sign of it would be a rollback
+/// offered in one place and absent in the other.
+@Suite struct BackupDestinationTests {
+
+    /// A private, empty defaults suite — never `.standard`, which would read and
+    /// write the developer's real preferences.
+    private func withDefaults(_ body: (UserDefaults) throws -> Void) throws {
+        let name = "BackupDestinationTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+        try body(defaults)
+    }
+
+    private func scratch() -> URL {
+        // UUID-suffixed: several worktrees of this repo run `swift test`
+        // concurrently against the same $TMPDIR.
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoBackupDestTest-\(UUID().uuidString)")
+    }
+
+    // MARK: - Persistence
+
+    @Test func nothingConfiguredMeansLocal() throws {
+        try withDefaults { defaults in
+            #expect(BackupDestination.load(from: defaults) == .local)
+        }
+    }
+
+    @Test func anExternalDestinationRoundTrips() throws {
+        try withDefaults { defaults in
+            let destination = BackupDestination(
+                kind: .external, path: "/Volumes/Archive/DuoBackups",
+                identity: "F1E2D3C4", volumeName: "Archive")
+            destination.save(into: defaults)
+            #expect(BackupDestination.load(from: defaults) == destination)
+        }
+    }
+
+    /// Going back to local is a switch, not an erasure: the disk stays
+    /// remembered so turning it on again is one click rather than another trip
+    /// through a file picker.
+    @Test func goingBackToLocalStillRemembersTheDisk() throws {
+        try withDefaults { defaults in
+            let disk = BackupDestination(
+                kind: .external, path: "/Volumes/Archive", identity: "OLD", volumeName: "Archive")
+            disk.save(into: defaults)
+            BackupDestination.local.save(into: defaults)
+
+            #expect(BackupDestination.load(from: defaults) == .local, "backups go local")
+            #expect(BackupDestination.remembered(from: defaults) == disk, "but the disk is kept")
+
+            // And switching back needs nothing but the switch.
+            disk.save(into: defaults)
+            #expect(BackupDestination.load(from: defaults) == disk)
+        }
+    }
+
+    /// Choosing a different folder replaces what was remembered — a stale
+    /// identity matched against the new folder would read as a different disk.
+    @Test func choosingAnotherFolderReplacesWhatIsRemembered() throws {
+        try withDefaults { defaults in
+            BackupDestination(kind: .external, path: "/Volumes/A", identity: "A").save(into: defaults)
+            let second = BackupDestination(kind: .external, path: "/Volumes/B", identity: "B")
+            second.save(into: defaults)
+            #expect(BackupDestination.remembered(from: defaults) == second)
+        }
+    }
+
+    /// Anyone who configured a disk before the switch existed must keep it. A
+    /// missing flag read as `false` would have turned their store local
+    /// silently, which looks exactly like never having moved it.
+    @Test func aDiskConfiguredBeforeTheSwitchExistedStaysOn() throws {
+        try withDefaults { defaults in
+            // Exactly what an older build wrote: the location, and no flag.
+            defaults.set("/Volumes/Archive", forKey: UpdateSettings.backupDestinationPathKey)
+            defaults.set("OLD", forKey: UpdateSettings.backupDestinationIdentityKey)
+
+            let loaded = BackupDestination.load(from: defaults)
+            #expect(loaded.kind == .external)
+            #expect(loaded.path == "/Volumes/Archive")
+        }
+    }
+
+    /// An empty string is not a destination. Without this it would resolve to
+    /// `URL(fileURLWithPath: "")`, which is the current directory — a place
+    /// backups must never be written.
+    @Test func anEmptyPathReadsAsLocal() throws {
+        try withDefaults { defaults in
+            defaults.set("", forKey: UpdateSettings.backupDestinationPathKey)
+            #expect(BackupDestination.load(from: defaults) == .local)
+        }
+    }
+
+    /// A path configured before the marker was written is legitimate — it reads
+    /// as "not verified yet", which is a different state from "matches".
+    @Test func anExternalPathWithoutAnIdentityStillLoads() throws {
+        try withDefaults { defaults in
+            defaults.set("/Volumes/Archive", forKey: UpdateSettings.backupDestinationPathKey)
+            let loaded = BackupDestination.load(from: defaults)
+            #expect(loaded.kind == .external)
+            #expect(loaded.identity == nil)
+        }
+    }
+
+    // MARK: - directory
+
+    @Test func localHasNoDirectory() {
+        #expect(BackupDestination.local.directory == nil)
+    }
+
+    @Test func externalResolvesItsDirectoryWithoutTouchingTheDisk() {
+        let path = "/Volumes/Definitely Not Mounted \(UUID().uuidString)/Backups"
+        let directory = BackupDestination(kind: .external, path: path).directory
+        #expect(directory?.path == path)
+        // Resolving must not have created it: conflating "configured" with
+        // "reachable" is how a detached disk turns into a directory quietly
+        // created on the boot volume, which then squats the mount point.
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    // MARK: - Volume marker
+
+    @Test func theMarkerRoundTrips() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let marker = BackupVolumeMarker(
+            volumeName: "Archive", volumeUUID: "ABC", filesystem: "exfat")
+        try marker.write(to: root)
+
+        let read = try #require(BackupVolumeMarker.read(at: root))
+        #expect(read.identity == marker.identity)
+        #expect(read.volumeName == "Archive")
+        #expect(read.filesystem == "exfat")
+    }
+
+    @Test func eachMarkerGetsItsOwnIdentity() {
+        #expect(BackupVolumeMarker().identity != BackupVolumeMarker().identity)
+    }
+
+    /// No marker means "this is not the disk we were configured for" — including
+    /// the case where nothing is mounted and the path is an empty directory
+    /// someone else created.
+    @Test func aDirectoryWithoutAMarkerReadsAsNil() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        #expect(BackupVolumeMarker.read(at: root) == nil)
+    }
+
+    @Test func anUnreadableMarkerReadsAsNilRatherThanThrowing() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("not json".utf8).write(
+            to: root.appendingPathComponent(BackupVolumeMarker.fileName))
+        #expect(BackupVolumeMarker.read(at: root) == nil)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreDestinationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreDestinationTests.swift
@@ -1,0 +1,460 @@
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// ``BackupStore`` once an external destination is configured: what it reports
+/// when the disk is not there, which store a read comes out of, and that a
+/// backup parked on the destination can still be restored.
+///
+/// Both seams are task-local, so these run in parallel with everything else
+/// without either store leaking into another suite.
+@Suite struct BackupStoreDestinationTests {
+
+    // MARK: - Fixtures
+
+    private func withStores(
+        destinationIdentity: String? = nil,
+        markerIdentity: String?? = .some(nil),
+        _ body: (_ outbox: URL, _ destination: URL) throws -> Void
+    ) throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory
+            .appendingPathComponent("DuoBackupStoreDest-\(UUID().uuidString)")
+        let outbox = base.appendingPathComponent("outbox", isDirectory: true)
+        // `isDirectory: true` so this URL is spelled the same way
+        // `BackupDestination.directory` spells it — URL equality is on the
+        // string, and a missing trailing slash makes an identical path unequal.
+        let destination = base.appendingPathComponent("disk", isDirectory: true)
+        defer { try? fm.removeItem(at: base) }
+        try fm.createDirectory(at: outbox, withIntermediateDirectories: true)
+        try fm.createDirectory(at: destination, withIntermediateDirectories: true)
+
+        // `markerIdentity` is doubly optional on purpose: `.some(nil)` writes a
+        // marker with a fresh identity, `.none` writes none at all.
+        let identity: String?
+        switch markerIdentity {
+        case .none:
+            identity = nil
+        case .some(let explicit):
+            let value = explicit ?? destinationIdentity ?? UUID().uuidString
+            try BackupVolumeMarker(identity: value, volumeName: "TestDisk")
+                .write(to: destination)
+            identity = value
+        }
+
+        let configured = BackupDestination(
+            kind: .external, path: destination.path,
+            identity: destinationIdentity ?? (markerIdentity == nil ? nil : identity),
+            volumeName: "TestDisk")
+
+        try BackupStore.$rootOverride.withValue(outbox) {
+            try BackupStore.$destinationOverride.withValue(configured) {
+                try body(outbox, destination)
+            }
+        }
+    }
+
+    @discardableResult
+    private func makeApp(named name: String, in dir: URL, marker: String) throws -> URL {
+        let fm = FileManager.default
+        let app = dir.appendingPathComponent(name)
+        let contents = app.appendingPathComponent("Contents")
+        try? fm.removeItem(at: app)
+        try fm.createDirectory(at: contents, withIntermediateDirectories: true)
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+          <key>CFBundleExecutable</key><string>App</string>
+          <key>CFBundleIdentifier</key><string>com.example.testapp</string>
+          <key>CFBundleName</key><string>App</string>
+          <key>CFBundlePackageType</key><string>APPL</string>
+        </dict></plist>
+        """
+        try Data(plist.utf8).write(to: contents.appendingPathComponent("Info.plist"))
+        try Data(marker.utf8).write(to: contents.appendingPathComponent("marker.txt"))
+        return app
+    }
+
+    private func marker(of app: URL) -> String? {
+        try? String(contentsOf: app.appendingPathComponent("Contents/marker.txt"), encoding: .utf8)
+    }
+
+    /// Stand in for the transfer that step 4 will perform: archive the outbox
+    /// copy onto the destination and write the sidecar it will carry. Built by
+    /// hand rather than by calling production code so these tests exercise the
+    /// *read* side against a realistic on-disk shape.
+    private func promoteToDestination(
+        key: String, outbox: URL, destination: URL, dropOutboxCopy: Bool
+    ) throws {
+        let fm = FileManager.default
+        let source = outbox.appendingPathComponent(key, isDirectory: true)
+        let target = destination.appendingPathComponent(key, isDirectory: true)
+        try fm.createDirectory(at: target, withIntermediateDirectories: true)
+
+        let entries = try fm.contentsOfDirectory(at: source, includingPropertiesForKeys: nil)
+        let bundle = try #require(entries.first { $0.pathExtension == "app" })
+        let archiveName = bundle.deletingPathExtension().lastPathComponent + ".aar"
+        let archive = target.appendingPathComponent(archiveName)
+        try BundleArchive.archive(bundle: bundle, to: archive)
+
+        let decoded = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: source.appendingPathComponent("backup.json")))
+        var sidecar = try #require(decoded as? [String: Any])
+        sidecar["archiveName"] = archiveName
+        sidecar["archiveSHA256"] = try BundleArchive.sha256(of: archive)
+        sidecar["pendingTransfer"] = false
+        try JSONSerialization.data(withJSONObject: sidecar)
+            .write(to: target.appendingPathComponent("backup.json"))
+
+        if dropOutboxCopy { try fm.removeItem(at: source) }
+    }
+
+    // MARK: - Verification
+
+    /// Fixture: one backup in each store, from two different apps.
+    private func twoStores(_ outbox: URL, _ destination: URL) throws -> URL {
+        let apps = outbox.deletingLastPathComponent().appendingPathComponent("apps")
+        try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+        let local = try makeApp(named: "Local.app", in: apps, marker: "local")
+        try BackupStore.save(
+            appPath: local, key: "local", version: "1.0", bundleID: "com.example.local")
+        let moved = try makeApp(named: "Moved.app", in: apps, marker: "moved")
+        try BackupStore.save(
+            appPath: moved, key: "moved", version: "2.0", bundleID: "com.example.moved")
+        try promoteToDestination(
+            key: "moved", outbox: outbox, destination: destination, dropOutboxCopy: true)
+        return apps
+    }
+
+    private func result(
+        _ outcomes: [BackupStore.VerifyOutcome], _ key: String
+    ) throws -> BackupStore.VerifyOutcome.Result {
+        try #require(outcomes.first { $0.key == key }).result
+    }
+
+    @Test func verifyPassesForUntouchedBackupsInBothStores() throws {
+        try withStores { outbox, destination in
+            _ = try twoStores(outbox, destination)
+            let outcomes = BackupStore.verify()
+            #expect(outcomes.count == 2)
+            #expect(try result(outcomes, "local") == .ok)
+            #expect(try result(outcomes, "moved") == .ok)
+        }
+    }
+
+    /// The point of recording a digest at transfer time: a byte that changed on
+    /// a foreign filesystem is caught by asking, not by attempting a rollback and
+    /// watching it fail.
+    @Test func verifyCatchesATamperedArchive() throws {
+        try withStores { outbox, destination in
+            _ = try twoStores(outbox, destination)
+            let archive = destination.appendingPathComponent("moved/Moved.aar")
+            var bytes = try Data(contentsOf: archive)
+            bytes[bytes.count - 1] ^= 0xFF
+            try bytes.write(to: archive)
+
+            let outcome = try result(BackupStore.verify(), "moved")
+            #expect(outcome.isFailure)
+            if case .mismatch = outcome {} else { Issue.record("expected a mismatch, got \(outcome)") }
+        }
+    }
+
+    @Test func verifyCatchesAChangedBundleInTheOutbox() throws {
+        try withStores { outbox, destination in
+            _ = try twoStores(outbox, destination)
+            try Data("tampered".utf8).write(
+                to: outbox.appendingPathComponent("local/Local.app/Contents/marker.txt"))
+
+            let outcome = try result(BackupStore.verify(), "local")
+            #expect(outcome.isFailure)
+        }
+    }
+
+    /// A backup written before fingerprints existed is not evidence of a
+    /// problem. Reporting it as damaged would be a false alarm; reporting it as
+    /// fine would be a reassurance nobody earned — so it gets its own answer,
+    /// and does not fail the run.
+    @Test func aBackupWithNothingRecordedIsNeitherPassNorFail() throws {
+        try withStores { outbox, destination in
+            _ = try twoStores(outbox, destination)
+            let sidecar = outbox.appendingPathComponent("local/backup.json")
+            var decoded = try #require(try JSONSerialization.jsonObject(
+                with: Data(contentsOf: sidecar)) as? [String: Any])
+            decoded["manifest"] = nil
+            try JSONSerialization.data(withJSONObject: decoded).write(to: sidecar)
+
+            let outcome = try result(BackupStore.verify(), "local")
+            #expect(!outcome.isFailure)
+            if case .unverifiable = outcome {} else {
+                Issue.record("expected unverifiable, got \(outcome)")
+            }
+        }
+    }
+
+    /// Why `--deep` is worth offering. The digest only ever proves the archive
+    /// is the one whose digest was recorded — swap both together and the shallow
+    /// check is satisfied by an archive holding the wrong app entirely. Only
+    /// unpacking it and comparing the manifest recorded at save time notices.
+    @Test func deepVerificationCatchesWhatTheDigestCannot() throws {
+        try withStores { outbox, destination in
+            let apps = try twoStores(outbox, destination)
+            let impostor = try makeApp(named: "Moved.app", in: apps, marker: "not the same app")
+            let archive = destination.appendingPathComponent("moved/Moved.aar")
+            try BundleArchive.archive(bundle: impostor, to: archive)
+
+            let sidecar = destination.appendingPathComponent("moved/backup.json")
+            var decoded = try #require(try JSONSerialization.jsonObject(
+                with: Data(contentsOf: sidecar)) as? [String: Any])
+            decoded["archiveSHA256"] = try BundleArchive.sha256(of: archive)
+            try JSONSerialization.data(withJSONObject: decoded).write(to: sidecar)
+
+            #expect(try result(BackupStore.verify(), "moved") == .ok,
+                    "the digest agrees, because it was recomputed over the swap")
+            let deep = try result(BackupStore.verify(deep: true), "moved")
+            #expect(deep.isFailure, "unpacking it is what notices")
+        }
+    }
+
+    /// A remnant with no sidecar is not a damaged backup, and must not appear in
+    /// a report whose every other row is something to act on. The sweeper owns
+    /// those.
+    @Test func verifyIgnoresDirectoriesThatAreNotBackups() throws {
+        try withStores { outbox, destination in
+            _ = try twoStores(outbox, destination)
+            try FileManager.default.createDirectory(
+                at: outbox.appendingPathComponent("remnant", isDirectory: true),
+                withIntermediateDirectories: true)
+            #expect(BackupStore.verify().count == 2)
+        }
+    }
+
+    // MARK: - Availability
+
+    @Test func withoutADestinationTheStoreIsLocalOnly() throws {
+        let outbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoLocalOnly-\(UUID().uuidString)")
+        try BackupStore.$rootOverride.withValue(outbox) {
+            try BackupStore.$destinationOverride.withValue(.local) {
+                #expect(BackupStore.availability() == .localOnly(outbox))
+                let resolved = try BackupStore.destinationRoot()
+                #expect(resolved == nil)
+            }
+        }
+    }
+
+    @Test func aMountedDirectoryWithAMatchingMarkerIsReady() throws {
+        try withStores { _, destination in
+            #expect(BackupStore.availability() == .ready(destination))
+            let resolved = try BackupStore.destinationRoot()
+            #expect(resolved == destination)
+        }
+    }
+
+    /// **The regression that matters most.** `save` used to reach the store via
+    /// `createDirectory(withIntermediateDirectories: true)`, which on a detached
+    /// disk quietly builds the whole path on the boot volume — and that directory
+    /// then squats the mount point, so the real disk arrives as `Archive 1` and
+    /// the backups split across two places that each look right.
+    @Test func anUnmountedDestinationIsRefusedAndNothingIsCreated() throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoNeverMounted-\(UUID().uuidString)")
+            .appendingPathComponent("Backups")
+        let configured = BackupDestination(
+            kind: .external, path: path.path, identity: "X", volumeName: "Archive")
+
+        try BackupStore.$destinationOverride.withValue(configured) {
+            #expect(BackupStore.availability()
+                == .volumeNotMounted(volumeName: "Archive", path: path.path))
+            #expect(throws: BackupStore.BackupError.self) {
+                _ = try BackupStore.destinationRoot()
+            }
+            #expect(BackupStore.reachableDestinationRoot == nil)
+        }
+        #expect(!FileManager.default.fileExists(atPath: path.path),
+                "resolving an unreachable destination must not create it")
+    }
+
+    /// An empty directory where the disk should be is the *usual* shape of "not
+    /// mounted" — something made the mount point — so it must not read as a
+    /// perfectly good, if empty, backup store.
+    @Test func aDirectoryWithoutOurMarkerIsNotOurDisk() throws {
+        try withStores(destinationIdentity: "expected", markerIdentity: .none) { _, destination in
+            guard case .volumeNotMounted = BackupStore.availability() else {
+                Issue.record("expected .volumeNotMounted, got \(BackupStore.availability())")
+                return
+            }
+            #expect(BackupStore.reachableDestinationRoot == nil)
+            _ = destination
+        }
+    }
+
+    @Test func anotherDiskAtTheSamePathIsReportedAsAMismatch() throws {
+        try withStores(destinationIdentity: "expected", markerIdentity: .some("actual")) { _, _ in
+            guard case .identityMismatch(let expected, let found, _)
+                = BackupStore.availability() else {
+                Issue.record("expected .identityMismatch, got \(BackupStore.availability())")
+                return
+            }
+            #expect(expected == "expected")
+            #expect(found == "actual")
+        }
+    }
+
+    // MARK: - Save degrades to the outbox
+
+    /// The agreed policy: an absent disk delays the copy, it does not cost the
+    /// rollback point.
+    @Test func saveStillSucceedsIntoTheOutboxWhenTheDiskIsMissing() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoSaveNoDisk-\(UUID().uuidString)")
+        let outbox = base.appendingPathComponent("outbox")
+        let apps = base.appendingPathComponent("apps")
+        let missing = base.appendingPathComponent("disk/Backups")
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+
+        let configured = BackupDestination(
+            kind: .external, path: missing.path, identity: "X", volumeName: "Archive")
+        try BackupStore.$rootOverride.withValue(outbox) {
+            try BackupStore.$destinationOverride.withValue(configured) {
+                let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+                let saved = try BackupStore.save(
+                    appPath: app, key: "k", version: "1.0", bundleID: "com.example.testapp")
+
+                #expect(saved.location == .outbox)
+                #expect(marker(of: saved.bundlePath) == "v1")
+                #expect(BackupStore.backup(forKey: "k") != nil)
+            }
+        }
+        #expect(!FileManager.default.fileExists(atPath: missing.path),
+                "a save must never conjure the destination directory")
+    }
+
+    // MARK: - Reads span both stores
+
+    @Test func aBackupOnTheDestinationIsFound() throws {
+        try withStores { outbox, destination in
+            let apps = outbox.deletingLastPathComponent().appendingPathComponent("apps")
+            try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+            try BackupStore.save(
+                appPath: app, key: "k", version: "1.0", bundleID: "com.example.testapp")
+            try promoteToDestination(
+                key: "k", outbox: outbox, destination: destination, dropOutboxCopy: true)
+
+            let found = try #require(BackupStore.backup(forKey: "k"))
+            #expect(found.location == .destination)
+            #expect(found.version == "1.0")
+            #expect(found.bundlePath.pathExtension == "aar")
+            #expect(BackupStore.allBackups()["k"]?.location == .destination)
+        }
+    }
+
+    /// A key in both stores resolves to the outbox: it is the newer copy by
+    /// construction, and restoring from it does not go over the cable.
+    @Test func theOutboxWinsWhenACopyExistsInBothStores() throws {
+        try withStores { outbox, destination in
+            let apps = outbox.deletingLastPathComponent().appendingPathComponent("apps")
+            try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+            try BackupStore.save(
+                appPath: app, key: "k", version: "1.0", bundleID: "com.example.testapp")
+            try promoteToDestination(
+                key: "k", outbox: outbox, destination: destination, dropOutboxCopy: false)
+
+            #expect(BackupStore.backup(forKey: "k")?.location == .outbox)
+            #expect(BackupStore.allBackups()["k"]?.location == .outbox)
+            // Both copies are listed: mid-transfer the backup really is occupying
+            // both disks, and merging the rows would hide half of what deleting
+            // it would free.
+            let rows = BackupStore.listing().filter { $0.key == "k" }
+            #expect(rows.count == 2)
+            #expect(Set(rows.map(\.location)) == [.outbox, .destination])
+        }
+    }
+
+    @Test func removingABackupDropsBothCopies() throws {
+        try withStores { outbox, destination in
+            let apps = outbox.deletingLastPathComponent().appendingPathComponent("apps")
+            try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+            try BackupStore.save(
+                appPath: app, key: "k", version: "1.0", bundleID: "com.example.testapp")
+            try promoteToDestination(
+                key: "k", outbox: outbox, destination: destination, dropOutboxCopy: false)
+
+            BackupStore.remove(forKey: "k")
+            #expect(BackupStore.backup(forKey: "k") == nil)
+            #expect(BackupStore.listing().filter { $0.key == "k" }.isEmpty)
+        }
+    }
+
+    /// A detached disk must read as "showing what's on this Mac", never as an
+    /// empty store — the difference is whether the user thinks their backups are
+    /// gone.
+    @Test func anUnreachableDestinationStillListsTheOutbox() throws {
+        try withStores { outbox, destination in
+            let apps = outbox.deletingLastPathComponent().appendingPathComponent("apps")
+            try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+            try BackupStore.save(
+                appPath: app, key: "k", version: "1.0", bundleID: "com.example.testapp")
+
+            // Simulate the disk going away by removing the marker.
+            try FileManager.default.removeItem(
+                at: destination.appendingPathComponent(BackupVolumeMarker.fileName))
+            #expect(BackupStore.backup(forKey: "k")?.location == .outbox)
+            #expect(BackupStore.allBackups().count == 1)
+        }
+    }
+
+    // MARK: - Restore from the destination
+
+    @Test func aBackupIsRestoredFromTheDestinationArchive() throws {
+        try withStores { outbox, destination in
+            let apps = outbox.deletingLastPathComponent().appendingPathComponent("apps")
+            try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+            try BackupStore.save(
+                appPath: app, key: "k", version: "1.0", bundleID: "com.example.testapp")
+            try promoteToDestination(
+                key: "k", outbox: outbox, destination: destination, dropOutboxCopy: true)
+
+            // The app moves on to v2, then rolls back.
+            try makeApp(named: "App.app", in: apps, marker: "v2")
+            #expect(marker(of: app) == "v2")
+
+            let version = try BackupStore.restore(forKey: "k", over: app)
+            #expect(version == "1.0")
+            #expect(marker(of: app) == "v1")
+        }
+    }
+
+    /// The archive digest is the only integrity question that can be asked of
+    /// bytes sitting on a foreign filesystem, and it has to be fatal: restoring a
+    /// truncated transfer over a working app is worse than not rolling back.
+    @Test func aTamperedDestinationArchiveIsRefused() throws {
+        try withStores { outbox, destination in
+            let apps = outbox.deletingLastPathComponent().appendingPathComponent("apps")
+            try FileManager.default.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "App.app", in: apps, marker: "v1")
+            try BackupStore.save(
+                appPath: app, key: "k", version: "1.0", bundleID: "com.example.testapp")
+            try promoteToDestination(
+                key: "k", outbox: outbox, destination: destination, dropOutboxCopy: true)
+
+            let archive = destination.appendingPathComponent("k/App.aar")
+            var bytes = try Data(contentsOf: archive)
+            bytes[bytes.count - 1] ^= 0xFF
+            try bytes.write(to: archive)
+
+            try makeApp(named: "App.app", in: apps, marker: "v2")
+            #expect(throws: BackupStore.BackupError.self) {
+                _ = try BackupStore.restore(forKey: "k", over: app)
+            }
+            #expect(marker(of: app) == "v2", "a refused rollback must leave the app alone")
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupTransferQueueTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupTransferQueueTests.swift
@@ -1,0 +1,445 @@
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// Moving a backup from the local outbox onto the external disk: that it lands
+/// intact, that the local copy is only dropped once it has, and that a disk
+/// which is not there costs a delay rather than a rollback point.
+@Suite struct BackupTransferQueueTests {
+
+    // MARK: - Fixtures
+
+    private struct Stores {
+        let base: URL
+        let outbox: URL
+        let destination: URL
+        let apps: URL
+    }
+
+    private func makeStores(mountDisk: Bool = true) throws -> Stores {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory
+            .appendingPathComponent("DuoTransferTest-\(UUID().uuidString)", isDirectory: true)
+        let stores = Stores(
+            base: base,
+            outbox: base.appendingPathComponent("outbox", isDirectory: true),
+            destination: base.appendingPathComponent("disk", isDirectory: true),
+            apps: base.appendingPathComponent("apps", isDirectory: true))
+        try fm.createDirectory(at: stores.outbox, withIntermediateDirectories: true)
+        try fm.createDirectory(at: stores.apps, withIntermediateDirectories: true)
+        if mountDisk {
+            try fm.createDirectory(at: stores.destination, withIntermediateDirectories: true)
+            try BackupVolumeMarker(identity: "disk-1", volumeName: "TestDisk")
+                .write(to: stores.destination)
+        }
+        return stores
+    }
+
+    private func destination(_ stores: Stores) -> BackupDestination {
+        BackupDestination(
+            kind: .external, path: stores.destination.path,
+            identity: "disk-1", volumeName: "TestDisk")
+    }
+
+    private func withStores(
+        mountDisk: Bool = true, _ body: (Stores) async throws -> Void
+    ) async throws {
+        let stores = try makeStores(mountDisk: mountDisk)
+        defer { try? FileManager.default.removeItem(at: stores.base) }
+        try await BackupStore.$rootOverride.withValue(stores.outbox) {
+            try await BackupStore.$destinationOverride.withValue(destination(stores)) {
+                try await body(stores)
+            }
+        }
+    }
+
+    @discardableResult
+    private func makeApp(named name: String, in dir: URL, marker: String) throws -> URL {
+        let fm = FileManager.default
+        let app = dir.appendingPathComponent(name)
+        let contents = app.appendingPathComponent("Contents")
+        try? fm.removeItem(at: app)
+        try fm.createDirectory(at: contents, withIntermediateDirectories: true)
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+          <key>CFBundleExecutable</key><string>App</string>
+          <key>CFBundleIdentifier</key><string>com.example.testapp</string>
+          <key>CFBundleName</key><string>App</string>
+          <key>CFBundlePackageType</key><string>APPL</string>
+        </dict></plist>
+        """
+        try Data(plist.utf8).write(to: contents.appendingPathComponent("Info.plist"))
+        try Data(marker.utf8).write(to: contents.appendingPathComponent("marker.txt"))
+        return app
+    }
+
+    private func marker(of app: URL) -> String? {
+        try? String(contentsOf: app.appendingPathComponent("Contents/marker.txt"), encoding: .utf8)
+    }
+
+    @discardableResult
+    private func saveBackup(
+        _ stores: Stores, key: String, appName: String = "App.app", marker: String = "v1"
+    ) throws -> URL {
+        let app = try makeApp(named: appName, in: stores.apps, marker: marker)
+        try BackupStore.save(
+            appPath: app, key: key, version: "1.0", bundleID: "com.example.testapp")
+        return app
+    }
+
+    // MARK: - The transfer itself
+
+    @Test func aTransferLandsTheArchiveAndDropsTheLocalCopy() async throws {
+        try await withStores { stores in
+            try saveBackup(stores, key: "k")
+            #expect(BackupStore.pendingTransferKeys() == ["k"])
+
+            let moved = try BackupStore.transferToDestination(forKey: "k")
+            #expect(moved.location == .destination)
+            #expect(moved.bundlePath.lastPathComponent == "App.aar")
+
+            let fm = FileManager.default
+            #expect(fm.fileExists(atPath: moved.bundlePath.path))
+            #expect(fm.fileExists(
+                atPath: stores.destination.appendingPathComponent("k/backup.json").path))
+            #expect(!fm.fileExists(atPath: stores.outbox.appendingPathComponent("k").path),
+                    "the local copy should be gone once the disk has it")
+            #expect(BackupStore.pendingTransferKeys().isEmpty)
+            #expect(BackupStore.backup(forKey: "k")?.location == .destination)
+        }
+    }
+
+    /// The end-to-end claim the whole design rests on: a backup that has been
+    /// through compression, a foreign filesystem and back still restores.
+    @Test func aTransferredBackupStillRestores() async throws {
+        try await withStores { stores in
+            let app = try saveBackup(stores, key: "k", marker: "v1")
+            try BackupStore.transferToDestination(forKey: "k")
+
+            try makeApp(named: "App.app", in: stores.apps, marker: "v2")
+            #expect(marker(of: app) == "v2")
+
+            let version = try BackupStore.restore(forKey: "k", over: app)
+            #expect(version == "1.0")
+            #expect(marker(of: app) == "v1")
+        }
+    }
+
+    /// Nothing is created and nothing is lost when the disk is not there — the
+    /// backup simply stays owed.
+    @Test func aTransferWithNoDiskTouchesNothing() async throws {
+        try await withStores(mountDisk: false) { stores in
+            try saveBackup(stores, key: "k")
+
+            #expect(throws: BackupStore.BackupError.self) {
+                try BackupStore.transferToDestination(forKey: "k")
+            }
+            let fm = FileManager.default
+            #expect(!fm.fileExists(atPath: stores.destination.path),
+                    "a refused transfer must not conjure the destination")
+            #expect(fm.fileExists(atPath: stores.outbox.appendingPathComponent("k").path))
+            #expect(BackupStore.backup(forKey: "k")?.location == .outbox)
+            #expect(BackupStore.pendingTransferKeys() == ["k"],
+                    "the copy is still owed")
+        }
+    }
+
+    /// The digest recorded at transfer time is read back off the destination, so
+    /// it certifies what actually landed — and a later corruption is caught
+    /// before anything is swapped over a working app.
+    @Test func aCorruptedArchiveIsCaughtOnRestore() async throws {
+        try await withStores { stores in
+            let app = try saveBackup(stores, key: "k", marker: "v1")
+            let moved = try BackupStore.transferToDestination(forKey: "k")
+
+            var bytes = try Data(contentsOf: moved.bundlePath)
+            bytes[bytes.count - 1] ^= 0xFF
+            try bytes.write(to: moved.bundlePath)
+
+            try makeApp(named: "App.app", in: stores.apps, marker: "v2")
+            #expect(throws: BackupStore.BackupError.self) {
+                _ = try BackupStore.restore(forKey: "k", over: app)
+            }
+            #expect(marker(of: app) == "v2", "a refused rollback must leave the app alone")
+        }
+    }
+
+    /// A directory `save` left behind when it refused a bundle is not a backup,
+    /// and must never enter the queue. Real remnants on a real machine: ToDesk
+    /// and VSCodium keep root-owned state inside their own bundles, so `save`
+    /// declines them and leaves the directory.
+    @Test func aRemnantWithNoSidecarIsNotOwed() async throws {
+        try await withStores { stores in
+            try saveBackup(stores, key: "good")
+            let remnant = stores.outbox.appendingPathComponent("junk", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: remnant.appendingPathComponent("ToDesk.app"),
+                withIntermediateDirectories: true)
+
+            #expect(BackupStore.pendingTransferKeys() == ["good"])
+        }
+    }
+
+    /// **One bad item must not hold up the rest.** A single key that can never
+    /// transfer used to end the whole run, leaving every remaining backup on the
+    /// boot volume — the exact opposite of what moving the store is for.
+    @Test func oneFailingKeyDoesNotStrandTheOthers() async throws {
+        try await withStores { stores in
+            try saveBackup(stores, key: "a", appName: "A.app")
+            try saveBackup(stores, key: "b", appName: "B.app")
+
+            let queue = BackupTransferQueue(maxAttempts: 2, backoffUnitNanos: 1_000)
+            // Poison first, so a run that stops on failure moves nothing at all.
+            await queue.enqueue("nope")
+            await queue.enqueue("a")
+            await queue.enqueue("b")
+            await queue.drain()
+
+            #expect(BackupStore.backup(forKey: "a")?.location == .destination)
+            #expect(BackupStore.backup(forKey: "b")?.location == .destination)
+            // And the failure is still reported rather than swallowed.
+            guard case .failed(_, _, let count) = await queue.state else {
+                Issue.record("expected .failed, got \(await queue.state)")
+                return
+            }
+            #expect(count == 1)
+        }
+    }
+
+    /// A backup taken **before** the disk was ever configured is still owed to
+    /// it. Filtering on a flag written at save time meant the backups someone
+    /// already had — the ones taking up the space they were trying to reclaim —
+    /// would never move.
+    @Test func backupsTakenBeforeTheDiskWasChosenStillMove() async throws {
+        let stores = try makeStores()
+        defer { try? FileManager.default.removeItem(at: stores.base) }
+
+        // Saved while backups were still local: no destination configured, so
+        // nothing marks this one as owed.
+        try await BackupStore.$rootOverride.withValue(stores.outbox) {
+            try await BackupStore.$destinationOverride.withValue(.local) {
+                try saveBackup(stores, key: "old")
+                #expect(BackupStore.pendingTransferKeys().isEmpty)
+            }
+        }
+
+        // The user then points the store at a disk.
+        try await BackupStore.$rootOverride.withValue(stores.outbox) {
+            try await BackupStore.$destinationOverride.withValue(destination(stores)) {
+                #expect(BackupStore.pendingTransferKeys() == ["old"])
+
+                let queue = BackupTransferQueue(backoffUnitNanos: 1_000)
+                await queue.resumePending()
+                await queue.drain()
+
+                #expect(await queue.state == .idle)
+                #expect(BackupStore.backup(forKey: "old")?.location == .destination)
+                #expect(!FileManager.default.fileExists(
+                    atPath: stores.outbox.appendingPathComponent("old").path))
+            }
+        }
+    }
+
+    // MARK: - The queue
+
+    @Test func theQueueDrainsEverythingOwed() async throws {
+        try await withStores { stores in
+            try saveBackup(stores, key: "a", appName: "A.app")
+            try saveBackup(stores, key: "b", appName: "B.app")
+
+            let queue = BackupTransferQueue(backoffUnitNanos: 1_000)
+            await queue.resumePending()
+            await queue.drain()
+
+            #expect(await queue.state == .idle)
+            #expect(BackupStore.pendingTransferKeys().isEmpty)
+            #expect(BackupStore.backup(forKey: "a")?.location == .destination)
+            #expect(BackupStore.backup(forKey: "b")?.location == .destination)
+        }
+    }
+
+    /// An absent disk suspends the queue instead of failing it, and — the part
+    /// that matters — does not consume the retry budget. A disk in a bag stays
+    /// in a bag for longer than five backoffs, and a transfer that had already
+    /// "failed" by the time it was plugged back in would never be picked up.
+    @Test func aMissingDiskSuspendsRatherThanFails() async throws {
+        try await withStores(mountDisk: false) { stores in
+            try saveBackup(stores, key: "k")
+
+            let queue = BackupTransferQueue(backoffUnitNanos: 1_000)
+            await queue.resumePending()
+            await queue.drain()
+
+            #expect(await queue.state == .waitingForDisk(pending: 1))
+            #expect(BackupStore.pendingTransferKeys() == ["k"])
+            #expect(BackupStore.backup(forKey: "k")?.location == .outbox)
+        }
+    }
+
+    /// And once the disk shows up, the same queue finishes the job.
+    @Test func aSuspendedQueueFinishesWhenTheDiskAppears() async throws {
+        let stores = try makeStores(mountDisk: false)
+        defer { try? FileManager.default.removeItem(at: stores.base) }
+
+        try await BackupStore.$rootOverride.withValue(stores.outbox) {
+            try await BackupStore.$destinationOverride.withValue(destination(stores)) {
+                try saveBackup(stores, key: "k")
+                let queue = BackupTransferQueue(backoffUnitNanos: 1_000)
+                await queue.resumePending()
+                await queue.drain()
+                #expect(await queue.state == .waitingForDisk(pending: 1))
+
+                // The disk is plugged in.
+                try FileManager.default.createDirectory(
+                    at: stores.destination, withIntermediateDirectories: true)
+                try BackupVolumeMarker(identity: "disk-1", volumeName: "TestDisk")
+                    .write(to: stores.destination)
+
+                await queue.drain()
+                #expect(await queue.state == .idle)
+                #expect(BackupStore.backup(forKey: "k")?.location == .destination)
+            }
+        }
+    }
+
+    /// A transfer that keeps failing while the disk is right there does exhaust
+    /// its attempts and reports — that is what the retry budget is for.
+    @Test func aTransferThatKeepsFailingIsReported() async throws {
+        try await withStores { _ in
+            let queue = BackupTransferQueue(maxAttempts: 2, backoffUnitNanos: 1_000)
+            await queue.enqueue("no-such-key")
+            await queue.drain()
+
+            guard case .failed(let key, _, _) = await queue.state else {
+                Issue.record("expected .failed, got \(await queue.state)")
+                return
+            }
+            #expect(key == "no-such-key")
+        }
+    }
+
+    @Test func enqueuingTheSameKeyTwiceOnlyCopiesItOnce() async throws {
+        try await withStores { stores in
+            try saveBackup(stores, key: "k")
+            let queue = BackupTransferQueue(backoffUnitNanos: 1_000)
+            await queue.enqueue("k")
+            await queue.enqueue("k")
+            await queue.drain()
+            #expect(await queue.state == .idle)
+        }
+    }
+
+    // MARK: - Sweeping interrupted work
+
+    @Test func staleScratchIsSweptFromBothStores() async throws {
+        try await withStores { stores in
+            let fm = FileManager.default
+            let old = Date().addingTimeInterval(-48 * 60 * 60)
+
+            // A save that never finished, in the outbox.
+            let staging = stores.outbox.appendingPathComponent(".staging-k", isDirectory: true)
+            try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+            try fm.setAttributes([.modificationDate: old], ofItemAtPath: staging.path)
+
+            // A transfer that never finished, on the disk: the `.partial` lives
+            // inside the key's own directory.
+            let keyDir = stores.destination.appendingPathComponent("k", isDirectory: true)
+            try fm.createDirectory(at: keyDir, withIntermediateDirectories: true)
+            let partial = keyDir.appendingPathComponent(".App.aar.partial")
+            try Data("half".utf8).write(to: partial)
+            try fm.setAttributes([.modificationDate: old], ofItemAtPath: partial.path)
+
+            BackupStore.sweepStaleScratch()
+
+            #expect(!fm.fileExists(atPath: staging.path))
+            #expect(!fm.fileExists(atPath: partial.path))
+        }
+    }
+
+    @Test func recentScratchIsLeftAlone() async throws {
+        try await withStores { stores in
+            let fm = FileManager.default
+            let staging = stores.outbox.appendingPathComponent(".staging-k", isDirectory: true)
+            try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+
+            BackupStore.sweepStaleScratch()
+            #expect(fm.fileExists(atPath: staging.path),
+                    "scratch from a transfer still running must survive")
+        }
+    }
+
+    /// mtime is the backstop, not the guard. A slow disk makes an in-flight
+    /// `.partial` legitimately old, and a network volume's timestamps come from
+    /// the server's clock, so the key a queue says is running is excluded
+    /// regardless of what its mtime claims.
+    @Test func inFlightScratchSurvivesEvenWhenItLooksStale() async throws {
+        try await withStores { stores in
+            let fm = FileManager.default
+            let staging = stores.outbox.appendingPathComponent(".staging-k", isDirectory: true)
+            try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+            try fm.setAttributes(
+                [.modificationDate: Date().addingTimeInterval(-48 * 60 * 60)],
+                ofItemAtPath: staging.path)
+
+            BackupStore.sweepStaleScratch(excluding: ["k"])
+            #expect(fm.fileExists(atPath: staging.path))
+        }
+    }
+
+    /// The shape that actually accumulated on a real machine: a key directory in
+    /// the outbox holding a whole app bundle and **no sidecar**. `save` leaves
+    /// one behind when it refuses a bundle it cannot fully read, and nothing
+    /// could see it afterwards — `backup(forKey:)` needs the sidecar,
+    /// `pruneOrphans` needs it to know which app the backup was for, and the
+    /// delete sheet is the only place it showed up at all. Hundreds of megabytes
+    /// per remnant, on the very disk the user moved the store off.
+    @Test func aSidecarLessDirectoryInTheOutboxIsSwept() async throws {
+        try await withStores { stores in
+            let fm = FileManager.default
+            let remnant = stores.outbox.appendingPathComponent("com.example.dead", isDirectory: true)
+            try fm.createDirectory(at: remnant, withIntermediateDirectories: true)
+            try makeApp(named: "Dead.app", in: remnant, marker: "x")
+            try fm.setAttributes(
+                [.modificationDate: Date().addingTimeInterval(-48 * 60 * 60)],
+                ofItemAtPath: remnant.path)
+
+            BackupStore.sweepStaleScratch()
+            #expect(!fm.fileExists(atPath: remnant.path))
+        }
+    }
+
+    /// The same directory while a transfer is working on it is not a remnant.
+    /// Between `createDirectory` and the sidecar write, a key directory on the
+    /// destination legitimately has no sidecar for as long as the archive takes —
+    /// minutes on a slow disk — so the in-flight key must win over mtime here too.
+    @Test func aSidecarLessDirectoryInFlightIsLeftAlone() async throws {
+        try await withStores { stores in
+            let fm = FileManager.default
+            let dir = stores.destination.appendingPathComponent("k", isDirectory: true)
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            try fm.setAttributes(
+                [.modificationDate: Date().addingTimeInterval(-48 * 60 * 60)],
+                ofItemAtPath: dir.path)
+
+            BackupStore.sweepStaleScratch(excluding: ["k"])
+            #expect(fm.fileExists(atPath: dir.path))
+        }
+    }
+
+    /// The sweeper must never touch a finished backup, only scratch.
+    @Test func sweepingLeavesRealBackupsAlone() async throws {
+        try await withStores { stores in
+            try saveBackup(stores, key: "k")
+            try BackupStore.transferToDestination(forKey: "k")
+
+            BackupStore.sweepStaleScratch(olderThan: 0)
+
+            #expect(BackupStore.backup(forKey: "k")?.location == .destination)
+            #expect(FileManager.default.fileExists(
+                atPath: stores.destination.appendingPathComponent("k/App.aar").path))
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BundleArchiveTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BundleArchiveTests.swift
@@ -1,0 +1,306 @@
+import CryptoKit
+import Darwin
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// Whether an app bundle survives a trip through an Apple Archive intact.
+///
+/// This is the load-bearing property of storing backups off the boot volume: the
+/// archive is what lets a destination filesystem that cannot represent a `.app`
+/// (exFAT, an SMB share) hold one anyway. If a round trip is lossy, storing
+/// backups as archives is not viable and the whole approach has to change, so
+/// these tests assert the property directly rather than trusting the tool's
+/// documentation.
+///
+/// Two separate assertions, because one does not imply the other:
+///
+/// - the `BackupManifest` matches, which is what the rollback gate checks; and
+/// - the vendor code signature still validates, which the manifest **cannot**
+///   tell us because it does not hash extended attributes.
+///
+/// A tree can come back byte-identical by the manifest's reckoning and still be a
+/// broken app.
+@Suite struct BundleArchiveTests {
+
+    // MARK: - Fixtures
+
+    private func scratch() -> URL {
+        // UUID-suffixed: several worktrees of this repo run `swift test`
+        // concurrently against the same $TMPDIR, and a shared fixture name means
+        // one run deletes another's directory mid-test.
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoBundleArchiveTest-\(UUID().uuidString)")
+    }
+
+    private func setXattr(_ name: String, _ value: String, on url: URL) throws {
+        let data = Data(value.utf8)
+        let rc = data.withUnsafeBytes { buf in
+            setxattr(url.path, name, buf.baseAddress, buf.count, 0, 0)
+        }
+        try #require(rc == 0, "setxattr(\(name)) failed: \(errno)")
+    }
+
+    private func xattrNames(of url: URL) -> [String] {
+        let size = listxattr(url.path, nil, 0, 0)
+        guard size > 0 else { return [] }
+        var buf = [CChar](repeating: 0, count: size)
+        guard listxattr(url.path, &buf, size, 0) == size else { return [] }
+        return buf.split(separator: 0)
+            .map { String(decoding: $0.map { UInt8(bitPattern: $0) }, as: UTF8.self) }
+            .sorted()
+    }
+
+    /// A bundle carrying every shape that a non-native filesystem is known to
+    /// mangle: symlinks (relative and absolute), extended attributes, non-default
+    /// permission bits, a hard-link pair, an empty directory, and a decomposed
+    /// (NFD) filename.
+    @discardableResult
+    private func makeNastyBundle(in dir: URL) throws -> URL {
+        let fm = FileManager.default
+        let app = dir.appendingPathComponent("Fixture.app")
+        let contents = app.appendingPathComponent("Contents")
+        let macOS = contents.appendingPathComponent("MacOS")
+        let resources = contents.appendingPathComponent("Resources")
+        let versions = contents.appendingPathComponent("Frameworks/F.framework/Versions")
+
+        for path in [macOS, resources, versions.appendingPathComponent("A"),
+                     contents.appendingPathComponent("EmptyDir")] {
+            try fm.createDirectory(at: path, withIntermediateDirectories: true)
+        }
+
+        let exec = macOS.appendingPathComponent("App")
+        try Data("hello executable\n".utf8).write(to: exec)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: exec.path)
+        try setXattr("com.apple.quarantine", "0081;00000000;Safari;", on: exec)
+
+        let plain = resources.appendingPathComponent("plain.txt")
+        try Data("plain\n".utf8).write(to: plain)
+        try setXattr("com.example.custom", "some-custom-value", on: plain)
+
+        let secret = resources.appendingPathComponent("private.txt")
+        try Data("secret\n".utf8).write(to: secret)
+        try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: secret.path)
+
+        // `Versions/Current -> A` is the shape every framework inside a real
+        // bundle uses; an absolute link is the one that breaks differently.
+        try fm.createSymbolicLink(
+            atPath: versions.appendingPathComponent("Current").path,
+            withDestinationPath: "A")
+        try fm.createSymbolicLink(
+            atPath: resources.appendingPathComponent("abs-link").path,
+            withDestinationPath: "/usr/bin/true")
+        try fm.createSymbolicLink(
+            atPath: resources.appendingPathComponent("rel-link").path,
+            withDestinationPath: "../MacOS/App")
+
+        let hardA = resources.appendingPathComponent("hard-a")
+        try Data("linked content\n".utf8).write(to: hardA)
+        try fm.linkItem(at: hardA, to: resources.appendingPathComponent("hard-b"))
+
+        // Decomposed "Café.txt" — normalization differences move a manifest that
+        // sorts by path string.
+        try Data("accented\n".utf8)
+            .write(to: resources.appendingPathComponent("Cafe\u{0301}.txt"))
+
+        return app
+    }
+
+    /// A small, really-signed app to prove the signature survives. Scanned rather
+    /// than hard-coded: no single app is guaranteed present on a dev machine.
+    private static let signedApp: URL? = {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: URL(fileURLWithPath: "/Applications"),
+            includingPropertiesForKeys: [.fileSizeKey], options: [.skipsHiddenFiles])
+        else { return nil }
+        let candidates = entries.filter { $0.pathExtension == "app" }.sorted {
+            $0.lastPathComponent < $1.lastPathComponent
+        }
+        for app in candidates {
+            // Cheap size guard first: a 900 MB Electron app makes this test slow
+            // for no extra signal.
+            let size = (try? fm.subpathsOfDirectory(atPath: app.path).count) ?? .max
+            guard size < 4000 else { continue }
+            guard (try? SignatureVerifier.verifyCodeSignature(appAt: app)) != nil else { continue }
+            return app
+        }
+        return nil
+    }()
+
+    // MARK: - The two load-bearing assertions
+
+    @Test(arguments: [BundleArchive.Compression.fast, .smallest])
+    func roundTripPreservesTheManifest(_ compression: BundleArchive.Compression) throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let app = try makeNastyBundle(in: root)
+        let before = try #require(BackupManifest.compute(for: app))
+
+        let archive = root.appendingPathComponent("fixture.aar")
+        try BundleArchive.archive(bundle: app, to: archive, compression: compression)
+
+        let restored = root.appendingPathComponent("Restored.app")
+        try BundleArchive.extract(archive: archive, into: restored)
+
+        let after = try #require(BackupManifest.compute(for: restored))
+        #expect(after == before, "\(compression) round trip changed the manifest")
+    }
+
+    /// The things `BackupManifest` does **not** hash, checked directly. Without
+    /// this, a round trip that dropped every extended attribute would still pass
+    /// the test above.
+    @Test func roundTripPreservesMetadataTheManifestIgnores() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let app = try makeNastyBundle(in: root)
+        let archive = root.appendingPathComponent("fixture.aar")
+        try BundleArchive.archive(bundle: app, to: archive)
+        let restored = root.appendingPathComponent("Restored.app")
+        try BundleArchive.extract(archive: archive, into: restored)
+
+        let fm = FileManager.default
+        let exec = "Contents/MacOS/App"
+        let plain = "Contents/Resources/plain.txt"
+        let secret = "Contents/Resources/private.txt"
+
+        // Extended attributes: the ones whose loss silently breaks a signature.
+        #expect(xattrNames(of: restored.appendingPathComponent(exec))
+            == xattrNames(of: app.appendingPathComponent(exec)))
+        #expect(xattrNames(of: restored.appendingPathComponent(plain))
+            .contains("com.example.custom"))
+
+        // Permission bits.
+        for relative in [exec, secret] {
+            let source = try fm.attributesOfItem(atPath: app.appendingPathComponent(relative).path)
+            let copy = try fm.attributesOfItem(
+                atPath: restored.appendingPathComponent(relative).path)
+            #expect(copy[.posixPermissions] as? Int == source[.posixPermissions] as? Int,
+                    "mode changed for \(relative)")
+        }
+
+        // Symlinks stay symlinks, pointing where they pointed.
+        for (relative, target) in [
+            ("Contents/Frameworks/F.framework/Versions/Current", "A"),
+            ("Contents/Resources/abs-link", "/usr/bin/true"),
+            ("Contents/Resources/rel-link", "../MacOS/App"),
+        ] {
+            let path = restored.appendingPathComponent(relative).path
+            #expect(try fm.destinationOfSymbolicLink(atPath: path) == target)
+        }
+
+        // Hard links stay linked rather than becoming two independent copies —
+        // `ditto`, which the local backup path uses, does not manage this.
+        let linkCount = try fm.attributesOfItem(
+            atPath: restored.appendingPathComponent("Contents/Resources/hard-a").path)
+        #expect(linkCount[.referenceCount] as? Int == 2)
+
+        #expect(fm.fileExists(atPath: restored.appendingPathComponent("Contents/EmptyDir").path))
+    }
+
+    /// Manifest equality does not imply a valid seal, so this asks the question
+    /// the manifest cannot.
+    @Test(.enabled(if: BundleArchiveTests.signedApp != nil))
+    func roundTripPreservesTheCodeSignature() throws {
+        let app = try #require(Self.signedApp)
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let archive = root.appendingPathComponent("signed.aar")
+        try BundleArchive.archive(bundle: app, to: archive)
+        let restored = root.appendingPathComponent(app.lastPathComponent)
+        try BundleArchive.extract(archive: archive, into: restored)
+
+        // Throws on failure; reaching the next line is the assertion.
+        try SignatureVerifier.verifyCodeSignature(appAt: restored)
+    }
+
+    // MARK: - Failure modes
+
+    @Test func archivingAMissingBundleFails() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let archive = root.appendingPathComponent("out.aar")
+        #expect(throws: BundleArchive.ArchiveError.self) {
+            try BundleArchive.archive(
+                bundle: root.appendingPathComponent("NoSuch.app"), to: archive)
+        }
+        #expect(!FileManager.default.fileExists(atPath: archive.path),
+                "a failed archive must not leave a file under the real name")
+    }
+
+    @Test func extractingAMissingArchiveFails() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        #expect(throws: BundleArchive.ArchiveError.self) {
+            try BundleArchive.extract(
+                archive: root.appendingPathComponent("nope.aar"),
+                into: root.appendingPathComponent("out"))
+        }
+    }
+
+    /// A truncated or altered archive must be detectable without unpacking it —
+    /// this digest is the integrity gate for the copy that lives on the
+    /// destination, where a tree-walking comparison is exactly what we cannot do.
+    @Test func digestChangesWhenTheArchiveIsTampered() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let app = try makeNastyBundle(in: root)
+        let archive = root.appendingPathComponent("fixture.aar")
+        try BundleArchive.archive(bundle: app, to: archive)
+
+        let original = try BundleArchive.sha256(of: archive)
+        #expect(original.count == 64)
+        #expect(try BundleArchive.sha256(of: archive) == original, "digest is not stable")
+
+        var bytes = try Data(contentsOf: archive)
+        bytes[bytes.count - 1] ^= 0xFF
+        try bytes.write(to: archive)
+
+        #expect(try BundleArchive.sha256(of: archive) != original)
+    }
+
+    /// A successful archive leaves the destination directory clean — no `.partial`
+    /// beside it, which the destination sweeper would otherwise have to guess about.
+    @Test func aSuccessfulArchiveLeavesNoPartialBehind() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let app = try makeNastyBundle(in: root)
+        let out = root.appendingPathComponent("dest", isDirectory: true)
+        try FileManager.default.createDirectory(at: out, withIntermediateDirectories: true)
+        try BundleArchive.archive(bundle: app, to: out.appendingPathComponent("fixture.aar"))
+
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: out.path)
+        #expect(leftovers == ["fixture.aar"], "unexpected leftovers: \(leftovers)")
+    }
+
+    @Test func archivingReplacesAnExistingArchiveAtTheSamePath() throws {
+        let root = scratch()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let app = try makeNastyBundle(in: root)
+        let archive = root.appendingPathComponent("fixture.aar")
+        try Data("stale".utf8).write(to: archive)
+
+        try BundleArchive.archive(bundle: app, to: archive)
+        let restored = root.appendingPathComponent("Restored.app")
+        try BundleArchive.extract(archive: archive, into: restored)
+        #expect(FileManager.default.fileExists(
+            atPath: restored.appendingPathComponent("Contents/MacOS/App").path))
+    }
+}


### PR DESCRIPTION
> Stacked on #55 — base retargets to `main` once that merges. The diff here is
> the backup-destination work only.

Backups are a real second copy of every app that gets updated, and on a Mac
that is short of space they are the main reason people turn the safety net off.
This lets the store point at an external disk or a NAS, while the boot volume
keeps only what has not been moved yet.

### The destination holds archives, not bundles

A `.app` is a directory whose meaning lives as much in its metadata as in its
bytes. An exFAT stick or an SMB share stores that approximately at best, which
breaks the restored app's code signature *and* makes the manifest recorded at
save time disagree with the tree read back — both of which surface on the day
the backup is actually needed.

Packing each bundle into a single Apple Archive (`/usr/bin/aa`) moves that
problem out of the destination's hands: the metadata is encoded inside the byte
stream, so the destination only has to hold one opaque file. It also keeps
`integrityHolds` untouched — all three rollback paths now compute their
manifest on APFS, so the comparison never straddles two filesystems.

Measured on Claude.app (802 MB, 3421 files):

| algorithm | archive | time |
|---|---|---|
| `lzfse` (default) | 330 MB (41%) | 1.8 s |
| `lzma` ("smallest") | 242 MB (30%) | 22 s |
| extract (`lzfse`) | — | 1.1 s |

3421 files becoming one is the bigger win on a share, where per-file round
trips rather than bandwidth are what make a NAS backup slow.

Round-tripping preserves the vendor code signature, asserted separately from
the manifest comparison — a tree can match byte for byte and still restore an
app whose seal is broken, because the manifest does not hash extended
attributes. AppCleaner, TestFlight, Pearcleaner and Claude all come back
`codesign --verify --deep --strict` clean.

### An unplugged disk is a delay, not a missing rollback point

`save` always writes to the boot volume first, exactly as it always has; a
background queue drains that outbox onto the disk afterwards. Install latency
is unchanged, the boot volume is reclaimed a minute later, and a disk that is
in a bag simply means the backup waits.

The transfer's ordering is the whole safety argument: the archive lands, its
digest is read back **from the destination**, the sidecar is written, and only
then is the local copy removed. At every point before that last step there is a
complete, restorable backup somewhere.

An install with the disk away still takes a backup. Only when the boot volume
is *also* tight does it skip — and then it says so on the row rather than
leaving the user to discover it at rollback time.

### Things a real machine taught this, which are now regression tests

- **Never conjure a directory at an unreachable destination.** `save` used to
  reach it through `createDirectory(withIntermediateDirectories:)`, which on a
  detached disk does not fail — it builds the path on the boot volume, squats
  the mount point, and the real disk then mounts beside the decoy as
  `Archive 1` with backups split across two places that each look correct.
- **The store owns its own subdirectory.** Rooted at the folder the user
  picked, a Documents folder read as 31 GB of backup storage and Clean Up would
  have `removeItem`'d their folders.
- **Adopting is idempotent.** Re-picking the shown path nested a second store
  inside the first; the newly empty one became the destination while every
  existing backup sat one level up, invisible.
- **What is owed is read from the sidecars, not from a flag written at save
  time.** Otherwise backups taken before a disk was ever chosen never move —
  on the machine this was built against, that was 23.87 GB, which is exactly
  the part the user was trying to reclaim.
- **A drain skips a failing entry and continues.** One backup that could never
  transfer — a remnant a refused save left behind — used to hold all 17
  remaining backups on the boot volume indefinitely.
- **Volume identity is a UUID we write ourselves.** Not
  `volumeUUIDStringKey` (not guaranteed on exFAT or SMB), and emphatically not
  `volumeIdentifierKey`, which is a mount-scoped token that changes on replug
  and would report a different disk every morning.
- **A pre-existing restore race**, surfaced by the new tests: the scratch
  directory was keyed on the app alone, so two concurrent restores of the same
  key deleted each other's working tree mid-copy.

### CLI

`duo backups sync` / `verify [--deep]` / `probe <path>`, and `list`/`verify`
now say on stderr when the disk is not reachable instead of reporting an empty
store. `probe` writes nothing, so it is safe to point at a share you are only
considering — and it is the honest answer to "will this work on my NAS?", since
SMB and NFS cannot be faked in a test.

`verify` reports three states, not two. A backup taken before fingerprints
existed is neither a pass nor a failure; calling it either would be a
reassurance nobody earned, or an error that trains people to ignore the exit
code.

### Verification

```
DuoUpdaterCore  1093 tests / 86 suites passed
CLI              119 tests / 18 suites passed
localizable keys agree — 448 in the catalog, all reachable
```

Exercised end to end on a real machine with a USB stick: 52 backups moved,
9.18 GB from ~23.4 GB (39%), every SHA-256 matching its sidecar, no nesting and
no sidecar-less directories left in the store.

### Not in scope

`CHANGELOG.md` — this repo names each section by version, so the user-facing
prose goes in when the version is bumped.
