### PR TITLE
Supersede an in-flight channel recheck instead of dropping the new one

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4549,11 +4549,20 @@ final class AppListModel {
         // read but touches no app bundle, so `appDirWatcher` above is blind to it,
         // and the two events we relied on before both miss the ordinary case — see
         // `ChannelBinding.preferenceWatchPaths` for the Surge timeline that made
-        // this necessary. A 1s debounce (vs the app watcher's 2s): a preference
-        // flush is one rename, not a multi-second bundle swap.
+        // this necessary.
+        //
+        // A quarter-second debounce, well under the app watcher's 2s: a preference
+        // flush is one rename, not a multi-second bundle swap, and the whole point
+        // of this stream is to put the row into its checking state before the user
+        // can act on a verdict their flip has just invalidated — every millisecond
+        // of debounce is time that row spends live and wrong. It used to be 1s,
+        // which was the bulk of the measured 2.4s a flip took to settle. Cutting it
+        // is only safe now that `recheckChannelSwitches` supersedes its own passes:
+        // a burst that fires several times just cancels itself down to the last
+        // one, where before each extra event was work we could not take back.
         let prefPaths = ChannelBinding.preferenceWatchPaths
         if !prefPaths.isEmpty {
-            let prefsWatcher = AppDirectoryWatcher(paths: prefPaths, debounce: 1) { [weak self] in
+            let prefsWatcher = AppDirectoryWatcher(paths: prefPaths, debounce: 0.25) { [weak self] in
                 Task { @MainActor in
                     await self?.recheckChannelSwitches(trigger: "prefs-watch")
                 }
@@ -4963,7 +4972,9 @@ final class AppListModel {
     @ObservationIgnored private var lastSeenChannelFingerprints: [String: String] = [:]
     /// Guards against overlapping passes — a bound app's launch and terminate
     /// notifications can arrive back to back — queuing duplicate rechecks.
-    @ObservationIgnored private var channelSwitchRecheckRunning = false
+    /// The channel-switch pass currently in flight, so a newer trigger can
+    /// supersede it (see `recheckChannelSwitches`).
+    @ObservationIgnored private var channelRecheckTask: Task<Void, Never>?
 
     /// The bound-app ids currently on screen. Main-actor (it reads `results`) but
     /// pure memory — the disk-touching half is `fingerprints(forBoundIDs:)`.
@@ -5015,33 +5026,82 @@ final class AppListModel {
     /// user comes back to DuoUpdater itself — the "leave the vendor app running"
     /// flow). Coalesced against overlapping calls.
     private func recheckChannelSwitches(trigger: String) async {
-        guard !results.isEmpty, !channelSwitchRecheckRunning else { return }
-        channelSwitchRecheckRunning = true
-        defer { channelSwitchRecheckRunning = false }
+        guard !results.isEmpty else { return }
+        // Latest wins. A pass already on the network was started from a choice the
+        // user has since left, so its verdict is not merely late — it is wrong, and
+        // letting it finish would write the superseded track into the row. Cancel it
+        // and start over rather than queueing behind it. Dropping the new trigger
+        // instead (what the old `channelSwitchRecheckRunning` guard did) was worse
+        // still: the flip was forgotten entirely, and because the fingerprints had
+        // already been booked, nothing compared them again — a row kept offering a
+        // prerelease to someone who had just opted out, for up to the watcher's
+        // 900s re-arm. See issue #74.
+        channelRecheckTask?.cancel()
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runChannelSwitchRecheck(trigger: trigger)
+        }
+        channelRecheckTask = task
+        await task.value
+    }
 
+    /// One pass of the above, as a cancellable unit.
+    ///
+    /// Fingerprints are booked per id, only once that id's recheck has actually
+    /// finished (`ChannelSwitchDetector.booked`). A pass cancelled partway leaves
+    /// the ids it never reached looking changed, so the pass that superseded it
+    /// picks them up instead of inheriting a cache that claims they were handled.
+    private func runChannelSwitchRecheck(trigger: String) async {
         let ids = onScreenBoundBundleIDs()
         guard !ids.isEmpty else { return }
         let current = await Task.detached(priority: .utility) {
             Self.fingerprints(forBoundIDs: ids)
         }.value
-        let (changed, next) = ChannelSwitchDetector.changes(
+        guard !Task.isCancelled else { return }
+        let (changed, _) = ChannelSwitchDetector.changes(
             current: current, lastSeen: lastSeenChannelFingerprints)
-        lastSeenChannelFingerprints = next
-        guard !changed.isEmpty else { return }
+        guard !changed.isEmpty else {
+            // Nothing flipped, but still seed first sightings and prune ids that
+            // dropped out of the scan — the bookkeeping `changes` would have done.
+            lastSeenChannelFingerprints = ChannelSwitchDetector.booked(
+                current: current, lastSeen: lastSeenChannelFingerprints,
+                changed: [], completed: [])
+            return
+        }
 
         let targets = results.filter {
             guard let id = $0.app.bundleID?.lowercased() else { return false }
             return changed.contains(id)
         }
-        for result in targets {
-            guard installing[result.id] == nil else { continue }
+        // Mark every target busy BEFORE the first network call, not one at a time as
+        // we reach it. The row's action button is replaced by the checking state, so
+        // this is what stops a click landing on a verdict the flip has already
+        // invalidated — the window between the toggle and the new answer is ~2.4s,
+        // and only the marked part of it is safe.
+        var claimed: [UpdateResult] = []
+        for result in targets where installing[result.id] == nil {
             installing[result.id] = .checking
+            claimed.append(result)
+        }
+        // Whatever happens below — finished, cancelled, or thrown out of — no row is
+        // left wearing a spinner that nothing is driving any more.
+        defer { for result in claimed { installing[result.id] = nil } }
+
+        var completed = Set<String>()
+        for result in claimed {
+            guard !Task.isCancelled else { break }
             let updated = await recheck(result)
+            guard !Task.isCancelled else { break }
             installing[result.id] = nil
             replaceRow(updated)
+            if let id = result.app.bundleID?.lowercased() { completed.insert(id) }
             Log.app.info(
                 "channel switch re-check (\(trigger, privacy: .public)): \(updated.app.name, privacy: .public) → \(String(describing: updated.status), privacy: .public)")
         }
+        lastSeenChannelFingerprints = ChannelSwitchDetector.booked(
+            current: current, lastSeen: lastSeenChannelFingerprints,
+            changed: changed, completed: completed)
+        guard !Task.isCancelled else { return }
         syncDockBadge()
     }
 

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -5036,9 +5036,26 @@ final class AppListModel {
         // already been booked, nothing compared them again — a row kept offering a
         // prerelease to someone who had just opted out, for up to the watcher's
         // 900s re-arm. See issue #74.
-        channelRecheckTask?.cancel()
+        let previous = channelRecheckTask
+        previous?.cancel()
         let task = Task { @MainActor [weak self] in
-            guard let self else { return }
+            // Cancelling only raises a flag. The superseded pass keeps running until
+            // its `recheck` returns — `recheckMany` scans on a DETACHED task, which
+            // cancellation cannot reach at all — and for that whole time it still
+            // holds `installing[id] = .checking` on the rows it claimed. Starting the
+            // new pass on top of that made it skip those very rows, because its claim
+            // filter is `installing[id] == nil`: it rechecked nothing, the dying pass
+            // rechecked nothing either, and the flip was acted on by neither. That is
+            // issue #74 moved rather than fixed — two flips half a second apart, or
+            // one flip plus any unrelated write to the machine-wide
+            // `~/Library/Preferences` during the pass, were enough to hit it.
+            //
+            // So wait the old pass out. It happens HERE, inside the new task, so that
+            // `channelRecheckTask` below is still assigned synchronously: a third
+            // trigger then cancels this task and chains behind it, instead of two
+            // triggers both getting past a suspension point and running at once.
+            _ = await previous?.value
+            guard let self, !Task.isCancelled else { return }
             await self.runChannelSwitchRecheck(trigger: trigger)
         }
         channelRecheckTask = task
@@ -5084,8 +5101,16 @@ final class AppListModel {
             claimed.append(result)
         }
         // Whatever happens below — finished, cancelled, or thrown out of — no row is
-        // left wearing a spinner that nothing is driving any more.
-        defer { for result in claimed { installing[result.id] = nil } }
+        // left wearing a spinner that nothing is driving any more. Narrowly, though:
+        // a row leaves `outstanding` the moment its own recheck lands, and the sweep
+        // only clears one still wearing the `.checking` THIS pass put on it. Between
+        // one row's recheck finishing and the next one's network call returning the
+        // user can press Update on the finished row, and a blind
+        // `installing[id] = nil` here would strip the stage off that install.
+        var outstanding = Set(claimed.map(\.id))
+        defer {
+            for id in outstanding where installing[id] == .checking { installing[id] = nil }
+        }
 
         var completed = Set<String>()
         for result in claimed {
@@ -5093,6 +5118,7 @@ final class AppListModel {
             let updated = await recheck(result)
             guard !Task.isCancelled else { break }
             installing[result.id] = nil
+            outstanding.remove(result.id)
             replaceRow(updated)
             if let id = result.app.bundleID?.lowercased() { completed.insert(id) }
             Log.app.info(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelSwitchDetector.swift
@@ -79,6 +79,37 @@ public enum ChannelSwitchDetector {
         return (changed, current)
     }
 
+    /// The cache to store after a pass that may not have finished every id.
+    ///
+    /// `changes` returns `current` wholesale for the caller to store, which is
+    /// right only when the caller then acts on every changed id. A pass that is
+    /// superseded partway — the user flipped the toggle again while the first
+    /// recheck was still on the network — must NOT book the ids it never got to,
+    /// or the flip it did not act on is remembered as already seen and nothing
+    /// compares it again. That left a row offering a prerelease to someone who
+    /// had just opted out, until an unrelated event happened to trigger another
+    /// pass (issue #74).
+    ///
+    /// So: start from `current` (seeding first sightings and pruning ids that
+    /// dropped out of the scan, exactly as `changes` does), then rewind every
+    /// changed-but-unfinished id to what it was, leaving it looking changed to
+    /// the next pass.
+    public static func booked(
+        current: [String: String],
+        lastSeen: [String: String],
+        changed: Set<String>,
+        completed: Set<String>
+    ) -> [String: String] {
+        var next = current
+        for id in changed.subtracting(completed) {
+            // `changes` only marks ids that were already in `lastSeen`, so the
+            // prior value exists; the `else` is unreachable and drops the key
+            // rather than inventing one.
+            if let prior = lastSeen[id] { next[id] = prior } else { next.removeValue(forKey: id) }
+        }
+        return next
+    }
+
     /// Whether an app launching or quitting is worth resolving channels for.
     ///
     /// `NSWorkspace`'s launch/terminate notifications fire for EVERY process on

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
@@ -183,3 +183,100 @@ import Foundation
         #expect(FileManager.default.fileExists(atPath: path), "\(path) does not exist")
     }
 }
+
+// MARK: - booked(): a superseded pass must not claim the ids it never reached
+
+/// The regression behind issue #74, as a sequence. A flip lands while an earlier
+/// pass is still on the network; the earlier pass is cancelled before it reaches
+/// that id. Booking `current` wholesale (what `changes` hands back, and what the
+/// caller used to store) would record the new fingerprint as already seen, so the
+/// next pass finds nothing changed and the row keeps the superseded track.
+@Test func aCancelledPassLeavesItsUnfinishedIDsLookingChanged() {
+    let stable = ChannelSwitchDetector.fingerprint(.init(channel: .stable))
+    let beta = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    let lastSeen = ["a": stable, "b": stable]
+    let current = ["a": beta, "b": beta]
+    let (changed, wholesale) = ChannelSwitchDetector.changes(current: current, lastSeen: lastSeen)
+    #expect(changed == ["a", "b"])
+
+    // "a" finished before the cancellation, "b" did not.
+    let next = ChannelSwitchDetector.booked(
+        current: current, lastSeen: lastSeen, changed: changed, completed: ["a"])
+    #expect(next["a"] == beta, "the id we acted on is booked")
+    #expect(next["b"] == stable, "the id we never reached is rewound, so it reads as changed again")
+
+    // The next pass picks "b" up. Booking wholesale would have lost it.
+    #expect(ChannelSwitchDetector.changes(current: current, lastSeen: next).changed == ["b"])
+    #expect(ChannelSwitchDetector.changes(current: current, lastSeen: wholesale).changed.isEmpty,
+            "this is the old behaviour, kept here as the thing that must not come back")
+}
+
+/// A pass that finished everything books exactly what `changes` would have.
+@Test func aCompletePassBooksEverything() {
+    let stable = ChannelSwitchDetector.fingerprint(.init(channel: .stable))
+    let beta = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    let lastSeen = ["a": stable]
+    let current = ["a": beta]
+    let (changed, wholesale) = ChannelSwitchDetector.changes(current: current, lastSeen: lastSeen)
+    #expect(ChannelSwitchDetector.booked(
+        current: current, lastSeen: lastSeen, changed: changed, completed: ["a"]) == wholesale)
+}
+
+/// Booking still seeds ids seen for the first time and prunes ids that dropped out
+/// of the scan — the bookkeeping `changes` did by returning `current` — even on a
+/// pass where nothing flipped or nothing completed.
+@Test func bookingStillSeedsAndPrunes() {
+    let beta = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    let next = ChannelSwitchDetector.booked(
+        current: ["new": beta], lastSeen: ["gone": beta], changed: [], completed: [])
+    #expect(next == ["new": beta])
+}
+
+/// Rapid flipping, end to end: flips that supersede one another must never let the
+/// cache settle on a state the user has already left.
+@Test func repeatedFlipsAlwaysConvergeOnTheLatestState() {
+    let stable = ChannelSwitchDetector.fingerprint(.init(channel: .stable))
+    let beta = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    let unstable = ChannelSwitchDetector.fingerprint(.init(channel: .unstable))
+    var lastSeen = ["app": stable]
+
+    // Each flip supersedes the pass before it, so no pass completes its id.
+    for fingerprint in [beta, unstable] {
+        let current = ["app": fingerprint]
+        let (changed, _) = ChannelSwitchDetector.changes(current: current, lastSeen: lastSeen)
+        #expect(changed == ["app"])
+        lastSeen = ChannelSwitchDetector.booked(
+            current: current, lastSeen: lastSeen, changed: changed, completed: [])
+        #expect(lastSeen["app"] == stable, "a superseded pass books nothing")
+    }
+
+    // The pass that finally runs to completion acts on where the user landed.
+    let settled = ["app": unstable]
+    let (changed, _) = ChannelSwitchDetector.changes(current: settled, lastSeen: lastSeen)
+    #expect(changed == ["app"])
+    lastSeen = ChannelSwitchDetector.booked(
+        current: settled, lastSeen: lastSeen, changed: changed, completed: ["app"])
+    #expect(ChannelSwitchDetector.changes(current: settled, lastSeen: lastSeen).changed.isEmpty,
+            "once a pass completes, the settled state stops re-triggering")
+}
+
+/// Flipping away and straight back, with nothing booked in between, correctly asks
+/// for no work at all: the state we last acted on IS the state the user ended in,
+/// so there is nothing to recheck. Rewinding an unfinished id restores the old
+/// fingerprint rather than clearing it, which is what makes this hold — clearing
+/// would make the id look new, and a first sighting seeds silently, which happens
+/// to reach the same place here but would not if the row on screen had meanwhile
+/// been written from the superseded verdict.
+@Test func aRoundTripBackToTheOriginalNeedsNoRecheck() {
+    let stable = ChannelSwitchDetector.fingerprint(.init(channel: .stable))
+    let beta = ChannelSwitchDetector.fingerprint(.init(channel: .beta))
+    var lastSeen = ["app": stable]
+
+    let (awayChanged, _) = ChannelSwitchDetector.changes(
+        current: ["app": beta], lastSeen: lastSeen)
+    lastSeen = ChannelSwitchDetector.booked(
+        current: ["app": beta], lastSeen: lastSeen, changed: awayChanged, completed: [])
+
+    #expect(ChannelSwitchDetector.changes(current: ["app": stable], lastSeen: lastSeen)
+        .changed.isEmpty)
+}


### PR DESCRIPTION
Fixes #74.

A channel flip that landed while a recheck was on the network was discarded, and the fingerprints had already been booked before the per-row work ran — so nothing compared that state again. The row kept offering the superseded track until an unrelated event happened to trigger another pass (another bound app's preferences changing, the watcher's 900s re-arm, wake, or the next full check). The user-visible result was a prerelease offer, carrying the major-upgrade badge, shown to someone who had just opted out.

## What changed

**Latest wins.** A new trigger cancels the pass in flight rather than being dropped by it. That pass was started from a choice the user has since left, so finishing it would write the superseded track into the row.

**Fingerprints are booked per id, after that id's recheck finishes.** `ChannelSwitchDetector.booked` rewinds the changed-but-unfinished ids, so a cancelled pass leaves them looking changed to whichever pass supersedes it, while still seeding first sightings and pruning ids that dropped out of the scan.

**Every changed row is marked `.checking` before the first network call**, not one at a time as the loop reaches it. The checking state replaces the row's action button, so this is what stops a click landing on a verdict the flip has already invalidated.

**The preference watcher's debounce drops 1s → 0.25s.** That second was the bulk of the ~2.4s a flip took to settle, all of it time the row spent live and wrong. Cutting it is only safe now that a burst cancels itself down to the last event instead of each extra one being work we could not take back. (The FSEvents stream latency is a separate, unchanged 1.0s.)

## Verification

`make test` — 1113 + 125 pass (2 pre-existing known issues).

Four new tests in Core pin the logic, including the old behaviour explicitly:

```swift
#expect(ChannelSwitchDetector.changes(current: current, lastSeen: wholesale).changed.isEmpty,
        "this is the old behaviour, kept here as the thing that must not come back")
```

Live, against BetterDisplay's own toggle — with #73 merged in locally, since that is the PR that binds BetterDisplay at all:

```
21:39:27  → 5.0.3      single flip, control
--- four flips, 1.2s apart, well inside the ~2.5s a pass takes ---
          → upToDate
          → 5.0.3
          → upToDate   final, matching the preference the user landed on
```

Five passes entered, three ran to completion; the two that were superseded are the mechanism working. `duo check`, as an independent process reading the preferences fresh, agrees.

## Scope

Shared by every `ChannelBinding` app — Surge, Fork, Tailscale, Alfred, OrbStack, TablePlus, CleanShot, IINA, DuoPaste, Ghostty. Pre-existing, and independent of #73; BetterDisplay is just the easiest one to trip, having two nested toggles.
