### PR TITLE
CapCut: two-track detection, in-app beta switch, one-click on both

### DIFF
--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -342,6 +342,102 @@ channel, and the live probe's from→to verdict.
 real bundle id / version / channel marker / detected channel / probe verdict per
 channel). That record is what backs a ✓ in the audit docs.
 
+### Phase 3⅞: What else does the vendor's updater DO? (the step that keeps getting skipped)
+
+Phases 1–3¾ all ask the same shape of question: *is there a feed we can read?*
+When the answer is "no", it is easy to write the app up and stop. That is how a
+whole capability goes missing — the audit is not wrong, it is **narrow**.
+
+Ask the orthogonal question: **what does this app's own updater do that we could
+consume, or that would break us if we ignored it?**
+
+**Answer every row in three columns. Never collapse them.**
+
+| | 客户端有这个能力? | 服务端现在真在发? | 我们能消费吗? |
+|---|---|---|---|
+| 增量 / 二进制补丁 | | | |
+| 按设备灰度（同一个 key 因人而异）| | | |
+| 按架构 / 按 OS 分轨 | | | |
+| 自更新器会不会和我们抢 | | | |
+
+Column 1 is usually answered from **strings in the binary**. Column 2 requires
+**hitting the real endpoint**. They are different claims, and a string is never
+evidence for column 2.
+
+This is not hypothetical. The CapCut audit's first draft said "the patch format
+isn't Sparkle's, so consuming it would need new machinery" — both halves wrong,
+both from inferring rather than opening the framework sitting in the bundle. The
+same draft said a field was "absent from `update_reminder`" when that key could
+never have lived there.
+
+**Delta / binary patch — how to actually check:**
+
+```bash
+# 1. Client capability: does the app carry a patch applier at all?
+strings -a "<app>/Contents/Frameworks/<vendor>.dylib" | grep -iE "delta|diffpatch|bspatch|hdiff"
+# Sparkle apps: the applier is in the framework's Autoupdate, NOT the main binary
+strings -a "<app>"/Contents/Frameworks/Sparkle.framework/Versions/*/Autoupdate \
+  | grep -iE "BinaryDelta|SUBinaryDelta|bspatch|sparkle:deltaFrom"
+plutil -p "<app>"/Contents/Frameworks/Sparkle.framework/Versions/*/Resources/Info.plist | grep Version
+
+# 2. Server reality: does a real response actually carry a patch URL?
+#    Do NOT grep for the key name you expect — scan the WHOLE body.
+python3 - <<'PY'
+import re; raw = open("body.json").read()
+print(sorted(set(re.findall(r'"([a-z0-9_.]*(?:diff|delta|patch)[a-z0-9_.]*)"\s*:', raw, re.I))))
+print(re.findall(r'"(https?://[^"]*\.(?:delta|patch|diff))"', raw) or "no patch URL")
+PY
+```
+
+If it is a **Sparkle** binary delta, we already apply it: `DeltaApplier` ships
+Sparkle's own `BinaryDelta`, and `VendorAppcastDeltas` pulls patches out of an
+appcast's `<sparkle:deltas>`. So "can we consume it" is usually a *plumbing*
+question — where does the patch URL come from — not a new-mechanism one.
+
+**Two traps that produced false "no" answers:**
+
+- **Log format strings are column 1, never column 2.** `cfg.diff_url=%s` in a
+  binary means the client can print that field. It says nothing about whether any
+  server populates it.
+- **Check the container before declaring a key absent.** A key spelled
+  `diff_update.enable` in the binary may be a top-level `diff_update` OBJECT in
+  the JSON. Confirm whether the schema is flat or nested (`[k for k in obj if "."
+  in k]`) before reporting "not there".
+
+**A pinned request parameter can silently foreclose this.** If the recipe pins a
+version/id in the query, ask what that pin costs beyond the field you pinned it
+for: patches are typically keyed *from* a version *to* a version, so a pinned
+fake version can never match a patch mapping. Record the cost even when it is
+zero today.
+
+### Reference: what a recipe can already express
+
+An audit that does not know a field exists will report the situation it covers as
+"not supported". Check this list before writing 「不可行」— it is derived from
+`VendorProbeRecipe`'s initializer, so verify against the source if it looks stale.
+
+| Field | Use it when |
+|---|---|
+| `versionIsBuild` | the endpoint's version matches `CFBundleVersion`, not the marketing string |
+| `displayVersionPattern` | the compared value is an ugly build id and there is a human one to show |
+| `publishedAtPattern` | the entry states its own release date (Release Log gets an exact time) |
+| `selectHighest` | the feed lists many releases and document order is not newest-first |
+| `entryStartPattern` | multi-entry feed: slice it so version/URL/date all come from ONE entry |
+| `channel` | this endpoint serves a non-stable track (source refuses cross-channel) |
+| `variant` | one channel legitimately has more than one endpoint worth asking |
+| `hostRequirement` | the build only runs on some Macs (arch / OS floor) — **detection half** |
+| `identities` (`ProbeIdentity`) | the endpoint only answers for a machine id the app already wrote to disk |
+| `track` (`RolloutTrack`) | one URL, several vendor-assigned tracks, picked by a request-borne value |
+| `requestBody` | the service answers nothing to a GET (Omaha-style) |
+| `requestHeaders` | a WAF needs a Referer, or rejects the default browser-ish UA |
+| `followRedirects: false` | the endpoint 302s to a huge binary and the version is in `Location` |
+| `install` + `ChannelProofRegistry` | one-click; a NON-STABLE channel install **requires** a proof entry |
+
+Adjacent machinery an audit should also weigh: `DeltaApplier` (applies Sparkle
+binary patches), `VendorAppcastDeltas` (pulls them out of an appcast),
+`RecipeSanity` (flags a version that appears verbatim in the request URL, and a
+feed that reads behind the installed copy).
+
 ### Phase 4: One-click install feasibility
 
 Only after detection is confirmed. For each supported channel:
@@ -391,6 +487,17 @@ centerpiece — it shows at a glance what's covered and what's not.
 - 源: ...
 - 端点: ...
 - 注意事项: (版本方案陷阱、rollout、WAF 等)
+
+## 增量更新（delta / binary patch）
+> 三栏分开写，每栏标证据来源。空着不如写「没查」。
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 有/无/没查 | 有/无/没查 | 能/不能/没查 |
+| 证据 | (binary strings / framework) | (真实响应，注明 date + 参数) | (哪条现成机制，或缺什么) |
+
+- 格式: Sparkle binary delta / 厂商自有 / 未知
+- 阻塞项: ...
 
 ## Changelog
 - 来源: Sparkle inline / recipe / WebView / 无

--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -77,6 +77,48 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
   枚举)，channel 门控路由到 `pkgs.tailscale.com/unstable` probe。`pkgs.tailscale.com/rc`
   **404**（无第三消费轨，已否决）。stable/unstable changelog 共用 tailscale.com/changelog。
 
+### Pattern B/C 续 — CapCut（2026-08-27 接 beta）
+
+- **CapCut** `com.lemon.lvoverseas` — 「Version update」窗口里的 **"Get early access to
+  beta features"** 复选框。信号**不在 UserDefaults 也不在沙盒容器里**：CapCut 是沙盒 app
+  （域在 `~/Library/Containers/com.lemon.lvoverseas/Data/Library/Preferences/`），但两个
+  plist 都没有这个键；Qt 把它写进容器外的 INI —— `~/Movies/CapCut/User Data/Config/
+  updateInfo` 的 `[General] joinBeta=true`。同目录 `globalSetting` 的 `enableAutoUpdate`
+  是**另一组**单选（自动装 vs 只通知），不是渠道，别读错。
+- 装机侧还有一个只读的构建标记：`Contents/Resources/PackageConfig.plist` →
+  `Channel Name`（stable 装机实测 `capcutpc_0`，beta 包名里是 `capcutpc_beta`）；
+  CapCut 自己把它抄进同目录的 `channel` 文件（`tea_channel=capcutpc_0`），所以不用
+  找 bundle 路径也能读到。**只在 `joinBeta` 完全没记录时**才用它兜底 —— binding 是
+  authoritative、会顶掉 `ReleaseChannel.detect()`，而 detect() 对 CapCut **不是**空
+  操作（beta 版本号带 `-betaN`，step 4 本来就判 `.beta`）；没记录就答 stable 会把一台
+  从没开过更新窗口的 beta 机器降级成 stable 并藏掉它的更新。`joinBeta=false`（用户显式
+  退出）仍然答 stable。
+- 门控方式 = channel-gated VendorProbe（无 feed-swap：CapCut 内嵌 Sparkle 只负责装，
+  没有 `SUFeedURL`，更新决策来自 ByteDance Settings SDK 的 `update_reminder.*`）。
+  两轨同一个匿名端点：`editor-api.capcutapi.com/service/settings/v3/`
+  （`aid=359289&device_platform=mac&channel=capcutpc_0&version_code=9.99`，四个参数缺一
+  就没有 `update_reminder`）。stable 读 `lastest_stable_url`、beta 读 `lastest_url`，
+  版本从包名的 `CapCut_9_3_0_4490_capcutpc_0_…` 里按段抽再用 `.` 拼。
+- 三个坑记在 `VendorProbeRecipe.swift` 的注释里：`update_url` 是**按设备灰度**的选择
+  （本机缓存里是 stable、匿名请求里是 beta，两轨都不能读它）；`lastest_sync_url` 是同一
+  对象里**第三个** `capcutpc_beta` 包且 build 更旧；`version_code` 会选灰度桶（实测
+  `1.0.0` 落到旧桶、`10.0.0` 直接没有 `update_reminder`）。
+- **两轨版本字段是反的**（挂载真包量的）：stable 的 short=version=`9.3.0`；beta 的
+  short=`9.3.4531`（没有任何 channel 词）、version=`9.4.0-beta4`。两个后果：
+  (a) `detect()` 拿的是 short，对 beta 装机**判不出 beta**，所以 `CapCutChannel` 是唯一信号；
+  (b) beta 配方必须 `versionIsBuild: true`，否则 `9.4.0-beta4` 比 `9.3.4531` 永远更新，
+  正在跑 beta4 的人会被无限劝装 beta4。
+- **两轨一键都已接**：`kind: .dmg`，`hostRequirement` = arm64（实测 `lipo` 只有 arm64，
+  厂商只发一份产物），Team `22MMUN2RN5` + notarized（两个真实 dmg 都核过，beta 轨还跑过
+  一次生产 `vendorDownloadPassesSignatureGate`：真下载 1.24 GB、真解包、真过闸），
+  dmg 里只有 `CapCut.app` + `/Applications` 软链，无 pkg / 无 launch item（brew cask
+  的 `{"app": ["CapCut.app"]}` + 只 `quit` 的 uninstall 是第二证人）。厂商只给 MD5，
+  `checksumPattern` 吃 base64 SHA-512，故未武装 checksum，Team 闸兜底。每次 ~1.24 GB。
+- `ChannelProofRegistry` 已登记 beta：`.artifact(#"_capcutpc_beta_"#)` —— token 是从
+  beta dmg 自己的 `PackageConfig.plist` 读的，不是照文件名习惯推的。
+- 同 bundle id 还有一份 **MAS 副本（adamId 1500855883，版本 19.2.0）**，版本方案完全不同；
+  两边不串全靠 `_MASReceipt`（`VendorProbeSource` 拒 MAS、`MacAppStoreSource` 拒非 MAS）。
+
 ### Pattern A 续 — VS Code Insiders（2026-06-06 接）
 
 - **VS Code Insiders** `com.microsoft.VSCodeInsiders`（显示名 "Code - Insiders" → detect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,4 +42,8 @@ vendor 换 DNS、改 manifest 结构、端点开始要 license,都发生过。�
   `git stash` / `merge` / `commit` 前先 `git status` + `git stash list`,确认没有另一个会话的在途改动。
 - 找不到某个文件或命令时,先考虑"它在另一个 checkout 里还没提交",不要断言"它不存在"。
 - 解冲突就在冲突块里改,不要把内容追加到文件末尾。
-- 分组提交(引擎 / CLI / 测试 / CHANGELOG),提交前先把分组方案给用户过目;`docs/` 默认不带进来,除非明确要求。
+- 分组提交(引擎 / CLI / 测试 / 文档 / CHANGELOG),提交前先把分组方案给用户过目。
+- **`docs/` 要带进来**,尤其是 `docs/app-audits/`。审计文档是改动的一部分,不是附属品:
+  「厂商包名里的 channel token 是什么」「两轨的版本字段是反的」「这个端点的必填参数会选灰度桶」
+  这类东西,下一个人重新发现一次的代价远高于多提交一个文件。近几个 recipe PR(Canva、
+  WorkBuddy、CapCut)都是连审计文档一起提的,这条曾经写成"默认不带",与实际做法相反。

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CapCutChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CapCutChannel.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// CapCut (`com.lemon.lvoverseas`, ByteDance) — a two-track app whose channel
+/// choice is a checkbox inside the app's own "Version update" window ("Get early
+/// access to beta features"), not a separate download.
+///
+/// The two tracks are real and visible in the vendor's own package names:
+///   * stable → `CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg`
+///   * beta   → `CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg`
+/// and the installed bundle states which one it is in
+/// `Contents/Resources/PackageConfig.plist` → `Channel Name` (`capcutpc_0` on a
+/// stable install, read off this machine 2026-08-27).
+///
+/// The checkbox itself is NOT in UserDefaults, and looking for it there is the
+/// trap this file exists to record. CapCut is sandboxed, so its preference domain
+/// lives at `~/Library/Containers/com.lemon.lvoverseas/Data/Library/Preferences/`
+/// — but neither plist in there carries the flag. Qt writes it to CapCut's own
+/// user-data tree instead, in an INI file:
+///
+///     ~/Movies/CapCut/User Data/Config/updateInfo
+///     [General]
+///     joinBeta=true
+///     need_show_automatic_updates_popup=false
+///
+/// That path is outside the sandbox container, so reading it does not go through
+/// the App-Data gate that `~/Library/Containers/<other app>/Data` does; `~/Movies`
+/// is also not one of the three user folders TCC challenges on
+/// (Desktop/Documents/Downloads). Both reads here were exercised from a terminal
+/// process, which is the weaker of the two contexts — if a future macOS extends
+/// the gate to `~/Movies`, this resolver goes quiet and every CapCut install reads
+/// as stable.
+///
+/// The sibling `globalSetting` file in the same directory holds
+/// `enableAutoUpdate`, which is the OTHER radio pair in CapCut's settings
+/// ("Automatic updates" vs "Get notified about updates") — that one decides
+/// whether CapCut installs on its own, not which track it installs FROM, so it is
+/// deliberately not read here.
+///
+/// Safety: `joinBeta=false` — the user opting OUT — resolves to `.stable`, and so
+/// does anything unparseable. But "no record at all" is deliberately NOT treated
+/// as stable, and that distinction is the whole reason a second file is read.
+/// `ChannelBinding` is AUTHORITATIVE — whatever it answers REPLACES
+/// `ReleaseChannel.detect()` — and `updateInfo` is written by the update window,
+/// so a beta install that has never opened that window has no record at all.
+/// Calling that "stable" labels the row Stable and pins it to a stable recipe
+/// that reports an older version than the build it is running, forever.
+///
+/// Nothing else on disk would catch that. Measured on the real beta artifact
+/// (`CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg`, downloaded and
+/// mounted 2026-08-27), a beta bundle reports:
+///
+///     CFBundleShortVersionString  9.3.4531      ← no channel word at all
+///     CFBundleVersion             9.4.0-beta4
+///
+/// and `ReleaseChannel.detect()` is handed the SHORT version, so its `-betaN`
+/// rule never fires: detect() calls a beta install stable. Bundle id, app name
+/// and app filename are identical across the two tracks as well. So this resolver
+/// is not merely the best signal for CapCut, it is the only one — which is why
+/// "no recorded preference" falls back to the build's own channel token rather
+/// than to a constant. The token comes from the file CapCut writes next to the
+/// preference:
+///
+///     ~/Movies/CapCut/User Data/Config/channel
+///     [General]
+///     tea_channel=capcutpc_0
+///
+/// which is CapCut's own copy of `Contents/Resources/PackageConfig.plist` →
+/// `Channel Name`. Both values are read off real bundles, not inferred from the
+/// filenames: `capcutpc_0` in this machine's stable install and `capcutpc_beta`
+/// in the mounted beta dmg (2026-08-27). Absent or anything other than the beta
+/// token → `.stable`, so this can never escalate a stable install.
+///
+/// The corner this fallback does not cover: a beta bundle that has never been
+/// launched has neither file, so it reads as stable until first run. Closing that
+/// would mean reading `PackageConfig.plist` out of the bundle, which needs the
+/// app's path — something `ChannelBinding.resolve(bundleID:)` is not given.
+///
+/// Known divergence, stated rather than hidden: `joinBeta` is the user's opt-IN,
+/// while the build CapCut itself offers is additionally gray-scaled per device by
+/// the vendor. On this machine (2026-08-27) `joinBeta=true` and CapCut still said
+/// "You are using the latest version" on 9.3.0, because the settings blob it was
+/// served had picked stable for that device (`update_url` = the 9.3.0 dmg) even
+/// though the beta track's newest build was 9.4.0-beta4. Our beta recipe reads
+/// the track's newest build (`lastest_url`), not the per-device pick, so a user
+/// who ticked the box can be shown a beta before CapCut's own rollout reaches
+/// them. That is the honest reading of "the beta channel", and it is the only one
+/// available without sending this machine's ByteDance device id to the vendor.
+enum CapCutChannel {
+    static let bundleID = "com.lemon.lvoverseas"
+
+    /// The package channel token CapCut stamps into a beta build. Stable builds
+    /// carry `capcutpc_0`, and so does the vendor's own fallback when the token is
+    /// missing entirely, which is why only the beta token is named here.
+    static let betaPackageToken = "capcutpc_beta"
+
+    /// Map CapCut's two on-disk signals to a resolution. Pure and tested.
+    ///
+    /// `joinBeta` nil means "CapCut has never recorded a preference" — see the
+    /// type's doc for why that must not collapse into `false`.
+    ///
+    /// No feed override and no Sparkle channel tag: CapCut embeds Sparkle only to
+    /// run the install, and builds the update decision itself from a ByteDance
+    /// settings blob (see the recipes in `VendorProbeRegistry`). The channel here
+    /// exists purely to pick which of those two recipes applies.
+    static func resolve(joinBeta: Bool?, packageChannel: String?) -> ResolvedChannel {
+        if let joinBeta { return ResolvedChannel(channel: joinBeta ? .beta : .stable) }
+        let onBetaBuild = packageChannel?
+            .caseInsensitiveCompare(betaPackageToken) == .orderedSame
+        return ResolvedChannel(channel: onBetaBuild ? .beta : .stable)
+    }
+
+    static func resolveCurrent() -> ResolvedChannel {
+        resolve(joinBeta: readJoinBeta(), packageChannel: readPackageChannel())
+    }
+
+    /// The directory holding both files this resolver reads. Exposed for the same
+    /// reason `SurgeChannel.defaultsFileURL` is:
+    /// `ChannelBinding.preferenceWatchCandidates` has to sit on it, and a watcher
+    /// aimed anywhere else would look perfectly healthy while never firing. CapCut
+    /// is the first bound app whose choice is neither in `~/Library/Preferences`
+    /// nor in its sandbox container, so deriving the watch root from here rather
+    /// than restating the path is what keeps the two from drifting apart.
+    static var configDirectoryURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Movies/CapCut/User Data/Config", isDirectory: true)
+    }
+
+    /// The INI holding the user's `joinBeta` choice.
+    static var updateInfoFileURL: URL {
+        configDirectoryURL.appendingPathComponent("updateInfo", isDirectory: false)
+    }
+
+    /// The INI holding the running build's own package channel (`tea_channel`).
+    static var packageChannelFileURL: URL {
+        configDirectoryURL.appendingPathComponent("channel", isDirectory: false)
+    }
+
+    /// Read `joinBeta` out of the `[General]` section of CapCut's `updateInfo`
+    /// INI. Nil when the file, the section or the key is missing.
+    static func readJoinBeta() -> Bool? {
+        guard let text = readINI(at: updateInfoFileURL) else { return nil }
+        return joinBeta(inINI: text)
+    }
+
+    /// Read `tea_channel` out of the `[General]` section of CapCut's `channel`
+    /// INI. Nil when the file, the section or the key is missing.
+    static func readPackageChannel() -> String? {
+        guard let text = readINI(at: packageChannelFileURL) else { return nil }
+        return packageChannel(inINI: text)
+    }
+
+    /// Both files are a handful of lines; the cap is there so a path that turns
+    /// out to be something else entirely is not read into memory wholesale.
+    private static func readINI(at url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url), data.count <= 64 * 1024
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// The `joinBeta` half, split out so it is testable without a file on disk.
+    /// Nil when the key is not present under `[General]`.
+    static func joinBeta(inINI text: String) -> Bool? {
+        guard let value = value(of: "joinBeta", inINI: text) else { return nil }
+        // Qt's QSettings writes `true`/`false`; `1`/`0` are accepted because the
+        // same kind of setting is stored as an integer in some of CapCut's other
+        // INIs and costs nothing to tolerate. Anything else — including an empty
+        // value — is a spelling we do not understand, and an unreadable preference
+        // must not be reported as a choice, so it reads as "no record" and hands
+        // the decision to the installed build.
+        switch value.lowercased() {
+        case "true", "1": return true
+        case "false", "0": return false
+        default: return nil
+        }
+    }
+
+    /// The `tea_channel` half. Nil when the key is not present under `[General]`.
+    static func packageChannel(inINI text: String) -> String? {
+        value(of: "tea_channel", inINI: text)
+    }
+
+    /// First value of `key` in the `[General]` section of an INI, or nil.
+    ///
+    /// Section-aware on purpose. Both files CapCut writes today have exactly one
+    /// section, but a bare "does the text contain joinBeta=true" scan would keep
+    /// answering true if the vendor moved the key under some other heading —
+    /// silently escalating a stable user to the beta track, which is the one
+    /// direction this resolver is not allowed to get wrong.
+    private static func value(of key: String, inINI text: String) -> String? {
+        var inGeneral = false
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("[") {
+                inGeneral = line.caseInsensitiveCompare("[General]") == .orderedSame
+                continue
+            }
+            guard inGeneral, let separator = line.firstIndex(of: "=") else { continue }
+            let name = line[..<separator].trimmingCharacters(in: .whitespaces)
+            guard name.caseInsensitiveCompare(key) == .orderedSame else { continue }
+            let value = line[line.index(after: separator)...]
+                .trimmingCharacters(in: .whitespaces)
+            // QSettings quotes values it considers to need it, and CapCut's own
+            // `looki_settings` in this same directory is full of them
+            // (`LookiDomainKey="https://…"`). Neither key read here is quoted
+            // today — but a quoted `"capcutpc_beta"` would silently stop matching
+            // the token and read as a stable build.
+            guard value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"")
+            else { return value }
+            return String(value.dropFirst().dropLast())
+        }
+        return nil
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -108,6 +108,17 @@ public enum ChannelProofRegistry {
         ChannelProofKey("org.mozilla.thunderbird", .esr): .artifact(#"/thunderbird/releases/[0-9.]+esr/"#),
         ChannelProofKey("org.mozilla.thunderbird-daily", .nightly): .artifact(#"/thunderbird/nightly/"#),
 
+        // MARK: Media
+        // CapCut's two tracks share one bundle id, one app name and one endpoint —
+        // the beta build does not even carry a channel word in the version
+        // `ReleaseChannel.detect()` reads (`9.3.4531`). The artifact name is where
+        // the vendor does say it: stable ships `…_capcutpc_0_creatortool.dmg` and
+        // beta `…_capcutpc_beta_creatortool.dmg`, and `capcutpc_beta` was read off
+        // the beta bundle's own `Contents/Resources/PackageConfig.plist` →
+        // `Channel Name` after mounting it (2026-08-27), so this is the vendor's
+        // own token rather than a filename convention we inferred.
+        ChannelProofKey("com.lemon.lvoverseas", .beta): .artifact(#"_capcutpc_beta_"#),
+
         // MARK: Chat / messaging
         ChannelProofKey("org.whispersystems.signal-desktop-beta", .beta): .artifact(#"signal-desktop-beta-mac-"#),
         ChannelProofKey("im.riot.nightly", .nightly): .artifact(#"/nightly/"#),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -65,6 +65,7 @@ public struct ResolvedChannel: Sendable, Equatable {
 ///                                                          (two Bools, three tracks, feed-tagged `pre`/`internal`)
 ///   * Tailscale→ `UserDefaults[UnstableUpdatesEnabled]` + `[RCUpdatesEnabled]`
 ///                                                          (two Bools, three tracks)
+///   * CapCut   → `~/Movies/CapCut/User Data/Config/updateInfo` (`joinBeta` in an INI)
 ///
 /// So there is no generic reader. `ChannelBinding` is the single authority the
 /// scanner consults; an app with no resolver returns nil and the generic
@@ -100,6 +101,7 @@ public enum ChannelBinding {
         IINAChannel.bundleID.lowercased(),
         AlfredChannel.bundleID.lowercased(),
         BetterDisplayChannel.bundleID.lowercased(),
+        CapCutChannel.bundleID.lowercased(),
     ]
 
     /// The directories holding every preference a resolver above reads, for a
@@ -156,6 +158,14 @@ public enum ChannelBinding {
         // Alfred's is nested deeper still, under a machine-specific `<hash>`
         // directory, so the watch is on the subtree rather than on one file.
         if let alfred = AlfredChannel.preferencesBaseURL { roots.append(alfred) }
+        // CapCut is the first bound app that is SANDBOXED and still does not keep
+        // the choice in its container: `joinBeta` is an INI under
+        // `~/Movies/CapCut/User Data/Config`. Neither of the two roots above
+        // contains it, so without this entry the watcher would be aimed at two
+        // directories CapCut never writes the flag to — the exact "guard looks
+        // healthy, discriminator is somewhere else" shape the Surge timeline
+        // above cost a fix to learn.
+        roots.append(CapCutChannel.configDirectoryURL)
         return roots
     }
 
@@ -191,6 +201,7 @@ public enum ChannelBinding {
         case GhosttyChannel.bundleID.lowercased(): return GhosttyChannel.resolveCurrent()
         case BetterDisplayChannel.bundleID.lowercased():
             return BetterDisplayChannel.resolveCurrent()
+        case CapCutChannel.bundleID.lowercased():  return CapCutChannel.resolveCurrent()
         default:                       return nil
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -4579,7 +4579,277 @@ public enum VendorProbeRegistry {
                 kind: .dmg,
                 checksumPattern:
                     #"Canva-[0-9][0-9.]*-universal\.dmg\s*\n\s*sha512:\s*([A-Za-z0-9+/=]+)"#)),
+
+        // MARK: - 2026-08-27 CapCut (ByteDance)
+
+        // CapCut has no appcast. It embeds Sparkle.framework — and `MacUpdater`
+        // inside `libVECreator.dylib` does drive `SUAppcastItem` — but the bundle
+        // carries NO `SUFeedURL`, and the decision of *what* to install is made
+        // before Sparkle sees it: `UpdateController` reads a block of
+        // `update_reminder.*` keys out of ByteDance's Settings SDK blob and
+        // synthesizes the item from them. There is no iTunes entry, no GitHub
+        // repo, and the vendor's own download page hands out a 3.6 MB
+        // `CapCut-Downloader.app` stub rather than a versioned artifact, so this
+        // endpoint is the only surface that answers at all.
+        //
+        // The endpoint is the Settings SDK's own, reconstructed from the shipped
+        // binaries rather than guessed: `libSettings.dylib`'s `SettingsRequest.cpp`
+        // spells the query (`?device_platform=&channel=&aid=&version_code=…`),
+        // `libVECreator.dylib` carries the app id (`359289`), and CapCut's
+        // `~/Movies/CapCut/User Data/Config/channel` carries the channel token
+        // (`tea_channel=capcutpc_0`). It needs no device id, no install id and no
+        // mssdk signature — a plain anonymous GET answers.
+        //
+        // Two-witness check on the answer, because a per-device rollout endpoint is
+        // exactly where an anonymous probe could quietly get a different world than
+        // the app does: the `lastest_*` fields in this anonymous response are
+        // byte-identical to the ones in the copy CapCut itself cached for this
+        // machine (`~/Movies/CapCut/User Data/MMKV/settings_json`, 2026-08-27).
+        // What does NOT agree is `update_version`/`update_url` — the vendor's
+        // per-device PICK, which was the stable 9.3.0 dmg in CapCut's own cache and
+        // the beta 9.4.0-beta4 dmg in the anonymous response. So these recipes read
+        // the track fields and never the pick; see `CapCutChannel` for what that
+        // divergence means for a user.
+        //
+        // TRAP, `version_code`: it is required (dropping it, or sending a value the
+        // vendor can't parse, removes `update_reminder` from the response entirely)
+        // AND it selects a rollout bucket. Measured 2026-08-27, all other
+        // parameters held fixed:
+        //     0.0.1 · 8.0.0 · 9.0.0 · 9.3.0 · 9.4.0 · 9.5.0 · 9.9 · 9.99 → beta 9.4.0-beta4
+        //     1.0.0 · 2.0.0 · 5.9.0                                      → beta 9.3.5-beta1
+        //     9 · 10.0.0 · 99.9.9 · 9.999.999 · (absent) · "x"           → no update_reminder
+        // The stable field was 9.3.0 for every value that answered at all, so only
+        // the beta recipe is exposed to this. `9.99` is pinned for both because it
+        // sits above every 9.x build the vendor has published — so it stays in the
+        // newest bucket rather than ageing into the legacy one, which is the only
+        // failure here that would be SILENT. Falling out of the window instead
+        // (when CapCut reaches 10.x, or if the vendor narrows the range) removes
+        // the key and the pattern matches nothing, which `duo verify` reports.
+        // Same "pin an impossible version to turn a should-I-update service into a
+        // what-is-latest one" move as WorkBuddy's `version=0.0.0` above, aimed the
+        // other way because CapCut's buckets run the other way.
+        //
+        // What pinning `version_code` COSTS, stated because it is not obvious:
+        // CapCut has a working binary-patch path (`UpdatingModel::startRunUpdateDiffPatch`,
+        // an `update.delta` alongside `update.dmg`, per-release `cfg.diff_url` /
+        // `cfg.diff_md5`, and gray keys `diff_update.enable` /
+        // `enable_fallback_try` / `fallback_try_count` / `package_version_mapping`).
+        // That last key is the tell: patches are keyed FROM a version TO a version.
+        // `9.99` is not a version anyone runs, so a request carrying it can never
+        // match a patch mapping — this recipe is structurally cut off from the
+        // delta route, not merely unlucky.
+        //
+        // Note what that evidence IS: `cfg.diff_url=%s` / `cfg.diff_md5=%s` are LOG
+        // FORMAT STRINGS in `updatecontroller.cpp` — CapCut printing its own
+        // `ReminderUpdateCfg` fields — not fields seen in a response. They prove
+        // the client can apply a patch, not that the server sends one.
+        //
+        // It costs nothing today, and this is checked in a way that does not depend
+        // on guessing the schema (probed 2026-08-27 at `version_code` 9.2.0, 9.3.0,
+        // 9.3.5 and 9.99): the settings object is FLAT — zero of its top-level keys
+        // contain a dot, so the binary's `diff_update.enable` means a top-level
+        // `diff_update` object — and that key is absent; a brute-force scan of the
+        // whole raw body finds no diff/delta/patch key that concerns app updates
+        // (the hits are draft sizes, material templates, network dispatch); and
+        // there is no `.delta`/`.patch`/`.diff` URL in the body at all. The vendor
+        // ships everyone the full package right now.
+        //
+        // (`update_reminder` was never the place to look, which is worth recording
+        // because the first version of this comment said it was: not one of the
+        // `update_reminder.*` keys registered in the binary carries a diff, patch
+        // or delta. `diff_update` is where it would live.)
+        //
+        // Worth knowing for the day it does: the patch is almost certainly a
+        // SPARKLE binary delta, i.e. the exact format `DeltaApplier` already
+        // applies. CapCut embeds stock Sparkle 2.7.0 (build 2044) and its
+        // `Autoupdate` carries the whole applier — `BinaryDelta`,
+        // `SUBinaryDeltaUnarchiver`, `SUBinaryDeltaCommon.m`, `/usr/bin/bspatch`,
+        // `sparkle:deltaFrom`, and Sparkle's "patch version too old" message — and
+        // `libVECreator` implements Sparkle's own `installerDidFailToApplyDeltaUpdate`
+        // callback and builds updates through
+        // `initWithAppcastItem:secondaryAppcastItem:…`, where `secondaryAppcastItem`
+        // IS Sparkle's delta slot. (Inference, not proof: no `.delta` is served, so
+        // none has been examined.)
+        //
+        // So consuming it would be plumbing, not new machinery: what is missing is
+        // a way to take a patch URL from a JSON field instead of from an appcast's
+        // `<sparkle:deltas>`, which is all `VendorAppcastDeltas` knows how to read.
+        // The real blocker is the pinned `version_code` above — a from→to mapping
+        // cannot match a version nobody runs — and un-pinning it needs a way to put
+        // the installed version on the wire, which no recipe field offers today.
+        //
+        // Two components, not three, is also load-bearing: `RecipeSanity` complains
+        // when an extracted version appears verbatim in the request URL (the tell
+        // for a pattern that matched the query instead of the body). `9.3.0` would
+        // trip that the moment stable is 9.3.0 — which it is today. CapCut versions
+        // are always three-segment, so a two-segment `version_code` can never
+        // collide with an answer.
+        //
+        // TRAP, `channel`: `capcutpc_beta` is a REAL CapCut channel token and is
+        // the wrong thing to send here — the endpoint returns no `update_reminder`
+        // at all for it (measured). `capcutpc_0` is what a stable install sends and
+        // what returns BOTH tracks, so both recipes send it. The channel a recipe
+        // serves is decided by which `lastest_*` key it reads, not by this
+        // parameter.
+        //
+        // Version scheme: the `lastest_*_version` integers are nibble-packed
+        // (590592 = 0x090300 = 9.3.0), which no regex can decode, so the version is
+        // read out of the artifact FILENAME instead — `CapCut_9_3_0_4490_…` — with
+        // one capture group per segment. `extractVersion` joins multiple groups
+        // with ".", which is what turns the vendor's underscores into the string
+        // the bundle reports. The `_4490_` build counter is matched and discarded.
+        //
+        // TRAP, and the reason the two recipes disagree about `versionIsBuild`:
+        // **the two tracks put their version in DIFFERENT Info.plist fields**, and
+        // they are swapped relative to each other. Both dmgs were downloaded and
+        // mounted on 2026-08-27 rather than reasoned about:
+        //
+        //   CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg
+        //       CFBundleShortVersionString  9.3.0
+        //       CFBundleVersion             9.3.0
+        //   CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg
+        //       CFBundleShortVersionString  9.3.4531      ← "9.3" + the build counter
+        //       CFBundleVersion             9.4.0-beta4   ← what the filename says
+        //
+        // So the filename version equals the beta bundle's BUILD field, not its
+        // marketing one. With `versionIsBuild: false` the engine would compare
+        // `9.4.0-beta4` against a beta install's marketing `9.3.4531` — 4 > 3 —
+        // and every beta user would be told to install the build they are already
+        // running, forever. `versionIsBuild: true` on the beta recipe routes it
+        // into `RemoteVersion.version` so it lands against `CFBundleVersion`, where
+        // an up-to-date beta compares EQUAL. Stable needs no such thing (both of
+        // its fields are the same string) and must not have it: mixing the two
+        // within one channel is what the guard in `channelProofsCoverEveryChannelRecipe`
+        // forbids, and across channels they are compared against different
+        // installed fields anyway.
+        //
+        // A consequence worth stating: for a beta install, `ReleaseChannel.detect()`
+        // sees only `9.3.4531` — its `-betaN` rule never fires — so the ONLY thing
+        // that can classify a beta bundle as beta is `CapCutChannel`. That is why
+        // its no-recorded-preference fallback reads the build's own channel token
+        // rather than deferring to detect().
+        //
+        // The channel token in each filename (`capcutpc_0` vs `capcutpc_beta`) is
+        // inside the pattern, not around it, so neither recipe can read the other
+        // track's artifact even if the vendor reordered the JSON — and the beta
+        // pattern is additionally pinned to `lastest_url` so it cannot drift onto
+        // `lastest_sync_url`, a THIRD `capcutpc_beta` artifact in the same object
+        // (9.3.5-beta1, build 4468 — an older build than the 4531 on `lastest_url`,
+        // so taking it would be a silent downgrade of the beta track).
+        //
+        // Only the beta pattern's third segment tolerates a `-betaN` suffix.
+        // Stable's ends at digits, on the Canva precedent: a prerelease wrongly
+        // published under `lastest_stable_url` then matches NOTHING and degrades to
+        // unknown, instead of being reported as a stable release.
+        //
+        // One-click: enabled on BOTH tracks, and every gate was checked against the
+        // real artifacts rather than assumed (2026-08-27, both dmgs downloaded and
+        // mounted). Each dmg holds `CapCut.app` and an `/Applications` symlink and
+        // nothing else — no pkg, no `LaunchDaemons`/`LaunchAgents`/
+        // `PrivilegedHelperTools`, and this machine has no CapCut launch item
+        // anywhere — so the bundle swap IS the whole update. The Homebrew cask
+        // agrees independently: `artifacts` is `{"app": ["CapCut.app"]}` and its
+        // `uninstall` is a bare `quit`, its `zap` only user data. Both bundles are
+        // Developer ID signed by Team `22MMUN2RN5` (BYTEDANCE PTE. LTD.) and
+        // `spctl -t install` reports "Notarized Developer ID" — the same Team the
+        // installed copy carries, which is `VendorInstaller`'s mandatory gate.
+        //
+        // The cask is also a second witness for the STABLE url itself: it points at
+        // the byte-identical `…CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg` this
+        // recipe resolves out of the settings blob.
+        //
+        // No `checksumPattern`: the vendor publishes `lastest_stable_url_md5` /
+        // `lastest_url_md5`, and `checksumPattern` consumes a base64 SHA-512. An
+        // MD5 cannot be fed to it, so the Team-ID gate is the guard here.
+        //
+        // Cost to know about: each install is a ~1.24 GB download. The registry's
+        // live signature-gate test deliberately runs on an allow-list of small
+        // artifacts, so adding this does not put a gigabyte into `make test`.
+        //
+        // `hostRequirement` is Apple silicon, and that is measured, not assumed:
+        // `lipo -archs` on the shipped build reports `arm64` and nothing else — on
+        // the launcher, on `libVECreator.dylib`, and on `CapCut Helper.app` — so
+        // the one dmg the vendor publishes cannot start on an Intel Mac. The
+        // vendor's own schema has `lastest_stable_cpu_architecture` /
+        // `lastest_cpu_architecture` keys (they are in the binary's string pool)
+        // but leaves them absent from the response, i.e. it is serving one
+        // artifact to everyone. Without the gate, an Intel Mac holding an older
+        // CapCut would be told about a version forever and handed a one-click that
+        // `SignatureVerifier`'s arch check can only refuse. Whether an Intel train
+        // ever existed is NOT established here — if one turns up, this is the line
+        // to revisit, and the shape to copy is Raycast's two-endpoint split.
+        //
+        // `downloadURL` (the manual fallback) points at the vendor's desktop page
+        // for both tracks. That page only ever hands out the stable downloader
+        // stub, which used to make it an active hazard for a beta user; with
+        // one-click resolving each track's own artifact, the manual link is now the
+        // fallback rather than the path, and the alternative (`nil`) would put a
+        // ~400 KB internal settings blob behind the user-facing link.
+        //
+        // A Mac App Store copy of CapCut shares this bundle id — and is a
+        // completely different train: `itunes.apple.com/lookup` for
+        // `com.lemon.lvoverseas` returns adamId 1500855883 at version **19.2.0**
+        // against this Developer ID build's 9.3.0. Nothing here can reach it:
+        // `VendorProbeSource.latestVersion(for:)` declines every `isMASApp`
+        // install, and `MacAppStoreSource` declines every non-store one, so the
+        // separation rests entirely on `_MASReceipt`. Were either gate to go, the
+        // two version schemes would produce a permanent phantom in one direction
+        // and a store-entitlement-destroying swap in the other.
+        //
+        // No `changelogURL`: `update_reminder` does carry release notes, but the
+        // same generic sentence for all three tracks ("Fixed some known issues…"),
+        // and capcut.com publishes no desktop release-notes page (/release-notes,
+        // /whats-new and /support/release-notes all 502, 2026-08-27). The honest
+        // "no release notes" state beats an unrelated page.
+        capCutRecipe(
+            channel: .stable, urlKey: "lastest_stable_url",
+            packageToken: "capcutpc_0", patchSegment: #"[0-9]+"#,
+            versionIsBuild: false),
+        capCutRecipe(
+            channel: .beta, urlKey: "lastest_url",
+            packageToken: "capcutpc_beta", patchSegment: #"[0-9]+(?:-beta[0-9]+)?"#,
+            versionIsBuild: true),
     ]
+
+    /// One CapCut track: the `update_reminder` key that names its artifact, plus
+    /// the token that artifact's filename carries.
+    ///
+    /// Those two thread through both patterns, which is the point of building them
+    /// here instead of writing them out twice. The version and the installer must
+    /// come from the SAME key — `update_reminder` holds four CapCut dmg URLs under
+    /// four keys, two of which name the same file today — and a hand-written pair
+    /// is exactly how one of them ends up reading `lastest_url` while the other
+    /// reads `lastest_sync_url`, resolving a version and an installer from two
+    /// different releases with nothing downstream able to see it.
+    ///
+    /// The endpoint is built once for the same reason: two copies could drift onto
+    /// different `version_code` rollout buckets.
+    private static func capCutRecipe(
+        channel: ReleaseChannel,
+        urlKey: String,
+        packageToken: String,
+        patchSegment: String,
+        versionIsBuild: Bool
+    ) -> VendorProbeRecipe {
+        let host = #"https://sf16-web-tos-buz\.capcutstatic\.com"#
+        return VendorProbeRecipe(
+            bundleID: CapCutChannel.bundleID,
+            url: URL(string: "https://editor-api.capcutapi.com/service/settings/v3/"
+                     + "?aid=359289&device_platform=mac&channel=capcutpc_0&version_code=9.99")!,
+            mode: .responseBody,
+            versionPattern:
+                #""\#(urlKey)"\s*:\s*"[^"]*/CapCut_([0-9]+)_([0-9]+)_(\#(patchSegment))_[0-9]+_\#(packageToken)_creatortool\.dmg""#,
+            downloadURL: URL(string: "https://www.capcut.com/tools/desktop-video-editor"),
+            versionIsBuild: versionIsBuild,
+            install: VendorInstallSpec(
+                // Host pinned rather than `[^"]+`: the channel token and the host
+                // are the only things in a resolved URL that say what this file is.
+                urlSource: .bodyPattern(
+                    #""\#(urlKey)"\s*:\s*"(\#(host)/[^"]*_\#(packageToken)_creatortool\.dmg)""#),
+                kind: .dmg),
+            channel: channel,
+            hostRequirement: VendorHostRequirement(architectures: [.arm64]))
+    }
 
     /// One WorkBuddy recipe: a site — which decides the bundle id, the update
     /// host and the changelog at once — crossed with a macOS architecture.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CapCutProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CapCutProbeRecipeTests.swift
@@ -76,6 +76,26 @@ struct CapCutProbeRecipeTests {
         VendorProbeRecipe.extractVersion(from: text, pattern: recipe.versionPattern)
     }
 
+    /// The installer URL a track's spec resolves out of `text`, or nil when the
+    /// pattern matches nothing.
+    ///
+    /// Records an issue rather than returning nil when the spec is not a
+    /// `.bodyPattern`, because three of the tests below assert a nil result: a
+    /// silent `return nil` on a changed spec shape would turn each of them into a
+    /// no-op that still reports green.
+    private static func installURL(
+        _ channel: ReleaseChannel, in text: String
+    ) throws -> String? {
+        let recipe = try Self.recipe(channel)
+        let spec = try #require(recipe.install)
+        guard case .bodyPattern(let pattern) = spec.urlSource else {
+            Issue.record(
+                "\(recipe.recipeID) is no longer a body-pattern install; every nil-result assertion in this suite has gone vacuous")
+            return nil
+        }
+        return VendorProbeRecipe.extractVersion(from: text, pattern: pattern)
+    }
+
     // MARK: - registry shape
 
     /// Derived from the registry, not a hand-written list: a third CapCut track
@@ -218,13 +238,7 @@ struct CapCutProbeRecipeTests {
         for channel in [ReleaseChannel.stable, .beta] {
             let recipe = try Self.recipe(channel)
             let version = try #require(Self.version(recipe, in: Self.body))
-            let spec = try #require(recipe.install)
-            guard case .bodyPattern(let pattern) = spec.urlSource else {
-                Issue.record("\(recipe.recipeID) is not a body-pattern install")
-                continue
-            }
-            let url = try #require(
-                VendorProbeRecipe.extractVersion(from: Self.body, pattern: pattern))
+            let url = try #require(try Self.installURL(channel, in: Self.body))
             #expect(url.hasPrefix("https://sf16-web-tos-buz.capcutstatic.com/"),
                     "the download host must be pinned, not matched with [^\"]+")
             // The vendor writes the version with underscores in the filename.
@@ -238,11 +252,6 @@ struct CapCutProbeRecipeTests {
     /// `capcutpc_<token>` in the filename are pinned, so this holds in both
     /// directions and regardless of JSON order.
     @Test func neitherInstallSpecCanResolveTheOthersArtifact() throws {
-        func installURL(_ channel: ReleaseChannel, in text: String) throws -> String? {
-            let spec = try #require(try Self.recipe(channel).install)
-            guard case .bodyPattern(let pattern) = spec.urlSource else { return nil }
-            return VendorProbeRecipe.extractVersion(from: text, pattern: pattern)
-        }
         let stableOnly = """
             {"lastest_stable_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
             capcut-web-buz-sg/packages/CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg"}
@@ -251,11 +260,11 @@ struct CapCutProbeRecipeTests {
             {"lastest_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
             capcut-web-buz-sg/packages/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg"}
             """
-        #expect(try installURL(.stable, in: betaOnly) == nil)
-        #expect(try installURL(.beta, in: stableOnly) == nil)
+        #expect(try Self.installURL(.stable, in: betaOnly) == nil)
+        #expect(try Self.installURL(.beta, in: stableOnly) == nil)
         // On the real body the beta spec must take `lastest_url`, never the older
         // `lastest_sync_url` build that sits ahead of it in the object.
-        let beta = try #require(try installURL(.beta, in: Self.body))
+        let beta = try #require(try Self.installURL(.beta, in: Self.body))
         #expect(beta.hasSuffix("CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg"))
     }
 
@@ -268,19 +277,10 @@ struct CapCutProbeRecipeTests {
             Issue.record("CapCut beta's proof should be an artifact marker")
             return
         }
-        let spec = try #require(try Self.recipe(.beta).install)
-        guard case .bodyPattern(let pattern) = spec.urlSource else { return }
-        let url = try #require(
-            VendorProbeRecipe.extractVersion(from: Self.body, pattern: pattern))
+        let url = try #require(try Self.installURL(.beta, in: Self.body))
         #expect(url.range(of: marker, options: [.regularExpression, .caseInsensitive]) != nil)
         // ...and must NOT match the stable artifact, or it proves nothing.
-        let stable = try #require(
-            Self.version(try Self.recipe(.stable), in: Self.body))
-        _ = stable
-        let stableSpec = try #require(try Self.recipe(.stable).install)
-        guard case .bodyPattern(let stablePattern) = stableSpec.urlSource else { return }
-        let stableURL = try #require(
-            VendorProbeRecipe.extractVersion(from: Self.body, pattern: stablePattern))
+        let stableURL = try #require(try Self.installURL(.stable, in: Self.body))
         #expect(stableURL.range(of: marker, options: [.regularExpression, .caseInsensitive])
             == nil)
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CapCutProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CapCutProbeRecipeTests.swift
@@ -1,0 +1,374 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// CapCut's two-track probe.
+///
+/// The recipes are looked up from the registry rather than restated here, and
+/// both are exercised against the `update_reminder` object captured VERBATIM from
+/// the vendor on 2026-08-27. That object is the whole hazard surface: it holds
+/// three `capcutpc_beta` artifacts and one `capcutpc_0` artifact side by side, so
+/// a pattern that is one key off resolves a real, live, correctly-signed build
+/// from the wrong track.
+struct CapCutProbeRecipeTests {
+
+    /// Verbatim slice of
+    /// `https://editor-api.capcutapi.com/service/settings/v3/?aid=359289&device_platform=mac&channel=capcutpc_0&version_code=9.99`,
+    /// 2026-08-27 — key order, spacing and all. The full response is ~376 KB of
+    /// unrelated feature flags; each recipe's pattern was confirmed to match
+    /// EXACTLY ONCE in that whole body, so keeping only this object here loses no
+    /// discriminating power (every other `CapCut_…dmg` string in the response is
+    /// in this object).
+    ///
+    /// The three decoys are the point:
+    ///   * `update_url`      — the vendor's per-DEVICE pick. Identical to the beta
+    ///                         URL for an anonymous request and to the STABLE one
+    ///                         in the copy CapCut cached for this machine, which
+    ///                         is exactly why no recipe may read it.
+    ///   * `lastest_sync_url`— a third `capcutpc_beta` artifact, build 4468 —
+    ///                         OLDER than `lastest_url`'s 4531.
+    ///   * `lastest_stable_url` vs `lastest_url` — one substring apart.
+    private static let body = """
+        {"data":{"__logid":"20260827175208134E0787F4B71D1BCC4E","settings_time":1787651528,\
+        "settings":{"update_reminder": {"lastest_stable_url_md5": "5e95c2e4cd0fed91d9f49a9d386717af", \
+        "update_frequency": 1, "current_version": 99900, "lastest_stable_version": 590592, \
+        "alwaysremind": 1, "lastest_stable_update_content": "- Fixed some known issues and improved \
+        the trimming experience.\\nWe thank you for supporting CapCut and look forward to creating \
+        beautiful moments together.", "build_number": 4531, "lastest_sync_builder_number": 4468, \
+        "lastest_stable_builder_number": 4490, "lastest_sync_url": \
+        "https://sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/CapCut_9_3_5-beta1_4468_capcutpc_beta_creatortool.dmg", \
+        "update_version": 590848, "timeinterval": 72, "update_url_md5": "bafa43171d14a736f255436447e52471", \
+        "lastest_sync_url_md5": "2f09cdbcc3c3e4f06135de7ea10c499a", "updatestyle": "prompt", \
+        "lastest_builder_number": 4531, "lastest_url_md5": "bafa43171d14a736f255436447e52471", \
+        "beta_number": "4", "lastest_version": 590848, "lastest_sync_version": 590597, \
+        "lastest_beta_number": "4", "lastest_url": \
+        "https://sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg", \
+        "update_url": \
+        "https://sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg", \
+        "lastest_stable_url": \
+        "https://sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg"}}},\
+        "message": "success"}
+        """
+
+    /// What each track's bundle actually reports, read off the real artifacts on
+    /// 2026-08-27 — the stable one from `/Applications/CapCut.app`, the beta one by
+    /// downloading and mounting `CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg`.
+    ///
+    /// The two tracks do NOT agree about which field carries what, and that is the
+    /// single most surprising fact about this app: stable puts the same string in
+    /// both fields, while beta's marketing version is `"9.3" + build counter` and
+    /// only its `CFBundleVersion` matches the filename. Hence one recipe with
+    /// `versionIsBuild` and one without.
+    private static let installedStableShortVersion = "9.3.0"
+    private static let installedStableBuildVersion = "9.3.0"
+    private static let installedBetaShortVersion = "9.3.4531"
+    private static let installedBetaBuildVersion = "9.4.0-beta4"
+
+    private static let recipes = VendorProbeRegistry.recipes
+        .filter { $0.bundleID == CapCutChannel.bundleID }
+
+    private static func recipe(_ channel: ReleaseChannel) throws -> VendorProbeRecipe {
+        try #require(recipes.first { $0.channel == channel },
+                     "no CapCut recipe for \(channel.rawValue)")
+    }
+
+    private static func version(_ recipe: VendorProbeRecipe, in text: String) -> String? {
+        VendorProbeRecipe.extractVersion(from: text, pattern: recipe.versionPattern)
+    }
+
+    // MARK: - registry shape
+
+    /// Derived from the registry, not a hand-written list: a third CapCut track
+    /// added later shows up here as a failure rather than as silent non-coverage.
+    @Test func capCutRegistersExactlyTheTwoTracksTheVendorPublishes() {
+        #expect(Set(Self.recipes.map(\.channel)) == [.stable, .beta])
+        #expect(Self.recipes.count == 2)
+        for recipe in Self.recipes {
+            #expect(recipe.variant == nil)
+            // Apple silicon only — `lipo -archs` on the shipped build reports
+            // `arm64` alone (launcher, libVECreator, and the helper app), and the
+            // vendor publishes ONE dmg. Without this an Intel Mac would be shown a
+            // version forever and handed a one-click the arch gate can only refuse.
+            #expect(recipe.hostRequirement?.architectures == [.arm64])
+            // No machine identifier and no rollout selector go on the wire: the
+            // endpoint answers anonymously, and keeping it that way is what stops
+            // this machine's ByteDance device id from reaching a verify report.
+            #expect(recipe.identities.isEmpty && recipe.track == nil)
+            #expect(recipe.install?.kind == .dmg)
+            #expect(recipe.install?.checksumPattern == nil,
+                    "the vendor publishes MD5; checksumPattern consumes base64 SHA-512")
+            #expect(recipe.changelogURL == nil, "no vendor release-notes page exists")
+            if case .responseBody = recipe.mode {} else {
+                Issue.record("\(recipe.recipeID) is not a body-parsing recipe")
+            }
+        }
+    }
+
+    /// Both tracks come off ONE endpoint. If they ever diverge, they can land in
+    /// different `version_code` rollout buckets and quietly report builds from two
+    /// different worlds — the failure the shared `capCutRecipe` helper exists to
+    /// make impossible.
+    @Test func bothTracksReadTheSameEndpoint() throws {
+        let urls = Set(Self.recipes.map(\.url))
+        #expect(urls.count == 1)
+        let url = try #require(urls.first)
+        let query = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems.map { Dictionary(uniqueKeysWithValues: $0.map { ($0.name, $0.value ?? "") }) })
+        // Every one of these is REQUIRED: drop any and the response comes back
+        // with no `update_reminder` at all (measured 2026-08-27).
+        #expect(query["aid"] == "359289")
+        #expect(query["device_platform"] == "mac")
+        #expect(query["version_code"] == "9.99")
+        // `capcutpc_beta` is a real CapCut channel token and returns NOTHING here.
+        // The beta track is selected by which key the pattern reads, never by this.
+        #expect(query["channel"] == "capcutpc_0")
+    }
+
+    /// `version_code` must stay two-segment, and this is the structural reason
+    /// rather than today's-answer reason: `RecipeSanity` flags a version that
+    /// appears verbatim in the request URL — the tell for a pattern that matched
+    /// the query instead of the body — and every CapCut release is three-segment,
+    /// so a two-segment query value can never BE an answer. Bumping the pinned
+    /// value to `9.3.0` would pass on the day it was written and start crying wolf
+    /// the moment the vendor's stable release caught up with it.
+    @Test func theVersionCodeCanNeverCollideWithAnAnswer() throws {
+        let url = try #require(Self.recipes.first?.url)
+        let versionCode = try #require(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?.first { $0.name == "version_code" }?.value)
+        #expect(versionCode.split(separator: ".").count == 2,
+                "'\(versionCode)' has as many segments as a CapCut release, so it can collide")
+        for channel in [ReleaseChannel.stable, .beta] {
+            let recipe = try Self.recipe(channel)
+            let version = try #require(Self.version(recipe, in: Self.body))
+            #expect(RecipeSanity.complaints(version: version, recipe: recipe).isEmpty,
+                    "\(recipe.recipeID) resolved '\(version)', which RecipeSanity objects to")
+        }
+    }
+
+    // MARK: - the version
+
+    /// The stable track resolves the marketing version the installed bundle
+    /// reports, dots and all — the underscore→dot join is what makes an
+    /// up-to-date CapCut compare equal instead of showing a phantom update.
+    @Test func theStableTrackMatchesTheInstalledMarketingVersion() throws {
+        let recipe = try Self.recipe(.stable)
+        #expect(recipe.versionIsBuild == false,
+                "stable's marketing and build fields are the same string")
+        let version = try #require(Self.version(recipe, in: Self.body))
+        #expect(version == Self.installedStableShortVersion)
+        #expect(VersionComparator.compare(version, Self.installedStableShortVersion)
+            == .orderedSame,
+            "an up-to-date CapCut would be shown a phantom update")
+    }
+
+    /// The beta track resolves the newest beta build, suffix intact.
+    @Test func theBetaTrackResolvesTheNewestBetaBuild() throws {
+        let recipe = try Self.recipe(.beta)
+        #expect(Self.version(recipe, in: Self.body) == "9.4.0-beta4")
+    }
+
+    /// The regression that only downloading the real beta artifact could find:
+    /// the two tracks put their version in DIFFERENT Info.plist fields.
+    ///
+    /// The beta bundle's marketing version is `9.3.4531` while the filename (and
+    /// its `CFBundleVersion`) say `9.4.0-beta4`. Compared as a marketing version —
+    /// which is what `versionIsBuild: false` would do — `9.4.0-beta4` beats
+    /// `9.3.4531` at the second component, 4 > 3, so a user sitting on exactly the
+    /// build the feed is offering would be told to install it, every check,
+    /// forever. Against `CFBundleVersion` it compares equal.
+    @Test func theBetaTrackComparesAgainstTheFieldThatActuallyMatches() throws {
+        let recipe = try Self.recipe(.beta)
+        #expect(recipe.versionIsBuild,
+                "beta's filename version is its CFBundleVersion, not its marketing string")
+        let version = try #require(Self.version(recipe, in: Self.body))
+        #expect(version == Self.installedBetaBuildVersion)
+        #expect(VersionComparator.compare(version, Self.installedBetaBuildVersion)
+            == .orderedSame,
+            "an up-to-date CapCut beta would be shown a phantom update")
+        // The failure this guards, spelled out: against the marketing field the
+        // same pair reads as an update.
+        #expect(VersionComparator.isNewer(version, than: Self.installedBetaShortVersion),
+                "if this stops being true the phantom is gone and this test lost its subject")
+        // A stable install that opted into betas must still be offered the beta:
+        // its CFBundleVersion is the plain 9.3.0.
+        #expect(VersionComparator.isNewer(version, than: Self.installedStableBuildVersion))
+    }
+
+    /// The vendor's build counter (`4490`, `4531`) is matched and discarded. It is
+    /// in neither `CFBundleShortVersionString` nor `CFBundleVersion` — both are the
+    /// bare "9.3.0" — so letting it into the version would be a phantom that never
+    /// clears.
+    @Test func theBuildCounterNeverReachesTheVersion() throws {
+        for channel in [ReleaseChannel.stable, .beta] {
+            let version = try #require(Self.version(try Self.recipe(channel), in: Self.body))
+            #expect(!version.contains("4490") && !version.contains("4531"))
+        }
+    }
+
+    // MARK: - one-click
+
+    /// The installer and the version must come out of the SAME `update_reminder`
+    /// key. The object holds four CapCut dmg URLs under four keys — two of them
+    /// naming the same file today — so a version pattern reading one and an
+    /// install pattern reading another would resolve two different releases, and
+    /// every gate downstream would still pass: same vendor, same Team, a real
+    /// notarized bundle.
+    @Test func eachTrackInstallsTheReleaseItReported() throws {
+        for channel in [ReleaseChannel.stable, .beta] {
+            let recipe = try Self.recipe(channel)
+            let version = try #require(Self.version(recipe, in: Self.body))
+            let spec = try #require(recipe.install)
+            guard case .bodyPattern(let pattern) = spec.urlSource else {
+                Issue.record("\(recipe.recipeID) is not a body-pattern install")
+                continue
+            }
+            let url = try #require(
+                VendorProbeRecipe.extractVersion(from: Self.body, pattern: pattern))
+            #expect(url.hasPrefix("https://sf16-web-tos-buz.capcutstatic.com/"),
+                    "the download host must be pinned, not matched with [^\"]+")
+            // The vendor writes the version with underscores in the filename.
+            #expect(url.contains(version.replacingOccurrences(of: ".", with: "_")),
+                    "\(recipe.recipeID) reported \(version) but would download \(url)")
+        }
+    }
+
+    /// Neither install spec may resolve the other track's artifact — the silent
+    /// cross-channel swap `ChannelArtifactProof` exists for. Both the key and the
+    /// `capcutpc_<token>` in the filename are pinned, so this holds in both
+    /// directions and regardless of JSON order.
+    @Test func neitherInstallSpecCanResolveTheOthersArtifact() throws {
+        func installURL(_ channel: ReleaseChannel, in text: String) throws -> String? {
+            let spec = try #require(try Self.recipe(channel).install)
+            guard case .bodyPattern(let pattern) = spec.urlSource else { return nil }
+            return VendorProbeRecipe.extractVersion(from: text, pattern: pattern)
+        }
+        let stableOnly = """
+            {"lastest_stable_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
+            capcut-web-buz-sg/packages/CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg"}
+            """
+        let betaOnly = """
+            {"lastest_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
+            capcut-web-buz-sg/packages/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg"}
+            """
+        #expect(try installURL(.stable, in: betaOnly) == nil)
+        #expect(try installURL(.beta, in: stableOnly) == nil)
+        // On the real body the beta spec must take `lastest_url`, never the older
+        // `lastest_sync_url` build that sits ahead of it in the object.
+        let beta = try #require(try installURL(.beta, in: Self.body))
+        #expect(beta.hasSuffix("CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg"))
+    }
+
+    /// The registered proof must actually match what the beta spec resolves —
+    /// a proof that no longer describes its recipe asserts nothing.
+    @Test func theRegisteredBetaProofMatchesTheResolvedArtifact() throws {
+        let proof = try #require(
+            ChannelProofRegistry.proofs[ChannelProofKey(CapCutChannel.bundleID, .beta)])
+        guard case .artifact(let marker) = proof else {
+            Issue.record("CapCut beta's proof should be an artifact marker")
+            return
+        }
+        let spec = try #require(try Self.recipe(.beta).install)
+        guard case .bodyPattern(let pattern) = spec.urlSource else { return }
+        let url = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.body, pattern: pattern))
+        #expect(url.range(of: marker, options: [.regularExpression, .caseInsensitive]) != nil)
+        // ...and must NOT match the stable artifact, or it proves nothing.
+        let stable = try #require(
+            Self.version(try Self.recipe(.stable), in: Self.body))
+        _ = stable
+        let stableSpec = try #require(try Self.recipe(.stable).install)
+        guard case .bodyPattern(let stablePattern) = stableSpec.urlSource else { return }
+        let stableURL = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.body, pattern: stablePattern))
+        #expect(stableURL.range(of: marker, options: [.regularExpression, .caseInsensitive])
+            == nil)
+    }
+
+    // MARK: - version ordering
+
+    /// The `-betaN` suffix sorts BELOW the suffix-less string a bundle reports
+    /// (the Mozilla `bN` precedent), so the beta recipe cannot phantom against an
+    /// install of that same marketing version — and a real version bump still
+    /// reads as newer.
+    @Test func theBetaSuffixSortsAsAPreReleaseRatherThanAhead() {
+        #expect(VersionComparator.isNewer("9.4.0-beta4", than: "9.4.0") == false)
+        #expect(VersionComparator.isNewer("9.4.0-beta4", than: "9.3.0"))
+        #expect(VersionComparator.isNewer("9.5.0-beta1", than: "9.4.0-beta4"))
+    }
+
+    // MARK: - cross-track isolation
+
+    /// Neither pattern may read the other track's artifact. Both the KEY and the
+    /// `capcutpc_<token>` inside the filename are pinned, so this holds even if
+    /// the vendor reorders the object.
+    @Test func neitherTrackCanResolveTheOthersArtifact() throws {
+        let stableOnly = """
+            {"lastest_stable_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
+            capcut-web-buz-sg/packages/CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg"}
+            """
+        let betaOnly = """
+            {"lastest_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
+            capcut-web-buz-sg/packages/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg"}
+            """
+        #expect(Self.version(try Self.recipe(.stable), in: betaOnly) == nil)
+        #expect(Self.version(try Self.recipe(.beta), in: stableOnly) == nil)
+    }
+
+    /// `lastest_sync_url` is a THIRD `capcutpc_beta` artifact in the same object,
+    /// at an OLDER build (4468 against 4531). A beta pattern anchored on the
+    /// filename alone would match it, and on this body it comes first — so the
+    /// probe would have silently reported 9.3.5-beta1 as the newest beta.
+    @Test func theBetaTrackIgnoresTheSyncArtifact() throws {
+        let syncOnly = """
+            {"lastest_sync_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
+            capcut-web-buz-sg/packages/CapCut_9_3_5-beta1_4468_capcutpc_beta_creatortool.dmg"}
+            """
+        #expect(Self.version(try Self.recipe(.beta), in: syncOnly) == nil)
+        // And on the real body, where the sync key is listed BEFORE `lastest_url`.
+        #expect(Self.version(try Self.recipe(.beta), in: Self.body) != "9.3.5-beta1")
+    }
+
+    /// `update_url` is the vendor's per-device pick, not a track. It was the
+    /// STABLE dmg in the copy CapCut cached for this machine and the BETA dmg in
+    /// the anonymous response captured here — the same key, two different answers
+    /// — so no recipe may be anchored to it.
+    @Test func noRecipeReadsThePerDevicePick() throws {
+        for recipe in Self.recipes {
+            #expect(!recipe.versionPattern.contains("\"update_url\""),
+                    "\(recipe.recipeID) is anchored to the per-device pick")
+        }
+        let pickOnly = """
+            {"update_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
+            capcut-web-buz-sg/packages/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg"}
+            """
+        for recipe in Self.recipes {
+            #expect(Self.version(recipe, in: pickOnly) == nil)
+        }
+    }
+
+    /// A response with no `update_reminder` at all — what the endpoint returns
+    /// once a `version_code` falls outside the vendor's rollout window — must
+    /// resolve NOTHING rather than something. That is the loud failure the pinned
+    /// `9.99` trades for, and `duo verify` reports it.
+    @Test func aResponseWithoutUpdateReminderResolvesNothing() throws {
+        let empty = """
+            {"data":{"__logid":"20260827175208134E0787F4B71D1BCC4E",\
+            "settings_time":1787651528},"message": "success"}
+            """
+        for recipe in Self.recipes {
+            #expect(Self.version(recipe, in: empty) == nil)
+        }
+    }
+
+    /// A beta build published without a `-betaN` suffix still resolves — the
+    /// suffix is optional — and still cannot be confused with a stable artifact.
+    @Test func aSuffixLessBetaBuildStillResolves() throws {
+        let plain = """
+            {"lastest_url": "https://sf16-web-tos-buz.capcutstatic.com/obj/\
+            capcut-web-buz-sg/packages/CapCut_9_4_1_4600_capcutpc_beta_creatortool.dmg"}
+            """
+        #expect(Self.version(try Self.recipe(.beta), in: plain) == "9.4.1")
+        #expect(Self.version(try Self.recipe(.stable), in: plain) == nil)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
@@ -192,6 +192,28 @@ import Foundation
     #expect(CapCutChannel.betaPackageToken == "capcutpc_beta")
 }
 
+/// The two filenames, pinned.
+///
+/// Nothing else in the suite would catch a typo in either: the INI parsers are
+/// tested against strings, and the watch-root test derives its expectation from
+/// `configDirectoryURL`, so it agrees with whatever these say. A wrong filename
+/// makes both reads return nil, which resolves to `.stable` — every CapCut
+/// install silently pinned to the stable track, with nothing anywhere reading as
+/// broken. Same reason `tablePlusUnlockHeaderValueIsTheLiteralServerExpects`
+/// exists.
+@Test func capCutReadsTheTwoFilesCapCutActuallyWrites() {
+    #expect(CapCutChannel.updateInfoFileURL.lastPathComponent == "updateInfo")
+    #expect(CapCutChannel.packageChannelFileURL.lastPathComponent == "channel")
+    let dir = CapCutChannel.configDirectoryURL.standardizedFileURL.path
+    #expect(dir.hasSuffix("/Movies/CapCut/User Data/Config"))
+    // Outside the sandbox container on purpose — the container path is the trap
+    // this resolver exists to record.
+    #expect(!dir.contains("Library/Containers"))
+    for file in [CapCutChannel.updateInfoFileURL, CapCutChannel.packageChannelFileURL] {
+        #expect(file.deletingLastPathComponent().standardizedFileURL.path == dir)
+    }
+}
+
 /// The `channel` INI CapCut writes beside `updateInfo`, verbatim from this
 /// machine 2026-08-27. It is CapCut's own copy of the bundle's
 /// `Contents/Resources/PackageConfig.plist` → `Channel Name`.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
@@ -150,7 +150,131 @@ import Foundation
     #expect(r.feedOverride == IINAChannel.stableFeed)
 }
 
+// MARK: - CapCut (`joinBeta` in an INI outside the sandbox container)
+
+@Test func capCutJoinBetaMapsToTheBetaTrack() {
+    let stableBuild = "capcutpc_0"
+    #expect(CapCutChannel.resolve(joinBeta: true, packageChannel: stableBuild).channel == .beta)
+    #expect(CapCutChannel.resolve(joinBeta: false, packageChannel: stableBuild).channel == .stable)
+    // A recorded choice wins over the build, in BOTH directions: opting out on a
+    // beta build is how a user asks to be moved back to stable.
+    #expect(CapCutChannel.resolve(joinBeta: false, packageChannel: "capcutpc_beta").channel
+        == .stable)
+    #expect(CapCutChannel.resolve(joinBeta: true, packageChannel: nil).channel == .beta)
+    // Channel-gated recipes, not a feed swap: CapCut has no appcast to point at.
+    let r = CapCutChannel.resolve(joinBeta: true, packageChannel: stableBuild)
+    #expect(r.feedOverride == nil)
+    #expect(r.feedHTTPHeaders.isEmpty)
+    #expect(r.sparkleChannelNames.isEmpty)
+}
+
+/// The distinction this resolver exists to keep: "no record" is not "opted out".
+///
+/// `ChannelBinding` is authoritative — it REPLACES `ReleaseChannel.detect()` —
+/// and `updateInfo` is written by the update window, so a beta install that has
+/// never opened that window has no record at all. Collapsing that into `.stable`
+/// would label it Stable and pin it to a stable recipe reporting an older version
+/// than the build it is running. It would also overwrite detect()'s own answer in
+/// the case where the beta bundle's version keeps its `-betaN` suffix, which
+/// detect() step 4 resolves to `.beta`.
+@Test func capCutWithNoRecordedChoiceMirrorsTheInstalledBuild() {
+    #expect(CapCutChannel.resolve(joinBeta: nil, packageChannel: "capcutpc_beta").channel
+        == .beta)
+    #expect(CapCutChannel.resolve(joinBeta: nil, packageChannel: "capcutpc_0").channel
+        == .stable)
+    // Never escalates when the build says nothing, or says something unfamiliar.
+    #expect(CapCutChannel.resolve(joinBeta: nil, packageChannel: nil).channel == .stable)
+    #expect(CapCutChannel.resolve(joinBeta: nil, packageChannel: "").channel == .stable)
+    #expect(CapCutChannel.resolve(joinBeta: nil, packageChannel: "capcutpc_7").channel
+        == .stable)
+    // `capcutpc_beta` is the token in the vendor's own beta package name, so a
+    // typo here would silently pin every beta build to stable.
+    #expect(CapCutChannel.betaPackageToken == "capcutpc_beta")
+}
+
+/// The `channel` INI CapCut writes beside `updateInfo`, verbatim from this
+/// machine 2026-08-27. It is CapCut's own copy of the bundle's
+/// `Contents/Resources/PackageConfig.plist` → `Channel Name`.
+@Test func capCutReadsTheBuildChannelOutOfTheRealINI() {
+    #expect(CapCutChannel.packageChannel(inINI: "[General]\ntea_channel=capcutpc_0")
+        == "capcutpc_0")
+    #expect(CapCutChannel.packageChannel(inINI: "[General]\ntea_channel=capcutpc_beta")
+        == "capcutpc_beta")
+    #expect(CapCutChannel.packageChannel(inINI: "[General]\njoinBeta=true") == nil)
+    #expect(CapCutChannel.packageChannel(inINI: "[Other]\ntea_channel=capcutpc_beta") == nil)
+    // QSettings quotes values it thinks need it, and CapCut's `looki_settings` in
+    // this same directory is full of quoted ones. A quoted token that kept its
+    // quotes would stop matching and read as a stable build.
+    #expect(CapCutChannel.packageChannel(inINI: "[General]\ntea_channel=\"capcutpc_beta\"")
+        == "capcutpc_beta")
+    #expect(CapCutChannel.resolve(joinBeta: nil, packageChannel:
+        CapCutChannel.packageChannel(inINI: "[General]\ntea_channel=\"capcutpc_beta\"")).channel
+        == .beta)
+    #expect(CapCutChannel.joinBeta(inINI: "[General]\njoinBeta=\"true\"") == true)
+}
+
+/// The exact bytes CapCut writes after the "Get early access to beta features"
+/// checkbox is ticked (`~/Movies/CapCut/User Data/Config/updateInfo`, read off
+/// this machine 2026-08-27), plus the sibling key that must not be mistaken for
+/// it — `need_show_automatic_updates_popup` is about the OTHER settings control.
+@Test func capCutReadsJoinBetaOutOfTheRealINI() {
+    let on = """
+        [General]
+        joinBeta=true
+        need_show_automatic_updates_popup=false
+        """
+    let off = """
+        [General]
+        joinBeta=false
+        need_show_automatic_updates_popup=false
+        """
+    #expect(CapCutChannel.joinBeta(inINI: on) == true)
+    #expect(CapCutChannel.joinBeta(inINI: off) == false)
+}
+
+/// Everything that is not a value we understand reads as "no record" (nil), which
+/// hands the decision to the installed build rather than asserting stable — the
+/// distinction `capCutWithNoRecordedChoiceMirrorsTheInstalledBuild` covers. What
+/// none of these may do is come back `true`.
+@Test func capCutReportsNoChoiceRatherThanGuessingOne() {
+    #expect(CapCutChannel.joinBeta(inINI: "") == nil)
+    #expect(CapCutChannel.joinBeta(inINI: "[General]") == nil)
+    #expect(CapCutChannel.joinBeta(inINI: "[General]\njoinBeta=") == nil)
+    #expect(CapCutChannel.joinBeta(inINI: "[General]\njoinBeta=maybe") == nil)
+    #expect(CapCutChannel.joinBeta(inINI: "joinBeta=true") == nil, "no section header")
+    // The key under a DIFFERENT section is the one a naive substring scan would
+    // get wrong, and it would get it wrong in the escalating direction.
+    #expect(CapCutChannel.joinBeta(inINI: "[Other]\njoinBeta=true") == nil)
+    // ...and a `[General]` section that comes after it still works.
+    #expect(CapCutChannel.joinBeta(inINI: "[Other]\njoinBeta=false\n[General]\njoinBeta=true")
+        == true)
+}
+
+/// Tolerated spellings, so a vendor writing the flag the way its other INIs
+/// store booleans doesn't silently pin every user to stable.
+@Test func capCutAcceptsTheBooleanSpellingsQtWrites() {
+    #expect(CapCutChannel.joinBeta(inINI: "[General]\njoinBeta=1") == true)
+    #expect(CapCutChannel.joinBeta(inINI: "[general]\nJoinBeta = TRUE") == true)
+    #expect(CapCutChannel.joinBeta(inINI: "[General]\njoinBeta=0") == false)
+    // Windows line endings: CapCut is a cross-platform Qt app and `updateInfo` is
+    // the same file on both. A parser that split on "\n" alone would leave a
+    // trailing "\r" on the value and read every choice as unrecognized.
+    #expect(CapCutChannel.joinBeta(inINI: "[General]\r\njoinBeta=true\r\n") == true)
+}
+
 // MARK: - Registry dispatch
+
+/// Derived from `boundBundleIDs` rather than hand-listed, because the two halves
+/// of a binding are registered in two different places: an id added to
+/// `boundBundleIDs` but forgotten in `resolve` would make the menu-bar app
+/// recheck that app on every launch, quit and preference write, and resolve
+/// nothing each time — a binding that reads as present and does nothing.
+@Test func everyBoundIDHasAResolverBehindIt() {
+    for id in ChannelBinding.boundBundleIDs {
+        #expect(ChannelBinding.resolve(bundleID: id) != nil,
+                "\(id) is in boundBundleIDs but ChannelBinding.resolve has no case for it")
+    }
+}
 
 @Test func channelBindingDispatchesKnownAppsAndIgnoresOthers() {
     // Unknown / nil bundles get no bespoke resolver → generic detection stays.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
@@ -155,6 +155,17 @@ import Foundation
             isWatched(alfred.standardizedFileURL.path),
             "Alfred's preferences tree is not under any watched root")
     }
+    // CapCut is the case the comment below warns about, made real: it IS
+    // sandboxed, and its choice is in neither `~/Library/Preferences` nor its
+    // container — it is an INI under `~/Movies/CapCut/User Data/Config`. The
+    // generic `~/Library/Preferences/<id>.plist` half of this test passes for it
+    // regardless, which is precisely why it needs its own assertion against the
+    // path its resolver actually reads.
+    for file in [CapCutChannel.updateInfoFileURL, CapCutChannel.packageChannelFileURL] {
+        #expect(
+            isWatched(file.standardizedFileURL.path),
+            "CapCut's \(file.lastPathComponent) — a file its resolver reads — is not under any watched root")
+    }
 
     // Everyone else resolves through `CFPreferencesCopyAppValue`, backed by
     // `~/Library/Preferences/<domain>.plist` for an unsandboxed app.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RaycastReleasesTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RaycastReleasesTests.swift
@@ -122,6 +122,15 @@ private let raycastChangelogFixture = #"""
             "vendor:com.workbuddy.workbuddy-ai:stable:x64",
             "vendor:com.workbuddy.workbuddy:stable:arm64",
             "vendor:com.workbuddy.workbuddy:stable:x64",
+            // CapCut: the vendor publishes ONE dmg per track and it is arm64-only
+            // (`lipo -archs` on the shipped build reports `arm64` for the launcher,
+            // `libVECreator.dylib` and the helper app). Unlike Raycast there is no
+            // fallback train to land an Intel Mac on, so gating these does take
+            // CapCut to "unknown" there — deliberately: the alternative is a
+            // permanent "update available" plus a one-click that the installer's
+            // architecture check can only refuse.
+            "vendor:com.lemon.lvoverseas:stable",
+            "vendor:com.lemon.lvoverseas:beta",
         ])
         let unrestricted = VendorProbeRegistry.recipes.filter { $0.hostRequirement == nil }
         #expect(unrestricted.count == VendorProbeRegistry.recipes.count - restricted.count)

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -26,6 +26,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**TablePlus**](com-tinyapp-tableplus.md) · `com.tinyapp.TablePlus` — B(stable/beta) C · 2 channels, shared ID + header-keyed ChannelBinding · **beta（IsReceiveBetaBuild=1）+ stable 两 channel 真机验证 ✓ + header 翻 710↔711 实证**（stable 经嵌套 pref 取值验证，改动已还原）· 2026-06-04
 - [x] [**DuoPaste**](io-duopaste-daemon.md) · `io.duopaste.daemon` — B(stable/beta) · 2 channels, shared ID + channel-tag ChannelBinding · **beta + stable 两 channel 真机验证 ✓**（beta 用 `…-beta` 构建；stable 经 `sparkleIncludePrereleases` 取值验证，改动已还原）· 2026-06-04
 - [x] [**CleanShot X**](pl-maketheweb-cleanshotx.md) · `pl.maketheweb.cleanshotx` — C B(license feed) · license-keyed Sparkle feed · **stable 本机验证 ✓**（legit feed head=4.8.8=installed）· 2026-06-04
+- [x] [**CapCut**](com-lemon-lvoverseas.md) · `com.lemon.lvoverseas` — P(stable/beta) B · 2 channels, shared ID + ChannelBinding（`joinBeta` 在容器外的 INI）· **全 channel 一键 ✓**（Team 22MMUN2RN5，两轨真实 dmg 挂载核对）· **两轨版本字段是反的**（beta 的 short=`9.3.4531` / version=`9.4.0-beta4`，故 beta `versionIsBuild:true`）· 同 id 有 MAS 副本（19.2.0），靠 `_MASReceipt` 分流 · 2026-08-27
 
 ## Microsoft Office family
 

--- a/docs/app-audits/com-lemon-lvoverseas.md
+++ b/docs/app-audits/com-lemon-lvoverseas.md
@@ -1,0 +1,406 @@
+# CapCut
+
+审计 2026-08-27。
+
+## 基本信息
+
+- Bundle ID: `com.lemon.lvoverseas`
+- App 名: `CapCut.app`（2.1 GB）
+- URL scheme: `capcut`
+- 官网 / 下载页: https://www.capcut.com/tools/desktop-video-editor
+- 观测版本: stable `9.3.0` / beta `9.4.0-beta4`
+- Team ID: `22MMUN2RN5` — BYTEDANCE PTE. LTD.，`spctl -t install` 判定
+  "Notarized Developer ID"（**两个渠道的真实 dmg 都验过**）
+- 架构: **arm64 only**（`lipo -archs` 对启动器 / `libVECreator.dylib` /
+  `CapCut Helper.app` 全部只有 `arm64`）。`LSMinimumSystemVersion` 写着 `10.14`，
+  那是没跟着更新的残留，不代表支持 Intel。
+- 自更新机制: **内嵌 Sparkle，但决策不走 appcast**
+
+Qt 应用（`QtQuick` / `QtQml` 一票 framework + `libmmkv` + CEF），不是 Electron。
+
+### 和 Sparkle 的关系（说清楚边界）
+
+`Contents/Frameworks/` 里是**原版 `Sparkle.framework` 2.7.0（build 2044）**，
+Versions/B（Sparkle 2.x 布局），带 `Autoupdate` / `Updater.app` / `XPCServices`，
+`Info.plist` 有 `SUEnableInstallerLauncherService`，
+而且 `libVECreator.dylib` 里**确实实现了 `SPUUpdaterDelegate` 的方法**：
+`feedURLStringForUpdater:`、`allowedChannelsForUpdater:`、
+`bestValidUpdateInAppcast:forUpdater:`。
+
+但它**没有 `SUFeedURL`**，而且同一个 `MacUpdater` 类里同时有：
+
+- 字面量 `sparkle:version` / `enclosure` / `length` —— 这是**用字典手搓 `SUAppcastItem`** 的形状；
+- `initWithAppcastItem:secondaryAppcastItem:downloadBookmarkData:downloadToken:` ——
+  即把**自己已经下好的文件**包成 `SPUDownloadedUpdate` 交给 Sparkle；
+- 自己的下载器（`[UpdatingModel] download update`、`update.dmg`、
+  `update_disk_space_setting.md5_check_switch` 自校验 md5）。
+
+**已确证**：没有 `SUFeedURL`，所以 `SparkleAppcastSource` 对它永远不应答；
+"更新到哪个版本" 由 `updatecontroller.cpp` 从 `update_reminder.*` 算出来。
+
+**未确证（我的推断，标出来）**：`feedURLStringForUpdater:` 到底是返回一个真 URL、
+返回一个本地写出来的 appcast（`file://`），还是干脆是个空实现 —— 只看字符串分辨不了。
+所以「Sparkle 只当安装器」是推断，不是事实。要坐实得挂调试器或抓包。
+对配方没有影响（无论哪种都没有我们能读的 appcast URL），但别把推断当结论往下传。
+
+## 那个 3.6 MB 的 dmg 是安装器不是包
+
+`CapCut_<id>_installer.dmg` 里是 `CapCut-Downloader.app`（`com.lemon.ccdownloader`）。
+官网下载按钮发的是这个 stub，文件名里的数字是一次投放的 delivery id
+（`POST /lv/v1/common/create_delivery_content` 返回的同形状 id），不是版本号。
+真包 1.24 GB，在 `sf16-web-tos-buz.capcutstatic.com`。
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+| | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|---|---|---|---|---|---|
+| **stable** | ✗ | ✗ | — | — | ✓ 一键 |
+| **beta** | ✗ | — | — | — | ✓ 一键 |
+
+当前生效源：**VendorProbe**。`duo check --check com.lemon.lvoverseas`：
+
+```
+  CapCut  9.3.0  →  9.4.0-beta4  [Vendor]
+```
+
+其余四条源为什么不答：
+
+- **Sparkle** — bundle 里没有 `SUFeedURL`，没有 feed 可读。
+- **Homebrew** — cask `capcut` 存在且**没有** `auto_updates`，所以只要 app 真的从
+  Caskroom 装的，`HomebrewCaskSource` 会答。本机不是（`brew list --cask` 无 capcut，
+  provenance 闸不过），所以让位给 VendorProbe。**注意 cask 的版本是 `9.3.0.4490`
+  （带 build），装机 `CFBundleShortVersionString` 是 `9.3.0`** —— 一台 brew 装的
+  CapCut 有幽灵更新的形状，但那是既有行为，与本次改动无关。
+- **MAS** — 见下面「同 id 两种分发」。
+- **GitHub** — 无公开发布仓库。
+
+### 同 id 两种分发（重要）
+
+`itunes.apple.com/lookup?bundleId=com.lemon.lvoverseas&entity=macSoftware` 返回
+**1 条**：`CapCut: Photo & Video Editor`，adamId `1500855883`，版本 **`19.2.0`**。
+
+也就是说 App Store 上那份和 Developer ID 这份**共用 bundle id，版本方案完全不同**
+（19.2.0 vs 9.3.0）。两边不串是靠两道既有闸，各自只认自己的：
+
+- `VendorProbeSource.latestVersion(for:)` —— `guard !app.isMASApp`，商店副本永不进配方；
+- `MacAppStoreSource.latestVersion(for:)` —— `guard app.isMASApp`，非商店副本永不进 MAS。
+
+判据是 `Contents/_MASReceipt`（本机这份没有）。任何一道闸松了，一个方向是永久幽灵
+更新（19.2.0 > 9.3.0），另一个方向是用 Developer ID 包覆盖掉商店副本、连带毁掉它的
+收据和 entitlement。加任何新源之前先看这一条。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---|---|---|---|---|---|
+| stable | `com.lemon.lvoverseas` | 共享 | `joinBeta` / `tea_channel` | ChannelBinding | ✓ 一键 |
+| beta | `com.lemon.lvoverseas` | 共享 | 同上 | ChannelBinding | ✓ 一键 |
+
+Pattern B/C（app 内切换）。开关在 app 自己的「Version update」窗口里，叫
+**"Get early access to beta features"**（`en.po` 的 `pc_version_update_checkbox`）。
+
+### 开关落在哪：三个都不是
+
+1. **不在 UserDefaults。** CapCut 是沙盒 app，域在
+   `~/Library/Containers/com.lemon.lvoverseas/Data/Library/Preferences/`，
+   那里两个 plist（`com.lemon.lvoverseas.plist` / `com.capcut.CapCut.plist`）都没有这个键。
+2. **不在 `PackageConfig.plist`。** 那个是构建标记，不是用户选择。
+3. **在容器外的 INI**：
+
+   ```ini
+   # ~/Movies/CapCut/User Data/Config/updateInfo
+   [General]
+   joinBeta=true
+   need_show_automatic_updates_popup=false
+   ```
+
+同目录 `globalSetting` 里的 `enableAutoUpdate` 是**另一组**单选（截图里的
+「Automatic updates」vs「Get notified about updates」），决定 CapCut 自己装不装，
+不是渠道，别读错。
+
+`~/Movies` 不是 TCC 三个受控用户目录（Desktop/Documents/Downloads）之一，也不走
+`~/Library/Containers/<别人>/Data` 那道 App-Data 闸。但两次读都只在终端进程里验过，
+GUI 上下文没验 —— 这是记忆里咬过两次的盲区，`CapCutChannel` 顶部注释里标了。
+
+### 装机侧构建标记
+
+`Contents/Resources/PackageConfig.plist`：
+
+| | 值 |
+|---|---|
+| stable 装机 | `Channel Name = capcutpc_0` |
+| beta dmg 挂载后 | `Channel Name = capcutpc_beta` |
+
+CapCut 启动时把它抄进 `~/Movies/CapCut/User Data/Config/channel`
+（`tea_channel=capcutpc_0`），所以不用 bundle 路径也能读到。
+`CapCutChannel` **只在 `joinBeta` 完全没记录时**用它兜底 —— 理由见下一节。
+
+### 为什么「没记录」不能当成 stable
+
+`updateInfo` 是**打开更新窗口才写**的文件。而 `ChannelBinding` 是 authoritative，
+它的答案会**顶掉** `ReleaseChannel.detect()`。
+
+关键是 detect() 对 CapCut 帮不上忙，这条是挂载真包量出来的：
+
+| dmg | `CFBundleShortVersionString` | `CFBundleVersion` | `Channel Name` |
+|---|---|---|---|
+| `CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg` | `9.3.0` | `9.3.0` | `capcutpc_0` |
+| `CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg` | `9.3.4531` | `9.4.0-beta4` | `capcutpc_beta` |
+
+`AppScanner` 喂给 `detect()` 的是 **short** version，beta 那份是 `9.3.4531` ——
+**没有任何 channel 词**，`-betaN` 规则根本不触发。bundle id、app 名、app 文件名两轨也
+完全一样。所以 `CapCutChannel` 不是「最好的信号」，它是**唯一的信号**；没记录时答
+stable 会把一台装了 beta、没开过更新窗口的机器打成 Stable，然后用 stable 配方报一个
+比它正在跑的还旧的版本，永远。
+
+三态：`joinBeta=true`→beta；`joinBeta=false`（用户显式退出）→stable；
+**没记录**→镜像 `tea_channel`。不认识的值（拼写变了）算「没记录」，不算显式退出。
+
+没覆盖的角落：一份**从没启动过**的 beta 包两个文件都没有，会读成 stable 直到首次运行。
+补它要读 bundle 里的 `PackageConfig.plist`，而 `ChannelBinding.resolve(bundleID:)`
+拿不到 app 路径。
+
+## 更新检测
+
+端点是从二进制里还原的，不是猜的：
+
+- `libSettings.dylib` 的 `SettingsRequest.cpp` 里有 query 拼接串
+  `?device_platform=&channel=&aid=&version_code=&rom_version=&iid=&did=…`；
+- `libVECreator.dylib` 里有 app id `359289`；
+- `~/Movies/CapCut/User Data/Config/channel` 给出 channel token。
+
+```
+https://editor-api.capcutapi.com/service/settings/v3/
+    ?aid=359289&device_platform=mac&channel=capcutpc_0&version_code=9.99
+```
+
+匿名可打，不需要 did/iid，不需要 mssdk 签名。返回 ~400 KB 配置，其中：
+
+```json
+"update_reminder": {
+  "lastest_stable_url":  "…/CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg",
+  "lastest_url":         "…/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg",
+  "lastest_sync_url":    "…/CapCut_9_3_5-beta1_4468_capcutpc_beta_creatortool.dmg",
+  "update_url":          "…/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg",
+  "lastest_stable_version": 590592, "lastest_version": 590848,
+  "lastest_beta_number": "4", …
+}
+```
+
+### 三个坑
+
+**1. `update_url` 是按设备灰度的选择，两轨都不能读。** 同一个 key，本机 CapCut 缓存
+（`~/Movies/CapCut/User Data/MMKV/settings_json`）里是 **stable 9.3.0**，匿名请求里是
+**beta 9.4.0-beta4**。`lastest_*` 两轨字段在两份里逐字节相同 —— 这也是「匿名探测拿到的
+是不是和 app 同一个世界」的两证人核对。
+
+**2. `lastest_sync_url` 是同一对象里第三个 `capcutpc_beta` 包，且 build 更旧**
+（4468 < 4531），在 JSON 里还排在 `lastest_url` 前面。beta pattern 必须锚 key。
+
+**3. `version_code` 是必填，而且它选灰度桶。** 其余参数固定，实测：
+
+| version_code | 结果 |
+|---|---|
+| `0.0.1` · `8.0.0` · `9.0.0` · `9.3.0` · `9.4.0` · `9.5.0` · `9.9` · `9.99` | beta = 9.4.0-beta4（当前桶）|
+| `1.0.0` · `2.0.0` · `5.9.0` | beta = 9.3.5-beta1（旧桶）|
+| `9` · `10.0.0` · `99.9.9` · `9.999.999` · 空 · `x` | 没有 `update_reminder` |
+
+stable 字段在**所有能应答的取值下都是 9.3.0**，所以只有 beta 轨暴露在这条上。
+配方钉 `9.99`：它高于厂商发过的任何 9.x，所以留在最新桶而不会老化进旧桶（旧桶是唯一
+**静默**错的方向）；掉出窗口（CapCut 进 10.x，或厂商收窄区间）则是 pattern 匹配不到 →
+`versionPatternNoMatch`，`duo verify` 会报。
+
+**两段而不是三段也是承重的**：`RecipeSanity` 会对「抽出的版本逐字出现在请求 URL 里」
+报警（那是 pattern 匹配到 query 而不是 body 的迹象）。CapCut 版本恒为三段，所以两段的
+`version_code` 结构上不可能等于任何一个答案。
+
+**钉 `9.99` 的另一个副作用，记下来**：它拿到的配置和真实版本**不是一个世界**——
+`version_code=9.3.0` 返回 383 个顶层 settings 键，`9.99` 返回 **777** 个
+（多出来的里就有 `mac_update_enable`）。我们只读 `update_reminder` 的两个 URL 字段，
+而那两个字段在两种取值下**逐字节相同**（复核过两次），所以当前无害；但这说明 9.99 落在
+一个「未来/内部」桶而不是普通客户端桶，任何以后想从这个响应里多读字段的改动，都必须
+重新核对该字段在真实 version_code 下是否一致。
+
+### 版本方案：两轨字段是反的
+
+```
+stable → versionIsBuild: false   (short = version = 9.3.0)
+beta   → versionIsBuild: true    (short = 9.3.4531, version = 9.4.0-beta4)
+```
+
+版本从**包名**抽（`lastest_*_version` 是 nibble-packed 整数，`590592 = 0x090300`，
+正则解不动），每段一个 capture group，`extractVersion` 用 `.` 拼回去；`_4490_` build
+计数器匹配掉不要。
+
+beta 那条如果照抄 stable 用 `versionIsBuild: false`，引擎会拿 `9.4.0-beta4` 去比
+beta 装机的 marketing `9.3.4531` —— 第二段 4 > 3 —— **正在跑着 beta4 的用户会被永远
+劝装 beta4**。改成比 `CFBundleVersion` 才相等。
+
+stable pattern 的第三段止于数字（Canva 那条教训）：万一预发被误推进
+`lastest_stable_url`，一个都不匹配、降级 unknown，而不是把预发当正式版报。
+
+## 增量更新（delta / diff patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | **有** | **无** | **不能（缺管道，非缺机制）** |
+| 证据 | `libVECreator` 字符串 + 内嵌 Sparkle 2.7.0 的 `Autoupdate` | 2026-08-27 打真实端点，4 个 version_code 全无 | `DeltaApplier` 现成，缺「从 JSON 取补丁 URL」 |
+
+- 格式：**极可能是 Sparkle binary delta**（推断，见下，未见过真补丁）
+- 阻塞项：①厂商不发 ②钉死的 `version_code=9.99` 匹配不到 from→to 映射 ③取 URL 的管道
+
+三层展开：
+
+**1. CapCut 自己有完整的增量路径**（`libVECreator.dylib` 实测字符串）：
+
+| 证据 | 含义 |
+|---|---|
+| `UpdatingModel::startRunUpdateDiffPatch` | 打补丁的入口 |
+| `update.delta` / `/update.delta`（与 `update.dmg` 并列） | 补丁产物文件名 |
+| `cfg.diff_url=%s` / `cfg.diff_md5=%s` | 每个 release 可带补丁 URL + md5 |
+| `diff_update.enable` / `.enable_fallback_try` / `.fallback_try_count` | 灰度开关 + 失败回退整包 |
+| `diff_update.package_version_mapping` | **补丁按 from→to 版本映射** |
+| Sparkle 侧 `installerDidFailToApplyDeltaUpdate` | 失败回调 |
+
+> **`diff_url` / `diff_md5` 是哪来的，说清楚**：它们是**二进制里的日志格式串**
+> —— `libVECreator.dylib` 中 `updatecontroller.cpp` 的字符串池里有
+> `(%s:%d,%s) cfg.diff_url=%s` 和 `cfg.diff_md5=%s`，紧挨着 `cfg.url=%s` /
+> `cfg.version=%X`，即 CapCut 在打印自己 `ReminderUpdateCfg` 结构体的字段。
+> **不是从任何响应里看到的**，是客户端「有这个能力」的证据，不是「服务端在发」的证据。
+>
+> 而且我原来那句「`update_reminder` 里没有 `diff_url`」**找错了地方**：二进制里
+> 登记的 `update_reminder.*` 键一个带 diff/patch/delta 的都没有，它本来就不会出现在
+> 那里。真正的来源应该是另一个顶层键 `diff_update`（二进制里有
+> `diff_update.enable` / `.enable_fallback_try` / `.fallback_try_count` /
+> `.package_version_mapping`，旁边还有 `macos` 和 `download_md5`）。
+
+**2. 但端点现在一个补丁都不发 —— 这条换成不依赖我猜结构的证据。**
+2026-08-27，`version_code` = 9.2.0 / 9.3.0 / 9.3.5 / 9.99 各打一次：
+
+- 响应的 settings 是**扁平非点号**结构（383 个顶层键里含 `.` 的为 **0**），所以二进制里的
+  `diff_update.enable` 对应的是顶层 `diff_update` 对象 —— 查这个键是对的；
+- 顶层 **`diff_update` 不存在**；
+- 对**整个原始响应体**暴力扫一遍：所有匹配 diff/delta/patch 的键全是无关的
+  （`draft_size_diff`、`material_template_diff`、`update_download_material_patch_diff`、
+  `effectab_enable_metal_flip_patch`、网络 `dispatch_*`…），没有一个是 app 更新补丁；
+- 响应体里**没有任何 `.delta` / `.patch` / `.diff` 结尾的 URL**。
+
+即厂商当前对谁都发整包。
+
+**3. 格式极可能就是 Sparkle 的，也就是我们已经能施加的那种。**
+CapCut 内嵌的是**原版 Sparkle 2.7.0（build 2044）**，它的 `Autoupdate` 里带着完整的
+delta applier：
+
+```
+BinaryDelta · SUBinaryDeltaUnarchiver · SUBinaryDeltaCommon.m · /usr/bin/bspatch
+sparkle:deltaFrom · sparkle:deltaFromSparkleExecutableSize
+"This patch version (%u.%u) is too old and potentially unsafe to apply…"
+```
+
+而 `libVECreator` 这边实现了 Sparkle 自己的 `installerDidFailToApplyDeltaUpdate`
+回调，并且用 `initWithAppcastItem:secondaryAppcastItem:downloadBookmarkData:downloadToken:`
+构造更新 —— **`secondaryAppcastItem` 就是 Sparkle 的 delta 槽位**。
+
+我们这边 `DeltaApplier` 直接 ship 并调用 Sparkle 的 `BinaryDelta` 可执行文件
+（格式 v3，Sparkle 2.1 起），所以**施加器是现成的、对得上的**。
+
+> **标注：这是推断不是实证。** 端点当前一个 `.delta` 都不发，所以没有任何一个真补丁被
+> 检查过。要坐实得等厂商开灰度、或抓到一个 `diff_url`。
+> （我第一版把这条写成了「格式不是 Sparkle 的、要接是新机制」，是错的 —— 那是没查
+> Sparkle framework 就下的结论。）
+
+**4. 真正卡住的是我们的请求，不是格式。** 两条：
+
+- 缺的是**管道不是机制**：`VendorAppcastDeltas` 只会从 appcast 的 `<sparkle:deltas>`
+  里取补丁 URL，而 CapCut 会把它放在 JSON 的 `diff_url`（配 `diff_md5`）。
+  要接是「多一个取 URL 的来源」，不是重写 applier。
+- **`package_version_mapping` 是按 from→to 键的，而配方钉的 `version_code=9.99`
+  是个不存在的版本** —— 这个请求永远匹配不到任何补丁映射。这是我钉假版本号的代价，
+  当时只权衡了「灰度桶 + `RecipeSanity` 不误报」，没想到它同时把增量这条路堵死了。
+  今天不损失（反正没补丁），但要恢复得让请求带**装机真实版本**，而现在没有任何 recipe
+  字段能把装机版本塞进 URL。
+
+结论：现在**不接**增量，代价是每次 1.24 GB 整包。真要接，顺序是
+①等厂商真的发 `diff_url` → ②解决「把装机版本送上 wire」→ ③给取补丁 URL 加一条 JSON 来源。
+施加和验证都不用新写（补丁产出的 bundle 照样过签名/Team/bundle id 三道闸）。
+
+## Changelog
+
+**没有接。** `update_reminder` 里确实带 `lastest_stable_update_content` /
+`lastest_update_content`，但三轨内容完全一样、且是一句套话
+（"Fixed some known issues and improved the trimming experience."）。
+capcut.com 也没有桌面端 release notes 页：`/release-notes`、`/whats-new`、
+`/support/release-notes` 全部 502。所以 `changelogURL` 留空，UI 显示 "no release notes"。
+
+## 一键安装
+
+- 状态：**两轨都已启用**，`kind: .dmg`。
+- 产物：各自 `update_reminder` key 里的绝对 URL，主机钉死
+  `sf16-web-tos-buz.capcutstatic.com`，文件名钉死自己的 `capcutpc_<token>`。
+- **为什么 `.dmg` 而不是 `.pkg`**：两个真 dmg 挂载后都只有 `CapCut.app` +
+  `Applications` 软链 + 背景图，没有 pkg、没有
+  `LaunchDaemons`/`LaunchAgents`/`PrivilegedHelperTools`，本机跑过 CapCut 也没有任何
+  launch item。Homebrew cask 独立佐证：`artifacts` 是 `{"app": ["CapCut.app"]}`，
+  `uninstall` 只有 `quit`，`zap` 只清用户数据。换 bundle 就是完整更新。
+- **cask 还是 stable URL 的第二个证人**：它指向的就是配方从 settings blob 里解出来的
+  同一个 `…CapCut_9_3_0_4490_capcutpc_0_creatortool.dmg`。
+- **没有 checksum 闸**：厂商给的是 `*_url_md5`（MD5），`checksumPattern` 吃的是
+  base64 SHA-512，喂不进去。强制闸只剩 Team ID —— 但那本来就是必过的那道。
+- 强制闸（`VendorInstaller`）：Developer ID 签名 + Team `22MMUN2RN5` + bundle id 一致。
+  两个渠道的真实 dmg 都已核对（`codesign` + `spctl -t install`），并且**生产路径实跑过**
+  （见下）。
+- **`hostRequirement` = Apple silicon**：`lipo -archs` 对启动器、`libVECreator.dylib`、
+  `CapCut Helper.app` 一律只报 `arm64`，而厂商只发一个 dmg。厂商 schema 里其实有
+  `lastest_stable_cpu_architecture` / `lastest_cpu_architecture`（在二进制字符串池里），
+  但响应里不带 —— 即当前一份产物发给所有人。不加这道闸的话，一台装着旧 CapCut 的 Intel
+  Mac 会被永久报「有更新」，然后拿到一个 `SignatureVerifier` 架构闸只可能拒绝的一键。
+  **历史上有没有过 Intel 轨，本次没有查实**；真出现了就照 Raycast 那种双端点拆法改。
+- **成本**：每次安装 ~1.24 GB 下载。registry 的实网签名闸测试
+  （`vendorDownloadPassesSignatureGate`）跑的是一份小产物白名单，加这条不会把 1 GB
+  塞进 `make test`。
+
+### 生产路径实跑
+
+把 `com.lemon.lvoverseas` 临时加进 `vendorDownloadPassesSignatureGate` 的白名单跑了一次
+（跑完已还原）。本机 `joinBeta=true`，所以走的是 beta 轨：
+
+```
+=== signature-gate check: CapCut (com.lemon.lvoverseas) ===
+download: https://sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/CapCut_9_4_0-beta4_4531_capcutpc_beta_creatortool.dmg  [dmg]
+Team ID  installed: 22MMUN2RN5  downloaded: 22MMUN2RN5
+✅ gate passed — would swap safely (no swap performed)
+```
+
+即：生产 downloader 真的下了 1.24 GB、真的挂载解包、`SignatureVerifier` 真的过闸。
+stable 轨没走这条 harness（本机 channel 解析成 beta），但同一 Team、同一形状，
+`codesign` / `spctl` 已单独核过。
+
+### Channel proof
+
+`ChannelProofKey("com.lemon.lvoverseas", .beta)` → `.artifact(#"_capcutpc_beta_"#)`。
+
+不是从文件名习惯推的：`capcutpc_beta` 是挂载 beta dmg 后从它自己的
+`Contents/Resources/PackageConfig.plist` → `Channel Name` 读出来的厂商 token。
+
+## 已知问题 / 取舍
+
+- **我们会比 CapCut 自己的灰度更早给 beta。** `joinBeta` 是用户的 opt-in，而厂商在
+  `update_url` 上还做了按设备灰度。本机 2026-08-27 `joinBeta=true`、CapCut 自己说
+  "You are using the latest version"（它拿到的 `update_url` 是 stable 9.3.0），而
+  beta 轨最新是 9.4.0-beta4。配方读的是轨道最新而不是按设备的选择 —— 这是「beta 渠道」
+  的诚实读法，也是不把本机 ByteDance device id 发出去的唯一读法。
+- **`downloadURL`（手动兜底）两轨都指向官网桌面页，而那页只发 stable stub。**
+  一键接上之后它退化成兜底而不是主路径；替代方案 `nil` 会回落到 `recipe.url`，等于把
+  ~400 KB 内部 settings blob 放到用户可见链接后面。厂商没有任何公开 beta 下载入口。
+- **beta 的 marketing 版本 `9.3.4531` 会显示在行里**，因为那就是 bundle 自报的。
+- 一份从没启动过的 beta 包会被读成 stable，见上。
+
+## 建议下一步
+
+1. CapCut 进 10.x 时 `version_code=9.99` 会掉出窗口 —— 那天 `duo verify` 会报
+   `versionPatternNoMatch`，改成新的两段值即可。
+2. 若哪天出现可核实的桌面端 release notes 页，补 `changelogURL`。
+3. 若要给 brew 装的 CapCut 修那个 `9.3.0.4490` vs `9.3.0` 的幽灵形状，那是
+   `HomebrewCaskSource` 的事，不是这条配方的事。


### PR DESCRIPTION
Integrates CapCut (`com.lemon.lvoverseas`, ByteDance) — version detection on both
tracks, the in-app beta switch as a `ChannelBinding`, and one-click install on
both. Only a changelog is missing, because the vendor publishes none.

`duo check --check com.lemon.lvoverseas` → `CapCut 9.3.0 → 9.4.0-beta4 [Vendor, in-place]`

## Where things live

CapCut has no appcast. It embeds stock **Sparkle 2.7.0** and drives
`SUAppcastItem`, but carries no `SUFeedURL`: `UpdateController` reads
`update_reminder.*` out of ByteDance's Settings SDK blob and builds the item
itself. The endpoint was reconstructed from the shipped binaries rather than
guessed, and answers an anonymous GET — no device id, no signature.

The beta checkbox is not in UserDefaults. CapCut is sandboxed, but neither plist
in its container holds the flag; Qt writes it to an INI *outside* the container
(`~/Movies/CapCut/User Data/Config/updateInfo` → `joinBeta`).

## The bug the 1.2 GB download caught

The two tracks put their version in **different Info.plist fields**, swapped:

| dmg | `CFBundleShortVersionString` | `CFBundleVersion` |
|---|---|---|
| `…_capcutpc_0_creatortool.dmg` | `9.3.0` | `9.3.0` |
| `…_capcutpc_beta_creatortool.dmg` | `9.3.4531` | `9.4.0-beta4` |

Compared as a marketing version, `9.4.0-beta4` beats `9.3.4531` at the second
component — so a beta user would have been told to install the build they were
already running, forever. Hence `versionIsBuild` on the beta recipe only.

The same measurement is why the channel binding is a tri-state: a beta bundle's
short version carries no channel word at all, so `ReleaseChannel.detect()` calls
a beta install stable. With no recorded preference the resolver mirrors the
build's own channel token rather than assuming stable.

## Verification

- `make test` — core 1268 / CLI 127 / localizable keys, `EXIT=0`
- `duo verify --only lvoverseas --vendor` — ✓ 2 ✗ 0, `warnings: []` on both
- `channel-verify --scan com.lemon.lvoverseas --expect beta` — production
  `AppScanner.scan()` → beta, probe → 9.4.0-beta4
- `vendorDownloadPassesSignatureGate` run once with CapCut added to its
  allow-list (reverted): real 1.24 GB download, unpack, Team `22MMUN2RN5` on both
  sides, gate passed
- Both patterns re-derived independently in Python against a freshly fetched
  body: exactly one match each; the body holds four CapCut dmg URLs, three of
  them `capcutpc_beta`

## Notable decisions

- **`hostRequirement: [.arm64]`** — `lipo` reports arm64 alone and the vendor
  ships one dmg, so an Intel Mac would otherwise get a permanent "update
  available" plus a one-click the arch check can only refuse. It takes CapCut to
  "unknown" there, deliberately.
- **`version_code=9.99` pinned** — required *and* it selects a rollout bucket. Two
  segments so it can never collide with a real (always three-segment) CapCut
  version under `RecipeSanity`. Cost recorded: patches are keyed from→to, so a
  pinned fake version forecloses the delta route if the vendor ever enables it.
- **No delta** — the client can apply one and it is almost certainly Sparkle's own
  format (its `Autoupdate` carries the whole `BinaryDelta` applier), but the
  endpoint serves no patch to any version_code tried. Split into client
  capability / server reality / can-we-consume in the audit doc.
- **A MAS copy shares this bundle id** at 19.2.0 against 9.3.0. The separation
  rests entirely on `_MASReceipt`, in both directions.

## Not verified

- Whether CapCut ever shipped an Intel train
- The stable track's gate through the harness (this machine resolves to beta);
  its dmg was checked with `codesign` / `spctl` instead
- `~/Movies` readability from the GUI app context — only a terminal process was used

## Also here

- `app-audit` skill gains a phase for "what else does the vendor's updater do",
  in three columns that may not be collapsed (client capability / server actually
  serving / can we consume), plus a reference table of recipe fields — it
  mentioned one of eight that exist, so an audit could report a covered situation
  as unsupported. This PR's first pass missed delta entirely; that is the fix.
- `CLAUDE.md`: `docs/` is carried with the change. The rule said the opposite of
  what the last several recipe PRs actually did.
