### PR TITLE
fix(tests): finish removing the self-shadowed helper calls

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EasyFindProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EasyFindProbeRecipeTests.swift
@@ -24,7 +24,7 @@ private let devonFreewareFixture = #"""
     }
 
     @Test func readsEasyFindsOwnVersionNotANeighboursOnTheSamePage() throws {
-        let recipe = try recipe()
+        let recipe = try self.recipe()
         #expect(VendorProbeRecipe.extractVersion(
             from: devonFreewareFixture, pattern: recipe.versionPattern) == "5.0.2")
         // XMenu's 1.9.11 sits EARLIER in the document, so a loose "Version X"

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GroupBProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GroupBProbeRecipeTests.swift
@@ -67,7 +67,7 @@ struct GroupBProbeRecipeTests {
     // MARK: Emacs
 
     @Test func emacsVersionPatternDropsTheRepackSuffix() throws {
-        let recipe = try #require(recipe("org.gnu.Emacs"))
+        let recipe = try #require(self.recipe("org.gnu.Emacs"))
         // The installed bundle reports plain `30.2` (verified by mounting the
         // 30.2-2 dmg) — the `-2` repack suffix must NOT survive extraction, or
         // the probe would claim a permanent phantom update.
@@ -76,7 +76,7 @@ struct GroupBProbeRecipeTests {
     }
 
     @Test func emacsInstallURLKeepsTheRealSuffixedFilename() throws {
-        let recipe = try #require(recipe("org.gnu.Emacs"))
+        let recipe = try #require(self.recipe("org.gnu.Emacs"))
         let spec = try #require(recipe.install)
         guard case .bodyPattern(let pattern) = spec.urlSource else {
             Issue.record("expected a body pattern"); return
@@ -89,7 +89,7 @@ struct GroupBProbeRecipeTests {
     }
 
     @Test func emacsPatternIsUnsuffixedWhenTheEntryIsNotARepack() throws {
-        let recipe = try #require(recipe("org.gnu.Emacs"))
+        let recipe = try #require(self.recipe("org.gnu.Emacs"))
         // A plain (non-repack) entry, e.g. "Emacs Version 30.1", must also match —
         // the `-N` group is optional, not required.
         let plain = "<title>Emacs Version 30.1</title>"
@@ -100,7 +100,7 @@ struct GroupBProbeRecipeTests {
     // MARK: Tor Browser
 
     @Test func torBrowserReadsTheVersionFieldVerbatim() throws {
-        let recipe = try #require(recipe("org.torproject.torbrowser"))
+        let recipe = try #require(self.recipe("org.torproject.torbrowser"))
         // Verified against the real install: CFBundleShortVersionString is
         // exactly "15.0.19" — same three-segment scheme as the feed, no
         // build/marketing split to work around.
@@ -110,7 +110,7 @@ struct GroupBProbeRecipeTests {
     }
 
     @Test func torBrowserInstallsTheBinaryFieldDirectly() throws {
-        let recipe = try #require(recipe("org.torproject.torbrowser"))
+        let recipe = try #require(self.recipe("org.torproject.torbrowser"))
         let spec = try #require(recipe.install)
         guard case .bodyPattern(let pattern) = spec.urlSource else {
             Issue.record("expected a body pattern"); return
@@ -123,7 +123,7 @@ struct GroupBProbeRecipeTests {
     // MARK: Zotero
 
     @Test func zoteroReadsTheMacEntryOfStandaloneVersions() throws {
-        let recipe = try #require(recipe("org.zotero.zotero"))
+        let recipe = try #require(self.recipe("org.zotero.zotero"))
         // Verified against the real install: CFBundleShortVersionString is
         // exactly "9.0.6", matching the page's literal verbatim.
         #expect(VendorProbeRecipe.extractVersion(
@@ -131,7 +131,7 @@ struct GroupBProbeRecipeTests {
     }
 
     @Test func zoteroReadsATwoSegmentVersion() throws {
-        let recipe = try #require(recipe("org.zotero.zotero"))
+        let recipe = try #require(self.recipe("org.zotero.zotero"))
         // Zotero 10.0 self-reports exactly "10.0" (verified by mounting
         // Zotero-10.0.dmg: CFBundleShortVersionString == CFBundleVersion == "10.0"),
         // so the two-segment page string is the correct thing to compare against —
@@ -141,7 +141,7 @@ struct GroupBProbeRecipeTests {
     }
 
     @Test func zoteroTwoSegmentVersionTemplatesTheInstallURL() throws {
-        let recipe = try #require(recipe("org.zotero.zotero"))
+        let recipe = try #require(self.recipe("org.zotero.zotero"))
         let spec = try #require(recipe.install)
         guard case .bodyTemplate(let template, let fields) = spec.urlSource else {
             Issue.record("expected a body template"); return
@@ -155,7 +155,7 @@ struct GroupBProbeRecipeTests {
     }
 
     @Test func zoteroInstallURLIsTemplatedFromTheMatchedVersion() throws {
-        let recipe = try #require(recipe("org.zotero.zotero"))
+        let recipe = try #require(self.recipe("org.zotero.zotero"))
         let spec = try #require(recipe.install)
         guard case .bodyTemplate(let template, let fields) = spec.urlSource else {
             Issue.record("expected a body template"); return
@@ -172,7 +172,7 @@ struct GroupBProbeRecipeTests {
 
     @Test func allThreeRecipesAreStableChannelAndOneClick() throws {
         for id in ["org.gnu.Emacs", "org.torproject.torbrowser", "org.zotero.zotero"] {
-            let recipe = try #require(recipe(id))
+            let recipe = try #require(self.recipe(id))
             #expect(recipe.channel == .stable)
             #expect(recipe.install != nil)
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GroupCProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GroupCProbeRecipeTests.swift
@@ -52,7 +52,7 @@ struct GroupCProbeRecipeTests {
     // MARK: - GrandPerspective
 
     @Test func grandPerspectiveReadsTheMacVersion() throws {
-        let recipe = try recipe("net.sourceforge.grandperspectiv")
+        let recipe = try self.recipe("net.sourceforge.grandperspectiv")
         #expect(recipe.url.absoluteString
             == "https://sourceforge.net/projects/grandperspectiv/best_release.json")
         #expect(VendorProbeRecipe.extractVersion(
@@ -60,7 +60,7 @@ struct GroupCProbeRecipeTests {
     }
 
     @Test func grandPerspectiveIsOneClick() throws {
-        let recipe = try recipe("net.sourceforge.grandperspectiv")
+        let recipe = try self.recipe("net.sourceforge.grandperspectiv")
         let spec = try #require(recipe.install)
         #expect(spec.kind == .dmg)
         guard case .bodyTemplate(let template, let fields) = spec.urlSource else {
@@ -79,7 +79,7 @@ struct GroupCProbeRecipeTests {
     // MARK: - TigerVNC — the top-level-vs-platform_releases.mac trap
 
     @Test func tigerVNCReadsTheMacVersionNotTheTopLevelWindowsOne() throws {
-        let recipe = try recipe("com.tigervnc.tigervnc")
+        let recipe = try self.recipe("com.tigervnc.tigervnc")
         // Sanity: the fixture really does have a Windows exe as its top-level
         // "release" — if this stops being true the fixture no longer proves
         // anything about the trap.
@@ -89,7 +89,7 @@ struct GroupCProbeRecipeTests {
     }
 
     @Test func tigerVNCIsOneClick() throws {
-        let recipe = try recipe("com.tigervnc.tigervnc")
+        let recipe = try self.recipe("com.tigervnc.tigervnc")
         let spec = try #require(recipe.install)
         #expect(spec.kind == .dmg)
         guard case .bodyTemplate(let template, let fields) = spec.urlSource else {
@@ -119,7 +119,7 @@ struct GroupCProbeRecipeTests {
         #expect(wrongValue == "/stable/1.16.0/tigervnc64-1.16.0.exe")
         #expect(!wrongValue.contains(".dmg"))
         // The real recipe pattern, scoped to platform_releases.mac, is immune.
-        let recipe = try recipe("com.tigervnc.tigervnc")
+        let recipe = try self.recipe("com.tigervnc.tigervnc")
         let correctValue = try #require(
             VendorProbeRecipe.extractVersion(from: tigerVNCFixture, pattern: recipe.versionPattern))
         #expect(correctValue == "1.16.0")
@@ -169,7 +169,7 @@ struct GroupCProbeRecipeTests {
     @Test func sourceForgeRecipesOverrideTheBrowserUserAgent() throws {
         for id in ["net.sourceforge.grandperspectiv",
                    "com.tigervnc.tigervnc"] {
-            let recipe = try recipe(id)
+            let recipe = try self.recipe(id)
             let ua = recipe.requestHeaders["User-Agent"]
             #expect(ua != nil, "\(id) must send its own User-Agent")
             #expect(ua?.contains("Mozilla") == false, "\(id) must not send a browser UA")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InkscapeChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InkscapeChangelogRecipeTests.swift
@@ -61,7 +61,7 @@ private let inkscapeWikiFixture = #"""
     }
 
     @Test func eachPageIsOneRelease() throws {
-        let recipe = try recipe()
+        let recipe = try self.recipe()
         #expect(recipe.maxEntries == 1)
         #expect(recipe.resolvedSource(forVersion: "1.4.4").absoluteString
             == "https://wiki.inkscape.org/wiki/Release_notes/1.4.4")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/OnePasswordFeedTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/OnePasswordFeedTests.swift
@@ -33,7 +33,7 @@ private let onePasswordFeedFixture = #"""
     /// here would report the 2022 release as current — which the UI renders as
     /// "up to date", forever, with nothing failing.
     @Test func theProbeTakesTheHighestVersionNotTheFirst() throws {
-        let probe = try probe()
+        let probe = try self.probe()
         #expect(probe.selectHighest)
         #expect(probe.url.absoluteString.hasSuffix("index.xml"))
         #expect(VendorProbeRecipe.extractVersion(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/OperaChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/OperaChangelogRecipeTests.swift
@@ -64,7 +64,7 @@ private let operaChangelogFixture = #"""
     /// not `{version}` — a page pinned to today's major stops covering the
     /// installed build within a few weeks.
     @Test func theSourceIsTemplatedOnTheMajor() throws {
-        let recipe = try recipe()
+        let recipe = try self.recipe()
         #expect(recipe.sourceTemplate?.contains("{major}") == true)
         #expect(recipe.resolvedSource(forVersion: "134.0.5954.56").absoluteString
             == "https://blogs.opera.com/desktop/changelog-for-134/")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TelegramDesktopProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TelegramDesktopProbeRecipeTests.swift
@@ -21,7 +21,7 @@ private let telegramCurrent4Fixture = #"""
     }
 
     @Test func readsTheDottedVersionFromTheRedirectTarget() throws {
-        let recipe = try #require(recipe("com.tdesktop.Telegram"))
+        let recipe = try #require(self.recipe("com.tdesktop.Telegram"))
         guard case .redirectFilename = recipe.mode else {
             Issue.record("expected the redirect-filename mode"); return
         }
@@ -37,7 +37,7 @@ private let telegramCurrent4Fixture = #"""
     /// must find nothing in it rather than latch onto a number that looks like a
     /// version.
     @Test func thePackedIntegerFeedIsNotMistakenForAVersion() throws {
-        let recipe = try #require(recipe("com.tdesktop.Telegram"))
+        let recipe = try #require(self.recipe("com.tdesktop.Telegram"))
         #expect(VendorProbeRecipe.extractVersion(
             from: telegramCurrent4Fixture, pattern: recipe.versionPattern) == nil)
     }
@@ -49,7 +49,7 @@ private let telegramCurrent4Fixture = #"""
     }
 
     @Test func downloadsTheSameRedirectItProbes() throws {
-        let recipe = try #require(recipe("com.tdesktop.Telegram"))
+        let recipe = try #require(self.recipe("com.tdesktop.Telegram"))
         let spec = try #require(recipe.install)
         guard case .redirect(let url) = spec.urlSource else {
             Issue.record("expected a redirect install source"); return

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/Top50BatchRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/Top50BatchRuleTests.swift
@@ -12,7 +12,7 @@ import Foundation
     /// actually answers. Pinned because the natural reading of "it has a
     /// SUFeedURL" is "it's already covered".
     @Test func hiddenBarReadsTagsNotItsEmptySparkleFeed() throws {
-        let rule = try rule("com.dwarvesv.minimalbar")
+        let rule = try self.rule("com.dwarvesv.minimalbar")
         #expect(rule.owner == "dwarvesf")
         #expect(rule.repo == "hidden")
         #expect(VendorProbeRecipe.extractVersion(from: "v1.10", pattern: rule.versionPattern)
@@ -33,7 +33,7 @@ import Foundation
     /// app bundle, so it must stay on the pkg route — an in-place bundle swap
     /// would leave everything except `XQuartz.app` at the old version.
     @Test func xquartzUsesThePackageRoute() throws {
-        let rule = try rule("org.xquartz.X11")
+        let rule = try self.rule("org.xquartz.X11")
         #expect(rule.installerKind == .pkg)
         #expect(VendorProbeRecipe.extractVersion(
             from: "XQuartz-2.8.6", pattern: rule.versionPattern) == "2.8.6")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
@@ -741,12 +741,12 @@ struct LaggingRemoteVersionTests {
 
     @Test func neverAskedKeepsTheUpdateButton() {
         let result = elevatedResult()
-        let environment = environment(elevationRequired: [fixturePath])
-        #expect(UpdatePolicy.requiresElevatedInstall(result, environment: environment),
+        let env = environment(elevationRequired: [fixturePath])
+        #expect(UpdatePolicy.requiresElevatedInstall(result, environment: env),
                 "the host reported this path as needing elevation")
-        #expect(!UpdatePolicy.elevationDeclined(result, settings: defaultSettings(), environment: environment),
+        #expect(!UpdatePolicy.elevationDeclined(result, settings: defaultSettings(), environment: env),
                 "needing a password is not the same as having refused one")
-        #expect(UpdatePolicy.canAutoInstall(result, settings: defaultSettings(), environment: environment),
+        #expect(UpdatePolicy.canAutoInstall(result, settings: defaultSettings(), environment: env),
                 "an app the user was never asked about must still offer Update")
     }
 
@@ -754,18 +754,18 @@ struct LaggingRemoteVersionTests {
 
     @Test func decliningTheAdministratorPromptRetiresTheOneClick() {
         let result = elevatedResult()
-        let environment = environment(elevationRequired: [fixturePath])
+        let env = environment(elevationRequired: [fixturePath])
         let settings = defaultSettings(declinedElevation: declinedKey())
-        #expect(UpdatePolicy.elevationDeclined(result, settings: settings, environment: environment))
-        #expect(!UpdatePolicy.canAutoInstall(result, settings: settings, environment: environment),
+        #expect(UpdatePolicy.elevationDeclined(result, settings: settings, environment: env))
+        #expect(!UpdatePolicy.canAutoInstall(result, settings: settings, environment: env),
                 "a refused prompt must not be re-raised on the next release")
     }
 
     @Test func clearingTheDeclineRestoresTheOneClick() {
         let result = elevatedResult()
-        let environment = environment(elevationRequired: [fixturePath])
+        let env = environment(elevationRequired: [fixturePath])
         #expect(UpdatePolicy.canAutoInstall(result, settings: defaultSettings(declinedElevation: []),
-                                            environment: environment),
+                                            environment: env),
                 "there must be a way back: an emptied decline set re-offers Update")
     }
 
@@ -793,10 +793,10 @@ struct LaggingRemoteVersionTests {
         // them so one refusal hid every copy.
         let sibling = "/Applications/Fixture Beta.app"
         let result = elevatedResult(path: sibling)
-        let environment = environment(elevationRequired: [fixturePath, sibling])
+        let env = environment(elevationRequired: [fixturePath, sibling])
         let settings = defaultSettings(declinedElevation: declinedKey())  // the OTHER copy
-        #expect(!UpdatePolicy.elevationDeclined(result, settings: settings, environment: environment))
-        #expect(UpdatePolicy.canAutoInstall(result, settings: settings, environment: environment))
+        #expect(!UpdatePolicy.elevationDeclined(result, settings: settings, environment: env))
+        #expect(UpdatePolicy.canAutoInstall(result, settings: settings, environment: env))
     }
 
     @Test func elevationIsMatchedOnThisExactInstall() {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatDevToolsTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatDevToolsTests.swift
@@ -233,7 +233,7 @@ struct WeChatDevToolsProbeTests {
     /// much lower version. The Nightly anchor closes its quote right after the id, so
     /// the prefix can't be read as a match.
     @Test func nightlyDoesNotMatchTheRetiredNightlyOldTrain() throws {
-        let recipe = try recipe(.nightly)
+        let recipe = try self.recipe(.nightly)
         #expect(VendorProbeRecipe.extractVersion(
             from: wechatDevToolsConfigFixture, pattern: recipe.versionPattern) != "2.01.2602282")
     }
@@ -249,7 +249,7 @@ struct WeChatDevToolsProbeTests {
             .nightly: "wechat_devtools_2.02.2608182_darwin_arm64.pkg",
         ]
         for (channel, filename) in expected {
-            let recipe = try recipe(channel)
+            let recipe = try self.recipe(channel)
             let install = try #require(recipe.install)
             #expect(install.kind == .pkg)
             guard case .bodyPattern(let pattern) = install.urlSource else {


### PR DESCRIPTION
接 [#86](https://github.com/jizhi0v0/duo-updater/pull/86) 里那个只修了 1/10 的收尾。

`16ff5f1` 修了一个文件就宣布完事。实际有 **10 个文件、31 处**。夜扫的 install-path dry-run 一直构建失败——编译器只是停在第一个错误上，修掉那个文件之后露出下一个。

## 为什么本地测试一直是绿的

`let x = try #require(x(...))` 在 **Swift 6.4 能编译、6.3.x 不能**（新绑定在自己的初始化表达式里遮蔽了 helper）。两个工具链都在用：

| | Swift | 结果 |
|---|---|---|
| 开发机 `make test` | 6.4 | 全绿，从来没见过这问题 |
| 夜扫机器 | 6.3.3 | **测试 target 根本编译不出来** |

代价是夜扫那台上 install-path dry-run 整个失效——而那是唯一一条把真实下载走一遍签名闸的检查（Sparkle 密钥轮换、Team 变更、归档解不开，只有它看得见）。

## 改法

- **27 处**是结构体实例方法 → 加 `self.`，其余一个字不动。
- **4 处**在 `UpdatePolicyTests`，调的是文件级自由函数，`self.` 够不着 → 改绑定名 `let env = environment(...)`，跟它下面两个测试里已有的 `let writable = environment(...)` 一致。

## 是按形状扫的，不是跟着编译器逐个修

```
let\s+([A-Za-z_]\w*)\s*=.*?(?<![.\w])\1\s*\(
```

现在全测试树零命中。注意 `ChangelogRecipeRegistry.recipe(...)` 这种**限定调用**不在其列，没误伤。

## 验证

```
make test（本机 Swift 6.4）                    →  1233 tests passed（1 个既有 known issue）
mini 上临时 worktree，swift build --build-tests
（Swift 6.3.3，即此前失败的那个工具链）        →  Build complete! (39.36s)
```

第二条是关键：在**真正会失败的那个工具链**上编过，而不是只在本机绿了就算。