### PR TITLE
recipes(canva): probe Canva's electron-updater feed

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -4552,6 +4552,13 @@ public enum VendorProbeRegistry {
         // Canva's published base64 sha512 matches the served bytes exactly, so the
         // checksum gate is armed on top of the mandatory Team-ID one.
         //
+        // The download host needs no `requestHeaders`, and that is measured rather
+        // than assumed — it is the failure class that resolves fine and then dies at
+        // download time, which is why AweSun carries a Referer and SourceForge a
+        // deliberately non-browser UA. `desktop-release.canva.com` answers the
+        // downloader's own `DuoUpdater/0.1` with 206 and honours a mid-file Range,
+        // so both the plain fetch and the resume path work unadorned.
+        //
         // No `changelogURL`, deliberately: Canva publishes no desktop release notes.
         // The changelogs on canva.dev belong to the Apps SDK and Connect APIs and
         // describe a different product, and www.canva.com answers a Cloudflare

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -4511,6 +4511,67 @@ public enum VendorProbeRegistry {
             assetHost: "download.codebuddy.cn", arch: .x86_64,
             downloadURL: URL(string: "https://www.workbuddy.cn/")!,
             changelogURL: URL(string: "https://www.codebuddy.cn/docs/workbuddy/Changelog")!),
+
+        // Canva — an Electron shell (`NSPrincipalClass` AtomApplication,
+        // Squirrel.framework) that self-updates through electron-updater. The feed
+        // is not a guess: the bundle's own `Contents/Resources/app-update.yml` names
+        // `provider: generic` at `https://desktop-release.canva.com`, and the
+        // Homebrew cask's `livecheck` reads that host's `latest-mac.yml` with
+        // `strategy :electron_builder`. The cask itself is `auto_updates true`, so
+        // `HomebrewCaskSource` declines it by design — and it was a release behind
+        // (1.123.1 against 1.124.0) when this was written. No `SUFeedURL`, no GitHub
+        // repo, and the iTunes lookup for this bundle id returns 0 results, so the
+        // probe is the only surface that answers at all.
+        //
+        // The two sides compare like-for-like: the feed's `version` is `1.124.0` and
+        // the shipped bundle's `CFBundleShortVersionString` is `1.124.0`. Its
+        // `CFBundleVersion` is an unrelated `3597652.392500792` that appears nowhere
+        // in the feed, which is why this is NOT `versionIsBuild`.
+        //
+        // Every pattern here ends at a run of digits and dots, and that is the
+        // load-bearing detail. `beta-mac.yml` exists on the same host and answers
+        // 200, but it is abandoned — `1.98.0-beta`, released 2024-11-12, against a
+        // stable 1.124.0 from 2026-08-25 — so no beta recipe is registered and no
+        // beta bundle id exists to carry one. The version pattern's trailing
+        // `\s*$` is what makes that safe in the other direction too: publish a
+        // `-beta` into the STABLE feed and the pattern matches NOTHING, so the app
+        // degrades to "unknown" rather than capturing `1.98.0`, reporting a
+        // prerelease as stable, and reading as a permanent downgrade against an
+        // installed 1.124.0. The artifact pattern is pinned the same way, so an
+        // install can never resolve `Canva-1.98.0-beta-universal.dmg`.
+        //
+        // One-click: the dmg holds `Canva.app` and nothing else — no pkg, no
+        // LaunchDaemon, no helper outside the bundle — so the bundle swap is the
+        // whole update. (The cask's `zap` names a
+        // `com.canva.availability-check-agent` LaunchAgent, the one thing that could
+        // have argued for `.pkg`; it is in neither the dmg nor a machine that has
+        // run Canva, so whatever writes it, the installer does not.) Verified
+        // 2026-08-27 on the real `Canva-1.124.0-universal.dmg`:
+        // com.canva.CanvaDesktop, 1.124.0, Team 5HD2ARTBFS, `spctl` "Notarized
+        // Developer ID". Unlike Signal, whose feed hash predates its own stapling,
+        // Canva's published base64 sha512 matches the served bytes exactly, so the
+        // checksum gate is armed on top of the mandatory Team-ID one.
+        //
+        // No `changelogURL`, deliberately: Canva publishes no desktop release notes.
+        // The changelogs on canva.dev belong to the Apps SDK and Connect APIs and
+        // describe a different product, and www.canva.com answers a Cloudflare
+        // interactive challenge, so nothing there could be confirmed to be a notes
+        // page. `downloadURL` therefore points at the plain download page, which
+        // does answer (200), rather than at the yml.
+        VendorProbeRecipe(
+            bundleID: "com.canva.CanvaDesktop",
+            url: URL(string: "https://desktop-release.canva.com/latest-mac.yml")!,
+            mode: .responseBody,
+            versionPattern: #"(?m)^version:\s*([0-9]+(?:\.[0-9]+)+)\s*$"#,
+            downloadURL: URL(string: "https://www.canva.com/download/"),
+            publishedAtPattern: #"(?m)^releaseDate:\s*'([^']+)'\s*$"#,
+            install: VendorInstallSpec(
+                urlSource: .bodyPatternRelative(
+                    #"(Canva-[0-9][0-9.]*-universal\.dmg)"#,
+                    base: URL(string: "https://desktop-release.canva.com/")!),
+                kind: .dmg,
+                checksumPattern:
+                    #"Canva-[0-9][0-9.]*-universal\.dmg\s*\n\s*sha512:\s*([A-Za-z0-9+/=]+)"#)),
     ]
 
     /// One WorkBuddy recipe: a site — which decides the bundle id, the update

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CanvaProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CanvaProbeRecipeTests.swift
@@ -1,0 +1,251 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Canva's electron-updater probe.
+///
+/// The recipe is looked up from the registry rather than restated here, and every
+/// expectation is checked against two response bodies captured verbatim from the
+/// vendor on 2026-08-27 — the stable feed the recipe reads, and the `-beta` feed
+/// sitting on the same host that it must refuse to read anything out of.
+struct CanvaProbeRecipeTests {
+
+    private static let bundleID = "com.canva.CanvaDesktop"
+
+    /// `https://desktop-release.canva.com/latest-mac.yml`, 2026-08-27. The dmg is
+    /// listed three times by the vendor; kept as-is so first-match behaviour is
+    /// exercised on the real shape.
+    private static let stableBody = """
+        version: 1.124.0
+        files:
+          - url: Canva-1.124.0-universal-mac.zip
+            sha512: rf69D6q9ZBW6Vd7/oHXwPH6twOpVrOqz0yHdjABjszJLTVirvGFcsHx+iAqMU4mJph0Ju9fhWCAv1ku+AmEqbw==
+            size: 220713510
+          - url: Canva-1.124.0-universal.dmg
+            sha512: XfyF0nxkrfpd7tQudevNMSPxDQ07YHywwSoK55hJ2aLydzVOU5VVcdtJWJt7n6/EMnV7fWV7BsJb3zW4S0epCg==
+            size: 229528957
+          - url: Canva-1.124.0-universal.dmg
+            sha512: XfyF0nxkrfpd7tQudevNMSPxDQ07YHywwSoK55hJ2aLydzVOU5VVcdtJWJt7n6/EMnV7fWV7BsJb3zW4S0epCg==
+            size: 229528957
+        path: Canva-1.124.0-universal-mac.zip
+        sha512: rf69D6q9ZBW6Vd7/oHXwPH6twOpVrOqz0yHdjABjszJLTVirvGFcsHx+iAqMU4mJph0Ju9fhWCAv1ku+AmEqbw==
+        releaseDate: '2026-08-25T02:56:23.561Z'
+        """
+
+    /// `https://desktop-release.canva.com/beta-mac.yml`, same host, same day —
+    /// still serving a build from November 2024.
+    private static let betaBody = """
+        version: 1.98.0-beta
+        files:
+          - url: Canva-1.98.0-beta-universal-mac.zip
+            sha512: EPqtGRQlAsHsqHQtXzZWgOm1le5cS1GvjcVS8N6HfqlR1NRrPShbAiTUgc32uMjXCMz4yfVmgzKuL34oEabRsA==
+            size: 181427293
+          - url: Canva-1.98.0-beta-universal.dmg
+            sha512: luJVZ/AvA+ldxSEutPW480OBGrySBRk9Gfkoj8XI06PskMgvNp+WRFrsKKGrLB5LrXTvEoZQFdC1In9IfwVG6A==
+            size: 188813458
+        path: Canva-1.98.0-beta-universal-mac.zip
+        sha512: EPqtGRQlAsHsqHQtXzZWgOm1le5cS1GvjcVS8N6HfqlR1NRrPShbAiTUgc32uMjXCMz4yfVmgzKuL34oEabRsA==
+        releaseDate: '2024-11-12T05:14:58.028Z'
+        """
+
+    /// `CFBundleShortVersionString` of the bundle inside
+    /// `Canva-1.124.0-universal.dmg`, read off the mounted dmg.
+    private static let installedShortVersion = "1.124.0"
+
+    /// `CFBundleVersion` of that same bundle — deliberately unlike the marketing
+    /// version, and absent from the feed.
+    private static let installedBuildVersion = "3597652.392500792"
+
+    private static let recipes = VendorProbeRegistry.recipes.filter { $0.bundleID == bundleID }
+
+    private enum RecipeShapeError: Error { case notARelativeBodyPattern(String) }
+
+    /// The install spec's filename pattern and the base it resolves against.
+    private static func installArtifact(
+        _ recipe: VendorProbeRecipe
+    ) throws -> (pattern: String, base: URL) {
+        let spec = try #require(recipe.install)
+        guard case .bodyPatternRelative(let pattern, let base) = spec.urlSource else {
+            throw RecipeShapeError.notARelativeBodyPattern(recipe.recipeID)
+        }
+        return (pattern, base)
+    }
+
+    private static func theRecipe() throws -> VendorProbeRecipe {
+        #expect(recipes.count == 1, "Canva should have exactly one recipe")
+        return try #require(recipes.first)
+    }
+
+    // MARK: - registry shape
+
+    /// One stable recipe, no channel and no variant. The beta feed is abandoned
+    /// (see the registry comment), so growing a channel here would need its own
+    /// evidence — and its own `ChannelProofRegistry` entry — rather than a copy
+    /// of this one.
+    @Test func canvaIsASingleStableRecipe() throws {
+        let recipe = try Self.theRecipe()
+        #expect(recipe.channel == .stable)
+        #expect(recipe.variant == nil)
+        #expect(recipe.hostRequirement == nil)  // the vendor ships one universal build
+        #expect(recipe.identities.isEmpty && recipe.track == nil)
+        if case .responseBody = recipe.mode {} else {
+            Issue.record("\(recipe.recipeID) is not a body-parsing recipe")
+        }
+    }
+
+    /// The endpoint is the one the app's own `app-update.yml` names, not a URL
+    /// found by guessing at the host's layout.
+    @Test func theProbeReadsTheAppsOwnUpdateFeed() throws {
+        let recipe = try Self.theRecipe()
+        #expect(recipe.url.absoluteString
+            == "https://desktop-release.canva.com/latest-mac.yml")
+        let (_, base) = try Self.installArtifact(recipe)
+        #expect(base.host() == recipe.url.host(),
+                "the installer must come off the same host the version was read from")
+    }
+
+    // MARK: - the version
+
+    /// The feed's `version` is the marketing string the bundle reports, so an
+    /// up-to-date install compares equal.
+    @Test func theFeedVersionMatchesTheInstalledMarketingVersion() throws {
+        let recipe = try Self.theRecipe()
+        let version = try #require(
+            VendorProbeRecipe.extractVersion(
+                from: Self.stableBody, pattern: recipe.versionPattern))
+        #expect(version == Self.installedShortVersion)
+        #expect(VersionComparator.compare(version, Self.installedShortVersion)
+            == .orderedSame,
+            "an up-to-date Canva would be shown a phantom update")
+    }
+
+    /// `CFBundleVersion` is nothing like the feed's version, so routing this into
+    /// the build field would compare `1.124.0` against `3597652.392500792` and
+    /// report an update that can never be satisfied.
+    @Test func theVersionIsMarketingNotBuild() throws {
+        let recipe = try Self.theRecipe()
+        #expect(!recipe.versionIsBuild)
+        #expect(recipe.displayVersionPattern == nil)
+        #expect(!Self.stableBody.contains(Self.installedBuildVersion))
+    }
+
+    /// The pattern reads the feed's own top-level `version:` line and not one of
+    /// the version-shaped numbers scattered through the filenames and sizes.
+    @Test func theVersionComesFromTheVersionLine() throws {
+        let recipe = try Self.theRecipe()
+        let body = """
+            version: 2.0.1
+            files:
+              - url: Canva-9.9.9-universal.dmg
+                size: 229528957
+            """
+        #expect(VendorProbeRecipe.extractVersion(
+            from: body, pattern: recipe.versionPattern) == "2.0.1")
+    }
+
+    // MARK: - the abandoned beta train
+
+    /// The whole point of ending every pattern at a digits-and-dots run: fed the
+    /// `-beta` feed, this recipe resolves NOTHING. Capturing `1.98.0` instead
+    /// would report a two-year-old prerelease as the stable release — and read as
+    /// a downgrade against 1.124.0, which no later check would clear.
+    @Test func theBetaTrainIsRefusedRatherThanTruncated() throws {
+        let recipe = try Self.theRecipe()
+        #expect(VendorProbeRecipe.extractVersion(
+            from: Self.betaBody, pattern: recipe.versionPattern) == nil,
+            "the recipe read a version out of the beta feed")
+
+        let (pattern, _) = try Self.installArtifact(recipe)
+        #expect(VendorProbeRecipe.extractVersion(from: Self.betaBody, pattern: pattern) == nil,
+                "the recipe would install the beta dmg")
+
+        let checksum = try #require(recipe.install?.checksumPattern)
+        #expect(VendorProbeRecipe.extractVersion(from: Self.betaBody, pattern: checksum) == nil)
+    }
+
+    /// The same refusal stated on the axis that would actually bite: a `-beta`
+    /// version published into the STABLE feed. "Unknown" is the correct outcome.
+    @Test func aPrereleaseInTheStableFeedReadsAsUnknown() throws {
+        let recipe = try Self.theRecipe()
+        let body = Self.stableBody.replacingOccurrences(
+            of: "version: 1.124.0", with: "version: 1.125.0-beta")
+        #expect(VendorProbeRecipe.extractVersion(
+            from: body, pattern: recipe.versionPattern) == nil)
+    }
+
+    // MARK: - the install artifact
+
+    /// The universal dmg, resolved against the feed's own directory. The vendor
+    /// lists it three times identically, so first-match is unambiguous.
+    @Test func theInstallResolvesTheUniversalDMG() throws {
+        let recipe = try Self.theRecipe()
+        let (pattern, base) = try Self.installArtifact(recipe)
+        let filename = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: pattern))
+        #expect(filename == "Canva-1.124.0-universal.dmg")
+        #expect(URL(string: filename, relativeTo: base)?.absoluteString
+            == "https://desktop-release.canva.com/Canva-1.124.0-universal.dmg")
+        #expect(recipe.install?.kind == .dmg)
+    }
+
+    /// The mac zip is listed FIRST in the feed and is what electron-updater itself
+    /// consumes; the pattern must skip past it to the dmg the spec declares.
+    /// Resolving the zip while declaring `.dmg` would hand `ArchiveExtractor` a
+    /// file it would try to mount.
+    @Test func theZipEntryIsNotMistakenForTheDMG() throws {
+        let recipe = try Self.theRecipe()
+        let (pattern, _) = try Self.installArtifact(recipe)
+        let filename = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: pattern))
+        #expect(filename.hasSuffix(".dmg"))
+        #expect(!filename.contains("-mac.zip"))
+    }
+
+    /// The checksum is the dmg's, not the zip's — the two sit in the same document
+    /// and the zip's is quoted twice, including on the trailing top-level `sha512`
+    /// line. Verifying the zip's digest against downloaded dmg bytes would abort
+    /// every install.
+    @Test func theChecksumBelongsToTheDMGAndNotTheZip() throws {
+        let recipe = try Self.theRecipe()
+        let pattern = try #require(recipe.install?.checksumPattern)
+        let digest = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: pattern))
+        // Captured from the real dmg: `shasum -a 512` over
+        // Canva-1.124.0-universal.dmg, base64-encoded, equals the feed's value.
+        #expect(digest
+            == "XfyF0nxkrfpd7tQudevNMSPxDQ07YHywwSoK55hJ2aLydzVOU5VVcdtJWJt7n6/EMnV7fWV7BsJb3zW4S0epCg==")
+        #expect(digest != "rf69D6q9ZBW6Vd7/oHXwPH6twOpVrOqz0yHdjABjszJLTVirvGFcsHx+iAqMU4mJph0Ju9fhWCAv1ku+AmEqbw==",
+                "that is the zip's digest")
+        #expect(Data(base64Encoded: digest)?.count == 64, "not a 512-bit digest")
+    }
+
+    // MARK: - the publish date
+
+    /// electron-builder writes `releaseDate` in single-quoted ISO8601 with
+    /// fractional seconds, which is what lets the Release Log place this release
+    /// exactly instead of inside an estimated window.
+    @Test func theReleaseDateParses() throws {
+        let recipe = try Self.theRecipe()
+        let pattern = try #require(recipe.publishedAtPattern)
+        let raw = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: pattern))
+        #expect(raw == "2026-08-25T02:56:23.561Z")
+        let date = try #require(ReleaseDate.parse(raw), "'\(raw)' did not parse")
+        #expect(date > Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(date < Date(timeIntervalSince1970: 2_000_000_000))
+    }
+
+    // MARK: - where the user is sent
+
+    /// The endpoint is a yml manifest, so the manual-download link must not fall
+    /// back to it. No changelog is registered at all — Canva publishes no desktop
+    /// release notes, and the canva.dev changelogs are a different product.
+    @Test func theUserIsSentToTheDownloadPageAndNowhereElse() throws {
+        let recipe = try Self.theRecipe()
+        let download = try #require(recipe.downloadURL)
+        #expect(download != recipe.url)
+        #expect(!download.absoluteString.hasSuffix(".yml"))
+        #expect(download.absoluteString == "https://www.canva.com/download/")
+        #expect(recipe.changelogURL == nil)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CanvaProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CanvaProbeRecipeTests.swift
@@ -183,7 +183,10 @@ struct CanvaProbeRecipeTests {
         let filename = try #require(
             VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: pattern))
         #expect(filename == "Canva-1.124.0-universal.dmg")
-        #expect(URL(string: filename, relativeTo: base)?.absoluteString
+        // Resolved the way `VendorProbeSource.resolveInstall` resolves it —
+        // `relativeTo:` then `.absoluteURL` — so a change to that joining rule
+        // shows up here rather than only in production.
+        #expect(URL(string: filename, relativeTo: base)?.absoluteURL.absoluteString
             == "https://desktop-release.canva.com/Canva-1.124.0-universal.dmg")
         #expect(recipe.install?.kind == .dmg)
     }
@@ -192,13 +195,23 @@ struct CanvaProbeRecipeTests {
     /// consumes; the pattern must skip past it to the dmg the spec declares.
     /// Resolving the zip while declaring `.dmg` would hand `ArchiveExtractor` a
     /// file it would try to mount.
+    ///
+    /// Asserted against a body holding ONLY zips, so it is the pattern under
+    /// test and not the fixture's ordering: on the real feed the dmg happens to
+    /// be where first-match lands, which a loosened pattern would still satisfy.
     @Test func theZipEntryIsNotMistakenForTheDMG() throws {
         let recipe = try Self.theRecipe()
         let (pattern, _) = try Self.installArtifact(recipe)
-        let filename = try #require(
-            VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: pattern))
-        #expect(filename.hasSuffix(".dmg"))
-        #expect(!filename.contains("-mac.zip"))
+        let zipsOnly = """
+            version: 1.124.0
+            files:
+              - url: Canva-1.124.0-universal-mac.zip
+                size: 220713510
+            path: Canva-1.124.0-universal-mac.zip
+            """
+        #expect(VendorProbeRecipe.extractVersion(from: zipsOnly, pattern: pattern) == nil,
+                "the pattern accepted a zip while the spec declares .dmg")
+        #expect(recipe.install?.kind == .dmg)
     }
 
     /// The checksum is the dmg's, not the zip's — the two sit in the same document
@@ -245,7 +258,8 @@ struct CanvaProbeRecipeTests {
         let download = try #require(recipe.downloadURL)
         #expect(download != recipe.url)
         #expect(!download.absoluteString.hasSuffix(".yml"))
-        #expect(download.absoluteString == "https://www.canva.com/download/")
+        #expect(download.host() != recipe.url.host(),
+                "the manual link must be a page a user can read, not the release CDN")
         #expect(recipe.changelogURL == nil)
     }
 }

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -90,6 +90,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**豆包输入法 (DoubaoIme)**](com-bytedance-inputmethod-doubaoime.md) · `com.bytedance.inputmethod.doubaoime` — P+C · 比厂商 version code（装机侧在自定义键 `Wave Build Version Number`，CFBundleVersion 是废号 1）· changelog 走 app 自己的更新接口 · detection-only（输入法整类闸）· channel-verify ✓ · 2026-08-21
 
 - [x] [**WorkBuddy (Tencent)**](com-workbuddy-workbuddy.md) · `com.workbuddy.workbuddy-ai` + `com.workbuddy.workbuddy` — P (one-click, both sites) · 两站两个独立 app，非 channel · 每站按架构分两条 recipe · 两站真实 DMG channel-verify ✓ · 2026-08-27
+- [x] [**Canva**](com-canva-CanvaDesktop.md) · `com.canva.CanvaDesktop` — P (one-click, dmg + feed sha512) · Electron 套壳，端点取自 app 自带 `app-update.yml` · cask 是 `auto_updates` 且滞后一版 · beta 轨道 2024-11 起废弃，pattern 以数字点结尾拒读 · 真实 DMG + live probe + `duo check` 全链 ✓ · 2026-08-27
 
 ## Single-channel — GitHub Releases
 

--- a/docs/app-audits/com-canva-CanvaDesktop.md
+++ b/docs/app-audits/com-canva-CanvaDesktop.md
@@ -13,9 +13,13 @@
 - 自更新机制: **electron-updater**（Electron 壳，`NSPrincipalClass = AtomApplication`，
   `Contents/Frameworks/` 下有 `Squirrel.framework` + `Electron Framework.framework`）
 
-这是个套壳：主可执行只有 `Contents/MacOS/Canva`，业务逻辑在 `Resources/app.asar`
-里，`Info.plist` 带 `ElectronAsarIntegrity`。对更新检测来说有用的推论只有一条 ——
-它走 electron-builder 那套 manifest，端点不用猜。
+确实是套壳，这条是实测的不是推的：`Contents/MacOS/` 只有一个可执行 `Canva`，
+业务逻辑在 `Resources/app.asar`（`Info.plist` 带 `ElectronAsarIntegrity`），而
+`strings app.asar` 里同时有 `https://www.canva.com`、`https://www.canva.com/_online`
+和 `BrowserWindow` / `loadURL` / `webContents` —— 即它开一个窗口去加载 canva.com。
+
+不过对更新检测来说，有用的推论只有一条：它走 electron-builder 那套 manifest，
+端点不用猜。
 
 ## 覆盖矩阵
 

--- a/docs/app-audits/com-canva-CanvaDesktop.md
+++ b/docs/app-audits/com-canva-CanvaDesktop.md
@@ -1,0 +1,153 @@
+# Canva
+
+审计 2026-08-27。
+
+## 基本信息
+
+- Bundle ID: `com.canva.CanvaDesktop`
+- App 名: `Canva.app`
+- URL scheme: `canva`
+- 官网 / 下载页: https://www.canva.com/download/
+- 观测版本: `1.124.0`（`CFBundleVersion` = `3597652.392500792`）
+- Team ID: `5HD2ARTBFS` — Canva Pty Ltd，`spctl` 判定 "Notarized Developer ID"
+- 自更新机制: **electron-updater**（Electron 壳，`NSPrincipalClass = AtomApplication`，
+  `Contents/Frameworks/` 下有 `Squirrel.framework` + `Electron Framework.framework`）
+
+这是个套壳：主可执行只有 `Contents/MacOS/Canva`，业务逻辑在 `Resources/app.asar`
+里，`Info.plist` 带 `ElectronAsarIntegrity`。对更新检测来说有用的推论只有一条 ——
+它走 electron-builder 那套 manifest，端点不用猜。
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+| | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|---|---|---|---|---|---|
+| **stable** | — | ✗ | — | — | ✓ 一键 |
+
+当前生效源：**VendorProbe**。其余四条源为什么都不答：
+
+- **Sparkle** — bundle 里没有 `SUFeedURL`（也没有 `SUEnableAutomaticChecks`）。
+- **Homebrew** — cask `canva` 存在，但是 `auto_updates true`，`HomebrewCaskSource`
+  按设计直接 `return nil`。而且它确实是滞后的：审计当天 cask 停在 `1.123.1`，
+  厂商 feed 已经是 `1.124.0`。
+- **MAS** — `itunes.apple.com/lookup?bundleId=com.canva.CanvaDesktop&entity=macSoftware`
+  返回 `resultCount: 0`。
+- **GitHub** — 没有公开发布仓库。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---|---|---|---|---|---|
+| stable | `com.canva.CanvaDesktop` | 独立 | — | — | ✓ |
+| beta | 无独立 bundle id | — | — | — | ✗ 废弃轨道，未接入 |
+
+**beta 轨道已经废弃，故意不接。** `https://desktop-release.canva.com/beta-mac.yml`
+仍然应答 200，但内容是 `1.98.0-beta`、`releaseDate: 2024-11-12`，而 stable 当天是
+`1.124.0` / `2026-08-25`。app 侧也没有任何 channel 偏好键或独立 bundle id 能把一台机器
+判进 beta。`alpha-mac.yml` / `arm64-mac.yml` / `latest-mac-arm64.yml` 全部 403。
+
+这条废弃轨道是 recipe 里所有 pattern 都以「数字和点」结尾的原因，见下。
+
+## 更新检测
+
+端点不是猜出来的，两处独立佐证：
+
+1. app 自带的 `Contents/Resources/app-update.yml`：
+
+   ```yaml
+   provider: generic
+   url: https://desktop-release.canva.com
+   useMultipleRangeRequest: false
+   updaterCacheDirName: canva-updater
+   ```
+
+2. Homebrew cask 的 `livecheck` 读同一份 manifest，`strategy :electron_builder`。
+
+recipe 落在 `https://desktop-release.canva.com/latest-mac.yml`：
+
+```yaml
+version: 1.124.0
+files:
+  - url: Canva-1.124.0-universal-mac.zip
+    sha512: rf69D6q9…
+    size: 220713510
+  - url: Canva-1.124.0-universal.dmg
+    sha512: XfyF0nxk…
+    size: 229528957
+  …（dmg 条目厂商重复列了三遍）
+path: Canva-1.124.0-universal-mac.zip
+sha512: rf69D6q9…
+releaseDate: '2026-08-25T02:56:23.561Z'
+```
+
+- **版本方案对齐**：feed 的 `version` = `1.124.0` = 装机 `CFBundleShortVersionString`。
+  `CFBundleVersion`（`3597652.392500792`）在 feed 里根本不出现，所以**不是**
+  `versionIsBuild`。
+- **pattern 末尾的 `\s*$` 是承重的**：万一 `-beta` 版本被推进 stable feed，
+  `(?m)^version:\s*([0-9]+(?:\.[0-9]+)+)\s*$` 会**一个都不匹配** → 降级 unknown，
+  而不是截出 `1.98.0` 把预发当正式版报（那还会相对已装的 `1.124.0` 读成降级并永久卡住）。
+- **`releaseDate`** 走 `publishedAtPattern`，单引号 ISO8601 带毫秒，`ReleaseDate` 能解析，
+  于是 Release Log 能给 Canva 打精确时间而不是 `≈` 窗口。
+
+生产验证（`duo verify --only canva`，2026-08-27）：
+
+```
+vendor probe  ✓ 1  ⚠ 0  ✗ 0  ~ 0  - 0
+```
+
+report 里 `"version": "1.124.0"`、`"warnings": []` —— 空 warnings 同时说明
+`installURLUnresolved` 和 `checksumPatternNoMatch` 都没触发，即一键的 URL 和 sha512
+都在生产路径上解出来了。
+
+`duo check` 全链（真实已装副本）：
+
+```
+source: Vendor   installedVersion: 1.124.0   latestVersion: 1.124.0   status: up-to-date
+```
+
+## Changelog
+
+**没有接。** Canva 不发布桌面端的 release notes：
+
+- canva.dev 上那几份 changelog 是 Apps SDK / Connect API / Print Partnerships 的，
+  是另一个产品，指过去等于给用户看错东西。
+- www.canva.com 各路 `/help/whats-new/`、`/newsroom/` 对非浏览器一律 403，浏览器访问
+  落到 Cloudflare 交互式验证页，无法确认背后是不是一份 notes 页。
+
+所以 `changelogURL` 留空（UI 显示 "no release notes"），`downloadURL` 指向
+`https://www.canva.com/download/`（curl 200，未被 challenge 拦）。
+
+## 一键安装
+
+- 状态: **已启用**，`kind: .dmg`。
+- 产物: `Canva-1.124.0-universal.dmg`，由 feed 里的文件名相对
+  `https://desktop-release.canva.com/` 解析而来 —— 与版本读自同一台主机、同一份响应。
+- **为什么 `.dmg` 而不是 `.pkg`**：挂载真实 dmg 后里面只有 `Canva.app` 和
+  `Applications` 软链，没有 pkg、没有 `LaunchDaemons` / `LaunchAgents` /
+  `PrivilegedHelperTools` / 系统扩展，`Contents/MacOS/` 只有一个可执行。
+  唯一值得怀疑的是 cask `zap` 里列的
+  `~/Library/LaunchAgents/com.canva.availability-check-agent.plist` —— 它既不在 dmg 里，
+  也不在这台跑过 Canva 的机器上，所以无论是谁写的，反正安装器不写它。换句话说
+  「换 bundle」就是完整的更新。
+- **checksum 闸已武装**：feed 公布的 base64 sha512 与实际下发的 dmg 字节**完全一致**
+  （本机 `shasum -a 512` 后 base64 == feed 值）。这点和 Signal 相反 —— Signal 的
+  feed hash 早于自家 stapling，对不上，所以那条 recipe 故意不设 checksum。
+- 强制闸（`VendorInstaller`）：Developer ID 签名 + Team `5HD2ARTBFS` + bundle id 一致。
+
+## 已知问题
+
+- feed 把 dmg 条目重复列了三遍（内容完全相同）。first-match 取第一条，无歧义，但
+  如果厂商哪天让这三条不再相同，就得改成 entry-scoped 解析。
+- mac zip（`Canva-1.124.0-universal-mac.zip`）在 feed 里排在 dmg **前面**，且它的
+  sha512 还在文档末尾又出现一次。artifact 与 checksum 两个 pattern 都必须锚到
+  `.dmg` 那条，否则会拿 zip 的摘要去校验 dmg 字节，每次安装都会中止。
+- Canva 是 Squirrel 自更新 app，所以 `UpdatePolicy.defersToSelfUpdater` 在
+  `vendorInstallPolicy == .deferWhenRunning` 且进程在跑时会让位给它自己的更新器。
+  这是既有行为，与本 recipe 无关。
+
+## 建议下一步
+
+1. 若 Canva 之后启用 beta 轨道（独立 bundle id 或 app 内 channel 开关），按
+   `ChannelProofRegistry` 的要求补 proof 再加 recipe，不要照抄 stable 这条。
+2. 若哪天出现可核实的桌面端 release notes 页，补 `changelogURL`。


### PR DESCRIPTION
Canva is now tracked. It is an Electron shell (`AtomApplication`, `Squirrel.framework`) that self-updates through electron-updater, and nothing in the standard stack answers for it — so it read as "unknown" until now.

## Why the probe is the only source

| Source | Why it declines |
|---|---|
| Sparkle | no `SUFeedURL` in the bundle |
| Homebrew | cask `canva` is `auto_updates true`, so `HomebrewCaskSource` returns nil by design — and it was a release behind (1.123.1 vs 1.124.0) |
| MAS | `itunes.apple.com/lookup?bundleId=com.canva.CanvaDesktop&entity=macSoftware` → `resultCount: 0` |
| GitHub | no public release repo |

## The endpoint is not a guess

Two independent sources name it: the bundle's own `Contents/Resources/app-update.yml` (`provider: generic`, `url: https://desktop-release.canva.com`), and the Homebrew cask's `livecheck`, which reads that host's `latest-mac.yml` with `strategy :electron_builder`.

## Three traps this recipe is shaped around

**The version scheme.** The feed's `version` is the marketing string the bundle reports (`1.124.0`). `CFBundleVersion` is an unrelated `3597652.392500792` that appears nowhere in the feed — hence *not* `versionIsBuild`.

**The abandoned beta train.** `beta-mac.yml` still answers 200 on the same host, serving `1.98.0-beta` from 2024-11-12 against a stable `1.124.0` from 2026-08-25. No beta recipe is registered, but the stable pattern still has to survive the day a `-beta` lands in the *stable* feed. Ending it at `\s*$` means it then matches **nothing** and the app degrades to "unknown" — instead of capturing `1.98.0`, reporting a prerelease as stable, and reading as a permanent downgrade against an installed `1.124.0`. The artifact pattern is pinned the same way, so an install can never resolve `Canva-1.98.0-beta-universal.dmg`.

**Which artifact the checksum belongs to.** The mac zip is listed *first* in the feed and its `sha512` appears twice, including on the trailing top-level line. Verifying the zip's digest against downloaded dmg bytes would abort every install, so both the artifact and checksum patterns are anchored to the `.dmg` entry.

## Why one-click, and why `.dmg`

The dmg holds `Canva.app` and nothing else — no pkg, no `LaunchDaemons`/`LaunchAgents`/`PrivilegedHelperTools`, no system extension, one executable in `Contents/MacOS/` — so a bundle swap is the whole update. The cask's `zap` names a `com.canva.availability-check-agent` LaunchAgent, the one thing that could have argued for `.pkg`; it is in neither the dmg nor a machine that has run Canva, so whatever writes it, the installer does not.

Read off the real `Canva-1.124.0-universal.dmg`: `com.canva.CanvaDesktop`, `1.124.0`, Team `5HD2ARTBFS`, `spctl` "Notarized Developer ID".

Unlike Signal — whose feed hash predates its own stapling, which is why that recipe has no checksum — Canva's published base64 sha512 matches the served bytes **exactly** (`shasum -a 512` over the downloaded dmg, base64-encoded, equals the feed value). So the checksum gate is armed on top of the mandatory Team-ID one.

## No changelog, deliberately

Canva publishes no desktop release notes. The changelogs on canva.dev belong to the Apps SDK and Connect APIs — a different product — and `www.canva.com` answers a Cloudflare interactive challenge, so nothing there could be confirmed to be a notes page. `downloadURL` points at `https://www.canva.com/download/` (curl 200, not challenged) rather than at the yml.

## Verification

Live, through the production path:

```
duo verify --only canva
vendor probe  ✓ 1  ⚠ 0  ✗ 0  ~ 0  - 0
```

The empty `warnings` array is the load-bearing half — it means neither `installURLUnresolved` nor `checksumPatternNoMatch` fired, so the one-click URL *and* the sha512 both resolved live.

End to end against the installed copy:

```
duo check canva --json
source: Vendor  installedVersion: 1.124.0  latestVersion: 1.124.0  status: up-to-date
```

Offline:

```
cd DuoUpdaterCore && swift test --filter CanvaProbeRecipeTests
✔ Test run with 12 tests in 1 suite passed after 0.004 seconds.

make test
✔ Test run with 1238 tests in 97 suites passed with 1 known issue
  (pre-existing Anki withKnownIssue, unrelated)
✔ Test run with 127 tests in 19 suites passed
✓ localizable keys agree — 413 in the catalog, all reachable
```

The 12 tests are derived from the registry — the recipe is looked up by bundle id and every expectation is computed from its own fields, so a registry edit is what they fail against. Both fixtures are response bodies captured verbatim from the vendor on 2026-08-27, including the beta feed the recipe must refuse to read anything out of.