### PR TITLE
BetterDisplay: render its changelog natively instead of embedding the vendor shell

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1278,9 +1278,11 @@ public enum ChangelogRecipeRegistry {
         // to the API directly gets the identical text, the version and date headings
         // the shell never had, and the history a per-tag page cannot hold.
         //
-        // Two recipes because the tracks split on GitHub's `prerelease` flag, and
-        // BetterDisplay resolves its channel from two Settings toggles rather than
-        // from the bundle id (see `BetterDisplayChannel`):
+        // THREE recipes, one per track — none of them removable as a duplicate,
+        // even though `.beta` and `.unstable` differ only in `channel`. The tracks
+        // split on GitHub's `prerelease` flag, and BetterDisplay resolves its
+        // channel from two Settings toggles rather than from the bundle id (see
+        // `BetterDisplayChannel`):
         //   * `.stable`   → prerelease: false — v4.3.6, v4.3.5, …
         //   * `.beta`     ("Receive pre-release updates") → prerelease: true —
         //                 v5.0.3, v5.0.2, … Includes the two `arm64_pre` builds

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1263,6 +1263,75 @@ public enum ChangelogRecipeRegistry {
             maxEntries: 20,
             structuredFormat: .gitHubReleases),
 
+        // BetterDisplay — the same GitHub release bodies the vendor's own page was
+        // already showing, rendered natively instead of in a web view.
+        //
+        // The appcast carries no `<description>`; every item points
+        // `<sparkle:releaseNotesLink>` at
+        // `waydabber.github.io/BetterDisplay/changelog.html?tag=<tag>`. That page is
+        // an EMPTY shell — fetched 2026-08-27, 1149 bytes, no body content at all.
+        // Its inline script reads `?tag`, GETs
+        // `api.github.com/repos/waydabber/BetterDummy/releases/tags/<tag>` (the old
+        // repo name, still redirecting) and renders `response.body` with marked.js.
+        // So the web view was rendering GitHub markdown the whole time, minus our
+        // styling and plus the vendor's "Download app for macOS" button image. Going
+        // to the API directly gets the identical text, the version and date headings
+        // the shell never had, and the history a per-tag page cannot hold.
+        //
+        // Two recipes because the tracks split on GitHub's `prerelease` flag, and
+        // BetterDisplay resolves its channel from two Settings toggles rather than
+        // from the bundle id (see `BetterDisplayChannel`):
+        //   * `.stable`   → prerelease: false — v4.3.6, v4.3.5, …
+        //   * `.beta`     ("Receive pre-release updates") → prerelease: true —
+        //                 v5.0.3, v5.0.2, … Includes the two `arm64_pre` builds
+        //                 (v5.0.0/v5.0.1), which are excluded from what we OFFER
+        //                 because they are Apple-silicon-only, but are real history
+        //                 and belong in the rail.
+        //   * `.unstable` ("Receive internal pre-release updates") → deliberately
+        //                 the same feed as `.beta`. The internal track has no
+        //                 per-version notes anywhere: its items link
+        //                 `changelog.html?tag=pre`, and that rolling release's body
+        //                 is static boilerplate about what internal builds are. The
+        //                 pre track is where those builds come from and the closest
+        //                 true history for them; without this third registration the
+        //                 channel-aware lookup would fall back to `.stable` and show
+        //                 an internal 5.x user the 4.x notes.
+        //
+        // That rolling `pre` release cannot leak into either rail as an entry titled
+        // "pre": GitHub orders this endpoint by `created_at`, and `pre` was created
+        // 2022-04-06 while the 40th-newest release is 2025-01-03 (both read
+        // 2026-08-27). It is far outside a `per_page=40` window and sinks further
+        // with every release the vendor cuts.
+        ChangelogRecipe(
+            bundleID: BetterDisplayChannel.bundleID,
+            source: URL(
+                string:
+                    "https://api.github.com/repos/waydabber/BetterDisplay/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 15,
+            channel: .stable,
+            structuredFormat: .gitHubReleases),
+
+        ChangelogRecipe(
+            bundleID: BetterDisplayChannel.bundleID,
+            source: URL(
+                string:
+                    "https://api.github.com/repos/waydabber/BetterDisplay/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 15,
+            channel: .beta,
+            structuredFormat: .gitHubReleases),
+
+        ChangelogRecipe(
+            bundleID: BetterDisplayChannel.bundleID,
+            source: URL(
+                string:
+                    "https://api.github.com/repos/waydabber/BetterDisplay/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 15,
+            channel: .unstable,
+            structuredFormat: .gitHubReleases),
+
         // Alcove — its own changelog API. Public and unauthenticated, unlike the
         // update endpoint on the same host, which is license-gated (see
         // `AlcoveUpdateSource`). Structured JSON: majors, each holding its point

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -121,11 +121,20 @@ public enum GitHubMarkdownParser {
         line.range(of: #"^<?https?://\S+>?$"#, options: .regularExpression) != nil
     }
 
-    /// A line whose entire content is one image, optionally wrapped in a link.
+    /// A line whose entire content is one image, optionally wrapped in a link —
+    /// in either spelling. GitHub release bodies are Markdown but accept raw HTML,
+    /// and vendors use both: LuLu opens with a Markdown `[![](shields.io/…)](…)`
+    /// sponsor banner, BetterDisplay closes every release with an HTML
+    /// `<a href="…dmg"><img src="…" alt="Download for macOS"/></a>` button. Neither
+    /// is a change, and as an "item" both are markup the reader cannot use — the
+    /// HTML one worse, since it reaches the pane as literal angle brackets.
     private static func isImageOnly(_ line: String) -> Bool {
         line.range(
             of: #"^\[?!\[[^\]]*\]\([^)]*\)\]?(\([^)]*\))?$"#,
             options: .regularExpression) != nil
+        || line.range(
+            of: #"^(?:<a\b[^>]*>\s*)?<img\b[^>]*/?>(?:\s*</a>)?$"#,
+            options: [.regularExpression, .caseInsensitive]) != nil
     }
 
     /// A checksum label (`… SHA256 …:`) or a line carrying a 32+ character hex run.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -37,7 +37,7 @@ public enum StructuredChangelogDecoder {
         case .zedGitHubReleases:
             return decodeZedGitHubReleases(body, channel: channel ?? .stable, maxEntries: maxEntries)
         case .gitHubReleases:
-            return decodeGitHubReleases(body, maxEntries: maxEntries)
+            return decodeGitHubReleases(body, channel: channel, maxEntries: maxEntries)
         case .alcoveChangelog:
             return decodeAlcoveChangelog(body, maxEntries: maxEntries)
         case .notionPageChunk:
@@ -564,23 +564,33 @@ public enum StructuredChangelogDecoder {
 
     // MARK: - Plain GitHub releases (api.github.com/repos/<owner>/<repo>/releases)
 
-    /// Decode a GitHub releases array into one entry per stable release, newest
-    /// first, using the same `GitHubMarkdownParser` the GitHub version source uses
-    /// — so a release body renders identically no matter which way we arrived at it.
+    /// Decode a GitHub releases array into one entry per release on the requested
+    /// track, newest first, using the same `GitHubMarkdownParser` the GitHub
+    /// version source uses — so a release body renders identically no matter which
+    /// way we arrived at it.
     ///
-    /// Prereleases are skipped: nothing here says which track the user is on, so
-    /// offering a prerelease's notes beside a stable install would be describing a
-    /// build they were never shown. A release whose body yields nothing at all
-    /// (empty, or only a checksum block) is skipped rather than shown as a bare
-    /// version heading — but a body of plain sentences is NOT, since the parser's
-    /// prose pass covers those.
-    static func decodeGitHubReleases(_ body: String, maxEntries: Int?) -> Changelog? {
+    /// GitHub's `prerelease` flag is the track split, and `channel` says which side
+    /// of it to read. `nil` — every recipe that registers no channel, which is all
+    /// of them but BetterDisplay's — means stable only, and is the behavior this
+    /// decoder has always had: offering a prerelease's notes beside a stable
+    /// install would describe a build the user was never shown. A recipe that DOES
+    /// name a channel is opting into the other side, and must only do so for a
+    /// channel the vendor actually publishes as GitHub prereleases; `.stable` on a
+    /// recipe means the same thing as `nil` here.
+    ///
+    /// A release whose body yields nothing at all (empty, or only a checksum block)
+    /// is skipped rather than shown as a bare version heading — but a body of plain
+    /// sentences is NOT, since the parser's prose pass covers those.
+    static func decodeGitHubReleases(
+        _ body: String, channel: ReleaseChannel? = nil, maxEntries: Int?
+    ) -> Changelog? {
         guard let data = body.data(using: .utf8),
               let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data)
         else { return nil }
 
+        let wantsPrerelease = channel != nil && channel != .stable
         var entries: [Changelog.Entry] = []
-        for release in releases where !release.prerelease && !release.draft {
+        for release in releases where release.prerelease == wantsPrerelease && !release.draft {
             guard let raw = release.body, !raw.isEmpty else { continue }
             let version = stripLeadingV(release.tagName)
             guard !version.isEmpty else { continue }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChangelogRecipeTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// Two releases from `api.github.com/repos/waydabber/BetterDisplay/releases`
+/// (fetched 2026-08-27): the newest stable and the newest plain pre-release, which
+/// is also the shape that has no bullets at all. v4.3.6's body is trimmed to one
+/// item per region — the two headings, the localization pair, the trailing links
+/// line and the download button are what the parser has to make decisions about;
+/// the other five change bullets add nothing to the test. Everything kept is
+/// verbatim. v5.0.2's body is whole.
+private let betterDisplayReleasesFixture = #"""
+[
+ {
+  "tag_name": "v5.0.2",
+  "prerelease": true,
+  "draft": false,
+  "published_at": "2026-08-11T17:40:35Z",
+  "body": "This updated BetterDisplay 5 pre-release adds improved soft-disconnected display handling, direct display connection controls in Settings, new display-group actions, and better touch compatibility on macOS 27 Golden Gate. Additionally, this version reintroduces Intel support for macOS 26 Tahoe. Other highlights in BetterDisplay 5 include advanced compositor filters, expanded display reporting and integration capabilities, HDMI-CEC control, improved per-display automation, app menu and OSD refinements, performance improvements, custom 3D LUT filters, a built-in app console, and compatibility updates for the latest macOS versions.\r\n\r\n_Please note that this pre-release was tested with macOS 27 Golden Gate public beta 3 (developer beta 5) and may not be fully compatible with earlier or later macOS 27 versions - an [updated release](https://github.com/waydabber/BetterDisplay/releases) is available._\r\n\r\n<a href=\"https://github.com/waydabber/BetterDisplay/releases/download/v5.0.2/BetterDisplay-v5.0.2-pre-release.dmg\"><img src=\"https://user-images.githubusercontent.com/37590873/219133640-8b7a0179-20a7-4e02-8887-fbbd2eaad64b.png\" width=\"175\" alt=\"Download for macOS\"/></a>"
+ },
+ {
+  "tag_name": "v4.3.6",
+  "prerelease": false,
+  "draft": false,
+  "published_at": "2026-08-11T17:40:14Z",
+  "body": "This version is a service release focused on bug fixes and compatibility improvements with macOS 27.\r\n\n_**macOS 27 Golden Gate beta users:** try the latest v5.x pre-release for even better macOS 27 support and additional features. BetterDisplay 5 supports macOS 26 or later (Apple Silicon & Intel). Go to `Settings` > `Application` > `Updates`, enable `Receive pre-release updates`, then use `Check for Updates`._\r\n\n### Changes\n\n- Fixed DDC capability retrieval through the console potentially hanging indefinitely - #5674\r\n- Improved default nits values for built-in displays on Intel Macs - #5684\r\n\n### Included Localizations\n\n- British English, Chinese Simplified, Chinese Traditional, Dutch, French, German, Hungarian, Italian, Japanese, Korean, Norwegian Bokmål, Polish, Portuguese Brazil, Romanian, Russian, Slovenian, Spanish, Swedish, Turkish, Ukrainian, and Vietnamese.\r\n- Contributors: @afkeceli, @AndryTi, @andrwmai, @BingoKingo, @brzenio, @cfuentea, @chihuahua-experience, @cristianritco, @dimaitre, @dotWee, @DrRoglaa, @dvanzoerlandt, @elislays08, @enormous-rat, @giulianopires, @gpnunes75, @HaiBliss, @hshsilver, @hw0603, @ibrayd, @jacktechstudio, @JulyIghor, @Kcraft059, @MapleLeaf14, @marcinkardas, @maximsenterprise, @MazlumSerbest, @mickimnet, @mikevic18, @MonolitheMedia, @moriLiu, @MStankiewiczOfficial, @niklasbogensperger, @old-cookie, @PatrykM13, @pavlik000-collab, @PuzzledUser, @SakiPapa, @shindgewongxj, @skantek, @sm-moshi, @stonkol, @sup3rb3ar, @yeager, @waydabber. AI was used for updating some of the localizations.\r\n\nFor previous release notes, visit the [GitHub Releases page](https://github.com/waydabber/BetterDisplay/releases). [Outdated license FAQ](https://github.com/waydabber/BetterDisplay/discussions/4620).\r\n\n<a href=\"https://github.com/waydabber/BetterDisplay/releases/download/v4.3.6/BetterDisplay-v4.3.6.dmg\"><img src=\"https://user-images.githubusercontent.com/37590873/219133640-8b7a0179-20a7-4e02-8887-fbbd2eaad64b.png\" width=\"175\" alt=\"Download for macOS\"/></a>"
+ }
+]
+"""#
+
+@Suite struct BetterDisplayChangelogRecipeTests {
+
+    private func recipe(_ channel: ReleaseChannel) throws -> ChangelogRecipe {
+        try #require(ChangelogRecipeRegistry.recipe(
+            forBundleID: BetterDisplayChannel.bundleID, channel: channel))
+    }
+
+    /// All three tracks read the same GitHub releases endpoint; only `channel`
+    /// differs, and that is what splits the feed inside the decoder.
+    @Test func everyTrackIsRegisteredAgainstTheReleasesAPI() throws {
+        let all = ChangelogRecipeRegistry.recipes(forBundleID: BetterDisplayChannel.bundleID)
+        #expect(all.count == 3)
+        #expect(Set(all.map(\.channel)) == [.stable, .beta, .unstable])
+        for r in all {
+            #expect(r.structuredFormat == .gitHubReleases)
+            #expect(r.mode == .json)
+            #expect(r.source.host == "api.github.com")
+            #expect(r.source.path == "/repos/waydabber/BetterDisplay/releases")
+        }
+    }
+
+    /// The internal track has no per-version notes of its own — its appcast items
+    /// link `changelog.html?tag=pre`, a rolling release whose body is boilerplate
+    /// (see `BetterDisplayChannel`). It is registered explicitly against the
+    /// pre-release feed BECAUSE the lookup's last resort is the `.stable` recipe:
+    /// without this registration someone on an internal 5.x build would be shown
+    /// the 4.x stable notes.
+    @Test func theInternalTrackReadsPreReleasesNotStable() throws {
+        #expect(try recipe(.unstable).channel == .unstable)
+        #expect(try recipe(.stable).channel == .stable)
+        #expect(try recipe(.beta).channel == .beta)
+    }
+
+    /// `prerelease` is the track split. A stable install must never be shown a
+    /// pre-release's notes, and vice versa.
+    @Test func theChannelDecidesWhichSideOfTheFeedIsRead() throws {
+        let stable = try #require(StructuredChangelogDecoder.decodeGitHubReleases(
+            betterDisplayReleasesFixture, channel: .stable, maxEntries: 15))
+        #expect(stable.entries.map(\.version) == ["4.3.6"])
+
+        for prereleaseTrack: ReleaseChannel in [.beta, .unstable] {
+            let pre = try #require(StructuredChangelogDecoder.decodeGitHubReleases(
+                betterDisplayReleasesFixture, channel: prereleaseTrack, maxEntries: 15))
+            #expect(pre.entries.map(\.version) == ["5.0.2"], "\(prereleaseTrack)")
+        }
+    }
+
+    /// No channel means stable only — the behavior every other `.gitHubReleases`
+    /// recipe (Waku, Shotbase) relies on, none of which registers a channel.
+    @Test func noChannelStillMeansStableOnly() throws {
+        let log = try #require(StructuredChangelogDecoder.decodeGitHubReleases(
+            betterDisplayReleasesFixture, channel: nil, maxEntries: 15))
+        #expect(log.entries.map(\.version) == ["4.3.6"])
+    }
+
+    /// Every BetterDisplay release closes with an HTML download button. It is not a
+    /// change, and it is worse than useless as an item: `<a href=…><img …/></a>`
+    /// reaches the pane as literal angle brackets. On a bulleted release the strict
+    /// pass never sees it; on a bullet-less one like v5.0.2 the prose pass does, and
+    /// `isImageOnly` is what drops it. Measured before the fix: 14 items across the
+    /// two tracks of the live 40-release feed were that markup.
+    @Test func theDownloadButtonIsNeverAChangeItem() throws {
+        for channel: ReleaseChannel in [.stable, .beta] {
+            let log = try #require(StructuredChangelogDecoder.decodeGitHubReleases(
+                betterDisplayReleasesFixture, channel: channel, maxEntries: 15))
+            let items = log.entries.flatMap(\.items)
+            #expect(!items.contains { $0.contains("<img") || $0.contains("<a href") })
+            #expect(!items.contains { $0.contains("Download for macOS") })
+        }
+    }
+
+    /// v5.0.2 has no list at all, so the prose pass carries it: two paragraphs of
+    /// real notes, and nothing else from a body whose third line is the button.
+    @Test func theBulletlessPreReleaseKeepsItsProse() throws {
+        let log = try #require(StructuredChangelogDecoder.decodeGitHubReleases(
+            betterDisplayReleasesFixture, channel: .beta, maxEntries: 15))
+        let entry = try #require(log.entries.first)
+        #expect(entry.date == "2026-08-11")
+        #expect(entry.items.count == 2)
+        #expect(entry.items[0].hasPrefix("This updated BetterDisplay 5 pre-release adds"))
+        #expect(entry.items[1].hasPrefix("_Please note that this pre-release was tested"))
+    }
+
+    /// The stable body's own decisions: the seven-region trim keeps the `### Changes`
+    /// bullets and the two under `### Included Localizations` (a real section of the
+    /// vendor's notes, not contributor noise GitHub generates), and drops the intro
+    /// prose, the pre-release promo and the "For previous release notes" line —
+    /// none of which is a bullet.
+    @Test func theStableBodyKeepsOnlyItsBullets() throws {
+        let log = try #require(StructuredChangelogDecoder.decodeGitHubReleases(
+            betterDisplayReleasesFixture, channel: .stable, maxEntries: 15))
+        let entry = try #require(log.entries.first)
+        #expect(entry.items.count == 4)
+        #expect(entry.items[0].hasPrefix("Fixed DDC capability retrieval"))
+        #expect(entry.items[3].hasPrefix("Contributors: @afkeceli"))
+        #expect(!entry.items.contains { $0.contains("For previous release notes") })
+        #expect(!entry.items.contains { $0.contains("service release focused on bug fixes") })
+    }
+}


### PR DESCRIPTION
## What was wrong

BetterDisplay's changelog pane was a `WKWebView` on
`waydabber.github.io/BetterDisplay/changelog.html?tag=v4.3.6` — a light page in a
dark app, with a giant "Download app for macOS" button and no version or date
heading.

That page turns out to be a **1149-byte empty shell** (fetched 2026-08-27). Its
inline script reads `?tag`, GETs
`api.github.com/repos/waydabber/BetterDummy/releases/tags/<tag>` (the old repo
name, still redirecting) and renders `response.body` with `marked.js`. So the web
view was already showing GitHub markdown — just none of our styling, and with the
vendor's download button in it.

The appcast itself carries no `<description>` on any item, so there was nothing
inline to fall back to either.

## What this does

Points a `.gitHubReleases` recipe at the API directly. Identical text, plus the
version/date headings the shell never had, plus the history a per-tag page cannot
hold.

Three recipes, because BetterDisplay picks its track from two Settings toggles
rather than from the bundle id (see `BetterDisplayChannel`):

| track | recipe channel | reads |
| --- | --- | --- |
| stable | `.stable` | `prerelease: false` — v4.3.6, v4.3.5, … |
| "Receive pre-release updates" | `.beta` | `prerelease: true` — v5.0.3, v5.0.2, … |
| "Receive internal pre-release updates" | `.unstable` | the same pre feed |

`internal` is registered explicitly **because** the lookup's last resort is the
`.stable` recipe: the internal track has no per-version notes anywhere (its items
link `changelog.html?tag=pre`, a rolling release whose body is boilerplate), and
without this someone on an internal 5.x build would be shown the 4.x notes.

## Two shared-code changes, both gated

1. **`decodeGitHubReleases` now honours the recipe's `channel`.** Its own comment
   named the limitation — "nothing here says which track the user is on" — so it
   skipped every prerelease. `channel` defaults to `nil` and `nil` still means
   stable only, so Waku and Shotbase (the only other recipes on this format, and
   neither registers a channel) decode byte-for-byte as before.

2. **`isImageOnly` now knows the HTML spelling of an image.** It only knew
   `[![](…)](…)`. It is used solely by the prose pass, which is where
   BetterDisplay's bullet-less pre-releases land — and there the button arrived as
   literal angle brackets. Reproduced red against the live 40-release feed: **14
   items** across the two tracks were that markup; 0 after.

## Verification

`make test`

```
Test run with 1180 tests in 94 suites passed after 53.802 seconds with 2 known issues.
Test run with 127 tests in 19 suites passed
✓ localizable keys agree — 411 in the catalog, all reachable
```

(The 2 known issues are the pre-existing KeePassXC ones.)

`make cli && duo verify --changelog --only betterdisplay` — all three recipes hit
the live endpoint:

```
changelog:pro.betterdisplay.BetterDisplay:stable   ok 4.3.6
changelog:pro.betterdisplay.BetterDisplay:beta     ok 5.0.3
changelog:pro.betterdisplay.BetterDisplay:unstable ok 5.0.3
```

Stable's newest matches the installed copy; the two prerelease tracks land on
5.0.3, the newest non-`arm64_pre` prerelease.

The full 40-release feed was also dumped through the real parser on both tracks
and read by hand: no entry lost its notes, no markup leaked into an item.

## Not changed on purpose

The `### Included Localizations` bullets (the language list and the contributor
line) stay as change items. They are genuinely in the vendor's notes, and the only
way to drop them is a section-skip keyword on the shared parser, which would take
real localization changes out of every other GitHub-sourced app's notes.