### PR TITLE
A recipe can drop a section by heading — starting with BetterDisplay's contributor roster

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -304,6 +304,23 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// page id on the same host).
     public let requestBody: Data?
 
+    /// Headings whose whole section this app's notes should drop, matched WHOLE and
+    /// case-insensitively (see `GitHubMarkdownParser.parse`). Only consulted by the
+    /// formats that go through `GitHubMarkdownParser` — `.gitHubReleases` and
+    /// `.zedGitHubReleases`; a recipe on any other format that sets this is a silent
+    /// no-op, which `ChangelogReviewRegressionTests` refuses.
+    ///
+    /// Per-recipe on purpose. `GitHubMarkdownParser.skippedSectionKeywords` is the
+    /// other way to do this and it is a substring rule applied to every app, which
+    /// is measurably the wrong tool here: a keyword wide enough to catch
+    /// BetterDisplay's contributor roster ("Included Localizations") also catches
+    /// `## Localization` in exelban/stats and `## 🌐 Localization` in block/goose,
+    /// both of which are real change bullets — as is BetterDisplay's own
+    /// "Localization Improvements", one release away from the roster. Measured
+    /// 2026-08-27 across the 67 GitHub-sourced repos in this codebase, 15 releases
+    /// each. So: name the exact headings, for the one app that has them.
+    public let skipSections: [String]
+
     public init(
         bundleID: String,
         source: URL,
@@ -323,7 +340,8 @@ public struct ChangelogRecipe: Codable, Sendable {
         imagePattern: String? = nil,
         structuredFormat: StructuredFormat? = nil,
         httpMethod: HTTPMethod = .get,
-        requestBody: Data? = nil
+        requestBody: Data? = nil,
+        skipSections: [String] = []
     ) {
         self.bundleID = bundleID
         self.source = source
@@ -344,6 +362,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         self.imagePattern = imagePattern
         self.httpMethod = httpMethod
         self.requestBody = requestBody
+        self.skipSections = skipSections
     }
 
     /// The actual page URL to fetch for a given target version. When
@@ -413,6 +432,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         imagePattern = try c.decodeIfPresent(String.self, forKey: .imagePattern)
         httpMethod = try c.decodeIfPresent(HTTPMethod.self, forKey: .httpMethod) ?? .get
         requestBody = try c.decodeIfPresent(Data.self, forKey: .requestBody)
+        skipSections = try c.decodeIfPresent([String].self, forKey: .skipSections) ?? []
     }
 }
 
@@ -421,6 +441,14 @@ public struct ChangelogRecipe: Codable, Sendable {
 /// web view). Adding a recipe is the same loop as a vendor probe: confirm it
 /// extracts real entries from the live page (see `ChangelogExtractorTests`) before
 /// landing it here.
+/// The two spellings BetterDisplay has used for its contributor roster, shared by
+/// its three per-track recipes so a third spelling is added in one place rather
+/// than three. See the recipes' comment for why this is per-app and whole-heading.
+private let betterDisplayContributorRosters = [
+    "Included Localizations",
+    "Localizations included in this release",
+]
+
 public enum ChangelogRecipeRegistry {
     public static let recipes: [ChangelogRecipe] = [
         // Air (JetBrains) — air.dev/changelog is a Vite/React SPA: the HTML is an
@@ -1304,6 +1332,15 @@ public enum ChangelogRecipeRegistry {
         // 2022-04-06 while the 40th-newest release is 2025-01-03 (both read
         // 2026-08-27). It is far outside a `per_page=40` window and sinks further
         // with every release the vendor cuts.
+        //
+        // `skipSections` drops the contributor roster. It is not a changelog: 18 of
+        // the newest 40 releases carry it, and between them they use only TWO
+        // distinct texts — the same paragraph repeated down a 15-row rail. The
+        // vendor gives no marker for it (no HTML comment, no `<details>` anywhere in
+        // those 40 bodies), so the heading IS the marker, and they have spelled it
+        // two ways. Both are listed. `### Localization Improvements` (v3.3.4) is
+        // deliberately NOT listed — that one holds real changes, which is why the
+        // match is whole-heading rather than a substring.
         ChangelogRecipe(
             bundleID: BetterDisplayChannel.bundleID,
             source: URL(
@@ -1312,7 +1349,8 @@ public enum ChangelogRecipeRegistry {
             mode: .json,
             maxEntries: 15,
             channel: .stable,
-            structuredFormat: .gitHubReleases),
+            structuredFormat: .gitHubReleases,
+            skipSections: betterDisplayContributorRosters),
 
         ChangelogRecipe(
             bundleID: BetterDisplayChannel.bundleID,
@@ -1322,7 +1360,8 @@ public enum ChangelogRecipeRegistry {
             mode: .json,
             maxEntries: 15,
             channel: .beta,
-            structuredFormat: .gitHubReleases),
+            structuredFormat: .gitHubReleases,
+            skipSections: betterDisplayContributorRosters),
 
         ChangelogRecipe(
             bundleID: BetterDisplayChannel.bundleID,
@@ -1332,7 +1371,8 @@ public enum ChangelogRecipeRegistry {
             mode: .json,
             maxEntries: 15,
             channel: .unstable,
-            structuredFormat: .gitHubReleases),
+            structuredFormat: .gitHubReleases,
+            skipSections: betterDisplayContributorRosters),
 
         // Alcove — its own changelog API. Public and unauthenticated, unlike the
         // update endpoint on the same host, which is license-gated (see

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -436,11 +436,6 @@ public struct ChangelogRecipe: Codable, Sendable {
     }
 }
 
-/// The verified recipe table. Looked up by bundle id when the detail window opens;
-/// a miss simply means we keep the existing behavior (embed `changelogURL` in a
-/// web view). Adding a recipe is the same loop as a vendor probe: confirm it
-/// extracts real entries from the live page (see `ChangelogExtractorTests`) before
-/// landing it here.
 /// The two spellings BetterDisplay has used for its contributor roster, shared by
 /// its three per-track recipes so a third spelling is added in one place rather
 /// than three. See the recipes' comment for why this is per-app and whole-heading.
@@ -449,6 +444,11 @@ private let betterDisplayContributorRosters = [
     "Localizations included in this release",
 ]
 
+/// The verified recipe table. Looked up by bundle id when the detail window opens;
+/// a miss simply means we keep the existing behavior (embed `changelogURL` in a
+/// web view). Adding a recipe is the same loop as a vendor probe: confirm it
+/// extracts real entries from the live page (see `ChangelogExtractorTests`) before
+/// landing it here.
 public enum ChangelogRecipeRegistry {
     public static let recipes: [ChangelogRecipe] = [
         // Air (JetBrains) — air.dev/changelog is a Vite/React SPA: the HTML is an

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -187,7 +187,8 @@ public enum ChangelogService {
         guard let body else { return nil }
         if let format = recipe.structuredFormat {
             return StructuredChangelogDecoder.decode(
-                body, format: format, channel: recipe.channel, maxEntries: recipe.maxEntries)
+                body, format: format, channel: recipe.channel, maxEntries: recipe.maxEntries,
+                skipSections: recipe.skipSections)
         }
         return ChangelogExtractor.extract(from: body, using: recipe)
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -36,13 +36,22 @@ public enum GitHubMarkdownParser {
     /// changes in this release.", is the live case; Waku's `v0.1.9`, "See
     /// CHANGELOG.md for details.", is another). Gated the same way the lenient pass
     /// is, so no body that already parsed changes at all.
-    public static func parse(body: String, version: String, date: String?) -> Changelog? {
-        var items = extractItems(from: body, lenient: false)
+    ///
+    /// `skipSections` is the per-recipe escape hatch (`ChangelogRecipe.skipSections`)
+    /// for a vendor who puts boilerplate under a heading of their own. Unlike
+    /// `skippedSectionKeywords`, which is a substring rule applied to EVERY app,
+    /// these are matched whole — case-insensitively, after trimming — against one
+    /// app's headings, so a heading that merely resembles one is untouched. Empty
+    /// by default, and an empty list is byte-for-byte the old behavior.
+    public static func parse(
+        body: String, version: String, date: String?, skipSections: [String] = []
+    ) -> Changelog? {
+        var items = extractItems(from: body, lenient: false, skipSections: skipSections)
         if items.isEmpty {
-            items = extractItems(from: body, lenient: true)
+            items = extractItems(from: body, lenient: true, skipSections: skipSections)
         }
         if items.isEmpty {
-            items = proseItems(from: body)
+            items = proseItems(from: body, skipSections: skipSections)
         }
         guard !items.isEmpty else { return nil }
         let entry = Changelog.Entry(version: version, date: date, items: items)
@@ -56,6 +65,29 @@ public enum GitHubMarkdownParser {
     private static let skippedSectionKeywords = [
         "new contributors", "contributors", "full changelog",
     ]
+
+    /// The heading text of a `## Heading` / `### Heading` line, lowercased and
+    /// trimmed — nil for any other line. One place, so the bullet passes and the
+    /// prose pass cannot drift on what counts as a heading.
+    private static func headingText(of trimmedLine: String) -> String? {
+        guard trimmedLine.hasPrefix("#") else { return nil }
+        return trimmedLine
+            .drop(while: { $0 == "#" })
+            .trimmingCharacters(in: .whitespaces)
+            .lowercased()
+    }
+
+    /// Whole-heading, case-insensitive match against a recipe's own `skipSections`.
+    /// Deliberately NOT a substring test: BetterDisplay's roster headings
+    /// ("Included Localizations", "Localizations included in this release") sit one
+    /// release away from "Localization Improvements", which carries real changes —
+    /// a substring rule wide enough to catch the first two eats the third.
+    private static func isSkipped(_ heading: String, by skipSections: [String]) -> Bool {
+        guard !skipSections.isEmpty else { return false }
+        return skipSections.contains {
+            $0.trimmingCharacters(in: .whitespaces).lowercased() == heading
+        }
+    }
 
     /// Extra headings the lenient pass skips: release bodies that aren't bullet
     /// changelogs often still carry a checksum/hash block, which we never want as
@@ -92,15 +124,23 @@ public enum GitHubMarkdownParser {
     ///     falls back to the renderer that shows the body whole.
     private static let proseItemCap = 12
 
-    private static func proseItems(from body: String) -> [String] {
+    private static func proseItems(from body: String, skipSections: [String] = []) -> [String] {
         guard body.range(of: #"(?m)^\s*\|"#, options: .regularExpression) == nil
         else { return [] }
         var items: [String] = []
         var inCodeBlock = false
+        var inSkippedSection = false
         for line in body.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix("```") { inCodeBlock.toggle(); continue }
-            if inCodeBlock || trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            // A recipe-declared section is skipped here too, so a vendor who writes
+            // their boilerplate as prose is handled the same as one who bullets it.
+            // Gated on a non-empty list, so the default path is unchanged.
+            if !inCodeBlock, let heading = headingText(of: trimmed) {
+                inSkippedSection = isSkipped(heading, by: skipSections)
+                continue
+            }
+            if inCodeBlock || inSkippedSection || trimmed.isEmpty { continue }
             if isImageOnly(trimmed) || isBareURL(trimmed) || isChecksum(trimmed) { continue }
             if skippedSectionKeywords.contains(where: {
                 trimmed.lowercased().hasPrefix("**\($0)")
@@ -147,7 +187,9 @@ public enum GitHubMarkdownParser {
         return line.range(of: #"\b[0-9a-fA-F]{32,}\b"#, options: .regularExpression) != nil
     }
 
-    private static func extractItems(from body: String, lenient: Bool) -> [String] {
+    private static func extractItems(
+        from body: String, lenient: Bool, skipSections: [String] = []
+    ) -> [String] {
         let lines = body.components(separatedBy: .newlines)
         let skipKeywords = lenient ? skippedSectionKeywords + lenientExtraSkipKeywords
                                    : skippedSectionKeywords
@@ -167,12 +209,9 @@ public enum GitHubMarkdownParser {
             if inCodeBlock { continue }
 
             // Section heading: ## Title or ### Title
-            if trimmed.hasPrefix("#") {
-                let heading = trimmed
-                    .drop(while: { $0 == "#" })
-                    .trimmingCharacters(in: .whitespaces)
-                    .lowercased()
+            if let heading = headingText(of: trimmed) {
                 inSkippedSection = skipKeywords.contains(where: { heading.contains($0) })
+                    || isSkipped(heading, by: skipSections)
                 continue
             }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -15,7 +15,7 @@ public enum StructuredChangelogDecoder {
     /// into at least one entry for the requested channel.
     public static func decode(
         _ body: String, format: ChangelogRecipe.StructuredFormat,
-        channel: ReleaseChannel?, maxEntries: Int?
+        channel: ReleaseChannel?, maxEntries: Int?, skipSections: [String] = []
     ) -> Changelog? {
         switch format {
         case .warpChannelVersions:
@@ -35,9 +35,12 @@ public enum StructuredChangelogDecoder {
         case .jetBrainsProductReleases:
             return decodeJetBrainsProductReleases(body, maxEntries: maxEntries)
         case .zedGitHubReleases:
-            return decodeZedGitHubReleases(body, channel: channel ?? .stable, maxEntries: maxEntries)
+            return decodeZedGitHubReleases(
+                body, channel: channel ?? .stable, maxEntries: maxEntries,
+                skipSections: skipSections)
         case .gitHubReleases:
-            return decodeGitHubReleases(body, channel: channel, maxEntries: maxEntries)
+            return decodeGitHubReleases(
+                body, channel: channel, maxEntries: maxEntries, skipSections: skipSections)
         case .alcoveChangelog:
             return decodeAlcoveChangelog(body, maxEntries: maxEntries)
         case .notionPageChunk:
@@ -470,7 +473,7 @@ public enum StructuredChangelogDecoder {
     /// exceptions). The list is already newest-first, so filtering by channel
     /// preserves that order; no re-sort needed (unlike Warp's unordered map).
     static func decodeZedGitHubReleases(
-        _ body: String, channel: ReleaseChannel, maxEntries: Int?
+        _ body: String, channel: ReleaseChannel, maxEntries: Int?, skipSections: [String] = []
     ) -> Changelog? {
         guard let data = body.data(using: .utf8),
               let releases = try? JSONDecoder().decode([ZedRelease].self, from: data)
@@ -491,7 +494,8 @@ public enum StructuredChangelogDecoder {
             // Preview user sitting on exactly that build must still find an entry
             // for their own version. That used to be a Zed-only fallback here;
             // it belongs in the parser, where every GitHub-sourced app gets it.
-            guard let parsed = GitHubMarkdownParser.parse(body: body, version: version, date: date),
+            guard let parsed = GitHubMarkdownParser.parse(
+                    body: body, version: version, date: date, skipSections: skipSections),
                   let entry = parsed.entries.first
             else { continue }
             entries.append(entry)
@@ -582,7 +586,8 @@ public enum StructuredChangelogDecoder {
     /// is skipped rather than shown as a bare version heading — but a body of plain
     /// sentences is NOT, since the parser's prose pass covers those.
     static func decodeGitHubReleases(
-        _ body: String, channel: ReleaseChannel? = nil, maxEntries: Int?
+        _ body: String, channel: ReleaseChannel? = nil, maxEntries: Int?,
+        skipSections: [String] = []
     ) -> Changelog? {
         guard let data = body.data(using: .utf8),
               let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data)
@@ -595,7 +600,8 @@ public enum StructuredChangelogDecoder {
             let version = stripLeadingV(release.tagName)
             guard !version.isEmpty else { continue }
             let date = isoDay(release.publishedAt)
-            guard let parsed = GitHubMarkdownParser.parse(body: raw, version: version, date: date),
+            guard let parsed = GitHubMarkdownParser.parse(
+                    body: raw, version: version, date: date, skipSections: skipSections),
                   let entry = parsed.entries.first
             else { continue }
             entries.append(entry)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChangelogRecipeTests.swift
@@ -29,11 +29,46 @@ private let betterDisplayReleasesFixture = #"""
 ]
 """#
 
+/// v3.3.4 and v3.3.3 (fetched 2026-08-27), trimmed to the sections that matter and
+/// two roster rows each; every line kept is verbatim. Together they hold all three
+/// heading shapes this app has used: the roster spelled two ways, and — in v3.3.4,
+/// one section above its own roster — `### Localization Improvements`, which is
+/// real changes and must survive.
+private let betterDisplayOlderReleasesFixture = #"""
+[
+ {
+  "tag_name": "v3.3.4",
+  "prerelease": false,
+  "draft": false,
+  "published_at": "2025-01-31T21:04:07Z",
+  "body": "## About this version\n\nThis release focuses on enhanced localization support, improved macOS 15.3 compatibility, and various bug fixes.\r\n\n### Localization Improvements\n\n- A new language selection feature has been added to the Settings window (bottom-left corner) for easy language switching. - #3972\r\n- Incomplete localizations (below 90% completion) have been removed to ensure a consistent user experience. - #3977\r\n\n### Bug Fixes\n\n- Resolved an issue where some text appeared unlocalized regardless of settings - #3980\r\n- Corrected various typos in the base language text - #3975\r\n\n### Included Localizations\n\nThis release includes the following localizations, with thanks to our contributors:\r\n\n- British English (@PuzzledUser)\r\n- Chinese, Simplified (@BingoKingo, @shindgewongxj, @hshsilver, @jacktechstudio)\r"
+ },
+ {
+  "tag_name": "v3.3.3",
+  "prerelease": false,
+  "draft": false,
+  "published_at": "2025-01-25T09:14:58Z",
+  "body": "### Enhancements\n\n- Improved mouse cursor responsiveness with mirrored virtual screens (thanks to @dave-fl) - #807\r\n\n### Localizations included in this release\n\n- **British English** (100%) -  @PuzzledUser\r\n- **French** (100%) - @Kcraft059\r"
+ }
+]
+"""#
+
 @Suite struct BetterDisplayChangelogRecipeTests {
 
     private func recipe(_ channel: ReleaseChannel) throws -> ChangelogRecipe {
         try #require(ChangelogRecipeRegistry.recipe(
             forBundleID: BetterDisplayChannel.bundleID, channel: channel))
+    }
+
+    /// Decode the way `ChangelogService.parse` does — through the registered recipe,
+    /// carrying its `skipSections`. A test that calls the decoder bare tests a
+    /// configuration that never ships.
+    private func decode(_ feed: String, _ channel: ReleaseChannel) throws -> Changelog {
+        let r = try recipe(channel)
+        let format = try #require(r.structuredFormat)
+        return try #require(StructuredChangelogDecoder.decode(
+            feed, format: format, channel: r.channel,
+            maxEntries: r.maxEntries, skipSections: r.skipSections))
     }
 
     /// All three tracks read the same GitHub releases endpoint; only `channel`
@@ -112,19 +147,64 @@ private let betterDisplayReleasesFixture = #"""
         #expect(entry.items[1].hasPrefix("_Please note that this pre-release was tested"))
     }
 
-    /// The stable body's own decisions: the seven-region trim keeps the `### Changes`
-    /// bullets and the two under `### Included Localizations` (a real section of the
-    /// vendor's notes, not contributor noise GitHub generates), and drops the intro
-    /// prose, the pre-release promo and the "For previous release notes" line —
-    /// none of which is a bullet.
-    @Test func theStableBodyKeepsOnlyItsBullets() throws {
+    /// The stable body as it actually ships: only the `### Changes` bullets survive.
+    /// The intro prose, the pre-release promo and the "For previous release notes"
+    /// line are dropped for being non-bullets; the two rows under
+    /// `### Included Localizations` are dropped by `skipSections`.
+    @Test func theStableBodyKeepsOnlyItsChangeBullets() throws {
+        let entry = try #require(decode(betterDisplayReleasesFixture, .stable).entries.first)
+        #expect(entry.items.count == 2)
+        #expect(entry.items[0].hasPrefix("Fixed DDC capability retrieval"))
+        #expect(entry.items[1].hasPrefix("Improved default nits values"))
+        #expect(!entry.items.contains { $0.contains("For previous release notes") })
+        #expect(!entry.items.contains { $0.contains("service release focused on bug fixes") })
+    }
+
+    // MARK: - The contributor roster
+
+    /// All three tracks carry the same roster headings, from one shared constant —
+    /// a fourth spelling must not have to be added in three places.
+    @Test func everyTrackSkipsTheSameRosterHeadings() throws {
+        for r in ChangelogRecipeRegistry.recipes(forBundleID: BetterDisplayChannel.bundleID) {
+            #expect(r.skipSections == [
+                "Included Localizations", "Localizations included in this release",
+            ])
+        }
+    }
+
+    /// Both spellings of the roster go, in the modern one-bullet-per-release form
+    /// and the old one-bullet-per-language form.
+    @Test func bothSpellingsOfTheRosterAreDropped() throws {
+        let items = try decode(betterDisplayOlderReleasesFixture, .stable)
+            .entries.flatMap(\.items)
+        #expect(!items.contains { $0.contains("@PuzzledUser") })
+        #expect(!items.contains { $0.contains("British English") })
+        #expect(!items.contains { $0.contains("with thanks to our contributors") })
+
+        let latest = try #require(decode(betterDisplayReleasesFixture, .stable).entries.first)
+        #expect(!latest.items.contains { $0.hasPrefix("Contributors: @") })
+    }
+
+    /// The whole point of matching a WHOLE heading rather than a substring.
+    /// `### Localization Improvements` sits one section above the roster in the very
+    /// same v3.3.4 body and holds real changes — a language switcher, and the removal
+    /// of under-90% translations. A `localization` keyword would take both.
+    @Test func aRealLocalizationSectionIsNotMistakenForTheRoster() throws {
+        let entry = try #require(decode(betterDisplayOlderReleasesFixture, .stable).entries.first)
+        #expect(entry.version == "3.3.4")
+        #expect(entry.items.count == 4)
+        #expect(entry.items[0].hasPrefix("A new language selection feature"))
+        #expect(entry.items[1].hasPrefix("Incomplete localizations (below 90% completion)"))
+        #expect(entry.items[2].hasPrefix("Resolved an issue where some text appeared unlocalized"))
+    }
+
+    /// A recipe with no `skipSections` is untouched — the default every other
+    /// `.gitHubReleases` recipe runs on. Same fixture, same channel, roster intact.
+    @Test func anEmptySkipListChangesNothing() throws {
         let log = try #require(StructuredChangelogDecoder.decodeGitHubReleases(
             betterDisplayReleasesFixture, channel: .stable, maxEntries: 15))
         let entry = try #require(log.entries.first)
         #expect(entry.items.count == 4)
-        #expect(entry.items[0].hasPrefix("Fixed DDC capability retrieval"))
         #expect(entry.items[3].hasPrefix("Contributors: @afkeceli"))
-        #expect(!entry.items.contains { $0.contains("For previous release notes") })
-        #expect(!entry.items.contains { $0.contains("service release focused on bug fixes") })
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
@@ -199,6 +199,22 @@ private let hbuilderXCodeSpanFixture = #"""
     }
 }
 
+/// `skipSections` is read only where the notes go through `GitHubMarkdownParser` —
+/// the two GitHub release formats. On any other recipe it is not an error, it is
+/// *nothing*: the field is set, the headings stay, and the only symptom is
+/// boilerplate the author thought they had removed. Derived from the registry so a
+/// recipe cannot declare it against a format that will never look.
+@Test func skipSectionsOnlyLandsOnAFormatThatReadsIt() {
+    let formatsThatRead: Set<ChangelogRecipe.StructuredFormat> = [
+        .gitHubReleases, .zedGitHubReleases,
+    ]
+    for recipe in ChangelogRecipeRegistry.recipes where !recipe.skipSections.isEmpty {
+        let format = recipe.structuredFormat
+        #expect(format.map(formatsThatRead.contains) == true,
+                "\(recipe.bundleID): skipSections is a no-op on \(format.map(\.rawValue) ?? "the regex path")")
+    }
+}
+
 // MARK: - Waku
 
 /// Waku's registered recipe reads GitHub releases, which carry the same bullets


### PR DESCRIPTION
Follow-up to https://github.com/jizhi0v0/duo-updater/pull/82. BetterDisplay's notes render natively now, but two of
every entry's bullets are its contributor roster — the language list and the
`Contributors: @…` wall.

## There is no marker to key off

Scanned all 40 recent release bodies: **zero HTML comments, zero
`<details>`/`<summary>`**. The only structure is the H3 heading text, and it has
drifted three ways:

```
 18  ### Included Localizations
  2  ### Localizations included in this release
  1  ### Localization Improvements      ← real changes, must survive
```

v3.3.4 carries the third and the first in the *same body*: a language-switcher
feature and the removal of under-90% translations, one section above a 20-row
credit list.

## Why not the existing global keyword list

`GitHubMarkdownParser.skippedSectionKeywords` is a substring rule applied to
every app. Measured what a `localization` keyword would cost — 67
GitHub-sourced repos in this codebase, 15 releases each, 2026-08-27:

| repo | heading | what's under it |
| --- | --- | --- |
| exelban/stats | `## Localization` ×6 | `- lang: improved Turkish localization (#3559)` — real |
| block/goose | `## 🌐 Localization` ×1 | Japanese / Hindi / Russian / Turkish locale support — real |
| espanso/espanso | `## New feature: Localized dates` ×1 | real |

Plus BetterDisplay's own `Localization Improvements`. A keyword wide enough to
catch the roster silently deletes real notes from at least two other apps.

## What this adds

`ChangelogRecipe.skipSections` — headings matched **whole** and
case-insensitively, per recipe. Empty by default; an empty list is byte-for-byte
the old behavior, which is what every other recipe runs on. Honoured by both
bullet passes and the prose pass, so a vendor who writes boilerplate as prose is
handled the same as one who bullets it.

BetterDisplay's three per-track recipes share one constant listing both roster
spellings.

A registry-derived guard refuses `skipSections` on a format that will never read
it — there it is not an error but *nothing*, and the only symptom would be
boilerplate the author thought they had removed.

## Verification

Against the live 40-release feed, through the registered recipe:

```
4.3.6   9 → 7 items      4.3.5  19 → 17      4.3.4  12 → 10      4.3.3  70 → 68
```

No `Contributors:` and no language-list bullet survives anywhere, in either
spelling. v3.3.4 comes out as exactly its 2 Localization-Improvements items plus
its 7 Bug-Fixes items — the roster and its prose intro gone, the real section
untouched.

`make test`

```
Test run with 1185 tests in 94 suites passed after 40.299 seconds with 2 known issues.
Test run with 127 tests in 19 suites passed
✓ localizable keys agree — 411 in the catalog, all reachable
```

`make cli && duo verify --changelog --only betterdisplay,shotbase,zed,waku` —
every recipe that touches this code path, live:

```
changelog:pro.betterdisplay.BetterDisplay:stable    ok 4.3.6
changelog:pro.betterdisplay.BetterDisplay:beta      ok 5.0.3
changelog:pro.betterdisplay.BetterDisplay:unstable  ok 5.0.3
changelog:dev.zed.Zed:stable                        ok 1.17.2
changelog:dev.zed.Zed-Preview:preview               ok 1.18.0
changelog:sh.waku:-                                 ok 0.1.15
changelog:com.shotbase.app:-                        ok 1.3.0
```