### PR TITLE
docs: reconcile app-audit docs with post-#91-#95 reality

### DIFF
--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -222,16 +222,16 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 `status: up-to-date` / latest == installed —— `SparkleAppcastSource` 会从**装机构建反推**
 `<sparkle:channel>`，beta 条目没被滤掉。**不需要 ChannelBinding，勿重开。**
 
-### Pattern A 未覆盖 —— 三个（`termius@beta` 已接，见 §1）
+### Pattern A 未覆盖 —— 两个（`termius@beta` 已接，见 §1；VSCodium Insiders 已接，
+见 issue #92、`docs/app-audits/com-vscodium-VSCodiumInsiders.md`）
 
 | cask 变体 | 装出来的 app | 本机 stable |
 |---|---|---|
 | `postman@canary` | `PostmanCanary.app` | Postman 12.25.6 |
 | `db-browser-for-sqlite@nightly` | `DB Browser for SQLite Nightly.app` | 3.13.1 |
-| `vscodium@insiders` | `VSCodium - Insiders.app` | 1.126.04524 |
 
 → 各自 `/app-audit`，但**都得先装一份对应渠道的包**才能拿到 bundle id 和版本方案，
-否则只是猜。三个都不急。
+否则只是猜。两个都不急。
 
 ### 同 bundle id + `@channel` cask —— 七个（渠道在**下载时**选，不是 app 内切）
 
@@ -255,7 +255,7 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 |---|---|---|---|---|---|
 | **Termius Beta** | `com.termius-beta.mac` 9.43.1 | **独立** | `CFBundleName`="Termius Beta" | Team `6KN952WR85` 公证 | **A，可接** |
 | **VSCodium Insiders** | `com.vscodium.VSCodiumInsiders` 1.126.04518-insider | **独立** | app 名 + 版本后缀 | Team `VC39D2VNQ7` 公证 | **A，可接** |
-| **DB Browser nightly** | 同 id 3.13.99 | 同 | **只有 app 文件名** `DB Browser for SQLite Nightly.app`（`CFBundleName` 仍是 "DB Browser for SQLite"）| Team `88DD6Y8X83` 公证 | **A-ish**，靠文件名，同 Android Studio 那条 `detect` step 0.5 |
+| **DB Browser nightly** | 同 id 3.13.99 | 同 | **只有 app 文件名** `DB Browser for SQLite Nightly.app`（`CFBundleName` 仍是 "DB Browser for SQLite"）| Team `88DD6Y8X83` 公证 | **A-ish**，靠文件名，`detect()` 已有自己的 step 0.6（issue #94；不是复用 Android Studio 的 step 0.5）|
 | **Freelens nightly** | 同 id `2.0.0-0-nightly-2026-08-26` | 同 | **版本串带 `nightly`** | Team `TFR6NT55MB` 公证 | 可接，但要给 `detect()` 加规则 |
 | **VLC nightly** | 同 id `4.0.0-dev` | 同 | 版本串带 `-dev` | **未签名**（`TeamIdentifier=not set`）| 检测可做，**一键不可**（Team 闸必拒）→ 立项 #95，`docs/app-audits/org-videolan-vlc.md` |
 | **KeePassXC snapshot** | 同 id `2.8.0-snapshot` | 同 | 版本串带 `-snapshot` | **无可用签名** | 同上；且该 URL 只有 x86_64（已核实无 arm64 替代路径）→ 立项 #95，`docs/app-audits/org-keepassxc-keepassxc.md` |
@@ -299,9 +299,12 @@ DB Browser 是 Developer ID 公证的，VLC 和 KeePassXC **完全没签名** �
    **错的**：`com.termius.mac` 是 MAS 沙盒购买副本，装机验证 `MacAppStoreSource`
    通用覆盖，不需要 registry；真正的官网 dmg stable 是 `com.termius-dmg.mac`，
    2026-08-16 已经在 `VendorProbeRecipe` 里注册，只是当时没人把两个 bundle id
-   对上号。**VSCodium Insiders** —— 独立 id、已公证，最省事，仍待接。
-2. **DB Browser nightly** —— 需要文件名检测，有 Android Studio 的现成范式。
-3. **Freelens / VLC / KeePassXC** —— 要先给 `detect()` 加版本串规则；后两者只能检测不能一键。
+   对上号。**VSCodium Insiders** —— 独立 id、已公证，已接（issue #92，2026-08-27，
+   `docs/app-audits/com-vscodium-VSCodiumInsiders.md`）。
+2. **DB Browser nightly** —— 需要文件名检测，有 Android Studio 的现成范式（`detect()`
+   已有自己的 step 0.6，见上）。
+3. **Freelens / VLC / KeePassXC** —— `detect()` 的版本串规则已加（issue #93 已解决）；
+   VLC/KeePassXC 尚未接 recipe，且后两者只能检测不能一键（未签名，见 issue #95）。
 4. **UTM / kitty** —— 归入 §3 死轨，本地无信号。
 
 ---
@@ -346,9 +349,10 @@ DB Browser 是 Developer ID 公证的，VLC 和 KeePassXC **完全没签名** �
   v1 的 3 段会 400），所以 probe 一律**不带** `version`。
 - ✗ **VLC — Nightly** · 同 `org.videolan.vlc`，nightlies 滚动构建无版本语义，不可区分
   **更正 2026-08-27（§2c）**：这条判断已过期——版本串其实带 `-dev`（`4.0.0-dev`），
-  只是现有 `detect()` 不认这种形状（阻塞于 #93）。真正永久挡住的不是检测，是签名：
-  nightly 完全未走 Developer ID（`TeamIdentifier=not set`），一键永远过不了
-  `VendorInstaller` 的 Team 闸。见 issue #95、`docs/app-audits/org-videolan-vlc.md`。
+  `detect()` 现在能认出这种形状（#93 已解决），只是仓库尚未为它接一条 recipe。
+  真正永久挡住的不是检测，是签名：nightly 完全未走 Developer ID
+  （`TeamIdentifier=not set`），一键永远过不了 `VendorInstaller` 的 Team 闸。
+  见 issue #95、`docs/app-audits/org-videolan-vlc.md`。
 - ✗ **Blender — Daily/Alpha/Beta** · 同 bundle id，builder.blender.org 滚动构建，无检测信号
 - ✅ **Figma — Beta** · 已接入（**更正旧判断：不是**应用内 flag）。独立 app：bundle `com.figma.DesktopBeta`、"Figma Beta.app"、独立端点 `desktop.figma.com/mac-arm/beta/`。Pattern A，VendorProbe(`channel: .beta`) + 一键安装（Team T8RA8NE3B7，2026-06-06 真机验证）
 - ✗ **GitHub Desktop — Beta** · 同 `com.github.GitHubClient`，beta tag 是 prerelease，stable rule 已排除

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -27,7 +27,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**DuoPaste**](io-duopaste-daemon.md) · `io.duopaste.daemon` — B(stable/beta) · 2 channels, shared ID + channel-tag ChannelBinding · **beta + stable 两 channel 真机验证 ✓**（beta 用 `…-beta` 构建；stable 经 `sparkleIncludePrereleases` 取值验证，改动已还原）· 2026-06-04
 - [x] [**CleanShot X**](pl-maketheweb-cleanshotx.md) · `pl.maketheweb.cleanshotx` — C B(license feed) · license-keyed Sparkle feed · **stable 本机验证 ✓**（legit feed head=4.8.8=installed）· 2026-06-04
 - [x] [**CapCut**](com-lemon-lvoverseas.md) · `com.lemon.lvoverseas` — P(stable/beta) B · 2 channels, shared ID + ChannelBinding（`joinBeta` 在容器外的 INI）· **全 channel 一键 ✓**（Team 22MMUN2RN5，两轨真实 dmg 挂载核对）· **两轨版本字段是反的**（beta 的 short=`9.3.4531` / version=`9.4.0-beta4`，故 beta `versionIsBuild:true`）· 同 id 有 MAS 副本（19.2.0），靠 `_MASReceipt` 分流 · 2026-08-27
-- [x] [**Termius**](com-termius-dmg-mac.md) · 三个独立 bundle id：`com.termius.mac`（MAS，`MacAppStoreSource` 通用覆盖，无 registry）/ `com.termius-dmg.mac`（官网 dmg，P stable，既有）/ `com.termius-beta.mac`（P beta，本次新增）— **全 channel 一键 ✓**（beta 用 universal dmg，Team 6KN952WR85）· stable 既有 recipe 装错架构（Intel 会装 arm64-only）已拆分为独立任务 · issue #91 · 2026-08-27
+- [x] [**Termius**](com-termius-dmg-mac.md) · 三个独立 bundle id：`com.termius.mac`（MAS，`MacAppStoreSource` 通用覆盖，无 registry）/ `com.termius-dmg.mac`（官网 dmg，P stable，既有）/ `com.termius-beta.mac`（P beta，本次新增）— **全 channel 一键 ✓**（beta 用 universal dmg，Team 6KN952WR85）· stable 既有 recipe 的 arm64-only 一键是刻意的 arm64-pin（DuoUpdater 自身 arm64-only），不是 bug；真正待修的是 `changelogURL` 404，已拆分为独立任务 · issue #91、#102 · 2026-08-27
 
 ## Microsoft Office family
 
@@ -64,7 +64,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] **Conductor** · `com.conductor.app` — P C · ✓ src=Vendor
 - [x] **Postman** · `com.postmanlabs.mac` — P C (one-click) · ✓ src=Vendor
 - [x] **AweSun** · `com.oray.sunlogin.macclient` — P C (one-click, WAF) · ✓ src=Vendor
-- [x] [**VLC**](org-videolan-vlc.md) · `org.videolan.vlc` — P C (one-click, two-stage changelog) · ✓ src=Vendor · nightly 共享 bundle id，未签名 → **一键永久不可**，检测阻塞于 #93（issue #95）
+- [x] [**VLC**](org-videolan-vlc.md) · `org.videolan.vlc` — P C (one-click, two-stage changelog) · ✓ src=Vendor · nightly 共享 bundle id，未签名 → **一键永久不可**，检测已可行（#93 已解决），尚未接 recipe（issue #95）
 - [ ] **Docker** · `com.docker.docker` — P · ⏭ skipped (cask now needs sudo to install)
 - [x] **Raycast** · `com.raycast.macos` — P · ✓ src=Vendor
 - [x] **Alfred** · `com.runningwithcrayons.Alfred` — P · ✓ src=Vendor
@@ -101,7 +101,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] **Stats** · `eu.exelban.Stats` — G (one-click) · ✓ src=GitHub · [audit](eu-exelban-Stats.md)
 - [x] **DBeaver** · `org.jkiss.dbeaver.core.product` — G · ✓ src=GitHub
 - [x] **Beekeeper Studio** · `io.beekeeperstudio.desktop` — G · ✓ src=GitHub
-- [x] [**KeePassXC**](org-keepassxc-keepassxc.md) · `org.keepassxc.keepassxc` — G (one-click) · ✓ src=GitHub · snapshot 共享 bundle id，完全无签名 → **一键永久不可**，检测阻塞于 #93（issue #95）
+- [x] [**KeePassXC**](org-keepassxc-keepassxc.md) · `org.keepassxc.keepassxc` — G (one-click) · ✓ src=GitHub · snapshot 共享 bundle id，完全无签名 → **一键永久不可**，检测已可行（#93 已解决），尚未接 recipe（issue #95）
 - [x] [**Insomnia**](com-insomnia-app.md) · `com.insomnia.app` — G C (one-click) · ✓ src=GitHub · changelog=insomnia.rest(`__NEXT_DATA__` JSON) · 修 stable 跨渠道误推（pattern 加 `$` 锚，2026-06-06）· beta/alpha 受阻于 detect() 不解析 `-beta.N` 后缀
 - [x] **Pearcleaner** · `com.alienator88.Pearcleaner` — G · ✓ src=GitHub
 - [x] **Macs Fan Control** · `com.crystalidea.macsfancontrol` — G · ✓ src=GitHub

--- a/docs/app-audits/com-termius-dmg-mac.md
+++ b/docs/app-audits/com-termius-dmg-mac.md
@@ -47,16 +47,22 @@ channel gap, it is a whole app we do not answer for」。这条断言不准确**
   不是一份共享 manifest），随时可能分叉，recipe 已按各自独立端点实现，不依赖这条
   巧合。
 
-**本审计还发现两条 issue 未涉及、且发现前既存于仓库的问题**（均已作为独立任务标记，
+**本审计还发现一条 issue 未涉及、且发现前既存于仓库的问题**（已作为独立任务标记，
 不在本 PR 修复范围）：
 
-1. **`com.termius-dmg.mac` 现有 recipe 的一键安装装错架构**：其 `install` 固定指向
-   `https://autoupdate.termius.com/mac-arm64/Termius.dmg`——挂载后 `lipo -info`
-   证实是 **纯 arm64**（Non-fat file）。Intel Mac 上一键安装会装上一个打不开的
-   二进制。
-2. **该 recipe 的 `changelogURL` 已经 404**：`https://termius.com/release-notes`
+1. **该 recipe 的 `changelogURL` 已经 404**：`https://termius.com/release-notes`
    在 2026-08-27 直接返回 404（`curl` 复测，不是 HEAD 误报），且该路径不在
    `https://termius.com/sitemap.xml` 里——网站已经改版，没有替代的 changelog 页。
+   见 issue #102。
+
+**审计过程中还核实了一条看起来像 bug、实际不是的观察**：`install` 固定指向
+`https://autoupdate.termius.com/mac-arm64/Termius.dmg`，挂载后 `lipo -info`
+证实是纯 arm64（Non-fat file）。这**不是**架构 bug——DuoUpdater 自身就是
+arm64-only（`App/project.yml` 的 `ARCHS: arm64`，理由是 registry 本来就
+全线只提供 arm64 端点/安装资产，universal 的 DuoUpdater 反而会把 Intel Mac
+骗去装打不开的 app），所以**不存在需要被服务的 Intel host**，pin 住
+`mac-arm64` 是正确设计，不是遗漏。issue #102 记录了这条更正，并且保留了
+最初的错误论断以防被重新提起。
 
 ## 覆盖矩阵
 
@@ -65,7 +71,7 @@ channel gap, it is a whole app we do not answer for」。这条断言不准确**
 |              | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
 |--------------|---------|----------|-----|--------|-------------|
 | **stable (MAS)** `com.termius.mac` | — | — | ✓（通用） | — | — |
-| **stable (dmg)** `com.termius-dmg.mac` | — | ✗ | — | — | ✓ 一键（**已存在的架构 bug，见上**）|
+| **stable (dmg)** `com.termius-dmg.mac` | — | ✗ | — | — | ✓ 一键（arm64-pinned by design，见 #102）|
 | **beta** `com.termius-beta.mac` | — | — | — | — | ✓ 一键（本 PR 新增）|
 
 当前生效源：MAS 装机 → **App Store**（通用，无 registry）；官网 dmg 装机 →
@@ -140,8 +146,9 @@ CNAME 下，不是两份不同的构建。
 ### stable（`com.termius-dmg.mac`）——本 PR 未改动，仅审计说明
 
 既存 recipe 读 `mac-arm64/latest-mac.yml`，一键装 `mac-arm64/Termius.dmg`——
-装机验证（挂载）它是纯 arm64。本机是 Apple Silicon，`duo verify --only termius`
-在这台机器上因此表现正常；架构 bug 只在 Intel 机器上炸，本 PR 未修（见「已知问题」）。
+装机验证（挂载）它是纯 arm64。这是刻意的：DuoUpdater 自身 `ARCHS: arm64`，
+不存在需要被服务的 Intel host，pin 住 `mac-arm64` 是正确设计而非 bug（见
+issue #102）。`duo verify --only termius` 在这台 Apple Silicon 机器上表现正常。
 
 ### beta（`com.termius-beta.mac`）——本 PR 新增
 
@@ -164,9 +171,10 @@ rollout:
 
 - **版本方案对齐**：feed `version` = `9.43.1` = 挂载后 `CFBundleShortVersionString`。
   没有 `versionIsBuild`。
-- **架构**：用的是 `mac-beta-universal`（不是 stable 那条 bug 复用的 `mac-arm64`），
-  挂载确认 `lipo -info` → `x86_64 arm64`，所以 Beta 这条 **没有** stable 那个
-  架构 bug，一台 recipe 服务任何 Mac，不需要 `hostRequirement`。
+- **架构**：用的是 `mac-beta-universal`（不是 stable 用的 `mac-arm64`），挂载确认
+  `lipo -info` → `x86_64 arm64`，所以 Beta 这条一台 recipe 服务任何 Mac，不需要
+  `hostRequirement`——这只是 vendor 端点选择不同，不代表 stable 的 `mac-arm64`
+  是 bug（DuoUpdater 自身 arm64-only，见 issue #102）。
 - **checksum 已武装**：feed 的 dmg sha512（base64）与 **实际下载字节**的
   `shasum -a 512 | base64` 完全一致——与 stable Termius 自己的两份构建
   （`mac-universal`、`mac-arm64`）一样，都不像 Signal Beta 那样被 CDN 二次 staple
@@ -221,8 +229,9 @@ Beta 的一键 URL 和 sha512 都在生产路径上解出来了。
 
 ## 一键安装
 
-- **stable (`com.termius-dmg.mac`)**：已启用（本 PR 之前就有），但**装的是 arm64-only
-  产物，Intel Mac 上会装出打不开的 app**——已知问题，已拆分为独立任务，未在本 PR 修。
+- **stable (`com.termius-dmg.mac`)**：已启用（本 PR 之前就有），装的是 arm64-only
+  产物——这是刻意的 arm64-pin（DuoUpdater 自身也是 arm64-only，不存在需要被服务的
+  Intel host），不是 bug，见 issue #102。
 - **beta (`com.termius-beta.mac`)**：本 PR 新启用，`kind: .dmg`，`urlSource: .fixed`
   （feed 里的文件名 `Termius Beta.dmg` 不带版本号，无法从 body 里解析出来，只能用固定
   URL——和既存 stable recipe 处理未带版本号文件名的方式一致）。装的是 **universal**
@@ -239,19 +248,21 @@ Beta 的一键 URL 和 sha512 都在生产路径上解出来了。
 
 ## 已知问题
 
-1. **`com.termius-dmg.mac` 一键安装在 Intel Mac 上会装错架构**（详见上文「issue
-   核对」与「更新检测」）。已拆分为独立任务，不在本 PR 范围。
-2. **`com.termius-dmg.mac` 的 `changelogURL` 已死**（404，站点无替代页）。已拆分
-   为独立任务的一部分记录，不在本 PR 范围（不影响功能，只影响 changelog 展示，
+1. **`com.termius-dmg.mac` 的 `changelogURL` 已死**（404，站点无替代页）。已拆分
+   为独立任务（issue #102），不在本 PR 范围（不影响功能，只影响 changelog 展示，
    降级为「no release notes」）。
-3. Beta 的一键读的是**轨道最新**而非**本机分配**（`rollout` 字段今天满量，无 device
+2. Beta 的一键读的是**轨道最新**而非**本机分配**（`rollout` 字段今天满量，无 device
    id 选择器）——继承自既存 stable recipe 的同一读法，不是本 PR 引入的新差异。
+
+（`com.termius-dmg.mac` 装的是 arm64-only 产物这件事**不是**已知问题——DuoUpdater
+自身 arm64-only，pin 住 `mac-arm64` 是正确设计，见 issue #102 与上文「issue 核对」。）
 
 ## 建议下一步
 
-1. 修 `com.termius-dmg.mac` 的架构 bug：改用 `mac-universal` 的 feed + dmg（已验证
-   版本相同、universal 架构），而不是 `mac-arm64`。
-2. 修或移除 `com.termius-dmg.mac` 的 `changelogURL`（当前 404）。
-3. 若 vendor 未来把 `rollout.freeUsers`/`paidUsers` 降到 100 以下，需要重新评估
+1. 修或移除 `com.termius-dmg.mac` 的 `changelogURL`（当前 404，见 issue #102）。
+2. 若 vendor 未来把 `rollout.freeUsers`/`paidUsers` 降到 100 以下，需要重新评估
    Beta（以及既存 stable）recipe 是否应该改读「本机分配」而非「轨道最新」——目前
    无法从这份 electron-builder 静态 manifest 得到 device 级别的分配信息。
+
+**不要**把 `com.termius-dmg.mac` 改成 `mac-universal` 的 feed + dmg——那不是修 bug，
+是把 arm64-pinned by design 的正确行为改坏，见 issue #102。

--- a/docs/app-audits/org-keepassxc-keepassxc.md
+++ b/docs/app-audits/org-keepassxc-keepassxc.md
@@ -13,7 +13,7 @@
 |              | Homebrew | GitHub Releases |
 |--------------|----------|------------------|
 | **stable**   | (cask `keepassxc`) | ✓ 检测 + 一键（`org.keepassxc.keepassxc`，Team `G2S7P7J672`，arm64 dmg）|
-| **snapshot** | (cask `keepassxc@snapshot`，Homebrew 已标记 deprecated，计划 2026-09-01 停用) | ○ 检测受阻于 #93；✗ 一键**永久**不可（未签名）|
+| **snapshot** | (cask `keepassxc@snapshot`，Homebrew 已标记 deprecated，计划 2026-09-01 停用) | ○ 检测已可行（#93 已解决），尚未接 recipe；✗ 一键**永久**不可（未签名）|
 
 `keepassxc@beta` 不是独立预发轨——指向的就是 stable 那个包（2.7.12），是别名，不是候选
 （见 `CHANNEL_COVERAGE_TODO.md` §2c）。真正的预发轨是 `keepassxc@snapshot`。
@@ -23,7 +23,7 @@
 | Channel  | Bundle ID | 独立/共享 | 本地渠道标记 | 签名 | 判定 |
 |----------|-----------|----------|-------------|------|------|
 | stable   | `org.keepassxc.keepassxc` | 共享 | — | Team `G2S7P7J672`，公证 | ✓ 已接入 |
-| snapshot | `org.keepassxc.keepassxc` | 共享 | 版本串带 `-snapshot`（`ReleaseChannel.detect()` 目前不识别，见 #93）| **完全无签名** | 检测阻塞于 #93；**一键永久不可**（见下）|
+| snapshot | `org.keepassxc.keepassxc` | 共享 | 版本串带 `-snapshot`（`ReleaseChannel.detect()` 已识别，#93 已解决）| **完全无签名** | 检测已可行，尚未接 recipe；**一键永久不可**（见下）|
 
 ## 为什么 snapshot 只能是 detection-only（issue #95）
 
@@ -76,7 +76,7 @@ issue 提的疑点——"`@snapshot` cask 这条 URL 是 x86_64，但**另有路
 "most recent development branch" 的快照，没提多架构。
 
 结论：**arm64 Mac 上想跑 snapshot 只能靠 Rosetta，没有原生 arm64 snapshot 可选**。这
-对检测层的含义（若 #93 落地后真要接检测）：不需要 `hostRequirement` 去"选对架构"——
+对检测层的含义（#93 已解决，若真要接检测）：不需要 `hostRequirement` 去"选对架构"——
 因为只有一种架构；但**在 arm64 Mac 上做检测本身要不要有意义**，取决于用户装的到底是
 不是这份 x86_64-only 包在 Rosetta 下跑的（`Info.plist` 不会说"这是 Rosetta 转译的"，
 只会显示 `KernelArchitecture`/`CFBundleExecutable` 都是 x86_64 二进制，AppScanner 现有
@@ -87,16 +87,17 @@ issue 提的疑点——"`@snapshot` cask 这条 URL 是 x86_64，但**另有路
 
 ## 结论
 
-- **检测**：阻塞于 #93（`detect()` 要认出版本串里的 `-snapshot` 才能把 snapshot 与
-  stable 分开；注意 `ReleaseChannel` 已经把*单词* `snapshot` 映射到 `.preview`,但只在
+- **检测**：已解决（#93）。`detect()` 现在能从版本串里的 `-snapshot` 后缀识别
+  snapshot（注意 `ReleaseChannel` 已经把*单词* `snapshot` 映射到 `.preview`,但只在
   `channelWord`(读 display name)里生效——KeePassXC 的 display name 是干净的
-  "KeePassXC",这条映射对它不触发,是版本串专属信号)。
-- **一键**：**永远不做**。完全无签名，`VendorInstaller` 的签名 gate 第一步就拒。#93
-  落地后如果有人想给 snapshot 接 channel-gated recipe，**不要带 `install:`**——保持
+  "KeePassXC",这条映射对它不触发,是版本串专属信号)，但仓库尚未为它接一条 recipe。
+- **一键**：**永远不做**。完全无签名，`VendorInstaller` 的签名 gate 第一步就拒。如果
+  有人想给 snapshot 接 channel-gated recipe，**不要带 `install:`**——保持
   detection-only。
 - 详见 issue #95、`CHANNEL_COVERAGE_TODO.md` §2c。
 
 ## 建议下一步
-1. #93 落地后，如果决定接 snapshot 检测：只加 `channel: .preview`（或对应枚举）的
-   GitHubReleaseRule 或 VendorProbeRecipe，**省略 `installAssetPattern`/`install:`**。
+1. 若决定接 snapshot 检测（`detect()` 已支持 `-snapshot` 后缀，#93 已解决）：只加
+   `channel: .preview`（或对应枚举）的 GitHubReleaseRule 或 VendorProbeRecipe，
+   **省略 `installAssetPattern`/`install:`**。
 2. 不必现在做——这不是本 issue 的范围，本 issue 只是把"一键必拒"这条写下来存档。

--- a/docs/app-audits/org-videolan-vlc.md
+++ b/docs/app-audits/org-videolan-vlc.md
@@ -12,7 +12,7 @@
 |             | Homebrew | VendorProbe |
 |-------------|----------|-------------|
 | **stable**  | (cask `vlc`) | ✓ 检测 + 一键（`org.videolan.vlc`，Team `75GAHG3SZQ`）|
-| **nightly** | (cask `vlc@nightly`，Homebrew 已标记 deprecated，计划 2026-09-01 停用) | ○ 检测受阻于 #93；✗ 一键**永久**不可（未签名）|
+| **nightly** | (cask `vlc@nightly`，Homebrew 已标记 deprecated，计划 2026-09-01 停用) | ○ 检测已可行（#93 已解决），尚未接 recipe；✗ 一键**永久**不可（未签名）|
 
 当前生效源（stable）: **VendorProbe**，`update.videolan.org/vlc/sparkle/vlc-arm64.xml`。
 
@@ -21,7 +21,7 @@
 | Channel | Bundle ID | 独立/共享 | 本地渠道标记 | 签名 | 判定 |
 |---------|-----------|----------|-------------|------|------|
 | stable  | `org.videolan.vlc` | 共享 | — | Team `75GAHG3SZQ`，公证 | ✓ 已接入 |
-| nightly | `org.videolan.vlc` | 共享 | 版本串带 `-dev`（`ReleaseChannel.detect()` 目前不识别，见 #93） | **未签名** | 检测阻塞于 #93；**一键永久不可**（见下）|
+| nightly | `org.videolan.vlc` | 共享 | 版本串带 `-dev`（`ReleaseChannel.detect()` 已识别，#93 已解决） | **未签名** | 检测已可行，尚未接 recipe；**一键永久不可**（见下）|
 
 ## 为什么 nightly 只能是 detection-only（issue #95）
 
@@ -55,9 +55,9 @@ VLC.app: code has no resources but signature indicates they must be present
 （`SignatureVerifier.verifyCodeSignature` + `verifyTeamIdentifierMatch`，
 `DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift`）要求下载物的
 Team ID 与已装 app **完全一致**——nightly 的 "not set" 不可能等于 stable 的
-`75GAHG3SZQ`，一键会在 gate 2/3 被拒。这一步与 stable 的一键路径无关、不受 #93 影响：
-即使 #93 落地、`detect()` 认出 `-dev` 后缀，**这条 gate 依然会拒**，只是拒的位置从
-「未检测到」变成「检测到了但装不上」——本 issue 存在的意义就是把这条提前写下来，
+`75GAHG3SZQ`，一键会在 gate 2/3 被拒。这一步与 stable 的一键路径无关，也不因
+#93 已解决而改变：`detect()` 现在能认出 `-dev` 后缀，但**这条 gate 依然会拒**，
+拒的位置停在「检测到了但装不上」——本 issue 存在的意义就是把这条提前写下来，
 不要等到真的接了 install spec 才在运行时发现。
 
 Homebrew 自己也独立标记了同一结论：`vlc@nightly` cask 被标 `Deprecated because it
@@ -105,15 +105,16 @@ VLC 没有这条——nightly 的 arm64/x86_64 dmg 是分开发布的两个文�
 
 ## 结论
 
-- **检测**：阻塞于 #93（`detect()` 要认出版本串里的 `-dev` 才能把 nightly 与 stable
-  分开）。
-- **一键**：**永远不做**。未签名，`VendorInstaller` 的 Team 闸必拒。#93 落地后如果有人
+- **检测**：已解决（#93）。`detect()` 现在能从版本串里的 `-dev` 后缀识别 nightly，
+  但仓库尚未为它接一条 VendorProbeRecipe。
+- **一键**：**永远不做**。未签名，`VendorInstaller` 的 Team 闸必拒。如果有人
   想给 nightly 接 channel-gated recipe，**不要带 `install:`**——保持 detection-only，
   跟 LibreWolf（`net-librewolf-librewolf.md`）、Wispr Flow 同一模式。
 - 详见 issue #95、`CHANNEL_COVERAGE_TODO.md` §2c。
 
 ## 建议下一步
-1. #93 落地后，如果决定接 nightly 检测：只加 `channel: .dev`（或对应枚举）的
-   VendorProbeRecipe，**省略 `install:`**，`downloadURL` 指到 nightly 目录页而不是
-   dmg（对照 `PageURLTests.detectionOnlyRecipesCarryAPage` 的约束）。
+1. 若决定接 nightly 检测（`detect()` 已支持 `-dev` 后缀，#93 已解决）：只加
+   `channel: .dev`（或对应枚举）的 VendorProbeRecipe，**省略 `install:`**，
+   `downloadURL` 指到 nightly 目录页而不是 dmg（对照
+   `PageURLTests.detectionOnlyRecipesCarryAPage` 的约束）。
 2. 不必现在做——这不是本 issue 的范围，本 issue 只是把"一键必拒"这条写下来存档。


### PR DESCRIPTION
## Summary

Adversarial review of the just-merged #91–#95 batch found three stale/wrong claims that survived into `main`'s documentation. Docs only — no `.swift` files touched, per instruction (Swift changes are being made in parallel by another session).

1. **Termius docs still recommended a withdrawn "fix".** `docs/app-audits/com-termius-dmg-mac.md` and `docs/app-audits/README.md` asserted the arm64-only install is a bug and told the reader to switch to the `mac-universal` feed/dmg. This is wrong: DuoUpdater itself is arm64-only by product decision (`App/project.yml`, `ARCHS: arm64`), so there is no Intel host to serve, and `mac-universal` would cost every user a ~47% larger download to serve a host class that cannot exist. Issue #102 records this correction (and deliberately keeps the withdrawn claim visible so it isn't re-filed). Rewrote all affected passages to point at #102 and reframe the arm64 pin as by-design; kept the real, still-open item (404 `changelogURL`).

2. **`CHANNEL_COVERAGE_TODO.md` said VSCodium Insiders was still unimplemented.** PR #99 shipped its recipe in the same merge; the doc commit (PR #100) was written in a separate worktree and never picked that up. Updated the "Pattern A 未覆盖" count from three to two, removed the `vscodium@insiders` row, and marked it done (issue #92, `docs/app-audits/com-vscodium-VSCodiumInsiders.md`). Also fixed a related stale claim: DB Browser nightly detection was described as reusing Android Studio's `detect()` step 0.5 — it now has its own step 0.6 (confirmed in `ReleaseChannel.swift`).

3. **Six places said detection was "blocked on #93."** #93 landed in the same merge (PR #96, `fix/prerelease-version-suffixes-93`), and `ReleaseChannel.detect()` now correctly resolves VLC's `4.0.0-dev` → `.dev` and KeePassXC's `2.8.0-snapshot` → `.preview` (verified against `versionTailChannelWords` in `ReleaseChannel.swift`). Reworded `docs/app-audits/org-videolan-vlc.md`, `docs/app-audits/org-keepassxc-keepassxc.md`, `docs/app-audits/README.md`, and `CHANNEL_COVERAGE_TODO.md` to say detection is resolved, and that both remain detection-only because the nightly/snapshot builds are unsigned (issue #95, unchanged constraint).

`DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift:15` carries the same stale "blocked on #93" comment but is a `.swift` file — left untouched, to be fixed separately.

## Extra finding not in the original list

`CHANNEL_COVERAGE_TODO.md` §1's "Pattern A — 独立 bundle id" table (the authoritative "已覆盖" list, lines ~19–35) never got a row added for VSCodium Insiders even though it's fully implemented (issue #92). I did not add one — out of scope for a docs-staleness cleanup PR — but flagging it since whoever owns §1 upkeep may want to add it.

## Test plan
- [x] Verified issue #102 content via `gh issue view 102`
- [x] Verified `App/project.yml` ARCHS: arm64 and its rationale comment
- [x] Verified VSCodium Insiders recipe exists (`GitHubReleasesSource.swift`, `GitHubReleaseRuleTests.swift`, `verify/baseline.json`)
- [x] Verified DB Browser nightly has its own `detect()` step 0.6 in `ReleaseChannel.swift` (not reusing Android Studio's step 0.5)
- [x] Verified issue #93 is closed and PR #96 (`fix/prerelease-version-suffixes-93`) added the nightly/-dev/-snapshot version-tail rules to `ReleaseChannel.swift`
- [x] Verified `versionTailChannelWords` maps `dev` → `.dev` and `snapshot` → `.preview`, matching the docs' claimed enum choices
- [x] `git diff --stat -- '*.swift'` is empty — no Swift files touched
- Not run per instructions: `make test`, `swift test`, `duo verify` (user is running builds in parallel)