### PR TITLE
Read nightly/-dev/-snapshot version tails as prerelease, not stable

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
@@ -169,6 +169,38 @@ public enum ReleaseChannel: String, Codable, Sendable, Hashable, CaseIterable {
             // `0.3.377-beta.1429+sha`, `0.1.1251-beta+sha` — don't trip it (verified
             // against the real installed bundles 2026-06-06).
             if fullyMatches(#"[0-9]+(\.[0-9]+)+-beta[0-9]+"#, version) { return .beta }
+
+            // A prerelease WORD in the version's dash-separated tail — the only
+            // local channel signal some nightly/snapshot builds have. Freelens
+            // nightly (`2.0.0-0-nightly-2026-08-26`), VLC nightly (`4.0.0-dev`)
+            // and the KeePassXC snapshot (`2.8.0-snapshot`) each ship the STABLE
+            // bundle id, the stable app filename and a clean `CFBundleName`, so
+            // steps 0–3 all see nothing and every one of them used to read as
+            // `.stable` (measured off the real packages 2026-08-27).
+            //
+            // Anchored the same way the rules above are, and for the same reason:
+            // the tail may contain only the word itself plus numeric components,
+            // so build metadata that is NOT a channel keeps reading as stable —
+            // `0.3.377-beta.1429+sha` (the shape the `-betaN` rule above already
+            // guards), `2026.8.190756-latest`, `6.5.2-366`, `3.22.3+105`. The
+            // word must also be a whole dash-delimited component, so
+            // `1.2.3-development` and `4.0.0-devmate` do not trip it.
+            //
+            // `dev` is the risky one — short, and a common non-channel token —
+            // which is why `ChannelProofRegistry.preReleaseTokens` deliberately
+            // spells it `devedition` rather than matching it bare. It is safe
+            // HERE only because this pattern is anchored to a whole version
+            // string with a dotted-numeric prefix, not matched as a substring.
+            //
+            // Verified before landing: replayed over every version in
+            // `verify/baseline.json` (272 covered recipes, swept 2026-08-27) and
+            // over the short AND build version of all 205 apps installed on the
+            // dev machine (406 strings). Zero of them change classification.
+            let lowered = version.lowercased()
+            for (word, channel) in versionTailChannelWords
+            where fullyMatches(versionTailPattern(word), lowered) {
+                return channel
+            }
         }
 
         return .stable
@@ -196,6 +228,23 @@ public enum ReleaseChannel: String, Codable, Sendable, Hashable, CaseIterable {
         }
         let range = NSRange(text.startIndex..., in: text)
         return regex.firstMatch(in: text, options: [], range: range) != nil
+    }
+
+    /// Prerelease words recognized in a version string's dash-separated tail
+    /// (step 4). `snapshot` maps to `.preview` to agree with the two places that
+    /// already rule on that word — `channelWord`'s table and the
+    /// `.snapshot`/`-snapshot` bundle-id suffix (Vivaldi Snapshot) — so a build
+    /// cannot land on a different channel depending on which signal saw it first.
+    /// Ordered most-specific-first like `channelWord` for the same reason.
+    private static let versionTailChannelWords: [(word: String, channel: ReleaseChannel)] = [
+        ("nightly", .nightly),
+        ("snapshot", .preview),
+        ("dev", .dev),
+    ]
+
+    /// Whole-string pattern for `<dotted numeric>[-<digits>…]-<word>[-<digits>…]`.
+    private static func versionTailPattern(_ word: String) -> String {
+        #"[0-9]+(\.[0-9]+)+(-[0-9]+)*-"# + word + #"(-[0-9]+)*"#
     }
 
     private static let nonStable: [ReleaseChannel] =

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
@@ -191,6 +191,93 @@ import Foundation
         keystoneChannel: nil) == .stable)
 }
 
+// MARK: - Prerelease WORD in the version tail (issue #93)
+
+/// Freelens nightly, VLC nightly and the KeePassXC snapshot each ship the STABLE
+/// bundle id, the stable app filename and a clean `CFBundleName` — the version
+/// string is their ONLY local channel signal, and all three used to read as
+/// `.stable`. Versions below were read off the real packages 2026-08-27.
+@Test func prereleaseWordInVersionTailFlipsOffStable() {
+    // Freelens nightly — a counter AND a date around the word.
+    #expect(ReleaseChannel.detect(
+        name: "Freelens", bundleID: "app.freelens.Freelens",
+        keystoneChannel: nil, version: "2.0.0-0-nightly-2026-08-26") == .nightly)
+    // VLC nightly — the bare word, no trailing components.
+    #expect(ReleaseChannel.detect(
+        name: "VLC", bundleID: "org.videolan.vlc",
+        keystoneChannel: nil, version: "4.0.0-dev") == .dev)
+    // KeePassXC snapshot.
+    #expect(ReleaseChannel.detect(
+        name: "KeePassXC", bundleID: "org.keepassxc.keepassxc",
+        keystoneChannel: nil, version: "2.8.0-snapshot") == .preview)
+    // Case is not a signal: the vendor may shout it.
+    #expect(ReleaseChannel.detect(
+        name: "VLC", bundleID: "org.videolan.vlc",
+        keystoneChannel: nil, version: "4.0.0-DEV") == .dev)
+}
+
+/// The mirror, and the expensive direction: a version tail that is build
+/// metadata rather than a channel must keep reading as `.stable`, or a working
+/// stable app stops being answered for. Every string here is either named in
+/// `ReleaseChannel`'s own comments or was live in the corpus on 2026-08-27.
+@Test func nonChannelVersionTailsStayStable() {
+    func detect(_ version: String) -> ReleaseChannel {
+        ReleaseChannel.detect(
+            name: "Some App", bundleID: "com.example.some",
+            keystoneChannel: nil, version: version)
+    }
+    // The shapes the `-betaN` rule above already guards — still guarded.
+    #expect(detect("0.3.377-beta.1429+sha") == .stable)
+    #expect(detect("0.1.1251-beta+sha") == .stable)
+    // Live on the dev machine 2026-08-27.
+    #expect(detect("0.3.384-beta.1440+fd58749") == .stable)
+    #expect(detect("0.1.1283-beta+dc86f01") == .stable)
+    // A NON-channel word in the tail (Kontena Lens ships this on stable).
+    #expect(detect("2026.8.190756-latest") == .stable)
+    // Numeric and build-metadata tails.
+    #expect(detect("6.5.2-366") == .stable)
+    #expect(detect("3.22.3+105") == .stable)
+    // Zen Browser stable — ends in a bare "b", must not read as a Mozilla beta.
+    #expect(detect("1.21.15b") == .stable)
+    // The word must be a WHOLE dash-delimited component. "dev" is the short,
+    // common token the rule is most exposed on, so it is pinned hardest.
+    #expect(detect("1.2.3-development") == .stable)
+    #expect(detect("1.2.3-devel") == .stable)
+    #expect(detect("4.0.0-devmate") == .stable)
+    #expect(detect("1.2.3-snapshotting") == .stable)
+    #expect(detect("1.2.3-nightlies") == .stable)
+    // Only numeric components may sit between the version and the word, so a
+    // tail of arbitrary words cannot smuggle one in.
+    #expect(detect("2026.8.190756-dev-preview-latest") == .stable)
+    // Needs a dotted-numeric prefix — a bare word is not a version.
+    #expect(detect("dev") == .stable)
+    #expect(detect("nightly-2026-08-26") == .stable)
+}
+
+/// Three places in the codebase rule on what a channel word means: this version
+/// tail, `channelWord` (display name), and the `.snapshot`/`-snapshot` bundle-id
+/// suffix. They must not disagree — otherwise the same build lands on a
+/// different channel depending on which signal happened to see it first, and the
+/// cross-channel gate stops being a gate. Compares two production paths rather
+/// than asserting a hardcoded answer, so it cannot drift silently.
+@Test func versionTailAgreesWithTheOtherChannelWordSignals() {
+    for word in ["nightly", "snapshot", "dev"] {
+        let fromVersion = ReleaseChannel.detect(
+            name: "Some App", bundleID: "com.example.some",
+            keystoneChannel: nil, version: "1.2.3-\(word)")
+        let fromName = ReleaseChannel.detect(
+            name: "Some App \(word)", bundleID: "com.example.some",
+            keystoneChannel: nil)
+        #expect(fromVersion == fromName,
+                Comment(rawValue: "version tail and display name disagree on "
+                                  + "\"\(word)\": \(fromVersion) vs \(fromName)"))
+    }
+    // ... and the bundle-id suffix path for the one word that has one.
+    #expect(ReleaseChannel.detect(
+        name: "Vivaldi", bundleID: "com.vivaldi.Vivaldi.snapshot",
+        keystoneChannel: nil) == .preview)
+}
+
 // MARK: - Scanner wires the channel onto InstalledApp
 
 private func makeApp(at dir: URL, name: String, info: [String: Any]) throws -> URL {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelVersionSweepTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelVersionSweepTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A new rule in `ReleaseChannel.detect()` step 4 is cheap to write and expensive
+/// to get wrong: it reads a string every covered app carries, so a rule that is a
+/// little too loose reclassifies apps that were being updated fine, and they go
+/// quiet rather than fail loudly.
+///
+/// Hand-written "must stay stable" lists (there is one next door in
+/// `ChannelGuardTests`) only cover the shapes somebody thought of. This replays
+/// the rule over the versions our recipes ACTUALLY resolved — `verify/baseline.json`,
+/// which the nightly `duo verify` sweep rewrites — so the guarded population grows
+/// on its own as coverage does.
+///
+/// If this fails after a sweep updated the baseline, that is the alarm working: a
+/// covered app has started shipping a version that classifies differently than its
+/// recipe declares. Read the diff before touching this test.
+@Test func noCoveredRecipeVersionContradictsItsDeclaredChannel() throws {
+    let baseline = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()   // DuoUpdaterCoreTests
+        .deletingLastPathComponent()   // Tests
+        .deletingLastPathComponent()   // DuoUpdaterCore
+        .deletingLastPathComponent()   // repo root
+        .appendingPathComponent("verify/baseline.json")
+
+    let data = try Data(contentsOf: baseline)
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    let entries = try #require(json?["entries"] as? [String: [String: Any]])
+    #expect(entries.count > 200, "baseline shrank unexpectedly — is it still the sweep's output?")
+
+    // Firefox Developer Edition reports `155.0b5`, which step 4's Mozilla
+    // `<maj>.<min>b<N>` rule reads as `.beta`. That is not a live defect and not
+    // this rule's doing: step 0 resolves Firefox from `application.ini`'s
+    // `RemotingName` (`firefox-dev`) and returns before step 4 is reached — see
+    // `ReleaseChannel.detect`'s header. Keyed by bundle id, not by version, so a
+    // version bump doesn't silently re-arm it.
+    let decidedBeforeStep4: Set<String> = ["org.mozilla.firefoxdeveloperedition"]
+
+    var contradictions: [String] = []
+    var checked = 0
+
+    for (key, entry) in entries {
+        guard let version = entry["lastGoodVersion"] as? String, !version.isEmpty else { continue }
+        // Keys are "<source>:<bundleID>:<channel>"; changelog rows carry "-".
+        let parts = key.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count >= 3 else { continue }
+        let bundleID = String(parts[1])
+        let declaredRaw = String(parts[parts.count - 1])
+        let declared = declaredRaw == "-" ? ReleaseChannel.stable
+            : (ReleaseChannel(rawValue: declaredRaw) ?? .stable)
+        if decidedBeforeStep4.contains(bundleID) { continue }
+        checked += 1
+
+        // Neutral name and no bundle id, so ONLY the version string can speak —
+        // this isolates step 4 from the signals that would normally outrank it.
+        let fromVersion = ReleaseChannel.detect(
+            name: "App", bundleID: nil, keystoneChannel: nil, version: version)
+
+        // Reading as `.stable` is always allowed: the recipe's own channel comes
+        // from elsewhere (bundle id, display name, an app preference). What must
+        // never happen is the version asserting a DIFFERENT non-stable channel.
+        if fromVersion != .stable && fromVersion != declared {
+            contradictions.append("\(key) version \(version) → \(fromVersion), declared \(declared)")
+        }
+    }
+
+    #expect(checked > 200, "swept too few entries — did the key format change?")
+    #expect(contradictions.isEmpty,
+            Comment(rawValue: "version strings contradict their recipe's channel:\n"
+                              + contradictions.sorted().joined(separator: "\n")))
+}


### PR DESCRIPTION
Closes #93.

`ReleaseChannel.detect()` step 4 matched only Mozilla's `b<N>`/`a<N>`/`esr` shapes and GitHub Desktop's `-beta<N>`. Three real prerelease builds carry a channel word none of those match, and all three read as `.stable`:

| build | `CFBundleShortVersionString` | was | now |
|---|---|---|---|
| Freelens nightly | `2.0.0-0-nightly-2026-08-26` | `.stable` | `.nightly` |
| VLC nightly | `4.0.0-dev` | `.stable` | `.dev` |
| KeePassXC snapshot | `2.8.0-snapshot` | `.stable` | `.preview` |

Each ships the stable bundle id, the stable app filename and a clean `CFBundleName`, so steps 0–3 see nothing and the version string is the only local signal.

## The regression sweep — the thing the issue called the actual risk

The issue asked whether any *other* covered app ships a version containing `nightly`, `dev` or `snapshot` that would change classification. Answer, measured rather than argued:

- **272 covered recipes** — every `lastGoodVersion` in `verify/baseline.json`, swept 2026-08-27 — **0 change classification.**
- **406 version strings** — the short *and* build version of all 205 apps installed on the dev machine — **0 change classification.**

Done by porting both the old and the new rule to Python and diffing their output over the real corpus, per the repo's "two independent witnesses" rule, before any Swift was written.

## What the issue left out

It warns about "two places that disagree about what `snapshot` means" — `channelWord` and the new rule. There are **three**: `ChannelProofRegistry.preReleaseTokens` also rules on channel words, and it deliberately spells `dev` as `devedition` because a bare `dev` trips things like `dl.devmate.com`. That corroborates the issue's instinct that `-dev` deserves the most scepticism, and it is why the new rule is anchored to a whole version string with a dotted-numeric prefix rather than matched as a substring. `snapshot` maps to `.preview` so all three agree.

The sweep also turned up a **pre-existing** oddity worth recording, not fixed here: Firefox Developer Edition reports `155.0b5`, which step 4's Mozilla rule reads as `.beta` while the recipe declares `.dev`. Not a live defect — step 0 resolves Firefox from `application.ini`'s `RemotingName` and returns before step 4 is reached — so it is documented and allowlisted by bundle id in the sweep test rather than silently accommodated.

## Tests

- `prereleaseWordInVersionTailFlipsOffStable` — the three measured builds, plus an uppercased tail.
- `nonChannelVersionTailsStayStable` — the mirror, and the expensive direction. Every string is either named in `ReleaseChannel`'s own comments (`0.3.377-beta.1429+sha`) or was live in the corpus (`2026.8.190756-latest`, `6.5.2-366`, `3.22.3+105`, `1.21.15b`).
- `versionTailAgreesWithTheOtherChannelWordSignals` — compares two production paths against each other rather than a hardcoded answer, so it cannot drift silently.
- `ChannelVersionSweepTests` — replays the rule over `verify/baseline.json`, so the guarded population grows with coverage. If it fails after a sweep updates the baseline, that is the alarm working.

Both guards were confirmed to **go red** against a deliberately loosened pattern, naming real covered apps (Kontena Lens stable, VS Code Insiders, HBuilderX Alpha), then restored.

## Verification

```
cd DuoUpdaterCore && swift test
━ Test run with 1273 tests in 99 suites passed after 73.302 seconds with 1 known issue.

swift test --package-path CLI
✔ Test run with 127 tests in 19 suites passed after 0.066 seconds.
```

## Not verified / deliberately not done

- No `CHANGELOG.md` entry. This is a prerequisite, not a feature — no covered app hits the new rule today (that is what the 0/272 means), so there is nothing user-facing to describe yet. The entry belongs to whichever PR actually covers Freelens/VLC/KeePassXC.
- A leading `v` (`v1.2.3-dev`) is not matched, consistent with the existing step-4 rules. Installed `CFBundleShortVersionString` values do not carry one.
- Whether version *comparison* copes with `2.0.0-0-nightly-2026-08-26` once a nightly recipe exists is untouched here and belongs to that recipe's PR.