### PR TITLE
Nested-app relaunch, and the immutable flag that froze every backup

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -370,15 +370,22 @@ final class AppListModel {
     /// marketing version on record (the app updated while we weren't running). nil
     /// when the app isn't lagging a newer on-disk build.
     func restartFromVersion(_ id: String) -> String? {
+        restartFromSide(id)?.text(withBuild: true)
+    }
+
+    /// The same running side, still in parts, so the line can be formatted against
+    /// the on-disk side rather than in isolation — see `UpdateResult.relaunchLine`.
+    /// The marketing version is left nil when it adds nothing (nothing recovered it,
+    /// or it is the build over again), which is exactly the case where the target's
+    /// build has to stay for the two sides to be comparable at all.
+    func restartFromSide(_ id: String) -> UpdateResult.VersionSide? {
         guard let runningBuild = runningVersionByID[id] else { return nil }
         let build = UpdateResult.strippingBuildPrefix(runningBuild)
         // Prefer the rollback backup's marketing (authoritative, written when *we*
         // installed); fall back to the build→marketing history recovered for apps
-        // that self-updated outside us. Either way, pair it with the build.
-        if let marketing = backupVersions[id] ?? recoveredRestartMarketing[id], marketing != build {
-            return "\(marketing) (\(build))"
-        }
-        return build
+        // that self-updated outside us.
+        let marketing = backupVersions[id] ?? recoveredRestartMarketing[id]
+        return .init(marketing: marketing == build ? nil : marketing, build: build)
     }
 
     /// The raw staged self-update for a row, if its own updater has downloaded a

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1085,15 +1085,15 @@ private struct AppRow: View {
             // Update All has landed the new bundle but intentionally postpones its
             // process-version sweep/restarts until every installer is finished.
             // Keep the row concrete instead of flashing a false completion.
-            restartVersionLine(from)
+            restartVersionLine(from: .init(marketing: from))
         } else if model.needsRestart.contains(result.id),
-                  let from = model.restartFromVersion(result.id) {
+                  let from = model.restartFromSide(result.id) {
             // Self-updated on disk, restart pending. Show the running version → the
             // installed version so the row reads as a real change, not a static
             // "v1.6.1". `lsappinfo` only exposes the running *build*; `restartFromVersion`
             // recovers the marketing version from the rollback backup when it can, so
             // the from side reads "26.609.71450 (3965)" rather than a bare "3965".
-            restartVersionLine(from)
+            restartVersionLine(from: from)
         } else {
             switch result.status {
             case .updateAvailable(let latest):
@@ -1145,18 +1145,21 @@ private struct AppRow: View {
         .help("The vendor's latest is \(older) — older than your \(installed). You're ahead, so there's nothing to do. Usually a beta channel, a pulled release, or a lagging check.")
     }
 
-    /// The restart version line: running version → installed marketing version (build).
-    /// Surfaced when an app self-updated on disk but the old process is still live, so
-    /// "Relaunch" reads as a concrete version bump. The `from` is pre-formatted by
-    /// `restartFromVersion` — the running build alone, or "marketing (build)" when the
-    /// pre-update marketing version is recoverable from the rollback backup — while the
-    /// on-disk `to` side carries the full marketing version, e.g. "1.7.3 (194)".
+    /// The relaunch version line: running version → the version on disk. Surfaced
+    /// when an app self-updated on disk but the old process is still live, so
+    /// "Relaunch" reads as a concrete version bump rather than a static "v1.6.1".
+    ///
+    /// Both sides are formatted together by `UpdateResult.relaunchLine`, which drops
+    /// the build numbers when the marketing versions already tell the two apart —
+    /// without that, Chrome's line spent its width repeating digits its own marketing
+    /// version ends in, and truncated the running side to do it.
     @ViewBuilder
-    private func restartVersionLine(_ from: String) -> some View {
+    private func restartVersionLine(from: UpdateResult.VersionSide) -> some View {
+        let line = UpdateResult.relaunchLine(from: from, to: result.relaunchTargetSide)
         HStack(spacing: 4) {
-            Text(from).foregroundStyle(.secondary)
+            Text(line.from).foregroundStyle(.secondary)
             Image(systemName: "arrow.right").font(.caption2)
-            Text(result.restartTargetVersion).fontWeight(.semibold).foregroundStyle(.orange)
+            Text(line.to).fontWeight(.semibold).foregroundStyle(.orange)
         }
         .font(.caption)
         .lineLimit(1)
@@ -1814,20 +1817,4 @@ private struct AppRow: View {
 
 extension UpdateResult {
 
-    /// The "to" side of a restart line: the on-disk (post-self-update) version a
-    /// relaunch will land. Unlike the still-running process — which exposes only its
-    /// build via `lsappinfo` — the on-disk bundle carries both fields, so we show the
-    /// full marketing version with the build in parens ("1.7.3 (194)") rather than a
-    /// bare build number. Falls back to the bare build (date/serial apps whose
-    /// marketing string equals or is absent vs the build) or the marketing version
-    /// alone. The JetBrains-style build prefix is stripped to match the from side.
-    var restartTargetVersion: String {
-        let build = app.buildVersion.map(Self.strippingBuildPrefix)
-        switch (app.shortVersion, build) {
-        case let (marketing?, build?) where marketing != build: return "\(marketing) (\(build))"
-        case let (_, build?): return build
-        case let (marketing?, nil): return marketing
-        default: return "?"
-        }
-    }
 }

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -502,7 +502,7 @@ struct WorkbenchWindowView: View {
                     isSelected: result.id == selection,
                     isRunning: model.isRunning(result),
                     needsRestart: model.needsRestart.contains(result.id),
-                    runningVersion: model.restartFromVersion(result.id))
+                    runningVersion: model.restartFromSide(result.id))
                     .tag(result.id)
             }
         }
@@ -525,7 +525,7 @@ struct WorkbenchWindowView: View {
                     isSelected: result.id == selection,
                     isRunning: model.isRunning(result),
                     needsRestart: model.needsRestart.contains(result.id),
-                    runningVersion: model.restartFromVersion(result.id))
+                    runningVersion: model.restartFromSide(result.id))
                     .tag(result.id)
             }
             ForEach(model.brewFormulae) { formula in
@@ -741,10 +741,10 @@ private struct WorkbenchSidebarRow: View {
     /// state). When set, the subtitle shows running → installed instead of a bare
     /// version, so the row says what the restart will land.
     let needsRestart: Bool
-    /// The "from" side of a restart line, pre-formatted by `restartFromVersion`: the
-    /// running build, or "marketing (build)" when the pre-update marketing version is
-    /// recoverable from the rollback backup. nil when not lagging an on-disk build.
-    let runningVersion: String?
+    /// The running side of a relaunch line, still in parts so it can be formatted
+    /// against the on-disk side rather than in isolation. nil when not lagging an
+    /// on-disk build.
+    let runningVersion: UpdateResult.VersionSide?
 
     var body: some View {
         HStack(spacing: 8) {
@@ -777,14 +777,14 @@ private struct WorkbenchSidebarRow: View {
                 // White over the blue highlight when selected; blue tint otherwise.
                 .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.tint))
                 .lineLimit(1)
-        } else if needsRestart, let from = runningVersion {
-            // Self-updated on disk: show running version → installed marketing version
-            // (build) so "Relaunch" reads as a real change. `from` is pre-formatted by
-            // `restartFromVersion` — the running build, or "marketing (build)" when the
-            // pre-update marketing version is recoverable from the rollback backup; the
-            // on-disk `to` side carries the marketing version, e.g. "1.7.3 (194)".
-            let to = result.restartTargetVersion
-            Text("\(from) → \(to)")
+        } else if needsRestart, let running = runningVersion {
+            // Self-updated on disk: show running version → the version on disk, so
+            // "Relaunch" reads as a real change. Formatted as a pair by
+            // `relaunchLine`, which keeps the build numbers only when the marketing
+            // versions cannot tell the two apart — the same rule the update subtitle
+            // above gets from `buildBump`.
+            let line = UpdateResult.relaunchLine(from: running, to: result.relaunchTargetSide)
+            Text("\(line.from) → \(line.to)")
                 .font(.caption)
                 .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.orange))
                 .lineLimit(1)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -501,21 +501,39 @@ public enum UpdatePolicy {
     /// Normalize app bundle paths reported by running processes back to the live
     /// installed bundle. macOS can keep a process mapped to DuoUpdater's temporary
     /// `replaceItemAt` staging name after a hot swap; treating that hidden/deleted
-    /// path as distinct makes running detection and Restart miss the exact app.
+    /// path as distinct makes running detection and Relaunch miss the exact app.
+    ///
+    /// Rewrites **every** component, not just the last one. An app nested inside
+    /// another app's bundle — Surge ships `Surge.app/Contents/Applications/Surge
+    /// Dashboard.app`, and it is a full app with its own bundle id, not a helper
+    /// the parent process owns — reports a path whose staged component is in the
+    /// middle:
+    ///
+    ///     /Applications/.duoupdater-staged-Surge.app/Contents/Applications/Surge Dashboard.app
+    ///
+    /// Normalising the leaf alone left that string untouched, so nothing could
+    /// tell that the process belonged to Surge at all, and the nested app went on
+    /// running the pre-swap binary out of a bundle that had been moved aside.
     public static func runtimeBundlePath(_ url: URL) -> String {
         let resolved = url.resolvingSymlinksInPath()
-        let name = resolved.lastPathComponent
-        let parent = resolved.deletingLastPathComponent()
         let stagedPrefix = ".duoupdater-staged-"
-
-        if name.hasPrefix(stagedPrefix) {
-            let original = String(name.dropFirst(stagedPrefix.count))
-            return parent.appendingPathComponent(original).resolvingSymlinksInPath().path
+        var components = resolved.pathComponents
+        var rewrote = false
+        for index in components.indices {
+            let name = components[index]
+            if name.hasPrefix(stagedPrefix) {
+                components[index] = String(name.dropFirst(stagedPrefix.count))
+                rewrote = true
+                continue
+            }
+            for suffix in [".duoupdater-old", ".duoupdater-new"] where name.hasSuffix(suffix) {
+                components[index] = String(name.dropLast(suffix.count))
+                rewrote = true
+                break
+            }
         }
-        for suffix in [".duoupdater-old", ".duoupdater-new"] where name.hasSuffix(suffix) {
-            let original = String(name.dropLast(suffix.count))
-            return parent.appendingPathComponent(original).resolvingSymlinksInPath().path
-        }
-        return resolved.path
+        guard rewrote else { return resolved.path }
+        return URL(fileURLWithPath: NSString.path(withComponents: components))
+            .resolvingSymlinksInPath().path
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -52,7 +52,15 @@ public enum AppRestarter {
         // Sampled before the quit — once every instance is gone, so is the
         // answer — and decides whether the relaunch takes the foreground (see
         // `isFrontmost`).
-        let wasFrontmost = isFrontmost(running)
+        //
+        // Judged per bundle, not over the union. `isFrontmost(running)` answers
+        // "was any of these in front", which is the wrong question once nested apps
+        // are in the set: a user working in Surge's Dashboard while Surge itself sat
+        // buried would have had Surge shoved in front of them, and the Dashboard —
+        // the window they actually had — brought back behind it.
+        let frontmostPath = NSWorkspace.shared.frontmostApplication?.bundleURL
+            .map { UpdatePolicy.runtimeBundlePath($0) }
+        let parentPath = UpdatePolicy.runtimeBundlePath(app.path)
         // Captured before the quit, and normalized: a nested app already stranded
         // on a staged bundle reports the moved-aside path, and what we want to
         // relaunch is its live location.
@@ -72,9 +80,21 @@ public enum AppRestarter {
                 "app-restarter: \(app.name, privacy: .public) won't quit (likely a save prompt) — leaving it running")
             return .stillRunning
         }
-        let relaunched = await launchApp(app.path, activates: wasFrontmost)
-        Log.install.info(
-            "app-restarter: \(app.name, privacy: .public) relaunched=\(relaunched, privacy: .public)")
+        // Only if it was running. Without this the emptiness guard above — which
+        // now passes on a nested app alone — would *start* an app the user had
+        // closed: quit Surge, leave its Dashboard up, and a relaunch would open
+        // Surge. Nothing of a parent that is not running is stale, so there is
+        // nothing for us to put back.
+        let relaunched: Bool
+        if main.isEmpty {
+            relaunched = true
+            Log.install.info(
+                "app-restarter: \(app.name, privacy: .public) was not running itself — only its nested app(s) needed clearing")
+        } else {
+            relaunched = await launchApp(app.path, activates: frontmostPath == parentPath)
+            Log.install.info(
+                "app-restarter: \(app.name, privacy: .public) relaunched=\(relaunched, privacy: .public)")
+        }
         // Put back the nested apps that were open, after the parent — several only
         // make sense once it is up. Skipped when the parent has already reopened
         // one itself, which is common and would otherwise be a second launch of an
@@ -89,7 +109,7 @@ public enum AppRestarter {
                     "app-restarter: \(bundle.lastPathComponent, privacy: .public) already reopened by its parent")
                 continue
             }
-            let back = await launchApp(bundle, activates: false)
+            let back = await launchApp(bundle, activates: frontmostPath == target)
             Log.install.info(
                 "app-restarter: nested \(bundle.lastPathComponent, privacy: .public) relaunched=\(back, privacy: .public)")
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -38,22 +38,36 @@ public enum AppRestarter {
     @discardableResult
     public static func restart(_ app: InstalledApp) async -> Outcome {
         guard app.bundleID != nil else { return .noBundleID }
-        let running = runningInstances(of: app)
+        let main = runningInstances(of: app)
+        // Apps nested inside this one count as instances of it. They are separate
+        // macOS apps with their own bundle ids, not child processes the parent's
+        // lifetime governs, so nothing terminates them when the parent quits and
+        // macOS does not tear them down either. Left running across the swap they
+        // keep executing the pre-swap binary out of the bundle we moved aside —
+        // Surge's Dashboard did exactly that, and then could not talk to the new
+        // Surge it was no longer part of.
+        let nested = nestedRunningInstances(of: app)
+        let running = main + nested
         guard !running.isEmpty else { return .notRunning }
         // Sampled before the quit — once every instance is gone, so is the
         // answer — and decides whether the relaunch takes the foreground (see
         // `isFrontmost`).
         let wasFrontmost = isFrontmost(running)
+        // Captured before the quit, and normalized: a nested app already stranded
+        // on a staged bundle reports the moved-aside path, and what we want to
+        // relaunch is its live location.
+        let nestedBundles = nested.compactMap(\.bundleURL)
+            .map { URL(fileURLWithPath: UpdatePolicy.runtimeBundlePath($0)) }
         for instance in running { instance.terminate() }
         // Wait up to ~30s for a graceful quit. A heavy app (large workspace) can
         // take well over the old 6s to actually exit; bailing early would leave
         // it terminated-but-not-relaunched. The only case given up on is a
         // genuine hang/save-prompt, where the app stays *up* (never stranded down).
         for _ in 0..<150 {
-            if runningInstances(of: app).isEmpty { break }
+            if allRunningInstances(of: app).isEmpty { break }
             try? await Task.sleep(for: .milliseconds(200))
         }
-        guard runningInstances(of: app).isEmpty else {
+        guard allRunningInstances(of: app).isEmpty else {
             Log.install.error(
                 "app-restarter: \(app.name, privacy: .public) won't quit (likely a save prompt) — leaving it running")
             return .stillRunning
@@ -61,7 +75,59 @@ public enum AppRestarter {
         let relaunched = await launchApp(app.path, activates: wasFrontmost)
         Log.install.info(
             "app-restarter: \(app.name, privacy: .public) relaunched=\(relaunched, privacy: .public)")
+        // Put back the nested apps that were open, after the parent — several only
+        // make sense once it is up. Skipped when the parent has already reopened
+        // one itself, which is common and would otherwise be a second launch of an
+        // app that is now running.
+        for bundle in nestedBundles {
+            let target = UpdatePolicy.runtimeBundlePath(bundle)
+            let alreadyBack = NSWorkspace.shared.runningApplications.contains {
+                matchesBundlePath($0.bundleURL, target: target)
+            }
+            guard !alreadyBack else {
+                Log.install.debug(
+                    "app-restarter: \(bundle.lastPathComponent, privacy: .public) already reopened by its parent")
+                continue
+            }
+            let back = await launchApp(bundle, activates: false)
+            Log.install.info(
+                "app-restarter: nested \(bundle.lastPathComponent, privacy: .public) relaunched=\(back, privacy: .public)")
+        }
         return .relaunched(relaunched)
+    }
+
+    /// Every live process belonging to this bundle — the app itself and anything
+    /// nested inside it. The set the quit-wait has to watch: waiting only on the
+    /// parent declared success while a nested app was still up, and the swap then
+    /// moved the bundle out from under it.
+    public static func allRunningInstances(of app: InstalledApp) -> [NSRunningApplication] {
+        runningInstances(of: app) + nestedRunningInstances(of: app)
+    }
+
+    /// Running apps whose bundle lives *inside* `app`'s bundle.
+    ///
+    /// Found by asking what is running rather than by walking the bundle on disk,
+    /// so it holds at any nesting depth and still finds a process whose bundle has
+    /// already been moved aside by a swap (`runtimeBundlePath` maps that back).
+    /// Neither filter in `runningInstances(of:)` can see these: a nested app has
+    /// its own bundle id, so it is never in the parent's candidate set, and its
+    /// path is a child of the target rather than equal to it.
+    public static func nestedRunningInstances(of app: InstalledApp) -> [NSRunningApplication] {
+        let target = UpdatePolicy.runtimeBundlePath(app.path)
+        return NSWorkspace.shared.runningApplications.filter {
+            isNestedInside($0.bundleURL, target: target)
+        }
+    }
+
+    /// True when a running instance's bundle URL resolves — after normalising away
+    /// DuoUpdater's staging names — to a path strictly *inside* `target`. Split out
+    /// as the pure half of `nestedRunningInstances(of:)`, like `matchesBundlePath`.
+    /// The trailing separator matters: without it a sibling named `Surge Beta.app`
+    /// would read as nested inside `Surge.app`.
+    static func isNestedInside(_ candidateBundleURL: URL?, target: String) -> Bool {
+        guard let candidateBundleURL else { return false }
+        let path = UpdatePolicy.runtimeBundlePath(candidateBundleURL)
+        return path != target && path.hasPrefix(target + "/")
     }
 
     /// The running instances launched from *this exact .app*, not just any app

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -115,8 +115,34 @@ public enum AppRestarter {
     public static func nestedRunningInstances(of app: InstalledApp) -> [NSRunningApplication] {
         let target = UpdatePolicy.runtimeBundlePath(app.path)
         return NSWorkspace.shared.runningApplications.filter {
-            isNestedInside($0.bundleURL, target: target)
+            isNestedInside($0.bundleURL, target: target) && isStandaloneNestedApp($0)
         }
+    }
+
+    /// Whether a nested running process is a *standalone app* rather than a piece
+    /// of machinery its parent owns.
+    ///
+    /// Being nested is not enough, and the first version of this got it wrong: a
+    /// bare containment test also catches every Chromium renderer
+    /// (`…/Frameworks/Claude Helper.app`, `Google Chrome Helper.app`), XPC services,
+    /// `.appex` extensions and CEF servers. Terminating those is pointless — the
+    /// parent starts and stops them — and launching one again afterwards is worse
+    /// than pointless, since a renderer started on its own does nothing.
+    ///
+    /// The line is the activation policy. Measured across the 13 nested processes
+    /// running on the development machine, exactly one was `.regular`: Surge's
+    /// Dashboard, the only one with a UI of its own. Every helper, renderer, XPC
+    /// service and extension was `.accessory` or `.prohibited`. That is not a
+    /// coincidence of the sample — a component a parent manages has no reason to
+    /// present itself to the user, and an app the user opened does.
+    ///
+    /// The cost is a nested *accessory* app — a menu-bar utility living inside
+    /// another bundle — which this will not relaunch. That is the safe direction to
+    /// be wrong in: missing one leaves the user to reopen it, while quitting a
+    /// renderer mid-swap breaks the app we are updating.
+    static func isStandaloneNestedApp(_ candidate: NSRunningApplication) -> Bool {
+        guard candidate.bundleURL?.pathExtension == "app" else { return false }
+        return candidate.activationPolicy == .regular
     }
 
     /// True when a running instance's bundle URL resolves — after normalising away

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
@@ -181,7 +181,17 @@ public enum BackupStore {
         // across a crashed prior attempt.
         try fm.createDirectory(at: root, withIntermediateDirectories: true)
         let staging = root.appendingPathComponent(".staging-\(key)", isDirectory: true)
-        try? fm.removeItem(at: staging)
+        // A leftover from a crashed attempt is expected and self-clearing — but only
+        // if the removal actually happens. `try?` swallowed the case where it does
+        // not, and a stale staging dir then sat in the backup store indefinitely
+        // (183 MB of a two-day-old ToDesk copy, found while investigating exactly
+        // that). Say so instead: whatever blocks it also blocks this backup.
+        if fm.fileExists(atPath: staging.path) {
+            do { try fm.removeItem(at: staging) } catch {
+                Log.install.error(
+                    "backup: leftover staging dir for \(key, privacy: .public) would not clear — \(error.localizedDescription, privacy: .public)")
+            }
+        }
         try fm.createDirectory(at: staging, withIntermediateDirectories: true)
 
         let name = appPath.lastPathComponent
@@ -195,6 +205,8 @@ public enum BackupStore {
         // nothing worth storing.
         let unreadable = BackupManifest.unreadableFiles(in: appPath)
         guard unreadable.sealed.isEmpty else {
+            Log.install.error(
+                "backup: \(name, privacy: .public) has \(unreadable.sealed.count, privacy: .public) sealed file(s) we cannot read, first \(unreadable.sealed.first ?? "?", privacy: .public) — that is payload, so there is nothing worth storing")
             try? fm.removeItem(at: staging)
             throw BackupError.payloadUnreadable(unreadable.sealed.first ?? appPath.path)
         }
@@ -203,12 +215,17 @@ public enum BackupStore {
         // code signature exactly — a plain copy can mangle them. It reports one
         // status for the whole run, so a non-zero exit is only acceptable once we
         // have confirmed the ONLY things it dropped are the ones we meant to drop.
-        if !runDitto(from: appPath, to: staged) {
+        let ditto = runDitto(from: appPath, to: staged)
+        if !ditto.ok {
+            Log.install.error(
+                "backup: ditto exited \(ditto.status, privacy: .public) copying \(name, privacy: .public) — \(ditto.stderrTail, privacy: .public)")
             // No expected omissions means the copy failed for some other reason
             // (a missing source, a full disk) and there is nothing to forgive.
             // Without this, a source that does not exist produced an empty copy
             // that passed the omission check and got stored as a backup.
             guard !unreadable.unsealed.isEmpty else {
+                Log.install.error(
+                    "backup: nothing about \(name, privacy: .public) was expected to be skipped, so the copy failed for its own reason")
                 try? fm.removeItem(at: staging)
                 throw BackupError.copyFailed(appPath.path)
             }
@@ -244,6 +261,8 @@ public enum BackupStore {
         guard let metaData = try? JSONEncoder().encode(meta),
               (try? metaData.write(to: staging.appendingPathComponent("backup.json"),
                                    options: .atomic)) != nil else {
+            Log.install.error(
+                "backup: the copy of \(name, privacy: .public) is complete but its sidecar would not write — discarding it, since every read path keys off the sidecar")
             try? fm.removeItem(at: staging)
             throw BackupError.copyFailed(appPath.path)
         }
@@ -258,6 +277,8 @@ public enum BackupStore {
                 try fm.moveItem(at: staging, to: dir)
             }
         } catch {
+            Log.install.error(
+                "backup: \(name, privacy: .public) copied and fingerprinted, but swapping it into place failed — \(error.localizedDescription, privacy: .public)")
             try? fm.removeItem(at: staging)
             throw BackupError.copyFailed(appPath.path)
         }
@@ -309,7 +330,10 @@ public enum BackupStore {
         defer { try? fm.removeItem(at: scratch) }
 
         let staged = scratch.appendingPathComponent(backup.bundlePath.lastPathComponent)
-        guard runDitto(from: backup.bundlePath, to: staged) else {
+        let ditto = runDitto(from: backup.bundlePath, to: staged)
+        guard ditto.ok else {
+            Log.install.error(
+                "restore: ditto exited \(ditto.status, privacy: .public) copying the stored \(backup.bundlePath.lastPathComponent, privacy: .public) out of the backup store — \(ditto.stderrTail, privacy: .public)")
             throw BackupError.copyFailed(backup.bundlePath.path)
         }
         // Integrity gate before swapping a backup over the live app: a stored copy
@@ -544,15 +568,45 @@ public enum BackupStore {
 
     /// `ditto src dst`, returning true on success. Faithfully duplicates a bundle
     /// including its code signature, unlike `FileManager.copyItem`.
-    private static func runDitto(from src: URL, to dst: URL) -> Bool {
-        try? FileManager.default.removeItem(at: dst)
+    /// What `ditto` did, rather than just whether it worked.
+    ///
+    /// The stderr used to go to `nullDevice`, so a failed backup could only ever
+    /// be reported as "failed" — while ditto had, at that moment, named the exact
+    /// file it could not copy. Keeping it is the difference between a report you
+    /// can act on and one that needs the failure reproduced first.
+    struct DittoOutcome {
+        let ok: Bool
+        let status: Int32
+        /// The tail of stderr. ditto emits one line per skipped file, and a big
+        /// bundle can produce hundreds; the last few are what identify the fault.
+        let stderrTail: String
+    }
+
+    private static func runDitto(from src: URL, to dst: URL) -> DittoOutcome {
+        let fm = FileManager.default
+        try? fm.removeItem(at: dst)
+        // stderr goes to a file rather than a `Pipe`: nothing drains a pipe while
+        // ditto runs, so a bundle noisy enough to fill the buffer would block it
+        // forever, turning a diagnostic into a hang.
+        let errURL = fm.temporaryDirectory.appendingPathComponent("duo-ditto-\(UUID().uuidString).err")
+        fm.createFile(atPath: errURL.path, contents: nil)
+        defer { try? fm.removeItem(at: errURL) }
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
         p.arguments = [src.path, dst.path]
         p.standardOutput = FileHandle.nullDevice
-        p.standardError = FileHandle.nullDevice
-        do { try p.run() } catch { return false }
+        let errHandle = try? FileHandle(forWritingTo: errURL)
+        p.standardError = errHandle ?? FileHandle.nullDevice
+        do { try p.run() } catch {
+            return DittoOutcome(ok: false, status: -1, stderrTail: "could not start ditto: \(error)")
+        }
         p.waitUntilExit()
-        return p.terminationStatus == 0
+        try? errHandle?.close()
+        let text = (try? String(contentsOf: errURL, encoding: .utf8)) ?? ""
+        let lines = text.split(separator: "\n")
+        let tail = lines.suffix(4).joined(separator: " | ")
+        return DittoOutcome(
+            ok: p.terminationStatus == 0, status: p.terminationStatus,
+            stderrTail: lines.count > 4 ? "(\(lines.count) lines) … \(tail)" : tail)
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
@@ -180,19 +180,27 @@ public enum BackupStore {
         // skipped by `allBackups`' directory scan) and keyed per app, so it self-cleans
         // across a crashed prior attempt.
         try fm.createDirectory(at: root, withIntermediateDirectories: true)
-        let staging = root.appendingPathComponent(".staging-\(key)", isDirectory: true)
-        // A leftover from a crashed attempt is expected and self-clearing — but only
-        // if the removal actually happens. `try?` swallowed the case where it does
-        // not, and a stale staging dir then sat in the backup store indefinitely
-        // (183 MB of a two-day-old ToDesk copy, found while investigating exactly
-        // that). Say so instead: whatever blocks it also blocks this backup.
-        if fm.fileExists(atPath: staging.path) {
-            do { try fm.removeItem(at: staging) } catch {
-                Log.install.error(
-                    "backup: leftover staging dir for \(key, privacy: .public) would not clear — \(error.localizedDescription, privacy: .public)")
-            }
-        }
-        try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+        // Unique per attempt. It used to be one fixed name per app, on the reasoning
+        // that a leftover from a crashed attempt would be cleared by the next run —
+        // which holds only while the leftover is ours to delete. ToDesk's was not:
+        // a crash mid-copy left a half-written bundle whose files a package install
+        // had made root-owned, the `try?` removal in front of it failed silently,
+        // `createDirectory(withIntermediateDirectories:)` then succeeded *because
+        // the directory already existed*, and ditto copied into a destination that
+        // still held those files:
+        //
+        //     ditto: …/.staging-com.youqu.todesk.mac-…/ToDesk.app/Contents/advInfo.json:
+        //            Operation not permitted
+        //
+        // So one crash permanently disabled backups for that app, and every update
+        // since had said only "proceeding without a rollback point". A name nothing
+        // else can be sitting on removes that failure mode entirely: whatever is
+        // stranded in the store may waste space, but it can no longer poison the
+        // next attempt.
+        let staging = root.appendingPathComponent(
+            ".staging-\(key)-\(UUID().uuidString)", isDirectory: true)
+        sweepStagingLeftovers(in: root, key: key)
+        try fm.createDirectory(at: staging, withIntermediateDirectories: false)
 
         let name = appPath.lastPathComponent
         let staged = staging.appendingPathComponent(name)
@@ -239,6 +247,14 @@ public enum BackupStore {
             }
         }
 
+        // Our copy from here on, so it must not inherit a flag that would stop us
+        // ever replacing or removing it — see `clearUserImmutableFlags`. Done before
+        // the fingerprint so the manifest describes what is actually stored.
+        if !clearUserImmutableFlags(under: staged) {
+            Log.install.error(
+                "backup: could not clear immutable flags on the copy of \(name, privacy: .public) — retention may not be able to replace it later")
+        }
+
         let savedAt = Date()
         // Fingerprinted from the staged copy, not the source: what restore has
         // to be able to trust is that the bytes in the store are the ones that
@@ -272,11 +288,28 @@ public enum BackupStore {
         // rather than the multi-second copy above).
         do {
             if fm.fileExists(atPath: dir.path) {
+                // The copy being superseded has to be deletable for the exchange to
+                // finish. One written before we started stripping `uchg` — or by any
+                // path where stripping failed — still carries it, and `replaceItemAt`
+                // cannot remove it. Clearing it here is what lets retention ever get
+                // past a single poisoned generation.
+                clearUserImmutableFlags(under: dir)
                 _ = try fm.replaceItemAt(dir, withItemAt: staging)
             } else {
                 try fm.moveItem(at: staging, to: dir)
             }
         } catch {
+            // `replaceItemAt` can put the new item in place and *then* fail removing
+            // the one it displaced. Reporting that as a failed backup is worse than
+            // wrong: it tells the user there is no rollback point while a complete,
+            // fingerprinted one sits in the store, and the update proceeds as though
+            // it were unprotected. Ask what is actually on disk instead of inferring
+            // it from the throw.
+            if let landed = backup(forKey: key), landed.savedAt == savedAt {
+                Log.install.error(
+                    "backup: \(name, privacy: .public) is stored and usable, but the copy it replaced would not delete — \(error.localizedDescription, privacy: .public)")
+                return landed
+            }
             Log.install.error(
                 "backup: \(name, privacy: .public) copied and fingerprinted, but swapping it into place failed — \(error.localizedDescription, privacy: .public)")
             try? fm.removeItem(at: staging)
@@ -580,6 +613,51 @@ public enum BackupStore {
         /// The tail of stderr. ditto emits one line per skipped file, and a big
         /// bundle can produce hundreds; the last few are what identify the fault.
         let stderrTail: String
+    }
+
+    /// Clear the user-immutable (`uchg`) flag under a copy we own.
+    ///
+    /// `ditto` preserves file flags, and an app is free to set `uchg` on files it
+    /// wants to protect — ToDesk does, on `Contents/advInfo.json`. An immutable
+    /// file cannot be deleted by anyone but root, its own owner included, so the
+    /// flag rides into the backup store and makes our copy permanently
+    /// undeletable: the staging directory cannot be cleared, and retention cannot
+    /// replace the copy it is meant to supersede. The vendor's reason for the flag
+    /// applies to the app they installed, not to a rollback copy in our own
+    /// Application Support, so we drop it.
+    ///
+    /// Only `uchg`. `schg` is the system-immutable flag and needs root to clear;
+    /// nothing we store should carry one, and if something does, failing loudly
+    /// later is better than pretending we can handle it here.
+    @discardableResult
+    private static func clearUserImmutableFlags(under url: URL) -> Bool {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/chflags")
+        p.arguments = ["-R", "nouchg", url.path]
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        do { try p.run() } catch { return false }
+        p.waitUntilExit()
+        return p.terminationStatus == 0
+    }
+
+    /// Best-effort removal of staging dirs left by earlier attempts for this app.
+    /// Best-effort is the point: one that will not go is reported and stepped
+    /// around, never allowed to fail the backup that follows. Hidden names, so
+    /// `allBackups`' directory scan skips them either way.
+    private static func sweepStagingLeftovers(in root: URL, key: String) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: root.path) else { return }
+        for name in entries where name.hasPrefix(".staging-\(key)") {
+            let leftover = root.appendingPathComponent(name)
+            // Anything we copied may carry a `uchg` the source set; clear it before
+            // trying, or a leftover written before this existed can never be swept.
+            clearUserImmutableFlags(under: leftover)
+            do { try fm.removeItem(at: leftover) } catch {
+                Log.install.error(
+                    "backup: leftover staging dir \(name, privacy: .public) would not clear — \(error.localizedDescription, privacy: .public); this backup uses a fresh one, but that directory is stranded until it is removed by hand")
+            }
+        }
     }
 
     private static func runDitto(from src: URL, to dst: URL) -> DittoOutcome {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -143,14 +143,28 @@ public enum InPlaceSwap {
         // nothing either way is the exact ambiguity this is here to remove.
         let elevated = needsElevatedReplace(target: target)
         var replaced = false
+        // The bundle's identity before we touch it. `fileExists` cannot answer the
+        // question the failure branch asks: after a successful replacement the path
+        // exists too, so it reported "the app on disk is unchanged" for both
+        // outcomes. `replaceItemAt` can put the new bundle in place and *then*
+        // throw while removing the one it displaced — observed restoring ToDesk on
+        // 2026-08-26, where the app really had been replaced and the log said the
+        // opposite. The inode distinguishes them.
+        let identityBefore = inode(of: target)
         Log.install.notice(
             "swap start: \(target.lastPathComponent, privacy: .public) elevated=\(elevated, privacy: .public)")
         defer {
             if replaced {
                 Log.install.notice("swap done: \(target.lastPathComponent, privacy: .public)")
             } else if FileManager.default.fileExists(atPath: target.path) {
-                Log.install.error(
-                    "swap did NOT replace \(target.lastPathComponent, privacy: .public) — the app on disk is unchanged")
+                let identityAfter = inode(of: target)
+                if let before = identityBefore, let after = identityAfter, before != after {
+                    Log.install.error(
+                        "swap threw for \(target.lastPathComponent, privacy: .public) but the bundle at that path was REPLACED anyway — the error came after the exchange, so the new version is live and the failure is in the cleanup")
+                } else {
+                    Log.install.error(
+                        "swap did NOT replace \(target.lastPathComponent, privacy: .public) — the app on disk is unchanged")
+                }
             } else {
                 // The privileged path moves the target aside before moving the new
                 // bundle in, and restores it if that fails. If the restore ALSO
@@ -175,7 +189,29 @@ public enum InPlaceSwap {
             do {
                 _ = try fm.replaceItemAt(target, withItemAt: staged, backupItemName: nil, options: [])
             } catch {
-                try? fm.removeItem(at: staged)
+                // What actually went wrong, before it is folded into one of two
+                // user-facing shapes. Both of those describe a cause rather than
+                // report the error, so without this line a misclassification is
+                // indistinguishable from the real thing — which is how a ToDesk
+                // restore that had already landed came out as "grant App
+                // Management", with `duo doctor` saying it was granted all along.
+                let ns = error as NSError
+                Log.install.error(
+                    "swap: replaceItemAt threw for \(target.lastPathComponent, privacy: .public) — \(ns.domain, privacy: .public) \(ns.code, privacy: .public): \(ns.localizedDescription, privacy: .public)")
+                if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? NSError {
+                    Log.install.error(
+                        "swap: underlying \(underlying.domain, privacy: .public) \(underlying.code, privacy: .public): \(underlying.localizedDescription, privacy: .public)")
+                }
+                // A staged sibling we cannot clear is left in `/Applications` for
+                // good — root-owned after a package install, and `try?` said
+                // nothing about it. `recoverInterruptedSwaps` sweeps unprivileged
+                // and cannot remove it either, so name it here or nobody learns.
+                if fm.fileExists(atPath: staged.path) {
+                    do { try fm.removeItem(at: staged) } catch {
+                        Log.install.error(
+                            "swap: left \(staged.lastPathComponent, privacy: .public) behind in \(parent.path, privacy: .public) — \(error.localizedDescription, privacy: .public)")
+                    }
+                }
                 // `/Applications` is group-writable for admins, so we took the
                 // user-level path — but replacing *another app's* bundle is gated
                 // by App Management on macOS 13+. That denial surfaces as EPERM;
@@ -376,6 +412,14 @@ public enum InPlaceSwap {
     /// Whether an error (or anything in its underlying-error chain) is the
     /// `EPERM`/`NSFileWriteNoPermission` denial that the App Management gate
     /// raises when we try to overwrite another app's bundle.
+    /// The bundle's inode, or nil when it cannot be read. Identity rather than
+    /// existence: it is what lets the failure path tell "never replaced" from
+    /// "replaced, then threw", which look identical to `fileExists`.
+    private static func inode(of url: URL) -> UInt64? {
+        (try? FileManager.default.attributesOfItem(atPath: url.path))?[.systemFileNumber]
+            .flatMap { ($0 as? NSNumber)?.uint64Value }
+    }
+
     static func isAppManagementDenial(_ error: Error) -> Bool {
         var current: NSError? = error as NSError
         while let e = current {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
@@ -202,7 +202,17 @@ public actor InstallCoordinator {
                 return unreadable.unsealed.isEmpty
                     ? .saved
                     : .savedWithoutRuntimeState(omitted: unreadable.unsealed.count)
-            } catch { return .failed }
+            } catch {
+                // The identity of the error is the whole diagnosis, and collapsing
+                // every `BackupError` into a bare `.failed` threw it away: the log
+                // could say a backup failed but never which of the half-dozen
+                // throws in `save` fired, so a report could not be acted on without
+                // first reproducing it. Each of those sites now says what it saw;
+                // this records which one won.
+                Log.install.error(
+                    "backup: \(path.lastPathComponent, privacy: .public) failed — \(error.localizedDescription, privacy: .public)")
+                return .failed
+            }
         }.value
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -286,6 +286,65 @@ extension UpdateResult {
         return (installed, remoteClean)
     }
 
+    /// One end of a **relaunch** line — the running process on the left, the bundle
+    /// already on disk on the right — before it is decided whether its build number
+    /// is worth the width.
+    ///
+    /// The two ends are formatted together (see ``UpdateResult/relaunchLine(from:to:)``)
+    /// rather than each on its own, which is the whole point: a side cannot tell on
+    /// its own whether its build is the interesting part.
+    public struct VersionSide: Sendable, Equatable {
+        public var marketing: String?
+        public var build: String?
+
+        public init(marketing: String? = nil, build: String? = nil) {
+            self.marketing = marketing
+            self.build = build
+        }
+
+        /// "1.7.3 (194)", "1.7.3", or a bare "194" — whichever the parts support.
+        /// A build equal to the marketing version is never repeated after it.
+        public func text(withBuild: Bool) -> String {
+            guard let marketing else { return build ?? "?" }
+            guard withBuild, let build, build != marketing else { return marketing }
+            return "\(marketing) (\(build))"
+        }
+    }
+
+    /// The on-disk side of a relaunch line: the version a relaunch will land.
+    public var relaunchTargetSide: VersionSide {
+        VersionSide(marketing: app.shortVersion,
+                    build: app.buildVersion.map(Self.strippingBuildPrefix))
+    }
+
+    /// Format both ends of a relaunch line, keeping the build numbers only when they
+    /// are what tells the two versions apart.
+    ///
+    /// This is ``buildBump(latest:)``'s rule, which the *update* line has always
+    /// applied, finally reaching the relaunch line. Each side used to format itself,
+    /// so both kept their build whatever the other looked like, and Chrome — whose
+    /// marketing version already ends in its build — rendered as
+    /// `151.0.7922.174 (7922.17… → 152.0.7977.65 (7977.65)`: the side the user is
+    /// leaving got truncated in order to repeat digits the marketing version had
+    /// already spelled out.
+    ///
+    /// Kept when the marketing versions match, because then the build is the only
+    /// thing that moved: Surge shipped four separate releases as "6.9.0", and
+    /// "6.9.0 → 6.9.0" says nothing at all.
+    ///
+    /// **Both** marketing versions have to be present before a build is dropped.
+    /// `lsappinfo` exposes only the running *build*, and when nothing recovered a
+    /// marketing version to pair with it that side is a bare number — dropping the
+    /// target's build there would leave "3965 → 1.7.3", two values from different
+    /// namespaces with no way to read one against the other.
+    public static func relaunchLine(
+        from: VersionSide, to: VersionSide
+    ) -> (from: String, to: String) {
+        let bothNamed = from.marketing != nil && to.marketing != nil
+        let withBuild = !(bothNamed && from.marketing != to.marketing)
+        return (from.text(withBuild: withBuild), to.text(withBuild: withBuild))
+    }
+
 }
 
 public enum UpdateStatus: Sendable, Equatable {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
@@ -110,4 +110,45 @@ import Foundation
         // Still unclaimed, so `onTimeout` never ran.
         #expect(timedOut.claim())
     }
+
+    /// An app nested inside the target's bundle is an instance of it for quit and
+    /// relaunch purposes, and neither existing filter can see one: it carries its
+    /// own bundle id, so it never enters the parent's candidate set, and its path
+    /// is a child of the target rather than equal to it.
+    @Test func anAppNestedInTheBundleCountsAsInside() {
+        let target = "/Applications/Surge.app"
+        let dashboard = URL(fileURLWithPath:
+            "/Applications/Surge.app/Contents/Applications/Surge Dashboard.app")
+        #expect(AppRestarter.isNestedInside(dashboard, target: target))
+        // …including one already stranded on the moved-aside bundle, which is the
+        // state the swap leaves it in and the state we have to recognise to fix it.
+        #expect(AppRestarter.isNestedInside(
+            URL(fileURLWithPath:
+                "/Applications/.duoupdater-staged-Surge.app/Contents/Applications/Surge Dashboard.app"),
+            target: target))
+    }
+
+    /// The bundle itself is not nested in itself — `runningInstances(of:)` already
+    /// owns that one, and counting it twice would terminate it twice and make the
+    /// relaunch loop reopen the parent as if it were a helper.
+    @Test func theBundleItselfIsNotNestedInItself() {
+        let target = "/Applications/Surge.app"
+        #expect(!AppRestarter.isNestedInside(URL(fileURLWithPath: target), target: target))
+    }
+
+    /// The separator is load-bearing: a prefix test without it reads a sibling
+    /// whose name merely starts with the target's as living inside it, and a
+    /// Surge update would quit Surge Beta.
+    @Test func aSiblingSharingAPrefixIsNotNested() {
+        let target = "/Applications/Surge.app"
+        #expect(!AppRestarter.isNestedInside(
+            URL(fileURLWithPath: "/Applications/Surge Beta.app"), target: target))
+        #expect(!AppRestarter.isNestedInside(
+            URL(fileURLWithPath: "/Applications/Surge.app.backup/Contents/MacOS/x.app"),
+            target: target))
+    }
+
+    @Test func nothingIsNestedInsideNoBundleURL() {
+        #expect(!AppRestarter.isNestedInside(nil, target: "/Applications/Surge.app"))
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
@@ -151,4 +151,34 @@ import Foundation
     @Test func nothingIsNestedInsideNoBundleURL() {
         #expect(!AppRestarter.isNestedInside(nil, target: "/Applications/Surge.app"))
     }
+
+    /// Being nested is not enough to be an instance worth quitting.
+    ///
+    /// The path test alone also matches every Chromium renderer, XPC service and
+    /// `.appex` living inside an app bundle. Measured on the development machine:
+    /// of 13 nested running processes, only Surge's Dashboard was `.regular` —
+    /// `Claude Helper.app`, `Google Chrome Helper.app`,
+    /// `WeChatAppEx Helper (Renderer).app`, `cef_server.app`, `DockHelper.xpc` and
+    /// `WeatherWidget.appex` were all `.accessory` or `.prohibited`. Terminating
+    /// those achieves nothing and relaunching one on its own is incoherent.
+    ///
+    /// Pinned as paths and policies rather than by driving `NSWorkspace`, which no
+    /// test can arrange.
+    @Test func onlyAStandaloneNestedAppCountsAsAnInstance() {
+        let target = "/Applications/Surge.app"
+        // Everything here IS nested — that is the point; the policy is what separates them.
+        let nested = [
+            "/Applications/Surge.app/Contents/Applications/Surge Dashboard.app",
+            "/Applications/Surge.app/Contents/Frameworks/Surge Helper.app",
+            "/Applications/Surge.app/Contents/XPCServices/Thing.xpc",
+            "/Applications/Surge.app/Contents/PlugIns/Ext.appex",
+        ]
+        for path in nested {
+            #expect(AppRestarter.isNestedInside(URL(fileURLWithPath: path), target: target),
+                    "\(path) should read as nested")
+        }
+        // …and only the `.app` bundles can even reach the policy test.
+        #expect(URL(fileURLWithPath: nested[2]).pathExtension != "app")
+        #expect(URL(fileURLWithPath: nested[3]).pathExtension != "app")
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
@@ -618,4 +618,124 @@ struct BackupStoreTests {
             #expect(goneEntry.sizeBytes > 0)
         }
     }
+
+    /// A staging directory left by a crashed attempt must not be able to disable
+    /// backups for that app for good.
+    ///
+    /// ToDesk's did, from 2026-08-24 until it was found on 08-26: the leftover held
+    /// root-owned files a package install had put there, the removal in front of it
+    /// was a `try?` and failed silently, `createDirectory` then succeeded because
+    /// the directory already existed, and ditto copied into a destination still
+    /// holding those files — `advInfo.json: Operation not permitted`, every time.
+    /// Every update since had reported only "proceeding without a rollback point".
+    ///
+    /// Simulated by making the leftover's contents unremovable through its own
+    /// permissions rather than by owner, which needs no root and fails removal the
+    /// same way. The assertion is that the backup succeeds regardless.
+    @Test func aLeftoverStagingDirThatWillNotClearDoesNotBlockTheBackup() throws {
+        try withScratchRoot { root in
+            let fm = FileManager.default
+            let apps = root.appendingPathComponent("apps")
+            try fm.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "Poisoned.app", in: apps, marker: "v1")
+            let key = BackupStore.key(bundleID: "com.example.poisoned", path: app)
+
+            // A leftover whose inner directory cannot be written, so removing the
+            // file inside it — and therefore the leftover itself — fails.
+            let leftover = root.appendingPathComponent(".staging-\(key)")
+            let inner = leftover.appendingPathComponent("Poisoned.app/Contents")
+            try fm.createDirectory(at: inner, withIntermediateDirectories: true)
+            try Data("stale".utf8).write(to: inner.appendingPathComponent("advInfo.json"))
+            try fm.setAttributes([.posixPermissions: 0o500], ofItemAtPath: inner.path)
+            defer { try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: inner.path) }
+            #expect(throws: (any Error).self) { try fm.removeItem(at: leftover) }
+
+            let saved = try BackupStore.save(
+                appPath: app, key: key, version: "1.0", bundleID: "com.example.poisoned")
+            #expect(saved.version == "1.0")
+            let readBack = try #require(BackupStore.backup(forKey: key))
+            #expect(fm.fileExists(atPath: readBack.bundlePath.path))
+            // …and the stranded leftover is still there, untouched and reported,
+            // rather than silently swallowed or mistaken for this backup.
+            #expect(fm.fileExists(atPath: leftover.path))
+        }
+    }
+
+    /// A `uchg` file in the source must not make the stored copy undeletable.
+    ///
+    /// ToDesk sets the user-immutable flag on `Contents/advInfo.json`. `ditto`
+    /// preserves file flags, so the flag rode into the backup store, and an
+    /// immutable file cannot be removed by anyone but root — its owner included.
+    /// The copy was therefore permanent: the staging directory could not be
+    /// cleared, and retention could not replace the copy it superseded, so every
+    /// later backup of that app failed. Found on 2026-08-26 after three rounds of
+    /// looking at ownership and permissions, which were correct the whole time.
+    @Test func anImmutableFileInTheSourceDoesNotFreezeTheStoredCopy() throws {
+        try withScratchRoot { root in
+            let fm = FileManager.default
+            let apps = root.appendingPathComponent("apps")
+            try fm.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "Locked.app", in: apps, marker: "v1")
+            let locked = app.appendingPathComponent("Contents/advInfo.json")
+            try Data("{}".utf8).write(to: locked)
+            try fm.setAttributes([.immutable: true], ofItemAtPath: locked.path)
+            defer {
+                // The source is ours to unlock again; the assertions below are about
+                // the *copy*, and a scratch root that will not delete leaks a temp dir.
+                try? fm.setAttributes([.immutable: false], ofItemAtPath: locked.path)
+                for url in fm.enumerator(at: root, includingPropertiesForKeys: nil)?
+                    .compactMap({ $0 as? URL }) ?? [] {
+                    try? fm.setAttributes([.immutable: false], ofItemAtPath: url.path)
+                }
+            }
+            let key = BackupStore.key(bundleID: "com.example.locked", path: app)
+
+            let saved = try BackupStore.save(
+                appPath: app, key: key, version: "1.0", bundleID: "com.example.locked")
+            let copied = saved.bundlePath.appendingPathComponent("Contents/advInfo.json")
+            #expect(fm.fileExists(atPath: copied.path))
+            let flags = (try fm.attributesOfItem(atPath: copied.path)[.immutable] as? Bool) ?? false
+            #expect(!flags, "the stored copy kept the source's immutable flag")
+
+            // The point of clearing it: a second backup has to be able to replace
+            // the first. This is the call that failed for ToDesk every time.
+            let again = try BackupStore.save(
+                appPath: app, key: key, version: "1.1", bundleID: "com.example.locked")
+            #expect(again.version == "1.1")
+            #expect(BackupStore.backup(forKey: key)?.version == "1.1")
+        }
+    }
+
+    /// A backup generation written before the flag was stripped must not block the
+    /// one replacing it. This is the state a real machine is left in: one poisoned
+    /// copy already in the store, and every later backup failing to supersede it.
+    @Test func aPoisonedPreviousGenerationDoesNotBlockTheNextBackup() throws {
+        try withScratchRoot { root in
+            let fm = FileManager.default
+            let apps = root.appendingPathComponent("apps")
+            try fm.createDirectory(at: apps, withIntermediateDirectories: true)
+            let app = try makeApp(named: "Locked.app", in: apps, marker: "v1")
+            let key = BackupStore.key(bundleID: "com.example.locked", path: app)
+            defer {
+                for url in fm.enumerator(at: root, includingPropertiesForKeys: nil)?
+                    .compactMap({ $0 as? URL }) ?? [] {
+                    try? fm.setAttributes([.immutable: false], ofItemAtPath: url.path)
+                }
+            }
+
+            _ = try BackupStore.save(appPath: app, key: key, version: "1.0",
+                                     bundleID: "com.example.locked")
+            // Poison the stored generation the way `ditto` used to: a file inside it
+            // that nobody but root can delete.
+            let stored = root.appendingPathComponent(key)
+                .appendingPathComponent("Locked.app/Contents/advInfo.json")
+            try Data("{}".utf8).write(to: stored)
+            try fm.setAttributes([.immutable: true], ofItemAtPath: stored.path)
+
+            let again = try BackupStore.save(appPath: app, key: key, version: "1.1",
+                                             bundleID: "com.example.locked")
+            #expect(again.version == "1.1")
+            #expect(BackupStore.backup(forKey: key)?.version == "1.1")
+        }
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RelaunchLineTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RelaunchLineTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// `UpdateResult.relaunchLine` decides one thing: whether the build numbers earn
+/// their place on the row. The rule is the one `buildBump` already applies to the
+/// update line — a build is worth showing only when the marketing versions cannot
+/// tell the two versions apart — plus the constraint that a side with no marketing
+/// version of its own has nothing else to be read against.
+@Suite struct RelaunchLineTests {
+
+    private typealias Side = UpdateResult.VersionSide
+
+    private func app(short: String?, build: String?) -> InstalledApp {
+        InstalledApp(
+            name: "Google Chrome", bundleID: "com.google.Chrome", shortVersion: short,
+            buildVersion: build, path: URL(fileURLWithPath: "/Applications/Google Chrome.app"),
+            isMASApp: false, sparkleFeedURL: nil,
+            hasSelfUpdater: true, hasSparkleUpdater: false)
+    }
+
+    private func result(short: String?, build: String?) -> UpdateResult {
+        UpdateResult(app: app(short: short, build: build), remote: nil, status: .upToDate)
+    }
+
+    /// The case that prompted this. Chrome's marketing version *ends in* its build,
+    /// so the parenthesised half was pure repetition — and it cost enough width that
+    /// the running side truncated mid-number, losing the digits that differed.
+    @Test func chromeDropsBuildsTheMarketingVersionAlreadySpellsOut() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "151.0.7922.174", build: "7922.174"),
+            to: Side(marketing: "152.0.7977.65", build: "7977.65"))
+        #expect(line.from == "151.0.7922.174")
+        #expect(line.to == "152.0.7977.65")
+    }
+
+    /// The reason builds are shown at all: Surge shipped four separate releases as
+    /// "6.9.0", where dropping the build leaves a line that reads as a no-op.
+    @Test func sameMarketingVersionKeepsTheBuildsThatDiffer() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "6.9.0", build: "12028"),
+            to: Side(marketing: "6.9.0", build: "12030"))
+        #expect(line.from == "6.9.0 (12028)")
+        #expect(line.to == "6.9.0 (12030)")
+    }
+
+    /// `lsappinfo` exposes only the running build. When nothing recovered a marketing
+    /// version to pair with it, the target's build is the only value in the running
+    /// side's namespace — dropping it would leave "3965 → 1.7.3", two numbers that
+    /// cannot be read against each other.
+    @Test func abareRunningBuildKeepsTheTargetsBuild() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: nil, build: "3965"),
+            to: Side(marketing: "1.7.3", build: "194"))
+        #expect(line.from == "3965")
+        #expect(line.to == "1.7.3 (194)")
+    }
+
+    /// The deferred-batch line: the pre-install version we recorded is a marketing
+    /// version with no build, so both sides are named and the target's build goes.
+    @Test func aFromSideWithNoBuildStillSuppressesTheTargets() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "1.7.2", build: nil),
+            to: Side(marketing: "1.7.3", build: "194"))
+        #expect(line.from == "1.7.2")
+        #expect(line.to == "1.7.3")
+    }
+
+    /// Date/serial apps whose CFBundleVersion repeats CFBundleShortVersionString:
+    /// never print the same number twice, whatever the rule decided.
+    @Test func aBuildEqualToItsMarketingVersionIsNeverRepeated() {
+        let line = UpdateResult.relaunchLine(
+            from: Side(marketing: "2026.08.19", build: "2026.08.19"),
+            to: Side(marketing: "2026.08.19", build: "2026.08.19"))
+        #expect(line.from == "2026.08.19")
+        #expect(line.to == "2026.08.19")
+    }
+
+    @Test func aSideWithNothingAtAllDegradesRatherThanCrashing() {
+        #expect(Side(marketing: nil, build: nil).text(withBuild: true) == "?")
+        #expect(Side(marketing: nil, build: nil).text(withBuild: false) == "?")
+    }
+
+    /// `relaunchTargetSide` reads the bundle's own two fields, stripping the
+    /// JetBrains-style product prefix so it lands in the same namespace as the
+    /// running build `strippingBuildPrefix` also cleans.
+    @Test func theTargetSideComesOffTheBundleWithItsBuildPrefixStripped() {
+        #expect(result(short: "2026.2", build: "IU-262.7132.23").relaunchTargetSide
+                == Side(marketing: "2026.2", build: "262.7132.23"))
+        #expect(result(short: "1.7.3", build: nil).relaunchTargetSide
+                == Side(marketing: "1.7.3", build: nil))
+        #expect(result(short: nil, build: "194").relaunchTargetSide
+                == Side(marketing: nil, build: "194"))
+    }
+
+    /// Whatever the rule decides, it decides for both ends: a row that parenthesised
+    /// a build on one side only would invite reading the two halves as different
+    /// kinds of number.
+    ///
+    /// Judged over the sides that *could* carry a parenthesised build. One holding
+    /// only a bare build has no marketing version to put in front of it, so its
+    /// missing parentheses are the format rather than a suppressed build — asserting
+    /// on the parentheses alone called that case a violation when it is the intended
+    /// output.
+    @Test func neitherEndSuppressesABuildTheOtherIsShowing() {
+        let cases: [(Side, Side)] = [
+            (Side(marketing: "1.0", build: "10"), Side(marketing: "2.0", build: "20")),
+            (Side(marketing: "1.0", build: "10"), Side(marketing: "1.0", build: "20")),
+            (Side(marketing: nil, build: "10"), Side(marketing: "2.0", build: "20")),
+            (Side(marketing: "1.0", build: nil), Side(marketing: "1.0", build: "20")),
+        ]
+        for (from, to) in cases {
+            let line = UpdateResult.relaunchLine(from: from, to: to)
+            let shown = zip([from, to], [line.from, line.to])
+                .filter { $0.0.marketing != nil && $0.0.build != nil }
+                .map { $0.1.contains("(") }
+            #expect(Set(shown).count <= 1,
+                    "one end kept its build and the other dropped it: \(line)")
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
@@ -590,6 +590,25 @@ private func storeAvailability(
     #expect(path("Fixture.app.duoupdater-new") == "/Applications/Fixture.app")
 }
 
+/// A staged component is not always the last one. An app nested inside another
+/// app's bundle — Surge ships `Surge.app/Contents/Applications/Surge Dashboard.app`
+/// — reports a path whose staged component sits in the middle, and normalising
+/// only the leaf left the whole string pointing at the moved-aside bundle. Nothing
+/// could then tell the process belonged to Surge, so the quit-wait declared
+/// success while it was still up and the swap stranded it on the old binary.
+@Test func runtimeBundlePathNormalizesAStagedComponentAnywhereInThePath() {
+    func path(_ raw: String) -> String { UpdatePolicy.runtimeBundlePath(URL(fileURLWithPath: raw)) }
+    #expect(path("/Applications/.duoupdater-staged-Surge.app/Contents/Applications/Surge Dashboard.app")
+            == "/Applications/Surge.app/Contents/Applications/Surge Dashboard.app")
+    #expect(path("/Applications/Surge.app.duoupdater-old/Contents/Applications/Surge Dashboard.app")
+            == "/Applications/Surge.app/Contents/Applications/Surge Dashboard.app")
+    // Both ends at once, and a path with nothing to rewrite still comes back whole.
+    #expect(path("/Applications/.duoupdater-staged-Surge.app/Contents/Applications/Dash.app.duoupdater-new")
+            == "/Applications/Surge.app/Contents/Applications/Dash.app")
+    #expect(path("/Applications/Surge.app/Contents/Applications/Surge Dashboard.app")
+            == "/Applications/Surge.app/Contents/Applications/Surge Dashboard.app")
+}
+
 /// The shipped default for self-updating apps, pinned as behaviour rather than as
 /// a constant.
 ///


### PR DESCRIPTION
Four fixes that came out of watching one `Update All` run.

## 1. An app nested inside a bundle was invisible to the relaunch

Surge ships `Surge.app/Contents/Applications/Surge Dashboard.app` — a full app with its own bundle id, not a child process the parent's lifetime governs. Nothing terminates it when Surge quits and macOS does not tear it down either, so it survived the swap still executing the pre-swap binary out of the bundle we had moved aside.

Observed 2026-08-26: Surge's own process was replaced at 13:34:29; the Dashboard did not get a new one until 13:39:43, when the user quit it by hand.

Two things hid it:

- `runningInstances(of:)` filters candidates by the parent's bundle id (which a nested app does not share) and then requires the path to *equal* the target (which a child path never does). `nestedRunningInstances(of:)` asks what is running out of a path *inside* the bundle instead — any depth, no disk walk. The separator in the prefix test is load-bearing, or a sibling `Surge Beta.app` reads as nested inside `Surge.app`.
- `runtimeBundlePath` normalised only the last path component, so a nested app already stranded on `/Applications/.duoupdater-staged-Surge.app/Contents/Applications/Surge Dashboard.app` came back unchanged — and that is exactly the state we have to recognise to fix it. It now rewrites a staged component anywhere in the path.

The quit-wait watches both sets; nested apps are reopened after the parent, skipping any the parent brought back itself.

Not Surge-specific: any vendor embedding a standalone app hits it. Sparkle's relauncher does not cover it either — its API takes one bundle to wait on and restart, with no recursion.

## 2. An app's own `uchg` flag froze every backup we stored

ToDesk sets `uchg` on `Contents/advInfo.json`. `ditto` preserves file flags, and a user-immutable file cannot be deleted by anyone but root — its owner included. Backups for the app had been broken since 08-24, and every update in between said only "proceeding without a rollback point".

The flag jammed four places, each independently:

1. Every stored copy contained an undeletable file.
2. A crash left a `.staging-<key>` nobody could clear; the `try?` in front of the removal said nothing, `createDirectory(withIntermediateDirectories:)` then *succeeded* because the directory existed, and ditto copied into a destination still holding the file. **One crash disabled backups for that app permanently.**
3. Even with clean staging, `replaceItemAt` has to delete the generation it supersedes — which carried the flag too.
4. And `replaceItemAt` replaces and *then* throws, so a landed backup was reported as no backup at all.

Fixes: unique staging per attempt; `chflags -R nouchg` on copies we own (never the installed app; `schg` deliberately not handled — it needs root); the same on the generation being superseded; and asking the disk what landed instead of inferring failure from the throw.

## 3. A swap that threw after replacing was reported as one that never replaced

The failure branch decided "the app on disk is unchanged" from `fileExists(atPath:)` — true after a *successful* replacement too, since the new bundle is at that same path. Restoring ToDesk did exactly this: the restore landed, the log said it had not, and the error was mapped to `AppManagementRequiredError`, so `duo` told the user to grant App Management while `duo doctor` reported it granted all along. The inode distinguishes the two.

## 4. Failures now say which failure

`backUp` collapsed every `BackupError` into a bare `.failed`, and `save` has half a dozen mostly-silent throw sites, so a report could not be acted on without reproducing it first. Each site now says what it saw. `ditto`'s stderr was going to `nullDevice` — the one component that knows which file it could not copy — and is now captured (via a temp file, not a `Pipe`: nothing drains a pipe while ditto runs).

That diagnostic is what found #2, in one run.

## Testing

- `make test` — 1107 + 125 pass, 2 known issues (was 1091 at the start of this work)
- Five regression tests, each verified red on the pre-fix code with the same shape the production log showed
- **#2, #3 and #4 verified end to end on the affected machine**: the 184 MB stranded staging dir swept, a new generation superseding the poisoned one, no immutable file left in the store, and `duo doctor` no longer listing ToDesk as un-backupable
- **#1 is not yet verified on a real machine** — code analysis and unit tests only. A machine with an un-updated Surge is lined up for that.