### PR TITLE
Point Termius's changelog at the page that still exists

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -3802,7 +3802,10 @@ public enum VendorProbeRegistry {
             mode: .responseBody,
             versionPattern: #"^version:\s*([0-9][^\s]*)"#,
             downloadURL: URL(string: "https://termius.com/download/macos"),
-            changelogURL: URL(string: "https://termius.com/release-notes"),
+            // `termius.com/release-notes` 404s (checked 2026-08-27). The live
+            // page is on the docs host; `termius.com/changelog` redirects here,
+            // so point at the destination rather than depend on the redirect.
+            changelogURL: URL(string: "https://docs.termius.com/changelog"),
             install: VendorInstallSpec(
                 urlSource: .fixed(
                     URL(string: "https://autoupdate.termius.com/mac-arm64/Termius.dmg")!),


### PR DESCRIPTION
Closes #102.

`com.termius-dmg.mac` carried `changelogURL: https://termius.com/release-notes`, which **404s** — so the row's release-notes button sent users to a dead page.

The replacement exists:

```
https://termius.com/release-notes    -> 404
https://termius.com/changelog        -> 200  (redirects to docs.termius.com/changelog)
https://docs.termius.com/changelog   -> 200
```

Title is *"Windows / Linux / macOS | Changelog | termius.docs"*, and `9.43.0` appears in the body — the same track this recipe reads — so it is the right page and not a marketing stub. The recipe names `docs.termius.com/changelog` directly rather than relying on the redirect continuing to exist.

### Correcting the record

The #91 investigation concluded "no replacement page exists in the vendor's sitemap". That was an absence claim derived from one method — searching the sitemap — and the plain `/changelog` URL answers 200. Same shape as the other absence claims this batch got wrong.

### Why it rotted silently

`ChangelogURLPolicyTests` iterates every recipe's `changelogURL`, but it checks the URL's **shape**, not that it resolves. Nothing anywhere fetches these. A liveness sweep would belong in `duo verify` alongside the ~150 requests it already makes, not in a unit test — flagging it rather than building it, since it is out of scope here.

### Verification

```
cd DuoUpdaterCore && swift test
━ Test run with 1290 tests in 101 suites passed after 76.880 seconds with 1 known issue.

swift test --package-path CLI
✔ Test run with 127 tests in 19 suites passed after 0.068 seconds.
```