### PR TITLE
fix(triage): the configured model was retired, so every call failed

### DIFF
--- a/.opencode/agent/duo-triage.md
+++ b/.opencode/agent/duo-triage.md
@@ -3,12 +3,20 @@ description: >-
   Re-derives a broken extraction pattern from a captured vendor response. Used
   only by `duo triage`; never for editing this repository.
 mode: primary
-# Chosen because it is reachable without a provider credential of its own and
-# bills nothing; the sibling `opencode-go/` and direct `deepseek/` routes both
-# need account-level access that not every checkout will have. Triage only ever
-# reads a captured response body, so a small model is enough.
+# The previous choice, `opencode/deepseek-v4-flash-free`, was RETIRED from the
+# provider some time before 2026-08-27 and no longer appears in `opencode
+# models`. Requesting a model that no longer exists does not fail cleanly:
+# the server answers a generic `UnknownError: Unexpected server error`, which
+# surfaces only as `opencode exited 1` in the sweep log, with nothing naming
+# the model. Every triage call had been failing that way — check `opencode
+# models` first when triage starts exiting 1 across the board.
+#
+# `opencode-go/` was previously avoided because it 403'd without account-level
+# access. That is no longer true for this account (verified 2026-08-27: both
+# `deepseek-v4-pro` and `deepseek-v4-flash` answer). Unlike the old `-free`
+# route this one may bill.
 # `duo triage --model` overrides it.
-model: opencode/deepseek-v4-flash-free
+model: opencode-go/deepseek-v4-pro
 temperature: 0.1
 permission:
   edit: deny


### PR DESCRIPTION
夜扫的 triage 步骤**一直在失败**，日志里只显示 `opencode exited 1`。

## 根因

`opencode/deepseek-v4-flash-free` 已从 provider 下架，`opencode models` 里不再有它。而请求一个不存在的模型**不会干净地失败**：

```
UnknownError: "Unexpected server error. Check server logs for details."  ref: err_8a9f7295
```

笼统的服务端错误，不提模型名。传到夜扫日志里就只剩 `opencode exited 1`——看不出是模型没了。

## 代价（翻历史日志）

```
14 ×  ghostty: timed out after 360s
12 ×  gh issue failed: dial tcp 198.18.0.229:443
 2 ×  workbuddy-ai: opencode exited 1
```

那 14 次超时 ≈ 84 分钟，烧在一条**陈旧 checkout 造出来的假 finding** 上。

## 改动

换成 `opencode-go/deepseek-v4-pro`。这条路线当初被避开是因为**没有账号级权限会 403**——2026-08-27 实测已不成立（`-pro` 和 `-flash` 都能应答）。与下架的 `-free` 不同，这条**可能计费**，是明确权衡后的选择。

注释现在记的是**失效特征**而不只是选型理由：下一个碰到的人看到的是 `opencode exited 1`，不会知道那意味着"模型没了"。

## 验证

```
duo triage --report … --baseline … --out …
  ✓ changelog:com.workbuddy.workbuddy-ai:-: noPatternOffered (confidence 0.15)
  exit=0
```

而且结论是对的——那个页面确实没有 pattern 可重新推导，它只是落后自己的发布轨道两个版本。