### PR TITLE
Fix Release Log fast-scroll blanking

### DIFF
--- a/App/Sources/ReleaseLogView.swift
+++ b/App/Sources/ReleaseLogView.swift
@@ -81,22 +81,26 @@ struct ReleaseLogView: View {
     // MARK: - Feed
 
     private var feed: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
-                ForEach(groups, id: \.day) { group in
-                    Section {
-                        ForEach(group.events) { row in
-                            ReleaseRow(event: row)
-                            if row.id != group.events.last?.id {
-                                Divider().padding(.leading, 52)
-                            }
-                        }
-                    } header: {
-                        dayHeader(group.day)
+        // A native List recycles a bounded set of rows and can jump straight to
+        // the scrollbar's target. ScrollView + LazyVStack only realizes views near
+        // its current position; on a long log, a fast scrollbar drag could outrun
+        // that work and briefly leave the viewport empty while SwiftUI caught up.
+        List {
+            ForEach(groups, id: \.day) { group in
+                Section {
+                    ForEach(group.events) { row in
+                        ReleaseRow(event: row)
+                            .listRowInsets(EdgeInsets())
+                            .listRowSeparator(row.id == group.events.last?.id ? .hidden : .visible)
+                            .alignmentGuide(.listRowSeparatorLeading) { _ in 52 }
                     }
+                } header: {
+                    dayHeader(group.day)
                 }
             }
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
     }
 
     private func dayHeader(_ day: Date) -> some View {


### PR DESCRIPTION
## Summary

- replace the Release Log timeline’s `ScrollView` + `LazyVStack` with a native plain `List`
- let AppKit recycle rows and jump directly to scrollbar targets instead of waiting for lazy stack realization
- preserve chronological day sections, pinned headers, row spacing, and inset separators

Fixes #59.

## Verification

- `xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug -destination platform=macOS CODE_SIGNING_ALLOWED=NO build`
- `swift test` in `DuoUpdaterCore` — 1065 tests passed, 2 known issues
- manually tested with the local 759-release / 106-app timeline, including rapid scrollbar dragging to the bottom