### PR TITLE
fix(vendor-probe): Android Studio canary/beta ignore feed publish-date ordering

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -63,11 +63,17 @@ public enum ChannelProofRegistry {
         // MORE STABLE (the stability floor documented on the recipes), so the marker
         // has to be that whole ladder, not just the channel's own name — Canary
         // resolves the newest of {Canary, Beta, RC}, Beta the newest of {Beta, RC}.
-        // That is not a bug being papered over: it is why a Canary install correctly
-        // moves onto `2026.1.4 RC 2` when it is newer than any open Canary, which is
-        // exactly what the feed served on 2026-08-26. Google's Beta train has in
-        // practice shipped RELEASE CANDIDATES for years (no `Beta` item since
-        // 2025-03-18), so `-rc<N>-` is the marker actually seen on both.
+        // That is not a bug being papered over: an RC genuinely is the legitimate
+        // answer for a Canary install once it is the highest build on the ladder —
+        // e.g. before a newer feature version's Canary train has opened. (It is NOT
+        // legitimate merely because the RC was the most recently PUBLISHED item —
+        // the feed is ordered by publish date, not by version, which is what made
+        // the canary recipe land on `2026.1.4 RC 2` over the already-published,
+        // already-newer `2026.2.1 Canary 2` on 2026-08-26; see issue #76 and
+        // `VendorProbeRecipe.entryStartPattern`, which now resolves that correctly.)
+        // Google's Beta train has in practice shipped RELEASE CANDIDATES for years
+        // (no `Beta` item since 2025-03-18), so `-rc<N>-` is the marker actually
+        // seen on both.
         // What the marker still excludes is the pair that WOULD be a cross-channel
         // install: `Release` (`android-studio-quail3-mac_arm.dmg`) and `Patch`
         // (`…-patch1-mac_arm.dmg`) — neither carries a ladder token.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -150,7 +150,11 @@ public struct ProbeOutcome: Sendable {
     public let httpStatus: Int?
     /// The text the version pattern was run against, capped at
     /// ``ProbeOutcome/maxSampleBytes``. This is what a human (or a triage step)
-    /// needs to see to fix a pattern.
+    /// needs to see to fix a pattern. For a recipe with `entryStartPattern` set,
+    /// this is the ONE winning entry `VendorProbeSource` scoped everything else
+    /// to — not the whole fetched body — so it matches what the recipe actually
+    /// resolved against, not just whatever fits in the first
+    /// ``ProbeOutcome/maxSampleBytes`` of the feed.
     public let bodySample: String?
     public let elapsedMs: Int
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -273,6 +273,35 @@ public struct VendorProbeRecipe: Sendable {
     /// probed text is a URL or a single plist value rather than a document.
     public let publishedAtPattern: String?
 
+    /// Optional regex marking where each entry begins in a body that lists
+    /// several releases — e.g. `\{"date":"` for a JSON feed whose items each
+    /// start with a `date` key. When set, the source slices the body into
+    /// entries at every match (one match's start to the next match's start,
+    /// last entry running to the end of the body), keeps the entries where
+    /// `versionPattern` matches, and picks the one whose extracted version
+    /// compares highest (the same `VersionComparator` ordering
+    /// `highestVersion`/`highestVersionedURL` use). `versionPattern`,
+    /// `displayVersionPattern`, `publishedAtPattern`, and the install spec's
+    /// `.bodyPattern`/`.bodyPatternRelative`/`.bodyTemplate` URL are then all
+    /// resolved against that ONE winning entry, so they can never land on
+    /// different releases — see `VendorProbeRecipe.highestVersionEntry`.
+    ///
+    /// This exists because a feed ordered by *publication date* rather than by
+    /// *version* breaks every first-match pattern above at once whenever two
+    /// release trains are open simultaneously (Android Studio: a newer feature
+    /// version's Canary can be published before an older version's RC, so the
+    /// RC — not the newer Canary — sits first in the feed). Flipping
+    /// `selectHighest` alone does not fix this: it would pick the version by
+    /// comparison while `displayVersionPattern` and the install URL stayed
+    /// first-match, landing on three different releases' worth of data.
+    ///
+    /// Nil (the default) leaves every pattern reading the whole body,
+    /// first-match, exactly as before this field existed. Also the fallback
+    /// when the pattern matches fewer than two entries, or when no entry's
+    /// `versionPattern` matches — better a possibly-stale first-match answer
+    /// than no answer at all.
+    public let entryStartPattern: String?
+
     /// When present, the app can be updated in place through its own channel: the
     /// source resolves the installer URL (and optional checksum) and hands it to
     /// `VendorInstaller`. Absent → detection only (the user is sent to download
@@ -337,6 +366,7 @@ public struct VendorProbeRecipe: Sendable {
         versionIsBuild: Bool = false,
         displayVersionPattern: String? = nil,
         publishedAtPattern: String? = nil,
+        entryStartPattern: String? = nil,
         install: VendorInstallSpec? = nil,
         requestBody: RequestBody? = nil,
         requestHeaders: [String: String] = [:],
@@ -360,6 +390,7 @@ public struct VendorProbeRecipe: Sendable {
         self.versionIsBuild = versionIsBuild
         self.displayVersionPattern = displayVersionPattern
         self.publishedAtPattern = publishedAtPattern
+        self.entryStartPattern = entryStartPattern
         self.install = install
         self.requestBody = requestBody
         self.requestHeaders = requestHeaders
@@ -493,6 +524,40 @@ public struct VendorProbeRecipe: Sendable {
             }
         }
         return best
+    }
+
+    /// The runtime behind `entryStartPattern`: slice `text` into entries at every
+    /// match of `entryStartPattern` (one match's start to the next match's
+    /// start, the last entry running to the end of `text`), keep the entries
+    /// where `versionPattern` matches, and return the substring of whichever
+    /// entry's extracted version compares highest.
+    ///
+    /// Nil when `entryStartPattern` matches fewer than two entries (nothing to
+    /// disambiguate) or when no entry's `versionPattern` matches — the caller
+    /// falls back to running its own extractor against the whole body, exactly
+    /// as it did before `entryStartPattern` existed.
+    public static func highestVersionEntry(
+        in text: String, entryStartPattern: String, versionPattern: String
+    ) -> String? {
+        guard let startRegex = try? NSRegularExpression(pattern: entryStartPattern)
+        else { return nil }
+        let ns = text as NSString
+        let full = NSRange(location: 0, length: ns.length)
+        let starts = startRegex.matches(in: text, options: [], range: full)
+            .map { $0.range.location }
+        guard starts.count > 1 else { return nil }
+
+        var best: (entry: String, version: String)?
+        for (index, start) in starts.enumerated() {
+            let end = index + 1 < starts.count ? starts[index + 1] : ns.length
+            let entry = ns.substring(with: NSRange(location: start, length: end - start))
+            guard let candidate = extractVersion(from: entry, pattern: versionPattern)
+            else { continue }
+            if best == nil || VersionComparator.isNewer(candidate, than: best!.version) {
+                best = (entry, candidate)
+            }
+        }
+        return best?.entry
     }
 }
 
@@ -2464,8 +2529,19 @@ public enum VendorProbeRegistry {
         // (An earlier "highest across all previews" version wrongly pushed
         //  `2026.1.3 Canary 1` at a Beta install that was already current; and the
         //  original channel-pure "Canary only" wrongly hid the RC the user wanted.
-        //  See `InstalledApp.prefersVendorProbeOverToolbox`.) The feed is
-        // newest-first, so the FIRST channel-set match is that set's newest build.
+        //  See `InstalledApp.prefersVendorProbeOverToolbox`.)
+        //
+        // NOT newest-first (see issue #76): the feed is ordered by PUBLICATION
+        // DATE, not by version. With two feature trains open at once, a newer
+        // train's Canary can publish AFTER an older train's RC — 2026-08-27 had
+        // `2026.1.4 RC 2` at item [0] and `2026.2.1 Canary 2`, the actually-newer
+        // build, at item [1] — so plain first-match on the channel set landed on
+        // the older train's RC. `entryStartPattern` slices the feed into its
+        // `{"date":…}` items and makes `versionPattern`/`displayVersionPattern`/
+        // the install URL all resolve against the ONE entry whose build compares
+        // highest, instead of three separate first-matches over the whole feed
+        // that could each land on a different entry (flipping `selectHighest` on
+        // `versionPattern` alone would have done exactly that — see its doc).
         // dmg patterns mirror each channel set — though these installs are
         // Toolbox-managed → detection-only, so the install spec is suppressed at the
         // source and the user updates through Toolbox; the dmg set just stays in
@@ -2482,6 +2558,8 @@ public enum VendorProbeRegistry {
             // build id ("AI-261.…"); the build still drives the comparison.
             displayVersionPattern:
                 #""name":"[^"]*\|\s*([^"]+)","channel":"(?:Canary|Beta|RC)""#,
+            // Each item starts with its own `"date"` key — see `entryStartPattern`.
+            entryStartPattern: #"\{"date":""#,
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(
                     #"(https://edgedl\.me\.gvt1\.com/android/studio/install/[0-9.]+/android-studio-[^"]*(?:canary|beta|rc)[0-9]*-mac_arm\.dmg)"#),
@@ -2500,6 +2578,8 @@ public enum VendorProbeRegistry {
             // build id ("AI-261.…"); the build still drives the comparison.
             displayVersionPattern:
                 #""name":"[^"]*\|\s*([^"]+)","channel":"(?:Beta|RC)""#,
+            // Each item starts with its own `"date"` key — see `entryStartPattern`.
+            entryStartPattern: #"\{"date":""#,
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(
                     #"(https://edgedl\.me\.gvt1\.com/android/studio/install/[0-9.]+/android-studio-[^"]*(?:beta|rc)[0-9]*-mac_arm\.dmg)"#),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -300,6 +300,38 @@ public struct VendorProbeRecipe: Sendable {
     /// when the pattern matches fewer than two entries, or when no entry's
     /// `versionPattern` matches — better a possibly-stale first-match answer
     /// than no answer at all.
+    ///
+    /// Narrowing to one entry also narrows `checksumPattern` (fine — a miss
+    /// there degrades loudly to `.checksumPatternNoMatch`) and the install
+    /// spec's `.bodyPattern`/`.bodyPatternRelative`/`.bodyTemplate` URL sources
+    /// (fine — that's the whole point). It is a TRAP for `.bodyPatternLast` and
+    /// `.bodyPatternHighestVersioned`: with only one entry left to search, "last
+    /// match" and "highest-versioned match" both collapse to plain first-match.
+    /// `.bodyPatternHighestVersioned` exists SPECIFICALLY as the
+    /// position-independent alternative to first-match (its own doc cites the
+    /// Docker 4.86-before-4.87 wrong-install this primitive is a sibling fix
+    /// for) — pairing it with `entryStartPattern` would quietly throw that
+    /// protection away. Don't combine them.
+    ///
+    /// Also re-anchors `^`, `$`, `\A`, `\z` and lookbehind to entry boundaries
+    /// rather than the whole body's — a pattern relying on "start/end of the
+    /// document" now means "start/end of one entry" instead. Six recipes in
+    /// this registry pin `versionPattern` with `^…$` today; none has adopted
+    /// `entryStartPattern`, and this is why one shouldn't without re-deriving
+    /// those patterns against a single sliced entry first.
+    ///
+    /// One more shape worth naming rather than discovering later: selection now
+    /// searches the feed's entire history, not just its recent head, so a
+    /// malformed or ancient build id that happens to out-rank everything
+    /// current under `VersionComparator` would pin the probe on it permanently
+    /// — a hazard first-match-over-a-recent-head never had, since a stale entry
+    /// simply ages out of view. Concretely, in Android Studio's own feed
+    /// (671 items, 2026-08-27): 42 of the 555 Canary/Beta/RC-labeled build ids
+    /// are two-segment 2018-era values like `AI-173.4688006` (`VersionComparator`
+    /// ranks `173` below `261`/`262`, so today none of them win — but a scheme
+    /// that changed digit count could invert that), and 198 lack the `|`
+    /// separator `displayVersionPattern` requires, so `display` would come back
+    /// nil for those even where `version` still resolves.
     public let entryStartPattern: String?
 
     /// When present, the app can be updated in place through its own channel: the
@@ -536,8 +568,18 @@ public struct VendorProbeRecipe: Sendable {
     /// disambiguate) or when no entry's `versionPattern` matches — the caller
     /// falls back to running its own extractor against the whole body, exactly
     /// as it did before `entryStartPattern` existed.
+    /// `selectHighest` mirrors the recipe's own flag: when true, EACH entry is
+    /// scored by its highest internal match (`highestVersion`) rather than its
+    /// first (`extractVersion`) — the same choice `VendorProbeSource` makes for
+    /// the whole body when there is no `entryStartPattern` at all. Without this,
+    /// a `selectHighest` recipe that also set `entryStartPattern` would have its
+    /// entries scored by first-match while the version it goes on to report
+    /// (computed by the caller with the SAME flag) uses highest-match — two
+    /// different readings of "highest" disagreeing on which entry even won.
+    /// No registry recipe combines the two today.
     public static func highestVersionEntry(
-        in text: String, entryStartPattern: String, versionPattern: String
+        in text: String, entryStartPattern: String, versionPattern: String,
+        selectHighest: Bool = false
     ) -> String? {
         guard let startRegex = try? NSRegularExpression(pattern: entryStartPattern)
         else { return nil }
@@ -547,17 +589,76 @@ public struct VendorProbeRecipe: Sendable {
             .map { $0.range.location }
         guard starts.count > 1 else { return nil }
 
+        let extractor = selectHighest ? Self.highestVersion : Self.extractVersion
         var best: (entry: String, version: String)?
         for (index, start) in starts.enumerated() {
             let end = index + 1 < starts.count ? starts[index + 1] : ns.length
             let entry = ns.substring(with: NSRange(location: start, length: end - start))
-            guard let candidate = extractVersion(from: entry, pattern: versionPattern)
-            else { continue }
+            guard let candidate = extractor(entry, versionPattern) else { continue }
             if best == nil || VersionComparator.isNewer(candidate, than: best!.version) {
                 best = (entry, candidate)
             }
         }
-        return best?.entry
+        guard let winner = best else { return nil }
+
+        // Defend the "one entry, one release" claim this primitive exists to
+        // make. It holds only while `entryStartPattern` slices between items —
+        // if a future feed ever nests the start marker INSIDE one item, entries
+        // split mid-item and the "winning" slice could carry one release's
+        // version alongside a different release's download URL, silently and
+        // with nothing failing: strictly worse than the pre-#76 first-match bug
+        // this primitive exists to fix, just relocated rather than gone. A
+        // genuinely self-contained entry shows up as its own `versionPattern`
+        // matching exactly once; more than that means the slice most likely
+        // isn't one release, so decline rather than trust it (the caller falls
+        // back to whole-body first-match). Skipped under `selectHighest`, where
+        // several matches inside one entry are the expected, wanted shape — the
+        // extractor above already picked the right one among them, same as it
+        // would over an un-sliced body.
+        if !selectHighest {
+            guard let versionRegex = try? NSRegularExpression(pattern: versionPattern)
+            else { return nil }
+            let winnerNS = winner.entry as NSString
+            let matchCount = versionRegex.numberOfMatches(
+                in: winner.entry, options: [], range: NSRange(location: 0, length: winnerNS.length))
+            guard matchCount == 1 else { return nil }
+        }
+        return winner.entry
+    }
+
+    /// A copy of this recipe with `entryStartPattern` replaced — every other
+    /// field carried over unchanged via `copy(...)` below. Exists so a caller
+    /// (an A/B test of this exact field, mainly) that wants to vary ONE field
+    /// can't silently drop another by hand-copying the initializer's full
+    /// argument list — which is exactly how a live-probe test comparing
+    /// "with the fix" against "without" dropped `identities`, `track` and
+    /// `variant` the first time this primitive shipped, three fields the two
+    /// arms of that test then no longer actually differed on by construction.
+    public func with(entryStartPattern: String?) -> Self {
+        copy(entryStartPattern: entryStartPattern)
+    }
+
+    /// Same, for `url` — the other field a live-probe A/B test needs to vary
+    /// (pointing the shipping recipe at a loopback stub instead of the real
+    /// endpoint) without touching anything else.
+    public func with(url: URL) -> Self {
+        copy(url: url)
+    }
+
+    /// The single place that reconstructs a recipe from `self` plus overrides —
+    /// so `with(entryStartPattern:)` and `with(url:)` can't drift out of sync
+    /// with each other, or with the initializer, the way two independent
+    /// hand-copies would.
+    private func copy(url: URL? = nil, entryStartPattern: String?? = nil) -> Self {
+        Self(
+            bundleID: bundleID, url: url ?? self.url, mode: mode, versionPattern: versionPattern,
+            downloadURL: downloadURL, changelogURL: changelogURL, selectHighest: selectHighest,
+            versionIsBuild: versionIsBuild, displayVersionPattern: displayVersionPattern,
+            publishedAtPattern: publishedAtPattern,
+            entryStartPattern: entryStartPattern ?? self.entryStartPattern,
+            install: install, requestBody: requestBody, requestHeaders: requestHeaders,
+            followRedirects: followRedirects, channel: channel, identities: identities,
+            track: track, variant: variant)
     }
 }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -322,15 +322,38 @@ public struct VendorProbeSource: UpdateSource {
     }
 
     /// The version one already-expanded endpoint reports, by the same extractor
-    /// a real probe uses — so a divergence means the tracks differ, not that two
-    /// code paths read the body differently.
+    /// AND the same entry-scoping (`scopedBody`) a real probe uses — so a
+    /// divergence means the tracks differ, not that two code paths read the body
+    /// differently. No registry recipe carries both `track` and
+    /// `entryStartPattern` today, but nothing should stop one from doing so
+    /// safely, and a `rolloutTrackVerdict` that read the wrong slice would
+    /// report a phantom `.diverged` straight into `duo verify`.
     private func trackVersion(_ recipe: VendorProbeRecipe, at endpoint: URL) async -> String? {
         guard case .success(let body) = await fetchBody(recipe, endpoint: endpoint)
         else { return nil }
         let extractor = recipe.selectHighest
             ? VendorProbeRecipe.highestVersion
             : VendorProbeRecipe.extractVersion
-        return extractor(body.text, recipe.versionPattern)
+        return extractor(Self.scopedBody(recipe, body.text), recipe.versionPattern)
+    }
+
+    /// The text a recipe's first-match patterns (`versionPattern`,
+    /// `displayVersionPattern`, `publishedAtPattern`, and the install spec's
+    /// `.bodyPattern`-family URL) should actually run against: the winning
+    /// entry when `entryStartPattern` slices the body and a version-pattern
+    /// match picks one (see `VendorProbeRecipe.highestVersionEntry`), otherwise
+    /// `body` verbatim — today's behaviour for every recipe that doesn't set
+    /// `entryStartPattern`, and the fallback when slicing produces no winner.
+    ///
+    /// The single choke point every reader of the fetched body goes through,
+    /// so a recipe with `entryStartPattern` set can't have one reader (say, a
+    /// future addition) forget to scope while the others do.
+    private static func scopedBody(_ recipe: VendorProbeRecipe, _ body: String) -> String {
+        recipe.entryStartPattern.flatMap {
+            VendorProbeRecipe.highestVersionEntry(
+                in: body, entryStartPattern: $0, versionPattern: recipe.versionPattern,
+                selectHighest: recipe.selectHighest)
+        } ?? body
     }
 
     /// What a mode's fetch step yields on success: the text the version pattern
@@ -372,8 +395,6 @@ public struct VendorProbeSource: UpdateSource {
             body = fetched
         }
 
-        let sample = ProbeOutcome.sample(body.text)
-
         // A recipe with `entryStartPattern` set names a feed that lists several
         // entries and is ordered by something other than version (publication
         // date, for Android Studio's preview feed): slice the body at that
@@ -382,10 +403,20 @@ public struct VendorProbeSource: UpdateSource {
         // and the install URL can never land on different releases. Falls back
         // to the whole body — today's behaviour — when the recipe sets no such
         // pattern, or when slicing/matching doesn't produce a winner.
-        let scope = recipe.entryStartPattern.flatMap {
-            VendorProbeRecipe.highestVersionEntry(
-                in: body.text, entryStartPattern: $0, versionPattern: recipe.versionPattern)
-        } ?? body.text
+        let scope = Self.scopedBody(recipe, body.text)
+
+        // The sample a human (or `duo triage`) sees to fix a broken pattern must
+        // be the SAME text the extractors below actually ran against — sampling
+        // `body.text` here would show a scoped recipe's reader a slice that isn't
+        // where its answer came from, and worse, silently hand `duo triage` the
+        // pre-#76 whole-body semantics for exactly the recipes this fix changed
+        // (`Triage.swift` validates a proposed pattern with
+        // `VendorProbeRecipe.extractVersion(from: finding.bodySample, ...)`).
+        // Safe on the failure path below too: whenever extraction fails, `scope`
+        // is already `body.text` by construction — `highestVersionEntry` only
+        // ever returns a winner it already confirmed `versionPattern` matches,
+        // so a scoped `scope` can't reach the miss branch.
+        let sample = ProbeOutcome.sample(scope)
 
         // Default to the first match (the app's own field, which structured
         // bodies list first); only ascending-order feeds opt into highest-wins.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -374,12 +374,25 @@ public struct VendorProbeSource: UpdateSource {
 
         let sample = ProbeOutcome.sample(body.text)
 
+        // A recipe with `entryStartPattern` set names a feed that lists several
+        // entries and is ordered by something other than version (publication
+        // date, for Android Studio's preview feed): slice the body at that
+        // pattern and narrow every first-match read below to the ONE entry whose
+        // own version compares highest, so `version`, `display`, `publishedAt`
+        // and the install URL can never land on different releases. Falls back
+        // to the whole body — today's behaviour — when the recipe sets no such
+        // pattern, or when slicing/matching doesn't produce a winner.
+        let scope = recipe.entryStartPattern.flatMap {
+            VendorProbeRecipe.highestVersionEntry(
+                in: body.text, entryStartPattern: $0, versionPattern: recipe.versionPattern)
+        } ?? body.text
+
         // Default to the first match (the app's own field, which structured
         // bodies list first); only ascending-order feeds opt into highest-wins.
         let extractor = recipe.selectHighest
             ? VendorProbeRecipe.highestVersion
             : VendorProbeRecipe.extractVersion
-        guard let version = extractor(body.text, recipe.versionPattern) else {
+        guard let version = extractor(scope, recipe.versionPattern) else {
             // Symmetric with `GitHubReleasesSource`, which has logged its
             // pattern misses since day one. A probe that fetched fine and matched
             // nothing is the exact shape of a vendor rewriting their page, and
@@ -392,7 +405,7 @@ public struct VendorProbeSource: UpdateSource {
             // value the pattern would have read — turns a "go read the page"
             // investigation into a one-line fix.
             if let would = VendorProbeRecipe.versionIfSegmentCountRelaxed(
-                from: body.text, pattern: recipe.versionPattern) {
+                from: scope, pattern: recipe.versionPattern) {
                 return fail(
                     .versionSegmentCountChanged(
                         wouldMatch: would, sampleBytes: body.text.utf8.count),
@@ -405,31 +418,34 @@ public struct VendorProbeSource: UpdateSource {
 
         // Optional clean marketing string to show instead of an ugly build id
         // (e.g. Android Studio's "2026.1.2 RC 1" vs "AI-261.…"). Display only; the
-        // build still drives the comparison. From the same body, so first-match.
+        // build still drives the comparison. From the same scope, so first-match
+        // within it belongs to the entry `versionPattern` matched.
         let display = recipe.displayVersionPattern.flatMap {
-            VendorProbeRecipe.extractVersion(from: body.text, pattern: $0)
+            VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
         }
 
-        // Optional authoritative publish time, from the same body (first match, so
-        // it belongs to the entry `versionPattern` matched). An unparseable or
+        // Optional authoritative publish time, from the same scope (first match,
+        // so it belongs to the entry `versionPattern` matched). An unparseable or
         // missing date is not a failure — it just means the Release Log falls back
         // to its estimated "≈" window, exactly as for recipes with no pattern.
         let publishedAt = ReleaseDate.parse(
             recipe.publishedAtPattern.flatMap {
-                VendorProbeRecipe.extractVersion(from: body.text, pattern: $0)
+                VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
             })
 
         var warnings: [ProbeWarning] = []
         var remote: RemoteVersion
 
         // If this recipe knows how to install in place, resolve the installer URL
-        // (and any checksum) now — from the same body we already have. A failure
-        // here just falls back to detection-only; it never blocks the version.
+        // (and any checksum) now — from the same scope we already narrowed the
+        // version to (so a `.bodyPattern` install URL can't resolve against a
+        // different entry than the version it's paired with). A failure here
+        // just falls back to detection-only; it never blocks the version.
         if allowInstall, let spec = recipe.install {
             var resolved: (url: URL, checksum: String?)?
             var transient: TransientInstallURL?
             do {
-                resolved = try await resolveInstall(spec, body: body.text, version: version)
+                resolved = try await resolveInstall(spec, body: scope, version: version)
             } catch let error as TransientInstallURL {
                 transient = error
             } catch {
@@ -440,6 +456,15 @@ public struct VendorProbeSource: UpdateSource {
                     recipe: recipe, version: version, install: spec, plan: plan,
                     resolvedDownload: body.resolvedDownload, display: display,
                     publishedAt: publishedAt,
+                    // Deliberately `body.text`, not `scope`: this parses the WHOLE
+                    // response as a Sparkle appcast document (`SparkleAppcastParser`)
+                    // rather than reading a pattern out of it, so an entry-scoped
+                    // fragment would not parse as XML at all. It is safe on its own
+                    // terms regardless of scoping — it re-matches `version` against
+                    // the parsed items itself and returns `[]` on anything but
+                    // exactly one match — and today's `entryStartPattern` recipes
+                    // (Android Studio's JSON feed) have no `sparkle:deltas` to find,
+                    // so this never fires for them either way.
                     deltas: VendorAppcastDeltas.patches(
                         inBody: body.text, forVersion: version))
                 // A recipe that names a checksum pattern but no longer matches one

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -995,25 +995,12 @@ private func verdict(
     #expect(canary.entryStartPattern != nil,
             "the fix opts the canary recipe into entry-scoped resolution")
 
-    // Same shipping recipe (same versionPattern/displayVersionPattern/install,
-    // straight from the registry), pointed at a loopback copy of the real
-    // body, with only `entryStartPattern` swapped — so this is a true A/B on
-    // the ONE thing the fix changes, not two hand-written recipes drifting
-    // independently of what actually ships.
-    func pointedAt(_ url: URL, entryStartPattern: String?) -> VendorProbeRecipe {
-        VendorProbeRecipe(
-            bundleID: canary.bundleID, url: url, mode: canary.mode,
-            versionPattern: canary.versionPattern, downloadURL: canary.downloadURL,
-            changelogURL: canary.changelogURL, selectHighest: canary.selectHighest,
-            versionIsBuild: canary.versionIsBuild,
-            displayVersionPattern: canary.displayVersionPattern,
-            publishedAtPattern: canary.publishedAtPattern,
-            entryStartPattern: entryStartPattern,
-            install: canary.install, requestBody: canary.requestBody,
-            requestHeaders: canary.requestHeaders, followRedirects: canary.followRedirects,
-            channel: canary.channel)
-    }
-
+    // Same shipping recipe object, straight from the registry, pointed at a
+    // loopback copy of the real body via `with(url:)` and `with(entryStartPattern:)`
+    // — copy methods that carry over EVERY other field, so this is a true A/B on
+    // the ONE thing the fix changes, not two hand-copied recipes that could
+    // silently drift from what actually ships (see those methods' doc: an
+    // earlier hand-copy here dropped `identities`/`track`/`variant`).
     let server = try RecipeVerificationTests.StubServer(body: body)
     defer { server.stop() }
 
@@ -1021,7 +1008,7 @@ private func verdict(
     // as it shipped before this fix) and the plain first-match over the whole
     // feed lands on the older 261 train's RC, exactly as `duo verify` caught.
     let redOutcome = await VendorProbeSource().probeDiagnostic(
-        pointedAt(server.url, entryStartPattern: nil))
+        canary.with(url: server.url).with(entryStartPattern: nil))
     #expect(
         redOutcome.remote?.version == "AI-261.26222.65.2614.16166871",
         "pre-fix recipe should reproduce the reported bug: first match over the whole feed lands on the older train's RC")
@@ -1030,8 +1017,7 @@ private func verdict(
     // GREEN — the shipping recipe resolves the entry whose OWN build compares
     // highest: version, display and the install URL all agree on the SAME
     // entry, the newer 262 train's Canary 2.
-    let outcome = await VendorProbeSource().probeDiagnostic(
-        pointedAt(server.url, entryStartPattern: canary.entryStartPattern))
+    let outcome = await VendorProbeSource().probeDiagnostic(canary.with(url: server.url))
     #expect(outcome.remote?.version == "AI-262.9437.185.2621.16128175")
     #expect(outcome.remote?.shortVersion == "2026.2.1 Canary 2")
     #expect(
@@ -1082,6 +1068,82 @@ private func verdict(
         in: onlySecondMatches, entryStartPattern: #"\{"date":""#,
         versionPattern: #""build":"(AI-[^"]+)""#)
     #expect(winner?.contains(#""build":"AI-9.0""#) == true)
+}
+
+/// A typo'd `entryStartPattern` doesn't fail loudly: `highestVersionEntry`
+/// swallows an uncompilable regex with `try?` and falls back to whole-body
+/// first-match — the exact pre-#76 behaviour, with nothing logged anywhere.
+/// This is the only net that would catch that mistake before it ships, so it
+/// has to be registry-wide, not just Android Studio's two recipes.
+@Test func entryStartPatternsInTheRegistryAreValidRegexes() {
+    for recipe in VendorProbeRegistry.recipes {
+        guard let pattern = recipe.entryStartPattern else { continue }
+        #expect(
+            (try? NSRegularExpression(pattern: pattern)) != nil,
+            "\(recipe.bundleID) [\(recipe.channel.rawValue)]: entryStartPattern '\(pattern)' does not compile as a regex")
+    }
+}
+
+/// The primitive's central claim — version/display/URL can never land on
+/// different releases — holds only while `entryStartPattern` slices BETWEEN
+/// items. If a future feed nested the start marker inside one item, the
+/// winning "entry" would straddle two releases: this pins that `entryStartPattern`
+/// declines (falls back to nil, same as any other disqualified winner) rather
+/// than silently trusting a slice that isn't self-contained.
+@Test func highestVersionEntryDeclinesAWinningEntryThatContainsMoreThanOneRelease() {
+    // Two `{"date":"` slices, but the SECOND one (which would win — "9.0" >
+    // "1.0") is contaminated: it contains two `versionPattern` matches, as if
+    // `entryStartPattern` had split mid-item and folded a second release's
+    // fields into what should have been one entry.
+    let midItemSplit =
+        #"{"date":"a","build":"AI-1.0"}{"date":"b","build":"AI-9.0"}{"stray":"AI-9.5"}"#
+    #expect(
+        VendorProbeRecipe.highestVersionEntry(
+            in: midItemSplit, entryStartPattern: #"\{"date":""#,
+            versionPattern: #"AI-([0-9.]+)"#) == nil,
+        "a winning entry with more than one versionPattern match must decline, not silently trust the slice")
+
+    // Control: the same shape, but the winning entry is clean (exactly one
+    // match) — must still resolve normally.
+    let clean = #"{"date":"a","build":"AI-1.0"}{"date":"b","build":"AI-9.0"}"#
+    let winner = VendorProbeRecipe.highestVersionEntry(
+        in: clean, entryStartPattern: #"\{"date":""#, versionPattern: #"AI-([0-9.]+)"#)
+    #expect(winner?.contains("AI-9.0") == true)
+}
+
+/// `selectHighest` must mean the same thing whether or not `entryStartPattern`
+/// is also set: entries are scored by the SAME extractor
+/// (`highestVersion`/`extractVersion`) the caller will apply to the winner
+/// afterwards, so the two can't disagree about which entry "the highest
+/// version" even refers to. No registry recipe combines the two today, but the
+/// primitive must not silently narrow `selectHighest`'s meaning if one does.
+@Test func highestVersionEntryScoresBySelectHighestWhenTheRecipeAsksForIt() {
+    // Entry A's FIRST match ("1.0") is lower than entry B's ("2.0"), but A
+    // contains a SECOND, higher match ("9.0") buried later — exactly the shape
+    // `selectHighest` exists to find over a whole body.
+    let body = #"{"date":"a","build":"AI-1.0","note":"superseded by AI-9.0"}{"date":"b","build":"AI-2.0"}"#
+    let pattern = #"AI-([0-9.]+)"#
+
+    // Without `selectHighest`, each entry is scored by its FIRST match: A
+    // reads "1.0", B reads "2.0" — B wins, and it has only one match, so no
+    // other invariant gets in the way.
+    let firstMatchWinner = VendorProbeRecipe.highestVersionEntry(
+        in: body, entryStartPattern: #"\{"date":""#, versionPattern: pattern)
+    #expect(firstMatchWinner?.contains(#""build":"AI-2.0""#) == true)
+    #expect(
+        firstMatchWinner.flatMap { VendorProbeRecipe.extractVersion(from: $0, pattern: pattern) }
+            == "2.0")
+
+    // WITH `selectHighest`, each entry is scored by its OWN highest match: A
+    // reads "9.0" (beating its own first-match "1.0"), B still reads "2.0" —
+    // A wins this time, even though A's first match alone would have lost.
+    let highestMatchWinner = VendorProbeRecipe.highestVersionEntry(
+        in: body, entryStartPattern: #"\{"date":""#, versionPattern: pattern, selectHighest: true)
+    #expect(highestMatchWinner?.contains("AI-1.0") == true)
+    #expect(
+        highestMatchWinner.flatMap { VendorProbeRecipe.highestVersion(from: $0, pattern: pattern) }
+            == "9.0",
+        "a selectHighest recipe must report 9.0, not silently degrade to entry-scored first-match (2.0)")
 }
 
 /// A stability-floor recipe's `ChannelArtifactProof` must accept EVERY build that

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -891,6 +891,13 @@ private func verdict(
         "EAP missed a real build bump")
 }
 
+// Pattern-level only: this drives `VendorProbeRecipe.extractVersion` directly
+// against a body that happens to already be in version order, so it does NOT
+// exercise `entryStartPattern`/`VendorProbeSource.probeOutcome`'s entry-scoped
+// resolution — the path production actually takes on the real (publish-date
+// ordered) feed. It stays as a pattern/stability-floor check; see
+// `androidStudioCanaryPicksTheNewestTrainNotTheMostRecentlyPublishedEntry` below
+// for the end-to-end ordering behaviour (issue #76).
 @Test func androidStudioPreviewObeysStabilityFloorAndShowsCleanVersion() {
     // Faithful newest-first slice spanning TWO feature versions: the next version's
     // Canary 1 (2026.1.3, newest overall) sits above the current version's RC 1
@@ -953,6 +960,128 @@ private func verdict(
         UpdateChecker.evaluate(installed: canaryOn7, remote: canaryRemote)
             == .updateAvailable(latest: "2026.1.3 Canary 1"),
         "Canary should advance onto the newest preview, shown as a clean version")
+}
+
+/// Issue #76: `jb.gg/android-studio-releases-list.json` is ordered by
+/// PUBLICATION DATE, not by version. When two feature trains are open at once
+/// that stops being the same thing as "newest first" — real ordering captured
+/// 2026-08-27 (671-item feed): `2026.1.4 RC 2` (older 261 train) sits at [0],
+/// the actually-newest build `2026.2.1 Canary 2` (262 train) sits at [1], one
+/// slot later, because Google happened to publish the RC a few hours after it.
+///
+/// Run end to end through `VendorProbeSource.probeDiagnostic` (not just
+/// pattern extraction) against that real body, so `version`,
+/// `displayVersionPattern` AND the install spec's URL are all checked
+/// together — the exact three first-match reads `entryStartPattern` exists to
+/// keep in sync (see its doc on `VendorProbeRecipe`; flipping `selectHighest`
+/// on the version alone would have desynced them instead of fixing anything).
+@Test func androidStudioCanaryPicksTheNewestTrainNotTheMostRecentlyPublishedEntry() async throws {
+    // Trimmed but real: dates, builds, names and channels are byte-for-byte
+    // what the feed served; only the sibling `.deb`/`.exe` download entries
+    // and the checksums were dropped to keep the fixture short.
+    let body = #"""
+    {"content":{"item":[\#
+    {"date":"August 25, 2026","platformBuild":"261.26222.65","download":[{"size":"1.5 GB","link":"https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.6/android-studio-quail4-rc2-mac_arm.dmg","checksum":"deadbeef"}],"build":"AI-261.26222.65.2614.16166871","platformVersion":"2026.1.4","name":"Android Studio Quail 4 | 2026.1.4 RC 2","channel":"RC","version":"2026.1.4.6"},\#
+    {"date":"August 20, 2026","platformBuild":"262.9437.185","download":[{"size":"1.5 GB","link":"https://edgedl.me.gvt1.com/android/studio/install/2026.2.1.2/android-studio-rabbit1-canary2-mac_arm.dmg","checksum":"deadbeef"}],"build":"AI-262.9437.185.2621.16128175","platformVersion":"2026.2.1","name":"Android Studio Rabbit 1 | 2026.2.1 Canary 2","channel":"Canary","version":"2026.2.1.2"},\#
+    {"date":"August 17, 2026","platformBuild":"262.9437.185","download":[{"size":"1.5 GB","link":"https://edgedl.me.gvt1.com/android/studio/install/2026.2.1.1/android-studio-rabbit1-canary1-mac_arm.dmg","checksum":"deadbeef"}],"build":"AI-262.9437.185.2621.16076543","platformVersion":"2026.2.1","name":"Android Studio Rabbit 1 | 2026.2.1 Canary 1","channel":"Canary","version":"2026.2.1.1"},\#
+    {"date":"August 17, 2026","platformBuild":"261.26222.65","download":[{"size":"1.5 GB","link":"https://edgedl.me.gvt1.com/android/studio/install/2026.1.4.5/android-studio-quail4-rc1-mac_arm.dmg","checksum":"deadbeef"}],"build":"AI-261.26222.65.2614.16087418","platformVersion":"2026.1.4","name":"Android Studio Quail 4 | 2026.1.4 RC 1","channel":"RC","version":"2026.1.4.5"}\#
+    ]}}
+    """#
+
+    let canary = try #require(
+        VendorProbeRegistry.recipes.first {
+            $0.bundleID == "com.google.android.studio" && $0.channel == .canary
+        })
+    #expect(canary.entryStartPattern != nil,
+            "the fix opts the canary recipe into entry-scoped resolution")
+
+    // Same shipping recipe (same versionPattern/displayVersionPattern/install,
+    // straight from the registry), pointed at a loopback copy of the real
+    // body, with only `entryStartPattern` swapped — so this is a true A/B on
+    // the ONE thing the fix changes, not two hand-written recipes drifting
+    // independently of what actually ships.
+    func pointedAt(_ url: URL, entryStartPattern: String?) -> VendorProbeRecipe {
+        VendorProbeRecipe(
+            bundleID: canary.bundleID, url: url, mode: canary.mode,
+            versionPattern: canary.versionPattern, downloadURL: canary.downloadURL,
+            changelogURL: canary.changelogURL, selectHighest: canary.selectHighest,
+            versionIsBuild: canary.versionIsBuild,
+            displayVersionPattern: canary.displayVersionPattern,
+            publishedAtPattern: canary.publishedAtPattern,
+            entryStartPattern: entryStartPattern,
+            install: canary.install, requestBody: canary.requestBody,
+            requestHeaders: canary.requestHeaders, followRedirects: canary.followRedirects,
+            channel: canary.channel)
+    }
+
+    let server = try RecipeVerificationTests.StubServer(body: body)
+    defer { server.stop() }
+
+    // RED — reproduces the reported bug: strip `entryStartPattern` (the recipe
+    // as it shipped before this fix) and the plain first-match over the whole
+    // feed lands on the older 261 train's RC, exactly as `duo verify` caught.
+    let redOutcome = await VendorProbeSource().probeDiagnostic(
+        pointedAt(server.url, entryStartPattern: nil))
+    #expect(
+        redOutcome.remote?.version == "AI-261.26222.65.2614.16166871",
+        "pre-fix recipe should reproduce the reported bug: first match over the whole feed lands on the older train's RC")
+    #expect(redOutcome.remote?.shortVersion == "2026.1.4 RC 2")
+
+    // GREEN — the shipping recipe resolves the entry whose OWN build compares
+    // highest: version, display and the install URL all agree on the SAME
+    // entry, the newer 262 train's Canary 2.
+    let outcome = await VendorProbeSource().probeDiagnostic(
+        pointedAt(server.url, entryStartPattern: canary.entryStartPattern))
+    #expect(outcome.remote?.version == "AI-262.9437.185.2621.16128175")
+    #expect(outcome.remote?.shortVersion == "2026.2.1 Canary 2")
+    #expect(
+        outcome.remote?.downloadURL?.absoluteString
+            == "https://edgedl.me.gvt1.com/android/studio/install/2026.2.1.2/"
+                + "android-studio-rabbit1-canary2-mac_arm.dmg")
+}
+
+/// Both Android Studio preview recipes must stay in lockstep on the fix — the
+/// stability floor spans both, and only opting canary in would leave beta
+/// exposed to the exact same cross-train ordering bug. Derived from the
+/// registry so a future third preview channel is covered automatically.
+@Test func androidStudioPreviewRecipesBothOptIntoEntryScopedResolution() {
+    let previews = VendorProbeRegistry.recipes.filter {
+        $0.bundleID == "com.google.android.studio" && $0.channel != .stable
+    }
+    #expect(!previews.isEmpty, "no Android Studio preview recipes in the registry")
+    for recipe in previews {
+        #expect(
+            recipe.entryStartPattern != nil,
+            "\(recipe.channel.rawValue) recipe must opt into entry-scoped resolution (issue #76)")
+    }
+}
+
+/// Unit coverage of the primitive itself, isolated from any real feed: slicing
+/// and the two ways it must decline (falling back to nil, which callers turn
+/// into "search the whole body" — see `VendorProbeSource.probeOutcome`) rather
+/// than crash or silently pick something arbitrary.
+@Test func highestVersionEntryFallsBackWhenThereIsNothingToDisambiguate() {
+    // Fewer than two `entryStartPattern` matches: nothing to slice.
+    #expect(
+        VendorProbeRecipe.highestVersionEntry(
+            in: #"{"date":"x","build":"AI-1.0"}"#,
+            entryStartPattern: #"\{"date":""#,
+            versionPattern: #""build":"(AI-[^"]+)""#) == nil)
+
+    // Two entries, but neither's version matches `versionPattern`: no winner.
+    let neitherMatches = #"{"date":"a","other":"1"}{"date":"b","other":"2"}"#
+    #expect(
+        VendorProbeRecipe.highestVersionEntry(
+            in: neitherMatches, entryStartPattern: #"\{"date":""#,
+            versionPattern: #""build":"(AI-[^"]+)""#) == nil)
+
+    // Two entries, only the SECOND matches: it wins even though it isn't
+    // first — the whole point of the primitive.
+    let onlySecondMatches = #"{"date":"a","other":"1"}{"date":"b","build":"AI-9.0"}"#
+    let winner = VendorProbeRecipe.highestVersionEntry(
+        in: onlySecondMatches, entryStartPattern: #"\{"date":""#,
+        versionPattern: #""build":"(AI-[^"]+)""#)
+    #expect(winner?.contains(#""build":"AI-9.0""#) == true)
 }
 
 /// A stability-floor recipe's `ChannelArtifactProof` must accept EVERY build that


### PR DESCRIPTION
## What was wrong

`jb.gg/android-studio-releases-list.json` is ordered by **publication date**, not by version. `VendorProbeRecipe.swift` documented the opposite assumption ("the feed is newest-first, so the FIRST channel-set match is that set's newest build"). When two feature trains are open at once — a common state, not an edge case — that assumption breaks.

**Real evidence**, fetched 2026-08-27 (671 items):

```
[0] RC      2026.1.4 RC 2      build AI-261.26222.65.2614.16166871   Aug 25
[1] Canary  2026.2.1 Canary 2  build AI-262.9437.185.2621.16128175   Aug 20
[2] Canary  2026.2.1 Canary 1  build AI-262.9437.185.2621.16076543   Aug 17
[3] RC      2026.1.4 RC 1      build AI-261.26222.65.2614.16087418   Aug 17
```

`262 > 261` (`VersionComparator`), so `[1]` is the actually-newest build — but it was published *before* the RC at `[0]`, so the canary recipe's `(?:Canary|Beta|RC)` first-match landed on the older 261 train's RC. This is exactly what `duo verify` caught:

```
⚠ WARN  vendor:com.google.android.studio:canary
    resolved  2026.1.4 RC 2
    warning   version went BACKWARDS since the last sweep (2026.2.1 Canary 2 → 2026.1.4 RC 2)
```

Not a channel leak (the stability floor — Canary → newest of {Canary, Beta, RC} — is intact and an RC is a legal answer) and not a downgrade (`VersionComparator` correctly ranks 262 > 261, so nobody on 262 was ever offered the 261 RC). It's a lag: a Canary-train user sits one feature version behind until the newer train happens to publish something more recently than the older train's next RC.

## Why the naive fix (flip `selectHighest`) is wrong

`VendorProbeSource.probeOutcome` reads **three** things from the response body by first-match, and none of them respect `selectHighest`:

1. `version` — the `versionPattern` capture (line ~382, pre-fix)
2. `display` — the `displayVersionPattern` capture (~line 409)
3. the install spec's `.bodyPattern` capture, for the download URL (`resolveInstall`)

Setting `selectHighest: true` on the canary recipe's version alone would have picked `AI-262.9437…` correctly for the *row*, while `displayVersionPattern` and the install URL stayed first-match and kept resolving the RC's own entry — the row would read `2026.2.1 Canary 2` while the download button fetched `quail4-rc2-mac_arm.dmg`. `VendorProbeRecipe.swift:53` already documents this exact failure mode (measured on Docker's appcast) for the general case; this issue is the same shape hitting Android Studio.

## The fix

A new opt-in primitive, `VendorProbeRecipe.entryStartPattern: String?` (default `nil`, so every other recipe in the registry is byte-identical to before). When set, `VendorProbeSource.probeOutcome` computes one `scope`:

- slice the body into entries at every match of `entryStartPattern` (that match's start → the next match's start; last entry runs to the end of the body)
- keep the entries where `versionPattern` matches
- pick the entry whose extracted version compares highest, via the same `VersionComparator` path `VendorProbeRecipe.highestVersion`/`highestVersionedURL` already use (no second comparator)

`version`, `displayVersionPattern`, `publishedAtPattern`, **and** the install spec's URL are then all resolved against that *one* winning entry substring — so they can never land on different releases. Falls back to today's whole-body behavior when the pattern matches fewer than two entries, or when no entry's `versionPattern` matches (better a possibly-stale first-match answer than no answer at all).

Applied to both Android Studio preview recipes (canary and beta) with `entryStartPattern: #"\{"date":""#` — each feed item starts with its own `"date"` key, and slicing there keeps a whole item (its download links included) together. Verified against the real 1MB/671-item feed that this pattern produces exactly 671 entries, one per item.

## What I deliberately did NOT touch

- `ReleaseChannel.detect`, `AppScanner`, `ToolboxSource`, or Toolbox gating.
- The stable Android Studio website recipe (unaffected — single-version page, no ordering ambiguity).
- Any other order-fragile recipe I noticed in passing. None jumped out during this change, but I did not go looking — out of scope for this issue.
- No new flags/knobs beyond `entryStartPattern` itself.
- `VendorAppcastDeltas.patches` still reads `body.text` (not `scope`) — deliberately: it parses the whole response as a Sparkle XML appcast, which a JSON entry fragment wouldn't parse as, and it does its own version-match safety independent of scoping. Commented in place.

## Tests

Added to `DuoUpdaterCoreTests/VendorProbeTests.swift`:
- `androidStudioCanaryPicksTheNewestTrainNotTheMostRecentlyPublishedEntry` — red→green regression using the real captured feed ordering above. Runs the *actual shipping* canary recipe (only `url`/`entryStartPattern` swapped) end-to-end through `VendorProbeSource.probeDiagnostic` against a loopback stub of that real body. Confirmed red by temporarily reverting the `VendorProbeSource` engine change alone (keeping the registry field) — it still reproduced the bug, proving the source-side change is what matters, not just the recipe flag.
- `androidStudioPreviewRecipesBothOptIntoEntryScopedResolution` — registry-derived, loops every non-stable Android Studio recipe rather than hand-listing canary/beta, so a future third preview channel is covered automatically.
- `highestVersionEntryFallsBackWhenThereIsNothingToDisambiguate` — unit coverage of the primitive's two fallback cases.
- `androidStudioChannelProofsSpanTheWholeStabilityFloor` (pre-existing) still passes unmodified — it asserts `recipe.install?.urlSource` is still `.bodyPattern`, which this fix does not change.

## Verification (raw output)

Full suite:

```
make test
```
```
✔ Test run with 1164 tests in 92 suites passed after 39.736 seconds with 2 known issues.
   (the 2 known issues are pre-existing tracked-flaky tests unrelated to this change:
    keepassxcRespinIsTheAssetSelected, ankiZeroPaddedTagComparesEqualToInstalled)
✔ Test run with 125 tests in 19 suites passed after 0.067 seconds.   [CLI package]
✓ localizable keys agree — 411 in the catalog, all reachable
```

(An earlier full run hit two total-misses on `com.google.android.studio [beta]` under the suite's full concurrent fan-out — re-ran that test alone and it passed cleanly in 7-10s each time; a second full `make test` run came back fully green with no android.studio issue at all. Network contention from ~150 concurrent live probes, not a code regression — the test file's own comments already document this exact failure shape for a differently-contended run.)

Per this repo's convention, a full `duo verify` sweep is ~150 requests / ~3 minutes and shouldn't be declared green off a partial run — so I did **not** run the full sweep, only the changed recipes:

```
swift run --package-path CLI duo verify --only android.studio
```
```
  duo verify
  3 vendor probes  0 GitHub rules  0 changelogs
  vendor probe  ✓ 3  ⚠ 0  ✗ 0  ~ 0  - 0
```

And fetched the live feed once directly to confirm the resolved versions against the real 671-item body (via `--report`/`--baseline`, which records the resolved version per recipe):

```json
"vendor:com.google.android.studio:canary": { "lastGoodVersion": "2026.2.1 Canary 2", ... }
"vendor:com.google.android.studio:beta":   { "lastGoodVersion": "2026.1.4 RC 2", ... }
"vendor:com.google.android.studio:stable": { "lastGoodVersion": "2026.1.3", ... }
```

Canary now resolves the newer 262 train's Canary 2 (previously would have resolved the stale 261 RC per the issue). Beta correctly stays on the RC — it doesn't accept Canary builds, so it was never exposed to this bug in the first place.

Fixes #76.
