### PR TITLE
Add Longbridge Desktop update support

### DIFF
--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -176,6 +176,9 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 - ✗ **Blender — Daily/Alpha/Beta** · 同 bundle id，builder.blender.org 滚动构建，无检测信号
 - ✅ **Figma — Beta** · 已接入（**更正旧判断：不是**应用内 flag）。独立 app：bundle `com.figma.DesktopBeta`、"Figma Beta.app"、独立端点 `desktop.figma.com/mac-arm/beta/`。Pattern A，VendorProbe(`channel: .beta`) + 一键安装（Team T8RA8NE3B7，2026-06-06 真机验证）
 - ✗ **GitHub Desktop — Beta** · 同 `com.github.GitHubClient`，beta tag 是 prerelease，stable rule 已排除
+- ✗ **Longbridge Desktop — Preview** · 已停更，不再接入。2026-08-25 实包验证旧
+  `0.15.0-preview.0` 是独立 `com.longbridge.app.desktop.preview`，可准确检测为 `.preview`；
+  stable `com.longbridge.app.desktop` 已接 VendorProbe + changelog + arm64 一键安装，二者不会串轨。
 
 ### 2026-06-06 渠道扫描确认 — 单 channel / 无 detectable beta
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCatalog.swift
@@ -31,6 +31,10 @@ public enum ChangelogCatalog {
         // we still want an explicit fallback page when the lazy fetch/parser
         // misses or the update check hasn't populated a remote changelog URL yet.
         "app.chatwise": URL(string: "https://chatwise.app/changelog")!,
+        // Longbridge Desktop — the structured recipe follows the exact version
+        // page. Keep the English release-notes index as a web fallback while an
+        // update result or a freshly added recipe has not populated yet.
+        "com.longbridge.app.desktop": URL(string: "https://longbridge.com/desktop/release-notes/")!,
         // WhatsApp — iOS-on-Mac (kind=software); MAS source scrapes the Mac page
         // for version comparison, but `remote` may be nil at render time if the
         // check hasn't finished. This catalog entry ensures the Mac App Store page

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1859,6 +1859,25 @@ public enum ChangelogRecipeRegistry {
             itemPatterns: [#"<li>(?<item>.*?)</li>"#],
             channel: .stable,
             sourceTemplate: "https://blogs.opera.com/desktop/changelog-for-{major}/"),
+
+        // Longbridge Desktop — use the English per-version page rather than the
+        // compact latest.json notes: the page carries the richer release body and
+        // some releases interleave screenshots with their change lines. Stop at
+        // Downloads so installer links never become changelog items. Videos are
+        // intentionally skipped (the native changelog model supports images); the
+        // item boundary before <video> also keeps its browser-fallback text out.
+        ChangelogRecipe(
+            bundleID: "com.longbridge.app.desktop",
+            source: URL(string: "https://longbridge.com/desktop/release-notes/v0.19.1")!,
+            entryPattern:
+                #"<div[^>]*class="vp-doc[^"]*"[^>]*>\s*<div>\s*<h1[^>]*>\s*v?(?<version>[0-9]+(?:\.[0-9]+)+).*?</h1>\s*<p>\s*<em>\s*Release Date:\s*(?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})\s*</em>\s*</p>(?<body>.*?)(?=<h2[^>]*id="downloads")"#,
+            itemPatterns: [
+                #"<(?:li|p)\b[^>]*>(?<item>.*?)(?=<img\b|<video\b|</(?:li|p)>)"#,
+            ],
+            maxEntries: 1,
+            channel: .stable,
+            sourceTemplate: "https://longbridge.com/desktop/release-notes/v{version}",
+            imagePattern: #"<img\b[^>]*\bsrc="(?<image>https://[^"]+)"#),
     ]
 
     /// Group recipes by lowercased bundle id. Most bundle ids map to a single

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -3956,6 +3956,32 @@ public enum VendorProbeRegistry {
         // and the tag is the release itself rather than a "best release" guess.
         // It stays detection-only either way — that is a property of upstream's
         // signature, not of the endpoint.
+
+        // MARK: - 2026-08-25 Longbridge Desktop
+
+        // Longbridge Desktop — the vendor's compact stable JSON is the same
+        // manifest used by its release-notes site. `version` matches the mounted
+        // app's CFBundleShortVersionString exactly (0.19.1); CFBundleVersion is a
+        // timestamp-like build (20260820.080114) and must not be compared.
+        //
+        // The response carries both macOS architectures. DuoUpdater currently
+        // runs this official-website install path on Apple Silicon, so the URL
+        // pattern is deliberately pinned to `macos-aarch64.dmg` instead of taking
+        // the first arbitrary dmg asset. Verified against the mounted 0.19.1
+        // artifact: com.longbridge.app.desktop, Team 45NG8MW7WK, accepted by
+        // Gatekeeper as Notarized Developer ID. The DMG is self-contained.
+        VendorProbeRecipe(
+            bundleID: "com.longbridge.app.desktop",
+            url: URL(string: "https://assets.lbkrs.com/github/release/longbridge-desktop/stable/latest.json")!,
+            mode: .responseBody,
+            versionPattern: #""version"\s*:\s*"([0-9]+(?:\.[0-9]+){1,4})""#,
+            downloadURL: URL(string: "https://longbridge.com/desktop/")!,
+            changelogURL: URL(string: "https://longbridge.com/desktop/release-notes/")!,
+            publishedAtPattern: #""published_at"\s*:\s*"([^"]+)""#,
+            install: VendorInstallSpec(
+                urlSource: .bodyPattern(
+                    #""url"\s*:\s*"(https://assets\.lbkrs\.com/github/release/longbridge-desktop/stable/longbridge-v[0-9.]+-macos-aarch64\.dmg)""#),
+                kind: .dmg)),
     ]
 
     /// One OrbStack recipe for a given channel: same appcast, regex anchored to

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LongbridgeIntegrationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LongbridgeIntegrationTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+private let longbridgeLatestFixture = #"""
+{"version":"0.19.1","created_at":"2026-08-20T10:13:36Z","published_at":"2026-08-20T07:46:53Z","release_notes":{"en":"### Improvements\r\n\r\n- Fixed an issue where the editor could quit unexpectedly.\r\n- Fixed vertical lists occasionally showing an unnecessary horizontal scrollbar.","zh-CN":"### 优化\r\n\r\n- 修复编辑器问题。","zh-HK":"### 優化\r\n\r\n- 修復編輯器問題。"},"assets":[{"name":"longbridge-v0.19.1-macos-aarch64.dmg","url":"https://assets.lbkrs.com/github/release/longbridge-desktop/stable/longbridge-v0.19.1-macos-aarch64.dmg","sha256":"a666daf0da71e524a378178f45cbd216d377a9cbe2cd8353ff6a77b1f6a74daa"},{"name":"longbridge-v0.19.1-macos-x86_64.dmg","url":"https://assets.lbkrs.com/github/release/longbridge-desktop/stable/longbridge-v0.19.1-macos-x86_64.dmg","sha256":"5d3325bd671735b4720e2ac7d232cedf9b4a8abf3953ff2247e17e54d9d134b5"}]}
+"""#
+
+private let longbridgeCurrentNotesFixture = #"""
+<main><div style="position:relative;" class="vp-doc _desktop_release-notes_v0_19_1" data-v-x><div>
+<h1 id="v0-19-1">v0.19.1 <a class="header-anchor">#</a></h1>
+<p><em>Release Date: 2026-08-20</em></p>
+<h3>Improvements</h3><ul>
+<li>Fixed an issue where the editor could quit unexpectedly.</li>
+<li>Fixed vertical lists occasionally showing an unnecessary horizontal scrollbar.</li>
+</ul><h2 id="downloads">Downloads</h2><ul><li>macOS installer</li></ul>
+</div></div></main>
+"""#
+
+private let longbridgeRichNotesFixture = #"""
+<main><div style="position:relative;" class="vp-doc _desktop_release-notes_v0_19_0" data-v-x><div>
+<h1 id="v0-19-0">v0.19.0 <a class="header-anchor">#</a></h1>
+<p><em>Release Date: 2026-08-19</em></p>
+<p><strong>Screening &amp; quant</strong></p><ul>
+<li>Screener: Added multi-dimensional filters.<video src="https://assets.lbkrs.com/demo.mp4">Your browser does not support the video tag.</video></li>
+<li>Financials: Added score details.<img src="https://assets.lbkrs.com/uploads/Score.png" alt="Score"></li>
+<li>Watchlist: Added list-width controls.</li>
+</ul><h2 id="downloads">Downloads</h2><ul><li>macOS installer</li></ul>
+</div></div></main>
+"""#
+
+@Suite struct LongbridgeIntegrationTests {
+    private func probe() throws -> VendorProbeRecipe {
+        try #require(VendorProbeRegistry.recipes.first {
+            $0.bundleID == "com.longbridge.app.desktop" && $0.channel == .stable
+        })
+    }
+
+    @Test func vendorProbeReadsMarketingVersionAndPublishedDate() throws {
+        let recipe = try probe()
+        #expect(VendorProbeRecipe.extractVersion(
+            from: longbridgeLatestFixture, pattern: recipe.versionPattern) == "0.19.1")
+        #expect(VendorProbeRecipe.extractVersion(
+            from: longbridgeLatestFixture,
+            pattern: try #require(recipe.publishedAtPattern)) == "2026-08-20T07:46:53Z")
+        #expect(recipe.versionIsBuild == false)
+    }
+
+    @Test func installerSelectsTheAppleSiliconDMG() throws {
+        let spec = try #require(try probe().install)
+        guard case .bodyPattern(let pattern) = spec.urlSource else {
+            Issue.record("Longbridge installer must resolve from the manifest body")
+            return
+        }
+        let url = VendorProbeRecipe.extractVersion(
+            from: longbridgeLatestFixture, pattern: pattern)
+        #expect(url?.hasSuffix("longbridge-v0.19.1-macos-aarch64.dmg") == true)
+        #expect(url?.contains("x86_64") == false)
+    }
+
+    private func changelogRecipe() throws -> ChangelogRecipe {
+        try #require(ChangelogRecipeRegistry.recipe(
+            forBundleID: "com.longbridge.app.desktop", channel: .stable))
+    }
+
+    @Test func changelogUsesTheExactEnglishVersionPage() throws {
+        let recipe = try changelogRecipe()
+        #expect(recipe.structuredFormat == nil)
+        #expect(recipe.resolvedSource(forVersion: "0.19.0").absoluteString
+            == "https://longbridge.com/desktop/release-notes/v0.19.0")
+
+        let entry = try #require(ChangelogExtractor.extract(
+            from: longbridgeCurrentNotesFixture, using: recipe)?.entries.first)
+        #expect(entry.version == "0.19.1")
+        #expect(entry.date == "2026-08-20")
+        #expect(entry.items == [
+            "Fixed an issue where the editor could quit unexpectedly.",
+            "Fixed vertical lists occasionally showing an unnecessary horizontal scrollbar.",
+        ])
+        #expect(entry.items.allSatisfy { !$0.contains("installer") })
+        #expect(entry.content.isEmpty)
+    }
+
+    @Test func richChangelogKeepsImagesInDocumentOrder() throws {
+        let entry = try #require(ChangelogExtractor.extract(
+            from: longbridgeRichNotesFixture, using: try changelogRecipe())?.entries.first)
+        #expect(entry.version == "0.19.0")
+        #expect(entry.items == [
+            "Screening & quant",
+            "Screener: Added multi-dimensional filters.",
+            "Financials: Added score details.",
+            "Watchlist: Added list-width controls.",
+        ])
+        #expect(entry.items.allSatisfy {
+            !$0.contains("does not support") && !$0.contains("installer")
+        })
+        #expect(entry.content == [
+            .note("Screening & quant"),
+            .note("Screener: Added multi-dimensional filters."),
+            .note("Financials: Added score details."),
+            .image(try #require(URL(string: "https://assets.lbkrs.com/uploads/Score.png"))),
+            .note("Watchlist: Added list-width controls."),
+        ])
+    }
+
+    @Test func changelogCatalogProvidesAWebFallback() {
+        #expect(ChangelogCatalog.url(forBundleID: "com.longbridge.app.desktop")?
+            .absoluteString == "https://longbridge.com/desktop/release-notes/")
+    }
+
+    @Test func manifestStillCarriesEnglishNotesAsVendorFallback() throws {
+        let recipe = try #require(ChangelogRecipeRegistry.recipe(
+            forBundleID: "com.longbridge.app.desktop", channel: .stable))
+        #expect(recipe.mode == .html)
+        #expect(longbridgeLatestFixture.contains("\"en\":\"### Improvements"))
+    }
+}


### PR DESCRIPTION
## Summary

- detect stable Longbridge Desktop releases from the vendor latest.json manifest
- resolve the official Apple Silicon DMG for one-click installation
- render English per-version release notes natively, including inline screenshots, with the official notes index as fallback
- leave the retired Preview bundle intentionally unsupported and document that channel decision

## Validation

- mounted and inspected stable v0.19.1 and retired preview v0.15.0-preview.0 DMGs
- verified the stable artifact hash, bundle identity, Developer ID team, notarization, and self-contained DMG layout
- `swift run --package-path CLI duo verify --only longbridge` (vendor probe + changelog pass)
- `make test`
- Debug App build via xcodebuild

## Notes

The changelog recipe targets `https://longbridge.com/desktop/release-notes/v{version}`. It extracts the English text and interleaves supported images in document order; embedded videos are skipped without leaking their browser-fallback text into the notes.