### PR TITLE
Drop the build numbers a relaunch line's versions already imply

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -370,15 +370,22 @@ final class AppListModel {
     /// marketing version on record (the app updated while we weren't running). nil
     /// when the app isn't lagging a newer on-disk build.
     func restartFromVersion(_ id: String) -> String? {
+        restartFromSide(id)?.text(withBuild: true)
+    }
+
+    /// The same running side, still in parts, so the line can be formatted against
+    /// the on-disk side rather than in isolation — see `UpdateResult.relaunchLine`.
+    /// The marketing version is left nil when it adds nothing (nothing recovered it,
+    /// or it is the build over again), which is exactly the case where the target's
+    /// build has to stay for the two sides to be comparable at all.
+    func restartFromSide(_ id: String) -> UpdateResult.VersionSide? {
         guard let runningBuild = runningVersionByID[id] else { return nil }
         let build = UpdateResult.strippingBuildPrefix(runningBuild)
         // Prefer the rollback backup's marketing (authoritative, written when *we*
         // installed); fall back to the build→marketing history recovered for apps
-        // that self-updated outside us. Either way, pair it with the build.
-        if let marketing = backupVersions[id] ?? recoveredRestartMarketing[id], marketing != build {
-            return "\(marketing) (\(build))"
-        }
-        return build
+        // that self-updated outside us.
+        let marketing = backupVersions[id] ?? recoveredRestartMarketing[id]
+        return .init(marketing: marketing == build ? nil : marketing, build: build)
     }
 
     /// The raw staged self-update for a row, if its own updater has downloaded a

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1085,15 +1085,15 @@ private struct AppRow: View {
             // Update All has landed the new bundle but intentionally postpones its
             // process-version sweep/restarts until every installer is finished.
             // Keep the row concrete instead of flashing a false completion.
-            restartVersionLine(from)
+            restartVersionLine(from: .init(marketing: from))
         } else if model.needsRestart.contains(result.id),
-                  let from = model.restartFromVersion(result.id) {
+                  let from = model.restartFromSide(result.id) {
             // Self-updated on disk, restart pending. Show the running version → the
             // installed version so the row reads as a real change, not a static
             // "v1.6.1". `lsappinfo` only exposes the running *build*; `restartFromVersion`
             // recovers the marketing version from the rollback backup when it can, so
             // the from side reads "26.609.71450 (3965)" rather than a bare "3965".
-            restartVersionLine(from)
+            restartVersionLine(from: from)
         } else {
             switch result.status {
             case .updateAvailable(let latest):
@@ -1145,18 +1145,21 @@ private struct AppRow: View {
         .help("The vendor's latest is \(older) — older than your \(installed). You're ahead, so there's nothing to do. Usually a beta channel, a pulled release, or a lagging check.")
     }
 
-    /// The restart version line: running version → installed marketing version (build).
-    /// Surfaced when an app self-updated on disk but the old process is still live, so
-    /// "Relaunch" reads as a concrete version bump. The `from` is pre-formatted by
-    /// `restartFromVersion` — the running build alone, or "marketing (build)" when the
-    /// pre-update marketing version is recoverable from the rollback backup — while the
-    /// on-disk `to` side carries the full marketing version, e.g. "1.7.3 (194)".
+    /// The relaunch version line: running version → the version on disk. Surfaced
+    /// when an app self-updated on disk but the old process is still live, so
+    /// "Relaunch" reads as a concrete version bump rather than a static "v1.6.1".
+    ///
+    /// Both sides are formatted together by `UpdateResult.relaunchLine`, which drops
+    /// the build numbers when the marketing versions already tell the two apart —
+    /// without that, Chrome's line spent its width repeating digits its own marketing
+    /// version ends in, and truncated the running side to do it.
     @ViewBuilder
-    private func restartVersionLine(_ from: String) -> some View {
+    private func restartVersionLine(from: UpdateResult.VersionSide) -> some View {
+        let line = UpdateResult.relaunchLine(from: from, to: result.relaunchTargetSide)
         HStack(spacing: 4) {
-            Text(from).foregroundStyle(.secondary)
+            Text(line.from).foregroundStyle(.secondary)
             Image(systemName: "arrow.right").font(.caption2)
-            Text(result.restartTargetVersion).fontWeight(.semibold).foregroundStyle(.orange)
+            Text(line.to).fontWeight(.semibold).foregroundStyle(.orange)
         }
         .font(.caption)
         .lineLimit(1)
@@ -1814,20 +1817,4 @@ private struct AppRow: View {
 
 extension UpdateResult {
 
-    /// The "to" side of a restart line: the on-disk (post-self-update) version a
-    /// relaunch will land. Unlike the still-running process — which exposes only its
-    /// build via `lsappinfo` — the on-disk bundle carries both fields, so we show the
-    /// full marketing version with the build in parens ("1.7.3 (194)") rather than a
-    /// bare build number. Falls back to the bare build (date/serial apps whose
-    /// marketing string equals or is absent vs the build) or the marketing version
-    /// alone. The JetBrains-style build prefix is stripped to match the from side.
-    var restartTargetVersion: String {
-        let build = app.buildVersion.map(Self.strippingBuildPrefix)
-        switch (app.shortVersion, build) {
-        case let (marketing?, build?) where marketing != build: return "\(marketing) (\(build))"
-        case let (_, build?): return build
-        case let (marketing?, nil): return marketing
-        default: return "?"
-        }
-    }
 }

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -502,7 +502,7 @@ struct WorkbenchWindowView: View {
                     isSelected: result.id == selection,
                     isRunning: model.isRunning(result),
                     needsRestart: model.needsRestart.contains(result.id),
-                    runningVersion: model.restartFromVersion(result.id))
+                    runningVersion: model.restartFromSide(result.id))
                     .tag(result.id)
             }
         }
@@ -525,7 +525,7 @@ struct WorkbenchWindowView: View {
                     isSelected: result.id == selection,
                     isRunning: model.isRunning(result),
                     needsRestart: model.needsRestart.contains(result.id),
-                    runningVersion: model.restartFromVersion(result.id))
+                    runningVersion: model.restartFromSide(result.id))
                     .tag(result.id)
             }
             ForEach(model.brewFormulae) { formula in
@@ -741,10 +741,10 @@ private struct WorkbenchSidebarRow: View {
     /// state). When set, the subtitle shows running → installed instead of a bare
     /// version, so the row says what the restart will land.
     let needsRestart: Bool
-    /// The "from" side of a restart line, pre-formatted by `restartFromVersion`: the
-    /// running build, or "marketing (build)" when the pre-update marketing version is
-    /// recoverable from the rollback backup. nil when not lagging an on-disk build.
-    let runningVersion: String?
+    /// The running side of a relaunch line, still in parts so it can be formatted
+    /// against the on-disk side rather than in isolation. nil when not lagging an
+    /// on-disk build.
+    let runningVersion: UpdateResult.VersionSide?
 
     var body: some View {
         HStack(spacing: 8) {
@@ -777,14 +777,14 @@ private struct WorkbenchSidebarRow: View {
                 // White over the blue highlight when selected; blue tint otherwise.
                 .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.tint))
                 .lineLimit(1)
-        } else if needsRestart, let from = runningVersion {
-            // Self-updated on disk: show running version → installed marketing version
-            // (build) so "Relaunch" reads as a real change. `from` is pre-formatted by
-            // `restartFromVersion` — the running build, or "marketing (build)" when the
-            // pre-update marketing version is recoverable from the rollback backup; the
-            // on-disk `to` side carries the marketing version, e.g. "1.7.3 (194)".
-            let to = result.restartTargetVersion
-            Text("\(from) → \(to)")
+        } else if needsRestart, let running = runningVersion {
+            // Self-updated on disk: show running version → the version on disk, so
+            // "Relaunch" reads as a real change. Formatted as a pair by
+            // `relaunchLine`, which keeps the build numbers only when the marketing
+            // versions cannot tell the two apart — the same rule the update subtitle
+            // above gets from `buildBump`.
+            let line = UpdateResult.relaunchLine(from: running, to: result.relaunchTargetSide)
+            Text("\(line.from) → \(line.to)")
                 .font(.caption)
                 .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.orange))
                 .lineLimit(1)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -286,6 +286,65 @@ extension UpdateResult {
         return (installed, remoteClean)
     }
 
+    /// One end of a **relaunch** line — the running process on the left, the bundle
+    /// already on disk on the right — before it is decided whether its build number
+    /// is worth the width.
+    ///
+    /// The two ends are formatted together (see ``UpdateResult/relaunchLine(from:to:)``)
+    /// rather than each on its own, which is the whole point: a side cannot tell on
+    /// its own whether its build is the interesting part.
+    public struct VersionSide: Sendable, Equatable {
+        public var marketing: String?
+        public var build: String?
+
+        public init(marketing: String? = nil, build: String? = nil) {
+            self.marketing = marketing
+            self.build = build
+        }
+
+        /// "1.7.3 (194)", "1.7.3", or a bare "194" — whichever the parts support.
+        /// A build equal to the marketing version is never repeated after it.
+        public func text(withBuild: Bool) -> String {
+            guard let marketing else { return build ?? "?" }
+            guard withBuild, let build, build != marketing else { return marketing }
+            return "\(marketing) (\(build))"
+        }
+    }
+
+    /// The on-disk side of a relaunch line: the version a relaunch will land.
+    public var relaunchTargetSide: VersionSide {
+        VersionSide(marketing: app.shortVersion,
+                    build: app.buildVersion.map(Self.strippingBuildPrefix))
+    }
+
+    /// Format both ends of a relaunch line, keeping the build numbers only when they
+    /// are what tells the two versions apart.
+    ///
+    /// This is ``buildBump(latest:)``'s rule, which the *update* line has always
+    /// applied, finally reaching the relaunch line. Each side used to format itself,
+    /// so both kept their build whatever the other looked like, and Chrome — whose
+    /// marketing version already ends in its build — rendered as
+    /// `151.0.7922.174 (7922.17… → 152.0.7977.65 (7977.65)`: the side the user is
+    /// leaving got truncated in order to repeat digits the marketing version had
+    /// already spelled out.
+    ///
+    /// Kept when the marketing versions match, because then the build is the only
+    /// thing that moved: Surge shipped four separate releases as "6.9.0", and
+    /// "6.9.0 → 6.9.0" says nothing at all.
+    ///
+    /// **Both** marketing versions have to be present before a build is dropped.
+    /// `lsappinfo` exposes only the running *build*, and when nothing recovered a
+    /// marketing version to pair with it that side is a bare number — dropping the
+    /// target's build there would leave "3965 → 1.7.3", two values from different
+    /// namespaces with no way to read one against the other.
+    public static func relaunchLine(
+        from: VersionSide, to: VersionSide
+    ) -> (from: String, to: String) {
+        let bothNamed = from.marketing != nil && to.marketing != nil
+        let withBuild = !(bothNamed && from.marketing != to.marketing)
+        return (from.text(withBuild: withBuild), to.text(withBuild: withBuild))
+    }
+
 }
 
 public enum UpdateStatus: Sendable, Equatable {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RelaunchLineTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RelaunchLineTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// `UpdateResult.relaunchLine` decides one thing: whether the build numbers earn
+/// their place on the row. The rule is the one `buildBump` already applies to the
+/// update line — a build is worth showing only when the marketing versions cannot
+/// tell the two versions apart — plus the constraint that a side with no marketing
+/// version of its own has nothing else to be read against.
+@Suite struct RelaunchLineTests {
+
+    private typealias Side = UpdateResult.VersionSide
+
+    private func app(short: String?, build: String?) -> InstalledApp {
+        InstalledApp(
+            name: "Google Chrome", bundleID: "com.google.Chrome", shortVersion: short,
+            buildVersion: build, path: URL(fileURLWithPath: "/Applications/Google Chrome.app"),
+            isMASApp: false, sparkleFeedURL: nil,
+            hasSelfUpdater: true, hasSparkleUpdater: false)
+    }
+
+    private func result(short: String?, build: String?) -> UpdateResult {
+        UpdateResult(app: app(short: short, build: build), remote: nil, status: .upToDate)
+    }
+
+    /// The case that prompted this. Chrome's marketing version *ends in* its build,
+    /// so the parenthesised half was pure repetition — and it cost enough width that
+    /// the running side truncated mid-number, losing the digits that differed.
+    @Test func chromeDropsBuildsTheMarketingVersionAlreadySpellsOut() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "151.0.7922.174", build: "7922.174"),
+            to: Side(marketing: "152.0.7977.65", build: "7977.65"))
+        #expect(line.from == "151.0.7922.174")
+        #expect(line.to == "152.0.7977.65")
+    }
+
+    /// The reason builds are shown at all: Surge shipped four separate releases as
+    /// "6.9.0", where dropping the build leaves a line that reads as a no-op.
+    @Test func sameMarketingVersionKeepsTheBuildsThatDiffer() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "6.9.0", build: "12028"),
+            to: Side(marketing: "6.9.0", build: "12030"))
+        #expect(line.from == "6.9.0 (12028)")
+        #expect(line.to == "6.9.0 (12030)")
+    }
+
+    /// `lsappinfo` exposes only the running build. When nothing recovered a marketing
+    /// version to pair with it, the target's build is the only value in the running
+    /// side's namespace — dropping it would leave "3965 → 1.7.3", two numbers that
+    /// cannot be read against each other.
+    @Test func abareRunningBuildKeepsTheTargetsBuild() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: nil, build: "3965"),
+            to: Side(marketing: "1.7.3", build: "194"))
+        #expect(line.from == "3965")
+        #expect(line.to == "1.7.3 (194)")
+    }
+
+    /// The deferred-batch line: the pre-install version we recorded is a marketing
+    /// version with no build, so both sides are named and the target's build goes.
+    @Test func aFromSideWithNoBuildStillSuppressesTheTargets() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "1.7.2", build: nil),
+            to: Side(marketing: "1.7.3", build: "194"))
+        #expect(line.from == "1.7.2")
+        #expect(line.to == "1.7.3")
+    }
+
+    /// Date/serial apps whose CFBundleVersion repeats CFBundleShortVersionString:
+    /// never print the same number twice, whatever the rule decided.
+    @Test func aBuildEqualToItsMarketingVersionIsNeverRepeated() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "2026.08.19", build: "2026.08.19"),
+            to: Side(marketing: "2026.08.19", build: "2026.08.19"))
+        #expect(line.from == "2026.08.19")
+        #expect(line.to == "2026.08.19")
+    }
+
+    @Test func aSideWithNothingAtAllDegradesRatherThanCrashing() {
+        #expect(Side(marketing: nil, build: nil).text(withBuild: true) == "?")
+        #expect(Side(marketing: nil, build: nil).text(withBuild: false) == "?")
+    }
+
+    /// `relaunchTargetSide` reads the bundle's own two fields, stripping the
+    /// JetBrains-style product prefix so it lands in the same namespace as the
+    /// running build `strippingBuildPrefix` also cleans.
+    @Test func theTargetSideComesOffTheBundleWithItsBuildPrefixStripped() {
+        #expect(result(short: "2026.2", build: "IU-262.7132.23").relaunchTargetSide
+                == Side(marketing: "2026.2", build: "262.7132.23"))
+        #expect(result(short: "1.7.3", build: nil).relaunchTargetSide
+                == Side(marketing: "1.7.3", build: nil))
+        #expect(result(short: nil, build: "194").relaunchTargetSide
+                == Side(marketing: nil, build: "194"))
+    }
+
+    /// Whatever the rule decides, it decides for both ends: a row that parenthesised
+    /// a build on one side only would invite reading the two halves as different
+    /// kinds of number.
+    ///
+    /// Judged over the sides that *could* carry a parenthesised build. One holding
+    /// only a bare build has no marketing version to put in front of it, so its
+    /// missing parentheses are the format rather than a suppressed build — asserting
+    /// on the parentheses alone called that case a violation when it is the intended
+    /// output.
+    @Test func neitherEndSuppressesABuildTheOtherIsShowing() {
+        let cases: [(Side, Side)] = [
+            (Side(marketing: "1.0", build: "10"), Side(marketing: "2.0", build: "20")),
+            (Side(marketing: "1.0", build: "10"), Side(marketing: "1.0", build: "20")),
+            (Side(marketing: nil, build: "10"), Side(marketing: "2.0", build: "20")),
+            (Side(marketing: "1.0", build: nil), Side(marketing: "1.0", build: "20")),
+        ]
+        for (from, to) in cases {
+            let line = UpdateResult.relaunchLine(from: from, to: to)
+            let shown = zip([from, to], [line.from, line.to])
+                .filter { $0.0.marketing != nil && $0.0.build != nil }
+                .map { $0.1.contains("(") }
+            #expect(Set(shown).count <= 1,
+                    "one end kept its build and the other dropped it: \(line)")
+        }
+    }
+}


### PR DESCRIPTION
The relaunch line formatted each end on its own, so both kept their build number whatever the other looked like. Chrome's marketing version *ends in* its own build, which made the row read:

```
151.0.7922.174 (7922.17…  →  152.0.7977.65 (7977.65)
```

The side the user is leaving truncated mid-number — spending that width to repeat digits the marketing version had already spelled out, and losing the ones that differ.

## The rule already existed one line over

The **update** line has never had this problem. `buildBump` shows a build only when the marketing version did not move; where the version already changed, the build is noise and is left out (that behaviour shipped in 0.3.59 for Download Traffic and has been on the update row since).

`UpdateResult.relaunchLine(from:to:)` is that rule applied to the *pair*. Both call sites — the menu row and the workbench subtitle — now go through it, because a side genuinely cannot tell on its own whether its build is the interesting part.

| | before | after |
|---|---|---|
| Chrome | `151.0.7922.174 (7922.17… → 152.0.7977.65 (7977.65)` | `151.0.7922.174 → 152.0.7977.65` |
| Surge (same marketing) | `6.9.0 (12028) → 6.9.0 (12030)` | unchanged — the build is the whole story |
| bare running build | `3965 → 1.7.3 (194)` | unchanged — see below |

## The constraint that is easy to get wrong

Both marketing versions have to be present before a build is dropped. `lsappinfo` exposes only the running *build*, so when nothing recovered a marketing version to pair with it, that side is a bare number. Dropping the target's build there would leave `3965 → 1.7.3` — two values from different namespaces with no way to read one against the other.

`restartFromSide` returns the parts and nils a marketing version that is only the build over again, so this case is recognised rather than guessed at.

## Placement

The formatter lives in Core beside `buildBump`, because that is where the rule it mirrors lives and because the old one sat in a view file where nothing could test it. `restartTargetVersion` is gone; `relaunchTargetSide` replaces it and has no remaining callers of its own.

## Testing

- `make test` — **1099** + 125 pass, 2 known issues (was 1091: +8 new)
- `RelaunchLineTests` pins Chrome's exact observed strings, the Surge same-marketing case, the bare-build case, the deferred-batch case (marketing with no build), a build identical to its marketing version, and the empty side
- one invariant test: neither end suppresses a build the other is showing. Its first draft asserted on the presence of parentheses and failed the bare-build case — parentheses are the *format*, not the decision, so it now judges only the sides that could carry a parenthesised build. Left in the diff with that written down.
- verified against the live state on the development Mac: Chrome is still disk `152.0.7977.65` / running `7922.174`, i.e. exactly the row in the report