### PR TITLE
Give App Store apps a rollback point, and make restoring one possible

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -13717,6 +13717,47 @@
         }
       }
     },
+    "Rolled back, but %@ updates through the App Store — it will offer this update again, and re-install it on its own if automatic app updates are on.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurückgesetzt – aber %@ wird über den App Store aktualisiert: Der Store bietet dieses Update sofort wieder an und installiert es von sich aus erneut, wenn automatische App-Updates aktiviert sind."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se revirtió, pero %@ se actualiza a través del App Store: volverá a ofrecer esta actualización y la instalará por su cuenta si las actualizaciones automáticas de apps están activadas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version restaurée, mais %@ se met à jour via l’App Store : celui-ci proposera de nouveau cette mise à jour et la réinstallera de lui-même si les mises à jour automatiques des apps sont activées."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロールバックしましたが、%@ は App Store 経由で更新されます。ストアはこのアップデートをすぐに再提示し、App の自動アップデートがオンなら自動で再インストールします。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откат выполнен, но %@ обновляется через App Store: он снова предложит это обновление и установит его сам, если включены автоматические обновления приложений."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已回滚，但 %@ 通过 App Store 更新：商店会立刻再次提示这次更新；如果开启了 App 自动更新，它还会自行装回去。"
+          }
+        }
+      }
+    },
     "Rollback": {
       "extractionState": "manual",
       "localizations": {

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2237,7 +2237,8 @@ final class AppListModel {
         // backup timestamp hadn't moved.
         let backupRoute = InstallCoordinator.route(
             for: result, requiresInstaller: requiresInstaller(result))
-        if prefs.keepBackups, InstallCoordinator.wantsBackup(backupRoute) {
+        if prefs.keepBackups, InstallCoordinator.wantsBackup(backupRoute),
+           !(backupRoute == .appStore && appStoreRouteWillNotInstall(result)) {
             await backupCurrent(result, route: backupRoute)
         }
 
@@ -3871,6 +3872,33 @@ final class AppListModel {
     /// Copy the app's current bundle into the backup store before we replace it,
     /// so the update can be undone. Best-effort: a failed backup logs and proceeds
     /// (the user opted into the update; a missing safety net mustn't block it).
+    /// True when the `.appStore` route is going to hand off or bail without
+    /// installing anything, decided from state we already have here.
+    ///
+    /// Used for one thing only: skipping the rollback point. The early-outs
+    /// themselves stay in the route below, which is where they belong — this
+    /// predicts them because the backup runs *first*, and a store bundle is the
+    /// most expensive copy we take (DingTalk is 1441 MB, Word 2750 MB; the clone
+    /// is cheap but the manifest SHA-256s every byte, measured at 8.7s for Word).
+    /// Paying that and then bailing also leaves a rollback point whose stored
+    /// version is the one still installed, so the row offers to "roll back" to
+    /// where it already is.
+    ///
+    /// Deliberately a *prediction*, not the guard itself: if the two ever drift
+    /// the cost is a wasted backup, never a wrong install. The `mas outdated`
+    /// pre-flight is not mirrored here — it costs a subprocess, which is the
+    /// thing this is trying to avoid spending.
+    private func appStoreRouteWillNotInstall(_ result: UpdateResult) -> Bool {
+        // Store-managed by the App Store app itself; we only open the deep link.
+        if result.app.isiOSAppOnMac { return true }
+        // Nothing to install against.
+        if result.remote?.appStore?.trackID == nil { return true }
+        // Region-locked apps are AX-only, and the AX route needs the grant first.
+        if result.remote?.appStore?.isRegionMismatch == true,
+           !AppStoreAXInstaller.isTrusted { return true }
+        return false
+    }
+
     private func backupCurrent(_ result: UpdateResult, route: InstallCoordinator.Route) async {
         let outcome = await InstallCoordinator.backUp(result.app, route: route)
         if case .savedWithoutRuntimeState(let omitted) = outcome {

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2228,10 +2228,9 @@ final class AppListModel {
         }
 
         // Back up the current bundle first (when enabled) so this update can be
-        // rolled back. Only for in-place swaps we perform ourselves — Homebrew and
-        // pkg installs go through their own tools and manage their own state.
-        // App Store apps are excluded: mas re-downloads through the store, which
-        // can always re-fetch the prior build, so a local backup is dead weight.
+        // rolled back — every route, App Store included: the store only ever
+        // offers an app's current version, so without a copy of our own that
+        // update is the one that cannot be undone.
         // Which routes are worth a rollback point is `InstallCoordinator`'s call,
         // shared so `duo install` cannot quietly skip the safety net the app
         // provides — it did, until a real install through the CLI showed the
@@ -3939,6 +3938,8 @@ final class AppListModel {
         let key = BackupStore.keyCandidates(bundleID: result.app.bundleID, path: target)
             .first { BackupStore.backup(forKey: $0) != nil }
             ?? BackupStore.key(bundleID: result.app.bundleID, path: target)
+        // Read while the backup is still addressable by key, for the note below.
+        let wasFromAppStore = BackupStore.backup(forKey: key)?.fromAppStore == true
         installErrors[id] = nil
         installing[id] = .installing
         // Same reason as an install: this row's rank is about to change (it stops
@@ -3974,6 +3975,17 @@ final class AppListModel {
             await computeSelfUpdateStaging()
             await refreshBackupIndex()
             installing[id] = nil
+            // The one rollback that another process can undo without being asked.
+            // The store lists the update again the moment the older bundle is back,
+            // and re-installs it by itself when automatic app updates are on (the
+            // default) — so the row has to say that the version on screen may not
+            // stay. Not registered in `inFlightNotes`: like `backupCurrent`'s
+            // warning it describes what just finished, so a settled row is exactly
+            // when it starts to matter.
+            if wasFromAppStore {
+                installNotes[id] = String(
+                    localized: "Rolled back, but \(updated.app.name) updates through the App Store — it will offer this update again, and re-install it on its own if automatic app updates are on.")
+            }
             Log.install.info("rollback done: \(updated.app.name, privacy: .public) → \(restored ?? "?", privacy: .public)")
             if needsRestart.contains(updated.id) {
                 UpdateNotifier.readyToRestart(app: updated.app.name, version: restored, appID: updated.app.bundleID)

--- a/CLI/Sources/DuoKit/Backups.swift
+++ b/CLI/Sources/DuoKit/Backups.swift
@@ -170,6 +170,18 @@ public enum Backups {
                   installed stays at its newer version.
                 """)
             }
+            // Same reason, different limit: the bundle comes back whole, but the
+            // store's opinion of it doesn't change. It lists the update again at
+            // once, and re-applies it by itself when automatic app updates are on
+            // — so this rollback can be undone without the user doing anything.
+            if stored?.fromAppStore == true {
+                print("""
+                  Note: this app updates through the App Store. Rolling back
+                  replaces the bundle, but the store will offer the update again
+                  straight away — and re-install it on its own if automatic app
+                  updates are turned on.
+                """)
+            }
         }
         guard assumeYes || confirm(app: app.name) else {
             print("Cancelled.")

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
@@ -53,6 +53,16 @@ public enum BackupStore {
         /// which is worth saying out loud rather than presenting as a clean
         /// rollback. Nil for backups written before this was recorded.
         public let fromPackageInstall: Bool?
+        /// Whether the update this backup was taken for was applied through the
+        /// App Store.
+        ///
+        /// It matters at restore time for a reason the other routes don't have: a
+        /// rollback here undoes the bundle but not the store's opinion of it. The
+        /// update reappears in App Store's Updates list immediately, and — with
+        /// automatic app updates on, which is the default — the store re-applies
+        /// it on its own, silently undoing the rollback. Worth saying while the
+        /// user is deciding. Nil for backups written before this was recorded.
+        public let fromAppStore: Bool?
     }
 
     /// JSON sidecar persisted next to a backed-up bundle.
@@ -66,6 +76,8 @@ public enum BackupStore {
         /// a stricter decoder would make every existing backup unreadable, and
         /// `backup(forKey:)` returns nil without a readable sidecar.
         var fromPackageInstall: Bool?
+        /// Optional for the same reason as `fromPackageInstall`.
+        var fromAppStore: Bool?
         /// Files deliberately left out of the copy: unreadable, and not covered
         /// by the code signature, so they are the app's own runtime state rather
         /// than shipped payload. Restoring without them is fine — the app writes
@@ -156,7 +168,7 @@ public enum BackupStore {
     @discardableResult
     public static func save(
         appPath: URL, key: String, version: String?, bundleID: String?,
-        fromPackageInstall: Bool = false
+        fromPackageInstall: Bool = false, fromAppStore: Bool = false
     ) throws -> Backup {
         let fm = FileManager.default
         let dir = root.appendingPathComponent(key, isDirectory: true)
@@ -223,7 +235,7 @@ public enum BackupStore {
         let meta = Meta(
             version: version, bundleID: bundleID,
             originalPath: appPath.path, bundleName: name, savedAt: savedAt,
-            fromPackageInstall: fromPackageInstall,
+            fromPackageInstall: fromPackageInstall, fromAppStore: fromAppStore,
             omittedFiles: unreadable.unsealed.isEmpty ? nil : unreadable.unsealed,
             manifest: manifest)
         // The sidecar is what EVERY read path keys off (`backup(forKey:)` returns nil
@@ -259,7 +271,7 @@ public enum BackupStore {
         if legacy != key { remove(forKey: legacy) }
         return Backup(
             key: key, version: version, bundlePath: dest, savedAt: savedAt,
-            fromPackageInstall: fromPackageInstall)
+            fromPackageInstall: fromPackageInstall, fromAppStore: fromAppStore)
     }
 
     // MARK: - Query
@@ -274,7 +286,7 @@ public enum BackupStore {
         guard FileManager.default.fileExists(atPath: bundle.path) else { return nil }
         return Backup(
             key: key, version: meta.version, bundlePath: bundle, savedAt: meta.savedAt,
-            fromPackageInstall: meta.fromPackageInstall)
+            fromPackageInstall: meta.fromPackageInstall, fromAppStore: meta.fromAppStore)
     }
 
     // MARK: - Restore

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -190,20 +190,40 @@ public enum InPlaceSwap {
 
     /// Whether replacing `target` has to go through the administrator prompt.
     ///
-    /// The test is the **parent directory**, not the bundle: `replaceItemAt`
-    /// stages its exchange as a sibling, so a bundle we could write into but whose
-    /// enclosing directory we cannot (`/Library/Input Methods` is `root:wheel`
-    /// 755, while `WeType.app` inside it is `root:staff` 775) still cannot be
-    /// swapped unprivileged. Sparkle reaches the same conclusion the same way, in
-    /// `SPUSystemNeedsAuthorizationAccessForBundlePath` — it requires writability
-    /// of the bundle *and* of its parent before it will skip escalation.
+    /// **Both** the bundle and its enclosing directory have to be writable before
+    /// we may skip escalation, and each half catches a case the other misses:
+    ///
+    ///   * the **parent**, because `replaceItemAt` stages its exchange as a
+    ///     sibling — a bundle we could write into but whose enclosing directory we
+    ///     cannot (`/Library/Input Methods` is `root:wheel` 755, while
+    ///     `WeType.app` inside it is `root:staff` 775) still cannot be swapped
+    ///     unprivileged;
+    ///   * the **bundle**, because the swap ends by deleting the bundle it
+    ///     replaced, and unlinking a tree needs write permission on the
+    ///     directories *inside* it. Every App Store app is `root:wheel` 755 in an
+    ///     `/Applications` that is `root:admin` 775 — writable parent, unwritable
+    ///     bundle — and so is every app a `.pkg` laid down as root.
+    ///
+    /// The parent-only test this used to be sent that whole second category down
+    /// the unprivileged path, where it could not work. Measured against a bundle
+    /// with those exact permissions: `replaceItemAt` throws
+    /// `NSCocoaErrorDomain 513` (`NSFileWriteNoPermissionError`) and leaves the app
+    /// on disk **unchanged** — and 513 is precisely what `isAppManagementDenial`
+    /// matches, so the failure was reported as `AppManagementRequiredError` and the
+    /// user was sent to grant an App Management permission that could not have
+    /// helped: the obstacle is POSIX ownership, not TCC. Sparkle's
+    /// `SPUSystemNeedsAuthorizationAccessForBundlePath` requires the same pair
+    /// (`isWritableFileAtPath:bundlePath && isWritableFileAtPath:parent`) before it
+    /// will skip escalation.
     ///
     /// Exposed so the UI can answer "will clicking Update raise a password
     /// prompt?" from the same predicate the swap itself branches on. A separately
     /// derived copy would drift, and the two disagreeing means either a prompt the
     /// row promised wouldn't appear, or one it never warned about.
     public static func needsElevatedReplace(target: URL) -> Bool {
-        !FileManager.default.isWritableFile(atPath: target.deletingLastPathComponent().path)
+        let fm = FileManager.default
+        return !fm.isWritableFile(atPath: target.path)
+            || !fm.isWritableFile(atPath: target.deletingLastPathComponent().path)
     }
 
     /// `InstallEnvironment.elevationRequiredPaths` for a set of installed bundles,
@@ -274,10 +294,33 @@ public enum InPlaceSwap {
         let old = shellQuote(target.path + ".duoupdater-old")
         let tgt = shellQuote(target.path)
         let src = shellQuote(newApp.path)
+        // Keep the replaced bundle's ownership. `ditto` running as root preserves
+        // the *source's* owner, and every source we hand it — a download we
+        // extracted, a rollback copy we made — belongs to the user. Without this
+        // the privileged path quietly converts a `root:wheel` app into a
+        // user-owned one: measured on a real store-installed app, whose bundle
+        // came back as `bobby:staff` after a rollback that was otherwise perfect.
+        // That relaxes who can write to an app in `/Applications` without anyone
+        // asking for it, and it makes `needsElevatedReplace` flip to false for the
+        // same app afterwards. Sparkle preserves ownership for the same reason
+        // (`changeOwnerAndGroupOfItemAtRootURL:toMatchURL:`).
+        //
+        // Non-fatal (`;`, not `&&`): the ids are read off the bundle we are about
+        // to replace, so failing here means something is wrong with the numbers,
+        // not with the update — and refusing to install a verified build over an
+        // ownership detail would be the worse trade. Interpolated as integers
+        // straight from `stat`, so there is nothing quotable in them.
+        let ownership: String = {
+            let attrs = try? FileManager.default.attributesOfItem(atPath: target.path)
+            guard let uid = (attrs?[.ownerAccountID] as? NSNumber)?.uint32Value,
+                  let gid = (attrs?[.groupOwnerAccountID] as? NSNumber)?.uint32Value
+            else { return "" }
+            return "/usr/sbin/chown -R \(uid):\(gid) \(new); "
+        }()
         let shell = """
         /bin/rm -rf \(new) \(old); \
         /usr/bin/ditto \(src) \(new) && \
-        /bin/mv \(tgt) \(old) && \
+        { \(ownership)/bin/mv \(tgt) \(old); } && \
         { /bin/mv \(new) \(tgt) || { /bin/mv \(old) \(tgt); false; }; } && \
         /bin/rm -rf \(old)
         """

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -47,6 +47,11 @@ public struct AuthorizationDeclinedError: LocalizedError {
 ///      failure leaves the original app fully intact rather than trashed-then-gone.
 public enum InPlaceSwap {
 
+    /// Held across the administrator panel in `privilegedReplace`, so two
+    /// installs running in parallel raise one panel after the other rather than
+    /// two at once. Nothing else takes it, so it cannot deadlock.
+    private static let elevationPanel = NSLock()
+
     /// Recover from a privileged swap (`privilegedReplace`) that was interrupted
     /// between its two renames: the installed app is then sitting at
     /// `<App>.app.duoupdater-old` while `<App>.app` itself is missing. Sweep
@@ -310,21 +315,42 @@ public enum InPlaceSwap {
         // not with the update — and refusing to install a verified build over an
         // ownership detail would be the worse trade. Interpolated as integers
         // straight from `stat`, so there is nothing quotable in them.
+        //
+        // Applied to the app *after* it is in place, not to `.duoupdater-new`
+        // before the renames. `recoverInterruptedSwaps` sweeps a stale
+        // `.duoupdater-new` unprivileged, with `try? removeItem` — so chowning the
+        // staged copy to root would leave a full-size leftover that the sweep
+        // silently cannot delete (EACCES on the first unlink inside a root-owned
+        // tree), stranded until the next privileged swap of that same app runs
+        // the leading `rm -rf`. Doing it last keeps the leftover ours to remove,
+        // and an interruption before the chown lands exactly the user-owned app
+        // that shipped before this existed — no worse than the status quo.
         let ownership: String = {
             let attrs = try? FileManager.default.attributesOfItem(atPath: target.path)
             guard let uid = (attrs?[.ownerAccountID] as? NSNumber)?.uint32Value,
                   let gid = (attrs?[.groupOwnerAccountID] as? NSNumber)?.uint32Value
             else { return "" }
-            return "/usr/sbin/chown -R \(uid):\(gid) \(new); "
+            return "/usr/sbin/chown -R \(uid):\(gid) \(tgt); "
         }()
         let shell = """
         /bin/rm -rf \(new) \(old); \
         /usr/bin/ditto \(src) \(new) && \
-        { \(ownership)/bin/mv \(tgt) \(old); } && \
+        /bin/mv \(tgt) \(old) && \
         { /bin/mv \(new) \(tgt) || { /bin/mv \(old) \(tgt); false; }; } && \
-        /bin/rm -rf \(old)
+        { \(ownership)/bin/rm -rf \(old); }
         """
         let appleScript = "do shell script \"\(escapeForAppleScript(shell))\" with administrator privileges"
+
+        // One password panel at a time. The apply pool allows two concurrent
+        // swaps, and now that every root-owned bundle takes this path (28 apps in
+        // `/Applications` on the development machine, 22 of them store-installed)
+        // a batch can reach it twice at once — two system panels stacked over each
+        // other, neither saying which app it belongs to. Blocking here rather than
+        // making `replace` async is deliberate: the callers are synchronous, and
+        // the thread this parks was going to sit in `waitUntilExit` waiting on the
+        // same human anyway, so this moves the wait rather than adding one.
+        elevationPanel.lock()
+        defer { elevationPanel.unlock() }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
@@ -141,6 +141,16 @@ public actor InstallCoordinator {
     /// forget: it will list the update again, and re-apply it on its own if
     /// automatic app updates are on. The restore path says so.
     ///
+    /// It is not free, and the tempting "APFS clones it, so it costs nothing"
+    /// argument only covers half the work. `ditto` into the backup store *is* a
+    /// clone (2750 MB of Word in 8.7s for ~16 MB of new blocks), but `save` then
+    /// fingerprints the copy, and `BackupManifest.compute` streams a SHA-256 over
+    /// every byte — another 8.7s for that same bundle. Store apps are the largest
+    /// things we back up, so this route is where that lands hardest: budget for
+    /// roughly a second per 150 MB before the update starts moving. The clone's
+    /// blocks then become the backup's own once the update replaces the original,
+    /// which is when a rollback point starts costing what it is worth.
+    ///
     /// `.installer` is included, with a caveat the restore path surfaces: a
     /// `.pkg` can lay down helpers, daemons and launch items beside the `.app`,
     /// and we only ever copy the bundle — so restoring gives an older app next

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
@@ -120,8 +120,26 @@ public actor InstallCoordinator {
 
     /// Whether to take a rollback point before this route runs.
     ///
-    /// `.appStore` is excluded because the store can always re-fetch a prior
-    /// build, so a local copy of a multi-gigabyte bundle is dead weight.
+    /// Every route, including `.appStore`. That one used to be excluded on the
+    /// grounds that "the store can always re-fetch a prior build, so a local copy
+    /// of a multi-gigabyte bundle is dead weight" — which is not true. The App
+    /// Store offers only an app's *current* version; there is no user-facing way
+    /// to ask it for the build you were running yesterday. (Its one backward-
+    /// looking prompt, "install the last compatible version", fires when the
+    /// current release needs a newer macOS than the machine has, and is not
+    /// rollback.) So the App Store route was the one route that applied an update
+    /// with no way back at all.
+    ///
+    /// The copy needs no privileges: App Store bundles are `root:wheel` 755 but
+    /// every file in them is world-readable (checked across all 22 store-installed
+    /// apps on the development machine — none had an unreadable file), and the
+    /// `_MASReceipt` travels with the bundle, so a restored copy carries the
+    /// receipt that was issued *for it* rather than a mismatched newer one.
+    /// Restoring one does need an administrator, because the installed bundle is
+    /// root-owned — `InPlaceSwap.needsElevatedReplace` recognises that and routes
+    /// it to the privileged swap. What a rollback here cannot do is make the store
+    /// forget: it will list the update again, and re-apply it on its own if
+    /// automatic app updates are on. The restore path says so.
     ///
     /// `.installer` is included, with a caveat the restore path surfaces: a
     /// `.pkg` can lay down helpers, daemons and launch items beside the `.app`,
@@ -131,9 +149,10 @@ public actor InstallCoordinator {
     /// is the case where you most want one: the system installer's change is the
     /// one we cannot watch land or undo ourselves.
     public static func wantsBackup(_ route: Route) -> Bool {
+        // Left as an exhaustive switch rather than a bare `true`: a new route has
+        // to state its answer here, which is the decision this function exists for.
         switch route {
-        case .homebrew, .vendor, .sparkle, .installer: return true
-        case .appStore:                                return false
+        case .homebrew, .vendor, .sparkle, .installer, .appStore: return true
         }
     }
 
@@ -156,6 +175,7 @@ public actor InstallCoordinator {
         let key = BackupStore.key(bundleID: app.bundleID, path: app.path)
         let version = app.shortVersion ?? app.buildVersion
         let fromPackage = (route == .installer)
+        let fromStore = (route == .appStore)
         let path = app.path
         let bundleID = app.bundleID
         return await Task.detached(priority: .userInitiated) { () -> BackupOutcome in
@@ -168,7 +188,7 @@ public actor InstallCoordinator {
             do {
                 try BackupStore.save(
                     appPath: path, key: key, version: version, bundleID: bundleID,
-                    fromPackageInstall: fromPackage)
+                    fromPackageInstall: fromPackage, fromAppStore: fromStore)
                 return unreadable.unsealed.isEmpty
                     ? .saved
                     : .savedWithoutRuntimeState(omitted: unreadable.unsealed.count)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
@@ -346,6 +346,27 @@ struct BackupStoreTests {
             try BackupStore.save(
                 appPath: app, key: key, version: "1.0", bundleID: "com.example.testapp")
             #expect(BackupStore.backup(forKey: key)?.fromPackageInstall == false)
+            #expect(BackupStore.backup(forKey: key)?.fromAppStore == false)
+        }
+    }
+
+    /// An App Store backup restores the bundle whole, so its caveat is not the
+    /// package one — nothing is left behind at a newer version. What it cannot do
+    /// is change the store's mind: the update is offered again at once, and
+    /// re-applied unattended when automatic app updates are on. The restore path
+    /// says so, and can only say so if the store remembers which route it was.
+    @Test func anAppStoreBackupRemembersThatTheStoreWillReofferTheUpdate() throws {
+        try withScratchRoot { root in
+            let app = try makeApp(named: "Fixture.app", in: root, marker: "v1")
+            let key = BackupStore.key(bundleID: "com.example.testapp", path: app)
+            try BackupStore.save(
+                appPath: app, key: key, version: "1.0", bundleID: "com.example.testapp",
+                fromAppStore: true)
+            let backup = BackupStore.backup(forKey: key)
+            #expect(backup?.fromAppStore == true)
+            // The two caveats are independent, and the store route is not a package
+            // install — reading it as one would promise a limit that doesn't apply.
+            #expect(backup?.fromPackageInstall == false)
         }
     }
 
@@ -367,6 +388,7 @@ struct BackupStoreTests {
             let backup = BackupStore.backup(forKey: key)
             #expect(backup != nil, "an older sidecar must still be readable")
             #expect(backup?.fromPackageInstall == nil, "unknown, not false")
+            #expect(backup?.fromAppStore == nil, "unknown, not false")
         }
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallLockTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallLockTests.swift
@@ -122,9 +122,10 @@ import Foundation
     }
 }
 
-/// Which routes get a rollback point, and whether the store remembers that a
-/// backup came from a `.pkg` — the restore path words itself differently for
-/// those, because only the app bundle comes back.
+/// Which routes get a rollback point, and whether the store remembers where a
+/// backup came from — the restore path words itself differently for a `.pkg`
+/// (only the app bundle comes back) and for the App Store (the bundle comes back
+/// but the store re-offers, and may re-apply, the update).
 @Suite struct BackupProvenanceTests {
 
     @Test func everyRouteWeApplyOurselvesGetsABackup() {
@@ -134,9 +135,12 @@ import Foundation
         // Included as of 2026-08-09: these had no rollback point at all, which is
         // the case where one is most wanted.
         #expect(InstallCoordinator.wantsBackup(.installer))
-        // The store re-downloads a prior build on demand, so a local copy of a
-        // multi-gigabyte bundle would be dead weight.
-        #expect(!InstallCoordinator.wantsBackup(.appStore))
+        // Included too, for the same reason and against a comment that used to
+        // claim the opposite: the App Store offers only an app's *current*
+        // version, so without a copy of our own this is the one route whose
+        // update cannot be undone. Asserted rather than assumed — this line read
+        // `!wantsBackup` for as long as the wrong justification stood.
+        #expect(InstallCoordinator.wantsBackup(.appStore))
     }
 
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
@@ -849,6 +849,58 @@ struct LaggingRemoteVersionTests {
     }
 }
 
+// MARK: - Which installs need an administrator
+
+/// `needsElevatedReplace` decides whether a swap goes through the password panel
+/// or through `replaceItemAt`. Getting it wrong in the permissive direction is not
+/// a prompt the user is spared: the unprivileged path then fails with
+/// `NSFileWriteNoPermissionError`, which `isAppManagementDenial` reads as a TCC
+/// denial — so the user is sent to grant App Management for an obstacle that is
+/// POSIX ownership and that App Management cannot lift.
+///
+/// Both fixtures are built with real permission bits rather than mocked, because
+/// the predicate's whole job is to report what the filesystem will allow.
+@Suite struct ElevatedReplaceDetectionTests {
+
+    /// A `.app` in `parent`, with `mode` applied to the bundle directory itself.
+    private func fixture(in parent: URL, mode: Int, named name: String) throws -> URL {
+        let app = parent.appendingPathComponent(name)
+        try FileManager.default.createDirectory(
+            at: app.appendingPathComponent("Contents"), withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: app.path)
+        return app
+    }
+
+    @Test func aBundleWeCannotWriteNeedsAdminEvenInAWritableParent() throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoElevationTest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        // 0o555 must be lifted before the tree can be removed, exactly the property
+        // under test — so the cleanup restores it first.
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: parent.appendingPathComponent("Locked.app").path)
+            try? FileManager.default.removeItem(at: parent)
+        }
+
+        // The App Store layout: `root:wheel` 755 bundle inside a `root:admin` 775
+        // `/Applications`. The user can rename the bundle but cannot empty it, and
+        // the swap ends by deleting the bundle it replaced.
+        let locked = try fixture(in: parent, mode: 0o555, named: "Locked.app")
+        #expect(InPlaceSwap.needsElevatedReplace(target: locked),
+                "a bundle we cannot write into must go through the administrator prompt")
+        #expect(InPlaceSwap.elevationRequiredPaths(for: [locked]).contains(locked.path),
+                "and the UI must be told the same thing the swap will do")
+
+        // An ordinary user-writable app in the same writable parent still takes the
+        // unprivileged path: this must not have become "always ask".
+        let ours = try fixture(in: parent, mode: 0o755, named: "Ours.app")
+        #expect(!InPlaceSwap.needsElevatedReplace(target: ours))
+        #expect(InPlaceSwap.elevationRequiredPaths(for: [ours]).isEmpty)
+    }
+}
+
 // MARK: - Input methods are never swapped in place
 
 /// An input method is registered with the system by the vendor's installer, and


### PR DESCRIPTION
Closes #56.

## What the issue got right, and what it missed

The issue's premise checks out: `wantsBackup` excluded `.appStore` on the
grounds that "the store can always re-fetch a prior build", and the App Store
serves only an app's *current* version. So the store route was the one route
that applied an update with no way back.

It also flagged the right open question — "restoring writes over a `root:wheel`
bundle, which needs elevation" — but assumed the machinery already handled it.
It did not, and that turned out to be a live bug wider than this issue.

## The measurement that changed the shape of the fix

`InPlaceSwap.needsElevatedReplace` tested only the **parent directory**. For a
store app that reads: `/Applications` is `root:admin` 775 → writable → "no
password needed". But the bundle itself is `root:wheel` 755, and the swap ends
by deleting the bundle it replaced — which needs write permission on the
directories *inside* it.

Built with those exact permission bits, `FileManager.replaceItemAt`:

- throws `NSCocoaErrorDomain 513` (`NSFileWriteNoPermissionError`),
- leaves the app on disk **unchanged**,
- leaves its `.duoupdater-staged-*` sibling behind.

513 is exactly what `isAppManagementDenial` matches — so every such failure was
reported as `AppManagementRequiredError`, sending the user to grant an App
Management permission that could never help. The obstacle is POSIX ownership,
not TCC.

On this machine that is **22 of 22** store-installed apps plus **6** further
root-owned ones. Note who it was biting: a *standard* user cannot write
`/Applications` at all, so the parent-only test already said yes for them. It
was **admin accounts** — the ordinary single-user Mac — that took the path that
could not succeed.

The doc comment already described the correct rule ("writability of the bundle
*and* of its parent"); only the code disagreed. Sparkle's
`SPUSystemNeedsAuthorizationAccessForBundlePath` is the same pair.

## Changes

1. **`needsElevatedReplace`** requires both the bundle and its parent to be
   writable. Root-owned bundles now take the privileged swap, which works.
2. **`privilegedReplace` keeps the replaced bundle's owner.** `ditto` as root
   preserves the *source's* owner, and our sources belong to the user — so
   without a `chown` the elevated path silently converted a `root:wheel` app
   into a user-owned one. Observed on a real store app. On a shared Mac that
   would leave one admin able to edit an app another user runs.
3. **`wantsBackup(.appStore)` is true**, and the doc comment that stated the
   wrong reason is replaced with the measurements behind the right one.
4. **The route is recorded** (`fromAppStore` in the sidecar) so the restore path
   can say the one thing that is specific to it: the store re-offers the update
   immediately, and re-applies it unattended when automatic app updates are on.
   Surfaced in `duo backups restore` (before the confirmation, beside the `.pkg`
   note) and on the menu-bar row after a rollback lands. Localized in all 7
   languages.

## Verification

`make test` — 1090 tests / 87 suites and 125 / 19 pass (2 pre-existing known
issues), plus `check_localizable_keys.py` green at 414 keys. `make install`
builds, signs and deploys with all 7 languages landing.

Beyond the unit tests, against real bundles:

| check | result |
|---|---|
| all 22 store apps readable without privileges | 0 unreadable files in any of them |
| predicate, before → after | 0/22 → 22/22 report `needsElevatedReplace` |
| save → mutate → restore, real store bundle | signature verifies, `_MASReceipt` intact, retention intact |
| live privileged rollback over `root:wheel` `/Applications/Developer.app` | version unchanged, codesign OK, receipt present, **owner still `root:wheel`**, no leftovers |

The ownership fix has its own red→green: the same live rollback run *before* it
left the bundle `bobby:staff`; after it, `root:wheel` both sides.

## Not in scope

- `CHANGELOG.md` — this repo writes release notes in the `release: prepare X`
  commit, not in feature PRs.
- Disk cost is real but unchanged in kind: `ditto` into the backup store is an
  APFS clone (2750 MB of Word in 8.7 s, ~16 MB of new blocks), and the blocks
  become the backup's own only once the update replaces the original. Gated by
  `keepBackups`, retention stays at one, and the Backups sheet shows the total.