### PR TITLE
Call every quit-and-reopen action Relaunch

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -6998,7 +6998,7 @@
         }
       }
     },
-    "Duo Updater checks for its own updates hourly on its own. Left off, a new version puts up a prompt and waits for you.\n\nTurned on, it is downloaded and then applied at a quiet moment — no prompt, no clicking. A quiet moment means nothing is being checked or installed, no window of Duo Updater's is open, and you are working in another app; it restarts itself there. Until such a moment comes it simply waits, and installs when you quit Duo Updater anyway.": {
+    "Duo Updater checks for its own updates hourly on its own. Left off, a new version puts up a prompt and waits for you.\n\nTurned on, it is downloaded and then applied at a quiet moment — no prompt, no clicking. A quiet moment means nothing is being checked or installed, no window of Duo Updater's is open, and you are working in another app; it relaunches itself there. Until such a moment comes it simply waits, and installs when you quit Duo Updater anyway.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -7010,13 +7010,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duo Updater comprueba sus propias actualizaciones cada hora por su cuenta. Si está desactivado, una versión nueva muestra un aviso y espera tu acción.\n\nSi está activado, se descarga y luego se aplica en un momento tranquilo, sin avisos ni clics. Un momento tranquilo significa que no se está comprobando ni instalando nada, que no hay ninguna ventana de Duo Updater abierta y que estás trabajando en otra app; entonces se reinicia por sí solo. Hasta que llegue ese momento, simplemente espera, e instala de todos modos cuando cierras Duo Updater."
+            "value": "Duo Updater comprueba sus propias actualizaciones cada hora por su cuenta. Si está desactivado, una versión nueva muestra un aviso y espera tu acción.\n\nSi está activado, se descarga y luego se aplica en un momento tranquilo, sin avisos ni clics. Un momento tranquilo significa que no se está comprobando ni instalando nada, que no hay ninguna ventana de Duo Updater abierta y que estás trabajando en otra app; entonces se reabre por sí solo. Hasta que llegue ese momento, simplemente espera, e instala de todos modos cuando cierras Duo Updater."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duo Updater vérifie lui-même ses propres mises à jour toutes les heures. Désactivé, une nouvelle version affiche une invite et attend votre action.\n\nActivé, elle est téléchargée puis appliquée à un moment calme — sans invite, sans clic. Un moment calme signifie que rien n'est en cours de vérification ni d'installation, qu'aucune fenêtre de Duo Updater n'est ouverte, et que vous travaillez dans une autre application ; il se redémarre alors lui-même. Tant qu'un tel moment n'arrive pas, il attend simplement et s'installe de toute façon quand vous quittez Duo Updater."
+            "value": "Duo Updater vérifie lui-même ses propres mises à jour toutes les heures. Désactivé, une nouvelle version affiche une invite et attend votre action.\n\nActivé, elle est téléchargée puis appliquée à un moment calme — sans invite, sans clic. Un moment calme signifie que rien n'est en cours de vérification ni d'installation, qu'aucune fenêtre de Duo Updater n'est ouverte, et que vous travaillez dans une autre application ; il se relance alors lui-même. Tant qu'un tel moment n'arrive pas, il attend simplement et s'installe de toute façon quand vous quittez Duo Updater."
           }
         },
         "ja": {
@@ -7034,7 +7034,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Duo Updater 会每小时自行检查自身的更新。关闭时，新版本会弹出提示并等待你操作。\n\n开启后，会在安静的时刻下载并应用更新 — 无提示、无需点击。安静的时刻是指没有正在进行的检查或安装、没有打开任何 Duo Updater 窗口，并且你正在其他应用中工作；届时它会自行重启。在这样的时刻到来之前它只会等待，并在你退出 Duo Updater 时顺便安装。"
+            "value": "Duo Updater 会每小时自行检查自身的更新。关闭时，新版本会弹出提示并等待你操作。\n\n开启后，会在安静的时刻下载并应用更新 — 无提示、无需点击。安静的时刻是指没有正在进行的检查或安装、没有打开任何 Duo Updater 窗口，并且你正在其他应用中工作；届时它会自行重新启动。在这样的时刻到来之前它只会等待，并在你退出 Duo Updater 时顺便安装。"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -452,7 +452,7 @@
         }
       }
     },
-    "%@ has its own update (%@) downloaded and waiting for the app to quit. Restarting from here would install that one over the version now on disk, so it wasn't restarted — quit %@ yourself when you're ready to take theirs.": {
+    "%@ has its own update (%@) downloaded and waiting for the app to quit. Relaunching from here would install that one over the version now on disk, so it wasn't relaunched — quit %@ yourself when you're ready to take theirs.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -464,13 +464,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ ya ha descargado su propia actualización (%@) y espera a que la app se cierre. Reiniciar desde aquí instalaría esa por encima de la versión que hay ahora en el disco, así que no se reinició: cierra %@ tú cuando quieras aceptar la suya."
+            "value": "%@ ya ha descargado su propia actualización (%@) y espera a que la app se cierre. Reabrir desde aquí instalaría esa por encima de la versión que hay ahora en el disco, así que no se reabrió: cierra %@ tú cuando quieras aceptar la suya."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ a téléchargé sa propre mise à jour (%@) et attend que l’app soit quittée. Redémarrer depuis ici installerait celle-ci par-dessus la version actuellement sur le disque, donc rien n’a été redémarré — quitte %@ toi-même quand tu veux prendre la leur."
+            "value": "%@ a téléchargé sa propre mise à jour (%@) et attend que l’app soit quittée. Relancer depuis ici installerait celle-ci par-dessus la version actuellement sur le disque, donc rien n’a été relancé — quitte %@ toi-même quand tu veux prendre la leur."
           }
         },
         "ja": {
@@ -488,7 +488,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 已经下载好它自己的更新（%@），正等着这个 app 退出。从这里重启会把那份更新覆盖到当前磁盘上的版本，所以没有重启 —— 想用它们那份的时候，请自己退出 %@。"
+            "value": "%@ 已经下载好它自己的更新（%@），正等着这个 app 退出。从这里重新启动会把那份更新覆盖到当前磁盘上的版本，所以没有重新启动 —— 想用它们那份的时候，请自己退出 %@。"
           }
         }
       }
@@ -3789,7 +3789,7 @@
         }
       }
     },
-    "After updating a running app, restart it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Restart” button.\n\nBackups keep one previous version of each app under Application Support, so an update can be undone. Retention is one backup per app — the previous version is replaced, not accumulated.": {
+    "After updating a running app, relaunch it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Relaunch” button.\n\nBackups keep one previous version of each app under Application Support, so an update can be undone. Retention is one backup per app — the previous version is replaced, not accumulated.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -3801,13 +3801,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tras actualizar una app en ejecución, se reinicia por ti para que la versión nueva surta efecto, sin un segundo clic. Se le pide a la app que se cierre con normalidad, así que los avisos de trabajo sin guardar siguen apareciendo, y cualquier app que no se cierre simplemente conserva su botón «Reiniciar».\n\nLas copias de seguridad conservan una versión anterior de cada app en Application Support, para poder deshacer una actualización. Se conserva una copia por app; la versión anterior se reemplaza, no se acumula."
+            "value": "Tras actualizar una app en ejecución, se reabre por ti para que la versión nueva surta efecto, sin un segundo clic. Se le pide a la app que se cierre con normalidad, así que los avisos de trabajo sin guardar siguen apareciendo, y cualquier app que no se cierre simplemente conserva su botón «Reabrir».\n\nLas copias de seguridad conservan una versión anterior de cada app en Application Support, para poder deshacer una actualización. Se conserva una copia por app; la versión anterior se reemplaza, no se acumula."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Après la mise à jour d'une application en cours d'exécution, elle est redémarrée pour vous afin que la nouvelle version prenne effet — sans second clic. Il est demandé à l'application de quitter normalement, donc les invites de travail non enregistré apparaissent toujours, et tout ce qui ne quitte pas conserve simplement son bouton « Redémarrer ».\n\nLes sauvegardes conservent une version précédente de chaque application sous Application Support, afin qu'une mise à jour puisse être annulée. La rétention est d'une sauvegarde par application — la version précédente est remplacée, pas accumulée."
+            "value": "Après la mise à jour d'une application en cours d'exécution, elle est relancée pour vous afin que la nouvelle version prenne effet — sans second clic. Il est demandé à l'application de quitter normalement, donc les invites de travail non enregistré apparaissent toujours, et tout ce qui ne quitte pas conserve simplement son bouton « Relancer ».\n\nLes sauvegardes conservent une version précédente de chaque application sous Application Support, afin qu'une mise à jour puisse être annulée. La rétention est d'une sauvegarde par application — la version précédente est remplacée, pas accumulée."
           }
         },
         "ja": {
@@ -3825,7 +3825,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "更新正在运行的应用后，会自动为你重启它，让新版本生效 — 无需再次点击。系统会正常请求该应用退出，因此未保存工作的提示仍会出现，任何拒绝退出的应用只会保留其“重启”按钮。\n\n备份会在“应用程序支持”中保留每个应用的一个先前版本，以便撤销更新。保留策略是每个应用一份备份 — 会替换先前版本，而不是不断累积。"
+            "value": "更新正在运行的应用后，会自动为你重新启动它，让新版本生效 — 无需再次点击。系统会正常请求该应用退出，因此未保存工作的提示仍会出现，任何拒绝退出的应用只会保留其“重新启动”按钮。\n\n备份会在“应用程序支持”中保留每个应用的一个先前版本，以便撤销更新。保留策略是每个应用一份备份 — 会替换先前版本，而不是不断累积。"
           }
         }
       }
@@ -9095,7 +9095,7 @@
         }
       }
     },
-    "Installed %@ — waiting for Update All to finish before restarting; click to restart now": {
+    "Installed %@ — waiting for Update All to finish before relaunching; click to relaunch now": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -9107,13 +9107,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ instalado; espera a que termine «Actualizar todo» antes de reiniciar. Haz clic para reiniciar ahora."
+            "value": "%@ instalado; espera a que termine «Actualizar todo» antes de reabrir. Haz clic para reabrir ahora."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ installé — attend la fin de « Tout mettre à jour » avant de redémarrer ; cliquez pour redémarrer maintenant"
+            "value": "%@ installé — attend la fin de « Tout mettre à jour » avant de relancer ; cliquez pour relancer maintenant"
           }
         },
         "ja": {
@@ -9131,7 +9131,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已安装 %@ — 等待“全部更新”完成后再重启；点击立即重启"
+            "value": "已安装 %@ — 等待“全部更新”完成后再重新启动；点击立即重新启动"
           }
         }
       }
@@ -13096,47 +13096,6 @@
         }
       }
     },
-    "Restart": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Neu starten"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reiniciar"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redémarrer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再起動"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перезапустить"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重新启动"
-          }
-        }
-      }
-    },
     "Restart Helper…": {
       "extractionState": "manual",
       "localizations": {
@@ -13178,7 +13137,7 @@
         }
       }
     },
-    "Restart now": {
+    "Relaunch now": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -13190,13 +13149,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Reiniciar ahora"
+            "value": "Reabrir ahora"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Redémarrer maintenant"
+            "value": "Relancer maintenant"
           }
         },
         "ja": {
@@ -13214,7 +13173,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "立即重启"
+            "value": "立即重新启动"
           }
         }
       }
@@ -13260,7 +13219,7 @@
         }
       }
     },
-    "Restart updated apps automatically": {
+    "Relaunch updated apps automatically": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -13272,13 +13231,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Reiniciar automáticamente las apps actualizadas"
+            "value": "Reabrir automáticamente las apps actualizadas"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Redémarrer automatiquement les applications mises à jour"
+            "value": "Relancer automatiquement les applications mises à jour"
           }
         },
         "ja": {
@@ -13296,12 +13255,12 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自动重启已更新的应用"
+            "value": "自动重新启动已更新的应用"
           }
         }
       }
     },
-    "Restarted on the new version.": {
+    "Relaunched on the new version.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -13313,13 +13272,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Se reinició con la versión nueva."
+            "value": "Se reabrió con la versión nueva."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Redémarré avec la nouvelle version."
+            "value": "Relancé avec la nouvelle version."
           }
         },
         "ja": {
@@ -13799,7 +13758,7 @@
         }
       }
     },
-    "Running %@ but %@ is installed — restart to apply it": {
+    "Running %@ but %@ is installed — relaunch to apply it": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -13811,13 +13770,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Se está ejecutando %@, pero está instalado %@; reinicia para aplicarlo"
+            "value": "Se está ejecutando %@, pero está instalado %@; reabre para aplicarlo"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ est en cours d'exécution mais %@ est installé — redémarrez pour l'appliquer"
+            "value": "%@ est en cours d'exécution mais %@ est installé — relancez pour l'appliquer"
           }
         },
         "ja": {
@@ -13835,12 +13794,12 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在运行 %@，但已安装 %@ — 重启以应用"
+            "value": "正在运行 %@，但已安装 %@ — 重新启动以应用"
           }
         }
       }
     },
-    "Running an older build — restart to apply the installed update": {
+    "Running an older build — relaunch to apply the installed update": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -13852,13 +13811,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Se está ejecutando una compilación anterior; reinicia para aplicar la actualización instalada"
+            "value": "Se está ejecutando una compilación anterior; reabre para aplicar la actualización instalada"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Une ancienne version est en cours d'exécution — redémarrez pour appliquer la mise à jour installée"
+            "value": "Une ancienne version est en cours d'exécution — relancez pour appliquer la mise à jour installée"
           }
         },
         "ja": {
@@ -13876,7 +13835,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在运行较旧的版本 — 重启以应用已安装的更新"
+            "value": "正在运行较旧的版本 — 重新启动以应用已安装的更新"
           }
         }
       }
@@ -15129,7 +15088,7 @@
         }
       }
     },
-    "Still running %@ — restart pending from an earlier update": {
+    "Still running %@ — relaunch pending from an earlier update": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -15141,13 +15100,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aún se está ejecutando %@; queda pendiente un reinicio de una actualización anterior"
+            "value": "Aún se está ejecutando %@; queda pendiente una reapertura de una actualización anterior"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ est toujours en cours d'exécution — redémarrage en attente d'une mise à jour précédente"
+            "value": "%@ est toujours en cours d'exécution — relance en attente d'une mise à jour précédente"
           }
         },
         "ja": {
@@ -15165,7 +15124,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仍在运行 %@ — 等待此前更新的重启"
+            "value": "仍在运行 %@ — 等待此前更新的重新启动"
           }
         }
       }
@@ -15539,7 +15498,7 @@
         }
       }
     },
-    "The update is installed; Update All is waiting to restart apps until the batch finishes": {
+    "The update is installed; Update All is waiting to relaunch apps until the batch finishes": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -15551,13 +15510,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "La actualización está instalada; «Actualizar todo» esperará a que termine el lote antes de reiniciar las apps"
+            "value": "La actualización está instalada; «Actualizar todo» esperará a que termine el lote antes de reabrir las apps"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "La mise à jour est installée ; « Tout mettre à jour » attend la fin du lot avant de redémarrer les applications"
+            "value": "La mise à jour est installée ; « Tout mettre à jour » attend la fin du lot avant de relancer les applications"
           }
         },
         "ja": {
@@ -15575,7 +15534,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "更新已安装；“全部更新”会等到本批次完成后再重启应用"
+            "value": "更新已安装；“全部更新”会等到本批次完成后再重新启动应用"
           }
         }
       }
@@ -16529,7 +16488,7 @@
         }
       }
     },
-    "Update is ready. Restart to apply it.": {
+    "Update is ready. Relaunch to apply it.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -16541,13 +16500,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "La actualización está lista. Reinicia para aplicarla."
+            "value": "La actualización está lista. Reabre para aplicarla."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "La mise à jour est prête. Redémarrez pour l'appliquer."
+            "value": "La mise à jour est prête. Relancez pour l'appliquer."
           }
         },
         "ja": {
@@ -16565,12 +16524,12 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "更新已就绪。重启以应用。"
+            "value": "更新已就绪。重新启动以应用。"
           }
         }
       }
     },
-    "Update to %@ is ready. Restart to apply it.": {
+    "Update to %@ is ready. Relaunch to apply it.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -16582,13 +16541,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "La actualización a %@ está lista. Reinicia para aplicarla."
+            "value": "La actualización a %@ está lista. Reabre para aplicarla."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "La mise à jour vers %@ est prête. Redémarrez pour l'appliquer."
+            "value": "La mise à jour vers %@ est prête. Relancez pour l'appliquer."
           }
         },
         "ja": {
@@ -16606,7 +16565,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "更新到 %@ 已就绪。重启以应用。"
+            "value": "更新到 %@ 已就绪。重新启动以应用。"
           }
         }
       }
@@ -17513,7 +17472,7 @@
         }
       }
     },
-    "You’re running an older version — restart to finish updating": {
+    "You’re running an older version — relaunch to finish updating": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -17525,13 +17484,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Estás usando una versión anterior; reinicia para terminar de actualizar"
+            "value": "Estás usando una versión anterior; reabre para terminar de actualizar"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vous utilisez une ancienne version — redémarrez pour terminer la mise à jour"
+            "value": "Vous utilisez une ancienne version — relancez pour terminer la mise à jour"
           }
         },
         "ja": {
@@ -17549,7 +17508,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "你正在运行较旧版本 — 重启以完成更新"
+            "value": "你正在运行较旧版本 — 重新启动以完成更新"
           }
         }
       }
@@ -17800,7 +17759,7 @@
         }
       }
     },
-    "launch, login, frequency, notify, restart, backup, rollback, concurrency, app store, self-updating, vendor": {
+    "launch, login, frequency, notify, relaunch, restart, backup, rollback, concurrency, app store, self-updating, vendor": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -17812,13 +17771,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "inicio, sesión, frecuencia, notificar, reiniciar, copia de seguridad, revertir, concurrencia, App Store, autoactualización, proveedor"
+            "value": "inicio, sesión, frecuencia, notificar, reabrir, reiniciar, copia de seguridad, revertir, concurrencia, App Store, autoactualización, proveedor"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "démarrage, connexion, fréquence, notification, redémarrer, sauvegarde, restauration, simultanéité, App Store, mise à jour automatique, éditeur"
+            "value": "démarrage, connexion, fréquence, notification, relancer, redémarrer, sauvegarde, restauration, simultanéité, App Store, mise à jour automatique, éditeur"
           }
         },
         "ja": {
@@ -17836,7 +17795,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "启动, 登录, 频率, 通知, 重启, 备份, 回滚, 并发, App Store, 自更新, 厂商"
+            "value": "启动, 登录, 频率, 通知, 重新启动, 重启, 备份, 回滚, 并发, App Store, 自更新, 厂商"
           }
         }
       }

--- a/App/Sources/AppDirectoryWatcher.swift
+++ b/App/Sources/AppDirectoryWatcher.swift
@@ -4,7 +4,7 @@ import CoreServices
 /// Watches the app install directories for on-disk changes and fires a debounced
 /// callback. We use it to notice a *background* self-update — Chrome's Keystone
 /// swapping in a new framework version, a Sparkle/Squirrel app replacing its own
-/// bundle, `brew upgrade` — and flip the menu-bar **Restart** badge promptly,
+/// bundle, `brew upgrade` — and flip the menu-bar **Relaunch** badge promptly,
 /// instead of waiting for the user to open the menu or for the next networked
 /// check (which, on a "Daily" frequency, could be ~24h away).
 ///

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -132,7 +132,7 @@ final class AppListModel {
     /// `needsRestart` from a version comparison that is blind to apps whose
     /// `Info.plist` version is frozen across builds (WeChat DevTools reports Electron's
     /// `36.6.0` on every 2.02.x build); this set is driven by launch time instead and
-    /// then unioned into `needsRestart` so the existing Restart affordance just works.
+    /// then unioned into `needsRestart` so the existing Relaunch affordance just works.
     /// See `reconcilePackageRestarts` and `PackageRestartState`.
     private(set) var packageRestartPending: Set<String> = []
     /// Rows we've already posted a "ready to restart" notification for after a pkg

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2555,7 +2555,7 @@ final class AppListModel {
                 Log.install.info("install done: \(updated.app.name, privacy: .public) now \(version ?? "?", privacy: .public) on disk, awaiting restart")
                 if notify { UpdateNotifier.readyToRestart(app: updated.app.name, version: version, appID: updated.app.bundleID) }
                 // Finish the job the user started: a one-click Update shouldn't leave
-                // a second "Restart" click dangling. Auto-restart unless the user
+                // a second "Relaunch" click dangling. Auto-relaunch unless the user
                 // opted out. In a batch we skip here and let `installAll` restart the
                 // whole set once at the end (so parallel installs don't quit apps out
                 // from under each other mid-run). `restart()` is graceful — it honors
@@ -3330,7 +3330,7 @@ final class AppListModel {
             // Deliberately says "the version on disk" rather than "the version
             // just installed": this is also reached from the Restart button on a
             // row that updated itself, where we installed nothing.
-            let note = String(localized: "\(result.app.name) has its own update (\(stagedVersion)) downloaded and waiting for the app to quit. Restarting from here would install that one over the version now on disk, so it wasn't restarted — quit \(result.app.name) yourself when you're ready to take theirs.")
+            let note = String(localized: "\(result.app.name) has its own update (\(stagedVersion)) downloaded and waiting for the app to quit. Relaunching from here would install that one over the version now on disk, so it wasn't relaunched — quit \(result.app.name) yourself when you're ready to take theirs.")
             installNotes[result.id] = note
             restartHoldBackNotes[result.id] = note
             // Deliberately NOT registered in `inFlightNotes`. A row offering a
@@ -4290,7 +4290,7 @@ final class AppListModel {
         // app stopped meanwhile). From here the normal Restart state owns the row.
         pendingBatchRestart.removeAll()
         // Auto-restart the apps this batch just updated and left awaiting a restart,
-        // so "Update All" doesn't leave a pile of "Restart" buttons (the per-app
+        // so "Update All" doesn't leave a pile of "Relaunch" buttons (the per-app
         // path defers to here in a batch). Only the apps we actually touched — not
         // a pre-existing badge from some background self-update — and graceful, the
         // same as the single-app flow. Done after the shared sweep above so

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -943,7 +943,7 @@ private struct AppRow: View {
                 Spacer()
                 // Minimum-width action slot, trailing-aligned: every control ends on
                 // the row's own trailing edge, so a narrow indicator (a bare ✓) shares
-                // a right edge with a wide button ("Restart now") *and* with the brew
+                // a right edge with a wide button ("Relaunch now") *and* with the brew
                 // footer's badge below, which is flush right against the same 12pt
                 // padding. Centring instead inset the narrow ones by ~27pt and broke
                 // that shared edge. The minimum still reserves a slot so the name
@@ -1113,7 +1113,7 @@ private struct AppRow: View {
             // instead, where it can be read in full, and the line keeps to the one
             // comparison that decides the click: what you have vs what is offered.
             .help(model.restartFromVersion(result.id).map {
-                String(localized: "Still running \($0) — restart pending from an earlier update")
+                String(localized: "Still running \($0) — relaunch pending from an earlier update")
             } ?? "")
             // Long date-style versions (Warp) would otherwise wrap mid-number;
             // keep it one line and shrink slightly instead.
@@ -1147,7 +1147,7 @@ private struct AppRow: View {
 
     /// The restart version line: running version → installed marketing version (build).
     /// Surfaced when an app self-updated on disk but the old process is still live, so
-    /// "Restart" reads as a concrete version bump. The `from` is pre-formatted by
+    /// "Relaunch" reads as a concrete version bump. The `from` is pre-formatted by
     /// `restartFromVersion` — the running build alone, or "marketing (build)" when the
     /// pre-update marketing version is recoverable from the rollback backup — while the
     /// on-disk `to` side carries the full marketing version, e.g. "1.7.3 (194)".
@@ -1413,7 +1413,7 @@ private struct AppRow: View {
     /// On disk it's current, but the running instance is older — offer a
     /// relaunch so the update actually takes effect.
     private var restartButton: some View {
-        Button("Restart") { Task { await model.restart(result) } }
+        Button("Relaunch") { Task { await model.restart(result) } }
             .lineLimit(1)
             .minimumScaleFactor(0.7)
             .controlSize(.small)
@@ -1426,13 +1426,13 @@ private struct AppRow: View {
     /// not reached its deferred restart phase. Keep an explicit action available so
     /// a slow unrelated installer never makes this completed download look lost.
     private var pendingBatchRestartButton: some View {
-        Button("Restart now") { Task { await model.restart(result) } }
+        Button("Relaunch now") { Task { await model.restart(result) } }
             .lineLimit(1)
             .minimumScaleFactor(0.7)
             .controlSize(.small)
             .buttonStyle(.bordered)
             .tint(.orange)
-            .help("Installed \(result.app.shortVersion ?? String(localized: "the new version")) — waiting for Update All to finish before restarting; click to restart now")
+            .help("Installed \(result.app.shortVersion ?? String(localized: "the new version")) — waiting for Update All to finish before relaunching; click to relaunch now")
     }
 
     /// The app self-downloaded a newer build (Squirrel/ShipIt staged it); a
@@ -1453,7 +1453,7 @@ private struct AppRow: View {
     /// An incremental App Store update is downloaded but the app is running, so the
     /// store wants to quit it to install. Tapping presses the store's Continue (via
     /// the AX installer's awaited `confirmQuit`); the app quits, the update lands,
-    /// and we reopen it. Labelled "Relaunch" to match the other quit-to-apply action.
+    /// and we reopen it. Labelled "Relaunch" like every other quit-to-apply action.
     private func quitToFinishButton(_ appName: String) -> some View {
         Button("Relaunch") { model.confirmQuit(result.id, proceed: true) }
             .lineLimit(1)
@@ -1490,9 +1490,9 @@ private struct AppRow: View {
     private var restartHelp: String {
         let disk = result.app.shortVersion ?? String(localized: "the new version")
         if let running = model.runningVersion(result.id) {
-            return String(localized: "Running \(running) but \(disk) is installed — restart to apply it")
+            return String(localized: "Running \(running) but \(disk) is installed — relaunch to apply it")
         }
-        return String(localized: "You’re running an older version — restart to finish updating")
+        return String(localized: "You’re running an older version — relaunch to finish updating")
     }
 
     /// pkg cask: download the official installer and open it (system installer

--- a/App/Sources/Preferences.swift
+++ b/App/Sources/Preferences.swift
@@ -185,7 +185,7 @@ final class Preferences {
     }
 
     /// After an in-place install of a *running* app, automatically quit and
-    /// relaunch it so the new version takes effect — instead of leaving a "Restart"
+    /// relaunch it so the new version takes effect — instead of leaving a "Relaunch"
     /// badge for a second click. Uses the same graceful quit as the manual button
     /// (honors save prompts; a refused/blocked quit just leaves the badge), so it
     /// never force-kills or loses unsaved work. Default ON — an opt-out convenience.

--- a/App/Sources/Settings/GeneralSettingsPage.swift
+++ b/App/Sources/Settings/GeneralSettingsPage.swift
@@ -89,12 +89,12 @@ struct GeneralSettingsPage: View {
     private var afterUpdateCard: some View {
         SettingsCard(
             header: "After an update",
-            footer: "After updating a running app, restart it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Restart” button.\n\nBackups keep one previous version of each app under Application Support, so an update can be undone. Retention is one backup per app — the previous version is replaced, not accumulated."
+            footer: "After updating a running app, relaunch it for you so the new version takes effect — no second click. The app is asked to quit normally, so unsaved-work prompts still appear and anything that won’t quit just keeps its “Relaunch” button.\n\nBackups keep one previous version of each app under Application Support, so an update can be undone. Retention is one backup per app — the previous version is replaced, not accumulated."
         ) {
             Toggle("Notify me when updates are found", isOn: $prefs.notifyOnUpdates)
                 .settingsRow()
             SettingsDivider()
-            Toggle("Restart updated apps automatically", isOn: $prefs.autoRestartAfterUpdate)
+            Toggle("Relaunch updated apps automatically", isOn: $prefs.autoRestartAfterUpdate)
                 .settingsRow()
             SettingsDivider()
             Toggle("Keep a backup so updates can be rolled back", isOn: $prefs.keepBackups)

--- a/App/Sources/Settings/SettingsSection.swift
+++ b/App/Sources/Settings/SettingsSection.swift
@@ -106,7 +106,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     private var localizedKeywords: [String] {
         let list: String
         switch self {
-        case .general:     list = String(localized: "launch, login, frequency, notify, restart, backup, rollback, concurrency, app store, self-updating, vendor", comment: "Comma-separated extra search terms for the General settings page")
+        case .general:     list = String(localized: "launch, login, frequency, notify, relaunch, restart, backup, rollback, concurrency, app store, self-updating, vendor", comment: "Comma-separated extra search terms for the General settings page")
         case .folders:     list = String(localized: "scan, locations, applications, path, directory", comment: "Comma-separated extra search terms for the Folders settings page")
         case .updates:     list = String(localized: "version, about, self", comment: "Comma-separated extra search terms for the Updates settings page")
         case .github:      list = String(localized: "token, personal access token, rate limit", comment: "Comma-separated extra search terms for the GitHub settings page")
@@ -136,7 +136,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     /// before still finds it, and the localized terms are new ground.
     private var englishAliases: [String] {
         switch self {
-        case .general:     return ["launch", "login", "frequency", "notify", "restart", "backup", "rollback", "concurrency", "app store", "mas", "self-updating", "vendor"]
+        case .general:     return ["launch", "login", "frequency", "notify", "relaunch", "restart", "backup", "rollback", "concurrency", "app store", "mas", "self-updating", "vendor"]
         case .folders:     return ["scan", "locations", "applications", "path", "directory"]
         case .updates:     return ["version", "sparkle", "about", "self"]
         case .github:      return ["token", "personal access token", "pat", "gh", "cli", "rate limit"]

--- a/App/Sources/Settings/UpdatesSettingsPage.swift
+++ b/App/Sources/Settings/UpdatesSettingsPage.swift
@@ -37,7 +37,7 @@ struct UpdatesSettingsPage: View {
             }
 
             SettingsCard(
-                footer: "Duo Updater checks for its own updates hourly on its own. Left off, a new version puts up a prompt and waits for you.\n\nTurned on, it is downloaded and then applied at a quiet moment — no prompt, no clicking. A quiet moment means nothing is being checked or installed, no window of Duo Updater's is open, and you are working in another app; it restarts itself there. Until such a moment comes it simply waits, and installs when you quit Duo Updater anyway."
+                footer: "Duo Updater checks for its own updates hourly on its own. Left off, a new version puts up a prompt and waits for you.\n\nTurned on, it is downloaded and then applied at a quiet moment — no prompt, no clicking. A quiet moment means nothing is being checked or installed, no window of Duo Updater's is open, and you are working in another app; it relaunches itself there. Until such a moment comes it simply waits, and installs when you quit Duo Updater anyway."
             ) {
                 Toggle("Install Duo Updater's own updates silently", isOn: $installsAutomatically)
                     .settingsRow()

--- a/App/Sources/UpdateNotifier.swift
+++ b/App/Sources/UpdateNotifier.swift
@@ -41,10 +41,10 @@ enum UpdateNotifier {
     /// old version. The user restarts it when ready, through the app's own quit
     /// flow. Carries a stable per-app identifier so that `restarted` can replace
     /// this banner in place once the new version is live, instead of leaving a
-    /// stale "Restart to apply it" stacked under the "Now running" confirmation.
+    /// stale "Relaunch to apply it" stacked under the "Now running" confirmation.
     static func readyToRestart(app: String, version: String?, appID: String?) {
-        let body = version.map { String(localized: "Update to \($0) is ready. Restart to apply it.") }
-            ?? String(localized: "Update is ready. Restart to apply it.")
+        let body = version.map { String(localized: "Update to \($0) is ready. Relaunch to apply it.") }
+            ?? String(localized: "Update is ready. Relaunch to apply it.")
         post(title: app, body: body,
              identifier: appID.map { "restart:\($0)" })
     }
@@ -100,10 +100,10 @@ enum UpdateNotifier {
 
     /// The user restarted and the new version is now live. Reuses the same stable
     /// identifier as `readyToRestart` so this confirmation *replaces* the pending
-    /// "Restart to apply it" banner in Notification Center rather than stacking a
+    /// "Relaunch to apply it" banner in Notification Center rather than stacking a
     /// second copy beneath it — one banner per app lifecycle, not two.
     static func restarted(app: String, version: String?, appID: String?) {
-        post(title: app, body: version.map { String(localized: "Now running \($0).") } ?? String(localized: "Restarted on the new version."),
+        post(title: app, body: version.map { String(localized: "Now running \($0).") } ?? String(localized: "Relaunched on the new version."),
              identifier: appID.map { "restart:\($0)" })
     }
 

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -555,7 +555,7 @@ struct WorkbenchWindowView: View {
 /// user reading an update's release notes can act on it right there — instead of
 /// having to reopen the menu-bar popover. A deliberately focused mirror of the
 /// popover's `trailing`: it covers the common, safe one-click states (install
-/// progress, Update, Restart, Relaunch) and otherwise stays out of the way, leaving
+/// progress, Update, Relaunch) and otherwise stays out of the way, leaving
 /// the gated cases (major upgrades, region locks) to the popover's richer affordances.
 private struct WorkbenchActionView: View {
     let result: UpdateResult
@@ -577,20 +577,20 @@ private struct WorkbenchActionView: View {
                 .tint(.orange)
                 .help("Quit the app to finish installing the update, then reopen it")
         } else if model.pendingBatchRestart[result.id] != nil {
-            Button("Restart now") { Task { await model.restart(result) } }
+            Button("Relaunch now") { Task { await model.restart(result) } }
                 .buttonStyle(.bordered)
                 .tint(.orange)
-                .help("The update is installed; Update All is waiting to restart apps until the batch finishes")
+                .help("The update is installed; Update All is waiting to relaunch apps until the batch finishes")
         } else if let staged = model.actionableStaged(result) {
             Button("Relaunch") { Task { await model.relaunchStagedUpdate(result) } }
                 .buttonStyle(.bordered)
                 .tint(.orange)
                 .help("\(result.app.name) already downloaded \(staged.version) — relaunch to apply it")
         } else if model.needsRestart.contains(result.id) && !result.hasUpdate {
-            Button("Restart") { Task { await model.restart(result) } }
+            Button("Relaunch") { Task { await model.restart(result) } }
                 .buttonStyle(.bordered)
                 .tint(.orange)
-                .help("Running an older build — restart to apply the installed update")
+                .help("Running an older build — relaunch to apply the installed update")
         } else if model.isActionableUpdate(result) {
             updateAction
         }
@@ -737,7 +737,7 @@ private struct WorkbenchSidebarRow: View {
     let isSelected: Bool
     /// Whether the app currently has a running process — shows the green live dot.
     let isRunning: Bool
-    /// Self-updated on disk, waiting for a relaunch to take effect (the "Restart"
+    /// Self-updated on disk, waiting for a relaunch to take effect (the "Relaunch"
     /// state). When set, the subtitle shows running → installed instead of a bare
     /// version, so the row says what the restart will land.
     let needsRestart: Bool
@@ -779,7 +779,7 @@ private struct WorkbenchSidebarRow: View {
                 .lineLimit(1)
         } else if needsRestart, let from = runningVersion {
             // Self-updated on disk: show running version → installed marketing version
-            // (build) so "Restart" reads as a real change. `from` is pre-formatted by
+            // (build) so "Relaunch" reads as a real change. `from` is pre-formatted by
             // `restartFromVersion` — the running build, or "marketing (build)" when the
             // pre-update marketing version is recoverable from the rollback backup; the
             // on-disk `to` side carries the marketing version, e.g. "1.7.3 (194)".
@@ -1015,7 +1015,7 @@ private struct DetailHeader: View {
                     versionLine
                 }
                 Spacer()
-                // The contextual primary action (Update / Restart / Relaunch / Get),
+                // The contextual primary action (Update / Relaunch / Get),
                 // so an update can be acted on right here while its notes are open —
                 // no trip back to the menu-bar popover.
                 WorkbenchActionView(result: result, model: model)


### PR DESCRIPTION
Closes #67.

Two labels stood for one gesture. A bundle its own updater had already swapped on disk said **Restart**; one whose updater had staged the build outside the bundle said **Relaunch**. The distinction is real internally — the first is ours to quit and reopen, the second has to be handed to the app's own ShipIt — but it is not actionable: the user does the same thing either way, and doing nothing has the same result either way, since both land on the next natural quit.

What made it visible was Chrome. Keystone replaces the bundle in place, so that row was the "Restart" one, while Chrome's own About page was saying "Relaunch" for the same pending action, at the same moment.

## The issue's width worry was misplaced

The catalog says the distinction was **always English-only**:

| | Restart | Relaunch |
|---|---|---|
| de | Neu starten | Neu starten |
| ja | 再起動 | 再起動 |
| ru | Перезапустить | Перезапустить |
| zh-Hans | 重新启动 | 重新启动 |
| es | Reiniciar | **Reabrir** |
| fr | Redémarrer | **Relancer** |

So four of six languages change nothing at all, and the two that do move onto the shorter half. Measured at the button's own font: **en +10.3pt, es −7.2, fr −15.7, de/ja/ru/zh 0.0**. The one language that grows is already carrying that exact button today — the staged-relaunch path has always been labelled "Relaunch".

Note the notification action buttons were *already* "Relaunch" (`NotificationController`), so a row could say Restart while its own notification said Relaunch.

## Scope

Changed: the menu and workbench buttons, the Settings toggle and its footer, the two ready-to-apply notifications and the confirmation, four tooltips/row notes, the Settings search terms (adds `relaunch`, keeps `restart`), and Updates' description of Duo Updater reopening itself.

Left alone deliberately:
- `Restart Helper…` — restarts the App Store daemon
- `sfltool resetbtm … and restart` — restarts the Mac
- `Dock restarted` — restarts the Dock
- `duo restart` — a CLI command whose own prose should keep matching its name

`Restart` merges into the existing `Relaunch` entry rather than being renamed onto a fresh key, so the catalog goes 412 → 411. The `AutoRestartAfterUpdate` defaults key and the `restart:<id>` notification identifiers are untouched, so no setting is lost and already-delivered notifications still de-duplicate.

Eleven comments that quoted the old label move with it — none of them now names a button that does not exist.

## Testing

- `make test` — 1091 + 125 pass, 2 known issues
- `check_localizable_keys.py` — 411 keys, all reachable
- specifier audit — 411 keys × 6 languages, 0 mismatches
- from the installed bundle, per language: `Restart` no longer resolves at all, 392 strings each, no empty `.lproj`
- UI harness, 7 languages × 3 states (self-updated on disk / Update All deferred / longest names). Worst case is Russian's widest label beside the longest names: names wrap, button intact, right edges aligned, no truncation.