### PR TITLE
Add Termius Beta VendorProbe recipe, correct #91's coverage claim

### DIFF
--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -32,6 +32,7 @@
 | **Discord** | ptb `com.hnc.DiscordPTB` · canary `com.hnc.DiscordCanary` | VendorProbe |
 | **HBuilderX** | alpha `io.dcloud.HBuilderXAlpha` | VendorProbe |
 | **Zed** | preview `dev.zed.Zed-Preview`（`channel: .preview`，2026-06-04 修 channel-gate 回归）| GitHub |
+| **Termius** | beta `com.termius-beta.mac`（issue #91，2026-08-27）| VendorProbe |
 
 ### Pattern A\* — 共享 bundle id，但 Mozilla `RemotingName` 可检测
 
@@ -221,17 +222,16 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 `status: up-to-date` / latest == installed —— `SparkleAppcastSource` 会从**装机构建反推**
 `<sparkle:channel>`，beta 条目没被滤掉。**不需要 ChannelBinding，勿重开。**
 
-### Pattern A 未覆盖 —— 四个（本机装了 stable，未装对应渠道）
+### Pattern A 未覆盖 —— 三个（`termius@beta` 已接，见 §1）
 
 | cask 变体 | 装出来的 app | 本机 stable |
 |---|---|---|
 | `postman@canary` | `PostmanCanary.app` | Postman 12.25.6 |
-| `termius@beta` | `Termius Beta.app` | Termius 9.43.1 |
 | `db-browser-for-sqlite@nightly` | `DB Browser for SQLite Nightly.app` | 3.13.1 |
 | `vscodium@insiders` | `VSCodium - Insiders.app` | 1.126.04524 |
 
 → 各自 `/app-audit`，但**都得先装一份对应渠道的包**才能拿到 bundle id 和版本方案，
-否则只是猜。四个都不急。
+否则只是猜。三个都不急。
 
 ### 同 bundle id + `@channel` cask —— 七个（渠道在**下载时**选，不是 app 内切）
 
@@ -294,8 +294,12 @@ DB Browser 是 Developer ID 公证的，VLC 和 KeePassXC **完全没签名** �
 
 ### 排序建议
 
-1. **Termius Beta**、**VSCodium Insiders** —— 独立 id、已公证，最省事。但注意 Termius
-   **stable 本身也还没覆盖**（`com.termius.mac` 不在任何 registry 里），那是另一个缺口。
+1. **Termius Beta** —— 已接（issue #91，2026-08-27，`docs/app-audits/com-termius-dmg-mac.md`）。
+   当时这里写「stable 本身也还没覆盖（`com.termius.mac` 不在任何 registry 里）」是
+   **错的**：`com.termius.mac` 是 MAS 沙盒购买副本，装机验证 `MacAppStoreSource`
+   通用覆盖，不需要 registry；真正的官网 dmg stable 是 `com.termius-dmg.mac`，
+   2026-08-16 已经在 `VendorProbeRecipe` 里注册，只是当时没人把两个 bundle id
+   对上号。**VSCodium Insiders** —— 独立 id、已公证，最省事，仍待接。
 2. **DB Browser nightly** —— 需要文件名检测，有 Android Studio 的现成范式。
 3. **Freelens / VLC / KeePassXC** —— 要先给 `detect()` 加版本串规则；后两者只能检测不能一键。
 4. **UTM / kitty** —— 归入 §3 死轨，本地无信号。

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -160,6 +160,10 @@ public enum ChannelProofRegistry {
         // cross-train resolve fails closed rather than silently succeeding.
         ChannelProofKey("com.longbridge.app.desktop.preview", .preview):
             .artifact(#"/longbridge-desktop/preview/"#),
+        // Termius Beta already has an independent bundle id (`com.termius-beta.mac`
+        // vs stable's `com.termius-dmg.mac`), so this is belt-and-suspenders: the
+        // resolved install URL's own path names the channel.
+        ChannelProofKey("com.termius-beta.mac", .beta): .artifact(#"/mac-beta-universal/"#),
     ]
 
     /// Every `(bundleID, channel)` in the vendor registry that carries an install

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -3805,6 +3805,53 @@ public enum VendorProbeRegistry {
                     URL(string: "https://autoupdate.termius.com/mac-arm64/Termius.dmg")!),
                 kind: .dmg)),
 
+        // Termius Beta — a genuinely independent bundle id from stable's
+        // `com.termius-dmg.mac` (issue #91), so no cross-channel risk and
+        // `ReleaseChannel.detect()` needs no new rule: `CFBundleName`/
+        // `CFBundleDisplayName` is "Termius Beta", which its existing
+        // standalone-word `channelWord` step already resolves to `.beta`.
+        //
+        // Same electron-builder feed shape as stable, on the SAME
+        // autoupdate.termius.com host stable already probes, just under the
+        // mac-beta-universal path — found by reading the vendor's own Homebrew
+        // cask (`Casks/t/termius.rb`), whose `livecheck` block points
+        // electron_builder-strategy readers at
+        // `https://autoupdate.termius.com/mac/latest-mac.yml` (stable's
+        // un-suffixed, Intel-only sibling of the arm64 feed above) — that is
+        // what led here, since the app's own bundled `app-update.yml` names an
+        // `acl: private` S3 bucket that a plain GET can't read (403, verified).
+        //
+        // Verified 2026-08-27 by downloading and mounting the real dmg:
+        // com.termius-beta.mac, 9.43.1, Team 6KN952WR85, Notarized Developer
+        // ID, not sandboxed — same Team as stable, so `VendorInstaller`'s Team
+        // gate holds. Unlike the arm64-only stable recipe above, this feed's
+        // dmg is confirmed UNIVERSAL (`lipo -info` on the downloaded artifact:
+        // x86_64 arm64), so one recipe correctly serves every Mac with no
+        // `hostRequirement` needed.
+        //
+        // checksumPattern is safe here — unlike Signal Beta, whose CDN staples
+        // the dmg AFTER electron-builder computed the feed's sha512 (see the
+        // comment on Signal's recipe above), Termius Beta's declared
+        // `sha512` for "Termius Beta.dmg" was independently verified
+        // 2026-08-27 to equal `shasum -a 512 | base64` of the downloaded file,
+        // byte for byte.
+        //
+        // No changelogURL: `https://termius.com/release-notes` (stable's own
+        // changelogURL, above) 404s as of 2026-08-27 and no replacement page
+        // exists in the vendor's sitemap — flagged separately, not fixed here.
+        VendorProbeRecipe(
+            bundleID: "com.termius-beta.mac",
+            url: URL(string: "https://autoupdate.termius.com/mac-beta-universal/latest-mac.yml")!,
+            mode: .responseBody,
+            versionPattern: #"^version:\s*([0-9][^\s]*)"#,
+            downloadURL: URL(string: "https://termius.com/beta-program"),
+            install: VendorInstallSpec(
+                urlSource: .fixed(
+                    URL(string: "https://autoupdate.termius.com/mac-beta-universal/Termius%20Beta.dmg")!),
+                kind: .dmg,
+                checksumPattern: #"Termius Beta\.dmg\s*\n\s*sha512:\s*([A-Za-z0-9+/=]+)"#),
+            channel: .beta),
+
         // Unity Hub — electron-builder feed. Despite the "Setup" in the asset
         // name this zip is NOT a stub installer: it expands to `Unity Hub.app`
         // itself (com.unity3d.unityhub, 3.20.1, Team 9QW8UQUTAA, notarized),

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TermiusProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TermiusProbeRecipeTests.swift
@@ -1,0 +1,225 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Termius stable + beta (issue #91).
+///
+/// Stable (`com.termius-dmg.mac`) was already registered before this issue was
+/// filed — the issue's own claim that Termius stable is "in no registry at all"
+/// checked the Mac App Store bundle id (`com.termius.mac`, generically covered by
+/// `MacAppStoreSource`, no registry entry needed) rather than the direct-download
+/// build's real bundle id. This file covers what the issue actually left
+/// unstarted: Beta, an independent bundle id (`com.termius-beta.mac`).
+///
+/// Every expectation below is checked against response bodies captured verbatim
+/// from the vendor on 2026-08-27:
+///   - `https://autoupdate.termius.com/mac-beta-universal/latest-mac.yml` (Beta,
+///     the feed the new recipe reads)
+///   - `https://autoupdate.termius.com/mac-arm64/latest-mac.yml` (Stable, the feed
+///     the pre-existing recipe reads — kept here only to show the two feeds are
+///     genuinely independent, not to re-test the stable recipe itself)
+struct TermiusProbeRecipeTests {
+
+    private static let stableBundleID = "com.termius-dmg.mac"
+    private static let betaBundleID = "com.termius-beta.mac"
+
+    /// `https://autoupdate.termius.com/mac-beta-universal/latest-mac.yml`,
+    /// 2026-08-27.
+    private static let betaBody = """
+        version: 9.43.1
+        files:
+          - url: Termius Beta.zip
+            sha512: 08ovSDodx5wGBfp/vLCwf49uVACJ9Xj95aPgn7Lm+Z0exazThLdCOVf/LwrRF4hjY+lBUzm4l45lG8rk6D9cLQ==
+            size: 239947907
+          - url: Termius Beta.dmg
+            sha512: Eo4XFtmNeDRfMA9X9N2yw2jHf7TS2o2GH4pbIbWpl2qEYBoXb7CIgIdQlLRzUb38LXO59/xUciQXgwuExlBE+w==
+            size: 249396295
+        path: Termius Beta.zip
+        sha512: 08ovSDodx5wGBfp/vLCwf49uVACJ9Xj95aPgn7Lm+Z0exazThLdCOVf/LwrRF4hjY+lBUzm4l45lG8rk6D9cLQ==
+        releaseDate: '2026-08-12T07:56:45.216Z'
+        rollout:
+          freeUsers: 100
+          paidUsers: 100
+        """
+
+    /// `https://autoupdate.termius.com/mac-arm64/latest-mac.yml` (Stable's own
+    /// feed), same day — proof the two channels read genuinely separate
+    /// endpoints, not a shared one filtered by tag.
+    private static let stableBody = """
+        version: 9.43.1
+        files:
+          - url: Termius.zip
+            sha512: w3b8pZD4Hb8fp4mqdKq2bOH4jp6k7T1WEpVJH8WivQoCM3dyluI8M0agiPxvy/NE97WOYIh0/kmPBjXQQ4r6PA==
+            size: 162402204
+          - url: Termius.dmg
+            sha512: wwEhambXFuGGS9kTTYjWiMvFXyOkJu+mSs/1noudKnu5yttsTDowQsCbS1E/cTK0nPBleKBj/nsbOYYNWqBY4A==
+            size: 169439149
+        path: Termius.zip
+        sha512: w3b8pZD4Hb8fp4mqdKq2bOH4jp6k7T1WEpVJH8WivQoCM3dyluI8M0agiPxvy/NE97WOYIh0/kmPBjXQQ4r6PA==
+        releaseDate: '2026-08-12T08:11:47.041Z'
+        rollout:
+          freeUsers: 100
+          paidUsers: 100
+        """
+
+    /// `CFBundleShortVersionString` of `Termius Beta.app`, read off the mounted
+    /// dmg (`https://autoupdate.termius.com/mac-beta-universal/Termius%20Beta.dmg`,
+    /// same day the bodies above were captured).
+    private static let installedBetaShortVersion = "9.43.1"
+
+    /// `shasum -a 512 Termius\ Beta.dmg | base64`, computed on the SAME downloaded
+    /// bytes the mount above verified — confirms the feed's declared sha512 is not
+    /// stale relative to what the CDN actually serves (unlike Signal Beta, whose
+    /// CDN staples the dmg after electron-builder wrote the feed).
+    private static let expectedBetaChecksum =
+        "Eo4XFtmNeDRfMA9X9N2yw2jHf7TS2o2GH4pbIbWpl2qEYBoXb7CIgIdQlLRzUb38LXO59/xUciQXgwuExlBE+w=="
+
+    private static func betaRecipe() throws -> VendorProbeRecipe {
+        let recipes = VendorProbeRegistry.recipes.filter { $0.bundleID == betaBundleID }
+        #expect(recipes.count == 1, "Termius Beta should have exactly one recipe")
+        return try #require(recipes.first)
+    }
+
+    // MARK: - registry shape
+
+    /// Two bundle ids, two recipes, one each — no accidental duplicate and no
+    /// channel collision (each reads its own feed, on its own bundle id).
+    @Test func termiusHasOneStableAndOneBetaRecipe() throws {
+        let stable = VendorProbeRegistry.recipes.filter { $0.bundleID == Self.stableBundleID }
+        let beta = VendorProbeRegistry.recipes.filter { $0.bundleID == Self.betaBundleID }
+        #expect(stable.count == 1)
+        #expect(beta.count == 1)
+        #expect(try #require(stable.first).channel == .stable)
+        #expect(try #require(beta.first).channel == .beta)
+        #expect(Self.stableBundleID != Self.betaBundleID,
+                "Pattern A: distinct bundle ids, so ReleaseChannel.detect() needs no new rule")
+    }
+
+    @Test func betaRecipeIsAResponseBodyRecipeWithNoHostRequirement() throws {
+        let recipe = try Self.betaRecipe()
+        if case .responseBody = recipe.mode {} else {
+            Issue.record("\(recipe.bundleID) is not a body-parsing recipe")
+        }
+        // Verified 2026-08-27 by `lipo -info` on the downloaded dmg: x86_64 arm64.
+        // A universal artifact needs no VendorHostRequirement gate.
+        #expect(recipe.hostRequirement == nil)
+        #expect(recipe.variant == nil)
+        #expect(recipe.identities.isEmpty && recipe.track == nil)
+    }
+
+    /// Same host stable already probes (`autoupdate.termius.com`), different path
+    /// — found via the vendor's own Homebrew cask `livecheck` block, not guessed.
+    @Test func theBetaProbeReadsItsOwnPathOnTheSameHost() throws {
+        let recipe = try Self.betaRecipe()
+        #expect(recipe.url.absoluteString
+            == "https://autoupdate.termius.com/mac-beta-universal/latest-mac.yml")
+        #expect(recipe.url.host() == "autoupdate.termius.com")
+    }
+
+    // MARK: - the version
+
+    @Test func theBetaVersionComesFromTheRealFeed() throws {
+        let recipe = try Self.betaRecipe()
+        let version = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.betaBody, pattern: recipe.versionPattern))
+        #expect(version == Self.installedBetaShortVersion)
+        #expect(VersionComparator.compare(version, Self.installedBetaShortVersion)
+            == .orderedSame,
+            "an up-to-date Termius Beta would be shown a phantom update")
+        #expect(!recipe.versionIsBuild)
+    }
+
+    /// The beta pattern must not silently also read stable's own feed — not a
+    /// cross-channel risk here (different bundle ids gate which recipe even
+    /// applies), but a broken pattern that happened to read ANY version-shaped
+    /// text would hide a real breakage. Both feeds report 9.43.1 today, which is
+    /// exactly the coincidence the issue flagged as worth re-checking later.
+    @Test func bothFeedsAgreeTodayButAreReadIndependently() throws {
+        let recipe = try Self.betaRecipe()
+        let betaVersion = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.betaBody, pattern: recipe.versionPattern))
+        let stableVersion = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: recipe.versionPattern))
+        #expect(betaVersion == stableVersion, "true today — 9.43.1 on both tracks")
+        #expect(recipe.url != VendorProbeRegistry.recipes
+            .first { $0.bundleID == Self.stableBundleID }?.url,
+            "the two channels must never share one endpoint")
+    }
+
+    // MARK: - the install artifact
+
+    @Test func theInstallResolvesTheFixedUniversalDMG() throws {
+        let recipe = try Self.betaRecipe()
+        let spec = try #require(recipe.install)
+        guard case .fixed(let url) = spec.urlSource else {
+            Issue.record("\(recipe.bundleID) install is not a fixed URL")
+            return
+        }
+        #expect(url.absoluteString
+            == "https://autoupdate.termius.com/mac-beta-universal/Termius%20Beta.dmg")
+        #expect(spec.kind == .dmg)
+    }
+
+    /// The checksum line belongs to the dmg, not the zip listed just above it in
+    /// the same document — and it matches bytes actually downloaded, not merely
+    /// the feed's own internal consistency.
+    @Test func theChecksumMatchesTheDownloadedDMGBytes() throws {
+        let recipe = try Self.betaRecipe()
+        let pattern = try #require(recipe.install?.checksumPattern)
+        let digest = try #require(
+            VendorProbeRecipe.extractVersion(from: Self.betaBody, pattern: pattern))
+        #expect(digest == Self.expectedBetaChecksum)
+        #expect(digest != "08ovSDodx5wGBfp/vLCwf49uVACJ9Xj95aPgn7Lm+Z0exazThLdCOVf/LwrRF4hjY+lBUzm4l45lG8rk6D9cLQ==",
+                "that is the zip's digest")
+        #expect(Data(base64Encoded: digest)?.count == 64, "not a 512-bit digest")
+    }
+
+    // MARK: - channel proof (mandatory: this recipe carries a non-stable install)
+
+    @Test func theChannelProofMatchesTheResolvedInstallURL() throws {
+        let key = ChannelProofKey(Self.betaBundleID, .beta)
+        let proof = try #require(ChannelProofRegistry.proofs[key])
+        guard case .artifact(let pattern) = proof else {
+            Issue.record("expected an .artifact proof for \(key)")
+            return
+        }
+        let recipe = try Self.betaRecipe()
+        guard case .fixed(let url) = recipe.install?.urlSource else {
+            Issue.record("install spec is not .fixed")
+            return
+        }
+        #expect(url.absoluteString.range(
+            of: pattern, options: [.regularExpression, .caseInsensitive]) != nil)
+        // And the guard is not vacuous: stable's own resolved URL must NOT match
+        // the beta proof.
+        #expect(Self.stableInstallURL().range(
+            of: pattern, options: [.regularExpression, .caseInsensitive]) == nil,
+            "the beta proof must not also match stable's installer")
+    }
+
+    private static func stableInstallURL() -> String {
+        guard let stable = VendorProbeRegistry.recipes.first(where: { $0.bundleID == stableBundleID }),
+              case .fixed(let url) = stable.install?.urlSource
+        else { return "" }
+        return url.absoluteString
+    }
+
+    // MARK: - detection needs no new rule (the issue's own claim, checked directly)
+
+    /// `CFBundleName`/`CFBundleDisplayName` is "Termius Beta" — the issue's claim
+    /// that `ReleaseChannel.detect()` resolves this via the standalone-word
+    /// `channelWord` step with no new rule, checked against the real function
+    /// rather than taken on faith. This is NOT a change to `ReleaseChannel.swift`
+    /// (untouched by this PR) — just a test of its existing behaviour.
+    @Test func detectResolvesTermiusBetaFromItsDisplayNameAlone() {
+        let channel = ReleaseChannel.detect(
+            name: "Termius Beta", bundleID: Self.betaBundleID, keystoneChannel: nil)
+        #expect(channel == .beta)
+    }
+
+    @Test func detectLeavesStableAlone() {
+        let channel = ReleaseChannel.detect(
+            name: "Termius", bundleID: Self.stableBundleID, keystoneChannel: nil)
+        #expect(channel == .stable)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TermiusProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TermiusProbeRecipeTests.swift
@@ -11,13 +11,11 @@ import Foundation
 /// build's real bundle id. This file covers what the issue actually left
 /// unstarted: Beta, an independent bundle id (`com.termius-beta.mac`).
 ///
-/// Every expectation below is checked against response bodies captured verbatim
-/// from the vendor on 2026-08-27:
-///   - `https://autoupdate.termius.com/mac-beta-universal/latest-mac.yml` (Beta,
-///     the feed the new recipe reads)
-///   - `https://autoupdate.termius.com/mac-arm64/latest-mac.yml` (Stable, the feed
-///     the pre-existing recipe reads — kept here only to show the two feeds are
-///     genuinely independent, not to re-test the stable recipe itself)
+/// Every expectation below is checked against the Beta response body captured
+/// verbatim from the vendor on 2026-08-27:
+/// `https://autoupdate.termius.com/mac-beta-universal/latest-mac.yml`. The
+/// pre-existing stable recipe is referenced only by its registered URL/install
+/// spec (never re-fetched or re-tested here) to confirm Beta doesn't share it.
 struct TermiusProbeRecipeTests {
 
     private static let stableBundleID = "com.termius-dmg.mac"
@@ -37,26 +35,6 @@ struct TermiusProbeRecipeTests {
         path: Termius Beta.zip
         sha512: 08ovSDodx5wGBfp/vLCwf49uVACJ9Xj95aPgn7Lm+Z0exazThLdCOVf/LwrRF4hjY+lBUzm4l45lG8rk6D9cLQ==
         releaseDate: '2026-08-12T07:56:45.216Z'
-        rollout:
-          freeUsers: 100
-          paidUsers: 100
-        """
-
-    /// `https://autoupdate.termius.com/mac-arm64/latest-mac.yml` (Stable's own
-    /// feed), same day — proof the two channels read genuinely separate
-    /// endpoints, not a shared one filtered by tag.
-    private static let stableBody = """
-        version: 9.43.1
-        files:
-          - url: Termius.zip
-            sha512: w3b8pZD4Hb8fp4mqdKq2bOH4jp6k7T1WEpVJH8WivQoCM3dyluI8M0agiPxvy/NE97WOYIh0/kmPBjXQQ4r6PA==
-            size: 162402204
-          - url: Termius.dmg
-            sha512: wwEhambXFuGGS9kTTYjWiMvFXyOkJu+mSs/1noudKnu5yttsTDowQsCbS1E/cTK0nPBleKBj/nsbOYYNWqBY4A==
-            size: 169439149
-        path: Termius.zip
-        sha512: w3b8pZD4Hb8fp4mqdKq2bOH4jp6k7T1WEpVJH8WivQoCM3dyluI8M0agiPxvy/NE97WOYIh0/kmPBjXQQ4r6PA==
-        releaseDate: '2026-08-12T08:11:47.041Z'
         rollout:
           freeUsers: 100
           paidUsers: 100
@@ -129,18 +107,18 @@ struct TermiusProbeRecipeTests {
         #expect(!recipe.versionIsBuild)
     }
 
-    /// The beta pattern must not silently also read stable's own feed — not a
-    /// cross-channel risk here (different bundle ids gate which recipe even
-    /// applies), but a broken pattern that happened to read ANY version-shaped
-    /// text would hide a real breakage. Both feeds report 9.43.1 today, which is
-    /// exactly the coincidence the issue flagged as worth re-checking later.
-    @Test func bothFeedsAgreeTodayButAreReadIndependently() throws {
+    /// The two channels must never share one endpoint — not a cross-channel risk
+    /// here (different bundle ids gate which recipe even applies), but a copied
+    /// URL would mean Beta silently started reading Stable's feed.
+    ///
+    /// NOT asserted here: that the two feeds report the same version. Both read
+    /// 9.43.1 as of 2026-08-27 (see the audit doc), which is a fact about that
+    /// day's vendor state, not an invariant of the recipe — the issue itself
+    /// flagged it as "worth re-checking when they diverge". Pinning that
+    /// equality here would turn the normal, expected day the tracks split into
+    /// a test failure.
+    @Test func theBetaAndStableRecipesReadDifferentEndpoints() throws {
         let recipe = try Self.betaRecipe()
-        let betaVersion = try #require(
-            VendorProbeRecipe.extractVersion(from: Self.betaBody, pattern: recipe.versionPattern))
-        let stableVersion = try #require(
-            VendorProbeRecipe.extractVersion(from: Self.stableBody, pattern: recipe.versionPattern))
-        #expect(betaVersion == stableVersion, "true today — 9.43.1 on both tracks")
         #expect(recipe.url != VendorProbeRegistry.recipes
             .first { $0.bundleID == Self.stableBundleID }?.url,
             "the two channels must never share one endpoint")

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -27,6 +27,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**DuoPaste**](io-duopaste-daemon.md) · `io.duopaste.daemon` — B(stable/beta) · 2 channels, shared ID + channel-tag ChannelBinding · **beta + stable 两 channel 真机验证 ✓**（beta 用 `…-beta` 构建；stable 经 `sparkleIncludePrereleases` 取值验证，改动已还原）· 2026-06-04
 - [x] [**CleanShot X**](pl-maketheweb-cleanshotx.md) · `pl.maketheweb.cleanshotx` — C B(license feed) · license-keyed Sparkle feed · **stable 本机验证 ✓**（legit feed head=4.8.8=installed）· 2026-06-04
 - [x] [**CapCut**](com-lemon-lvoverseas.md) · `com.lemon.lvoverseas` — P(stable/beta) B · 2 channels, shared ID + ChannelBinding（`joinBeta` 在容器外的 INI）· **全 channel 一键 ✓**（Team 22MMUN2RN5，两轨真实 dmg 挂载核对）· **两轨版本字段是反的**（beta 的 short=`9.3.4531` / version=`9.4.0-beta4`，故 beta `versionIsBuild:true`）· 同 id 有 MAS 副本（19.2.0），靠 `_MASReceipt` 分流 · 2026-08-27
+- [x] [**Termius**](com-termius-dmg-mac.md) · 三个独立 bundle id：`com.termius.mac`（MAS，`MacAppStoreSource` 通用覆盖，无 registry）/ `com.termius-dmg.mac`（官网 dmg，P stable，既有）/ `com.termius-beta.mac`（P beta，本次新增）— **全 channel 一键 ✓**（beta 用 universal dmg，Team 6KN952WR85）· stable 既有 recipe 装错架构（Intel 会装 arm64-only）已拆分为独立任务 · issue #91 · 2026-08-27
 
 ## Microsoft Office family
 

--- a/docs/app-audits/com-termius-dmg-mac.md
+++ b/docs/app-audits/com-termius-dmg-mac.md
@@ -1,0 +1,257 @@
+# Termius
+
+审计 2026-08-27（issue #91）。
+
+## 基本信息
+
+Termius 的 stable 在这台机器上以 **两种完全不同的发行形态** 存在，各有自己的
+bundle id——这是 issue #91 本身没有说清楚的地方，见下「issue 核对」。
+
+- 官网 / 下载页: https://termius.com/download/macos
+- Beta 计划页: https://termius.com/beta-program
+- 观测版本（两条形态、两个渠道，当天全部相同）: `9.43.1`
+- Team ID: `6KN952WR85` — Termius Corporation，`spctl` 判定 "Notarized Developer ID"
+- 自更新机制: **electron-updater**（`NSPrincipalClass = AtomApplication`，
+  `Contents/Resources/app-update.yml` 声明 `provider: s3`）
+
+| 形态 | Bundle ID | 沙盒 | 来源 |
+|---|---|---|---|
+| Mac App Store 购买 | `com.termius.mac` | 是（`_MASReceipt` + `com.apple.security.app-sandbox`）| App Store |
+| 官网直接下载 | `com.termius-dmg.mac` | 否 | `download.termius.com` / `autoupdate.termius.com` |
+| Beta（官网） | `com.termius-beta.mac` | 否 | 同上，`-beta-universal` 路径 |
+
+## issue 核对
+
+**issue 说 `com.termius.mac`「appears in no registry — this is not only a
+channel gap, it is a whole app we do not answer for」。这条断言不准确**：
+
+- `com.termius.mac` 确实不在任何 registry 里——但那是因为它 **不需要**。装机验证
+  （`itunes.apple.com/lookup?bundleId=com.termius.mac&country=us&entity=macSoftware`，
+  2026-08-27）返回 `resultCount: 1`、`kind: "mac-software"`、`version: "9.43.1"`——
+  和本机 `_MASReceipt` 的沙盒装机完全一致。`MacAppStoreSource` 对任何
+  `app.isMASApp` 的装机都通用生效，**不经过任何 registry**，所以这条 bundle id
+  已经被回答，issue 说的「we do not answer for it」不成立。
+- issue 检查 registry 时漏了一件事：**同一个 vendor 用了两个不同的 bundle id**
+  分流 MAS 与直接下载（`com.termius.mac` vs `com.termius-dmg.mac`），装机的
+  `Info.plist` 是权威证据——`com.termius.mac` 是 MAS 沙盒副本，`com.termius-dmg.mac`
+  才是官网 dmg 的真实 id。这条区分是这份审计新确认的。
+- **真正需要覆盖、也真正缺失的 `com.termius-dmg.mac`，其实已经在 `VendorProbeRecipe`
+  里注册了**（2026-08-16 提交，早于本 issue 提出的 2026-08-27），本 PR 之前就存在。
+  issue 说它「appears in no registry」时查的显然是 `com.termius.mac`，从未查过
+  `com.termius-dmg.mac`。
+- issue 关于「where does a version come from — 这是没做的活」这条判断是**对的**，
+  而且是本 PR 真正要交付的部分：Beta 此前完全没有 recipe，本 PR 补上。
+- issue 提到「Whether stable and beta share a version scheme...both read 9.43.1
+  today」——已验证：截至 2026-08-27，三份独立 feed（`mac-universal`、`mac-arm64`、
+  `mac-beta-universal`）版本号相同，但这是**巧合而非架构保证**（三个是三份独立文件，
+  不是一份共享 manifest），随时可能分叉，recipe 已按各自独立端点实现，不依赖这条
+  巧合。
+
+**本审计还发现两条 issue 未涉及、且发现前既存于仓库的问题**（均已作为独立任务标记，
+不在本 PR 修复范围）：
+
+1. **`com.termius-dmg.mac` 现有 recipe 的一键安装装错架构**：其 `install` 固定指向
+   `https://autoupdate.termius.com/mac-arm64/Termius.dmg`——挂载后 `lipo -info`
+   证实是 **纯 arm64**（Non-fat file）。Intel Mac 上一键安装会装上一个打不开的
+   二进制。
+2. **该 recipe 的 `changelogURL` 已经 404**：`https://termius.com/release-notes`
+   在 2026-08-27 直接返回 404（`curl` 复测，不是 HEAD 误报），且该路径不在
+   `https://termius.com/sitemap.xml` 里——网站已经改版，没有替代的 changelog 页。
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|              | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|--------------|---------|----------|-----|--------|-------------|
+| **stable (MAS)** `com.termius.mac` | — | — | ✓（通用） | — | — |
+| **stable (dmg)** `com.termius-dmg.mac` | — | ✗ | — | — | ✓ 一键（**已存在的架构 bug，见上**）|
+| **beta** `com.termius-beta.mac` | — | — | — | — | ✓ 一键（本 PR 新增）|
+
+当前生效源：MAS 装机 → **App Store**（通用，无 registry）；官网 dmg 装机 →
+**VendorProbe**（stable/beta 各自独立 recipe）。
+
+- **Sparkle** — 三种形态的 `Info.plist` 都没有 `SUFeedURL`。
+- **Homebrew** — cask `termius` 存在，`auto_updates true`，`HomebrewCaskSource`
+  按设计返回 nil；cask 的 `livecheck` 反而是找到官网 feed host 的线索（见下）。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---|---|---|---|---|---|
+| stable (MAS) | `com.termius.mac` | 独立 | — | — | ✓（`MacAppStoreSource` 通用覆盖）|
+| stable (dmg) | `com.termius-dmg.mac` | 独立 | — | — | ✓（已存在，本 PR 未改）|
+| beta | `com.termius-beta.mac` | 独立 | `CFBundleName`="Termius Beta" | `channelWord` 标准词匹配，无需新规则 | ✓（本 PR 新增）|
+
+Beta 是 Pattern A（issue 判断准确）：三个 bundle id 两两独立，`ReleaseChannel.detect()`
+不需要任何新规则——`channelWord` 现有的标准词表（`beta`）已经能从
+`CFBundleName`/`CFBundleDisplayName` = "Termius Beta" 里识别出来（`DuoUpdaterCore/
+Sources/DuoUpdaterCore/Models/ReleaseChannel.swift` 未改动，直接用测试验证了这个行为，
+见 `TermiusProbeRecipeTests.detectResolvesTermiusBetaFromItsDisplayNameAlone`）。
+
+## 更新检测
+
+### 端点是怎么找到的
+
+app 自带的 `Contents/Resources/app-update.yml`：
+
+```yaml
+provider: s3
+bucket: termius.desktop.autoupdate
+region: us-east-1
+endpoint: https://s3.amazonaws.com
+acl: private
+path: mac-universal
+updaterCacheDirName: termius-updater
+```
+
+`acl: private` 不是摆设——直接对着这份 config 猜出的 S3 路径（
+`https://download.termius.com/mac-universal/latest-mac.yml`、
+`https://download.termius.com/latest-mac.yml`）实测均为 **403**（`urllib` 复测，
+非 HEAD 误报）。真正能公开读到 `latest-mac.yml` 的host不是这个S3域，而是
+**`autoupdate.termius.com`**——线索来自 Homebrew cask 的 `livecheck` 块：
+
+```ruby
+# Casks/t/termius.rb
+livecheck do
+  url "https://autoupdate.termius.com/mac/latest-mac.yml"
+  strategy :electron_builder
+end
+```
+
+这条 cask 元数据是 2026-08-16 那条既存 recipe 的落地依据（其注释未明写来源，
+本次审计重新核实并补充）；本 PR 沿着同一台 host 找到了 Beta 的路径。
+
+### 各路径的真实内容（2026-08-27 实测，`curl`/`urllib` 直读，非猜测）
+
+| 路径 | `version` | dmg size (bytes) | 架构（`lipo -info` 挂载实测）|
+|---|---|---|---|
+| `autoupdate.termius.com/mac/latest-mac.yml` | 9.43.1 | 175860846 | 未挂载（Intel-only，cask 的无后缀 arch）|
+| `autoupdate.termius.com/mac-arm64/latest-mac.yml` | 9.43.1 | 169439149 | **纯 arm64**（Non-fat，已挂载验证）|
+| `autoupdate.termius.com/mac-universal/latest-mac.yml` | 9.43.1 | 249384231 | **x86_64 + arm64**（已挂载验证）|
+| `autoupdate.termius.com/mac-beta-universal/latest-mac.yml` | 9.43.1 | 249396295 | **x86_64 + arm64**（已挂载验证）|
+
+`download.termius.com/mac-universal/Termius.dmg` 与
+`download.termius.com/mac-beta-universal/Termius%20Beta.dmg`（issue 原文引用的两条
+"latest" 链接）与 `autoupdate.termius.com` 对应路径下的同名文件 **字节相同**
+（`Content-Length`、`Last-Modified`、`ETag` 全部一致）——是同一份产物挂在两个
+CNAME 下，不是两份不同的构建。
+
+### stable（`com.termius-dmg.mac`）——本 PR 未改动，仅审计说明
+
+既存 recipe 读 `mac-arm64/latest-mac.yml`，一键装 `mac-arm64/Termius.dmg`——
+装机验证（挂载）它是纯 arm64。本机是 Apple Silicon，`duo verify --only termius`
+在这台机器上因此表现正常；架构 bug 只在 Intel 机器上炸，本 PR 未修（见「已知问题」）。
+
+### beta（`com.termius-beta.mac`）——本 PR 新增
+
+```yaml
+version: 9.43.1
+files:
+  - url: Termius Beta.zip
+    sha512: 08ovSDodx5wGBfp/vLCwf49uVACJ9Xj95aPgn7Lm+Z0exazThLdCOVf/LwrRF4hjY+lBUzm4l45lG8rk6D9cLQ==
+    size: 239947907
+  - url: Termius Beta.dmg
+    sha512: Eo4XFtmNeDRfMA9X9N2yw2jHf7TS2o2GH4pbIbWpl2qEYBoXb7CIgIdQlLRzUb38LXO59/xUciQXgwuExlBE+w==
+    size: 249396295
+path: Termius Beta.zip
+sha512: 08ovSDodx5wGBfp/vLCwf49uVACJ9Xj95aPgn7Lm+Z0exazThLdCOVf/LwrRF4hjY+lBUzm4l45lG8rk6D9cLQ==
+releaseDate: '2026-08-12T07:56:45.216Z'
+rollout:
+  freeUsers: 100
+  paidUsers: 100
+```
+
+- **版本方案对齐**：feed `version` = `9.43.1` = 挂载后 `CFBundleShortVersionString`。
+  没有 `versionIsBuild`。
+- **架构**：用的是 `mac-beta-universal`（不是 stable 那条 bug 复用的 `mac-arm64`），
+  挂载确认 `lipo -info` → `x86_64 arm64`，所以 Beta 这条 **没有** stable 那个
+  架构 bug，一台 recipe 服务任何 Mac，不需要 `hostRequirement`。
+- **checksum 已武装**：feed 的 dmg sha512（base64）与 **实际下载字节**的
+  `shasum -a 512 | base64` 完全一致——与 stable Termius 自己的两份构建
+  （`mac-universal`、`mac-arm64`）一样，都不像 Signal Beta 那样被 CDN 二次 staple
+  过，所以 `checksumPattern` 是安全的，不是形同虚设的字段。
+- **`rollout: freeUsers/paidUsers: 100`**：当前是满量发布（100/100），这条 feed
+  读的是**轨道最新**而不是**本机被分配到的构建**——没有 device id 之类的选择器，
+  request 不携带任何本机身份。今天两者恰好相同（100% 全量），但架构上不等价：
+  如果 vendor 未来把这两个数字调低做灰度，这条 recipe 依然会读到「轨道上已发布
+  的最新版」而不是「这台机器的灰度桶」。跟 CapCut beta 是同一类可接受的例外
+  （读轨道最新），记录在案，不是本 PR 引入的新风险，因为 stable 那条既存 recipe
+  本来就是同一种读法。
+- **没有 changelogURL**：`https://termius.com/release-notes`（stable 那条既存
+  recipe 用的）已经 404，站点地图里也没有替代页，所以没有给 Beta 编一个同样会
+  404 的链接，UI 走「no release notes」。`downloadURL` 用了确认存在的
+  `https://termius.com/beta-program`（200，真实的 Beta Program 落地页）。
+
+生产验证（`swift run --package-path CLI duo verify --only termius`，2026-08-27，
+本 worktree 构建）：
+
+```
+vendor probe  ✓ 2  ⚠ 0  ✗ 0  ~ 0  - 0
+```
+
+`--samples --report` 的 JSON 输出（两条都 `"status": "ok"`，`"warnings": []`）：
+
+```json
+{
+  "bundleID": "com.termius-beta.mac", "channel": "beta",
+  "version": "9.43.1", "status": "ok", "warnings": []
+},
+{
+  "bundleID": "com.termius-dmg.mac", "channel": "stable",
+  "version": "9.43.1", "status": "ok", "warnings": []
+}
+```
+
+空 `warnings` 说明 `installURLUnresolved` 和 `checksumPatternNoMatch` 都没触发——
+Beta 的一键 URL 和 sha512 都在生产路径上解出来了。
+
+`swift test`（DuoUpdaterCoreTests 的 `vendorResolvesInstallPlans`，同一天，打生产
+端点）里 Termius Beta 一行：
+
+```
+• com.termius-beta.mac [beta]: v9.43.1  [dmg] sha512✓
+    https://autoupdate.termius.com/mac-beta-universal/Termius%20Beta.dmg
+```
+
+## Changelog
+
+**没有接。** 站点没有可用的 release notes 页（见上「issue 核对」的第 2 条发现）。
+既存 stable recipe 的 `changelogURL` 已死，Beta 新 recipe 干脆不设。
+
+## 一键安装
+
+- **stable (`com.termius-dmg.mac`)**：已启用（本 PR 之前就有），但**装的是 arm64-only
+  产物，Intel Mac 上会装出打不开的 app**——已知问题，已拆分为独立任务，未在本 PR 修。
+- **beta (`com.termius-beta.mac`)**：本 PR 新启用，`kind: .dmg`，`urlSource: .fixed`
+  （feed 里的文件名 `Termius Beta.dmg` 不带版本号，无法从 body 里解析出来，只能用固定
+  URL——和既存 stable recipe 处理未带版本号文件名的方式一致）。装的是 **universal**
+  产物（挂载验证 `x86_64 arm64`），Intel/Apple Silicon 都能装。
+  - **读的是**：轨道最新（`rollout: 100/100`，见上）。今天等价于「人人可从
+    `termius.com/beta-program` 拿到的构建」，vendor 未来做灰度时可能不再等价，
+    已在「更新检测」一节记录，接受同 stable 一致的既有做法。
+  - `ChannelProofRegistry` 已登记（`ChannelArtifactProof.swift`）：
+    `ChannelProofKey("com.termius-beta.mac", .beta): .artifact(#"/mac-beta-universal/"#)`——
+    独立 bundle id 已经隔离了跨渠道风险，这条是 belt-and-suspenders，断言解析出的
+    安装 URL 路径里确实带 `mac-beta-universal`。
+  - 强制闸（`VendorInstaller`）：Notarized Developer ID + Team `6KN952WR85` +
+    bundle id 一致——挂载已验证 Team 与 stable 相同。
+
+## 已知问题
+
+1. **`com.termius-dmg.mac` 一键安装在 Intel Mac 上会装错架构**（详见上文「issue
+   核对」与「更新检测」）。已拆分为独立任务，不在本 PR 范围。
+2. **`com.termius-dmg.mac` 的 `changelogURL` 已死**（404，站点无替代页）。已拆分
+   为独立任务的一部分记录，不在本 PR 范围（不影响功能，只影响 changelog 展示，
+   降级为「no release notes」）。
+3. Beta 的一键读的是**轨道最新**而非**本机分配**（`rollout` 字段今天满量，无 device
+   id 选择器）——继承自既存 stable recipe 的同一读法，不是本 PR 引入的新差异。
+
+## 建议下一步
+
+1. 修 `com.termius-dmg.mac` 的架构 bug：改用 `mac-universal` 的 feed + dmg（已验证
+   版本相同、universal 架构），而不是 `mac-arm64`。
+2. 修或移除 `com.termius-dmg.mac` 的 `changelogURL`（当前 404）。
+3. 若 vendor 未来把 `rollout.freeUsers`/`paidUsers` 降到 100 以下，需要重新评估
+   Beta（以及既存 stable）recipe 是否应该改读「本机分配」而非「轨道最新」——目前
+   无法从这份 electron-builder 静态 manifest 得到 device 级别的分配信息。


### PR DESCRIPTION
## Summary

- Adds a `VendorProbeRecipe` for Termius Beta (`com.termius-beta.mac`, `channel: .beta`), the genuinely uncovered gap issue #91 asked for.
- Registers the mandatory `ChannelProofRegistry` entry for its install spec.
- Corrects issue #91's central claim: `com.termius.mac` is the Mac App Store bundle id, generically covered by `MacAppStoreSource` (no registry entry needed at all). The direct-download stable bundle id is actually `com.termius-dmg.mac`, which was **already registered 2026-08-16** — the issue never checked that id, so its "we do not answer for it" claim doesn't hold.
- Adds a registry-derived regression test file (not a hand-written list) and an app-audit doc.
- Flags two pre-existing, adjacent issues found while verifying — **not fixed in this PR**, spun off as separate background tasks instead: the existing stable recipe's install spec resolves an arm64-only dmg regardless of host architecture (Intel Macs would get a build that won't launch), and its `changelogURL` now 404s with no replacement page on the vendor's site.

Closes #91

## What was verified (with commands, raw output pasted into the audit doc and PR description below)

- **Bundle identity, three distinct forms** — confirmed by `mdls`/`codesign`/`spctl` on the installed MAS copy and by downloading + mounting (`hdiutil attach`) both the direct-download stable dmg and the Beta dmg from the vendor's own CDN:
  - `com.termius.mac` — MAS, sandboxed (`_MASReceipt` + `com.apple.security.app-sandbox`).
  - `com.termius-dmg.mac` — direct download, not sandboxed, Team `6KN952WR85`, Notarized Developer ID.
  - `com.termius-beta.mac` — direct download, not sandboxed, Team `6KN952WR85`, Notarized Developer ID, `CFBundleDisplayName`="Termius Beta".
- **MAS coverage for `com.termius.mac`** — `itunes.apple.com/lookup?bundleId=com.termius.mac&country=us&entity=macSoftware` returns `resultCount: 1`, `kind: "mac-software"`, `version: "9.43.1"`, matching the installed MAS copy exactly. `MacAppStoreSource` answers any `app.isMASApp` install generically — confirmed by reading its source, not assumed.
- **The version endpoint** (the actual unstarted work per the issue) — `https://autoupdate.termius.com/mac-beta-universal/latest-mac.yml` fetched with a real GET (not guessed, not inferred from a status code): a public, unauthenticated electron-builder feed reporting `version: 9.43.1`, found by reading the vendor's own Homebrew cask `livecheck` block (`Casks/t/termius.rb`), since the app's bundled `app-update.yml` names a private (`acl: private`) S3 bucket that returns 403 on a plain GET (verified — not assumed from the yml's `acl` field alone).
- **The install artifact is universal** — `lipo -info` on the downloaded and mounted `Termius Beta.dmg`: `x86_64 arm64`. (By contrast, the existing stable recipe's install target, `mac-arm64/Termius.dmg`, is confirmed **non-fat, arm64-only** — a pre-existing bug, not touched here, spun off separately.)
- **Checksum integrity** — the feed's declared base64 SHA-512 for `Termius Beta.dmg` was compared against `shasum -a 512 <downloaded file> | xxd -r -p | base64` on the actual downloaded bytes: **exact match**. Added as `checksumPattern`.
- `cd DuoUpdaterCore && swift test` — **1279 tests passed, 0 failures, 1 pre-existing known issue (Anki, unrelated) in 100 suites.**
- `swift test --package-path CLI` — **127 tests passed, 0 failures, 19 suites.**
- `swift run --package-path CLI duo verify --only termius` (built from this worktree, not the stale installed `duo`) — `vendor probe ✓ 2 ⚠ 0 ✗ 0 ~ 0 - 0`, both stable and beta green against production endpoints.
- `swift run --package-path CLI duo verify --only termius --samples --report ...` — both recipes `"status": "ok"`, `"version": "9.43.1"`, `"warnings": []` (empty warnings confirms the beta install URL and checksum both resolved on the live path, not just in the test fixture).
- `swift test --filter vendorResolvesInstallPlans` (the registry-derived live sweep) — resolved `com.termius-beta.mac [beta]: v9.43.1 [dmg] sha512✓` against production, alongside all other channel recipes.
- Full `make test` was intentionally **not run** per instructions (its `check_localizable_keys.py` step would lock-conflict with other agents using the shared `/tmp/duo-loc-check` cache right now) — to be run at final acceptance.

## Not verified / explicitly flagged, not fixed here

- The existing stable recipe's install spec downloads an **arm64-only** dmg unconditionally — verified via `lipo -info`, not fixed in this PR (spun off as a separate background task: "Fix Termius stable install: arm64-only dmg pinned for all Macs").
- The existing stable recipe's `changelogURL` (`https://termius.com/release-notes`) now 404s, confirmed via real GET (not a HEAD artifact) and cross-checked against the vendor's `sitemap.xml` (no replacement page listed). Documented in the audit doc, not fixed in this PR.
- Beta's feed carries a `rollout: {freeUsers: 100, paidUsers: 100}` field with no per-device selector in the request — today that means "newest on the track" and "what's actually allocated" coincide (100% rollout), but the recipe has no way to tell if the vendor ever stages below 100%. This is the same read-the-track-newest shape the pre-existing stable recipe already uses, documented but not a new risk introduced here.
- Whether the vendor will keep issuing simultaneous stable/beta releases at identical version numbers (true today, called out in the issue and re-verified, but explicitly not architecturally guaranteed — each recipe reads its own independent feed regardless).
