### PR TITLE
Refine menu layout and self-update changelog

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -4117,43 +4117,43 @@
         }
       }
     },
-    "Always download & replace, then restart": {
+    "Always replace": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Immer herunterladen & ersetzen, dann neu starten"
+            "value": "Immer ersetzen"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descargar y reemplazar siempre, luego reiniciar"
+            "value": "Reemplazar siempre"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toujours télécharger et remplacer, puis redémarrer"
+            "value": "Toujours remplacer"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "常にダウンロードして置き換え、その後再起動する"
+            "value": "常に置き換える"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Всегда загружать и заменять, затем перезапускать"
+            "value": "Всегда заменять"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "始终下载并替换，然后重启"
+            "value": "始终替换"
           }
         }
       }
@@ -6236,43 +6236,43 @@
         }
       }
     },
-    "Defer to the app’s own updater while it’s running": {
+    "Defer while running": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Solange die App läuft, dem eigenen Update-Tool der App den Vortritt lassen"
+            "value": "Zurückstellen, solange geöffnet"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dejar que el propio actualizador de la app actúe mientras se está ejecutando"
+            "value": "Aplazar mientras se ejecuta"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Laisser l'outil de mise à jour propre à l'application faire son travail pendant qu'elle est ouverte"
+            "value": "Différer pendant l'exécution"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "実行中はアプリ自身の更新機能に任せる"
+            "value": "実行中は延期"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Полагаться на встроенный обновитель приложения, пока оно запущено"
+            "value": "Отложить, пока запущено"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "应用运行时优先使用其自身的更新程序"
+            "value": "运行时延后"
           }
         }
       }
@@ -7824,43 +7824,43 @@
         }
       }
     },
-    "Full download (no extra permission)": {
+    "Full download": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vollständiger Download (keine zusätzliche Berechtigung)"
+            "value": "Vollständiger Download"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descarga completa (sin permisos adicionales)"
+            "value": "Descarga completa"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Téléchargement complet (aucune permission supplémentaire)"
+            "value": "Téléchargement complet"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "完全ダウンロード（追加の権限は不要）"
+            "value": "完全ダウンロード"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Полная загрузка (без доп. разрешений)"
+            "value": "Полная загрузка"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "完整下载（无需额外权限）"
+            "value": "完整下载"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -7080,47 +7080,6 @@
         }
       }
     },
-    "Duo Updater updated itself to %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duo Updater hat sich selbst auf %@ aktualisiert"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duo Updater se actualizó a %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duo Updater s'est mis à jour vers %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duo Updater は %@ に自己更新しました"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duo Updater обновился до версии %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duo Updater 已自我更新至 %@"
-          }
-        }
-      }
-    },
     "Duo Updater updates itself separately from the managed app list, through Sparkle-signed direct downloads. The button above forces a check right now, whether or not automatic installs are on.": {
       "extractionState": "manual",
       "localizations": {
@@ -9255,47 +9214,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在安装…"
-          }
-        }
-      }
-    },
-    "It installs its own updates quietly — see what changed": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installiert eigene Updates im Hintergrund – Änderungen ansehen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instala sus propias actualizaciones en segundo plano; ver qué cambió"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installe ses propres mises à jour discrètement — voir les changements"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自身のアップデートを静かにインストールします — 変更点を見る"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Устанавливает свои обновления незаметно — посмотреть, что изменилось"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "它会静默安装自身的更新 — 查看更新内容"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -6740,49 +6740,49 @@
         }
       }
     },
-    "Downloaded this month": {
+    "Downloaded this month: %@": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Downloaded this month"
+            "value": "Downloaded this month: %@"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diesen Monat heruntergeladen"
+            "value": "Diesen Monat heruntergeladen: %@"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Descargado este mes"
+            "value": "Descargado este mes: %@"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Téléchargé ce mois-ci"
+            "value": "Téléchargé ce mois-ci : %@"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "今月のダウンロード量"
+            "value": "今月のダウンロード量: %@"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Загружено в этом месяце"
+            "value": "Загружено в этом месяце: %@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "本月已下载"
+            "value": "本月已下载：%@"
           }
         }
       }

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -628,22 +628,22 @@ final class AppListModel {
     // MARK: - "We updated ourselves while you weren't looking"
 
     /// The version Duo Updater silently updated itself to since the user last saw
-    /// release notes, or nil. Drives the menu banner.
+    /// release notes, or nil. Drives the bright sparkles beside the menu's version.
     ///
     /// Computed once at launch rather than on every read: the running version
     /// cannot change inside a process, and the record is cleared the moment the
     /// user opens the notes, so a stored value is the honest model.
     private(set) var silentSelfUpdate: String?
 
-    /// The version this build reports. One place, so the banner, the notes window
+    /// The version this build reports. One place, so the menu, the notes window
     /// and the record can never disagree about what "running" means.
     static var runningSelfVersion: String? {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
     }
 
-    /// Resolve the banner state at launch. Seeds the record silently for a fresh
+    /// Resolve the unread-release state at launch. Seeds the record silently for a fresh
     /// install or a rollback (see `SelfUpdateNotice`), and otherwise leaves it
-    /// alone — the record is what makes the banner reappear until it is read, so
+    /// alone — the record is what keeps the sparkles bright until it is read, so
     /// it must NOT be cleared here.
     func resolveSilentSelfUpdate() {
         let running = Self.runningSelfVersion
@@ -4278,10 +4278,10 @@ final class AppListModel {
         }
     }
 
-    /// True when there's more than one app "Update All" would act on — used to
-    /// decide whether to show the batch button.
+    /// True when at least one app "Update All" would act on — used to decide
+    /// whether to show the batch button.
     var canUpdateAll: Bool {
-        !isInstallingAll && !isScanning && !isChecking && installing.isEmpty && installAllTargets().count > 1
+        !isInstallingAll && !isScanning && !isChecking && installing.isEmpty && !installAllTargets().isEmpty
     }
 
     // MARK: - Ignore / skip

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4278,10 +4278,14 @@ final class AppListModel {
         }
     }
 
-    /// True when at least one app "Update All" would act on — used to decide
-    /// whether to show the batch button.
+    /// True when there's more than one app "Update All" would act on — used to
+    /// decide whether to show the batch button.
+    ///
+    /// More than one, not at least one: with a single target the row's own
+    /// "Update" button is already right there, and a batch button beside it is a
+    /// second control for exactly the same action.
     var canUpdateAll: Bool {
-        !isInstallingAll && !isScanning && !isChecking && installing.isEmpty && !installAllTargets().isEmpty
+        !isInstallingAll && !isScanning && !isChecking && installing.isEmpty && installAllTargets().count > 1
     }
 
     // MARK: - Ignore / skip

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -636,7 +636,13 @@ struct MenuContentView: View {
         guard let month = model.trafficSummary.calendarMonths(1).last, month.bytes > 0 else {
             return title
         }
-        return "\(title) · \(ByteFormat.string(month.bytes)) this month"
+        // The figure that used to sit in the footer, now that the row is icons
+        // only. A localized key rather than interpolated English: the separator
+        // has nothing to translate, but "downloaded this month" does — and each
+        // locale wants its own punctuation around the number (fr's space before
+        // the colon, zh's full-width one).
+        let figure = String(localized: "Downloaded this month: \(ByteFormat.string(month.bytes))")
+        return "\(title) · \(figure)"
     }
 
     /// Reserve the brew row for any machine with Homebrew installed — always, even

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -467,14 +467,31 @@ struct MenuContentView: View {
 
             HStack(alignment: .top, spacing: 8) {
                 // One line, at full size, truncating when it must. The slot is
-                // whatever the Update All button leaves.
+                // whatever the Update All button leaves — expressed as a frame,
+                // not as a trailing `Spacer`.
+                //
+                // Both halves of that matter, and they pull opposite ways.
+                // `fixedSize` made the line DEMAND its ideal width, so when the
+                // line outgrew the slot nothing gave: the whole header — title
+                // included — slid left and the button hung past the popover's
+                // edge (reproduced in es and fr by pushing the count to four
+                // digits). But a greedy `Spacer` at the same priority as the text
+                // takes room the line still wants, which clipped fr and es at six
+                // updates with the button's own width sitting unused beside them.
+                // A `fixedSize` button plus `maxWidth: .infinity` here serves the
+                // button its ideal first and hands the line exactly the rest,
+                // where `lineLimit` truncates instead of overflowing. Verified in
+                // all seven shipped languages: nothing truncates at realistic
+                // counts, and the four-digit case ends in an ellipsis inside the
+                // popover instead of over its edge. The tooltip carries the whole
+                // line either way.
                 Text(statusLine)
                     .font(.system(size: 11.5, weight: .regular))
                     .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .layoutPriority(1)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .help(Text(statusLine))
-                Spacer()
                 if model.canUpdateAll {
                     Button("Update All") { Task { await model.installAll() } }
                         .lineLimit(1)

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -402,29 +402,38 @@ struct MenuContentView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .top, spacing: 8) {
-                HStack(alignment: .bottom, spacing: 5) {
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
                     Text("Duo Updater")
                         .font(.system(size: 16, weight: .medium))
                     if let version = AppListModel.runningSelfVersion {
-                        Text("v\(version)")
-                            .font(.system(size: 10, weight: .regular))
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                            .fixedSize()
+                        // The version and the sparkles are ONE button, not a label
+                        // beside a 10pt glyph. Since the self-update banner went
+                        // away this is the only route into the notes anywhere in
+                        // the app, and a lone sparkle that small reads as
+                        // decoration; the version number is the natural thing to
+                        // click for "what changed", and taking both roughly
+                        // triples the hit target.
                         Button {
                             openWindow(id: SelfChangelogView.windowID)
                             model.surfaceWindow(sceneID: SelfChangelogView.windowID)
                         } label: {
-                            Image(systemName: "sparkles")
-                                .foregroundStyle(model.silentSelfUpdate == nil ? Color.secondary : Color.yellow)
+                            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                                Text("v\(version)")
+                                    .monospacedDigit()
+                                    .foregroundStyle(.secondary)
+                                Image(systemName: "sparkles")
+                                    .foregroundStyle(model.silentSelfUpdate == nil ? Color.secondary : Color.yellow)
+                            }
+                            // Baseline-aligned rather than nudged: a symbol has a
+                            // text baseline of its own, so this lands the sparkle
+                            // on the version's without a hand-tuned offset.
+                            .font(.system(size: 10))
+                            .fixedSize()
+                            .contentShape(Rectangle())
                         }
-                        .buttonStyle(.borderless)
-                        .font(.system(size: 10))
+                        .buttonStyle(.plain)
                         .help("What's New — Duo Updater's own release notes")
                         .accessibilityLabel("What's New")
-                        .alignmentGuide(.bottom) { dimensions in
-                            dimensions[.bottom] + 1
-                        }
                     }
                 }
                 .padding(.top, 2)

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -48,6 +48,16 @@ private struct ListHeightKey: PreferenceKey {
     }
 }
 
+private enum MenuLayoutMetrics {
+    static let width: CGFloat = 370
+
+    // AppRow's fit threshold was measured at the original 360pt popover width.
+    // Carry any future width change into that budget instead of leaving the row
+    // logic calibrated to stale geometry.
+    private static let calibratedWidth: CGFloat = 360
+    static let appRowFitBudget: CGFloat = 260 + (width - calibratedWidth)
+}
+
 struct MenuContentView: View {
     @Bindable var model: AppListModel
     @State private var showAll = false
@@ -113,10 +123,6 @@ struct MenuContentView: View {
                 rateLimitBanner
                 Divider()
             }
-            if let version = model.silentSelfUpdate {
-                selfUpdateBanner(version)
-                Divider()
-            }
             if showCheckFailureBanner {
                 checkFailureBanner
                 Divider()
@@ -136,7 +142,7 @@ struct MenuContentView: View {
             Divider()
             footer
         }
-        .frame(width: 360)
+        .frame(width: MenuLayoutMetrics.width)
         .task {
             model.refreshPermissionStatus()
             // One-time wiring: arm the background-check loop and teach the
@@ -296,7 +302,7 @@ struct MenuContentView: View {
     /// Show the "couldn't be checked" banner whenever any row errored — except when
     /// the rate-limit banner above is already accounting for every one of them. That
     /// banner is the more specific answer (add a token), so stacking a generic
-    /// "retry" underneath it in a 360pt popover would only cost room.
+    /// "retry" underneath it in this compact popover would only cost room.
     ///
     /// Suppressed for the whole round, via `isRefreshing` rather than
     /// `isScanning`/`isChecking`: rows carry the previous cycle's `.error` until the
@@ -326,24 +332,37 @@ struct MenuContentView: View {
     /// many rows we have no answer for, names the error most of them share, and
     /// re-checks just those rows rather than everything.
     private var checkFailureBanner: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-            VStack(alignment: .leading, spacing: 1) {
-                Text("\(model.failedCheckCount) apps could not be checked")
-                    .font(.caption).fontWeight(.medium)
-                Text(model.failedCheckSummary ?? String(localized: "Every update source failed"))
-                    .font(.caption2).foregroundStyle(.secondary)
-                    .lineLimit(1).truncationMode(.middle)
+        HStack(alignment: .center, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("\(model.failedCheckCount) apps could not be checked")
+                        .font(.caption).fontWeight(.medium)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text(model.failedCheckSummary ?? String(localized: "Every update source failed"))
+                        .font(.caption2).foregroundStyle(.secondary)
+                        .lineLimit(1).truncationMode(.middle)
+                }
             }
+            .layoutPriority(1)
             Spacer()
             if model.isRetryingFailedChecks {
                 ProgressView().controlSize(.small)
             } else {
-                Button("Retry") { Task { await model.retryFailedChecks() } }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .help("Check these apps again — the settled rows are left alone")
+                Button {
+                    Task { await model.retryFailedChecks() }
+                } label: {
+                    HStack(spacing: 3) {
+                        Text("Retry")
+                        Text("\(model.failedCheckCount)").monospacedDigit()
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .fixedSize(horizontal: true, vertical: false)
+                .help("Check these apps again — the settled rows are left alone")
             }
         }
         .padding(.horizontal, 12)
@@ -353,39 +372,6 @@ struct MenuContentView: View {
 
     /// Aggregate counterpart to the per-row "Rate-limited" badge: one tap
     /// deep-links to Settings → GitHub to add a token (60/hour → 5000/hour).
-    /// "Duo Updater updated itself to X" — the one thing the silent self-update
-    /// design cannot tell you on its own.
-    ///
-    /// Shown until it is read, not for a fixed time: an update that landed while
-    /// the Mac was idle overnight would otherwise expire before the user ever
-    /// opened the menu, which is exactly the case this exists for. Opening the
-    /// notes clears it.
-    private func selfUpdateBanner(_ version: String) -> some View {
-        Button {
-            openWindow(id: SelfChangelogView.windowID)
-            model.surfaceWindow(sceneID: SelfChangelogView.windowID)
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "sparkles")
-                    .foregroundStyle(.tint)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Duo Updater updated itself to \(version)")
-                        .font(.caption).fontWeight(.medium)
-                    Text("It installs its own updates quietly — see what changed")
-                        .font(.caption2).foregroundStyle(.secondary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer()
-                Image(systemName: "chevron.right").font(.caption2).foregroundStyle(.tertiary)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-
     private var rateLimitBanner: some View {
         Button {
             model.requestedSettingsSection = .github
@@ -414,118 +400,104 @@ struct MenuContentView: View {
     }
 
     private var header: some View {
-        HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Duo Updater").font(.headline)
-                // One line, at full size, truncating when it must. The slot is
-                // whatever the Update All button leaves, and a translated button
-                // is wider — Russian gets 167pt for a sentence that wants 247.
-                // Shrinking it to fit was unreadable and a second line unbalanced
-                // the header, so the tail gets cut and the tooltip carries the
-                // whole thing. Explicit, because without a limit the same
-                // sentence wrapped in one state and truncated in another.
-                Text(statusLine)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .help(Text(statusLine))
-            }
-            Spacer()
-            if model.canUpdateAll {
-                // Deliberately no `minimumScaleFactor`. Offering one made the label
-                // *willing* to be squeezed, and SwiftUI took the offer: with a short
-                // list the button came out 67x17 instead of 75x20 — the same header,
-                // measured at 360x55 both times, with 82pt of Spacer sitting empty
-                // beside the shrunken label. The trigger is the popover's height, not
-                // the "Show all" toggle (a search that lengthens the list does it
-                // too), so it is SwiftUI resolving the window against a different
-                // proposal — and neither `layoutPriority` nor `fixedSize` stops it.
-                // Removing the option does.
-                //
-                // Safe for every language we ship: the widest label is French at
-                // ~115pt (measured off the built .strings at the small system font,
-                // 11pt), which still leaves the status line above the ~167pt its own
-                // comment budgets for it. A future translation wider than that would
-                // truncate rather than shrink — worth re-checking there, not here.
-                Button("Update All") { Task { await model.installAll() } }
-                    .lineLimit(1)
-                    .controlSize(.small)
-                    .buttonStyle(.borderedProminent)
-                    .help("Install every pending update that can be applied automatically")
-            }
-            Button {
-                Task { await model.refresh() }
-            } label: {
-                // One box, both states — so the button cannot resize mid-check.
-                // Left as an if/else the two states sized themselves (`arrow.clockwise`
-                // 14pt, a `.small` ProgressView 16pt), and since this row is
-                // trailing-aligned behind a `Spacer` the extra 2pt came off the LEADING
-                // edge: the spinner appeared ~1pt left of the icon it replaced and the
-                // row twitched on every check. Measured, in layout points, off a
-                // screenshot of the real controls (ink centres, not frames):
-                // if/else dx=-1.31, this dx=-0.31 — under half a pixel at 2x.
-                //
-                // 16pt, not the symbol's 14: an overlay on the narrower frame clipped
-                // 1.5pt off the spinner (busy ink 14.3 wide vs 15.8 here).
-                //
-                // No positional nudge, in either axis: the two ink centres already
-                // coincide (dx=-0.31, dy=0.00, stable across three captured animation
-                // frames). What reads as "it jumped left / up" is a SIZE difference —
-                // a `.small` spinner inks 15.8x15.9 against the arrow's 11.4x13.9, so
-                // it spills ~2pt past the arrow on every side. The gear pins the right
-                // side, so the growth only has room to show on the left, which is why
-                // it reads as drifting there. Offsetting to "correct" that would move a
-                // correctly centred spinner off centre; scaling it is the real fix.
-                //
-                // 0.72 = 11.4/15.8 — the arrow's ink width over the spinner's, so the
-                // two footprints match. Verified crisp at 1:1 against a nearest-
-                // neighbour blow-up of the real controls; `.mini` (9.9) undershoots the
-                // arrow and renders thin. `scaleEffect` is render-only, so the 16pt box
-                // — and the button's width — stay put.
-                Group {
-                    if model.isScanning || model.isChecking {
-                        ProgressView().controlSize(.small).scaleEffect(0.72)
-                    } else {
-                        Image(systemName: "arrow.clockwise")
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top, spacing: 8) {
+                HStack(alignment: .bottom, spacing: 5) {
+                    Text("Duo Updater")
+                        .font(.system(size: 16, weight: .medium))
+                    if let version = AppListModel.runningSelfVersion {
+                        Text("v\(version)")
+                            .font(.system(size: 10, weight: .regular))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                            .fixedSize()
+                        Button {
+                            openWindow(id: SelfChangelogView.windowID)
+                            model.surfaceWindow(sceneID: SelfChangelogView.windowID)
+                        } label: {
+                            Image(systemName: "sparkles")
+                                .foregroundStyle(model.silentSelfUpdate == nil ? Color.secondary : Color.yellow)
+                        }
+                        .buttonStyle(.borderless)
+                        .font(.system(size: 10))
+                        .help("What's New — Duo Updater's own release notes")
+                        .accessibilityLabel("What's New")
+                        .alignmentGuide(.bottom) { dimensions in
+                            dimensions[.bottom] + 1
+                        }
                     }
                 }
-                .frame(width: 16, height: 16)
+                .padding(.top, 2)
+                Spacer()
+                HStack(spacing: 8) {
+                    Button {
+                        Task { await model.refresh() }
+                    } label: {
+                        // Keep both refresh states in the same 16pt layout box.
+                        Group {
+                            if model.isScanning || model.isChecking {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .scaleEffect(0.72)
+                                    .offset(y: 1)
+                            } else {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                        }
+                        .frame(width: 16, height: 16)
+                        .padding(.top, 4)
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(!model.canRefresh)
+                    .help("Rescan and check for updates")
+                    Button {
+                        openWindow(id: SettingsView.windowID)
+                        model.surfaceWindow(sceneID: SettingsView.windowID)
+                    } label: {
+                        Image(systemName: "gearshape")
+                            .padding(.top, 5)
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Settings")
+                }
+                .font(.system(size: 13))
+                .offset(y: -1)
             }
-            .buttonStyle(.borderless)
-            .disabled(!model.canRefresh)
-            .help("Rescan and check for updates")
-            Button {
-                openWindow(id: SettingsView.windowID)
-                model.surfaceWindow(sceneID: SettingsView.windowID)
-            } label: {
-                Image(systemName: "gearshape")
+            .padding(.top, 10)
+
+            HStack(alignment: .top, spacing: 8) {
+                // One line, at full size, truncating when it must. The slot is
+                // whatever the Update All button leaves.
+                Text(statusLine)
+                    .font(.system(size: 11.5, weight: .regular))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .layoutPriority(1)
+                    .help(Text(statusLine))
+                Spacer()
+                if model.canUpdateAll {
+                    Button("Update All") { Task { await model.installAll() } }
+                        .lineLimit(1)
+                        .controlSize(.small)
+                        .buttonStyle(.borderedProminent)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .help("Install every pending update that can be applied automatically")
+                } else {
+                    Color.clear.frame(width: 0, height: 20)
+                }
             }
-            .buttonStyle(.borderless)
-            .help("Settings")
+            .padding(.top, 8)
+            .padding(.bottom, 5)
         }
-        .padding(12)
+        .padding(.horizontal, 12)
     }
 
     private var statusLine: String {
         // `isRefreshing`, not `isChecking`: the scan leg and the TestFlight read come
         // first, and during those the line below would report the PREVIOUS round's
         // unanswered rows as if they were this round's verdict.
-        if model.isRefreshing {
-            return String(localized: "Checking \(model.results.count) apps…")
-        }
-        let updates = model.updateCount
-        let failed = model.failedCheckCount
-        // "up to date" is a claim about every app, and it is only true when every
-        // app actually answered. With rows still in `.error` the honest line names
-        // them instead — the banner above carries the reason and the retry.
-        let base: String
-        if updates > 0 {
-            base = String(localized: "\(updates) updates available")
-        } else if failed > 0 {
-            base = String(localized: "\(failed) of \(model.results.count) apps not checked")
-        } else {
-            base = String(localized: "\(model.results.count) apps · up to date")
-        }
+        let base = statusBaseLine
+        if model.isRefreshing { return base }
         // The timestamp joins on with a separator and no verb. "checked" was a
         // word the relative time already implies, and it cost more room than the
         // header has: translated, the line ran 247pt against the 167pt left over
@@ -536,6 +508,24 @@ struct MenuContentView: View {
             return "\(base) · \(Self.checkedAgo(last))"
         }
         return base
+    }
+
+    private var statusBaseLine: String {
+        if model.isRefreshing {
+            return String(localized: "Checking \(model.results.count) apps…")
+        }
+        let updates = model.updateCount
+        let failed = model.failedCheckCount
+        // "up to date" is a claim about every app, and it is only true when every
+        // app actually answered. With rows still in `.error` the honest line names
+        // them instead — the banner above carries the reason and the retry.
+        if updates > 0 {
+            return String(localized: "\(updates) updates available")
+        }
+        if failed > 0 {
+            return String(localized: "\(failed) of \(model.results.count) apps not checked")
+        }
+        return String(localized: "\(model.results.count) apps · up to date")
     }
 
     /// "just now" / "2m ago". Guards the just-finished case: the
@@ -586,15 +576,6 @@ struct MenuContentView: View {
             .font(.caption)
             .help("Release Log — when the apps you track shipped each version")
             Button {
-                openWindow(id: SelfChangelogView.windowID)
-                model.surfaceWindow(sceneID: SelfChangelogView.windowID)
-            } label: {
-                Image(systemName: "sparkles")
-            }
-            .buttonStyle(.borderless)
-            .font(.caption)
-            .help("What's New — Duo Updater's own release notes")
-            Button {
                 openWindow(id: TrafficWindowView.windowID)
                 model.surfaceWindow(sceneID: TrafficWindowView.windowID)
             } label: {
@@ -602,22 +583,7 @@ struct MenuContentView: View {
             }
             .buttonStyle(.borderless)
             .font(.caption)
-            .help("Download Traffic — what keeping these apps updated has cost")
-            // "How much this month?" is the question asked most often, and putting
-            // the figure right here answers it without opening anything. Hidden
-            // until there's something to show so it never renders as a bare "Zero KB".
-            //
-            // `calendarMonths(1)`, not `months.last`: the latter is the last month
-            // that *had* a download, so in a quiet month it would keep showing an
-            // older total under a label that says "this month".
-            if let month = model.trafficSummary.calendarMonths(1).last, month.bytes > 0 {
-                Text(ByteFormat.string(month.bytes))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-                    .lineLimit(1)
-                    .help("Downloaded this month")
-            }
+            .help(footerTrafficHelp)
             Button {
                 openWindow(id: WorkbenchWindowView.windowID)
                 model.surfaceWindow(sceneID: WorkbenchWindowView.windowID)
@@ -627,14 +593,24 @@ struct MenuContentView: View {
             .buttonStyle(.borderless)
             .font(.caption)
             .help("Open Window — release notes and settings")
-            Button("Quit") { NSApp.terminate(nil) }
-                .buttonStyle(.borderless)
-                .font(.caption)
-                .lineLimit(1)
-                .minimumScaleFactor(0.85)
+            Button { NSApp.terminate(nil) } label: {
+                Image(systemName: "power")
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+            .help("Quit")
+            .accessibilityLabel("Quit")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    private var footerTrafficHelp: String {
+        let title = String(localized: "Download Traffic — what keeping these apps updated has cost")
+        guard let month = model.trafficSummary.calendarMonths(1).last, month.bytes > 0 else {
+            return title
+        }
+        return "\(title) · \(ByteFormat.string(month.bytes)) this month"
     }
 
     /// Reserve the brew row for any machine with Homebrew installed — always, even
@@ -863,12 +839,13 @@ private struct AppRow: View {
 
     /// Whether the name column still holds together next to a readout `width`
     /// wide. Six readout widths were rendered against the real row layout and
-    /// each one's wrap point recorded; the budget came out as `260 - width`,
+    /// each one's wrap point recorded; at the original 360pt popover the budget
+    /// came out as `260 - width`,
     /// taking the low end of the six intercepts (261…267.6) and 4pt of slack on
     /// top. The slack is the lesson from the percentage label, which wrapped
     /// because its slot was sized to the exact measurement.
     private func nameFits(besideReadout width: CGFloat) -> Bool {
-        nameColumnDemand <= 260 - width - 4
+        nameColumnDemand <= MenuLayoutMetrics.appRowFitBudget - width - 4
     }
 
     /// How much of a download readout the name leaves room for. Widest first —

--- a/App/Sources/SelfChangelogView.swift
+++ b/App/Sources/SelfChangelogView.swift
@@ -22,6 +22,20 @@ struct SelfChangelogView: View {
     /// published seconds ago may take a moment to appear here.)
     private static let source = URL(
         string: "https://raw.githubusercontent.com/jizhi0v0/duo-updater/main/CHANGELOG.md")!
+    /// CHANGELOG.md deliberately contains only prose. GitHub Releases is the
+    /// authoritative clock for when each of those versions became available.
+    private static let releasesSource = URL(
+        string: "https://api.github.com/repos/jizhi0v0/duo-updater/releases?per_page=100")!
+
+    private struct PublishedRelease: Decodable {
+        let tagName: String
+        let publishedAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case publishedAt = "published_at"
+        }
+    }
 
     private enum LoadState {
         case loading
@@ -43,10 +57,10 @@ struct SelfChangelogView: View {
             .frame(minWidth: 560, minHeight: 420)
             .task {
             // Marked here rather than at the click: any route into this window —
-            // the banner, the menu button, macOS restoring it after a relaunch —
-            // means the notes were put in front of the user, and the banner should
-            // stop nagging. Doing it at the call site would leave one of those
-            // routes announcing forever.
+            // the menu sparkles, macOS restoring it after a relaunch — means the
+            // notes were put in front of the user, and the bright unread state should
+            // clear. Doing it at the call site would leave one of those routes
+            // announcing forever.
             model.markSelfUpdateSeen()
             await load()
         }
@@ -63,6 +77,7 @@ struct SelfChangelogView: View {
                 changelog: changelog,
                 itemStyle: .paragraphs,
                 runningVersion: runningVersion,
+                showsDatesInline: true,
                 showsLayoutPicker: false)
         case .loading:
             ProgressView()
@@ -110,9 +125,41 @@ struct SelfChangelogView: View {
                 state = .failed(String(localized: "The file loaded but carried no release sections."))
                 return
             }
-            state = .loaded(changelog)
+            state = .loaded(await addingReleaseDates(to: changelog))
         } catch {
             state = .failed(error.localizedDescription)
         }
+    }
+
+    /// Date lookup is enrichment, not a second requirement for opening the
+    /// notes. A rate limit or transient GitHub API failure leaves the changelog
+    /// usable, just without dates.
+    private func addingReleaseDates(to changelog: Changelog) async -> Changelog {
+        var request = URLRequest(url: Self.releasesSource)
+        request.cachePolicy = .returnCacheDataElseLoad
+        request.timeoutInterval = 10
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        guard let (data, response) = try? await URLSession.updates.data(for: request),
+              let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode),
+              let releases = try? JSONDecoder().decode([PublishedRelease].self, from: data)
+        else { return changelog }
+
+        let dates = Dictionary(uniqueKeysWithValues: releases.compactMap { release -> (String, String)? in
+            guard let timestamp = release.publishedAt, timestamp.count >= 10 else { return nil }
+            let version = release.tagName.hasPrefix("v") ? String(release.tagName.dropFirst()) : release.tagName
+            return (version, String(timestamp.prefix(10)))
+        })
+
+        let entries = changelog.entries.map { entry in
+            Changelog.Entry(
+                title: entry.title,
+                version: entry.version,
+                date: dates[entry.version] ?? entry.date,
+                items: entry.items,
+                content: entry.content)
+        }
+        return Changelog(entries: entries, itemSyntax: changelog.itemSyntax)
     }
 }

--- a/App/Sources/SelfChangelogView.swift
+++ b/App/Sources/SelfChangelogView.swift
@@ -24,8 +24,22 @@ struct SelfChangelogView: View {
         string: "https://raw.githubusercontent.com/jizhi0v0/duo-updater/main/CHANGELOG.md")!
     /// CHANGELOG.md deliberately contains only prose. GitHub Releases is the
     /// authoritative clock for when each of those versions became available.
-    private static let releasesSource = URL(
-        string: "https://api.github.com/repos/jizhi0v0/duo-updater/releases?per_page=100")!
+    ///
+    /// Paged, because the changelog outlives one page. At this repo's cadence
+    /// (twenty releases in the six days to 0.3.63) the list passes 100 within
+    /// weeks, and a single-page read would then quietly drop the date off every
+    /// older entry — a rail half dated and half not, sized off the mixture.
+    private static func releasesSource(page: Int) -> URL {
+        URL(string: "https://api.github.com/repos/jizhi0v0/duo-updater/releases"
+            + "?per_page=\(releasesPerPage)&page=\(page)")!
+    }
+
+    private static let releasesPerPage = 100
+
+    /// Stop after this many pages whatever happens. Dates are an enrichment, not
+    /// a reason to spend an unbounded slice of the unauthenticated 60/hour
+    /// budget — and every version the notes can show is inside the first few.
+    private static let maxReleasePages = 3
 
     private struct PublishedRelease: Decodable {
         let tagName: String
@@ -133,24 +147,51 @@ struct SelfChangelogView: View {
 
     /// Date lookup is enrichment, not a second requirement for opening the
     /// notes. A rate limit or transient GitHub API failure leaves the changelog
-    /// usable, just without dates.
+    /// usable, just without dates — and a page that fails mid-walk keeps the
+    /// dates the earlier pages already produced.
     private func addingReleaseDates(to changelog: Changelog) async -> Changelog {
-        var request = URLRequest(url: Self.releasesSource)
-        request.cachePolicy = .returnCacheDataElseLoad
-        request.timeoutInterval = 10
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        var dates: [String: String] = [:]
+        // Stop as soon as every version the notes can show has an answer, so the
+        // common case stays one request.
+        var wanted = Set(changelog.entries.map(\.version))
 
-        guard let (data, response) = try? await URLSession.updates.data(for: request),
-              let http = response as? HTTPURLResponse,
-              (200..<300).contains(http.statusCode),
-              let releases = try? JSONDecoder().decode([PublishedRelease].self, from: data)
-        else { return changelog }
+        for page in 1...Self.maxReleasePages where !wanted.isEmpty {
+            var request = URLRequest(url: Self.releasesSource(page: page))
+            // Revalidate rather than serve whatever is cached. The version a
+            // reader most wants a date for is the one that just landed on their
+            // Mac, and `returnCacheDataElseLoad` answers from a copy taken before
+            // that release existed — the one entry guaranteed to be missing is the
+            // one they opened the window for. A 304 costs nothing against the
+            // rate limit.
+            request.cachePolicy = .reloadRevalidatingCacheData
+            request.timeoutInterval = 10
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
 
-        let dates = Dictionary(uniqueKeysWithValues: releases.compactMap { release -> (String, String)? in
-            guard let timestamp = release.publishedAt, timestamp.count >= 10 else { return nil }
-            let version = release.tagName.hasPrefix("v") ? String(release.tagName.dropFirst()) : release.tagName
-            return (version, String(timestamp.prefix(10)))
-        })
+            guard let (data, response) = try? await URLSession.updates.data(for: request),
+                  let http = response as? HTTPURLResponse,
+                  (200..<300).contains(http.statusCode),
+                  let releases = try? JSONDecoder().decode([PublishedRelease].self, from: data),
+                  !releases.isEmpty
+            else { break }
+
+            for release in releases {
+                guard let timestamp = release.publishedAt, timestamp.count >= 10 else { continue }
+                let version = release.tagName.hasPrefix("v")
+                    ? String(release.tagName.dropFirst()) : release.tagName
+                // Newest-first, first writer wins — so a version that was tagged
+                // twice keeps its latest publication. Deliberately not
+                // `Dictionary(uniqueKeysWithValues:)`, which TRAPS on a duplicate
+                // key: `v0.3.63` and `0.3.63` are two legal tags that collide the
+                // moment the "v" is stripped, and the notes window would crash
+                // rather than show a date it wasn't sure about.
+                if dates[version] == nil { dates[version] = String(timestamp.prefix(10)) }
+                wanted.remove(version)
+            }
+            // A short page is the last page.
+            if releases.count < Self.releasesPerPage { break }
+        }
+
+        guard !dates.isEmpty else { return changelog }
 
         let entries = changelog.entries.map { entry in
             Changelog.Entry(

--- a/App/Sources/Settings/GeneralSettingsPage.swift
+++ b/App/Sources/Settings/GeneralSettingsPage.swift
@@ -174,57 +174,25 @@ struct GeneralSettingsPage: View {
 
 // MARK: - Adaptive picker row
 
-/// Carries the measured width of a picker row up to the row itself, so the
-/// share-of-the-row rule below has a number to work with.
-private struct PickerRowWidthKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-/// A settings picker that keeps its label and popup on one line — the way the
-/// rest of macOS lays these out — and only stacks the label above the popup when
-/// one line would be cramped.
-///
-/// "Cramped" is defined as the popup wanting more than `maxPopupShare` of the
-/// row: German and Russian option labels ("Immer herunterladen und ersetzen,
-/// dann neu starten") blow well past that, and the single-line layout was
-/// clipping them, which is why both rows were stacked unconditionally when
-/// localization landed.
-///
-/// The rule is expressed by reserving the rest of the row for the label with
-/// `minWidth`: a popup that needs more than its share pushes the HStack past
-/// the row, and `ViewThatFits` drops to the stacked candidate. `rowWidth` is 0
-/// on the first pass — the one-line candidate is then judged on its natural
-/// width alone, and the layout settles once the measurement lands.
+/// A settings picker that follows the standard macOS label-left/control-right
+/// row. The popup gets all remaining width instead of making the whole row
+/// stack when one localized option happens to be long; its menu still presents
+/// the full strings even if an exceptionally narrow window compresses the
+/// current selection.
 private struct AdaptivePickerRow<Content: View>: View {
     let title: Text
     @ViewBuilder var picker: Content
 
-    /// How much of the row the popup may take before the row stacks instead.
-    private let maxPopupShare: CGFloat = 0.6
-
-    @State private var rowWidth: CGFloat = 0
-
     var body: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 12) {
-                title
-                    .font(.callout)
-                    .frame(minWidth: rowWidth * (1 - maxPopupShare), alignment: .leading)
-                picker.fixedSize()
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                title.font(.callout)
-                picker
-            }
+        HStack(spacing: 12) {
+            title
+                .font(.callout)
+                .fixedSize(horizontal: true, vertical: false)
+            Spacer(minLength: 0)
+            picker
+                .fixedSize(horizontal: false, vertical: true)
+                .layoutPriority(1)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(GeometryReader { geo in
-            Color.clear.preference(key: PickerRowWidthKey.self, value: geo.size.width)
-        })
-        .onPreferenceChange(PickerRowWidthKey.self) { rowWidth = $0 }
+        .frame(maxWidth: .infinity)
     }
 }

--- a/App/Sources/Settings/GeneralSettingsPage.swift
+++ b/App/Sources/Settings/GeneralSettingsPage.swift
@@ -175,24 +175,39 @@ struct GeneralSettingsPage: View {
 // MARK: - Adaptive picker row
 
 /// A settings picker that follows the standard macOS label-left/control-right
-/// row. The popup gets all remaining width instead of making the whole row
-/// stack when one localized option happens to be long; its menu still presents
-/// the full strings even if an exceptionally narrow window compresses the
-/// current selection.
+/// row whenever the label and the popup both fit at their natural widths, and
+/// stacks the label above the popup when they do not.
+///
+/// Both halves of the one-line candidate are `fixedSize`, so `ViewThatFits`
+/// only chooses it when the row can show the whole label AND the whole selected
+/// option. That distinction is the point: these options are sentences ("Always
+/// download & replace, then restart"), and a popup handed a squeezed slot does
+/// not stack or shrink — it truncates the current selection. At the 660pt window
+/// minimum that happened in every language we ship, English included
+/// ("Full download (no extra permissi…"), which left the reader unable to see
+/// which route was active without opening the menu.
+///
+/// Ideal widths, so no measurement pass: `Spacer(minLength: 0)` contributes 0 to
+/// the candidate's ideal size, leaving it as label + 12 + popup.
 private struct AdaptivePickerRow<Content: View>: View {
     let title: Text
     @ViewBuilder var picker: Content
 
     var body: some View {
-        HStack(spacing: 12) {
-            title
-                .font(.callout)
-                .fixedSize(horizontal: true, vertical: false)
-            Spacer(minLength: 0)
-            picker
-                .fixedSize(horizontal: false, vertical: true)
-                .layoutPriority(1)
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                title
+                    .font(.callout)
+                    .fixedSize(horizontal: true, vertical: false)
+                Spacer(minLength: 0)
+                picker.fixedSize()
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                title.font(.callout)
+                picker
+            }
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1199,6 +1199,9 @@ struct ChangelogEntriesView: View {
     /// The version the reader is on, marked in the rail. Nil for a vendor
     /// changelog, where the row itself is already about the app they have.
     var runningVersion: String?
+    /// Duo Updater's own history uses compact version + date rows. Vendor
+    /// changelogs retain the two-line treatment because their titles can be long.
+    var showsDatesInline: Bool = false
     /// Whether to offer the side-by-side / long-scroll switch.
     ///
     /// Off for our own notes: with 53 versions the rail is the only sane way to
@@ -1222,7 +1225,7 @@ struct ChangelogEntriesView: View {
     /// 85th percentile fits the great majority; the upper clamp caps a lone runaway
     /// title (and the lower clamp keeps a terse changelog from getting cramped).
     /// Measured with AppKit since the labels are known up front — no GeometryReader.
-    private static func railWidth(for changelog: Changelog) -> CGFloat {
+    private static func railWidth(for changelog: Changelog, showsDatesInline: Bool) -> CGFloat {
         let labelFont = NSFont.preferredFont(forTextStyle: .callout)
         let dateFont = NSFont.preferredFont(forTextStyle: .caption2)
         let rowWidths = changelog.entries
@@ -1232,14 +1235,21 @@ struct ChangelogEntriesView: View {
                 let dateW = (entry.date?.isEmpty == false)
                     ? (entry.date! as NSString).size(withAttributes: [.font: dateFont]).width
                     : 0
-                return max(labelW, dateW)
+                return showsDatesInline && dateW > 0
+                    ? labelW + 6 + dateW
+                    : max(labelW, dateW)
             }
             .sorted()
         guard !rowWidths.isEmpty else { return 200 }
         let pick = rowWidths[Int((Double(rowWidths.count - 1) * 0.85).rounded())]
-        // Row chrome: line .horizontal(10)×2 + rail .padding(8)×2.
+        // Row chrome: line .horizontal(10)×2 + rail .padding(8)×2. Inline dates
+        // also reserve the current-version dot and its gap; without that small
+        // accessory budget only the running row truncates its otherwise identical
+        // date, which makes the rail look inconsistently sized.
         let chrome: CGFloat = 20 + 16
-        return min(max(pick + chrome, 140), 360)
+        let inlineAccessory: CGFloat = showsDatesInline ? 16 : 0
+        let minimum: CGFloat = showsDatesInline ? 156 : 140
+        return min(max(pick + chrome + inlineAccessory, minimum), 360)
     }
 
     var body: some View {
@@ -1289,9 +1299,11 @@ struct ChangelogEntriesView: View {
             // re-measure the rail (its width depends only on the changelog).
             .onChange(of: changelog) {
                 selection = 0
-                cachedRailWidth = Self.railWidth(for: changelog)
+                cachedRailWidth = Self.railWidth(for: changelog, showsDatesInline: showsDatesInline)
             }
-            .onAppear { cachedRailWidth = Self.railWidth(for: changelog) }
+            .onAppear {
+                cachedRailWidth = Self.railWidth(for: changelog, showsDatesInline: showsDatesInline)
+            }
         }
     }
 
@@ -1307,7 +1319,8 @@ struct ChangelogEntriesView: View {
         return HStack(spacing: 0) {
             ChangelogVersionList(
                 entries: changelog.entries, selection: $selection,
-                runningVersion: runningVersion)
+                runningVersion: runningVersion,
+                showsDatesInline: showsDatesInline)
                 .frame(width: cachedRailWidth)
             Divider()
             // Scroll back to the top on switch WITHOUT changing identity. This used
@@ -1364,6 +1377,7 @@ private struct ChangelogVersionList: View {
     /// says where they stand in it. Nil for a vendor changelog, where "the version
     /// you have" is already the row's own subject and the rail is just navigation.
     var runningVersion: String?
+    var showsDatesInline = false
 
     var body: some View {
         let selected = min(max(selection, 0), entries.count - 1)
@@ -1377,6 +1391,12 @@ private struct ChangelogVersionList: View {
                                     .font(.callout)
                                     .fontWeight(index == selected ? .semibold : .regular)
                                     .lineLimit(1)
+                                if showsDatesInline, let date = entry.date, !date.isEmpty {
+                                    Text(date)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
                                 if isRunning(entry) {
                                     // A filled dot, not the word "current": the rail
                                     // is narrow and sized from its labels, so a word
@@ -1387,7 +1407,7 @@ private struct ChangelogVersionList: View {
                                         .help("The version you're running")
                                 }
                             }
-                            if let date = entry.date, !date.isEmpty {
+                            if !showsDatesInline, let date = entry.date, !date.isEmpty {
                                 Text(date).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
                             }
                         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateSettings.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateSettings.swift
@@ -22,9 +22,20 @@ public enum AppStoreUpdateStrategy: String, CaseIterable, Identifiable, Sendable
     /// migration.
     public static let availableCases: [Self] = [.full]
 
+    /// Deliberately terse. These labels sit in a popup button whose slot is the
+    /// settings row, and the sentence-length versions they replaced ("Full
+    /// download (no extra permission)") could not be shown whole at the window's
+    /// own minimum width in ANY language we ship — the popup truncated its own
+    /// current selection, so the setting could not be read without opening the
+    /// menu. Everything the parenthetical carried is in the card's footer, which
+    /// has room for it.
+    ///
+    /// `.incremental` keeps its longer label: it is not in `availableCases`, so
+    /// nothing renders it, and re-translating a string no one can see would be
+    /// churn for its own sake.
     public var label: String {
         switch self {
-        case .full:        return String(localized: "Full download (no extra permission)")
+        case .full:        return String(localized: "Full download")
         case .incremental: return String(localized: "Incremental (needs Accessibility)")
         }
     }
@@ -71,10 +82,14 @@ public enum VendorInstallPolicy: String, CaseIterable, Identifiable, Sendable {
 
     public var id: String { rawValue }
 
+    /// Terse for the same reason as `AppStoreUpdateStrategy.label`, and worded to
+    /// match the footer exactly: it already names these two by their short names
+    /// ("Always replace" — the default … switch to "Defer while running"), so the
+    /// popup and the prose explaining it now say the same thing.
     public var label: String {
         switch self {
-        case .deferWhenRunning: return String(localized: "Defer to the app’s own updater while it’s running")
-        case .alwaysOverwrite:  return String(localized: "Always download & replace, then restart")
+        case .deferWhenRunning: return String(localized: "Defer while running")
+        case .alwaysOverwrite:  return String(localized: "Always replace")
         }
     }
 }


### PR DESCRIPTION
## Summary
- tighten and rebalance the menu header, move the self-update indicator beside the version, and use icon-only footer actions
- improve update/failure action layout, expand the localized menu width, and keep install-routing pickers aligned in one row
- enrich Duo Updater release notes with GitHub publication dates and show them inline in the version rail

## Testing
- `swift test --package-path DuoUpdaterCore` (1074 tests passed, 2 known issues)
- release build and signed local install via `bash scripts/install.sh`
- verified all packaged languages: de, en, es, fr, ja, ru, zh-Hans