### PR TITLE
recipes(vscodium): cover VSCodium Insiders

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1148,10 +1148,10 @@ public enum GitHubReleaseRegistry {
             installerKind: .zip),
 
         // VSCodium Insiders — its own repo (VSCodium/vscodium-insiders), its own
-        // bundle id com.vscodium.VSCodiumInsiders. NOT VS Code Insiders
-        // (com.microsoft.VSCodeInsiders, already covered above) — different
-        // product, different cask (`vscodium@insiders` vs
-        // `visual-studio-code@insiders`).
+        // bundle id com.vscodium.VSCodiumInsiders. NOT VS Code Insiders (the
+        // com.microsoft.VSCodeInsiders VendorProbeRecipe in
+        // VendorProbeRecipe.swift) — different product, different cask
+        // (`vscodium@insiders` vs `visual-studio-code@insiders`).
         //
         // Detection needs no `ReleaseChannel` change, but not for the reason it
         // might look like: the bundle id has no `.insiders`/`-insiders` SUFFIX
@@ -1163,18 +1163,21 @@ public enum GitHubReleaseRegistry {
         // `GitHubReleaseRuleTests` pins this against `ReleaseChannel.detect`
         // directly so the assumption can't silently stop holding.
         //
-        // CRUCIAL, same trap as VS Code Insiders above: tags carry the `-insider`
-        // suffix (`1.126.04518-insider`), which IS part of both
-        // CFBundleShortVersionString and CFBundleVersion on the installed app —
-        // verified by downloading the real asset and reading Info.plist directly
-        // (not just trusting the tag). The default pattern
+        // CRUCIAL — this is the SECOND instance of a trap the VS Code Insiders
+        // recipe (VendorProbeRecipe.swift) already hit, not a VSCodium quirk:
+        // tags carry the `-insider` suffix (`1.126.04518-insider`), which IS
+        // part of both CFBundleShortVersionString and CFBundleVersion on the
+        // installed app — verified by downloading the real asset and reading
+        // Info.plist directly (not just trusting the tag). The default pattern
         // `v?([0-9]+(?:\.[0-9]+)+)` stops at the last digit run and drops the
         // suffix; `VersionComparator` then pads the missing 4th component to "0",
         // which outranks the text token "insider" (a numeric component always
-        // beats a textual one), so the bare "1.126.04518" would read as NEWER
-        // than the correctly-suffixed installed version — a permanent phantom
-        // update on an up-to-date install, never resolving. The pattern below
-        // keeps the suffix in the capture so it compares equal instead.
+        // beats a textual one — see VersionComparator.swift), so the bare
+        // "1.126.04518" would read as NEWER than the correctly-suffixed
+        // installed version — a permanent phantom update on an up-to-date
+        // install, never resolving. Any other `-insider`-suffixed product would
+        // hit the same trap; the pattern below keeps the suffix in the capture
+        // so it compares equal instead.
         //
         // x64 asset: unlike the arm64-only pattern above (which is pinned that
         // way regardless of whether an x64 build exists — not touched here),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1147,6 +1147,62 @@ public enum GitHubReleaseRegistry {
             installAssetPattern: #"^VSCodium-darwin-arm64-[0-9.]+\.zip$"#,
             installerKind: .zip),
 
+        // VSCodium Insiders — its own repo (VSCodium/vscodium-insiders), its own
+        // bundle id com.vscodium.VSCodiumInsiders. NOT VS Code Insiders
+        // (com.microsoft.VSCodeInsiders, already covered above) — different
+        // product, different cask (`vscodium@insiders` vs
+        // `visual-studio-code@insiders`).
+        //
+        // Detection needs no `ReleaseChannel` change, but not for the reason it
+        // might look like: the bundle id has no `.insiders`/`-insiders` SUFFIX
+        // (it's the single camelCase component "VSCodiumInsiders", no separator
+        // before "Insiders"), so `detect`'s bundle-id-suffix step does not fire.
+        // What actually resolves it to `.preview` is the display name step: the
+        // installed app's CFBundleName/CFBundleDisplayName is "VSCodium -
+        // Insiders" (confirmed below), and "Insiders" is a standalone word there.
+        // `GitHubReleaseRuleTests` pins this against `ReleaseChannel.detect`
+        // directly so the assumption can't silently stop holding.
+        //
+        // CRUCIAL, same trap as VS Code Insiders above: tags carry the `-insider`
+        // suffix (`1.126.04518-insider`), which IS part of both
+        // CFBundleShortVersionString and CFBundleVersion on the installed app —
+        // verified by downloading the real asset and reading Info.plist directly
+        // (not just trusting the tag). The default pattern
+        // `v?([0-9]+(?:\.[0-9]+)+)` stops at the last digit run and drops the
+        // suffix; `VersionComparator` then pads the missing 4th component to "0",
+        // which outranks the text token "insider" (a numeric component always
+        // beats a textual one), so the bare "1.126.04518" would read as NEWER
+        // than the correctly-suffixed installed version — a permanent phantom
+        // update on an up-to-date install, never resolving. The pattern below
+        // keeps the suffix in the capture so it compares equal instead.
+        //
+        // x64 asset: unlike the arm64-only pattern above (which is pinned that
+        // way regardless of whether an x64 build exists — not touched here),
+        // this repo DOES publish `VSCodium-darwin-x64-<ver>-insider.zip`
+        // alongside the arm64 one (GET /repos/VSCodium/vscodium-insiders/
+        // releases/latest, verified 2026-08-27: both present, 165 assets total,
+        // exactly these 2 match). `GitHubReleaseRule` has no `hostRequirement`
+        // field — that's a `VendorProbeRecipe`-only concept — so no gating is
+        // needed: matching both filenames lets the existing arch-aware
+        // `installableAsset` selection (HostArch) pick the native build.
+        //
+        // One-click: verified 2026-08-27 by downloading the real
+        // VSCodium-darwin-arm64-1.126.04518-insider.zip and reading the
+        // extracted app directly — CFBundleIdentifier
+        // com.vscodium.VSCodiumInsiders, CFBundleShortVersionString/
+        // CFBundleVersion both "1.126.04518-insider", `codesign -dv` shows
+        // TeamIdentifier VC39D2VNQ7 (same team as stable) with a stapled
+        // notarization ticket, and `spctl -a --type execute` returns "accepted,
+        // source=Notarized Developer ID" — passes VendorInstaller's same-Team
+        // gate.
+        GitHubReleaseRule(
+            bundleID: "com.vscodium.VSCodiumInsiders",
+            owner: "VSCodium", repo: "vscodium-insiders",
+            versionPattern: #"^([0-9]+(?:\.[0-9]+)+-insider)$"#,
+            installAssetPattern: #"^VSCodium-darwin-(?:arm64|x64)-[0-9.]+-insider\.zip$"#,
+            installerKind: .zip,
+            channel: .preview),
+
         // balenaEtcher — an arm64 and an x64 dmg ship together (plus darwin zips of
         // the same builds), so the pattern pins the arm64 dmg.
         // One-click: io.balena.etcher, Team 66H43P8FRG, notarized.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
@@ -72,6 +72,28 @@ import Foundation
         name: "Discord", bundleID: "com.hnc.DiscordPTB", keystoneChannel: nil) == .stable)
 }
 
+// VSCodium Insiders ships as bundle id `com.vscodium.VSCodiumInsiders` — like
+// HBuilderX Alpha / Discord PTB above, that's a single glued camelCase
+// component ("VSCodiumInsiders", no separator before "Insiders"), so `detect`'s
+// bundle-id-suffix step (which only fires on a `.`/`-` separated
+// `-insiders`/`.insiders`) does NOT resolve it. What DOES is the display-name
+// step: the installed app's CFBundleName/CFBundleDisplayName is "VSCodium -
+// Insiders" (confirmed 2026-08-27 by downloading the real release asset and
+// reading Info.plist), and "Insiders" is a standalone word there. This is the
+// linchpin GitHubReleasesSource's channel gate needs to route the
+// com.vscodium.VSCodiumInsiders rule to a Preview install rather than skipping
+// it as an unmatched-channel stable one.
+@Test func vscodiumInsidersDisplayNameSignalsPreview() {
+    #expect(ReleaseChannel.detect(
+        name: "VSCodium - Insiders", bundleID: "com.vscodium.VSCodiumInsiders",
+        keystoneChannel: nil) == .preview)
+    // The glued bundle id alone (no separator before "Insiders") does NOT signal
+    // it — a bare "VSCodium" display name would stay stable.
+    #expect(ReleaseChannel.detect(
+        name: "VSCodium", bundleID: "com.vscodium.VSCodiumInsiders",
+        keystoneChannel: nil) == .stable)
+}
+
 @Test func mozillaVersionSuffixSignalsChannel() {
     // FALLBACK path only. A REAL installed Firefox/Thunderbird strips the `b`/`esr`
     // suffix from `CFBundleShortVersionString` (Beta reports "152.0", ESR

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubAssetSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubAssetSelectionTests.swift
@@ -112,6 +112,10 @@ struct GitHubAssetSelectionTests {
          ["opencode-desktop-mac-arm64.dmg", "opencode-desktop-mac-x64.dmg"]),
         (#"^OpenChamber-[0-9.]+-mac-(?:arm64|x64)\.dmg$"#,
          ["OpenChamber-1.4.0-mac-arm64.dmg", "OpenChamber-1.4.0-mac-x64.dmg"]),
+        // VSCodium Insiders: same alternation shape, real 1.126.04518-insider
+        // filenames (verified 2026-08-27 against the live release).
+        (#"^VSCodium-darwin-(?:arm64|x64)-[0-9.]+-insider\.zip$"#,
+         ["VSCodium-darwin-arm64-1.126.04518-insider.zip", "VSCodium-darwin-x64-1.126.04518-insider.zip"]),
         // Anki: `apple`/`intel` rather than arch tokens, so the arm build reads as
         // arch-neutral and only the Intel one is recognised as foreign.
         (#"^anki-[0-9.]+-mac-(apple|intel)\.dmg$"#,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -279,6 +279,66 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
     #expect(!matches("vscodium-cli-darwin-arm64-1.126.04524.tar.gz", "com.vscodium"))
 }
 
+/// VSCodium Insiders — own repo (VSCodium/vscodium-insiders), distinct bundle
+/// id. Fixture is the REAL `/releases/latest` response for tag
+/// `1.126.04518-insider`, verified 2026-08-27 (`GET
+/// /repos/VSCodium/vscodium-insiders/releases/latest`): 165 assets, exactly the
+/// two darwin zips below match, and the tag/asset shapes are what's asserted.
+@Test func vscodiumInsidersRuleKeepsInsiderSuffixInVersion() {
+    // The `-insider` suffix MUST survive extraction — see the registry comment.
+    // A pattern that stopped at the digits (like the default
+    // `v?([0-9]+(?:\.[0-9]+)+)`) would drop it; the trap is pinned separately in
+    // `vscodiumInsidersMissingSuffixWouldBeAPermanentPhantomUpdate` below.
+    #expect(extract("1.126.04518-insider", "com.vscodium.VSCodiumInsiders") == "1.126.04518-insider")
+    // A bare stable-shaped tag (no repo actually publishes this, but the pattern
+    // must not accept it either) is rejected.
+    #expect(extract("1.126.04518", "com.vscodium.VSCodiumInsiders") == nil)
+
+    // Both real darwin assets from the fixture release match…
+    #expect(matches("VSCodium-darwin-arm64-1.126.04518-insider.zip", "com.vscodium.VSCodiumInsiders"))
+    #expect(matches("VSCodium-darwin-x64-1.126.04518-insider.zip", "com.vscodium.VSCodiumInsiders"))
+    // …but the stable build's un-suffixed filename, the CLI tarball, and the
+    // checksum sidecars beside the real asset must not.
+    #expect(!matches("VSCodium-darwin-arm64-1.126.04518.zip", "com.vscodium.VSCodiumInsiders"))
+    #expect(!matches("vscodium-cli-darwin-arm64-1.126.04518-insider.tar.gz", "com.vscodium.VSCodiumInsiders"))
+    #expect(!matches("VSCodium-darwin-arm64-1.126.04518-insider.zip.sha256", "com.vscodium.VSCodiumInsiders"))
+
+    // Insiders' `/releases/latest` returns a non-prerelease object (verified
+    // above), so the rule reads it directly rather than walking the list.
+    #expect(rule("com.vscodium.VSCodiumInsiders").usePrereleases == false)
+    // MUST be channel-gated to `.preview`, or the source's channel gate skips it
+    // for a real Insiders install (same regression class as Zed Preview above).
+    #expect(rule("com.vscodium.VSCodiumInsiders").channel == .preview)
+    #expect(rule("com.vscodium.VSCodiumInsiders").installerKind == .zip)
+}
+
+/// The trap the registry comment and issue #92 call out by name, replayed
+/// through the real comparator rather than asserted by description. Verified
+/// 2026-08-27 against the real downloaded arm64 asset's Info.plist:
+/// CFBundleShortVersionString and CFBundleVersion are both
+/// "1.126.04518-insider" — so this is the actual installed-side string, not a
+/// guess.
+@Test func vscodiumInsidersMissingSuffixWouldBeAPermanentPhantomUpdate() {
+    let installed = "1.126.04518-insider"
+    // What the DEFAULT rule pattern (`v?([0-9]+(?:\.[0-9]+)+)`) would have
+    // extracted from the same real tag — the suffix is gone.
+    let defaultExtracted = VendorProbeRecipe.extractVersion(
+        from: "1.126.04518-insider", pattern: #"v?([0-9]+(?:\.[0-9]+)+)"#)
+    #expect(defaultExtracted == "1.126.04518")
+    // A missing trailing component pads to "0", which OUTRANKS the text token
+    // "insider" (VersionComparator: a numeric component always beats a textual
+    // one) — so the bare remote would forever read as newer than the correctly
+    // suffixed installed version, even though it is the exact same release.
+    #expect(VersionComparator.isNewer(defaultExtracted!, than: installed))
+
+    // The shipping rule's pattern keeps the suffix, so remote == installed
+    // compares equal — no phantom update.
+    let shipping = extract("1.126.04518-insider", "com.vscodium.VSCodiumInsiders")
+    #expect(shipping == installed)
+    #expect(!VersionComparator.isNewer(shipping!, than: installed))
+    #expect(VersionComparator.compare(shipping!, installed) == .orderedSame)
+}
+
 @Test func balenaEtcherRulePinsArm64Dmg() {
     #expect(extract("v2.1.6", "io.balena.etcher") == "2.1.6")
     #expect(matches("balenaEtcher-2.1.6-arm64.dmg", "io.balena.etcher"))
@@ -546,6 +606,7 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
         "io.podmandesktop.PodmanDesktop": "containers/podman-desktop",
         "com.bitwarden.desktop": "bitwarden/clients",
         "com.vscodium": "VSCodium/vscodium",
+        "com.vscodium.VSCodiumInsiders": "VSCodium/vscodium-insiders",
         "io.balena.etcher": "balena-io/etcher",
         "com.intelliscapesolutions.caffeine": "IntelliScape/caffeine",
         "org.godotengine.godot": "godotengine/godot",

--- a/docs/app-audits/com-vscodium-VSCodiumInsiders.md
+++ b/docs/app-audits/com-vscodium-VSCodiumInsiders.md
@@ -1,0 +1,176 @@
+# VSCodium Insiders
+
+审计 2026-08-27,配合 issue #92。
+
+## 基本信息
+
+- Bundle ID: `com.vscodium.VSCodiumInsiders`
+- App 名: `VSCodium - Insiders.app`
+- CFBundleName / CFBundleDisplayName: `VSCodium - Insiders`
+- 官网 / 下载页: https://github.com/VSCodium/vscodium-insiders/releases
+- 观测版本: `CFBundleShortVersionString` = `CFBundleVersion` = `1.126.04518-insider`
+- Team ID: `VC39D2VNQ7`(Baptiste Augrain)—与 stable `com.vscodium` 同一个 Team,
+  `spctl -a --type execute` 判定 `accepted, source=Notarized Developer ID`
+- 与 **VS Code Insiders**(`com.microsoft.VSCodeInsiders`,已接入)是完全不同的产品:
+  不同 bundle id、不同仓库、不同 Homebrew cask(`vscodium@insiders` vs
+  `visual-studio-code@insiders`)。2026-08-27 的渠道扫描一开始把两者混了,这份审计
+  和对应的 recipe 只管 VSCodium 这一支。
+
+以上四项(bundle id / 版本 / Team / notarized)不是抄 issue #92 的原始截图,是本次
+审计重新下载 `VSCodium-darwin-arm64-1.126.04518-insider.zip`(GitHub Releases 原始
+资产,211013018 字节,校验完整后 `ditto` 解包)、直接读 `Info.plist` 和跑
+`codesign -dv` / `spctl -a` 得到的独立结果 —— 与 issue 描述完全吻合,两个独立见证。
+
+## 覆盖矩阵
+
+> ✓ = 已接入 ○ = 可接入(未实现) ✗ = 已调查不可行 — = 不适用
+
+| | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|---|---|---|---|---|---|
+| **preview** | — | ○(未实现) | — | ✓ 一键 | — |
+
+当前生效源:**GitHubReleasesSource**。
+
+- **GitHub** — `VSCodium/vscodium-insiders` 是官方独立仓库,`/releases/latest`
+  直接给出 macOS 资产,不需要猜测端点。本次接入的就是这一条。
+- **Homebrew** — cask `vscodium@insiders` 存在(`CHANNEL_COVERAGE_TODO.md` §2c
+  已列出实测版本 `1.126.04524`,注意 cask 版本号读的是 stable 的构建号规则,当天与
+  GitHub 侧存在滞后窗口),未接入;GitHub 源已经覆盖,没有必要再加一条会退化到同一
+  仓库的重复源。
+- **Sparkle** — VSCodium 系列不走 Sparkle,`Info.plist` 无 `SUFeedURL`。
+- **MAS** — 不在 App Store 分发。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---|---|---|---|---|---|
+| stable | `com.vscodium` | 独立 | — | — | ✓(已有) |
+| preview(Insiders) | `com.vscodium.VSCodiumInsiders` | 独立 | 见下 | `channel: .preview` | ✓ |
+
+**detect() 命中的路径,和 issue 里暗示的不一样。** issue #92 说"distinct bundle id"
+就意味着检测免费,但 bundle id 是单个 camelCase 段 `VSCodiumInsiders`,"Insiders"
+前面没有 `.`/`-` 分隔符,所以 `ReleaseChannel.detect` 里靠**分隔符**识别的
+"`.insiders`/`-insiders` 后缀"那一步根本不触发。真正命中的是**显示名**那一步:
+装机 `CFBundleName`/`CFBundleDisplayName` 是 `"VSCodium - Insiders"`,里面
+"Insiders" 是一个独立词,`channelWord()` 按词边界匹配到它 → `.preview`。这条链路
+用 `ChannelGuardTests.vscodiumInsidersDisplayNameSignalsPreview()` 直接钉住
+(同时钉住"裸 bundle id 不触发"的反例),而不是改 `ReleaseChannel.swift`——按分工
+那个文件本次改动不touch。
+
+## 更新检测
+
+`GitHubReleaseRule`(`DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift`):
+
+```swift
+GitHubReleaseRule(
+    bundleID: "com.vscodium.VSCodiumInsiders",
+    owner: "VSCodium", repo: "vscodium-insiders",
+    versionPattern: #"^([0-9]+(?:\.[0-9]+)+-insider)$"#,
+    installAssetPattern: #"^VSCodium-darwin-(?:arm64|x64)-[0-9.]+-insider\.zip$"#,
+    installerKind: .zip,
+    channel: .preview)
+```
+
+实测(`GET /repos/VSCodium/vscodium-insiders/releases/latest`,2026-08-27):
+
+```
+tag_name: 1.126.04518-insider
+prerelease: false
+165 个 assets,其中 darwin 相关两个:
+  VSCodium-darwin-arm64-1.126.04518-insider.zip
+  VSCodium-darwin-x64-1.126.04518-insider.zip
+```
+
+- **`-insider` 后缀必须留在比较用的版本里 —— 这是本次审计要结的第一个"未验证"。**
+  已验证:装机 `CFBundleShortVersionString`/`CFBundleVersion` 都是
+  `1.126.04518-insider`(见上,读自真实解包的 `Info.plist`)。默认 pattern
+  `v?([0-9]+(?:\.[0-9]+)+)` 会在最后一段数字处停下,吃不到 `-insider`;
+  `VersionComparator` 把「缺失的第 4 段」补成数字 `"0"`,而数字分量恒大于文本分量
+  (`insider` 是文本),于是缺后缀的 `1.126.04518` 会被判定"比装机的
+  `1.126.04518-insider` 新"——**同一个版本被永久读成待更新**,不会随时间自愈。
+  `GitHubReleaseRuleTests.vscodiumInsidersMissingSuffixWouldBeAPermanentPhantomUpdate()`
+  把这条陷阱在真实 `VersionComparator` 上复现了一遍,不是靠注释描述。上面这条 recipe
+  的 pattern 把后缀纳入捕获组,所以 remote == installed 时比较结果是
+  `.orderedSame`,不会有 phantom update。
+- **x64 资产是否存在 —— 第二个"未验证",已用真实响应结清:存在。** 与 stable 那条
+  `installAssetPattern`(只认 arm64,即使 stable 仓库也确实同时发布了
+  `VSCodium-darwin-x64-….zip`——那是既有决定,本次不动)不同,这条 recipe 的 pattern
+  用 `(?:arm64|x64)` 同时匹配两个真实文件名,交给已有的架构感知选择逻辑
+  (`GitHubReleaseRule.installableAsset` + `HostArch`)按本机架构挑正确的一个。
+  `GitHubAssetSelectionTests.selectionIsIndependentOfListOrder` 用真实的两个文件名
+  验证了这一步在正反序下都选对。
+- **issue 把"要不要 `hostRequirement`"作为 x64 问题的落点,这个说法本身有出入,已在
+  代码注释里改写清楚。** `hostRequirement` 是 `VendorProbeRecipe` 独有的字段,
+  `GitHubReleaseRule` 根本没有这个概念——它从来靠 `installAssetPattern` +
+  `installableAsset` 的架构感知选择来处理多架构,不需要额外的宿主门控。所以 x64
+  存在与否影响的只是 pattern 该匹配几个文件名,不涉及"加不加 hostRequirement"这个
+  并不存在的选项。
+
+生产验证(`swift run --package-path CLI duo verify --only vscodium`,针对本
+worktree 构建的 CLI,2026-08-27):
+
+```
+duo verify
+0 vendor probes  2 GitHub rules  0 changelogs
+─────────────────────────────────────────────
+GitHub rule   ✓ 2  ⚠ 0  ✗ 0  ~ 0  - 0
+total          ✓ 2  ⚠ 0  ✗ 0  ~ 0  - 0      2s
+```
+
+`--samples` report(`report.json`)里两条 finding:
+
+```json
+{"bundleID": "com.vscodium.VSCodiumInsiders", "channel": "preview",
+ "version": "1.126.04518-insider", "status": "ok", "warnings": []}
+{"bundleID": "com.vscodium", "channel": "stable",
+ "version": "1.126.04524", "status": "ok", "warnings": []}
+```
+
+全量 `duo verify --samples`(135 vendor probes + 69 GitHub rules + 68
+changelogs,~95s)同一天也跑过一遍:GitHub rule 一栏 `✓ 69 ⚠ 0 ✗ 0`,新增这一条
+包含在 69 里,没有引入新的 warning;仅有的两条 warning(WorkBuddy 的 changelog、
+LibreOffice 的 vendor probe)与本次改动无关,是既有问题。
+
+## Changelog
+
+**未接。** VSCodium 系列(含 stable)目前都没有 `ChangelogRecipe`——上游发行页
+`https://github.com/VSCodium/vscodium-insiders/releases` 本身就是可读的 GitHub
+Releases 页,`downloadURL` 已经指向这里,UI 能直接展示;如果之后要接原生 changelog,
+可以复用 stable 若接入时选的解析方式(目前 stable 同样没有接)。
+
+## 一键安装
+
+- 状态:**已启用**,`kind: .zip`。
+- 产物:`VSCodium-darwin-arm64-1.126.04518-insider.zip` /
+  `VSCodium-darwin-x64-1.126.04518-insider.zip`,按本机架构由
+  `installableAsset` 选择。
+- **Team + notarization 门禁验证**:按 CLAUDE.md 的要求,没有只信任 issue 里的截图,
+  本次审计重新下载了 arm64 资产并现场验证——`codesign -dv` 显示
+  `TeamIdentifier=VC39D2VNQ7`、`Notarization Ticket=stapled`;
+  `spctl -a -vv --type execute` 返回 `accepted, source=Notarized Developer ID`。
+  与已装 `com.vscodium` stable 同一个 Team ID,`VendorInstaller` 的强制同 Team 闸
+  会放行。
+- **`ChannelProofRegistry` 不适用,不是漏做。** 该注册表(以及
+  `channelProofsCoverEveryChannelRecipe` 穷举测试)只扫描
+  `VendorProbeRegistry.recipes`,`GitHubReleaseRule` 从不在它的覆盖范围内——两种
+  recipe 类型的"跨渠道误装"防线是分开设计的。对 `GitHubReleaseRule` 来说,
+  channel 隔离靠的是 stable/preview 从**两个不同的仓库**(`VSCodium/vscodium` vs
+  `VSCodium/vscodium-insiders`)读,不存在共享端点、靠 URL token 区分渠道的那种风险
+  ——`ChannelArtifactProof` 要防的正是"同一个端点被两个渠道共用"的场景,这里根本
+  不成立。
+
+## 已知问题
+
+- stable 的 `installAssetPattern` 是纯 arm64(`^VSCodium-darwin-arm64-…\.zip$`),
+  即使 stable 仓库同一天也在发布 `VSCodium-darwin-x64-….zip`。这是既有状态,本次
+  审计顺带确认了它,但按"外科手术式改动"的要求没有去改——如果要修,应该是
+  `com.vscodium` 那条单独的改动,不属于 #92。
+- 未接 Homebrew 源(`vscodium@insiders` cask 存在但会与 GitHub 源重复,故意不加)。
+
+## 建议下一步
+
+1. 若 VSCodium stable 那条 arm64-only 的 `installAssetPattern` 后续要补 x64,
+   参考本次 insiders 这条的 `(?:arm64|x64)` 写法和对应的
+   `GitHubAssetSelectionTests.multiCandidateCases` 条目。
+2. 若之后要给 VSCodium(stable 或 insiders)接原生 changelog,GitHub Releases 页
+   本身就是候选源。


### PR DESCRIPTION
## Summary

Covers VSCodium Insiders (`com.vscodium.VSCodiumInsiders`, repo
`VSCodium/vscodium-insiders`) via `GitHubReleasesSource`, closing #92.

- New `GitHubReleaseRule` alongside the existing VSCodium stable rule, gated
  `channel: .preview`.
- The `-insider` suffix is kept in the compared version — the default rule
  pattern drops it, and `VersionComparator` would then read a correctly
  up-to-date install as perpetually behind forever (a numeric component
  always outranks a text one, so the missing 4th component reads as "newer"
  than the installed `-insider` tail).
- Install pattern matches both `VSCodium-darwin-arm64-…` and
  `VSCodium-darwin-x64-…` (the repo publishes both), letting the existing
  arch-aware `installableAsset` selection pick the native build. No
  `hostRequirement` — that field belongs to `VendorProbeRecipe`, which
  `GitHubReleaseRule` doesn't have.
- Detection-only vs. one-click: shipped **with** an install spec — Team ID
  and notarization were independently re-verified (see below), matching
  stable's Team.

## What issue #92 got right, what it left out

Right: the `-insider` suffix trap (correctly flagged as needing the same fix
as VS Code Insiders' recipe), and that this is a different product from VS
Code Insiders.

Left out / stated imprecisely:

- **"Distinct bundle id" is why the issue says detection is free — that's not
  quite the mechanism.** `com.vscodium.VSCodiumInsiders` is one glued
  camelCase bundle-id component; there's no `.`/`-` separator before
  "Insiders", so `ReleaseChannel.detect`'s bundle-id-suffix step does **not**
  fire on it. What actually resolves the install to `.preview` is the
  **display-name** step: the installed app's `CFBundleName`/
  `CFBundleDisplayName` is `"VSCodium - Insiders"`, and "Insiders" is a
  standalone word there. Detection does work without touching
  `ReleaseChannel.swift` (per instructions, not touched) — but via a
  different path than the issue implies. Pinned with a dedicated test
  (`ChannelGuardTests.vscodiumInsidersDisplayNameSignalsPreview`), not a code
  change.
- **The x64 question was framed as "does this need a `hostRequirement`" —
  that field doesn't exist on the recipe type this app uses.**
  `hostRequirement` is `VendorProbeRecipe`-only. `GitHubReleaseRule` has no
  such field; it already does arch-aware asset selection via
  `installAssetPattern` + `installableAsset`. The real question the x64
  finding settles is just how broad the pattern should be — confirmed x64
  **does** exist in this repo (unlike the arm64-only stable rule, which is a
  pre-existing, unrelated gap — noted in the audit doc, not touched here).

## Verified (commands + real output below)

**Real GitHub API**, `GET /repos/VSCodium/vscodium-insiders/releases/latest`:
tag `1.126.04518-insider`, `prerelease: false`, 165 assets including both
`VSCodium-darwin-arm64-1.126.04518-insider.zip` and
`VSCodium-darwin-x64-1.126.04518-insider.zip`.

**Real downloaded asset** (arm64 zip, 211013018 bytes, verified complete —
first attempt truncated at 201292079 bytes, a known local-proxy-chokes-on-
large-files trap; resumed with `Range` requests to completion), extracted and
inspected directly rather than trusting the issue's screenshot:

```
$ /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" ".../Info.plist"
com.vscodium.VSCodiumInsiders
$ /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" ".../Info.plist"
1.126.04518-insider
$ /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" ".../Info.plist"
1.126.04518-insider
$ /usr/libexec/PlistBuddy -c "Print :CFBundleName" ".../Info.plist"
VSCodium - Insiders

$ codesign -dv --verbose=4 "VSCodium - Insiders.app"
...
Authority=Developer ID Application: Baptiste Augrain (VC39D2VNQ7)
TeamIdentifier=VC39D2VNQ7
Notarization Ticket=stapled

$ spctl -a -vv --type execute "VSCodium - Insiders.app"
.../VSCodium - Insiders.app: accepted
source=Notarized Developer ID
```

Second, independent witness: `VSCodium/vscodium`'s own `prepare_vscode.sh`
(fetched from GitHub) sets, for `VSCODE_QUALITY=insider`:
`darwinBundleIdentifier = com.vscodium.VSCodiumInsiders`,
`nameShort = nameLong = "VSCodium - Insiders"` — matches the extracted
Info.plist exactly.

**`cd DuoUpdaterCore && swift test`** (full suite, not just the new tests):

```
✔ Test run with 1272 tests in 99 suites passed after 46.023 seconds with 1 known issue.
```

(The 1 known issue is `ankiZeroPaddedTagComparesEqualToInstalled`'s
pre-existing `withKnownIssue`, unrelated to this change.)

**`swift test --package-path CLI`**:

```
✔ Test run with 127 tests in 19 suites passed after 0.064 seconds.
```

**Red before green**: `GitHubReleaseRuleTests.vscodiumInsidersMissingSuffixWouldBeAPermanentPhantomUpdate`
replays the trap through the real `VersionComparator` — asserts the default
pattern extracts `"1.126.04518"` (suffix dropped) from the real tag, and that
`VersionComparator.isNewer("1.126.04518", than: "1.126.04518-insider")` is
`true` (the bug), then asserts the shipping pattern keeps the suffix and
compares `.orderedSame` (the fix).

**`swift run --package-path CLI duo verify --only vscodium --samples`**
(worktree-built CLI, not the stale installed one), live against the real
endpoint:

```
duo verify
0 vendor probes  2 GitHub rules  0 changelogs
─────────────────────────────────────────────
GitHub rule   ✓ 2  ⚠ 0  ✗ 0  ~ 0  - 0
total          ✓ 2  ⚠ 0  ✗ 0  ~ 0  - 0      2s
```

report.json:
```json
{"bundleID": "com.vscodium.VSCodiumInsiders", "channel": "preview", "version": "1.126.04518-insider", "status": "ok", "warnings": []}
{"bundleID": "com.vscodium", "channel": "stable", "version": "1.126.04524", "status": "ok", "warnings": []}
```

**Full `duo verify --samples`** (135 vendor probes + 69 GitHub rules + 68
changelogs, ~95s) — GitHub rule column `✓ 69 ⚠ 0 ✗ 0`; the new rule is among
the 69 and introduces no new warnings. The only 2 warnings in the whole sweep
(WorkBuddy changelog, LibreOffice vendor-probe scheme mismatch) are
pre-existing and unrelated.

## Not verified / explicitly out of scope

- **Whether `vscodium@insiders`'s Homebrew cask lags the GitHub feed** the
  way `CHANNEL_COVERAGE_TODO.md` notes for other casks — not relevant since
  Homebrew isn't the source used here, but flagged in the audit doc as
  未验证 rather than silently assumed current.
- **VSCodium stable's arm64-only `installAssetPattern`**, despite the stable
  repo also publishing an x64 zip (confirmed live during this investigation)
  — pre-existing, unrelated to #92, not touched (surgical diff). Noted in
  the audit doc's "已知问题" / "建议下一步" for a future separate PR.
- No `ChannelArtifactProof` entry was added — verified `ChannelProofRegistry`
  and its exhaustiveness test (`channelProofsCoverEveryChannelRecipe`) only
  scan `VendorProbeRegistry.recipes`, never `GitHubReleaseRule`, so there is
  no such registry slot for this recipe type. Documented in the audit doc
  rather than silently skipped.

## Files

- `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift`
  — the new rule.
- `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift`,
  `GitHubAssetSelectionTests.swift`, `ChannelGuardTests.swift` — regression
  coverage (extraction, asset selection incl. order-independence, channel
  detection, and the phantom-update trap replayed through the real
  comparator).
- `docs/app-audits/com-vscodium-VSCodiumInsiders.md` — full audit.

Closes #92
