### PR TITLE
fix: give AppRestarter a real case for nested-only restarts

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3396,6 +3396,17 @@ final class AppListModel {
                     app: result.app.name, version: onDisk.short ?? result.app.shortVersion,
                     appID: result.app.bundleID)
             }
+        case .nestedOnly(let relaunched):
+            // The app itself was never running — only a stranded nested app (e.g.
+            // Surge's Dashboard) needed clearing — so the update still applies the
+            // moment the app is next opened by hand. Clear the same state
+            // `.relaunched` does, but never post `.restarted`: the app is not
+            // running, so "Now running X" would be a false notification.
+            needsRestart.remove(result.id)
+            pendingBatchRestart[result.id] = nil
+            runningVersionByID[result.id] = nil
+            settlePackageRestart(result.id)
+            Log.app.info("restart: \(result.app.name, privacy: .public) was not running itself — nested app(s) cleared, relaunched=\(relaunched, privacy: .public)")
         }
     }
 

--- a/CLI/Sources/DuoKit/Restart.swift
+++ b/CLI/Sources/DuoKit/Restart.swift
@@ -48,16 +48,21 @@ public enum Restart {
         case .stillRunning:      return "still running — likely a save prompt, left it alone"
         case .relaunched(true):  return "restarted"
         case .relaunched(false): return "quit, but the relaunch failed"
+        case .nestedOnly(relaunched: true):
+            return "wasn't running itself — its nested app(s) were cleared and came back"
+        case .nestedOnly(relaunched: false):
+            return "wasn't running itself — its nested app(s) were cleared, but didn't come back"
         }
     }
 
-    /// Whether this outcome should push the process exit code to 1. Only the two
+    /// Whether this outcome should push the process exit code to 1. Only the
     /// shapes where the app is left worse off than a clean restart count: still up
-    /// when it should have quit, or quit but never came back.
+    /// when it should have quit, quit but never came back, or a nested app that
+    /// was quit for the swap and never came back either.
     static func isFailure(_ outcome: AppRestarter.Outcome) -> Bool {
         switch outcome {
-        case .stillRunning, .relaunched(false): return true
-        case .noBundleID, .notRunning, .relaunched(true): return false
+        case .stillRunning, .relaunched(false), .nestedOnly(relaunched: false): return true
+        case .noBundleID, .notRunning, .relaunched(true), .nestedOnly(relaunched: true): return false
         }
     }
 }

--- a/CLI/Tests/DuoKitTests/RestartTests.swift
+++ b/CLI/Tests/DuoKitTests/RestartTests.swift
@@ -36,4 +36,22 @@ import DuoUpdaterCore
         #expect(!Restart.isFailure(.notRunning))
         #expect(!Restart.isFailure(.noBundleID))
     }
+
+    /// `.nestedOnly` covers the app-wasn't-running-itself case (see #72): the
+    /// nested app(s) it needed cleared came back, so nothing is left worse off
+    /// than before the restart was asked for.
+    @Test func nestedOnlyThatCameBackIsNotAFailure() {
+        #expect(!Restart.isFailure(.nestedOnly(relaunched: true)))
+        #expect(Restart.describe(.nestedOnly(relaunched: true))
+            == "wasn't running itself — its nested app(s) were cleared and came back")
+    }
+
+    /// The nested app was quit for the swap and never came back — that is worse
+    /// off than doing nothing, the same reasoning as `.relaunched(false)`, so it
+    /// must also push the exit code to 1.
+    @Test func nestedOnlyThatDidNotComeBackIsAFailure() {
+        #expect(Restart.isFailure(.nestedOnly(relaunched: false)))
+        #expect(Restart.describe(.nestedOnly(relaunched: false))
+            == "wasn't running itself — its nested app(s) were cleared, but didn't come back")
+    }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -24,8 +24,20 @@ public enum AppRestarter {
         /// Quit was requested but the app never actually exited within the
         /// timeout — almost always a save prompt. Left running, untouched.
         case stillRunning
-        /// Every running instance quit; `true` if the relaunch also succeeded.
+        /// The app itself was running (whether or not anything was nested inside
+        /// it), got quit, and we tried to bring it back. `true` if that relaunch
+        /// succeeded. Reached only when `main` was non-empty — see `nestedOnly`
+        /// for the case where the app itself was never running at all.
         case relaunched(Bool)
+        /// The app itself was **not** running — nothing of its own was stale —
+        /// but a nested app inside it (Surge's Dashboard, say) was still up,
+        /// stranded on the bundle we'd moved aside, so that alone got quit and
+        /// relaunched. The app itself is deliberately never started here:
+        /// starting something the user had closed is not what a restart is for.
+        /// `true` if every nested app that had to come back did — a nested app
+        /// skipped because it was already back (its parent reopened it itself)
+        /// counts as back.
+        case nestedOnly(relaunched: Bool)
     }
 
     /// Quit every running instance of `app` and relaunch it once they've all
@@ -85,21 +97,34 @@ public enum AppRestarter {
         // closed: quit Surge, leave its Dashboard up, and a relaunch would open
         // Surge. Nothing of a parent that is not running is stale, so there is
         // nothing for us to put back.
-        let relaunched: Bool
         if main.isEmpty {
-            relaunched = true
+            // Put back the nested apps that were open. `nestedBundles` can't be
+            // empty here: `running` (= main + nested) was non-empty and main is,
+            // so something in `nested` was.
+            let results = await reopenNestedApps(nestedBundles, frontmostPath: frontmostPath)
+            let relaunched = allNestedBack(results)
             Log.install.info(
-                "app-restarter: \(app.name, privacy: .public) was not running itself — only its nested app(s) needed clearing")
-        } else {
-            relaunched = await launchApp(app.path, activates: frontmostPath == parentPath)
-            Log.install.info(
-                "app-restarter: \(app.name, privacy: .public) relaunched=\(relaunched, privacy: .public)")
+                "app-restarter: \(app.name, privacy: .public) was not running itself — only its nested app(s) needed clearing (nested relaunched=\(relaunched, privacy: .public))")
+            return .nestedOnly(relaunched: relaunched)
         }
+        let relaunched = await launchApp(app.path, activates: frontmostPath == parentPath)
+        Log.install.info(
+            "app-restarter: \(app.name, privacy: .public) relaunched=\(relaunched, privacy: .public)")
         // Put back the nested apps that were open, after the parent — several only
-        // make sense once it is up. Skipped when the parent has already reopened
-        // one itself, which is common and would otherwise be a second launch of an
-        // app that is now running.
-        for bundle in nestedBundles {
+        // make sense once it is up. Skipped (inside `reopenNestedApps`) when the
+        // parent has already reopened one itself, which is common and would
+        // otherwise be a second launch of an app that is now running.
+        _ = await reopenNestedApps(nestedBundles, frontmostPath: frontmostPath)
+        return .relaunched(relaunched)
+    }
+
+    /// Relaunch each nested app that was quit alongside its parent, skipping any
+    /// the parent already brought back itself. One result per bundle, in order —
+    /// `true` for a launch that succeeded and for one skipped because it was
+    /// already back.
+    private static func reopenNestedApps(_ bundles: [URL], frontmostPath: String?) async -> [Bool] {
+        var results: [Bool] = []
+        for bundle in bundles {
             let target = UpdatePolicy.runtimeBundlePath(bundle)
             let alreadyBack = NSWorkspace.shared.runningApplications.contains {
                 matchesBundlePath($0.bundleURL, target: target)
@@ -107,13 +132,22 @@ public enum AppRestarter {
             guard !alreadyBack else {
                 Log.install.debug(
                     "app-restarter: \(bundle.lastPathComponent, privacy: .public) already reopened by its parent")
+                results.append(true)
                 continue
             }
             let back = await launchApp(bundle, activates: frontmostPath == target)
             Log.install.info(
                 "app-restarter: nested \(bundle.lastPathComponent, privacy: .public) relaunched=\(back, privacy: .public)")
+            results.append(back)
         }
-        return .relaunched(relaunched)
+        return results
+    }
+
+    /// Whether every nested app we tried to bring back is back. Split out as the
+    /// pure half of the `main.isEmpty` branch above — the only piece of that path
+    /// testable without a live `NSWorkspace`.
+    static func allNestedBack(_ results: [Bool]) -> Bool {
+        results.allSatisfy { $0 }
     }
 
     /// Every live process belonging to this bundle — the app itself and anything

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -41,8 +41,11 @@ public enum AppRestarter {
     }
 
     /// Quit every running instance of `app` and relaunch it once they've all
-    /// exited. An app that isn't running at all is a no-op (`.notRunning`) —
-    /// there is nothing whose in-memory code is stale.
+    /// exited. Only a total no-op (`.notRunning`) if *nothing* is running —
+    /// neither the app itself nor anything nested inside it. An app that isn't
+    /// running while something nested in it still is gets that nested app quit
+    /// and relaunched same as always (`.nestedOnly`); the app itself is simply
+    /// never one of the things put back.
     ///
     /// Graceful only: quits are `terminate()`, which honours save prompts, never
     /// a force-kill. An app that puts up such a prompt and won't exit is left
@@ -114,6 +117,13 @@ public enum AppRestarter {
         // make sense once it is up. Skipped (inside `reopenNestedApps`) when the
         // parent has already reopened one itself, which is common and would
         // otherwise be a second launch of an app that is now running.
+        //
+        // Result discarded on purpose, not an oversight: `.relaunched`'s Bool
+        // answers only for the parent. Folding a nested miss in here would report
+        // `false` for a parent that came back fine and swallow a correct "Now
+        // running X" notification — one of the wrong fixes issue #72 called out.
+        // Each nested app's own outcome is already reported by its own log line
+        // inside `reopenNestedApps`.
         _ = await reopenNestedApps(nestedBundles, frontmostPath: frontmostPath)
         return .relaunched(relaunched)
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
@@ -181,4 +181,27 @@ import Foundation
         #expect(URL(fileURLWithPath: nested[2]).pathExtension != "app")
         #expect(URL(fileURLWithPath: nested[3]).pathExtension != "app")
     }
+
+    // MARK: - Nested-only outcome (#72)
+
+    /// `allNestedBack` is the pure half of the `main.isEmpty` branch: `restart(_:)`
+    /// itself can't be driven here (it talks to `NSWorkspace` directly), but the
+    /// decision it folds into `.nestedOnly(relaunched:)` — "did every nested app we
+    /// tried to bring back actually come back" — is pure and is exactly the piece
+    /// issue #72 was about: it must never quietly become `true` when something
+    /// didn't come back, or `false` when everything did.
+    @Test func allNestedBackIsTrueOnlyWhenEveryOneCameBack() {
+        #expect(AppRestarter.allNestedBack([true]))
+        #expect(AppRestarter.allNestedBack([true, true]))
+        #expect(!AppRestarter.allNestedBack([false]))
+        #expect(!AppRestarter.allNestedBack([true, false]))
+    }
+
+    /// The `main.isEmpty` branch is only ever reached with at least one nested
+    /// app to report on (`running = main + nested` was non-empty and `main` was
+    /// empty), but the helper itself must not assume that — an empty result set
+    /// answers vacuously true rather than crashing or reading as a failure.
+    @Test func allNestedBackOnNoResultsIsVacuouslyTrue() {
+        #expect(AppRestarter.allNestedBack([]))
+    }
 }


### PR DESCRIPTION
## What `true` was lying about

`AppRestarter.restart(_:)` had a branch for "the app itself wasn't running, but a nested app (e.g. Surge's Dashboard) was stranded on the bundle we moved aside, so we quit and relaunched *that*." It returned `.relaunched(true)` unconditionally from that branch. `Outcome.relaunched(Bool)` is documented as "Every running instance quit; `true` if the relaunch also succeeded" — but nothing of the app itself was quit or relaunched, so the hardcoded `true` never described what happened, and a failed nested relaunch was invisible to the caller even though the app itself was fine.

## Why the four "obvious fixes" the issue lists are all wrong

- **Fold the nested result into the existing Bool** — "parent came back fine, one nested window didn't" would report `false` and swallow a *correct* "Now running X" notification.
- **Keep `true` in the `main.isEmpty` branch** (the status quo) — posts "Now running Surge 6.9.0" while Surge isn't running at all. A false notification is worse than an imprecise Bool.
- **Return `false` in that branch** — suppresses the notification correctly, but then the log reads `relaunched=false`, which says the relaunch failed when there was nothing of the parent to relaunch. Trades a wrong notification for a misleading log line — exactly the kind of log this codebase has been bitten by before.
- **Return `.notRunning`** — its doc says "nothing was quit or relaunched," which is false here (the nested app was), and it would skip the state-clearing the caller does for `.relaunched`.

## The new case

```swift
case nestedOnly(relaunched: Bool)
```

The app itself was never running (and is deliberately never started — that behavior is untouched). The Bool answers a different question than `.relaunched`'s: whether every nested app that had to come back actually did (a nested app skipped because its parent already reopened it counts as back). `.relaunched(Bool)`'s doc comment now says explicitly it's only reached when the app itself was running.

`AppRestarter.restart` factors the nested-reopen loop into `reopenNestedApps(_:frontmostPath:)`, shared by both branches, plus a small pure helper `allNestedBack(_:)` that both branches can be tested against. The `main.isEmpty` branch now logs `"...only its nested app(s) needed clearing (nested relaunched=<bool>)"` — never the false `relaunched=false` the issue calls out.

## Both consumers (the issue only named one)

- **`App/Sources/AppListModel.swift`** (the one the issue names, ~line 3385): `.nestedOnly` clears the same state `.relaunched` does (`needsRestart.remove`, `pendingBatchRestart[…] = nil`, `runningVersionByID[…] = nil`, `settlePackageRestart`), and never posts `UpdateNotifier.restarted(...)` — the app isn't running, so "Now running X" would be false. That suppression is the user-visible point of this change.
- **`CLI/Sources/DuoKit/Restart.swift`** — the issue didn't mention this one, but `duo restart` switches over the same `Outcome` and both switches (`describe`, `isFailure`) are exhaustive with no `default`, so the compiler forced a decision here too:
  - `describe`: its own honest line, distinct wording for `nestedOnly(true)` vs `nestedOnly(false)`.
  - `isFailure`: `.nestedOnly(false)` is a failure (a nested app quit for the swap and never came back leaves the app worse off than doing nothing — same reasoning already documented for `.relaunched(false)`), `.nestedOnly(true)` is not. Updated the doc comment on `isFailure` to name the third failing shape.

## Test coverage — what is and isn't covered

- `CLI/Tests/DuoKitTests/RestartTests.swift`: `describe`/`isFailure` for both `.nestedOnly(true)` and `.nestedOnly(false)`.
- `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift`: the pure `allNestedBack(_:)` helper — true only when every result is true, including the (never actually hit, since `main.isEmpty` implies `nested` is non-empty) empty-input case.
- **Not covered by any test**: `AppRestarter.restart()` itself has no seam onto `NSWorkspace`/`NSRunningApplication`, so the `main.isEmpty` branch that constructs `.nestedOnly` and the `AppListModel` switch arm that suppresses the notification are both verified only by reading the code, not by a test exercising them end to end. Per the task's scope, I did not introduce a protocol/DI seam to make `restart()` unit-testable — that's a larger refactor than this bug, and out of scope here.

## Verification

```
$ make test
...
✔ Test run with 1163 tests in 92 suites passed after 32.216 seconds with 2 known issues.
...
✔ Test run with 127 tests in 19 suites passed after 0.063 seconds.
python3 scripts/check_localizable_keys.py
✓ localizable keys agree — 411 in the catalog, all reachable
```
Exit code 0. The "2 known issues" are pre-existing `withKnownIssue`-wrapped tests in `GitHubReleaseRuleTests.swift`, unrelated to this change (confirmed by grepping the failing test names against files touched here).

Fixes #72