### PR TITLE
recipes(workbuddy): add WorkBuddy's international and China sites

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -4412,7 +4412,145 @@ public enum VendorProbeRegistry {
                     #""url"\s*:\s*"(https://assets\.lbkrs\.com/github/release/longbridge-desktop/preview/longbridge-v[0-9.]+-preview\.[0-9]+-macos-aarch64\.dmg)""#),
                 kind: .dmg),
             channel: .preview),
+
+        // MARK: - 2026-08-27 WorkBuddy (Tencent)
+
+        // WorkBuddy ships as TWO separate apps, not two channels of one. Tencent
+        // runs an international site and a China site, each with its own bundle
+        // id, its own app name, its own update host and its own release train:
+        //
+        //   com.workbuddy.workbuddy-ai  "WorkBuddy AI.app"  www.workbuddy.ai  5.4.2
+        //   com.workbuddy.workbuddy     "WorkBuddy.app"     www.workbuddy.cn  5.3.14
+        //
+        // Both are Electron, both signed by Team FN2V63AD2J (Tencent Technology
+        // (Shanghai) Company Limited), and the two builds carry byte-identical
+        // updater code — so the ONLY thing that routes an install to its own train
+        // is the bundle id, which is exactly the key a recipe is looked up by.
+        // Nothing here is a `channel`: both trains are stable, and neither app can
+        // ever be handed the other's artifact.
+        //
+        // The endpoint is the one the app's own `AbstractUpdateService` calls:
+        // `<base>/v2/update?platform=workbuddy-{os}-{arch}&version=<installed>`,
+        // where `<base>` is the product's API endpoint and defaults to
+        // `copilot.tencent.com` (which answers identically to www.workbuddy.cn).
+        // No auth: the `x-user-id` / `x-tenant-id` parameters the app appends are
+        // optional and we send neither.
+        //
+        // TRAP, and the reason `version=0.0.0` is pinned into the URL: this is a
+        // "should I update?" service, not a "what is the latest?" one. Passing the
+        // version you already run returns **204 No Content** (measured 2026-08-27:
+        // 5.3.14 → 204 on the CN host, 5.4.2 → 204 on the intl host), which would
+        // make the probe go dark precisely when it should say "up to date". An
+        // impossibly old version is what turns it into a latest-version query.
+        //
+        // TRAP, version scheme: the endpoint reports a FOUR-segment string
+        // ("5.4.2.36857725") whose last segment is a build counter that appears
+        // NOWHERE in the installed bundle — both `CFBundleShortVersionString` and
+        // `CFBundleVersion` are the bare "5.4.2". Comparing the raw field would
+        // read 36857725 > (nothing) forever, the permanent phantom update
+        // `versionIsBuild` exists to prevent — but `versionIsBuild` is the wrong
+        // fix here, since the build counter is not the app's CFBundleVersion
+        // either. So capture group 1 takes only the first three segments and the
+        // fourth is matched-and-discarded. Consequence to accept knowingly: a
+        // vendor respin that bumps ONLY the build counter is invisible to us.
+        // The optional fourth segment keeps the pattern matching if the vendor
+        // ever drops back to a plain three-part version.
+        //
+        // Architecture: the endpoint serves both Macs and currently answers the
+        // same version to each, but the `url` it hands back is arch-specific
+        // (`/darwin-arm64/…` vs `/darwin-x64/…`). One recipe reading the arm64
+        // endpoint would therefore offer an Intel Mac a zip it cannot run. Hence
+        // one recipe per architecture, split by `hostRequirement` rather than by
+        // channel (the Raycast v1/v2 shape) so exactly one is eligible on any
+        // given Mac, and the install pattern is additionally pinned to its own
+        // `darwin-<arch>` path so a recipe cannot resolve the other arch's
+        // artifact even if the endpoint were to start ignoring the query.
+        //
+        // Sites: the two recipes are one helper apart, and BOTH CDN paths are
+        // `/workbuddy/saas/darwin-<arch>/`, so the path alone does not say which
+        // site an artifact came from. Each recipe therefore pins its own download
+        // host as well. Without that, a later edit that swaps a host — or a vendor
+        // that points one site's `/v2/update` at the other site's CDN — would have
+        // one-click quietly replace a WorkBuddy AI install with the China build,
+        // and nothing downstream could see it: same vendor, same Team, a real
+        // notarized bundle, so the signature gate passes, and `ChannelProofRegistry`
+        // does not apply because both recipes are `.stable`. Pinned, the same
+        // situation degrades loudly instead (`installURLUnresolved`, which the
+        // nightly `duo verify` sweep reports).
+        //
+        // One-click: the JSON's `url` is a plain, unsigned object on Tencent COS
+        // (intl: `codebuddy-1328495429.cos.accelerate.myqcloud.com`; CN:
+        // `download.codebuddy.cn`). The `sha256hash` field alongside it is a
+        // SHA-256 hex digest, which `checksumPattern` (SHA-512, base64) cannot
+        // consume, so it is left unused and Team FN2V63AD2J gates the swap.
+        // Verified 2026-08-27 against both vendor DMGs at the same paths: the
+        // `.dmg` sibling of each `.zip` matches the published installer byte
+        // count, and both bundles are Developer ID signed under FN2V63AD2J.
+        //
+        // Changelog: each site's page is the one the app itself links (the build
+        // branches on `isOverseas()`); the intl page ran behind its own train at
+        // the time of writing (newest entry 5.2.7 against a 5.4.2 release) while
+        // the CN page was current.
+        workBuddyRecipe(
+            bundleID: "com.workbuddy.workbuddy-ai", host: "www.workbuddy.ai",
+            assetHost: "codebuddy-1328495429.cos.accelerate.myqcloud.com", arch: .arm64,
+            downloadURL: URL(string: "https://www.workbuddy.ai/")!,
+            changelogURL: URL(string: "https://www.workbuddy.ai/docs/workbuddy/Changelog")!),
+        workBuddyRecipe(
+            bundleID: "com.workbuddy.workbuddy-ai", host: "www.workbuddy.ai",
+            assetHost: "codebuddy-1328495429.cos.accelerate.myqcloud.com", arch: .x86_64,
+            downloadURL: URL(string: "https://www.workbuddy.ai/")!,
+            changelogURL: URL(string: "https://www.workbuddy.ai/docs/workbuddy/Changelog")!),
+        workBuddyRecipe(
+            bundleID: "com.workbuddy.workbuddy", host: "www.workbuddy.cn",
+            assetHost: "download.codebuddy.cn", arch: .arm64,
+            downloadURL: URL(string: "https://www.workbuddy.cn/")!,
+            changelogURL: URL(string: "https://www.codebuddy.cn/docs/workbuddy/Changelog")!),
+        workBuddyRecipe(
+            bundleID: "com.workbuddy.workbuddy", host: "www.workbuddy.cn",
+            assetHost: "download.codebuddy.cn", arch: .x86_64,
+            downloadURL: URL(string: "https://www.workbuddy.cn/")!,
+            changelogURL: URL(string: "https://www.codebuddy.cn/docs/workbuddy/Changelog")!),
     ]
+
+    /// One WorkBuddy recipe: a site — which decides the bundle id, the update
+    /// host and the changelog at once — crossed with a macOS architecture.
+    ///
+    /// The `slug` threads through three places that must agree: the `platform`
+    /// the endpoint is asked about, the `darwin-<arch>` path the install URL is
+    /// pinned to, and the `variant` that keeps the two same-channel recipes'
+    /// `recipeID`s (and so their verify baselines) apart. Building all three from
+    /// one value is what stops an arm64 recipe from ever quoting an x64 artifact.
+    ///
+    /// `assetHost` is the other half of that: the two sites' artifact PATHS are
+    /// identical, so the host is the only thing in a resolved URL that says which
+    /// site it came from, and it is pinned rather than matched with `[^"]+`.
+    private static func workBuddyRecipe(
+        bundleID: String,
+        host: String,
+        assetHost: String,
+        arch: HostArch,
+        downloadURL: URL,
+        changelogURL: URL
+    ) -> VendorProbeRecipe {
+        let slug = arch == .arm64 ? "arm64" : "x64"
+        let assetHostPattern = assetHost.replacingOccurrences(of: ".", with: #"\."#)
+        return VendorProbeRecipe(
+            bundleID: bundleID,
+            url: URL(string:
+                "https://\(host)/v2/update?platform=workbuddy-darwin-\(slug)&version=0.0.0")!,
+            mode: .responseBody,
+            versionPattern: #""productVersion"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)(?:\.[0-9]+)?""#,
+            downloadURL: downloadURL,
+            changelogURL: changelogURL,
+            publishedAtPattern: #""timestamp"\s*:\s*([0-9]{9,})"#,
+            install: VendorInstallSpec(
+                urlSource: .bodyPattern(
+                    #""url"\s*:\s*"(https://\#(assetHostPattern)/workbuddy/saas/darwin-\#(slug)/WorkBuddy-darwin-\#(slug)-[^"]+\.zip)""#),
+                kind: .zip),
+            variant: slug,
+            hostRequirement: VendorHostRequirement(architectures: [arch]))
+    }
 
     /// One OrbStack recipe for a given channel: same appcast, regex anchored to
     /// that `<sparkle:channel>` tag (newest-first → first match is correct), and

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RaycastReleasesTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RaycastReleasesTests.swift
@@ -105,9 +105,26 @@ private let raycastChangelogFixture = #"""
 
     /// A recipe with no requirement is unchanged by the gate — the property that
     /// keeps this field inert for the rest of the registry.
+    ///
+    /// The gated recipes are named rather than counted. A bare count told you a
+    /// number had moved but not which recipe moved it, and gating a recipe is
+    /// exactly the kind of change that must be deliberate: a `hostRequirement`
+    /// DROPS its recipe on machines that fail it, so one added by accident takes
+    /// an app to "unknown" on those Macs and says nothing anywhere.
     @Test func recipesWithoutARequirementRunEverywhere() {
+        let restricted = VendorProbeRegistry.recipes.filter { $0.hostRequirement != nil }
+        #expect(Set(restricted.map(\.recipeID)) == [
+            // Raycast v2: arm64 + macOS 26, with v1 as the fallback train.
+            "vendor:com.raycast.macos:stable:v2",
+            // WorkBuddy: one recipe per architecture per site, so the install URL
+            // can never be the other architecture's zip.
+            "vendor:com.workbuddy.workbuddy-ai:stable:arm64",
+            "vendor:com.workbuddy.workbuddy-ai:stable:x64",
+            "vendor:com.workbuddy.workbuddy:stable:arm64",
+            "vendor:com.workbuddy.workbuddy:stable:x64",
+        ])
         let unrestricted = VendorProbeRegistry.recipes.filter { $0.hostRequirement == nil }
-        #expect(unrestricted.count == VendorProbeRegistry.recipes.count - 1)
+        #expect(unrestricted.count == VendorProbeRegistry.recipes.count - restricted.count)
         #expect(unrestricted.allSatisfy { $0.runs(onOS: "14.0.0", arch: .x86_64) })
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WorkBuddyProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WorkBuddyProbeRecipeTests.swift
@@ -1,0 +1,284 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// WorkBuddy's four recipes: two sites (international / China), each crossed with
+/// the two macOS architectures the vendor ships.
+///
+/// The whole suite is DERIVED from the registry — the recipes are found by bundle
+/// id prefix and every per-recipe expectation is computed from that recipe's own
+/// `variant`, so a fifth recipe (or a renamed variant) is covered the day it lands
+/// instead of the day someone remembers to extend a hand-written list.
+struct WorkBuddyProbeRecipeTests {
+
+    /// The two sites and the version each served when the recipes were written.
+    /// `body` is the endpoint's response captured verbatim on 2026-08-27.
+    private struct Site {
+        let bundleID: String
+        let host: String
+        /// `CFBundleShortVersionString` of the real bundle for that train, read
+        /// off the vendor's own DMG — deliberately the THREE-segment string, which
+        /// is the point of the version pattern.
+        let installedShortVersion: String
+        let bodies: [String: String]  // variant slug → captured response body
+    }
+
+    private static let sites: [Site] = [
+        Site(
+            bundleID: "com.workbuddy.workbuddy-ai",
+            host: "www.workbuddy.ai",
+            installedShortVersion: "5.4.2",
+            bodies: [
+                "arm64": #"{"version":"5.4.2.36857725","url":"https://codebuddy-1328495429.cos.accelerate.myqcloud.com/workbuddy/saas/darwin-arm64/WorkBuddy-darwin-arm64-5.4.2.36857725-d74591c4.zip","productVersion":"5.4.2.36857725","sha256hash":"5d28d2b009dddb661ca8f2b1821dc57f853132071ae23101465f385d016a7743","timestamp":1787580925,"hash":"","name":"","supportsFastUpdate":false}"#,
+                "x64": #"{"version":"5.4.2.36857725","url":"https://codebuddy-1328495429.cos.accelerate.myqcloud.com/workbuddy/saas/darwin-x64/WorkBuddy-darwin-x64-5.4.2.36857725-d74591c4.zip","productVersion":"5.4.2.36857725","sha256hash":"0f1dce554df89f5e50db04823144e01faee7ea88483875cdc7066406d15b362b","timestamp":1787580925,"hash":"","name":"","supportsFastUpdate":false}"#,
+            ]),
+        Site(
+            bundleID: "com.workbuddy.workbuddy",
+            host: "www.workbuddy.cn",
+            installedShortVersion: "5.3.14",
+            bodies: [
+                "arm64": #"{"version":"5.3.14.36279234","url":"https://download.codebuddy.cn/workbuddy/saas/darwin-arm64/WorkBuddy-darwin-arm64-5.3.14.36279234-825709d4.zip","productVersion":"5.3.14.36279234","sha256hash":"a7c18fecd2939f8bd7a00ab5accdd905dbc5bbd5927291c9c5762541c1bd6a61","timestamp":1787002434,"hash":"","name":"","supportsFastUpdate":false}"#,
+                "x64": #"{"version":"5.3.14.36279234","url":"https://download.codebuddy.cn/workbuddy/saas/darwin-x64/WorkBuddy-darwin-x64-5.3.14.36279234-825709d4.zip","productVersion":"5.3.14.36279234","sha256hash":"25fe856763ff917e3086135f445c1016085ef7130433661994840e7a4c0a09ce","timestamp":1787002434,"hash":"","name":"","supportsFastUpdate":false}"#,
+            ]),
+    ]
+
+    private static let recipes = VendorProbeRegistry.recipes.filter {
+        $0.bundleID.hasPrefix("com.workbuddy.")
+    }
+
+    private static func installPattern(_ recipe: VendorProbeRecipe) throws -> String {
+        let spec = try #require(recipe.install)
+        guard case .bodyPattern(let pattern) = spec.urlSource else {
+            throw RecipeShapeError.notABodyPattern(recipe.recipeID)
+        }
+        #expect(spec.kind == .zip)
+        return pattern
+    }
+
+    private enum RecipeShapeError: Error { case notABodyPattern(String) }
+
+    // MARK: - registry shape
+
+    /// The two sites are two APPS, not two channels: distinct bundle ids, both
+    /// stable. Nothing about this app family may ever grow a channel, because a
+    /// channel is the one axis that could route one site's artifact at the other
+    /// site's install.
+    @Test func bothSitesAreSeparateStableApps() throws {
+        #expect(Set(Self.recipes.map(\.bundleID)) == Set(Self.sites.map(\.bundleID)))
+        #expect(Self.recipes.allSatisfy { $0.channel == .stable })
+        #expect(!Self.recipes.isEmpty)
+    }
+
+    /// Each (bundle id, channel) group carries one recipe per architecture, and
+    /// each declares the `hostRequirement` that makes exactly one of them eligible
+    /// on any given Mac. Without this the arm64 recipe would out-rank — and then
+    /// hand an unrunnable zip to — an Intel install.
+    @Test func eachSiteSplitsByArchitectureAndOnlyByArchitecture() throws {
+        let byBundle = Dictionary(grouping: Self.recipes, by: \.bundleID)
+        for (bundleID, group) in byBundle {
+            #expect(Set(group.compactMap(\.variant)) == ["arm64", "x64"],
+                    "\(bundleID) should have exactly an arm64 and an x64 recipe")
+            for recipe in group {
+                let slug = try #require(recipe.variant)
+                let expected: HostArch = slug == "arm64" ? .arm64 : .x86_64
+                let requirement = try #require(
+                    recipe.hostRequirement, "\(recipe.recipeID) has no hostRequirement")
+                #expect(requirement.architectures == [expected])
+                // Architecture only — no OS floor was observed for either train,
+                // and inventing one would silently strand machines.
+                #expect(requirement.minimumSystemVersion == nil)
+                #expect(requirement.isSatisfied(byOS: "26.0", arch: expected))
+                #expect(!requirement.isSatisfied(
+                    byOS: "26.0", arch: expected == .arm64 ? .x86_64 : .arm64))
+            }
+        }
+    }
+
+    /// The endpoint is a "should I update?" service: handing it the version you
+    /// already run answers 204 No Content. `version=0.0.0` is what makes it a
+    /// latest-version query, so its presence is pinned, as is the `platform` slug
+    /// agreeing with the recipe's own variant.
+    @Test func everyEndpointAsksAsAnImpossiblyOldClient() throws {
+        for recipe in Self.recipes {
+            let slug = try #require(recipe.variant)
+            let url = recipe.url.absoluteString
+            #expect(url.contains("version=0.0.0"),
+                    "\(recipe.recipeID) would get a 204 for an up-to-date install")
+            #expect(url.contains("platform=workbuddy-darwin-\(slug)"),
+                    "\(recipe.recipeID) asks about the wrong architecture")
+            #expect(url.hasPrefix("https://"))
+            // No account identifiers on the wire: the app's own `x-user-id` /
+            // `x-tenant-id` parameters are optional and we send neither.
+            #expect(!url.contains("x-user-id") && !url.contains("x-tenant-id"))
+            #expect(recipe.identities.isEmpty && recipe.track == nil)
+        }
+    }
+
+    /// Each recipe reads the site whose bundle id it targets. A crossed host would
+    /// offer the CN train to an international install and vice versa — the two
+    /// have independent version numbers, so it would be silent and permanent.
+    @Test func eachRecipeReadsItsOwnSite() throws {
+        for site in Self.sites {
+            for recipe in Self.recipes where recipe.bundleID == site.bundleID {
+                #expect(recipe.url.host() == site.host,
+                        "\(recipe.recipeID) probes \(recipe.url.host() ?? "?"), not \(site.host)")
+            }
+        }
+    }
+
+    // MARK: - the version scheme (the phantom-update trap)
+
+    /// The endpoint reports four segments; the installed bundle reports three, and
+    /// the fourth appears in NEITHER `CFBundleShortVersionString` nor
+    /// `CFBundleVersion`. Comparing the raw field would read "update available"
+    /// forever, so the pattern must discard it — and must leave the compared value
+    /// exactly equal to what the real bundle reports.
+    @Test func theBuildCounterIsDiscardedSoAnUpToDateInstallCompensatesEqual() throws {
+        for site in Self.sites {
+            for recipe in Self.recipes where recipe.bundleID == site.bundleID {
+                let slug = try #require(recipe.variant)
+                let body = try #require(site.bodies[slug])
+                let version = try #require(
+                    VendorProbeRecipe.extractVersion(
+                        from: body, pattern: recipe.versionPattern),
+                    "\(recipe.recipeID) resolved no version from its captured body")
+                #expect(version == site.installedShortVersion)
+                #expect(VersionComparator.compare(version, site.installedShortVersion)
+                    == .orderedSame,
+                    "\(recipe.recipeID) would report a phantom update against an install of \(site.installedShortVersion)")
+                // The build counter is in the body and must not be in the answer.
+                #expect(body.contains("\(site.installedShortVersion)."))
+                #expect(!version.contains("\(site.installedShortVersion)."))
+                // It is the marketing version, not a build: routing it into the
+                // build field would compare it against `CFBundleVersion` instead.
+                #expect(!recipe.versionIsBuild)
+            }
+        }
+    }
+
+    /// A vendor that drops back to a plain three-segment version must not silently
+    /// take the probe dark — the fourth segment is optional in the pattern.
+    @Test func aThreeSegmentVersionStillMatches() throws {
+        let recipe = try #require(Self.recipes.first)
+        let body = #"{"productVersion":"6.0.0","timestamp":1787580925}"#
+        #expect(VendorProbeRecipe.extractVersion(
+            from: body, pattern: recipe.versionPattern) == "6.0.0")
+    }
+
+    /// The pattern reads `productVersion` — the field the app's own updater
+    /// prefers — and not some other version-shaped number in the document.
+    @Test func theVersionComesFromProductVersion() throws {
+        let recipe = try #require(Self.recipes.first)
+        let body = #"{"version":"9.9.9.1","productVersion":"5.4.2.36857725","timestamp":1787580925}"#
+        #expect(VendorProbeRecipe.extractVersion(
+            from: body, pattern: recipe.versionPattern) == "5.4.2")
+    }
+
+    // MARK: - the install artifact
+
+    /// Every recipe resolves the zip its own captured body names.
+    @Test func eachRecipeInstallsTheArtifactItsOwnBodyNames() throws {
+        for site in Self.sites {
+            for recipe in Self.recipes where recipe.bundleID == site.bundleID {
+                let slug = try #require(recipe.variant)
+                let body = try #require(site.bodies[slug])
+                let pattern = try Self.installPattern(recipe)
+                let resolved = try #require(
+                    VendorProbeRecipe.extractVersion(from: body, pattern: pattern),
+                    "\(recipe.recipeID) resolved no install URL")
+                #expect(resolved.hasSuffix(".zip"))
+                #expect(resolved.contains("/darwin-\(slug)/"))
+                #expect(resolved.contains("WorkBuddy-darwin-\(slug)-"))
+            }
+        }
+    }
+
+    /// The guard that makes the architecture split real: an arm64 recipe fed the
+    /// x64 response (and vice versa) must resolve NOTHING rather than quietly hand
+    /// back a bundle this Mac cannot run. `hostRequirement` already keeps the wrong
+    /// recipe from being selected; this is the second lock, for the day the
+    /// endpoint starts ignoring its own `platform` parameter.
+    @Test func noRecipeResolvesTheOtherArchitecturesArtifact() throws {
+        for site in Self.sites {
+            for recipe in Self.recipes where recipe.bundleID == site.bundleID {
+                let slug = try #require(recipe.variant)
+                let otherSlug = slug == "arm64" ? "x64" : "arm64"
+                let otherBody = try #require(site.bodies[otherSlug])
+                let pattern = try Self.installPattern(recipe)
+                #expect(VendorProbeRecipe.extractVersion(
+                    from: otherBody, pattern: pattern) == nil,
+                    "\(recipe.recipeID) accepted the \(otherSlug) artifact")
+            }
+        }
+    }
+
+    /// The sibling guard to the architecture one, on the other axis: the two
+    /// sites' artifact paths are IDENTICAL (`/workbuddy/saas/darwin-<arch>/…`),
+    /// so only the host says which site a zip came from. Fed the other site's
+    /// response, a recipe must resolve nothing rather than install the other
+    /// site's build — which the Team ID gate could never catch, both sites being
+    /// signed by the same team.
+    @Test func noRecipeResolvesTheOtherSitesArtifact() throws {
+        for site in Self.sites {
+            let others = Self.sites.filter { $0.bundleID != site.bundleID }
+            #expect(!others.isEmpty)
+            for recipe in Self.recipes where recipe.bundleID == site.bundleID {
+                let slug = try #require(recipe.variant)
+                let pattern = try Self.installPattern(recipe)
+                for other in others {
+                    // Same architecture, other site: the ONLY difference is the host.
+                    let otherBody = try #require(other.bodies[slug])
+                    #expect(VendorProbeRecipe.extractVersion(
+                        from: otherBody, pattern: pattern) == nil,
+                        "\(recipe.recipeID) accepted \(other.bundleID)'s artifact")
+                }
+            }
+        }
+    }
+
+    /// `sha256hash` is a SHA-256 hex digest; `checksumPattern` consumes base64
+    /// SHA-512. Asserting it would fail every download, so it is deliberately
+    /// unset and the Team ID signature gate carries the swap.
+    @Test func theSHA256FieldIsDeliberatelyUnused() throws {
+        for recipe in Self.recipes {
+            let spec = try #require(recipe.install)
+            #expect(spec.checksumPattern == nil)
+        }
+    }
+
+    // MARK: - the publish date
+
+    /// `timestamp` is a bare Unix epoch in seconds, which `ReleaseDate` accepts.
+    @Test func theTimestampParsesAsAPublishDate() throws {
+        for site in Self.sites {
+            for recipe in Self.recipes where recipe.bundleID == site.bundleID {
+                let slug = try #require(recipe.variant)
+                let body = try #require(site.bodies[slug])
+                let pattern = try #require(recipe.publishedAtPattern)
+                let raw = try #require(
+                    VendorProbeRecipe.extractVersion(from: body, pattern: pattern))
+                let date = try #require(ReleaseDate.parse(raw),
+                                        "\(recipe.recipeID): '\(raw)' did not parse")
+                // Sanity: inside the window this vendor could plausibly have
+                // published in, so a millisecond epoch (year ~58000) would fail.
+                #expect(date > Date(timeIntervalSince1970: 1_700_000_000))
+                #expect(date < Date(timeIntervalSince1970: 2_000_000_000))
+            }
+        }
+    }
+
+    // MARK: - where the user is sent
+
+    /// The probe endpoint returns raw JSON, so neither the manual-download link nor
+    /// the changelog may fall back to it.
+    @Test func theUserIsSentToAPageRatherThanTheJSONEndpoint() throws {
+        for recipe in Self.recipes {
+            let download = try #require(recipe.downloadURL)
+            let changelog = try #require(recipe.changelogURL)
+            #expect(download != recipe.url)
+            #expect(changelog != recipe.url)
+            #expect(!download.absoluteString.contains("/v2/update"))
+            #expect(!changelog.absoluteString.contains("/v2/update"))
+        }
+    }
+}

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -89,6 +89,8 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 - [x] [**豆包输入法 (DoubaoIme)**](com-bytedance-inputmethod-doubaoime.md) · `com.bytedance.inputmethod.doubaoime` — P+C · 比厂商 version code（装机侧在自定义键 `Wave Build Version Number`，CFBundleVersion 是废号 1）· changelog 走 app 自己的更新接口 · detection-only（输入法整类闸）· channel-verify ✓ · 2026-08-21
 
+- [x] [**WorkBuddy (Tencent)**](com-workbuddy-workbuddy.md) · `com.workbuddy.workbuddy-ai` + `com.workbuddy.workbuddy` — P (one-click, both sites) · 两站两个独立 app，非 channel · 每站按架构分两条 recipe · 两站真实 DMG channel-verify ✓ · 2026-08-27
+
 ## Single-channel — GitHub Releases
 
 - [x] **RustDesk** · `com.carriez.rustdesk` — G C (one-click) · ✓ src=GitHub

--- a/docs/app-audits/com-workbuddy-workbuddy.md
+++ b/docs/app-audits/com-workbuddy-workbuddy.md
@@ -1,0 +1,144 @@
+# WorkBuddy (Tencent)
+
+审计 2026-08-27。一份文档覆盖两个 bundle id —— WorkBuddy 是**两个 app**，不是一个
+app 的两个 channel。
+
+## 基本信息
+
+| | 国际站 | 国内站 |
+|---|---|---|
+| Bundle ID | `com.workbuddy.workbuddy-ai` | `com.workbuddy.workbuddy` |
+| App 名 | WorkBuddy AI.app | WorkBuddy.app |
+| URL scheme | `workbuddy-ai` | `workbuddy` |
+| 官网 | https://www.workbuddy.ai | https://www.workbuddy.cn |
+| 观测版本 | 5.4.2 | 5.3.14 |
+| Team ID | `FN2V63AD2J` — Tencent Technology (Shanghai) Company Limited | 同左 |
+| 自更新机制 | 自研（Electron + `electron.net.fetch`，非 electron-updater，无 `app-update.yml`，无 Sparkle） | 同左 |
+
+两个包的 updater 代码**逐字节相同**；分流完全靠 build 时烤进 product config 的
+`endpoint`（`getUpdateBaseUrl()` 就是读它）。因此**唯一**把安装引到自己那条轨道
+上的东西是 bundle id —— 而 bundle id 正是 recipe 的查找键，两条轨道天然不可能串。
+
+国际版另有 `TuringShield.bundle`（腾讯安全 SDK），国内版没有；这属于两站构建差异，
+与更新检测无关。
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+| | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|---|---|---|---|---|---|
+| **stable（国际站）** | — | — | — | — | ✓ 一键 |
+| **stable（国内站）** | — | — | — | — | ✓ 一键 |
+
+当前生效源：**VendorProbe**（前四条源全部不适用：无 `SUFeedURL`、无 cask、非 MAS、
+无公开 GitHub 发布）。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---|---|---|---|---|---|
+| stable | `com.workbuddy.workbuddy-ai` | 独立 | — | — | ✓ |
+| stable | `com.workbuddy.workbuddy` | 独立 | — | — | ✓ |
+
+**没有非 stable channel。** 两个 bundle 里都不存在 `KSChannelID`、`RemotingName`、
+可读的 `package.json` channel 字段或任何偏好键；`ReleaseChannel.detect()` 对两者都
+判 stable，与实际相符。"国际站 / 国内站"是**发布站点**这条轴，不是质量轨道那条轴，
+不应该被建模成 channel —— 建成 channel 反而会给出一个能把一站的包投给另一站安装的
+路径，而现在这条路径不存在。
+
+## 更新检测
+
+端点就是 app 自己的 `AbstractUpdateService` 调的那个：
+
+```
+<base>/v2/update?platform=workbuddy-{os}-{arch}&version=<已装版本>
+```
+
+`<base>` 默认 `https://copilot.tencent.com`（与 `www.workbuddy.cn` 应答一致）。
+无鉴权：app 会追加的 `x-user-id` / `x-tenant-id` 是可选的，recipe 两个都不发。
+
+响应（2026-08-27 实测，国际站 arm64）：
+
+```json
+{"version":"5.4.2.36857725",
+ "url":"https://codebuddy-1328495429.cos.accelerate.myqcloud.com/workbuddy/saas/darwin-arm64/WorkBuddy-darwin-arm64-5.4.2.36857725-d74591c4.zip",
+ "productVersion":"5.4.2.36857725",
+ "sha256hash":"5d28d2b0…","timestamp":1787580925,
+ "hash":"","name":"","supportsFastUpdate":false}
+```
+
+### 陷阱一：这是「我该更新吗」而不是「最新是多少」
+
+把你**已经在跑的版本**传进去，端点回 **204 No Content**（实测：国内站传 5.3.14 →
+204，国际站传 5.4.2 → 204）。照搬会让探针恰好在"应该说已是最新"的时候变哑。
+所以 recipe 的 URL 里把 `version=0.0.0` 钉死，才把它变成一个 latest 查询。
+
+### 陷阱二：版本方案（幻影更新）
+
+端点报四段 `5.4.2.36857725`，最后一段是 build 计数器，**在已装 bundle 里哪儿都
+没有** —— `CFBundleShortVersionString` 和 `CFBundleVersion` 都是光秃秃的 `5.4.2`。
+直接比原值等于 `36857725 > (无)`，是那种永远清不掉的幻影更新。
+
+`versionIsBuild` 在这里是**错的解**：那个计数器也不是 app 的 `CFBundleVersion`。
+正解是正则只捕前三段、第四段匹配后丢弃。代价要明说：**vendor 只动 build 计数器的
+重新出包，我们看不见。** 第四段写成可选，是为了 vendor 哪天退回三段式时不会静默失配。
+
+### 陷阱三：架构
+
+端点两个架构都服务，且目前对两者回同一个版本 —— 但它给回的 `url` 是分架构的
+（`/darwin-arm64/…` vs `/darwin-x64/…`）。一条读 arm64 端点的 recipe 会给 Intel Mac
+递一个跑不了的 zip。所以每站注册**两条 recipe**，用 `hostRequirement` 分流
+（Raycast v1/v2 的形状），任一台 Mac 上恰好一条合格；install 正则再各自钉死自己的
+`darwin-<arch>` 路径，这样即便端点哪天开始无视 `platform` 参数，也解析不出另一架构
+的产物。
+
+## Changelog
+
+| | URL | 状态 |
+|---|---|---|
+| 国际站 | https://www.workbuddy.ai/docs/workbuddy/Changelog | 200，但**落后于自己的轨道**（写作时最新条目 5.2.7，而发布版是 5.4.2） |
+| 国内站 | https://www.codebuddy.cn/docs/workbuddy/Changelog | 200，与 5.3.14 同步 |
+
+两个 URL 都是 app 自己链的（构建按 `isOverseas()` 分支）。走 `changelogURL`
+（WebView），没写 `ChangelogRecipe` —— 页面是文档站渲染，原生条目化收益不大，
+而且国际站那份本身就滞后。
+
+## 一键安装
+
+- 状态：**支持**（检测 + 一键，两站均是）
+- 格式：`.zip`（端点 JSON 的 `url` 字段；同路径下有同名 `.dmg`，但那是推断出来的，
+  端点没声明，所以不用）
+- 签名闸：Team `FN2V63AD2J`，两站同一个，与已装包一致 → `VendorInstaller` 放行
+- **install 正则钉死各自的下载 host**（intl `codebuddy-1328495429.cos.accelerate.myqcloud.com`，
+  CN `download.codebuddy.cn`）：两站的产物**路径完全相同**（`/workbuddy/saas/darwin-<arch>/`），
+  host 是解析结果里唯一能说明"这包来自哪一站"的东西。不钉的话，一次改错 host 的编辑、
+  或 vendor 把一站的 `/v2/update` 指到另一站 CDN，就会让一键把国际版悄悄换成国内版 ——
+  而且下游一个都拦不住：同厂商、同 Team、真正的公证包，签名闸看不出来，
+  `ChannelProofRegistry` 又只管非 stable。钉死之后同样的情况变成**响亮失败**
+  （`installURLUnresolved`，夜扫 `duo verify` 会报）。守卫见 `noRecipeResolvesTheOtherSitesArtifact`
+- `sha256hash` **故意不用**：那是 SHA-256 hex，而 `checksumPattern` 吃的是 base64
+  SHA-512，接不上；由签名闸兜底
+
+## 已知问题
+
+- 只动 build 计数器的重新出包检测不到（见陷阱二）——已知代价，不是缺陷。
+- 国际站 changelog 页滞后于其发布轨道，vendor 侧问题，我们这边无解。
+- x64 那两条 recipe 的产物没有下载挂载验证过，只验证了「存在 + 分架构命名」；
+  跨架构不误取由单测守着（见 `application-test/records/com-workbuddy-workbuddy.md`）。
+
+## 验证
+
+```sh
+swift run --package-path application-test channel-verify <WorkBuddy DMG>   # 两站真实 bundle 均 ✓
+duo verify --only workbuddy                                                # 4 vendor probes ✓ 4 ⚠ 0 ✗ 0
+```
+
+实证记录见 `application-test/records/com-workbuddy-workbuddy.md`；
+回归测试见 `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WorkBuddyProbeRecipeTests.swift`
+（从 registry 推导，12 条）。
+
+## 建议下一步
+
+无。两站的检测与一键都已接入并验证。若将来 vendor 的 changelog 页值得原生条目化，
+再走 `/fragile-recipe WorkBuddy`（Changelog 路径）。


### PR DESCRIPTION
接入 WorkBuddy（腾讯），**两站都接**，检测 + 一键安装。

## 关键结论：这是两个 app，不是两个 channel

| | 国际站 | 国内站 |
|---|---|---|
| Bundle ID | `com.workbuddy.workbuddy-ai` | `com.workbuddy.workbuddy` |
| App 名 | WorkBuddy AI.app | WorkBuddy.app |
| 更新 host | `www.workbuddy.ai` | `www.workbuddy.cn`（= `copilot.tencent.com`） |
| 观测版本 | 5.4.2 | 5.3.14 |
| Team | `FN2V63AD2J` | 同左 |

两个包的 updater 代码逐字节相同，分流靠 build 时烤进 product config 的 `endpoint`。
两个 bundle 里都不存在 `KSChannelID` / `RemotingName` / channel 偏好键 —— "国际站 vs 国内站"
是**发布站点**这条轴，不是质量轨道那条轴。建成 channel 反而会造出一条把一站的包投给另一站
安装的路径，而现在这条路径不存在。

## 三个端点陷阱

1. **它是「我该更新吗」不是「最新是多少」。** 传入已装版本回 **204 No Content**
   （实测 5.3.14→204 / 5.4.2→204），照搬会让探针恰好在该说"已最新"时变哑。URL 里钉死
   `version=0.0.0`。
2. **四段版本号。** 端点报 `5.4.2.36857725`，末段 build 计数器在已装 bundle 里哪儿都没有
   （`CFBundleShortVersionString` 和 `CFBundleVersion` 都是 `5.4.2`）。比原值 = 永久幻影更新；
   `versionIsBuild` 也是错解（那不是 app 的 CFBundleVersion）。只捕前三段，第四段可选。
   已知代价：只动 build 计数器的重新出包看不见。
3. **版本与架构无关，下载 URL 与架构有关。** 所以每站按架构分两条 recipe，用
   `hostRequirement` 分流（Raycast v1/v2 形状）。

## 两条守卫（下游都拦不住的那两种）

- 喂另一**架构**的响应 → 必须解析不出，否则 Intel Mac 拿到 arm64 包。
- 喂另一**站点**的响应 → 必须解析不出。两站产物路径**完全相同**
  （`/workbuddy/saas/darwin-<arch>/`），host 是唯一能区分的东西；串了的话签名闸看不出来
  （同厂商、同 Team、真公证包），`ChannelProofRegistry` 又只管非 stable。所以 install
  正则连 host 一起钉死，串站变成响亮失败而不是静默装错。

## 验证

```
make test                      →  1226 tests / 96 suites passed（1 个既有 known issue: Anki）
duo verify --only workbuddy    →  vendor probe ✓ 4  ⚠ 0  ✗ 0
channel-verify <两站真实 DMG>   →  均 detected stable，latest == installed，verdict "up to date"
```

正则另用 Python 移植后独打真实响应体做第二个证人：两站 × 两架构版本均等于已装短版本、
install URL 均为本架构本站产物、跨架构/跨站均 0 泄漏。

审计文档：`docs/app-audits/com-workbuddy-workbuddy.md`