### PR TITLE
fix(cli): refuse the flags and operands no subcommand reads

### DIFF
--- a/CLI/Sources/DuoKit/ArgParser.swift
+++ b/CLI/Sources/DuoKit/ArgParser.swift
@@ -12,7 +12,22 @@ public struct Args {
     /// `--flag` (value `""`) and `--flag value` / `--flag=value`.
     private(set) var flags: [String: String] = [:]
     /// Everything that isn't a flag or a flag's value.
-    public private(set) var operands: [String] = []
+    public var operands: [String] {
+        seen.readOperands = true
+        return positional
+    }
+    private var positional: [String] = []
+    private let seen = Seen()
+
+    /// What this invocation actually asked the parser for. `unrecognised()`
+    /// judges the command line against this rather than against a declared
+    /// table of flags per subcommand: a table is a second list, and second
+    /// lists drift out of sync with the `case` that reads them — quietly, since
+    /// the drift only shows up as a flag nobody validates.
+    private final class Seen {
+        var flags: Set<String> = []
+        var readOperands = false
+    }
 
     /// Flags that take a following value. Anything not listed is a boolean, so
     /// `duo verify --json --only foo` parses the way you'd expect rather than
@@ -47,29 +62,76 @@ public struct Args {
         while i < rest.count {
             let token = rest[i]
             guard token.hasPrefix("--") else {
-                operands.append(token)
+                positional.append(token)
                 i += 1
                 continue
             }
             let body = String(token.dropFirst(2))
             if let eq = body.firstIndex(of: "=") {
                 flags[String(body[body.startIndex..<eq])] = String(body[body.index(after: eq)...])
-            } else if Self.valueFlags.contains(body), i + 1 < rest.count {
+            } else if Self.valueFlags.contains(body), i + 1 < rest.count,
+                      !rest[i + 1].hasPrefix("--") {
                 flags[body] = rest[i + 1]
                 i += 1
             } else {
+                // Either a boolean, or a value flag with nothing usable after
+                // it. Recorded as empty either way and sorted out by
+                // `unrecognised()`, which knows whether the value was required.
                 flags[body] = ""
             }
             i += 1
         }
     }
 
-    public func has(_ name: String) -> Bool { flags[name] != nil }
+    public func has(_ name: String) -> Bool {
+        seen.flags.insert(name)
+        return flags[name] != nil
+    }
     public func value(_ name: String) -> String? {
+        seen.flags.insert(name)
         guard let raw = flags[name], !raw.isEmpty else { return nil }
         return raw
     }
     public func int(_ name: String) -> Int? { value(name).flatMap(Int.init) }
+
+    /// The first token this invocation can't account for, or nil if it is clean.
+    ///
+    /// Call it once the options are built and before anything runs — that is the
+    /// last moment where refusing is free, and it is also the first moment where
+    /// `seen` is complete. Without it an unrecognised flag reads as absent, and
+    /// absent is rarely harmless: for `verify` it means the whole ~150-request
+    /// sweep instead of the one recipe `--only` was meant to name, and `--githubb`
+    /// spends the unauthenticated GitHub rate limit on the way past.
+    ///
+    /// The corollary for whoever adds the next flag: read it unconditionally. A
+    /// flag read only inside an `if` is a flag this refuses whenever that `if`
+    /// is false, because from here "never asked about" and "not accepted" are
+    /// the same thing.
+    public func unrecognised() -> UsageError? {
+        let accepted = seen.flags.isEmpty
+            ? "`duo \(subcommand)` takes no flags"
+            : "accepted: " + seen.flags.sorted().map { "--\($0)" }.joined(separator: " ")
+
+        for name in flags.keys.sorted() where !seen.flags.contains(name) {
+            return UsageError("unknown flag '--\(name)' for `duo \(subcommand)`; \(accepted)")
+        }
+        // `--only --samples` and a trailing `--only` both land here: the value
+        // flag is present but empty, which every reader turns back into "not
+        // given at all".
+        for name in flags.keys.sorted()
+        where Self.valueFlags.contains(name) && flags[name]?.isEmpty == true {
+            return UsageError("--\(name) needs a value")
+        }
+        // No operand in this CLI is an app named `-something`, so a leading dash
+        // here is a misspelled flag that the loop above never saw.
+        if let stray = positional.first(where: { $0.hasPrefix("-") }) {
+            return UsageError("unknown flag '\(stray)' for `duo \(subcommand)`; \(accepted)")
+        }
+        if !seen.readOperands, let stray = positional.first {
+            return UsageError("`duo \(subcommand)` takes no arguments, got '\(stray)'; \(accepted)")
+        }
+        return nil
+    }
 }
 
 /// A malformed invocation, carried back to `main.swift` so the message and the

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -27,7 +27,7 @@ commands:
                 against the captured response before anyone reads it.
   reconcile     Turn a verify report into GitHub issues — one per broken recipe,
                 closed automatically when it heals.
-  help          Show this message.
+  help          Show this message. So does --help after any command.
 
 list / check options:
   [<app>…]            Which apps, resolved as an install path, then a bundle id,
@@ -157,10 +157,24 @@ exit codes:
   2  usage error
 """
 
+// `--help` and `-h` are answered before parsing, because `Args` refuses a
+// leading dash as a subcommand: `duo --help` never reaches the switch below, and
+// `duo verify --help` parses as a `verify` run carrying a flag nobody reads —
+// which is to say the full ~150-request sweep.
+if CommandLine.arguments.dropFirst().contains(where: { $0 == "--help" || $0 == "-h" }) {
+    print(usage)
+    exit(0)
+}
+
 guard let args = Args(CommandLine.arguments) else {
     print(usage)
     exit(2)
 }
+
+// Assigned by every branch, called only after the command line has been checked
+// over — see the `unrecognised()` call below. Building the options and running
+// them are deliberately two steps so that a typo costs nothing.
+let run: () async -> Int32
 
 switch args.subcommand {
 case "list", "check":
@@ -179,7 +193,7 @@ case "list", "check":
     if !options.sources.isEmpty && !options.checkForUpdates {
         die("--source needs a source to have answered; use `duo check --source …`", code: 2)
     }
-    exit(await Check.run(options))
+    run = { await Check.run(options) }
 
 case "install":
     var options = Install.Options()
@@ -192,12 +206,12 @@ case "install":
     case .success(let routes): options.routes = routes
     case .failure(let failure): die(failure.description, code: 2)
     }
-    exit(await Install.run(options))
+    run = { await Install.run(options) }
 
 case "restart":
     var options = Restart.Options()
     options.queries = args.operands
-    exit(await Restart.run(options))
+    run = { await Restart.run(options) }
 
 case "ignore", "unignore", "skip", "unskip":
     guard let action = Visibility.Action(rawValue: args.subcommand) else {
@@ -205,7 +219,7 @@ case "ignore", "unignore", "skip", "unskip":
     }
     var options = Visibility.Options(action: action, queries: args.operands)
     options.json = args.has("json")
-    exit(await Visibility.run(options))
+    run = { await Visibility.run(options) }
 
 case "backups":
     let operation: Backups.Options.Operation
@@ -223,10 +237,11 @@ case "backups":
     var options = Backups.Options(operation: operation)
     options.json = args.has("json")
     options.assumeYes = args.has("yes")
-    exit(await Backups.run(options))
+    run = { await Backups.run(options) }
 
 case "doctor":
-    exit(await Doctor.run(json: args.has("json")))
+    let json = args.has("json")
+    run = { await Doctor.run(json: json) }
 
 case "verify":
     var options = VerifyOptions()
@@ -245,7 +260,7 @@ case "verify":
     options.baselinePath = args.value("baseline").map { URL(fileURLWithPath: $0) }
     options.jsonPath = args.value("report").map { URL(fileURLWithPath: $0) }
     options.markdownPath = args.value("markdown").map { URL(fileURLWithPath: $0) }
-    exit(await Verify.run(options))
+    run = { await Verify.run(options) }
 
 case "triage":
     guard let report = args.value("report"), let out = args.value("out") else {
@@ -261,22 +276,32 @@ case "triage":
     if let cap = args.int("max-calls") { triage.maxCalls = max(0, cap) }
     if let budget = args.int("budget") { triage.budget = TimeInterval(budget) }
     triage.dryRun = args.has("dry-run")
-    exit(Triage.run(triage))
+    run = { Triage.run(triage) }
 
 case "reconcile":
     guard let report = args.value("report"), let baseline = args.value("baseline") else {
         die("reconcile needs --report <path> and --baseline <path>\n\n\(usage)", code: 2)
     }
-    exit(Reconcile.run(Reconcile.Options(
+    let reconcile = Reconcile.Options(
         reportPath: URL(fileURLWithPath: report),
         baselinePath: URL(fileURLWithPath: baseline),
         triagePath: args.value("triage").map { URL(fileURLWithPath: $0) },
-        dryRun: args.has("dry-run"))))
+        dryRun: args.has("dry-run"))
+    run = { Reconcile.run(reconcile) }
 
-case "help", "--help", "-h":
+case "help":
     print(usage)
     exit(0)
 
 default:
     die("unknown command '\(args.subcommand)'\n\n\(usage)", code: 2)
 }
+
+// Nothing has run yet: every branch above only reads flags and builds options.
+// A flag no branch read is a typo, and a typo that parses as "absent" is how
+// `duo verify --githubb` turns a one-recipe check into the whole sweep.
+if let problem = args.unrecognised() {
+    die("\(problem)\n\ntry `duo \(args.subcommand) --help`", code: 2)
+}
+
+exit(await run())

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -1,0 +1,95 @@
+import Testing
+@testable import DuoKit
+
+/// What `duo` does with a command line it doesn't recognise.
+///
+/// It used to do nothing at all. An unread flag parsed as absent, and absent is
+/// not a neutral default: `duo verify --help` printed no help and swept all
+/// three registries instead — ~150 requests against real vendor endpoints, and
+/// the unauthenticated GitHub rate limit spent on the way past. Every typo
+/// widened the sweep the same way, `--githubb` and `--vendors` and an `--only`
+/// with nothing after it alike.
+///
+/// The accepted set is declared nowhere. It is whatever the subcommand's branch
+/// in `main.swift` read, so these tests read flags the way a branch does and
+/// then ask what was left over.
+@Suite struct ArgParserTests {
+
+    private func args(_ argv: String...) -> Args { Args(["duo"] + argv)! }
+
+    @Test func aFlagNobodyReadsIsRefusedAndTheAlternativesAreNamed() {
+        let args = self.args("verify", "--githubb")
+        _ = args.has("github")
+        _ = args.has("vendor")
+
+        let problem = args.unrecognised()?.description
+        #expect(problem?.contains("unknown flag '--githubb'") == true)
+        #expect(problem?.contains("accepted: --github --vendor") == true)
+    }
+
+    @Test func aFlagTheCommandReadsIsFine() {
+        let args = self.args("verify", "--samples", "--only=workbuddy")
+        #expect(args.has("samples"))
+        #expect(args.value("only") == "workbuddy")
+        #expect(args.unrecognised() == nil)
+    }
+
+    /// `duo verify --only workbuddy --vendor` — narrowing the sweep two ways at
+    /// once, which is the whole point of having the flags, so it has to survive.
+    @Test func aValueFlagDoesNotSwallowTheFlagAfterIt() {
+        let args = self.args("verify", "--only", "workbuddy", "--vendor")
+        #expect(args.value("only") == "workbuddy")
+        #expect(args.has("vendor"))
+        #expect(args.unrecognised() == nil)
+    }
+
+    /// Both spellings of the same slip. `--only --samples` is the nastier one:
+    /// it used to bind `--samples` as the value, so the sweep ran scoped to a
+    /// bundle id no recipe has and the sample dump silently never happened.
+    @Test func aValueFlagWithNothingUsableAfterItIsRefused() {
+        for tail in [[] as [String], ["--samples"]] {
+            let args = Args(["duo", "verify", "--only"] + tail)!
+            _ = args.value("only")
+            _ = args.has("samples")
+            #expect(args.unrecognised()?.description == "--only needs a value")
+        }
+    }
+
+    /// Derived from the enum rather than spelled out: a fourth registry would
+    /// otherwise get a flag that nothing checks is still accepted.
+    @Test func everyRegistryIsAcceptedUnderItsOwnName() {
+        for registry in Registry.allCases {
+            let args = self.args("verify", "--\(registry.rawValue)")
+            _ = Registry.allCases.filter { args.has($0.rawValue) }
+            #expect(args.unrecognised() == nil, "--\(registry.rawValue) should be accepted")
+        }
+    }
+
+    /// `duo verify workbuddy` is the `--only` you forgot to type, and it used to
+    /// cost the full sweep.
+    @Test func aStrayWordIsRefusedByACommandThatReadsNoOperands() {
+        let args = self.args("verify", "workbuddy")
+        _ = args.value("only")
+        #expect(args.unrecognised()?.description.contains("takes no arguments, got 'workbuddy'") == true)
+    }
+
+    @Test func aCommandThatTakesAppsStillTakesThem() {
+        let args = self.args("check", "Alcove", "Docker")
+        #expect(args.operands == ["Alcove", "Docker"])
+        #expect(args.unrecognised() == nil)
+    }
+
+    /// One dash short. No app is called `-json`, so resolving it as a name would
+    /// only report the wrong failure.
+    @Test func aFlagMissingADashIsNotAnAppName() {
+        let args = self.args("check", "-json")
+        #expect(args.operands == ["-json"])
+        #expect(args.unrecognised()?.description.contains("unknown flag '-json'") == true)
+    }
+
+    @Test func aCommandWithNoFlagsOfItsOwnSaysThatInstead() {
+        let args = self.args("restart", "--json")
+        _ = args.operands
+        #expect(args.unrecognised()?.description.contains("`duo restart` takes no flags") == true)
+    }
+}


### PR DESCRIPTION
`duo verify --help` printed no help. It parsed as a `verify` run carrying a flag nobody read, and an unread flag reads as absent — which for `verify` means all three registries: ~150 requests against real vendor endpoints, with the unauthenticated GitHub budget spent on the way past. Every typo widened the sweep the same way — `--githubb`, `--vendors`, a trailing `--only`, or the `--only` you forgot to type in front of a bundle id.

## The gap was never verify's

`Args` collected flags and no caller ever asked what was left over, so `duo doctor --bogus` and `duo restart --json` ran too. Fixed once, in the parser.

```
$ duo verify --only zzz-no-such-bundle --help     # before
nothing to verify — no recipe matches zzz-no-such-bundle    ← --help swallowed, run proceeds
$ duo doctor --bogus                              # before
  duo doctor …                                              ← runs, exit 0
```

## The accepted set is derived, not declared

`Args` records which flags the subcommand actually read, and that recording *is* the accepted list — which is also what the error prints, so it can never name a flag that no longer exists or omit one that does.

A table of allowed flags per subcommand would be a second list, and `ArgParser.swift` already carries the scar of one: `valueFlags` fails quietly when it drifts. Two flags prove the point — `--budget` is accepted by `triage` and appears in no usage text, and `--timeout` sits in `valueFlags` with no consumer at all. A hand-written table would have got both wrong.

The switch in `main.swift` now builds a closure per subcommand instead of exiting from inside it, so the check runs once — after the options are built, before any of them runs — and a subcommand added later cannot forget it.

**Corollary for the next flag: read it unconditionally.** A flag read only inside an `if` is a flag this refuses whenever that `if` is false. It's in the doc comment on `unrecognised()`.

## Also in scope, same silent widening

- A value flag with nothing usable after it is an error rather than an empty string. `duo verify --only --samples` used to bind `--samples` as the value, so the sweep ran scoped to a bundle id no recipe has *and* the sample dump never happened, both without a word.
- An operand given to a subcommand that reads none is an error. `duo verify workbuddy` is the missing `--only`, and it cost the full sweep.
- An operand starting with a dash is reported as a misspelled flag. No app is named `-json`, so resolving it as a name only reports the wrong failure.
- `--help` / `-h` are answered before parsing, because `Args` refuses a leading dash as a subcommand — which is why the switch's `case "--help"` was unreachable dead code.

## Verification

`make test` exit 0 — DuoUpdaterCore **1290 tests / 101 suites** passed (1 pre-existing known issue), CLI **136 tests / 20 suites** passed, localizable keys ✓. New `ArgParserTests` is 9 of those; its registry case is derived from `Registry.allCases`, so a fourth registry cannot arrive with a flag nothing checks is accepted.

Against the live endpoints, after `make cli`:

```
$ duo verify --help                    → usage, exit 0
$ duo verify --bogus                   → unknown flag '--bogus' for `duo verify`; accepted:
                                         --baseline --changelog --github --markdown
                                         --max-concurrency --no-installed --only --report
                                         --samples --vendor                        exit 2
$ duo verify --only                    → --only needs a value                      exit 2
$ duo verify --only workbuddy --vendor → 4 vendor probes  ✓4 ✗0                    exit 0
$ duo verify --only wb --vendor --max-concurrency 2 --report … --baseline …
                                       → ✓4, both files written                    exit 0
$ duo check Alcove / list --json / backups restore / backups bogus → unchanged
```

**Not covered by tests:** the single `unrecognised()` call after the switch. `main.swift` is an executable target `DuoKitTests` cannot import, so that wiring is covered by the manual runs above only.

## Behaviour changes beyond the reported bug

Each one used to be silently ignored:

1. `duo verify workbuddy` (missing `--only`) was a full sweep; now an error.
2. Misspelled flags on every other subcommand (`duo restart --json`, `duo doctor --bogus`) now error.
3. `duo --help` exits 0 instead of 2. Bare `duo` still exits 2.
4. `duo check -json` (one dash short) was resolved as an app name; now reported as a flag.

`CHANGELOG.md` is untouched — per `git log`, only `release: prepare` commits touch it. This is a user-visible CLI change and is worth a line at the next release prep.
