### PR TITLE
Support BetterDisplay's three update tracks

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
@@ -79,6 +79,13 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
     /// from the app's channel preference at scan time (see `ChannelBinding`).
     public let sparkleFeedHeaders: [String: String]
 
+    /// The `<sparkle:channel>` tags this install is opted into, when the feed
+    /// spells them differently from `releaseChannel.rawValue` (BetterDisplay's
+    /// `pre` / `internal`). Empty = derive the tag from `releaseChannel`, which
+    /// is every other app. Set at scan time from `ChannelBinding`, and only
+    /// consulted when `channelIsAuthoritative` is true.
+    public let sparkleChannelNames: Set<String>
+
     /// `SUPublicEDKey` — the app's base64 Ed25519 public key. Used to verify
     /// the EdDSA signature on a downloaded Sparkle update.
     public let sparkleEdPublicKey: String?
@@ -182,6 +189,7 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
         isTestFlightApp: Bool = false,
         sparkleFeedURL: URL?,
         sparkleFeedHeaders: [String: String] = [:],
+        sparkleChannelNames: Set<String> = [],
         sparkleEdPublicKey: String? = nil,
         hasSelfUpdater: Bool = false,
         hasSparkleUpdater: Bool = false,
@@ -201,6 +209,7 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
         self.isTestFlightApp = isTestFlightApp
         self.sparkleFeedURL = sparkleFeedURL
         self.sparkleFeedHeaders = sparkleFeedHeaders
+        self.sparkleChannelNames = sparkleChannelNames
         self.sparkleEdPublicKey = sparkleEdPublicKey
         self.hasSelfUpdater = hasSelfUpdater
         self.hasSparkleUpdater = hasSparkleUpdater

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -204,6 +204,7 @@ public struct AppScanner: Sendable {
                 isTestFlightApp: true,
                 sparkleFeedURL: app.sparkleFeedURL,
                 sparkleFeedHeaders: app.sparkleFeedHeaders,
+                sparkleChannelNames: app.sparkleChannelNames,
                 sparkleEdPublicKey: app.sparkleEdPublicKey,
                 hasSelfUpdater: app.hasSelfUpdater,
                 hasSparkleUpdater: app.hasSparkleUpdater,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -471,6 +471,7 @@ public struct AppScanner: Sendable {
         // a beta build. See `ChannelBinding`.
         var channelIsAuthoritative = false
         var feedHeaders: [String: String] = [:]
+        var feedChannelNames: Set<String> = []
         // WeChat DevTools states its channel outright in its own `package.json`
         // (`versionType`), which beats every heuristic `detect` has: the three
         // channels share one bundle id, one app name, and a version string with no
@@ -484,6 +485,7 @@ public struct AppScanner: Sendable {
             channelIsAuthoritative = true
             if let feed = bound.feedOverride { feedURL = feed }
             feedHeaders = bound.feedHTTPHeaders
+            feedChannelNames = bound.sparkleChannelNames
         }
 
         return InstalledApp(
@@ -498,6 +500,7 @@ public struct AppScanner: Sendable {
             isTestFlightApp: isTestFlight,
             sparkleFeedURL: feedURL,
             sparkleFeedHeaders: feedHeaders,
+            sparkleChannelNames: feedChannelNames,
             sparkleEdPublicKey: (plist["SUPublicEDKey"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
             hasSelfUpdater: hasSelfUpdater,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/BetterDisplayChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/BetterDisplayChannel.swift
@@ -106,7 +106,15 @@ enum BetterDisplayChannel {
     }
 
     private static func readBoolPref(_ key: String) -> Bool {
-        (CFPreferencesCopyAppValue(key as CFString,
-                                   bundleID as CFString) as? NSNumber)?.boolValue ?? false
+        // Force a fresh read from cfprefsd before each look: this menu-bar process
+        // runs for days and can otherwise serve a value it cached before
+        // BetterDisplay wrote the toggle — which would defeat the whole point here,
+        // since the flip is exactly what `ChannelSwitchDetector` is watching for.
+        // `IINAChannel` and `TablePlusChannel` both carry this call for the same
+        // reason. One synchronize per key is redundant but free; the two keys are
+        // read back to back and the second sync finds nothing to do.
+        CFPreferencesAppSynchronize(bundleID as CFString)
+        return (CFPreferencesCopyAppValue(key as CFString,
+                                          bundleID as CFString) as? NSNumber)?.boolValue ?? false
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/BetterDisplayChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/BetterDisplayChannel.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// BetterDisplay (`pro.betterdisplay.BetterDisplay`) ships THREE tracks through
+/// ONE Sparkle appcast (`betterdisplay.pro/betterdisplay/sparkle/appcast.xml`),
+/// selected by two toggles in Settings → Application → Updates:
+///   * stable            → the untagged items (4.3.6 is the newest, 2026-08-26)
+///   * "Receive pre-release updates"          → `<sparkle:channel>pre`
+///   * "Receive internal pre-release updates" → `<sparkle:channel>internal`
+///
+/// The second toggle is only rendered once the first is on, so the GUI exposes
+/// three states, not four. `internal` therefore SUBSUMES `pre`: a user with both
+/// on must still be offered the plain `pre` builds when they are newer, which is
+/// why this resolves to a Set of tag names rather than a single one. The vendor
+/// states both halves outright, on the `pre` release itself
+/// (`api.github.com/repos/waydabber/BetterDisplay/releases/tags/pre`, read
+/// 2026-08-26): "Internal builds auto-update to newer internal builds until a
+/// proper pre-release or stable release comes by. To keep receiving internal
+/// builds even when a stable version was downloaded, enable `Receive pre-release
+/// updates` and then `Receive internal pre-release updates`."
+///
+/// Note for anyone adding a changelog recipe here later: the internal track's
+/// `<sparkle:releaseNotesLink>` is `changelog.html?tag=pre`, and that tag is a
+/// ROLLING GitHub release (published 2023-06-14, 26 assets accumulated across
+/// v3.0.5…v5.0.4) whose body is static boilerplate about what internal builds
+/// are — there are no per-version notes on that track at all. Only `pre` and
+/// stable items point at a real per-version tag.
+///
+/// Why a binding at all, when `SparkleAppcastSource` already infers the channel
+/// from the running build: the inference cannot see an opt-in the user has not
+/// yet acted on. Reproduced on this machine 2026-08-26 — BetterDisplay 4.3.6
+/// (build 50119, a stable-track build) with both toggles on, the vendor's own
+/// updater offering v5.0.4, and `duo check` reporting "up-to-date" because the
+/// installed build matches the untagged 4.3.6 item. The vendor documents the
+/// inference as the fallback, not the rule ("If you are already running a
+/// pre-release version, you'll receive pre-release updates until the next stable
+/// release even if this option is disabled").
+///
+/// The preference keys, read off `~/Library/Preferences/pro.betterdisplay.BetterDisplay.plist`
+/// on 2026-08-26 while flipping the GUI toggles:
+///     both off  → `preReleaseChannel` ABSENT,  `internalReleaseChannel` ABSENT
+///     both on   → `preReleaseChannel` 1,       `internalReleaseChannel` 1
+///     pre only  → `preReleaseChannel` 1,       `internalReleaseChannel` 0
+/// So the keys are absent until first touched and thereafter written explicitly,
+/// including a literal 0 on the way back down — the same behaviour Tailscale's
+/// equivalent pair shows. `readBoolPref` treats absent and 0 alike, so both
+/// spellings of "off" land on the same track.
+///
+/// ⚠️ `arm64_pre` is deliberately NOT in any allowed set. It is a real fourth tag
+/// in the feed and its builds are **arm64-only**. Measured 2026-08-26 by mounting
+/// every artifact in question and reading `lipo -archs`, so the tag↔architecture
+/// boundary is observed on both sides rather than extrapolated from one sample:
+///     5.0.0  arm64_pre  arm64            5.0.2  pre        x86_64 arm64
+///     5.0.1  arm64_pre  arm64            5.0.3  pre        x86_64 arm64
+///                                        5.0.4  internal   x86_64 arm64
+///                                        4.3.6  untagged   x86_64 arm64
+/// (2.3.9 and 3.5.6b are universal too.) Every one of those artifacts is signed
+/// by Team 299YSU96J7, the same identity as the installed app — so the signature
+/// gate cannot catch a cross-architecture mistake here either.
+/// Why the tag exists at all is unconfirmed; the timeline reads as "the first two
+/// v5 previews shipped Apple-silicon-only, and the tag kept Intel users on the
+/// `pre` track from being handed one", but the vendor has not said so.
+/// Nothing in the feed says so: the items declare no `<sparkle:hardwareRequirements>`
+/// and the enclosure is named `BetterDisplay-v5.0.1-pre-release.dmg` with no arch
+/// token, so `SparkleAppcastSource.archVerdict` would rate them `.neutral` and
+/// happily offer them to an Intel Mac that cannot run them. Excluding the tag
+/// costs nothing: 5.0.2+ moved to `pre` with a higher version, so an `arm64_pre`
+/// item could never be the offered update anyway — only two rows of changelog
+/// history are lost.
+///
+/// Safety: an unreadable or absent key falls back to `.stable` — the shipped
+/// default — so we never push a prerelease at someone who did not opt in.
+enum BetterDisplayChannel {
+    static let bundleID = "pro.betterdisplay.BetterDisplay"
+
+    /// The feed's tag for the plain pre-release track.
+    static let preTag = "pre"
+    /// The feed's tag for the internal track.
+    static let internalTag = "internal"
+
+    /// Map the two flags to a resolution. Pure and tested.
+    ///
+    /// `internalEnabled` is checked first and carries `preTag` with it, mirroring
+    /// the GUI's nesting. A hypothetical on-disk state with `internalReleaseChannel`
+    /// set but `preReleaseChannel` clear — not reachable through the GUI, but
+    /// producible by a `defaults write` or a future vendor bug — still resolves to
+    /// the internal track rather than silently downgrading, the same defensive
+    /// tie-break `TailscaleChannel.resolve` documents.
+    static func resolve(preEnabled: Bool, internalEnabled: Bool) -> ResolvedChannel {
+        if internalEnabled {
+            // `.unstable` is the closest `ReleaseChannel` case for a track the
+            // vendor itself calls "unstable, may contain major bugs". The feed's
+            // own spelling travels separately, in `sparkleChannelNames`.
+            return ResolvedChannel(
+                channel: .unstable, sparkleChannelNames: [preTag, internalTag]
+            )
+        }
+        if preEnabled {
+            return ResolvedChannel(channel: .beta, sparkleChannelNames: [preTag])
+        }
+        return ResolvedChannel(channel: .stable)
+    }
+
+    static func resolveCurrent() -> ResolvedChannel {
+        resolve(preEnabled: readBoolPref("preReleaseChannel"),
+                internalEnabled: readBoolPref("internalReleaseChannel"))
+    }
+
+    private static func readBoolPref(_ key: String) -> Bool {
+        (CFPreferencesCopyAppValue(key as CFString,
+                                   bundleID as CFString) as? NSNumber)?.boolValue ?? false
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -17,14 +17,35 @@ public struct ResolvedChannel: Sendable, Equatable {
     /// tag. Empty for every other app.
     public let feedHTTPHeaders: [String: String]
 
+    /// The `<sparkle:channel>` names this resolution unlocks, when the feed does
+    /// NOT spell the channel the way `ReleaseChannel.rawValue` does.
+    ///
+    /// `SparkleAppcastSource` normally derives the tag from the channel itself
+    /// (`.beta` → "beta"), which works because every feed-tagged app until now
+    /// happened to agree with that spelling. BetterDisplay does not: its appcast
+    /// tags prereleases `pre` and `internal`, and `ReleaseChannel` has no case
+    /// that spells either. Deriving the tag there would build an allowed set of
+    /// {default, "beta"} — matching NOTHING in the feed — and silently drop the
+    /// user off their track.
+    ///
+    /// A Set rather than one name because a track can subsume a lower one: a
+    /// BetterDisplay user with both toggles on is opted into `internal` AND
+    /// `pre`, and must be offered whichever is newer.
+    ///
+    /// Empty (the default) = derive from `channel`, i.e. every app that existed
+    /// before this field. Only consulted when the resolution is authoritative.
+    public let sparkleChannelNames: Set<String>
+
     public init(
         channel: ReleaseChannel,
         feedOverride: URL? = nil,
-        feedHTTPHeaders: [String: String] = [:]
+        feedHTTPHeaders: [String: String] = [:],
+        sparkleChannelNames: Set<String> = []
     ) {
         self.channel = channel
         self.feedOverride = feedOverride
         self.feedHTTPHeaders = feedHTTPHeaders
+        self.sparkleChannelNames = sparkleChannelNames
     }
 }
 
@@ -40,6 +61,8 @@ public struct ResolvedChannel: Sendable, Equatable {
 ///   * OrbStack → `UserDefaults[updates_optinChannel]`               (String: the channel name)
 ///   * TablePlus→ `UserDefaults[ViewSetting][IsReceiveBetaBuild]`     (Bool: true→beta, via header)
 ///   * CleanShot→ `UserDefaults[activationKey]`                       (String: license key → personalized feed)
+///   * BetterDisplay → `UserDefaults[preReleaseChannel]` + `[internalReleaseChannel]`
+///                                                          (two Bools, three tracks, feed-tagged `pre`/`internal`)
 ///   * Tailscale→ `UserDefaults[UnstableUpdatesEnabled]` + `[RCUpdatesEnabled]`
 ///                                                          (two Bools, three tracks)
 ///
@@ -76,6 +99,7 @@ public enum ChannelBinding {
         TailscaleChannel.bundleID.lowercased(),
         IINAChannel.bundleID.lowercased(),
         AlfredChannel.bundleID.lowercased(),
+        BetterDisplayChannel.bundleID.lowercased(),
     ]
 
     /// The directories holding every preference a resolver above reads, for a
@@ -165,6 +189,8 @@ public enum ChannelBinding {
         case IINAChannel.bundleID.lowercased():    return IINAChannel.resolveCurrent()
         case AlfredChannel.bundleID.lowercased():  return AlfredChannel.resolveCurrent()
         case GhosttyChannel.bundleID.lowercased(): return GhosttyChannel.resolveCurrent()
+        case BetterDisplayChannel.bundleID.lowercased():
+            return BetterDisplayChannel.resolveCurrent()
         default:                       return nil
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
@@ -43,10 +43,19 @@ public enum ChannelSwitchDetector {
             .sorted { $0.key < $1.key }
             .map { "\($0.key)=\($0.value)" }
             .joined(separator: "&")
+        // Sorted for the same reason as the headers: a Set has no order, and the
+        // fingerprint must not depend on one. Included because a binding can hold
+        // `.channel` steady while moving between feed tags — BetterDisplay's
+        // `pre` and `internal` happen to map to different `ReleaseChannel` cases
+        // today, but nothing guarantees the next one will, and leaving the field
+        // out would make such a switch invisible to `changes` — the same failure
+        // the `feedOverride` component above exists to prevent for CleanShot.
+        let tagPart = resolved.sparkleChannelNames.sorted().joined(separator: ",")
         let raw = [
             resolved.channel.rawValue,
             resolved.feedOverride?.absoluteString ?? "",
             headerPart,
+            tagPart,
         ].joined(separator: "|")
         let digest = SHA256.hash(data: Data(raw.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -167,15 +167,12 @@ public struct SparkleAppcastSource: UpdateSource {
     ) -> [SparkleAppcastItem] {
         guard !items.isEmpty else { return [] }
         // Sparkle's real rule: the default (untagged) channel is allowed to
-        // everyone, plus the one channel the user opted into. We learn that
-        // channel authoritatively from the app's own preference when we can
-        // (this catches "opted into beta but still on a stable build", which the
-        // installed build alone can't reveal); otherwise we infer it from the
-        // build they're running.
-        let optedChannel = app.channelIsAuthoritative
-            ? sparkleChannelName(app.releaseChannel)
-            : channel(ofInstalled: app, in: items)
-        let allowed: Set<String?> = optedChannel == nil ? [nil] : [nil, optedChannel]
+        // everyone, plus whatever the user opted into — read from the app's own
+        // preference when a binding exists (this catches "opted into beta but
+        // still on a stable build", which the installed build alone can't
+        // reveal), else inferred from the build they're running. See
+        // `allowedChannels`.
+        let allowed = allowedChannels(for: app, in: items)
         let usable = items.filter { item in
             // Skip delta updates — they patch a specific old build.
             guard item.deltaFrom == nil else { return false }
@@ -262,6 +259,39 @@ public struct SparkleAppcastSource: UpdateSource {
     private enum ArchVerdict: Int, Comparable {
         case native, neutral, foreignButRunnable, unrunnable
         static func < (lhs: ArchVerdict, rhs: ArchVerdict) -> Bool { lhs.rawValue < rhs.rawValue }
+    }
+
+    /// The `<sparkle:channel>` values an app may be offered: always the default
+    /// (untagged) channel, plus whatever the user opted into.
+    ///
+    /// Three ways we learn the opt-in, most authoritative first:
+    ///  1. A `ChannelBinding` that named the feed's tags outright
+    ///     (`sparkleChannelNames`). Needed when the feed does not spell a channel
+    ///     the way `ReleaseChannel.rawValue` does — BetterDisplay tags `pre` and
+    ///     `internal`, neither of which is a `ReleaseChannel` case — and needed as
+    ///     a Set because one opt-in can unlock several tags at once (BetterDisplay's
+    ///     "internal" toggle also keeps the plain `pre` builds).
+    ///  2. A `ChannelBinding` that only named the channel: derive the tag from it,
+    ///     which is what every binding did before (1) existed and still what
+    ///     DuoPaste/Fork/OrbStack/… want.
+    ///  3. No binding: infer from the build the user is actually running.
+    ///
+    /// Kept as one function so the "default channel is always allowed" rule can't
+    /// drift between the branches.
+    static func allowedChannels(
+        for app: InstalledApp, in items: [SparkleAppcastItem]
+    ) -> Set<String?> {
+        var allowed: Set<String?> = [nil]
+        guard app.channelIsAuthoritative else {
+            if let inferred = channel(ofInstalled: app, in: items) { allowed.insert(inferred) }
+            return allowed
+        }
+        if !app.sparkleChannelNames.isEmpty {
+            for name in app.sparkleChannelNames { allowed.insert(name) }
+            return allowed
+        }
+        if let derived = sparkleChannelName(app.releaseChannel) { allowed.insert(derived) }
+        return allowed
     }
 
     /// The Sparkle channel the installed build sits on, found by matching the

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChannelTests.swift
@@ -1,0 +1,294 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// BetterDisplay ships three tracks through ONE appcast, tagged `pre` and
+/// `internal` — spellings `ReleaseChannel.rawValue` cannot produce. The binding
+/// therefore names the feed's tags outright (`sparkleChannelNames`); these tests
+/// pin that down against the vendor's REAL feed.
+///
+/// Four items captured verbatim from
+/// `betterdisplay.pro/betterdisplay/sparkle/appcast.xml` on 2026-08-26 — one per
+/// distinct channel spelling in that feed, plus the untagged stable line. Kept
+/// byte-for-byte (indentation, the newline inside `<sparkle:releaseNotesLink>`)
+/// because the whitespace is exactly what the parser has to survive.
+private let betterDisplayFeedFixture = #"""
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <item>
+            <title>5.0.4</title>
+            <pubDate>Mon, 24 Aug 2026 21:45:16 +0200</pubDate>
+            <sparkle:channel>internal</sparkle:channel>
+            <sparkle:releaseNotesLink>
+                https://waydabber.github.io/BetterDisplay/changelog.html?tag=pre
+            </sparkle:releaseNotesLink>
+            <sparkle:version>52989</sparkle:version>
+            <sparkle:shortVersionString>5.0.4</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.3</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/waydabber/BetterDisplay/releases/download/pre/BetterDisplay-v5.0.4-b52989.zip" length="25544140" type="application/octet-stream" sparkle:edSignature="o3JbwYVFXaNQlxz8lxfcPRKdsPA9CdHGIUrNtZWcUiDbZnAkvNGINVJQlPLDgIwRdMCrJ2W/TuwqjONgcLsyCw=="/>
+        </item>
+        <item>
+            <title>5.0.3</title>
+            <pubDate>Tue, 18 Aug 2026 22:37:01 +0200</pubDate>
+            <sparkle:channel>pre</sparkle:channel>
+            <sparkle:releaseNotesLink>
+                https://waydabber.github.io/BetterDisplay/changelog.html?tag=v5.0.3
+            </sparkle:releaseNotesLink>
+            <sparkle:version>52922</sparkle:version>
+            <sparkle:shortVersionString>5.0.3</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.3</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/waydabber/BetterDisplay/releases/download/v5.0.3/BetterDisplay-v5.0.3-pre-release.dmg" length="25605853" type="application/octet-stream" sparkle:edSignature="GD8V8LBBghqh7R+bEiJH5M58DhbaUR3Of/P2S4AblpnvKY9rh0IBI7xjaTPgRkXcpa+OgDB0qzcqPDVTAVeODQ=="/>
+        </item>
+        <item>
+            <title>4.3.6</title>
+            <pubDate>Tue, 11 Aug 2026 14:40:39 +0200</pubDate>
+            <sparkle:releaseNotesLink>
+                https://waydabber.github.io/BetterDisplay/changelog.html?tag=v4.3.6
+            </sparkle:releaseNotesLink>
+            <sparkle:version>50119</sparkle:version>
+            <sparkle:shortVersionString>4.3.6</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.2</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/waydabber/BetterDisplay/releases/download/v4.3.6/BetterDisplay-v4.3.6.dmg" length="23958493" type="application/octet-stream" sparkle:edSignature="i7Gbqcw7Lg8mciAil2EE7U6rQSQnK/ZfMvWe0TxPHdikFY0qqNFXaBzrISGmpwDku5jgwLzzPNyKASiSC7MGCw=="/>
+        </item>
+        <item>
+            <title>5.0.1</title>
+            <pubDate>Thu, 23 Jul 2026 09:09:51 +0200</pubDate>
+            <sparkle:channel>arm64_pre</sparkle:channel>
+            <sparkle:releaseNotesLink>
+                https://waydabber.github.io/BetterDisplay/changelog.html?tag=v5.0.1
+            </sparkle:releaseNotesLink>
+            <sparkle:version>52622</sparkle:version>
+            <sparkle:shortVersionString>5.0.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.3</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/waydabber/BetterDisplay/releases/download/v5.0.1/BetterDisplay-v5.0.1-pre-release.dmg" length="16831019" type="application/octet-stream" sparkle:edSignature="E2Ix6WdRBQqK/ww1PeSwTu9B8w1CnzlBwtoOfHddZD3yGZdgq446fe21QUOmPfVqNeDaMga7oi+SKG70d+bcCw=="/>
+        </item>
+    </channel>
+</rss>
+"""#
+
+@Suite struct BetterDisplayChannelTests {
+    private static let bundleID = BetterDisplayChannel.bundleID
+
+    private var items: [SparkleAppcastItem] {
+        SparkleAppcastParser.parse(Data(betterDisplayFeedFixture.utf8))
+    }
+
+    /// An install pinned to a version/build, wearing whatever the resolver
+    /// produced for a given pair of toggle states — the same fields
+    /// `AppScanner` copies out of `ChannelBinding`.
+    private func app(
+        short: String, build: String, preEnabled: Bool, internalEnabled: Bool
+    ) -> InstalledApp {
+        let bound = BetterDisplayChannel.resolve(
+            preEnabled: preEnabled, internalEnabled: internalEnabled)
+        return InstalledApp(
+            name: "BetterDisplay", bundleID: Self.bundleID,
+            shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/BetterDisplay.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://betterdisplay.pro/betterdisplay/sparkle/appcast.xml"),
+            sparkleChannelNames: bound.sparkleChannelNames,
+            sparkleEdPublicKey: "key",
+            releaseChannel: bound.channel,
+            channelIsAuthoritative: true)
+    }
+
+    private func best(
+        short: String, build: String, preEnabled: Bool, internalEnabled: Bool,
+        hostArch: HostArch = .arm64
+    ) -> String? {
+        SparkleAppcastSource.bestItem(
+            for: app(short: short, build: build,
+                     preEnabled: preEnabled, internalEnabled: internalEnabled),
+            from: items, osVersion: "27.0", hostArch: hostArch,
+            allowingIntelTranslation: true
+        )?.shortVersionString
+    }
+
+    // MARK: - The fixture itself
+
+    @Test func theFeedReallySpellsChannelsPreAndInternal() {
+        let byVersion = Dictionary(
+            uniqueKeysWithValues: items.map { ($0.shortVersionString ?? "", $0.channel) })
+        #expect(byVersion["4.3.6"] == .some(nil), "stable line is untagged")
+        #expect(byVersion["5.0.3"] == "pre")
+        #expect(byVersion["5.0.4"] == "internal")
+        #expect(byVersion["5.0.1"] == "arm64_pre")
+    }
+
+    /// The whole reason this binding exists: no `ReleaseChannel` case spells
+    /// these, so deriving the tag from the channel would build an allowed set
+    /// that matches nothing in the feed.
+    @Test func noReleaseChannelCaseSpellsTheseTags() {
+        for channel in ReleaseChannel.allCases {
+            let derived = SparkleAppcastSource.sparkleChannelName(channel)
+            #expect(derived != "pre")
+            #expect(derived != "internal")
+            #expect(derived != "arm64_pre")
+        }
+    }
+
+    // MARK: - Resolver (two Bools → three tracks)
+
+    @Test func bothOffIsStableAndClaimsNoTags() {
+        let r = BetterDisplayChannel.resolve(preEnabled: false, internalEnabled: false)
+        #expect(r.channel == .stable)
+        #expect(r.sparkleChannelNames.isEmpty)
+        #expect(r.feedOverride == nil, "channel-tag app: one feed, never a swap")
+        #expect(r.feedHTTPHeaders.isEmpty)
+    }
+
+    @Test func preOnlyUnlocksPre() {
+        let r = BetterDisplayChannel.resolve(preEnabled: true, internalEnabled: false)
+        #expect(r.channel == .beta)
+        #expect(r.sparkleChannelNames == ["pre"])
+    }
+
+    /// The GUI nests the internal toggle under the pre one, so opting into
+    /// internal keeps the plain pre builds — the newer of the two must win.
+    @Test func internalSubsumesPre() {
+        let r = BetterDisplayChannel.resolve(preEnabled: true, internalEnabled: true)
+        #expect(r.channel == .unstable)
+        #expect(r.sparkleChannelNames == ["pre", "internal"])
+    }
+
+    @Test func internalWithoutPreStillResolvesToInternal() {
+        // Not reachable through the GUI; a defaults write or a vendor bug could
+        // produce it. Never silently downgrade someone below what they set.
+        let r = BetterDisplayChannel.resolve(preEnabled: false, internalEnabled: true)
+        #expect(r.channel == .unstable)
+        #expect(r.sparkleChannelNames == ["pre", "internal"])
+    }
+
+    // MARK: - Gating against the real feed
+
+    /// The regression this whole change exists for, reproduced from the real
+    /// machine state on 2026-08-26: BetterDisplay 4.3.6 (build 50119, a
+    /// STABLE-track build) with both toggles on. Build-inference alone sees a
+    /// stable build and offers nothing; the vendor's own updater offers 5.0.4.
+    @Test func stableBuildOptedIntoInternalIsOfferedTheInternalRelease() {
+        #expect(best(short: "4.3.6", build: "50119",
+                     preEnabled: true, internalEnabled: true) == "5.0.4")
+    }
+
+    @Test func stableBuildOptedIntoPreStopsAtPreNotInternal() {
+        #expect(best(short: "4.3.6", build: "50119",
+                     preEnabled: true, internalEnabled: false) == "5.0.3")
+    }
+
+    @Test func stableBuildWithBothTogglesOffStaysOnStable() {
+        #expect(best(short: "4.3.6", build: "50119",
+                     preEnabled: false, internalEnabled: false) == "4.3.6")
+    }
+
+    @Test func preUserIsNeverPushedTheInternalBuild() {
+        #expect(best(short: "5.0.3", build: "52922",
+                     preEnabled: true, internalEnabled: false) == "5.0.3")
+    }
+
+    /// `arm64_pre` is a real tag in this feed and its builds are arm64-only, but
+    /// the feed declares no `<sparkle:hardwareRequirements>` and the enclosure
+    /// carries no arch token — so `archVerdict` would rate it `.neutral` and
+    /// offer it to an Intel Mac that cannot run it. It is excluded from every
+    /// track; 5.0.2+ superseded it, so nothing is lost but changelog rows.
+    @Test func arm64PreIsNeverInAnyAllowedSet() {
+        for (pre, int) in [(false, false), (true, false), (true, true)] {
+            let allowed = SparkleAppcastSource.allowedChannels(
+                for: app(short: "4.3.6", build: "50119",
+                         preEnabled: pre, internalEnabled: int),
+                in: items)
+            #expect(!allowed.contains("arm64_pre"))
+        }
+    }
+
+    /// Every track keeps the untagged line available — Sparkle's own rule, and
+    /// what lets a prerelease user land back on stable when it overtakes them.
+    @Test func theDefaultChannelIsAllowedOnEveryTrack() {
+        for (pre, int) in [(false, false), (true, false), (true, true)] {
+            let allowed = SparkleAppcastSource.allowedChannels(
+                for: app(short: "4.3.6", build: "50119",
+                         preEnabled: pre, internalEnabled: int),
+                in: items)
+            #expect(allowed.contains(nil))
+        }
+    }
+
+    /// The red this change turns green, pinned so it cannot come back: with the
+    /// tags derived from the channel — which is all the code could do before
+    /// `sparkleChannelNames` — the allowed set is {default, "unstable"}, and this
+    /// feed has nothing tagged "unstable". The internal opt-in collapses to
+    /// stable and 5.0.4 is never offered.
+    @Test func derivingTagsFromTheChannelAloneWouldMissTheWholeV5Line() {
+        let derivedOnly = InstalledApp(
+            name: "BetterDisplay", bundleID: Self.bundleID,
+            shortVersion: "4.3.6", buildVersion: "50119",
+            path: URL(fileURLWithPath: "/Applications/BetterDisplay.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://betterdisplay.pro/betterdisplay/sparkle/appcast.xml"),
+            sparkleChannelNames: [],   // what the old code effectively had
+            sparkleEdPublicKey: "key",
+            releaseChannel: .unstable, channelIsAuthoritative: true)
+        #expect(SparkleAppcastSource.allowedChannels(for: derivedOnly, in: items)
+            == [nil, "unstable"])
+        #expect(SparkleAppcastSource.bestItem(
+            for: derivedOnly, from: items, osVersion: "27.0",
+            hostArch: .arm64, allowingIntelTranslation: true
+        )?.shortVersionString == "4.3.6",
+        "no item is tagged \"unstable\", so the opt-in silently collapses to stable")
+    }
+
+    /// Opting a 4.x install into a prerelease track walks it across BetterDisplay's
+    /// PAID major boundary: v5 is a free upgrade only for Pro licenses bought after
+    /// 2025-01-01, and the vendor's own notes warn that an outdated license "cannot
+    /// activate a new or deactivated BetterDisplay 5 installation". So the offer
+    /// this change unlocks must also carry the major-upgrade flag the UI warns on.
+    /// It does, and by the fallback tier rather than the authoritative one: this
+    /// feed declares no `minimumAutoupdateVersion` anywhere, and "Sparkle" is not a
+    /// license-neutral source, so the marketing-major bump 4→5 is what trips it.
+    @Test func theInternalOfferIsFlaggedAsAMajorUpgrade() throws {
+        let installed = app(short: "4.3.6", build: "50119",
+                            preEnabled: true, internalEnabled: true)
+        let item = try #require(SparkleAppcastSource.bestItem(
+            for: installed, from: items, osVersion: "27.0",
+            hostArch: .arm64, allowingIntelTranslation: true))
+        #expect(item.minimumAutoupdateVersion == nil, "no floor declared — tier 2 applies")
+        let remote = RemoteVersion(
+            shortVersion: item.shortVersionString, version: item.version,
+            downloadURL: item.enclosureURL, sourceName: "Sparkle",
+            minimumAutoupdateVersion: item.minimumAutoupdateVersion)
+        let result = UpdateResult(app: installed, remote: remote, status: .updateAvailable(latest: item.shortVersionString ?? ""))
+        #expect(result.isMajorUpgrade)
+    }
+
+    // MARK: - No regression for apps without the new field
+
+    /// An app whose binding names no tags keeps deriving them from the channel,
+    /// which is every binding that existed before `sparkleChannelNames`.
+    @Test func anAppWithNoNamedTagsStillDerivesFromItsChannel() {
+        let duoPaste = InstalledApp(
+            name: "DuoPaste", bundleID: "io.duopaste.daemon",
+            shortVersion: "1.0", buildVersion: "100",
+            path: URL(fileURLWithPath: "/Applications/DuoPaste.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"),
+            sparkleEdPublicKey: "key",
+            releaseChannel: .beta, channelIsAuthoritative: true)
+        let allowed = SparkleAppcastSource.allowedChannels(for: duoPaste, in: items)
+        #expect(allowed == [nil, "beta"])
+    }
+
+    /// And an app with no binding at all still infers from the running build.
+    @Test func withoutABindingTheRunningBuildStillDecides() {
+        let inferred = InstalledApp(
+            name: "BetterDisplay", bundleID: Self.bundleID,
+            shortVersion: "5.0.3", buildVersion: "52922",
+            path: URL(fileURLWithPath: "/Applications/BetterDisplay.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://betterdisplay.pro/betterdisplay/sparkle/appcast.xml"),
+            sparkleEdPublicKey: "key",
+            releaseChannel: .stable, channelIsAuthoritative: false)
+        #expect(SparkleAppcastSource.allowedChannels(for: inferred, in: items)
+            == [nil, "pre"])
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
@@ -183,3 +183,38 @@ import Foundation
         #expect(FileManager.default.fileExists(atPath: path), "\(path) does not exist")
     }
 }
+
+/// The fingerprint covers the WHOLE resolution, and `sparkleChannelNames` is part
+/// of it. BetterDisplay's three tracks happen to carry three different
+/// `ReleaseChannel` cases today, so its flips would be caught either way — but a
+/// binding whose tracks share a channel and differ only in the feed tags they
+/// unlock would be invisible, which is the same shape as the CleanShot case the
+/// `feedOverride` component exists for.
+@Test func fingerprintDistinguishesFeedTagsUnderOneChannel() {
+    let pre = ResolvedChannel(channel: .beta, sparkleChannelNames: ["pre"])
+    let both = ResolvedChannel(channel: .beta, sparkleChannelNames: ["pre", "internal"])
+    #expect(ChannelSwitchDetector.fingerprint(pre) != ChannelSwitchDetector.fingerprint(both))
+
+    let (changed, _) = ChannelSwitchDetector.changes(
+        current: ["pro.betterdisplay.betterdisplay": ChannelSwitchDetector.fingerprint(both)],
+        lastSeen: ["pro.betterdisplay.betterdisplay": ChannelSwitchDetector.fingerprint(pre)])
+    #expect(changed == ["pro.betterdisplay.betterdisplay"])
+}
+
+/// A Set has no order; the fingerprint must not inherit one.
+@Test func fingerprintIsStableAcrossTagOrder() {
+    #expect(ChannelSwitchDetector.fingerprint(.init(channel: .unstable, sparkleChannelNames: ["pre", "internal"]))
+        == ChannelSwitchDetector.fingerprint(.init(channel: .unstable, sparkleChannelNames: ["internal", "pre"])))
+}
+
+/// Omitting the tags and passing an empty set are the same resolution, so they
+/// must fingerprint alike — every binding that predates the field takes the
+/// default, and the two spellings appear side by side in `ChannelBinding`.
+///
+/// Not a cross-version concern: `lastSeenChannelFingerprints` lives in memory and
+/// is seeded from empty on each launch, so changing the fingerprint's input
+/// format cannot make old entries read as changed.
+@Test func noTagsIsUnchangedFromTheChannelAlone() {
+    #expect(ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+        == ChannelSwitchDetector.fingerprint(.init(channel: .beta, sparkleChannelNames: [])))
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
@@ -25,6 +25,7 @@ final class TestFlightInventoryTests: XCTestCase {
             isMASApp: isMAS, isTestFlightApp: isTestFlight,
             sparkleFeedURL: URL(string: "https://example.com/appcast.xml"),
             sparkleFeedHeaders: ["X-Channel": "beta"],
+            sparkleChannelNames: ["pre", "internal"],
             sparkleEdPublicKey: "fixture-key", hasSelfUpdater: true,
             releaseChannel: .beta, channelIsAuthoritative: true,
             toolboxInstalledBuild: "toolbox-build", appStoreAdamID: 123)
@@ -44,6 +45,13 @@ final class TestFlightInventoryTests: XCTestCase {
         XCTAssertEqual(retagged.path, app.path)
         XCTAssertEqual(retagged.sparkleFeedURL, app.sparkleFeedURL)
         XCTAssertEqual(retagged.sparkleFeedHeaders, app.sparkleFeedHeaders)
+        // The rebuild lists fields by hand, so a field added to `InstalledApp` after
+        // this test was written is dropped silently — its default is what a caller
+        // that never heard of it would pass. `sparkleChannelNames` defaults to the
+        // empty set, which is not "unset" but a MEANING: "derive the feed tag from
+        // the channel". For a BetterDisplay-shaped feed that builds an allowed set
+        // matching nothing, and the user falls back to stable with no error anywhere.
+        XCTAssertEqual(retagged.sparkleChannelNames, app.sparkleChannelNames)
         XCTAssertEqual(retagged.sparkleEdPublicKey, app.sparkleEdPublicKey)
         XCTAssertEqual(retagged.releaseChannel, app.releaseChannel)
         XCTAssertEqual(retagged.toolboxInstalledBuild, app.toolboxInstalledBuild)


### PR DESCRIPTION
BetterDisplay ships three tracks through one Sparkle appcast, selected by two toggles in its own Settings. We saw none of them: `SparkleAppcastSource` infers a user's channel from the build they are running, which cannot see an opt-in the user has not yet acted on.

Reproduced on a real install before the fix — BetterDisplay 4.3.6 (build 50119, a stable-track build) with both toggles on:

```
vendor's own updater : An update to v5.0.4 is available!
duo check            : {"installedVersion":"4.3.6","latestVersion":"4.3.6","status":"up-to-date"}
```

## Why this needed a shared change

The feed spells its channels `pre` and `internal`. `sparkleChannelName` derives the tag mechanically from `ReleaseChannel.rawValue`, and no case spells either — so a binding that only named a channel would have produced an allowed set of `{default, "beta"}`, matched nothing in the feed, and dropped the user off their track without failing.

`ResolvedChannel` can now carry the feed's own tag names. The field is empty for every existing binding, so DuoPaste / Fork / Surge / OrbStack / TablePlus / CleanShot / Tailscale / IINA / Alfred / Ghostty keep deriving from the channel exactly as before; two tests pin that edge.

## On `arm64_pre`

The feed has a fourth tag, and it is a trap: those builds are **arm64-only**, but the items declare no `<sparkle:hardwareRequirements>` and the enclosures carry no arch token, so `archVerdict` rates them `.neutral` and would offer one to an Intel Mac. Measured by mounting the real artifacts:

| artifact | channel | archs |
|---|---|---|
| 5.0.0 | `arm64_pre` | arm64 |
| 5.0.1 | `arm64_pre` | arm64 |
| 5.0.2 | `pre` | x86_64 arm64 |
| 5.0.3 | `pre` | x86_64 arm64 |
| 5.0.4 | `internal` | x86_64 arm64 |
| 4.3.6 | untagged | x86_64 arm64 |

Excluded from every track. 5.0.2+ superseded those builds, so nothing is lost but two rows of changelog history.

## Verification

- `make test` — 1124 + 125 tests pass (2 pre-existing known issues)
- Live, on the real machine, walking the GUI toggles through all three states:

| toggles | `preReleaseChannel` | `internalReleaseChannel` | `duo check` |
|---|---|---|---|
| both off | `0` / absent | `0` / absent | up-to-date 4.3.6 |
| pre only | `1` | `0` | update 5.0.3 |
| both on | `1` | `1` | update 5.0.4 |

- Every artifact above is signed by Team `299YSU96J7`, the same identity as the installed app.
- The 4.x→5.x offer carries `isMajorUpgrade`, so the UI warns about BetterDisplay's paid major boundary (v5 is a free upgrade only for Pro licenses bought after 2025-01-01). Pinned by a test.

## Not included

- **No changelog recipe.** The appcast's `releaseNotesLink` already renders per-version notes in the existing WebView path, and the internal track's link is a rolling GitHub tag whose body is static boilerplate — a recipe could not do better there.
- **No CHANGELOG entry**, since the next version number isn't decided; this is user-visible and should get one at release time.
- A pre-existing coalescing defect in `recheckChannelSwitches`, surfaced while testing this — filed separately.
