### PR TITLE
fix(android-studio): the canary channel proof must span its stability floor

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -59,9 +59,20 @@ public enum ChannelProofRegistry {
         // stable's `type=release`, and the install pattern reads the dmg out of
         // that response body.
         ChannelProofKey("com.jetbrains.intellij-EAP", .preview): .recipeAnchor(#"type=eap"#),
-        // Android Studio: Google's Beta train ships RELEASE CANDIDATES, so `-rc<N>-`
-        // (not `-beta-`) is the marker to expect there; Canary ships `-canary<N>-`.
-        ChannelProofKey("com.google.android.studio", .canary): .artifact(#"-canary[0-9]*-mac"#),
+        // Android Studio: each preview channel accepts builds at its own quality OR
+        // MORE STABLE (the stability floor documented on the recipes), so the marker
+        // has to be that whole ladder, not just the channel's own name — Canary
+        // resolves the newest of {Canary, Beta, RC}, Beta the newest of {Beta, RC}.
+        // That is not a bug being papered over: it is why a Canary install correctly
+        // moves onto `2026.1.4 RC 2` when it is newer than any open Canary, which is
+        // exactly what the feed served on 2026-08-26. Google's Beta train has in
+        // practice shipped RELEASE CANDIDATES for years (no `Beta` item since
+        // 2025-03-18), so `-rc<N>-` is the marker actually seen on both.
+        // What the marker still excludes is the pair that WOULD be a cross-channel
+        // install: `Release` (`android-studio-quail3-mac_arm.dmg`) and `Patch`
+        // (`…-patch1-mac_arm.dmg`) — neither carries a ladder token.
+        ChannelProofKey("com.google.android.studio", .canary):
+            .artifact(#"-(canary|beta|rc)[0-9]*-mac"#),
         ChannelProofKey("com.google.android.studio", .beta): .artifact(#"-(beta|rc)[0-9]*-mac"#),
         ChannelProofKey("io.dcloud.HBuilderXAlpha", .alpha): .artifact(#"-alpha\."#),
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -955,6 +955,115 @@ private func verdict(
         "Canary should advance onto the newest preview, shown as a clean version")
 }
 
+/// A stability-floor recipe's `ChannelArtifactProof` must accept EVERY build that
+/// recipe is designed to resolve — and still reject the ones it is not.
+///
+/// Android Studio's preview recipes deliberately reach DOWN the quality ladder
+/// (Canary → newest of {Canary, Beta, RC}; Beta → newest of {Beta, RC}), so their
+/// marker cannot be the channel's own name. Written as `-canary[0-9]*-mac`, the
+/// canary proof failed the moment Google's newest preview was an RC rather than a
+/// Canary — `2026.1.4 RC 2` on 2026-08-26, resolved off the RIGHT train and
+/// reported as a possible cross-channel install. The marker was narrower than the
+/// floor, not the recipe wrong.
+///
+/// Derived from the registry, so a new Android Studio channel is covered the day
+/// it is added, and neither side can be widened alone: narrowing the proof below
+/// the floor fails the first half, widening it into `.*` fails the second.
+@Test func androidStudioChannelProofsSpanTheWholeStabilityFloor() {
+    // Real items, one per channel label the feed ships today, captured from
+    // jb.gg/android-studio-releases-list.json on 2026-08-26 (trimmed to the fields
+    // the patterns read, plus the arm64 dmg the install spec reads).
+    //
+    // `Beta` is absent on purpose: Google has published no `Beta` item since
+    // 2025-03-18, and that last one predates the codename filenames — it is
+    // `android-studio-2024.3.2.9-mac_arm.dmg`, byte-shaped exactly like a Release
+    // of the same era, so NO url marker could tell them apart. The Beta train ships
+    // release candidates in practice, which is what `rc` in both markers covers.
+    let items: [(label: String, fields: String, dmg: String)] = [
+        ("Canary",
+         #""build":"AI-262.9437.185.2621.16128175","platformVersion":"2026.2.1","name":"Android Studio Rabbit 1 | 2026.2.1 Canary 2","channel":"Canary","version":"2026.2.1.2""#,
+         "https://edgedl.me.gvt1.com/android/studio/install/2026.2.1.2/android-studio-rabbit1-canary2-mac_arm.dmg"),
+        ("RC",
+         #""build":"AI-261.26222.65.2614.16166871","platformVersion":"2026.1.4","name":"Android Studio Quail 4 | 2026.1.4 RC 2","channel":"RC","version":"2026.1.4.6""#,
+         "https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.6/android-studio-quail4-rc2-mac_arm.dmg"),
+        ("Release",
+         #""build":"AI-261.26222.65.2613.15948027","platformVersion":"2026.1.4","name":"Android Studio Quail 3 | 2026.1.3","channel":"Release","version":"2026.1.3.7""#,
+         "https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.7/android-studio-quail3-mac_arm.dmg"),
+        ("Patch",
+         #""build":"AI-261.26222.65.2613.16025427","platformVersion":"2026.1.4","name":"Android Studio Quail 3 | 2026.1.3 Patch 1","channel":"Patch","version":"2026.1.3.8""#,
+         "https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.8/android-studio-quail3-patch1-mac_arm.dmg"),
+    ]
+
+    let recipes = VendorProbeRegistry.recipes.filter {
+        $0.bundleID == "com.google.android.studio" && $0.channel != .stable
+    }
+    #expect(!recipes.isEmpty, "no non-stable Android Studio recipes in the registry")
+
+    var floors: [ReleaseChannel: Set<String>] = [:]
+    for recipe in recipes {
+        guard case .bodyPattern(let installPattern)? = recipe.install?.urlSource else {
+            Issue.record("\(recipe.channel.rawValue) install spec is no longer a bodyPattern")
+            continue
+        }
+        var floor: [String] = []
+        for item in items {
+            // A one-item body, shaped like the feed. Whether the recipe's OWN
+            // version pattern matches it is what puts this label on that recipe's
+            // floor — no hand-kept ladder is written down here.
+            let body =
+                #"{"content":{"item":[{"download":[{"link":"\#(item.dmg)"}],\#(item.fields)}]}}"#
+            let build = VendorProbeRecipe.extractVersion(from: body, pattern: recipe.versionPattern)
+            // And judge the proof against the URL the recipe would really hand the
+            // installer, resolved by its own install pattern out of that same body.
+            let resolved = VendorProbeRecipe.extractVersion(from: body, pattern: installPattern)
+
+            guard let build else {
+                // Off the floor → the marker must still say so, or it has stopped
+                // discriminating and a Release/Patch could ride in unnoticed.
+                let complaint = RecipeSanity.crossChannelArtifact(
+                    recipe: recipe,
+                    remote: VendorProbeSource.makeRemoteVersion(
+                        recipe: recipe, version: "AI-0", install: recipe.install,
+                        plan: nil, resolvedDownload: URL(string: item.dmg)!))
+                let why = "\(recipe.channel.rawValue)'s marker accepts a \(item.label) artifact "
+                    + "(\(item.dmg)) the recipe itself refuses — it no longer discriminates"
+                #expect(complaint != nil, "\(why)")
+                continue
+            }
+            floor.append(item.label)
+
+            guard let url = resolved.flatMap(URL.init(string:)) else {
+                let why = "\(recipe.channel.rawValue) accepts the \(item.label) build but its "
+                    + "install pattern resolves no URL from that entry — it would fall through to "
+                    + "an older release's artifact"
+                Issue.record("\(why)")
+                continue
+            }
+            let complaint = RecipeSanity.crossChannelArtifact(
+                recipe: recipe,
+                remote: VendorProbeSource.makeRemoteVersion(
+                    recipe: recipe, version: build, install: recipe.install,
+                    plan: nil, resolvedDownload: url))
+            let why = "\(recipe.channel.rawValue) resolves \(item.label) builds by design, but "
+                + "its channel proof rejects the artifact: \(complaint ?? "")"
+            #expect(complaint == nil, "\(why)")
+        }
+        #expect(!floor.isEmpty, "\(recipe.channel.rawValue) accepts none of the sampled builds")
+        floors[recipe.channel] = Set(floor)
+    }
+
+    // The floors must still NEST — a less stable channel reaches everything a more
+    // stable one does, plus its own. Two floors that are equal, or that merely
+    // overlap, mean the version patterns stopped expressing the ladder, and every
+    // assertion above would go on passing vacuously.
+    for (a, b) in floors.flatMap({ l in floors.map { (l, $0) } }) where a.key != b.key {
+        let nested = a.value.isSubset(of: b.value) || b.value.isSubset(of: a.value)
+        let why = "\(a.key.rawValue) reaches \(a.value.sorted()) and \(b.key.rawValue) reaches "
+            + "\(b.value.sorted()) — neither contains the other, so they are no longer one ladder"
+        #expect(nested && a.value != b.value, "\(why)")
+    }
+}
+
 // WeChat's public appcast: the current release is emitted once per system-version
 // band (all carrying the same `sparkle:version`), plus older items. A trimmed but
 // faithful slice — item 1 has the enclosure dmg; item 3 is DOCTYPE-wrapped and has

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -999,7 +999,10 @@ private func verdict(
     }
     #expect(!recipes.isEmpty, "no non-stable Android Studio recipes in the registry")
 
-    var floors: [ReleaseChannel: Set<String>] = [:]
+    // Keyed by nothing: two recipes may deliberately share a `(bundleID, channel)`
+    // behind a `variant` (see `channelProofsCoverEveryChannelRecipe`), and a
+    // dictionary would let one silently overwrite the other's floor.
+    var floors: [(channel: ReleaseChannel, floor: Set<String>)] = []
     for recipe in recipes {
         guard case .bodyPattern(let installPattern)? = recipe.install?.urlSource else {
             Issue.record("\(recipe.channel.rawValue) install spec is no longer a bodyPattern")
@@ -1049,18 +1052,28 @@ private func verdict(
             #expect(complaint == nil, "\(why)")
         }
         #expect(!floor.isEmpty, "\(recipe.channel.rawValue) accepts none of the sampled builds")
-        floors[recipe.channel] = Set(floor)
+        floors.append((recipe.channel, Set(floor)))
     }
 
     // The floors must still NEST — a less stable channel reaches everything a more
     // stable one does, plus its own. Two floors that are equal, or that merely
     // overlap, mean the version patterns stopped expressing the ladder, and every
     // assertion above would go on passing vacuously.
-    for (a, b) in floors.flatMap({ l in floors.map { (l, $0) } }) where a.key != b.key {
-        let nested = a.value.isSubset(of: b.value) || b.value.isSubset(of: a.value)
-        let why = "\(a.key.rawValue) reaches \(a.value.sorted()) and \(b.key.rawValue) reaches "
-            + "\(b.value.sorted()) — neither contains the other, so they are no longer one ladder"
-        #expect(nested && a.value != b.value, "\(why)")
+    for i in floors.indices {
+        for j in floors.indices where j > i {
+            let (a, b) = (floors[i], floors[j])
+            // Variants of ONE channel are two readings of the same rung; only
+            // different channels have to sit at different heights.
+            guard a.channel != b.channel else { continue }
+            let reach = "\(a.channel.rawValue) reaches \(a.floor.sorted()) and "
+                + "\(b.channel.rawValue) reaches \(b.floor.sorted())"
+            guard a.floor != b.floor else {
+                #expect(Bool(false), "\(reach) — the same rung, so the ladder has collapsed")
+                continue
+            }
+            let nested = a.floor.isSubset(of: b.floor) || b.floor.isSubset(of: a.floor)
+            #expect(nested, "\(reach) — neither contains the other, so this is no longer a ladder")
+        }
     }
 }
 


### PR DESCRIPTION
`vendorResolvesInstallPlans` was failing on `main` (not a regression from any open branch), and `duo verify --only android` was warning:

```
⚠ WARN  vendor:com.google.android.studio:canary
    resolved …/android-studio-quail4-rc2-mac_arm.dmg, which carries no canary
    marker (expected /-canary[0-9]*-mac/) — the install may be crossing channels
```

## Verdict: the marker was wrong, not the recipe

Read from the raw feed body (`jb.gg/android-studio-releases-list.json` → 307 → TeamCity, 200, 1,014,621 bytes), newest-first head:

| channel | name | date | mac_arm dmg |
|---|---|---|---|
| `RC` | 2026.1.4 RC 2 | Aug 25 2026 | `…quail4-rc2-mac_arm.dmg` |
| `Canary` | 2026.2.1 Canary 2 | Aug 20 2026 | `…rabbit1-canary2-mac_arm.dmg` |
| `Canary` | 2026.2.1 Canary 1 | Aug 17 2026 | `…rabbit1-canary1-mac_arm.dmg` |

The canary recipe's version pattern is `"channel":"(?:Canary|Beta|RC)"` — the **stability floor** documented on the recipe itself ("Canary install → newest of {Canary, Beta, RC}"). The newest item in that set is the RC, so resolving `-rc2-mac_arm.dmg` is the recipe working as designed. Google does not serve an RC *on* the Canary channel; our recipe deliberately reaches down the ladder, and the proof table was written assuming canary-only filenames.

Two more facts from the body that shaped the fix: no `Beta` item has shipped since **2025-03-18**, and **no item in the entire feed has ever carried a `-beta<N>-` filename token** — the Beta train ships RCs in practice.

## Changes

- **Engine** — canary marker `-canary[0-9]*-mac` → `-(canary|beta|rc)[0-9]*-mac`, mirroring the recipe's floor (beta's marker already allowed `rc`). It still excludes the two artifacts that *would* be a cross-channel install: `Release` (`…quail3-mac_arm.dmg`) and `Patch` (`…quail3-patch1-mac_arm.dmg`), neither of which carries a ladder token.
- **Test** — `androidStudioChannelProofsSpanTheWholeStabilityFloor`, derived from `VendorProbeRegistry` rather than a hand-written list. Each recipe's floor is discovered by running its *own* version pattern over real captured feed items; the artifact judged is the one its *own* install pattern resolves. Two directions plus a nesting check so it can't pass vacuously.

Advisory-only check — no resolution behavior changes, nothing user-visible, so no CHANGELOG entry.

## Verification

Proven red both ways before restoring the fix:

```
narrow marker  →  ✘ canary resolves RC builds by design, but its channel proof rejects the artifact
marker "-mac"  →  ✘ canary's marker accepts a Release artifact … it no longer discriminates
```

`make test` → `1091 tests in 87 suites passed … with 2 known issues` + `125 tests in 19 suites passed`, exit 0.

`swift run --package-path CLI duo verify --only android` → `vendor probe ✓ 3 ⚠ 0 ✗ 0` (was `✓ 2 ⚠ 1` before the fix).

`vendorResolvesInstallPlans` now passes; the plan it prints is unchanged (`[canary] v2026.1.4 RC 2 → …quail4-rc2-mac_arm.dmg`).

## Noted, not changed

The install pattern requires a ladder token in the filename but the version pattern does not. In the pre-codename era (and for that last `Beta` item, `android-studio-2024.3.2.9-mac_arm.dmg`) the version pattern matches an item whose dmg the install pattern skips — the install would fall through to an *older* release's artifact while reporting the newer version. Cross-*version*, not cross-*channel*, and not firing today since every current-era item carries a token. The new test records it as an `Issue` if it ever starts happening; the patterns are left alone as out of scope.