### PR TITLE
Read DB Browser for SQLite's nightly from its bundle filename

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
@@ -107,6 +107,40 @@ public enum ReleaseChannel: String, Codable, Sendable, Hashable, CaseIterable {
             return .stable
         }
 
+        // 0.6 DB Browser for SQLite — its nightly is the second app whose only
+        //     on-disk channel signal is the BUNDLE FILENAME. It ships the stable
+        //     bundle id (`net.sourceforge.sqlitebrowser`), a clean `CFBundleName`
+        //     ("DB Browser for SQLite" — the scanner's display name, so
+        //     `channelWord` sees no word), and a version that is not a channel
+        //     token. Homebrew's `@nightly` cask installs it as
+        //     "DB Browser for SQLite Nightly.app", alongside stable rather than
+        //     over it (cask artifact read 2026-08-27).
+        //
+        //     Why this matters even though we can never UPDATE a nightly: the
+        //     vendor hardcodes `CFBundleShortVersionString`/`CFBundleVersion` to
+        //     `3.13.99` in the checked-in `src/app.plist`, and has since
+        //     2023-11-11 ("Update version number to 3.13.99 (new nightly)"). The
+        //     build date lives in a separate `BUILD_VERSION` compile define that
+        //     never reaches the plist, which is why even Homebrew has to version
+        //     that cask by the asset date. So a nightly's version never moves and
+        //     no update can be offered for it — but STABLE is covered here with a
+        //     one-click install spec, and a nightly install currently reads as
+        //     `.stable`, which puts it in that recipe's reach. It is masked today
+        //     only by the accident that the frozen `3.13.99` sorts above stable's
+        //     `3.13.1`; the day stable ships 3.14.x the stable dmg starts being
+        //     offered — and installed — over a nightly.
+        //
+        //     Unlike Android Studio above this does NOT return `.stable` in the
+        //     negative case. Android Studio has to, because its other signals are
+        //     actively misleading; DB Browser's are merely absent, so falling
+        //     through keeps the normal path available to a track we have not
+        //     characterised yet (the repo's `continuous` prereleases ship as
+        //     `DB.Browser.for.SQLite-dev-<sha>.dmg` — unverified, see #94).
+        if bundleID == "net.sourceforge.sqlitebrowser",
+           bundleFileName?.lowercased().contains("nightly") == true {
+            return .nightly
+        }
+
         // 1. Keystone's own channel id — authoritative when present.
         if let ks = keystoneChannel?.trimmingCharacters(in: .whitespacesAndNewlines),
            !ks.isEmpty {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
@@ -191,6 +191,63 @@ import Foundation
         keystoneChannel: nil) == .stable)
 }
 
+// MARK: - DB Browser for SQLite nightly: filename is the only signal (issue #94)
+
+/// The nightly ships the STABLE bundle id, a clean `CFBundleName` and a version
+/// that is not a channel token, so the bundle filename is the whole signal.
+/// Filenames from Homebrew's casks, read 2026-08-27:
+/// stable `DB Browser for SQLite.app`, `@nightly` `DB Browser for SQLite Nightly.app`.
+@Test func dbBrowserNightlyChannelFromBundleFilename() {
+    func detect(_ fileName: String) -> ReleaseChannel {
+        ReleaseChannel.detect(
+            name: "DB Browser for SQLite", bundleID: "net.sourceforge.sqlitebrowser",
+            keystoneChannel: nil, version: "3.13.99", bundleFileName: fileName)
+    }
+    #expect(detect("DB Browser for SQLite Nightly.app") == .nightly)
+    #expect(detect("DB Browser for SQLite.app") == .stable)
+    // The version is a frozen placeholder, not a channel token, and must stay
+    // one — 3.13.99 is what BOTH tracks report.
+    #expect(ReleaseChannel.detect(
+        name: "DB Browser for SQLite", bundleID: "net.sourceforge.sqlitebrowser",
+        keystoneChannel: nil, version: "3.13.99") == .stable)
+    // Scoped to this bundle id: another app in a "… Nightly.app" is not swept up
+    // by this rule (it falls through to the ordinary signals).
+    #expect(ReleaseChannel.detect(
+        name: "Some App", bundleID: "com.example.other",
+        keystoneChannel: nil, bundleFileName: "Some App Nightly.app") == .stable)
+}
+
+/// The reason the rule above is worth having, given that a nightly can never be
+/// UPDATED (its version is frozen at `3.13.99`): stable is covered by a real
+/// registry rule that carries a one-click install spec, and without the channel
+/// the nightly install sits squarely in that rule's reach. Drives the REAL
+/// registry entry rather than a fixture, so it cannot drift away from shipping
+/// behaviour.
+@Test func dbBrowserStableRecipeDoesNotReachTheNightly() async throws {
+    let rule = try #require(
+        GitHubReleaseRegistry.rules.first { $0.bundleID == "net.sourceforge.sqlitebrowser" })
+    #expect(rule.channel == .stable)
+    // If this stops being true the cross-channel risk goes away with it, and
+    // this test should be re-read rather than deleted.
+    #expect(rule.installAssetPattern != nil,
+            "stable rule lost its install spec — the hazard this guards has changed")
+
+    let source = GitHubReleasesSource(rules: [rule])
+    let nightly = InstalledApp(
+        name: "DB Browser for SQLite", bundleID: "net.sourceforge.sqlitebrowser",
+        shortVersion: "3.13.99", buildVersion: "3.13.99",
+        path: URL(fileURLWithPath: "/Applications/DB Browser for SQLite Nightly.app"),
+        isMASApp: false, sparkleFeedURL: nil,
+        releaseChannel: ReleaseChannel.detect(
+            name: "DB Browser for SQLite", bundleID: "net.sourceforge.sqlitebrowser",
+            keystoneChannel: nil, version: "3.13.99",
+            bundleFileName: "DB Browser for SQLite Nightly.app"))
+
+    #expect(nightly.releaseChannel == .nightly)
+    // Skipped before any fetch — a network call here would be a bug on its own.
+    #expect(try await source.latestVersion(for: nightly) == nil)
+}
+
 // MARK: - Scanner wires the channel onto InstalledApp
 
 private func makeApp(at dir: URL, name: String, info: [String: Any]) throws -> URL {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
@@ -177,20 +177,6 @@ import Foundation
         keystoneChannel: nil, bundleFileName: "Some App") == .stable)
 }
 
-@Test func plainStableAppsStayStable() {
-    #expect(ReleaseChannel.detect(
-        name: "Google Chrome", bundleID: "com.google.Chrome",
-        keystoneChannel: nil) == .stable)
-    // Channel words embedded in a longer token must NOT trip detection
-    // (word-boundary matching), or we'd skip legitimate stable apps.
-    #expect(ReleaseChannel.detect(
-        name: "Developer Tools", bundleID: "com.example.devtools",
-        keystoneChannel: nil) == .stable)
-    #expect(ReleaseChannel.detect(
-        name: "Betamax", bundleID: "com.example.betamax",
-        keystoneChannel: nil) == .stable)
-}
-
 // MARK: - DB Browser for SQLite nightly: filename is the only signal (issue #94)
 
 /// The nightly ships the STABLE bundle id, a clean `CFBundleName` and a version
@@ -246,6 +232,20 @@ import Foundation
     #expect(nightly.releaseChannel == .nightly)
     // Skipped before any fetch — a network call here would be a bug on its own.
     #expect(try await source.latestVersion(for: nightly) == nil)
+}
+
+@Test func plainStableAppsStayStable() {
+    #expect(ReleaseChannel.detect(
+        name: "Google Chrome", bundleID: "com.google.Chrome",
+        keystoneChannel: nil) == .stable)
+    // Channel words embedded in a longer token must NOT trip detection
+    // (word-boundary matching), or we'd skip legitimate stable apps.
+    #expect(ReleaseChannel.detect(
+        name: "Developer Tools", bundleID: "com.example.devtools",
+        keystoneChannel: nil) == .stable)
+    #expect(ReleaseChannel.detect(
+        name: "Betamax", bundleID: "com.example.betamax",
+        keystoneChannel: nil) == .stable)
 }
 
 // MARK: - Scanner wires the channel onto InstalledApp


### PR DESCRIPTION
Closes #94.

The nightly ships the stable bundle id (`net.sourceforge.sqlitebrowser`), a clean `CFBundleName` ("DB Browser for SQLite") and a version that is not a channel token, so the **bundle filename is the only signal**. Second app in that shape after Android Studio, so this follows the issue's own call and stays a scoped rule rather than becoming a table (that was reserved for a third case).

## The gating question, answered first

The issue says, in bold: *"Check this before writing anything"* — if `3.13.99` never increments, version comparison cannot see a new nightly and the recipe would be pointless. It is a fixed placeholder, and the evidence is upstream rather than inferred from two downloads:

- `src/app.plist` **hardcodes** both `CFBundleShortVersionString` and `CFBundleVersion` to the literal `3.13.99`. Not templated, not substituted.
- `CMakeLists.txt` sets the build date into `BUILD_VERSION`, a compile define consumed by `version.h` — *"only used by the nightly version to add the date of the build"*. It never reaches the plist.
- It has been `3.13.99` since **2023-11-11** (`Update version number to 3.13.99 (new nightly) in master branch`) — about 21 months.
- Independent witness: Homebrew's `db-browser-for-sqlite@nightly` cask versions itself `20260810`, the **asset date**, because the plist version is useless for this.

So the issue's fear is confirmed: **a nightly can never be offered an update.** No recipe here, and none should be added.

## What the issue left out — why detection is still worth doing

The issue frames the version question as deciding whether "the whole recipe would be pointless," and stops there. But there is a second, live reason that has nothing to do with updating the nightly:

**Stable is already covered, with a one-click install spec** (`GitHubReleaseRule` for `net.sourceforge.sqlitebrowser`, `installAssetPattern` + `.dmg`, Team C34AV33YLK). A nightly install reads as `.stable` today, which puts it squarely in that rule's reach.

It is masked right now only by an accident: the frozen `3.13.99` sorts *above* stable's `3.13.1`, so nothing is offered. The day stable ships **3.14.x**, `3.14.0 > 3.13.99` and the stable dmg starts being offered — and one-click installed — over a nightly. That is precisely the cross-channel swap `ReleaseChannel` exists to prevent, and it is dated rather than hypothetical.

`dbBrowserStableRecipeDoesNotReachTheNightly` drives the **real registry rule** end to end and states that hazard directly.

## Design note

Unlike Android Studio's block this does **not** return `.stable` in the negative case. Android Studio has to, because its other signals are actively misleading ("Preview Beta" would mis-resolve through `channelWord`). DB Browser's other signals are merely *absent*, so falling through keeps the ordinary path available to a track we have not characterised yet.

## Verification

```
cd DuoUpdaterCore && swift test
━ Test run with 1271 tests in 99 suites passed after 49.655 seconds with 1 known issue.

swift test --package-path CLI
✔ Test run with 127 tests in 19 suites passed after 0.063 seconds.
```

Both new tests were confirmed to **go red** with the detect rule removed, then restored.

## Not verified

- **The `continuous` track.** The repo also publishes `continuous` prereleases as `DB.Browser.for.SQLite-dev-<sha>.dmg`. I did not download one, so its app filename, bundle id and version are unknown, and it is left explicitly out of scope (noted in the code comment). If it installs under a filename without "nightly", this rule falls through and it still reads as `.stable`.
- I did **not** re-download the nightly dmg. The app filename is corroborated by two independent sources instead — the issue author's own measurement, and Homebrew's `@nightly` cask artifact stanza (`DB Browser for SQLite Nightly.app`, installed alongside stable rather than over it), read 2026-08-27.
- No `CHANGELOG.md` entry: nothing user-visible changes until stable ships 3.14.x, and nobody covered by this repo is running the nightly today.