### PR TITLE
Corrections from the post-merge adversarial review

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
@@ -270,7 +270,10 @@ public enum ReleaseChannel: String, Codable, Sendable, Hashable, CaseIterable {
     /// `.snapshot`/`-snapshot` bundle-id suffix (Vivaldi Snapshot) — so a build
     /// cannot land on a different channel depending on which signal saw it first.
     /// Ordered most-specific-first like `channelWord` for the same reason.
-    private static let versionTailChannelWords: [(word: String, channel: ReleaseChannel)] = [
+    /// Internal, not private, so the cross-signal agreement test can iterate the
+    /// REAL table instead of a hand-copied list that would silently stop covering
+    /// a word added here.
+    static let versionTailChannelWords: [(word: String, channel: ReleaseChannel)] = [
         ("nightly", .nightly),
         ("snapshot", .preview),
         ("dev", .dev),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1160,8 +1160,12 @@ public enum GitHubReleaseRegistry {
         // What actually resolves it to `.preview` is the display name step: the
         // installed app's CFBundleName/CFBundleDisplayName is "VSCodium -
         // Insiders" (confirmed below), and "Insiders" is a standalone word there.
-        // `GitHubReleaseRuleTests` pins this against `ReleaseChannel.detect`
-        // directly so the assumption can't silently stop holding.
+        // `ChannelGuardTests.vscodiumInsidersDisplayNameSignalsPreview` pins our
+        // half of this against `ReleaseChannel.detect`. It cannot pin the VENDOR's
+        // half: the display name is their string, and if VSCodium ever glues it
+        // ("VSCodiumInsiders", the shape the bundle id already has) `detect`
+        // returns `.stable`, the channel gate skips this rule, and the app goes
+        // quiet with the test still green. That is the failure to watch for here.
         //
         // CRUCIAL — this is the SECOND instance of a trap the VS Code Insiders
         // recipe (VendorProbeRecipe.swift) already hit, not a VSCodium quirk:
@@ -1179,15 +1183,18 @@ public enum GitHubReleaseRegistry {
         // hit the same trap; the pattern below keeps the suffix in the capture
         // so it compares equal instead.
         //
-        // x64 asset: unlike the arm64-only pattern above (which is pinned that
-        // way regardless of whether an x64 build exists — not touched here),
-        // this repo DOES publish `VSCodium-darwin-x64-<ver>-insider.zip`
-        // alongside the arm64 one (GET /repos/VSCodium/vscodium-insiders/
-        // releases/latest, verified 2026-08-27: both present, 165 assets total,
-        // exactly these 2 match). `GitHubReleaseRule` has no `hostRequirement`
-        // field — that's a `VendorProbeRecipe`-only concept — so no gating is
-        // needed: matching both filenames lets the existing arch-aware
-        // `installableAsset` selection (HostArch) pick the native build.
+        // arm64 ONLY, deliberately, even though this repo also publishes
+        // `VSCodium-darwin-x64-<ver>-insider.zip`. Matching both looked free —
+        // `installableAsset` prefers the native slice — but this track ships
+        // PLATFORM-PARTIAL releases: tag `1.126.04405-insider` carries an x64
+        // macOS zip and no arm64 one (checked against the API 2026-08-27). On
+        // such a release a both-arch pattern reaches `installableAsset` step 3,
+        // which on Apple silicon with Rosetta returns the FOREIGN build — so an
+        // arm64 Insiders install gets swapped for an Intel one. Pinning arm64
+        // makes that release carry no installable asset instead, and the
+        // list-fallback below then offers nothing until an arm64 build exists,
+        // which is the right answer for a host class that is all we ship to
+        // (`App/project.yml`, `ARCHS: arm64`).
         //
         // One-click: verified 2026-08-27 by downloading the real
         // VSCodium-darwin-arm64-1.126.04518-insider.zip and reading the
@@ -1202,7 +1209,7 @@ public enum GitHubReleaseRegistry {
             bundleID: "com.vscodium.VSCodiumInsiders",
             owner: "VSCodium", repo: "vscodium-insiders",
             versionPattern: #"^([0-9]+(?:\.[0-9]+)+-insider)$"#,
-            installAssetPattern: #"^VSCodium-darwin-(?:arm64|x64)-[0-9.]+-insider\.zip$"#,
+            installAssetPattern: #"^VSCodium-darwin-arm64-[0-9.]+-insider\.zip$"#,
             installerKind: .zip,
             channel: .preview),
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelGuardTests.swift
@@ -337,10 +337,13 @@ import Foundation
 /// tail, `channelWord` (display name), and the `.snapshot`/`-snapshot` bundle-id
 /// suffix. They must not disagree — otherwise the same build lands on a
 /// different channel depending on which signal happened to see it first, and the
-/// cross-channel gate stops being a gate. Compares two production paths rather
-/// than asserting a hardcoded answer, so it cannot drift silently.
+/// cross-channel gate stops being a gate. Both the words and the answers come
+/// from production — the words from `versionTailChannelWords` itself, the answers
+/// from two live `detect()` paths — so adding a word there cannot leave this
+/// check silently covering nothing.
 @Test func versionTailAgreesWithTheOtherChannelWordSignals() {
-    for word in ["nightly", "snapshot", "dev"] {
+    #expect(!ReleaseChannel.versionTailChannelWords.isEmpty)
+    for (word, _) in ReleaseChannel.versionTailChannelWords {
         let fromVersion = ReleaseChannel.detect(
             name: "Some App", bundleID: "com.example.some",
             keystoneChannel: nil, version: "1.2.3-\(word)")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelVersionSweepTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelVersionSweepTests.swift
@@ -33,8 +33,10 @@ import Foundation
     // `<maj>.<min>b<N>` rule reads as `.beta`. That is not a live defect and not
     // this rule's doing: step 0 resolves Firefox from `application.ini`'s
     // `RemotingName` (`firefox-dev`) and returns before step 4 is reached — see
-    // `ReleaseChannel.detect`'s header. Keyed by bundle id, not by version, so a
-    // version bump doesn't silently re-arm it.
+    // `ReleaseChannel.detect`'s header. Matched against the key's SUBJECT field,
+    // not the version, so a version bump doesn't silently re-arm it. Vendor and
+    // changelog rows put a bundle id there; GitHub rows put `owner/repo` — an
+    // entry here has to be spelled the way its own row spells it.
     let decidedBeforeStep4: Set<String> = ["org.mozilla.firefoxdeveloperedition"]
 
     var contradictions: [String] = []
@@ -42,14 +44,24 @@ import Foundation
 
     for (key, entry) in entries {
         guard let version = entry["lastGoodVersion"] as? String, !version.isEmpty else { continue }
-        // Keys are "<source>:<bundleID>:<channel>"; changelog rows carry "-".
+        // Keys are "<source>:<subject>:<channel>[:<variant>]". Three shapes live
+        // in this file and they do NOT agree on what the middle field is:
+        //   vendor:com.termius-beta.mac:beta            subject = bundle id
+        //   changelog:ai.elementlabs.lmstudio:-         subject = bundle id, no channel
+        //   github:VSCodium/vscodium-insiders:preview   subject = OWNER/REPO
+        // and 9 rows carry a fourth, variant component:
+        //   vendor:com.anthropic.claudefordesktop:stable:rollout
+        //   vendor:com.workbuddy.workbuddy:stable:arm64
+        // so the channel is `parts[2]`, NOT the last component — reading the last
+        // one turns `…:beta:arm64` into channel "arm64", which coerces to
+        // `.stable` and would report a legitimate `1.2.3-beta1` as a contradiction.
         let parts = key.split(separator: ":", omittingEmptySubsequences: false)
         guard parts.count >= 3 else { continue }
-        let bundleID = String(parts[1])
-        let declaredRaw = String(parts[parts.count - 1])
+        let subject = String(parts[1])
+        let declaredRaw = String(parts[2])
         let declared = declaredRaw == "-" ? ReleaseChannel.stable
             : (ReleaseChannel(rawValue: declaredRaw) ?? .stable)
-        if decidedBeforeStep4.contains(bundleID) { continue }
+        if decidedBeforeStep4.contains(subject) { continue }
         checked += 1
 
         // Neutral name and no bundle id, so ONLY the version string can speak —

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubAssetSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubAssetSelectionTests.swift
@@ -112,10 +112,6 @@ struct GitHubAssetSelectionTests {
          ["opencode-desktop-mac-arm64.dmg", "opencode-desktop-mac-x64.dmg"]),
         (#"^OpenChamber-[0-9.]+-mac-(?:arm64|x64)\.dmg$"#,
          ["OpenChamber-1.4.0-mac-arm64.dmg", "OpenChamber-1.4.0-mac-x64.dmg"]),
-        // VSCodium Insiders: same alternation shape, real 1.126.04518-insider
-        // filenames (verified 2026-08-27 against the live release).
-        (#"^VSCodium-darwin-(?:arm64|x64)-[0-9.]+-insider\.zip$"#,
-         ["VSCodium-darwin-arm64-1.126.04518-insider.zip", "VSCodium-darwin-x64-1.126.04518-insider.zip"]),
         // Anki: `apple`/`intel` rather than arch tokens, so the arm build reads as
         // arch-neutral and only the Intel one is recognised as foreign.
         (#"^anki-[0-9.]+-mac-(apple|intel)\.dmg$"#,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -294,9 +294,14 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
     // must not accept it either) is rejected.
     #expect(extract("1.126.04518", "com.vscodium.VSCodiumInsiders") == nil)
 
-    // Both real darwin assets from the fixture release match…
+    // The arm64 darwin asset matches…
     #expect(matches("VSCodium-darwin-arm64-1.126.04518-insider.zip", "com.vscodium.VSCodiumInsiders"))
-    #expect(matches("VSCodium-darwin-x64-1.126.04518-insider.zip", "com.vscodium.VSCodiumInsiders"))
+    // …and the x64 one deliberately does NOT. This track ships platform-partial
+    // releases (`1.126.04405-insider` is x64-only), where matching x64 would let
+    // `installableAsset` step 3 hand an Apple-silicon install an Intel build
+    // under Rosetta. Not matching it makes that release carry no installable
+    // asset, which is the outcome we want. See the rule's comment.
+    #expect(!matches("VSCodium-darwin-x64-1.126.04518-insider.zip", "com.vscodium.VSCodiumInsiders"))
     // …but the stable build's un-suffixed filename, the CLI tarball, and the
     // checksum sidecars beside the real asset must not.
     #expect(!matches("VSCodium-darwin-arm64-1.126.04518.zip", "com.vscodium.VSCodiumInsiders"))

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UnsignedNightlyInstallSpecTests.swift
@@ -12,9 +12,9 @@ import Foundation
 /// (`SignatureVerifier.verifyTeamIdentifierMatch`) would refuse the swap, so
 /// neither may ever carry an install spec.
 ///
-/// Detection for these two channels doesn't exist yet (blocked on #93), so
-/// today each `where` below matches zero recipes — that's expected, not a
-/// broken filter. What tells the two apart is the presence anchor each test
+/// `detect()` now resolves both channels (#93 landed: `4.0.0-dev` → `.dev`,
+/// `2.8.0-snapshot` → `.preview`), but neither has a RECIPE, so today each
+/// `where` below matches zero recipes — that's expected, not a broken filter. What tells the two apart is the presence anchor each test
 /// starts with: it fails if the bundle id it's filtering for ever stops
 /// existing in the registry at all (typo'd, renamed by the vendor, or moved
 /// to a different registry), which is exactly the failure mode that would


### PR DESCRIPTION
An adversarial review of the merged #91–#95 batch found four code defects. All were reproduced before fixing.

## 1. VSCodium Insiders could install an Intel build over an arm64 one

The rule matched both arches. That looked free — `installableAsset` prefers the native slice — but **this track ships platform-partial releases**. Verified against the API:

```
$ gh api repos/VSCodium/vscodium-insiders/releases/tags/1.126.04405-insider --jq '.assets[].name' | grep darwin
VSCodium-darwin-x64-1.126.04405-insider.zip
VSCodium-darwin-x64-1.126.04405-insider.zip.sha1
VSCodium-darwin-x64-1.126.04405-insider.zip.sha256
```

No arm64 asset. On that release the both-arch pattern reaches `installableAsset` step 3 — `guard arch == .arm64, canRunIntel` — which returns the **foreign** build, so an Apple-silicon Insiders install gets replaced by an Intel one under Rosetta. That is step 3's documented intent when it is the only option, but here it was reachable only because the pattern volunteered an asset that should not have counted.

Pinning arm64 makes that release carry no installable asset, so the list-fallback offers nothing until an arm64 build exists — the right answer when `App/project.yml` ships `ARCHS: arm64` and Apple silicon is the entire host population.

```
OLD (both-arch)    matches 1 -> ['VSCodium-darwin-x64-1.126.04405-insider.zip']
NEW (arm64-only)   matches 0 -> none, release skipped
```

Also drops the rule from `multiCandidateCases` (it no longer admits several assets) and flips the x64 assertion in `GitHubReleaseRuleTests` with the reason recorded.

## 2. A cross-reference pointing at the wrong file, and overclaiming

The comment said `GitHubReleaseRuleTests` pins the detection assumption. `grep -c "ReleaseChannel.detect"` in that file returns **0** — the test is `vscodiumInsidersDisplayNameSignalsPreview` in `ChannelGuardTests.swift`. The earlier "point cross-refs at file+symbol" pass fixed the neighbours and missed this one.

It also claimed more than the test can deliver. The assumption is that the vendor's `CFBundleName` is "VSCodium - Insiders" — a **vendor-side** fact. The test hardcodes that string, so if VSCodium ever glues it, `detect()` returns `.stable`, the channel gate skips the rule, and the app goes **silently quiet with the test still green**. The comment now says so.

## 3. `ChannelVersionSweepTests` parsed the channel from the wrong field

It read `parts.last`. Measured against `verify/baseline.json`: **9 rows carry a fourth variant component** (`vendor:com.anthropic.claudefordesktop:stable:rollout`, `vendor:com.workbuddy.workbuddy:stable:arm64`, …), so the channel parsed as `"arm64"` → coerced to `.stable`. It cannot false-pass today, but the day a non-stable recipe grows a variant, a legitimate `1.2.3-beta1` would be reported as a contradiction — a loud failure for a correct state, which is how tests get weakened. Now reads `parts[2]`.

Its comment also said the middle field is a bundle id. For the **69 `github:` rows it is `owner/repo`**, which means the `decidedBeforeStep4` allowlist could never have matched a GitHub-sourced app. Comment now names all three real key shapes.

## 4. "Cannot drift silently" was false

`versionTailAgreesWithTheOtherChannelWordSignals` iterated a hand-written `["nightly", "snapshot", "dev"]`. The *answers* came from production; the *word list* did not — so a fourth entry in `versionTailChannelWords` would have been silently uncovered. Exactly what `CLAUDE.md` forbids, in a test whose own comment claimed immunity.

`versionTailChannelWords` is now internal and the test iterates it. Confirmed to go red against a deliberately disagreeing entry:

```
✘ version tail and display name disagree on "insiders": beta vs preview
```

## Verification

```
cd DuoUpdaterCore && swift test
━ Test run with 1290 tests in 101 suites passed after 70.451 seconds with 1 known issue.

swift test --package-path CLI
✔ Test run with 127 tests in 19 suites passed after 0.065 seconds.
```

Findings 1 and 4 were each confirmed to fail first, then restored.

## Not in this PR

The review also found stale documentation (a merged audit doc still recommending the withdrawn `mac-universal` change, `CHANNEL_COVERAGE_TODO.md` listing VSCodium Insiders as unimplemented, six files saying detection is "blocked on #93"). Those are #104, docs-only, to keep this diff reviewable.