### PR TITLE
VLC nightly and KeePassXC snapshot: detection-only forever (unsigned)

### DIFF
--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -257,8 +257,8 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 | **VSCodium Insiders** | `com.vscodium.VSCodiumInsiders` 1.126.04518-insider | **独立** | app 名 + 版本后缀 | Team `VC39D2VNQ7` 公证 | **A，可接** |
 | **DB Browser nightly** | 同 id 3.13.99 | 同 | **只有 app 文件名** `DB Browser for SQLite Nightly.app`（`CFBundleName` 仍是 "DB Browser for SQLite"）| Team `88DD6Y8X83` 公证 | **A-ish**，靠文件名，同 Android Studio 那条 `detect` step 0.5 |
 | **Freelens nightly** | 同 id `2.0.0-0-nightly-2026-08-26` | 同 | **版本串带 `nightly`** | Team `TFR6NT55MB` 公证 | 可接，但要给 `detect()` 加规则 |
-| **VLC nightly** | 同 id `4.0.0-dev` | 同 | 版本串带 `-dev` | **未签名**（`TeamIdentifier=not set`）| 检测可做，**一键不可**（Team 闸必拒）|
-| **KeePassXC snapshot** | 同 id `2.8.0-snapshot` | 同 | 版本串带 `-snapshot` | **无可用签名** | 同上；且该 URL 只有 x86_64 |
+| **VLC nightly** | 同 id `4.0.0-dev` | 同 | 版本串带 `-dev` | **未签名**（`TeamIdentifier=not set`）| 检测可做，**一键不可**（Team 闸必拒）→ 立项 #95，`docs/app-audits/org-videolan-vlc.md` |
+| **KeePassXC snapshot** | 同 id `2.8.0-snapshot` | 同 | 版本串带 `-snapshot` | **无可用签名** | 同上；且该 URL 只有 x86_64（已核实无 arm64 替代路径）→ 立项 #95，`docs/app-audits/org-keepassxc-keepassxc.md` |
 | **UTM beta** | 同 id 5.0.4 / build 123 | 同 | **无**（stable 4.7.5 / build 118，都不带 channel 词，Resources 里无标记文件）| Team `WDNLXAD4W8` 公证 | **D，本地不可判** |
 | **kitty nightly** | 同 id 0.48.2 | 同 | **无，版本与 stable 完全相同** | Team `NTY7FVCEKP` 公证 | **D** |
 | **Postman Canary** | — | — | — | — | **死轨**：cask `disabled: true`，版本停在 `11.2.14-canary240621-0734`（2024-06），stable 已 12.25.6 |
@@ -341,6 +341,10 @@ DB Browser 是 Developer ID 公证的，VLC 和 KeePassXC **完全没签名** �
   另：`?version=` 参数只在客户端**落后**时回 200，已是最新则回 **204 No Content**（且只收 4 段版本号，
   v1 的 3 段会 400），所以 probe 一律**不带** `version`。
 - ✗ **VLC — Nightly** · 同 `org.videolan.vlc`，nightlies 滚动构建无版本语义，不可区分
+  **更正 2026-08-27（§2c）**：这条判断已过期——版本串其实带 `-dev`（`4.0.0-dev`），
+  只是现有 `detect()` 不认这种形状（阻塞于 #93）。真正永久挡住的不是检测，是签名：
+  nightly 完全未走 Developer ID（`TeamIdentifier=not set`），一键永远过不了
+  `VendorInstaller` 的 Team 闸。见 issue #95、`docs/app-audits/org-videolan-vlc.md`。
 - ✗ **Blender — Daily/Alpha/Beta** · 同 bundle id，builder.blender.org 滚动构建，无检测信号
 - ✅ **Figma — Beta** · 已接入（**更正旧判断：不是**应用内 flag）。独立 app：bundle `com.figma.DesktopBeta`、"Figma Beta.app"、独立端点 `desktop.figma.com/mac-arm/beta/`。Pattern A，VendorProbe(`channel: .beta`) + 一键安装（Team T8RA8NE3B7，2026-06-06 真机验证）
 - ✗ **GitHub Desktop — Beta** · 同 `com.github.GitHubClient`，beta tag 是 prerelease，stable rule 已排除

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1202,6 +1202,10 @@ public enum GitHubReleaseRegistry {
         // notarized, so the worst case is a superseded packaging of the version the
         // user was going to get anyway — never a cross-train swap.
         // One-click: org.keepassxc.keepassxc, Team G2S7P7J672, notarized.
+        //
+        // If a snapshot-channel rule is ever added for this bundle id: no
+        // `installAssetPattern`/`installerKind` — snapshot ships completely
+        // unsigned (docs/app-audits/org-keepassxc-keepassxc.md, #95).
         GitHubReleaseRule(
             bundleID: "org.keepassxc.keepassxc",
             owner: "keepassxreboot", repo: "keepassxc",

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2346,6 +2346,9 @@ public enum VendorProbeRegistry {
 
         // VLC — official Sparkle appcast. Lists releases ascending, so
         // highestVersion (not first) picks the current one.
+        //
+        // If a nightly-channel variant of this recipe is ever added: no `install:`
+        // — nightly is ad-hoc signed, no Team ID (docs/app-audits/org-videolan-vlc.md, #95).
         VendorProbeRecipe(
             bundleID: "org.videolan.vlc",
             url: URL(string: "https://update.videolan.org/vlc/sparkle/vlc-arm64.xml")!,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Issue #95: VLC nightly (`org.videolan.vlc`, `4.0.0-dev`) and the KeePassXC
+/// snapshot (`org.keepassxc.keepassxc`, `2.8.0-snapshot`) share their bundle id
+/// with an already-covered, notarized stable build, but ship completely
+/// unsigned themselves — VLC nightly ad-hoc (`TeamIdentifier=not set`),
+/// KeePassXC snapshot with no signature at all (verified 2026-08-27 against the
+/// real downloads, see `docs/app-audits/org-videolan-vlc.md` /
+/// `org-keepassxc-keepassxc.md`). `VendorInstaller`'s Team-ID gate
+/// (`SignatureVerifier.verifyTeamIdentifierMatch`) would refuse the swap, so
+/// neither may ever carry an install spec.
+///
+/// Detection for these two channels doesn't exist yet (blocked on #93), so
+/// today this iterates zero matching recipes — that's expected. The guard is
+/// for the day a nightly/snapshot-channel recipe gets added and copy-pastes an
+/// `install:`/`installAssetPattern` from a sibling nightly that (unlike these
+/// two) genuinely is notarized, e.g. Freelens or DB Browser nightly.
+@Suite struct UnsignedNightlyInstallSpecTests {
+
+    @Test func vlcNonStableRecipesCarryNoInstallSpec() {
+        for recipe in VendorProbeRegistry.recipes
+        where recipe.bundleID == "org.videolan.vlc" && recipe.channel != .stable {
+            #expect(
+                recipe.install == nil,
+                "\(recipe.bundleID) (\(recipe.channel)): nightly is unsigned — must stay detection-only, see issue #95")
+        }
+    }
+
+    @Test func keePassXCNonStableRulesCarryNoInstallSpec() {
+        for rule in GitHubReleaseRegistry.rules
+        where rule.bundleID == "org.keepassxc.keepassxc" && rule.channel != .stable {
+            #expect(
+                rule.installAssetPattern == nil && rule.installerKind == nil,
+                "\(rule.bundleID) (\(rule.channel)): snapshot is unsigned — must stay detection-only, see issue #95")
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift
@@ -13,13 +13,25 @@ import Foundation
 /// neither may ever carry an install spec.
 ///
 /// Detection for these two channels doesn't exist yet (blocked on #93), so
-/// today this iterates zero matching recipes — that's expected. The guard is
-/// for the day a nightly/snapshot-channel recipe gets added and copy-pastes an
-/// `install:`/`installAssetPattern` from a sibling nightly that (unlike these
-/// two) genuinely is notarized, e.g. Freelens or DB Browser nightly.
+/// today each `where` below matches zero recipes — that's expected, not a
+/// broken filter. What tells the two apart is the presence anchor each test
+/// starts with: it fails if the bundle id it's filtering for ever stops
+/// existing in the registry at all (typo'd, renamed by the vendor, or moved
+/// to a different registry), which is exactly the failure mode that would
+/// otherwise leave the `where` silently matching nothing forever while this
+/// suite kept reporting green. Once a real non-stable recipe exists, the
+/// second `#expect` in each test starts actually exercising the guard: no
+/// `install:`/`installAssetPattern` may be copy-pasted onto it from a sibling
+/// nightly that (unlike these two) genuinely is notarized, e.g. Freelens or
+/// DB Browser nightly.
 @Suite struct UnsignedNightlyInstallSpecTests {
 
     @Test func vlcNonStableRecipesCarryNoInstallSpec() {
+        // Presence anchor — see suite doc comment.
+        #expect(
+            VendorProbeRegistry.recipes.contains { $0.bundleID == "org.videolan.vlc" },
+            "org.videolan.vlc is no longer in VendorProbeRegistry — this test's filter would be vacuous")
+
         for recipe in VendorProbeRegistry.recipes
         where recipe.bundleID == "org.videolan.vlc" && recipe.channel != .stable {
             #expect(
@@ -29,6 +41,11 @@ import Foundation
     }
 
     @Test func keePassXCNonStableRulesCarryNoInstallSpec() {
+        // Presence anchor — see suite doc comment.
+        #expect(
+            GitHubReleaseRegistry.rules.contains { $0.bundleID == "org.keepassxc.keepassxc" },
+            "org.keepassxc.keepassxc is no longer in GitHubReleaseRegistry — this test's filter would be vacuous")
+
         for rule in GitHubReleaseRegistry.rules
         where rule.bundleID == "org.keepassxc.keepassxc" && rule.channel != .stable {
             #expect(

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -63,7 +63,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] **Conductor** · `com.conductor.app` — P C · ✓ src=Vendor
 - [x] **Postman** · `com.postmanlabs.mac` — P C (one-click) · ✓ src=Vendor
 - [x] **AweSun** · `com.oray.sunlogin.macclient` — P C (one-click, WAF) · ✓ src=Vendor
-- [x] **VLC** · `org.videolan.vlc` — P C (one-click, two-stage changelog) · ✓ src=Vendor
+- [x] [**VLC**](org-videolan-vlc.md) · `org.videolan.vlc` — P C (one-click, two-stage changelog) · ✓ src=Vendor · nightly 共享 bundle id，未签名 → **一键永久不可**，检测阻塞于 #93（issue #95）
 - [ ] **Docker** · `com.docker.docker` — P · ⏭ skipped (cask now needs sudo to install)
 - [x] **Raycast** · `com.raycast.macos` — P · ✓ src=Vendor
 - [x] **Alfred** · `com.runningwithcrayons.Alfred` — P · ✓ src=Vendor
@@ -100,6 +100,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] **Stats** · `eu.exelban.Stats` — G (one-click) · ✓ src=GitHub · [audit](eu-exelban-Stats.md)
 - [x] **DBeaver** · `org.jkiss.dbeaver.core.product` — G · ✓ src=GitHub
 - [x] **Beekeeper Studio** · `io.beekeeperstudio.desktop` — G · ✓ src=GitHub
+- [x] [**KeePassXC**](org-keepassxc-keepassxc.md) · `org.keepassxc.keepassxc` — G (one-click) · ✓ src=GitHub · snapshot 共享 bundle id，完全无签名 → **一键永久不可**，检测阻塞于 #93（issue #95）
 - [x] [**Insomnia**](com-insomnia-app.md) · `com.insomnia.app` — G C (one-click) · ✓ src=GitHub · changelog=insomnia.rest(`__NEXT_DATA__` JSON) · 修 stable 跨渠道误推（pattern 加 `$` 锚，2026-06-06）· beta/alpha 受阻于 detect() 不解析 `-beta.N` 后缀
 - [x] **Pearcleaner** · `com.alienator88.Pearcleaner` — G · ✓ src=GitHub
 - [x] **Macs Fan Control** · `com.crystalidea.macsfancontrol` — G · ✓ src=GitHub

--- a/docs/app-audits/org-keepassxc-keepassxc.md
+++ b/docs/app-audits/org-keepassxc-keepassxc.md
@@ -1,0 +1,102 @@
+# KeePassXC
+
+## 基本信息
+- Bundle ID: `org.keepassxc.keepassxc`（stable / snapshot **共享同一 id**）
+- 已验证版本: stable 由 GitHub Releases 覆盖（Team `G2S7P7J672`，公证）；snapshot
+  `2.8.0-snapshot`（build `290601`，2026-08-24，**x86_64-only**）
+- 自更新机制: 无内嵌自更新，本仓库靠 GitHub Releases 检测
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查、**永久**不可行  — = 不适用
+
+|              | Homebrew | GitHub Releases |
+|--------------|----------|------------------|
+| **stable**   | (cask `keepassxc`) | ✓ 检测 + 一键（`org.keepassxc.keepassxc`，Team `G2S7P7J672`，arm64 dmg）|
+| **snapshot** | (cask `keepassxc@snapshot`，Homebrew 已标记 deprecated，计划 2026-09-01 停用) | ○ 检测受阻于 #93；✗ 一键**永久**不可（未签名）|
+
+`keepassxc@beta` 不是独立预发轨——指向的就是 stable 那个包（2.7.12），是别名，不是候选
+（见 `CHANNEL_COVERAGE_TODO.md` §2c）。真正的预发轨是 `keepassxc@snapshot`。
+
+## Channel 详情
+
+| Channel  | Bundle ID | 独立/共享 | 本地渠道标记 | 签名 | 判定 |
+|----------|-----------|----------|-------------|------|------|
+| stable   | `org.keepassxc.keepassxc` | 共享 | — | Team `G2S7P7J672`，公证 | ✓ 已接入 |
+| snapshot | `org.keepassxc.keepassxc` | 共享 | 版本串带 `-snapshot`（`ReleaseChannel.detect()` 目前不识别，见 #93）| **完全无签名** | 检测阻塞于 #93；**一键永久不可**（见下）|
+
+## 为什么 snapshot 只能是 detection-only（issue #95）
+
+来源：#95（2026-08-27 channel sweep §2c 之后单独立项），本次 PR 重新下载真机验证。
+
+### 重新验证：签名（本次实测，非转抄 issue）
+
+下载当日（2026-08-27）最新 snapshot build `KeePassXC-2.8.0-snapshot.dmg`
+（`https://snapshot.keepassxc.org/build-290601/`），SHA-256 与官方 `.DIGEST` 文件
+（`d840649…ca8344`）逐字节核对一致，也与 Homebrew cask 记录的 sha256 一致。挂载后对
+`KeePassXC.app` 跑：
+
+```
+$ codesign -dv --verbose=4 KeePassXC.app
+KeePassXC.app: code object is not signed at all
+
+$ spctl -a -vv KeePassXC.app
+KeePassXC.app: rejected
+source=no usable signature
+```
+
+比 issue 原文更精确一步：这不是"某种弱签名验不过"，是**完全没有签名**
+（`code object is not signed at all`）。`VendorInstaller` 的 gate 2
+（`SignatureVerifier.verifyCodeSignature`，
+`DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift`）第一步就会拒——
+连 Team ID 比对都轮不到。跟 VLC nightly 的 ad-hoc 签名比,这个连"有签名但不认"的阶段
+都没到,拒绝理由更直接。
+
+Homebrew 自己也独立标记了同一结论：`keepassxc@snapshot` cask 被标
+`Deprecated because it does not pass the macOS Gatekeeper check!`，计划 2026-09-01
+停用（本次核查 2026-08-27 的 cask 源码，供佐证，非本仓库验证的替代）。
+
+### 松散尾 —— snapshot 的 x86_64-only dmg：核实为真，无 arm64 替代路径
+
+`lipo -info` 确认这不是 universal 构建：
+
+```
+$ lipo -info KeePassXC.app/Contents/MacOS/KeePassXC
+Non-fat file: …/KeePassXC is architecture: x86_64
+```
+
+Homebrew cask 本身的 `caveats` 也写着 `requires_rosetta`，与这个结果一致。
+
+issue 提的疑点——"`@snapshot` cask 这条 URL 是 x86_64，但**另有路径**存在 arm64 build
+吗"——本次实测排除了：`snapshot.keepassxc.org` 每个 build 目录下**只发布一个 macOS
+产物**（`KeePassXC-2.8.0-snapshot.dmg`），Windows/Linux 侧倒是分了
+`x64.msi`/`x64.zip`/`x86_64.AppImage`，唯独 macOS 没有按架构区分的第二个文件。核了
+当前 build（`build-290601`，2026-08-24）和一个更早的 build（`build-289983`，
+2026-08-09），目录结构一致，没有 arm64 变体。`README.md`（服务器根目录）也只说这是
+"most recent development branch" 的快照，没提多架构。
+
+结论：**arm64 Mac 上想跑 snapshot 只能靠 Rosetta，没有原生 arm64 snapshot 可选**。这
+对检测层的含义（若 #93 落地后真要接检测）：不需要 `hostRequirement` 去"选对架构"——
+因为只有一种架构；但**在 arm64 Mac 上做检测本身要不要有意义**，取决于用户装的到底是
+不是这份 x86_64-only 包在 Rosetta 下跑的（`Info.plist` 不会说"这是 Rosetta 转译的"，
+只会显示 `KernelArchitecture`/`CFBundleExecutable` 都是 x86_64 二进制，AppScanner 现有
+逻辑读的是 bundle 本身的架构，不区分是否在转译层下运行）——这不影响"能不能检测"，
+只是提醒：如果将来做，检测出的版本号对 arm64 用户和 x86_64 用户是同一份东西，不需要
+按 host arch 分流。反正一键不可行，这条对本 issue 没有阻塞意义,只是记下来避免下一个人
+重新查一遍。
+
+## 结论
+
+- **检测**：阻塞于 #93（`detect()` 要认出版本串里的 `-snapshot` 才能把 snapshot 与
+  stable 分开；注意 `ReleaseChannel` 已经把*单词* `snapshot` 映射到 `.preview`,但只在
+  `channelWord`(读 display name)里生效——KeePassXC 的 display name 是干净的
+  "KeePassXC",这条映射对它不触发,是版本串专属信号)。
+- **一键**：**永远不做**。完全无签名，`VendorInstaller` 的签名 gate 第一步就拒。#93
+  落地后如果有人想给 snapshot 接 channel-gated recipe，**不要带 `install:`**——保持
+  detection-only。
+- 详见 issue #95、`CHANNEL_COVERAGE_TODO.md` §2c。
+
+## 建议下一步
+1. #93 落地后，如果决定接 snapshot 检测：只加 `channel: .preview`（或对应枚举）的
+   GitHubReleaseRule 或 VendorProbeRecipe，**省略 `installAssetPattern`/`install:`**。
+2. 不必现在做——这不是本 issue 的范围，本 issue 只是把"一键必拒"这条写下来存档。

--- a/docs/app-audits/org-videolan-vlc.md
+++ b/docs/app-audits/org-videolan-vlc.md
@@ -1,0 +1,119 @@
+# VLC
+
+## 基本信息
+- Bundle ID: `org.videolan.vlc`（stable / nightly **共享同一 id**）
+- 已验证版本: stable 由 VendorProbe 覆盖；nightly `4.0.0-dev`（build `20260827-0413`，arm64）
+- 自更新机制: 内嵌 Sparkle（`SUFeedURL`），但更新决策走本仓库的 VendorProbe recipe，不吃 vendor 自己的 appcast 选型逻辑
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查、**永久**不可行  — = 不适用
+
+|             | Homebrew | VendorProbe |
+|-------------|----------|-------------|
+| **stable**  | (cask `vlc`) | ✓ 检测 + 一键（`org.videolan.vlc`，Team `75GAHG3SZQ`）|
+| **nightly** | (cask `vlc@nightly`，Homebrew 已标记 deprecated，计划 2026-09-01 停用) | ○ 检测受阻于 #93；✗ 一键**永久**不可（未签名）|
+
+当前生效源（stable）: **VendorProbe**，`update.videolan.org/vlc/sparkle/vlc-arm64.xml`。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 本地渠道标记 | 签名 | 判定 |
+|---------|-----------|----------|-------------|------|------|
+| stable  | `org.videolan.vlc` | 共享 | — | Team `75GAHG3SZQ`，公证 | ✓ 已接入 |
+| nightly | `org.videolan.vlc` | 共享 | 版本串带 `-dev`（`ReleaseChannel.detect()` 目前不识别，见 #93） | **未签名** | 检测阻塞于 #93；**一键永久不可**（见下）|
+
+## 为什么 nightly 只能是 detection-only（issue #95）
+
+来源：#95（2026-08-27 channel sweep §2c 之后单独立项），本次 PR 重新下载真机验证。
+
+### 重新验证：签名（本次实测，非转抄 issue）
+
+下载当日（2026-08-27）arm64 nightly `vlc-4.0.0-dev-arm64-54a50fd7.dmg`
+（`https://artifacts.videolan.org/vlc/nightly-macos-arm64/20260827-0413/`），
+SHA-512 与官方 `SHA512SUM` 逐字节核对一致，挂载后对 `VLC.app` 跑：
+
+```
+$ codesign -dv --verbose=4 VLC.app
+Executable=…/VLC.app/Contents/MacOS/VLC
+Identifier=VLC
+Format=app bundle with Mach-O thin (arm64)
+CodeDirectory v=20400 size=540 flags=0x20002(adhoc,linker-signed) hashes=14+0 location=embedded
+…
+Signature=adhoc
+Info.plist=not bound
+TeamIdentifier=not set
+Sealed Resources=none
+Internal requirements=none
+
+$ spctl -a -vv VLC.app
+VLC.app: code has no resources but signature indicates they must be present
+```
+
+`Signature=adhoc` / `TeamIdentifier=not set`：ad-hoc 签名，没有 Developer ID Team。
+`VendorInstaller.applyVerified` 的 gate 2/3
+（`SignatureVerifier.verifyCodeSignature` + `verifyTeamIdentifierMatch`，
+`DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift`）要求下载物的
+Team ID 与已装 app **完全一致**——nightly 的 "not set" 不可能等于 stable 的
+`75GAHG3SZQ`，一键会在 gate 2/3 被拒。这一步与 stable 的一键路径无关、不受 #93 影响：
+即使 #93 落地、`detect()` 认出 `-dev` 后缀，**这条 gate 依然会拒**，只是拒的位置从
+「未检测到」变成「检测到了但装不上」——本 issue 存在的意义就是把这条提前写下来，
+不要等到真的接了 install spec 才在运行时发现。
+
+Homebrew 自己也独立标记了同一结论：`vlc@nightly` cask 被标 `Deprecated because it
+does not pass the macOS Gatekeeper check!`，计划 2026-09-01 停用（本次核查
+2026-08-27 的 cask 源码，供佐证，非本仓库验证的替代）。
+
+### 松散尾 1 —— arm64 nightly 的 `SUFeedURL` 指向 `vlc-intel64.xml`：核实为真错
+
+`VLC.app/Contents/Info.plist` 里：
+
+```
+$ /usr/libexec/PlistBuddy -c "Print :SUFeedURL" VLC.app/Contents/Info.plist
+https://update.videolan.org/vlc/sparkle/vlc-intel64.xml
+```
+
+`lipo -info` 确认这不是 universal 构建，是**纯 arm64** 单架构二进制：
+
+```
+$ lipo -info VLC.app/Contents/MacOS/VLC
+Non-fat file: …/VLC is architecture: arm64
+```
+
+排除了"vendor 就一份 feed 打进所有架构，反正是同一份 Info.plist 模板"的可能——因为
+两份 feed 本身内容并不相同，实测两条 feed 各自 enclosure 都是按架构分列的：
+
+```
+$ curl -sL https://update.videolan.org/vlc/sparkle/vlc-arm64.xml   | grep -oE 'url="[^"]+"' | tail -3
+url="http://get.videolan.org/vlc/3.0.23/macosx/vlc-3.0.23-arm64.dmg"
+$ curl -sL https://update.videolan.org/vlc/sparkle/vlc-intel64.xml | grep -oE 'url="[^"]+"' | tail -3
+url="http://get.videolan.org/vlc/3.0.23/macosx/vlc-3.0.23-intel64.dmg"
+```
+
+本仓库 stable 的 VendorProbe recipe 本身就是靠这个区分选的 `vlc-arm64.xml`
+（`VendorProbeRecipe.swift`）。结论：**这是 vendor 的 nightly 打包脚本把错误的 feed
+URL 烤进了 arm64 build 的 Info.plist，不是"一份 feed 服务所有架构"的正常做法**——
+真错，不是设计。因为 nightly 本来就不可能一键，这个错本身对本仓库没有后果，只是把
+issue 提的疑点坐实。
+
+### 松散尾 2（不适用于 VLC，见 KeePassXC 那份文档）
+
+VLC 没有这条——nightly 的 arm64/x86_64 dmg 是分开发布的两个文件
+（`vlc-4.0.0-dev-arm64-*.dmg` / `vlc-4.0.0-dev-x86_64-*.dmg`，见
+`artifacts.videolan.org/vlc/nightly-macos-{arm64,x86_64}/`），跟 KeePassXC snapshot
+的单一 x86_64-only dmg是两码事。
+
+## 结论
+
+- **检测**：阻塞于 #93（`detect()` 要认出版本串里的 `-dev` 才能把 nightly 与 stable
+  分开）。
+- **一键**：**永远不做**。未签名，`VendorInstaller` 的 Team 闸必拒。#93 落地后如果有人
+  想给 nightly 接 channel-gated recipe，**不要带 `install:`**——保持 detection-only，
+  跟 LibreWolf（`net-librewolf-librewolf.md`）、Wispr Flow 同一模式。
+- 详见 issue #95、`CHANNEL_COVERAGE_TODO.md` §2c。
+
+## 建议下一步
+1. #93 落地后，如果决定接 nightly 检测：只加 `channel: .dev`（或对应枚举）的
+   VendorProbeRecipe，**省略 `install:`**，`downloadURL` 指到 nightly 目录页而不是
+   dmg（对照 `PageURLTests.detectionOnlyRecipesCarryAPage` 的约束）。
+2. 不必现在做——这不是本 issue 的范围，本 issue 只是把"一键必拒"这条写下来存档。


### PR DESCRIPTION
## What

Closes #95. Blocked on #93 (open, not touched here — `ReleaseChannel.swift` untouched per the parallel-PR boundary). This PR is documentation-only plus a registry-derived guard test; no detection or install behavior changes.

VLC nightly (`org.videolan.vlc`, `4.0.0-dev`) and the KeePassXC snapshot (`org.keepassxc.keepassxc`, `2.8.0-snapshot`) both share their bundle id with an already-covered, notarized stable build, but ship **unsigned** themselves. `VendorInstaller`'s Team-ID gate would refuse the swap. The constraint: **never wire an install spec for either, ever.**

## What I re-verified myself (raw commands/output in the two audit docs)

- Downloaded today's (2026-08-27) arm64 VLC nightly from `artifacts.videolan.org`, SHA-512 checked against the vendor's own `SHA512SUM`.
  - `codesign -dv --verbose=4`: `Signature=adhoc`, `TeamIdentifier=not set`.
  - `spctl -a -vv`: rejects.
  - `lipo -info`: confirms it's a genuine single-arch (arm64) Mach-O, not universal.
- Downloaded today's KeePassXC snapshot build (`build-290601`) from `snapshot.keepassxc.org`, SHA-256 checked against the vendor's `.DIGEST` (and it matches the Homebrew cask's recorded sha256).
  - `codesign -dv --verbose=4`: `code object is not signed at all` — stronger than the issue's paraphrase, this is a full absence of signature, not merely "no usable signature" at the spctl layer.
  - `spctl -a -vv`: `rejected / source=no usable signature`.
  - `lipo -info`: confirms x86_64-only.
- Homebrew independently flags both casks `Deprecated because it does not pass the macOS Gatekeeper check!` (disable scheduled 2026-09-01) — cited as corroboration, not as a substitute for the above.

## The two loose ends, settled

- **VLC arm64 nightly's `SUFeedURL` points at `vlc-intel64.xml`** — verified as a **genuine vendor bug**, not "one feed template for every arch": diffed `vlc-arm64.xml` vs `vlc-intel64.xml`'s enclosures and they really do serve arch-distinct dmgs (this repo's own stable VLC recipe relies on that split). The nightly binary is confirmed single-arch arm64 (not universal), so pointing it at the Intel feed is a real misconfiguration in the vendor's nightly build. Has no consequence for us either way since nightly can never be one-click.
- **KeePassXC snapshot arm64 build** — checked `snapshot.keepassxc.org`'s current and an older build directory: only one macOS artifact is ever published per build (no arch suffix, unlike the Windows/Linux artifacts which do split), and `lipo` confirms it's x86_64. Matches the cask's `requires_rosetta` caveat. **No arm64 snapshot exists anywhere** — not a `hostRequirement` gap, just a single-architecture upstream build.

## What's unverified / out of scope

- Whether #93 (`detect()` recognizing `-dev`/`-snapshot` version tails) actually lands as described — that's a separate, parallel PR I did not touch.
- Full `/app-audit`-depth coverage matrices for VLC/KeePassXC stable beyond what's already in the registry — out of scope for this issue.

## Where the constraint lives, and why

- `docs/app-audits/org-videolan-vlc.md`, `docs/app-audits/org-keepassxc-keepassxc.md` — new, following the repo's per-app audit doc convention (modeled on `com-insomnia-app.md`'s "blocked channel" section, since neither app had an audit doc before). Carries the full raw verification output, both loose ends, and the reasoning — this is the artifact meant to survive so nobody re-derives it.
- `CHANNEL_COVERAGE_TODO.md` — cross-linked the §2c VLC/KeePassXC rows to the new docs, and corrected a **stale §3 dead-track entry** I found while reading the ledger: "✗ VLC — Nightly · nightlies rolling build, no version semantics, indistinguishable" is left over from the 2026-06-04 sweep and is now wrong — the 2026-08-27 §2c investigation (and #93) show the version string does carry usable semantics (`-dev`). Left the original line intact and appended a `更正 2026-08-27` correction in the same style the ledger already uses for Raycast, so nobody reads §3 first and wrongly concludes "already investigated, don't reopen."
- One-to-two-line comments at the exact site a future author would paste a nightly/snapshot recipe next to (`VendorProbeRecipe.swift`'s VLC block, `GitHubReleasesSource.swift`'s KeePassXC block) — this is "next to where install specs are declared," per the issue's suggested landing spot.
- `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift` — a small registry-derived test (pattern borrowed from `PageURLTests.detectionOnlyRecipesCarryAPage`): asserts that any non-stable-channel recipe for these two bundle ids in `VendorProbeRegistry`/`GitHubReleaseRegistry` carries no install spec. It passes trivially today (no such recipe exists — detection itself is blocked on #93), but turns into a real, enforced guard the moment someone adds a nightly/snapshot channel entry and reaches for the wrong sibling to copy from (Freelens/kitty/DB Browser nightlies *are* notarized, so copy-paste is a real risk, which is the whole reason this issue exists). I recommend keeping it — it's cheap and converts a written-down constraint into an enforced one rather than relying on the next author reading the doc.

## What I did NOT do

- Did not touch `ReleaseChannel.swift` (owned by the parallel #93 PR).
- Did not add any install spec, `hostRequirement`, or new "detection-only" mechanism — the repo already expresses detection-only by omitting `install:`/`installAssetPattern`, so I used that rather than inventing anything new.

## Verification

```
$ cd DuoUpdaterCore && swift test
━ Test run with 1271 tests in 100 suites passed after 59.382 seconds with 1 known issue.

$ swift test --package-path CLI
✔ Test run with 127 tests in 19 suites passed after 0.065 seconds.
```

(1 known issue is a pre-existing marked xfail, unrelated to this change — not introduced here.)