### PR TITLE
fix: three checks that could not fail — Edge's dead links, GitHub channel proofs, WorkBuddy's permanent warning

### DIFF
--- a/CLI/Sources/DuoKit/ChangelogLinkSweep.swift
+++ b/CLI/Sources/DuoKit/ChangelogLinkSweep.swift
@@ -1,0 +1,210 @@
+import Foundation
+import DuoUpdaterCore
+
+/// Fetch every recipe's `changelogURL` and say which ones are dead.
+///
+/// The gap this closes (issue #107): a `changelogURL` is not parsed by anything,
+/// so no other check in this sweep touches it. `ChangelogURLPolicyTests` asserts
+/// its *shape* — https, no credentials, no IP literal — and a shape stays valid
+/// forever after the page behind it is retired. A vendor moves their docs, the
+/// release-notes button starts opening a 404, and every test stays green. Three
+/// Microsoft Edge channels sat that way until someone fetched all 87 by hand.
+///
+/// **Advisory by construction.** Only 404 and 410 — the two codes that mean the
+/// server is asserting the page is gone — become a warning. Everything else is a
+/// machine note: a 403 is far more often a bot wall than a dead page, a 429 or a
+/// 5xx is the vendor having a bad minute, and a dropped connection is this
+/// machine's network. Filing issues for those would train the reader to ignore
+/// the ones that matter.
+///
+/// **This runs on URLSession, and that is the point.** Issue #107 measured the
+/// registry with `curl` and reported AnyDesk's changelog as a 403; through
+/// `URLSession` the same URL answers 200 (HEAD and GET alike, verified
+/// 2026-08-28), because the bot wall is reading the client, not the URL. The app
+/// opens these pages in a WebView on Apple's networking stack, so a check that
+/// asks the way the app asks measures the thing the user will actually see — and
+/// a whole class of phantom "dead page" findings never exists.
+///
+/// **What it cannot see:** a soft 404 — a 200 page whose body says "not found".
+/// Detecting that means reading and judging the body of every changelog page in
+/// the registry, which is a different (and much noisier) check than this one.
+enum ChangelogLinkSweep {
+
+    /// What the vendor's server said about one changelog page.
+    enum Verdict: Sendable, Equatable {
+        /// 2xx — the page answers.
+        case alive
+        /// 404/410. The server is stating the page does not exist.
+        case gone(Int)
+        /// Any other status, or no response at all. Says nothing about the page.
+        case inconclusive(String)
+    }
+
+    /// This check's own session, deliberately NOT the shared `URLSession.updates`.
+    ///
+    /// This is the only place in the codebase that issues a HEAD and a GET for the
+    /// same URL, and `sweepChangelog` later GETs some of those URLs for real. A
+    /// zero-length HEAD response sitting in a shared `URLCache` is exactly the
+    /// kind of thing that turns into an empty body and a "recipe broken" issue for
+    /// a page that is fine — and `URLRequest.versionFeedCachePolicy`'s own
+    /// documentation is about how invisible that class of failure is. Nothing here
+    /// benefits from a cache (every request ignores it on the way out anyway), so
+    /// the safe move is to have no store to poison.
+    private static let linkSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.urlCache = nil
+        config.timeoutIntervalForRequest = 15
+        config.httpMaximumConnectionsPerHost = 8
+        return URLSession(configuration: config)
+    }()
+
+    /// Browser-ish, matching `VendorProbeSource`: several docs hosts serve a
+    /// different (or no) response to an unrecognised agent, and a 403 we provoked
+    /// ourselves would be noise in a check whose whole job is to be quiet.
+    private static let userAgent =
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+        + "(KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+
+    /// Distinct changelog pages across `recipes`, in a stable order, minus any
+    /// page another part of the sweep is already fetching.
+    ///
+    /// Deduplicated because several recipes legitimately share one page — Chrome's
+    /// four channels, Firefox's trains — and asking the same host the same
+    /// question four times is four times the rate-limit exposure for no extra
+    /// signal.
+    ///
+    /// `alreadyFetched` is the stronger version of the same argument. 17 of the 87
+    /// pages are ALSO a `ChangelogRecipe.source`, which `sweepChangelog` fetches
+    /// with a GET and parses in the same run. Asking again would be a wasted
+    /// request, and worse, a second opinion that can disagree with the first: one
+    /// report saying a recipe parsed 2 entries from a page and, two lines down,
+    /// that the same page is gone. A GET that came back with a parseable document
+    /// is the better evidence, so a page that has one is not asked twice.
+    static func pages(
+        of recipes: [VendorProbeRecipe], alreadyFetched: Set<String> = []
+    ) -> [URL] {
+        var seen = Set<String>()
+        var out: [URL] = []
+        for recipe in recipes {
+            guard let url = recipe.changelogURL else { continue }
+            guard !alreadyFetched.contains(url.absoluteString) else { continue }
+            if seen.insert(url.absoluteString).inserted { out.append(url) }
+        }
+        return out
+    }
+
+    /// HEAD every page, grouped by host with the sweep's usual per-host pacing.
+    static func statuses(
+        of recipes: [VendorProbeRecipe], alreadyFetched: Set<String> = [],
+        options: VerifyOptions
+    ) async -> [String: Verdict] {
+        let urls = pages(of: recipes, alreadyFetched: alreadyFetched)
+        guard !urls.isEmpty else { return [:] }
+
+        let groups = Dictionary(grouping: urls, by: { $0.host ?? "-" })
+            .values.sorted { ($0[0].host ?? "-") < ($1[0].host ?? "-") }
+        let delay = options.perHostDelay
+
+        var out: [String: Verdict] = [:]
+        var next = 0
+        await withTaskGroup(of: [(String, Verdict)].self) { group in
+            func addNext() {
+                guard next < groups.count else { return }
+                let batch = groups[next]
+                next += 1
+                group.addTask {
+                    var produced: [(String, Verdict)] = []
+                    for (index, url) in batch.enumerated() {
+                        if index > 0 {
+                            try? await Task.sleep(
+                                for: delay + .milliseconds(Int.random(in: 0...100)))
+                        }
+                        produced.append((url.absoluteString, await verdict(for: url)))
+                    }
+                    return produced
+                }
+            }
+            for _ in 0..<min(options.hostConcurrency, groups.count) { addNext() }
+            for await produced in group {
+                for (key, value) in produced { out[key] = value }
+                addNext()
+            }
+        }
+        return out
+    }
+
+    /// One page: HEAD to ask cheaply, and **GET before believing any bad news.**
+    ///
+    /// A HEAD is a request for the headers of a GET, and plenty of hosts do not
+    /// implement it that way. The first full live run of this check flagged both
+    /// WorkBuddy changelog pages as gone: `www.workbuddy.ai` and
+    /// `www.codebuddy.cn` answer HEAD with **404** and GET with **200** and 31 KB
+    /// of the page (measured 2026-08-28) — a static-site host that only generates
+    /// routes for GET. Two working recipes, accused by name, on a check whose
+    /// whole justification is that it stays quiet.
+    ///
+    /// So a HEAD may only ever confirm a page ALIVE. Anything else is re-asked
+    /// the way a browser would ask, and the GET's answer is the one that counts.
+    /// The first draft retried on 403/405/400 only — chosen from the codes that
+    /// obviously mean "not that method", which quietly assumed a 404 could be
+    /// trusted from a request no browser makes. It cannot. The cost is one extra
+    /// request per unhealthy page, on a path that is rare by construction.
+    static func verdict(for url: URL, session: URLSession = linkSession) async -> Verdict {
+        if case .alive = await status(of: url, method: "HEAD", session: session) {
+            return .alive
+        }
+        return await status(of: url, method: "GET", session: session)
+    }
+
+    private static func status(
+        of url: URL, method: String, session: URLSession
+    ) async -> Verdict {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = 15
+        // A cached 200 from an earlier sweep would hide the day the page died,
+        // which is the only day this check exists for.
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        let response: URLResponse
+        do { (_, response) = try await session.data(for: request) }
+        catch {
+            // A host that does not resolve is worth saying out loud rather than
+            // filing under "the network was unhappy". Retiring a docs subdomain
+            // outright is one of the ways a vendor kills a changelog page, and it
+            // is the one shape of this check's blind spot that a reader can act
+            // on — so it stays non-accusing (DNS fails for local reasons too) but
+            // stops reading as ordinary transport noise.
+            if (error as? URLError)?.code == .cannotFindHost {
+                return .inconclusive("does not resolve — the host itself may be retired")
+            }
+            return .inconclusive("could not be reached")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            return .inconclusive("answered with a non-HTTP response")
+        }
+        switch http.statusCode {
+        case 200..<300: return .alive
+        case 404, 410:  return .gone(http.statusCode)
+        default:        return .inconclusive("answered HTTP \(http.statusCode)")
+        }
+    }
+
+    /// How a verdict should read in the report, or nil when there is nothing to
+    /// say. A machine note never promotes a finding to `.warn` — see
+    /// `Finding.machineNotePrefix`.
+    static func complaint(for verdict: Verdict, url: URL) -> String? {
+        switch verdict {
+        case .alive:
+            return nil
+        case .gone(let code):
+            return "its release-notes page is gone: \(url.absoluteString) returns HTTP "
+                + "\(code) — the button in the app opens a dead page"
+        case .inconclusive(let detail):
+            return Finding.machineNotePrefix
+                + "changelogURLUnverified: \(url.absoluteString) \(detail), which is as "
+                + "consistent with a bot wall as with a dead page — needs a human with a browser"
+        }
+    }
+}

--- a/CLI/Sources/DuoKit/ChangelogLinkSweep.swift
+++ b/CLI/Sources/DuoKit/ChangelogLinkSweep.swift
@@ -176,7 +176,11 @@ enum ChangelogLinkSweep {
             // is the one shape of this check's blind spot that a reader can act
             // on — so it stays non-accusing (DNS fails for local reasons too) but
             // stops reading as ordinary transport noise.
-            if (error as? URLError)?.code == .cannotFindHost {
+            // Both codes mean the name did not resolve; which one Foundation
+            // surfaces depends on the resolver, so matching only one would leave
+            // half of this branch's own case reading as ordinary network noise.
+            if let code = (error as? URLError)?.code,
+               code == .cannotFindHost || code == .dnsLookupFailed {
                 return .inconclusive("does not resolve — the host itself may be retired")
             }
             return .inconclusive("could not be reached")

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -455,7 +455,9 @@ public enum Verify {
             // honest move is to skip the cross-check rather than to invent a
             // complaint the recipe can never clear.
             if let version, recipe.covers(appVersion: version),
-               let complaint = changelogLagComplaint(entry: top, detected: version) {
+               let complaint = changelogLagComplaint(
+                   entry: top, detected: version,
+                   acknowledged: recipe.acknowledgedStaleEntry) {
                 warnings.append(complaint)
             }
             return Finding(
@@ -561,7 +563,16 @@ public enum Verify {
     /// Flag a changelog only when it trails the detected version at
     /// major.minor — see the call site for why the full-string comparison had to
     /// go.
-    static func changelogLagComplaint(entry: String, detected: String) -> String? {
+    static func changelogLagComplaint(
+        entry: String, detected: String, acknowledged: String? = nil
+    ) -> String? {
+        // The vendor is the stale one and somebody has already read the live page
+        // and said so — see `ChangelogRecipe.acknowledgedStaleEntry` for why this
+        // is a version rather than an off switch. Scoped to the exact entry the
+        // acknowledgement names, so it stops applying the moment the page moves in
+        // EITHER direction: forward (the vendor published; worth one look) or
+        // backward (the pattern slipped to an older section; worth a lot more).
+        if let acknowledged, entry == acknowledged { return nil }
         // Plenty of recipes deliberately capture a headline into the `version`
         // group, because the vendor simply doesn't number their release notes —
         // Figma and Notion both title entries "AI credit user limits…". Comparing

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -73,6 +73,17 @@ public enum Verify {
         // templated changelog URLs need.
         if options.registries.contains(.vendor) {
             findings += await sweepVendor(vendor, options: options, installed: installed)
+            // The pages `sweepChangelog` will GET and parse below are excluded:
+            // its answer is better evidence than a HEAD, and two checks on one URL
+            // in one report can contradict each other. When the changelog registry
+            // is not being swept there is no such answer coming, so nothing is
+            // excluded and every page is asked.
+            let fetchedByChangelogSweep: Set<String> = options.registries.contains(.changelog)
+                ? Set(changelog.map(\.source.absoluteString))
+                : []
+            findings = await foldingChangelogLinks(
+                into: findings, recipes: vendor,
+                alreadyFetched: fetchedByChangelogSweep, options: options)
         }
         if options.registries.contains(.github) {
             findings += await sweepGitHub(github, options: options, installed: installed)
@@ -248,6 +259,50 @@ public enum Verify {
                 finding = finding.observing(note)
             }
             return finding
+        }
+    }
+
+    /// Attach each vendor finding the verdict on its own `changelogURL`.
+    ///
+    /// A separate pass rather than a step inside `sweepVendor`, for two reasons.
+    /// The pages are DEDUPLICATED — Chrome's three channels share one release-notes
+    /// page, as do Firefox's trains — so doing it per recipe would ask some hosts
+    /// the same question three times. And a changelog page almost never lives on
+    /// the same host as the probe endpoint, so the per-host pacing `sweepVendor`
+    /// applies to `edgeupdates.microsoft.com` says nothing about how hard we are
+    /// leaning on `learn.microsoft.com`; the link sweep groups by its own hosts.
+    ///
+    /// Costs one request per distinct page (87 as of 2026-08-28) on top of the
+    /// ~150 the sweep already makes. See `ChangelogLinkSweep` for why only 404 and
+    /// 410 are allowed to accuse anyone.
+    private static func foldingChangelogLinks(
+        into findings: [Finding], recipes: [VendorProbeRecipe],
+        alreadyFetched: Set<String>, options: VerifyOptions
+    ) async -> [Finding] {
+        let verdicts = await ChangelogLinkSweep.statuses(
+            of: recipes, alreadyFetched: alreadyFetched, options: options)
+        guard !verdicts.isEmpty else { return findings }
+        // Keyed by recipe id, which is what a `Finding` carries — the same recipe
+        // id `Baseline` and the issue history are keyed on.
+        var pages: [String: URL] = [:]
+        for recipe in recipes {
+            if let url = recipe.changelogURL { pages[recipe.recipeID] = url }
+        }
+        // Only `ok` findings can carry this: `adding(warning:)` promotes `ok` to
+        // `warn` and leaves every other status alone, so a verdict folded onto an
+        // `infra` or `skipped` finding would be paid for and then never printed —
+        // `Report.text` iterates the actionable statuses only. Not worth widening
+        // the report for: a probe endpoint having a bad minute delays this page's
+        // verdict by one sweep, and the sweep runs nightly.
+        return findings.map { finding in
+            guard finding.registry == .vendor,
+                  let url = pages[finding.recipeID],
+                  let verdict = verdicts[url.absoluteString],
+                  let complaint = ChangelogLinkSweep.complaint(for: verdict, url: url)
+            else { return finding }
+            return complaint.hasPrefix(Finding.machineNotePrefix)
+                ? finding.observing(complaint)
+                : finding.adding(warning: complaint)
         }
     }
 

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -78,8 +78,19 @@ public enum Verify {
             // in one report can contradict each other. When the changelog registry
             // is not being swept there is no such answer coming, so nothing is
             // excluded and every page is asked.
+            //
+            // A version-templated recipe is NOT one of them, and that distinction
+            // is the whole correctness of this set: its `source` is only a
+            // fallback, and what `sweepChangelog` actually requests is
+            // `resolvedSource(forVersion:)`. Excluding by `source` there would
+            // remove a URL from this sweep that nothing else ever asks for —
+            // three of them today (WeChat, Longbridge stable and preview) — and
+            // leave exactly the silent rot #107 exists to end. On a runner with
+            // nothing installed those recipes are `.skipped` and not fetched at
+            // all, so the gap would be permanent rather than occasional.
             let fetchedByChangelogSweep: Set<String> = options.registries.contains(.changelog)
-                ? Set(changelog.map(\.source.absoluteString))
+                ? Set(changelog.lazy.filter { $0.sourceTemplate == nil }
+                    .map(\.source.absoluteString))
                 : []
             findings = await foldingChangelogLinks(
                 into: findings, recipes: vendor,
@@ -265,9 +276,9 @@ public enum Verify {
     /// Attach each vendor finding the verdict on its own `changelogURL`.
     ///
     /// A separate pass rather than a step inside `sweepVendor`, for two reasons.
-    /// The pages are DEDUPLICATED — Chrome's three channels share one release-notes
+    /// The pages are DEDUPLICATED — Chrome's four channels share one release-notes
     /// page, as do Firefox's trains — so doing it per recipe would ask some hosts
-    /// the same question three times. And a changelog page almost never lives on
+    /// the same question four times. And a changelog page almost never lives on
     /// the same host as the probe endpoint, so the per-host pacing `sweepVendor`
     /// applies to `edgeupdates.microsoft.com` says nothing about how hard we are
     /// leaning on `learn.microsoft.com`; the link sweep groups by its own hosts.

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -366,7 +366,16 @@ public enum Verify {
                 outcome, registry: .github, host: "api.github.com",
                 pattern: rule.versionPattern, attempts: attempt + 1,
                 installed: installed["vendor:\(rule.bundleID):\(rule.channel.rawValue)"],
-                sanity: { _, _ in [] })
+                // Issue #101: this used to pass `{ _, _ in [] }`. The vendor
+                // sweep asked "did this install spec resolve its OWN channel's
+                // build" and the GitHub sweep asked nothing, so a non-stable rule
+                // that skipped the gate produced silence where a recipe produced
+                // a finding — and the asymmetry was invisible at the point where
+                // somebody adds a rule.
+                sanity: { _, remote in
+                    [RecipeSanity.crossChannelArtifact(rule: rule, remote: remote)]
+                        .compactMap { $0 }
+                })
             // The GitHub sweep never ran this cross-check — only the vendor sweep
             // did — so the one registry where a tag can outrun the macOS artifact
             // was also the one with no second opinion. GitHub releases carry a

--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 @testable import DuoKit
+import DuoUpdaterCore
 
 /// The baseline is the only part of the verifier that remembers anything, which
 /// makes it the only part that can distinguish "broken" from "broken twice" and
@@ -298,6 +299,53 @@ import Foundation
     @Test func aChangelogAWholeReleaseBehindIsFlagged() {
         let complaint = Verify.changelogLagComplaint(entry: "1.85", detected: "1.123.4")
         #expect(complaint?.contains("trails") == true)
+    }
+
+    /// Issue #88: the complaint that can never clear.
+    ///
+    /// WorkBuddy's international docs site carries two entries and stops at 5.2.7
+    /// while its own endpoint ships 5.4.2 — verified live, and the identical
+    /// pattern returns 58 entries from the Chinese site, so the recipe is right
+    /// and the vendor is the stale one. Every sweep flagged it; every sweep
+    /// re-filed a "recipe degraded" issue against working code.
+    @Test func anAcknowledgedVendorLagIsNotFlagged() {
+        #expect(Verify.changelogLagComplaint(
+            entry: "5.2.7", detected: "5.4.2", acknowledged: "5.2.7") == nil)
+    }
+
+    /// …and the acknowledgement is deliberately NOT an off switch, which is the
+    /// only reason it is safe to have. It holds for exactly the entry it names,
+    /// so the check comes back the moment the page moves in either direction:
+    /// backward means the pattern slipped to an older section (the failure this
+    /// check exists for, now on a recipe nobody is watching), forward means the
+    /// vendor published and a human should re-read the situation.
+    @Test func anAcknowledgementDoesNotSilenceTheRecipeForever() {
+        // The pattern slipped to an older section.
+        #expect(Verify.changelogLagComplaint(
+            entry: "4.7.5", detected: "5.4.2", acknowledged: "5.2.7")?.contains("trails") == true)
+        // The vendor published something newer, but still not current.
+        #expect(Verify.changelogLagComplaint(
+            entry: "5.3.0", detected: "5.4.2", acknowledged: "5.2.7")?.contains("trails") == true)
+        // And an acknowledgement never invents a complaint where there was none:
+        // once the vendor catches up the check passes on its own merits.
+        #expect(Verify.changelogLagComplaint(
+            entry: "5.4.2", detected: "5.4.2", acknowledged: "5.2.7") == nil)
+    }
+
+    /// Derived from the registry rather than a hand-written list, so an
+    /// acknowledgement added later is covered too: this field silences a real
+    /// detector, so every use of it has to be an entry that some page actually
+    /// serves, not a wildcard or a leftover from a vendor who has since caught up.
+    @Test func everyAcknowledgedStaleEntryIsAConcreteVersion() {
+        let acknowledged = ChangelogRecipeRegistry.recipes
+            .compactMap { recipe in recipe.acknowledgedStaleEntry.map { (recipe.recipeID, $0) } }
+        for (recipeID, entry) in acknowledged {
+            #expect(entry.first?.isNumber == true,
+                    "\(recipeID) acknowledges '\(entry)', which is not version-shaped — changelogLagComplaint only ever compares version-shaped entries, so this can only be a typo that silences nothing or a wildcard that silences everything")
+        }
+        // The one this shipped for. Pinned by bundle id rather than by count, so
+        // adding a second acknowledgement elsewhere does not have to touch this.
+        #expect(acknowledged.contains { $0.0.contains("com.workbuddy.workbuddy-ai") })
     }
 
     /// Codex numbers builds and notes alike as `YY.MDD`, so the date lands in the

--- a/CLI/Tests/DuoKitTests/ChangelogLinkSweepTests.swift
+++ b/CLI/Tests/DuoKitTests/ChangelogLinkSweepTests.swift
@@ -206,6 +206,43 @@ struct ChangelogLinkSweepTests {
         #expect(Set(chrome.map(\.absoluteString)).count == 1)
     }
 
+    /// A version-templated recipe must NOT take its page out of this sweep.
+    ///
+    /// The exclusion above is sound only for recipes that actually fetch their
+    /// `source`. A templated one fetches `resolvedSource(forVersion:)` instead —
+    /// `source` is just the fallback — so excluding by `source` would drop a URL
+    /// from the link sweep that nothing else ever requests, which is the silent
+    /// rot this whole check exists to end. Three registry recipes are templated
+    /// AND share a vendor `changelogURL` (WeChat, Longbridge stable and preview),
+    /// and on a runner with nothing installed they are `.skipped` and never
+    /// fetched at all, so the gap would be permanent.
+    ///
+    /// Derived from the registries, so it keeps holding as recipes come and go.
+    @Test func templatedRecipesDoNotRemoveTheirPageFromTheSweep() {
+        let vendorPages = Set(
+            VendorProbeRegistry.recipes.compactMap(\.changelogURL).map(\.absoluteString))
+        let templatedOverlap = Set(
+            ChangelogRecipeRegistry.recipes
+                .filter { $0.sourceTemplate != nil && vendorPages.contains($0.source.absoluteString) }
+                .map(\.source.absoluteString))
+        try! #require(!templatedOverlap.isEmpty,
+                      "no templated recipe shares a changelogURL any more — re-read whether this guard still has a case to guard")
+
+        // What `Verify.run` builds: only the recipes that really fetch `source`.
+        let excluded = Set(
+            ChangelogRecipeRegistry.recipes
+                .filter { $0.sourceTemplate == nil }
+                .map(\.source.absoluteString))
+        #expect(excluded.isDisjoint(with: templatedOverlap))
+
+        let swept = Set(ChangelogLinkSweep.pages(
+            of: VendorProbeRegistry.recipes, alreadyFetched: excluded).map(\.absoluteString))
+        for page in templatedOverlap {
+            #expect(swept.contains(page),
+                    "\(page) is fetched by nobody: the changelog sweep resolves a templated URL instead, and the link sweep excluded it")
+        }
+    }
+
     // MARK: the Edge recipes this issue was filed about
 
     /// Microsoft did not retire these — it renamed them, from

--- a/CLI/Tests/DuoKitTests/ChangelogLinkSweepTests.swift
+++ b/CLI/Tests/DuoKitTests/ChangelogLinkSweepTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+import DuoUpdaterCore
+
+@testable import DuoKit
+
+/// The check that would have caught the Edge pages (issue #107).
+///
+/// A `changelogURL` is never parsed, so no other sweep check touches it: a
+/// vendor retires the page, the button opens a 404, and every test stays green
+/// because the URL's *shape* is still perfectly valid. Three Microsoft Edge
+/// channels sat that way until someone fetched all 87 by hand.
+///
+/// What is worth testing here is not the fetch — it is the judgment. This check
+/// runs against 87 third-party docs sites on every sweep, and it is one wrong
+/// classification away from filing public issues against recipes that work.
+struct ChangelogLinkSweepTests {
+
+    private func url(_ s: String) -> URL { URL(string: s)! }
+
+    // MARK: what may accuse a recipe
+
+    /// Only a server ASSERTING the page does not exist is allowed to be a
+    /// warning, because only a warning accumulates a streak and files an issue.
+    @Test func onlyGoneStatusesProduceAWarning() {
+        let page = url("https://learn.microsoft.com/deployedge/microsoft-edge-relnotes")
+        for code in [404, 410] {
+            let complaint = ChangelogLinkSweep.complaint(for: .gone(code), url: page)
+            let text = try! #require(complaint)
+            #expect(!text.hasPrefix(Finding.machineNotePrefix),
+                    "HTTP \(code) is the vendor stating the page is gone — it must accuse")
+            #expect(text.contains(page.absoluteString),
+                    "the report has to name the dead URL or nobody can fix it")
+        }
+    }
+
+    /// …and it must still name it AFTER redaction, which is the only form anyone
+    /// reads.
+    ///
+    /// `Finding.init` runs `Redactor.text` over every warning, and one registry
+    /// URL trips it: Notion's release-notes page ends in a 32-character hex id,
+    /// which is indistinguishable from an opaque license key, so `«redacted»`
+    /// replaces it. Asserting on `complaint(for:url:)` alone would have missed
+    /// that entirely — it checks the string before the only transformation that
+    /// can damage it.
+    ///
+    /// What must survive is enough to find the page: scheme, host, and the part of
+    /// the path a human can search for. The finding also carries the recipe id, so
+    /// a redacted tail costs nobody the fix.
+    @Test func theDeadURLSurvivesRedaction() {
+        let notion = url(
+            "https://notion.notion.site/What-s-New-Mac-Windows-5936dabc8dd6497895786c91b9d6f12a")
+        let complaint = try! #require(ChangelogLinkSweep.complaint(for: .gone(404), url: notion))
+        let published = Finding(
+            recipeID: "vendor:notion.id:stable", registry: .vendor,
+            bundleID: "notion.id", channel: "stable", status: .ok, version: "4.19.0",
+            warnings: [complaint], endpointHost: "notion.notion.site")
+        let text = try! #require(published.publicWarnings.first)
+        #expect(text.contains("https://notion.notion.site/What-s-New-Mac-Windows"),
+                "redaction ate more than the opaque id — the report no longer names the page")
+        #expect(text.contains("404"))
+    }
+
+    /// A 403 is as consistent with Cloudflare as with a dead page, and a sweep
+    /// that files issues for those trains its reader to ignore it.
+    ///
+    /// Issue #107 reported AnyDesk's changelog as a 403 — measured with `curl`.
+    /// Through `URLSession` it answers 200 (verified 2026-08-28), so the wall was
+    /// reading the client rather than guarding a dead page, and the real sweep
+    /// never sees this case for that URL. The synthetic verdict below is
+    /// deliberate: what needs pinning is that an inconclusive status stays silent,
+    /// not which vendor happens to produce one this month.
+    @Test func aBotWallIsANoteRatherThanAnAccusation() {
+        let complaint = ChangelogLinkSweep.complaint(
+            for: .inconclusive("answered HTTP 403"),
+            url: url("https://vendor.invalid/changelog"))
+        let text = try! #require(complaint)
+        #expect(text.hasPrefix(Finding.machineNotePrefix))
+    }
+
+    /// And the note really does stay silent all the way through — attached to a
+    /// finding it must not promote it, or the distinction above is a spelling.
+    @Test func aNoteNeverPromotesTheFinding() {
+        let finding = Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable",
+            status: .ok, version: "9.5.4",
+            endpointHost: "vendor.invalid", pattern: "([0-9.]+)")
+        let note = ChangelogLinkSweep.complaint(
+            for: .inconclusive("answered HTTP 403"),
+            url: url("https://vendor.invalid/changelog"))!
+        #expect(finding.observing(note).status == .ok)
+        #expect(finding.observing(note).publicWarnings.isEmpty)
+    }
+
+    /// A host that no longer resolves reads as its own thing.
+    ///
+    /// It stays a note rather than an accusation — DNS fails for local reasons,
+    /// and a sweep box behind a broken resolver must not file 87 issues — but
+    /// "does not resolve" is the one inconclusive shape a reader can act on,
+    /// because retiring the whole docs subdomain is a real way for a vendor to
+    /// kill a changelog page.
+    @Test func aHostThatDoesNotResolveSaysSo() {
+        let text = try! #require(ChangelogLinkSweep.complaint(
+            for: .inconclusive("does not resolve — the host itself may be retired"),
+            url: url("https://docs.gone.invalid/changelog")))
+        #expect(text.hasPrefix(Finding.machineNotePrefix))
+        #expect(text.contains("does not resolve"))
+    }
+
+    /// A page that answers is not worth a line in the report at all.
+    @Test func aLivePageSaysNothing() {
+        #expect(ChangelogLinkSweep.complaint(
+            for: .alive, url: url("https://tailscale.com/changelog")) == nil)
+    }
+
+    /// The bug the first full live run caught, pinned so it cannot come back.
+    ///
+    /// A HEAD is *supposed* to be a GET without the body, and plenty of hosts do
+    /// not implement it that way. `www.workbuddy.ai` and `www.codebuddy.cn`
+    /// answer HEAD with 404 and GET with 200 and a full page (measured
+    /// 2026-08-28). The first draft of `verdict` retried only on 403/405/400 —
+    /// the codes that obviously mean "not that method" — and so reported both
+    /// pages as gone, by name, on findings that were otherwise `ok`. Two working
+    /// recipes would have been accused on the next nightly sweep.
+    ///
+    /// The rule that fixes it is the one this test states: **a HEAD may only
+    /// confirm a page alive.** Anything else gets re-asked with GET, and the
+    /// GET's answer is the authoritative one.
+    ///
+    /// Driven through a stub protocol rather than the network, so it keeps
+    /// meaning something on a machine with no route to either vendor.
+    @Test func aHeadOnlyEverConfirmsAPageAlive() async {
+        let page = url("https://vendor.invalid/docs/Changelog")
+
+        // The WorkBuddy shape: HEAD 404, GET 200. Must be alive.
+        StubProtocol.responses = ["HEAD": 404, "GET": 200]
+        #expect(await ChangelogLinkSweep.verdict(for: page, session: StubProtocol.session())
+            == .alive)
+
+        // A page that is really gone answers both, and must still be caught —
+        // otherwise the fix has simply turned the check off.
+        StubProtocol.responses = ["HEAD": 404, "GET": 404]
+        #expect(await ChangelogLinkSweep.verdict(for: page, session: StubProtocol.session())
+            == .gone(404))
+
+        // And the GET is authoritative in the other direction too: a HEAD that
+        // says 200 is believed without a second request, which is what keeps the
+        // healthy path at one request per page.
+        StubProtocol.responses = ["HEAD": 200, "GET": 404]
+        #expect(await ChangelogLinkSweep.verdict(for: page, session: StubProtocol.session())
+            == .alive)
+
+        // A bot wall on both verbs stays inconclusive rather than becoming an
+        // accusation.
+        StubProtocol.responses = ["HEAD": 403, "GET": 403]
+        #expect(await ChangelogLinkSweep.verdict(for: page, session: StubProtocol.session())
+            == .inconclusive("answered HTTP 403"))
+    }
+
+    // MARK: what gets fetched
+
+    /// Several recipes legitimately share one page — Chrome's four channels,
+    /// Firefox's trains — and asking one host the same question four times is
+    /// four times the rate-limit exposure for no extra signal.
+    ///
+    /// Derived from the registry rather than asserted as a number, so this keeps
+    /// meaning something as recipes come and go: whatever the registry holds, the
+    /// sweep must cover all of it and no more. (An earlier draft also asserted
+    /// that `pages` has no duplicates, which `pages` guarantees by construction
+    /// with a `Set` — true no matter how broken the rest of it was.)
+    @Test func everyDeclaredPageIsSweptExactlyOnce() {
+        let pages = ChangelogLinkSweep.pages(of: VendorProbeRegistry.recipes)
+        let declared = Set(VendorProbeRegistry.recipes.compactMap(\.changelogURL)
+            .map(\.absoluteString))
+        #expect(Set(pages.map(\.absoluteString)) == declared)
+        #expect(pages.count < VendorProbeRegistry.recipes.compactMap(\.changelogURL).count,
+                "nothing is being deduplicated — either the registry stopped sharing pages or pages(of:) stopped collapsing them")
+    }
+
+    /// A page another check already fetches is not asked a second time: 17 of the
+    /// 87 are also a `ChangelogRecipe.source`, which `sweepChangelog` GETs and
+    /// parses in the same run. Two checks on one URL can contradict each other in
+    /// one report — "parsed 2 entries" and "the page is gone" — and the GET is the
+    /// better evidence.
+    @Test func pagesTheChangelogSweepAlreadyFetchesAreSkipped() {
+        let shared = Set(ChangelogRecipeRegistry.recipes.map(\.source.absoluteString))
+        let all = ChangelogLinkSweep.pages(of: VendorProbeRegistry.recipes)
+        let trimmed = ChangelogLinkSweep.pages(
+            of: VendorProbeRegistry.recipes, alreadyFetched: shared)
+        #expect(trimmed.count < all.count, "the two registries no longer overlap at all — re-read whether this exclusion still earns its place")
+        #expect(!trimmed.contains { shared.contains($0.absoluteString) })
+        // …and nothing else was dropped along the way.
+        #expect(Set(all.map(\.absoluteString)).subtracting(shared)
+            == Set(trimmed.map(\.absoluteString)))
+    }
+
+    /// Chrome is the concrete case the dedupe exists for, and it is worth
+    /// pinning: if a future edit gives each channel its own page this test wants
+    /// to be re-read rather than to quietly pass.
+    @Test func chromesFourChannelsShareOnePage() {
+        let chrome = VendorProbeRegistry.recipes
+            .filter { $0.bundleID.hasPrefix("com.google.Chrome") }
+            .compactMap(\.changelogURL)
+        #expect(chrome.count == 4, "Chrome now has \(chrome.count) channels carrying a changelog URL")
+        #expect(Set(chrome.map(\.absoluteString)).count == 1)
+    }
+
+    // MARK: the Edge recipes this issue was filed about
+
+    /// Microsoft did not retire these — it renamed them, from
+    /// `microsoft-edge-relnotes-<channel>` to `microsoft-edge-relnote-<channel>`
+    /// (singular). Issue #107 concluded "genuinely gone" after trying three
+    /// alternatives that were all *plural*, which is why the fix is one letter
+    /// for two of the three.
+    @Test func edgeStableAndBetaPointAtThePagesThatExist() {
+        func recipe(_ bundleID: String) -> VendorProbeRecipe {
+            // `#require`d, not optional-chained: `changelog(x) == nil` would also
+            // be satisfied by the recipe having been deleted, so the Dev
+            // assertion below could not tell "deliberately has no notes page"
+            // from "is gone from the registry".
+            try! #require(VendorProbeRegistry.recipes.first { $0.bundleID == bundleID },
+                          "\(bundleID) is no longer in the registry")
+        }
+        func changelog(_ bundleID: String) -> URL? { recipe(bundleID).changelogURL }
+        #expect(changelog("com.microsoft.edgemac")?.absoluteString
+            == "https://learn.microsoft.com/deployedge/microsoft-edge-relnote-stable-channel")
+        #expect(changelog("com.microsoft.edgemac.Beta")?.absoluteString
+            == "https://learn.microsoft.com/deployedge/microsoft-edge-relnote-beta-channel")
+        // Dev is the one that really is gone: `deployedge`'s own `toc.json`
+        // (2026-08-28) lists release notes for Beta, Stable, Mobile Beta and
+        // Mobile Stable and nothing else, and Learn's search API returns no Dev
+        // page either. Pointing the button at Beta's or Stable's notes would show
+        // a Dev user another train's changes — the same call Thunderbird Daily
+        // gets — so this must stay nil rather than drift to a "close enough" page.
+        #expect(changelog("com.microsoft.edgemac.Dev") == nil)
+    }
+}
+
+/// Answers by HTTP method, so the HEAD-vs-GET rule can be tested without a
+/// network route to any vendor.
+private final class StubProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var responses: [String: Int] = [:]
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func stopLoading() {}
+
+    override func startLoading() {
+        let method = request.httpMethod ?? "GET"
+        let code = Self.responses[method] ?? 200
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: code, httpVersion: "HTTP/1.1", headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -173,6 +173,32 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// meet exactly at 2.0.
     public let belowAppVersion: String?
 
+    /// The newest entry this vendor's page is KNOWN to stop at, when the page is
+    /// genuinely behind the builds the vendor is shipping.
+    ///
+    /// `duo verify` flags a changelog whose newest entry trails the detected
+    /// version by a whole release, on the theory that the entry pattern is reading
+    /// a stale section. Usually right. Sometimes the pattern is perfect and the
+    /// VENDOR is the stale one — WorkBuddy's international docs site carries two
+    /// entries and stops at 5.2.7 (2026-07-17) while its own endpoint ships 5.4.2,
+    /// and the identical pattern returns 58 entries from the Chinese site. There
+    /// is nothing to fix, so the warning can never clear: it re-files an issue
+    /// every sweep against a recipe that works (issue #88).
+    ///
+    /// **A version, not a boolean, and that is the whole design.** A `true` here
+    /// would switch the check off for this recipe forever, silencing the one
+    /// detector that would notice the day the pattern really does break. Naming
+    /// the version means the acknowledgement is only good while the page still
+    /// says exactly that: if the pattern slips to an older section the complaint
+    /// comes back, if the vendor publishes anything newer the complaint comes back
+    /// once so a human can re-read the situation, and if the vendor catches up
+    /// entirely the check passes on its own and this field can go.
+    ///
+    /// Set it only after reading the live page and confirming the vendor is the
+    /// one behind — record what you saw next to the recipe, as WorkBuddy's comment
+    /// does. nil for every recipe whose notes track its releases (the common case).
+    public var acknowledgedStaleEntry: String?
+
     /// Whether this recipe restricts itself to a version range at all. Used to keep
     /// the lookup's behaviour byte-identical for every recipe that doesn't: a group
     /// with no windows is never filtered, so a nil version can't start excluding
@@ -404,7 +430,8 @@ public struct ChangelogRecipe: Codable, Sendable {
         structuredFormat: StructuredFormat? = nil,
         httpMethod: HTTPMethod = .get,
         requestBody: Data? = nil,
-        skipSections: [String] = []
+        skipSections: [String] = [],
+        acknowledgedStaleEntry: String? = nil
     ) {
         self.bundleID = bundleID
         self.source = source
@@ -428,6 +455,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         self.httpMethod = httpMethod
         self.requestBody = requestBody
         self.skipSections = skipSections
+        self.acknowledgedStaleEntry = acknowledgedStaleEntry
     }
 
     /// The actual page URL to fetch for a given target version. When
@@ -500,6 +528,8 @@ public struct ChangelogRecipe: Codable, Sendable {
         httpMethod = try c.decodeIfPresent(HTTPMethod.self, forKey: .httpMethod) ?? .get
         requestBody = try c.decodeIfPresent(Data.self, forKey: .requestBody)
         skipSections = try c.decodeIfPresent([String].self, forKey: .skipSections) ?? []
+        acknowledgedStaleEntry = try c.decodeIfPresent(
+            String.self, forKey: .acknowledgedStaleEntry)
     }
 }
 
@@ -2258,6 +2288,16 @@ public enum ChangelogRecipeRegistry {
         // (2026-07-17) while its own endpoint ships 5.4.2. A future reader finding
         // "only 2 entries" has found the vendor's page, not a broken recipe — the
         // CN page, parsed by the identical pattern, returns 58.
+        //
+        // That is also why the intl recipe carries `acknowledgedStaleEntry`
+        // (issue #88). `duo verify` reads 5.2.7 against a detected 5.4.2, calls it
+        // a whole release behind, and files "recipe degraded" — a complaint that
+        // can never clear, because there is nothing on our side to fix. Re-checked
+        // live 2026-08-28: intl still 2 entries topping out at 5.2.7, CN still
+        // parsing, newest 5.3.14 (2026-08-17). The acknowledgement names 5.2.7
+        // rather than switching the check off, so the day the pattern slips to an
+        // older section — or the vendor finally publishes — the sweep speaks up
+        // again.
         ChangelogRecipe(
             bundleID: "com.workbuddy.workbuddy",
             source: URL(string: "https://www.workbuddy.cn/docs/workbuddy/Changelog")!,
@@ -2268,7 +2308,8 @@ public enum ChangelogRecipeRegistry {
             bundleID: "com.workbuddy.workbuddy-ai",
             source: URL(string: "https://www.workbuddy.ai/docs/workbuddy/Changelog")!,
             entryPattern: Self.workBuddyEntryPattern,
-            itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#]),
+            itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#],
+            acknowledgedStaleEntry: "5.2.7"),
     ]
 
     /// Group recipes by lowercased bundle id. Most bundle ids map to a single

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -174,6 +174,73 @@ public enum ChannelProofRegistry {
             .map { ChannelProofKey($0.bundleID, $0.channel) }
     }
 
+    /// The same proof, for `GitHubReleaseRegistry` (issue #101).
+    ///
+    /// **A separate map, not extra keys in `proofs`.** `ChannelProofKey` is
+    /// `(bundleID, channel)` and says nothing about which registry it came from,
+    /// so one map would silently collide the day a bundle id appears in both
+    /// registries on the same channel — the entry written for one would be
+    /// checked against the other, and the exhaustiveness test would pass while
+    /// proving the wrong thing. No such pair exists today
+    /// (`channelProofMapsDoNotCollide` measures it rather than assuming), and
+    /// keeping them apart means the day one does exist is not a silent day.
+    ///
+    /// A GitHub rule's protection is real but structural: it lives in whichever
+    /// pattern the author happened to write, and nothing re-derives it. All three
+    /// rules below gate the channel in their `versionPattern` — a stable tag
+    /// cannot satisfy `-pre`, `-beta<N>` or `-insider` — which is why the live
+    /// sweep of 2026-08-27 found nothing misresolving. What was missing is any
+    /// statement that this is REQUIRED. A future rule written with the registry's
+    /// default `v?([0-9]+(?:\.[0-9]+)+)` plus `usePrereleases: true` plus a
+    /// non-stable channel would have no discriminator at all, and nothing
+    /// anywhere would say so.
+    ///
+    /// Verified against the live Releases API 2026-08-28. All three are provable
+    /// from the URL because GitHub builds an asset URL as
+    /// `…/releases/download/<tag>/<name>` — the tag the `versionPattern` matched
+    /// is IN the path, so an `.artifact` proof here asserts the same thing the
+    /// version pattern does, but against what was actually resolved rather than
+    /// against what someone meant to write.
+    public static let githubProofs: [ChannelProofKey: ChannelArtifactProof] = [
+        // `Zed-aarch64.dmg` is byte-identical in name to stable's — the tag is
+        // the only discriminator, and it is in the path:
+        // `…/download/v1.18.0-pre/Zed-aarch64.dmg`.
+        ChannelProofKey("dev.zed.Zed-Preview", .preview): .artifact(#"/download/v[0-9.]+-pre/"#),
+        // Likewise `GitHub.Desktop-arm64.zip`:
+        // `…/download/release-3.6.5-beta1/GitHub.Desktop-arm64.zip`.
+        ChannelProofKey("com.github.GitHubClient", .beta):
+            .artifact(#"/download/release-[0-9.]+-beta[0-9]+/"#),
+        // VSCodium Insiders names the channel in the tag AND in the asset filename,
+        // and lives in its own repository besides.
+        //
+        // Anchored to the tag segment on purpose. A bare `-insider` would be
+        // satisfied by `VSCodium/vscodium-insiders` in the path of EVERY url this
+        // rule can ever resolve, which is the same fact the stable branch of
+        // `crossChannelArtifact(rule:remote:)` below refuses to check on — read
+        // there it prevents a false accusation, read here it would have been a
+        // permanent false acquittal, and the proof could not have failed for any
+        // input. Live releases could not show this: every real tag in that repo
+        // carries `-insider` too, so the loose pattern and the anchored one agree
+        // on all 57 of them and disagree only on the artifact this exists to
+        // catch. Caught in adversarial review of #101, not by measurement.
+        ChannelProofKey("com.vscodium.VSCodiumInsiders", .preview):
+            .artifact(#"/download/[^/]*-insider"#),
+    ]
+
+    /// Every `(bundleID, channel)` in the GitHub registry that carries an install
+    /// spec and is NOT on stable — the set `githubProofs` has to cover.
+    ///
+    /// Scoped to install-carrying rules for the same reason the vendor side is:
+    /// a detection-only rule resolves no artifact, so there is no wrong build for
+    /// it to hand anyone. Today that is no restriction at all — every non-stable
+    /// GitHub rule carries an install spec — but writing it as the same
+    /// predicate keeps the two registries answerable to one rule.
+    public static var channelGitHubRulesWithInstall: [ChannelProofKey] {
+        GitHubReleaseRegistry.rules
+            .filter { $0.installAssetPattern != nil && $0.channel != .stable }
+            .map { ChannelProofKey($0.bundleID, $0.channel) }
+    }
+
     /// Pre-release tokens that must never appear in a STABLE recipe's installer
     /// URL — the mirror of the same failure, and the worse direction: pushing a
     /// nightly onto someone who chose stable.
@@ -234,6 +301,60 @@ extension RecipeSanity {
             else { return nil }
             return "recipe is no longer anchored on /\(pattern)/ — nothing ties its "
                 + "\(recipe.channel.rawValue) install to that channel"
+        }
+    }
+
+    /// The same check for a `GitHubReleaseRule` (issue #101).
+    ///
+    /// The GitHub sweep passed `sanity: { _, _ in [] }`, so the one registry
+    /// where a tag can outrun what it claims to be was also the one with no
+    /// second opinion about WHICH channel it resolved. A vendor recipe that
+    /// skipped its proof got a hard finding; a GitHub rule in the same situation
+    /// got silence, and the asymmetry was invisible exactly where it mattered —
+    /// at the point where somebody adds a rule.
+    ///
+    /// Advisory, like the recipe overload. Returns nil when there is nothing to
+    /// judge: a detection-only rule resolves no artifact, and its `downloadURL`
+    /// is the repository's releases PAGE rather than a build, so there is no
+    /// wrong thing for it to have handed anyone.
+    public static func crossChannelArtifact(
+        rule: GitHubReleaseRule, remote: RemoteVersion
+    ) -> String? {
+        guard rule.installAssetPattern != nil,
+              let url = remote.downloadURL?.absoluteString else { return nil }
+        let key = ChannelProofKey(rule.bundleID, rule.channel)
+
+        guard rule.channel != .stable else {
+            // The mirror direction is deliberately NOT checked here, and that is
+            // a measurement rather than an oversight. `preReleaseTokens` matches
+            // scheme+host+path, and every GitHub asset URL carries `owner/repo`
+            // in its path — so a stable rule in a repo whose name contains one of
+            // those words would be a permanent false accusation. The vendor side
+            // does not have that problem because its paths are the vendor's own.
+            // A stable GitHub rule's protection is `/releases/latest`, which
+            // GitHub computes with prereleases excluded (and `stableOnly` for the
+            // list fallback — see `GitHubReleasesSource.resolve`).
+            return nil
+        }
+
+        guard let proof = ChannelProofRegistry.githubProofs[key] else {
+            return "no channel proof registered for \(key) — nothing checks that its "
+                + "install spec resolves its own channel's build rather than stable's"
+        }
+
+        switch proof {
+        case .artifact(let pattern):
+            guard url.range(of: pattern, options: [.regularExpression, .caseInsensitive]) == nil
+            else { return nil }
+            return "resolved \(url), which carries no \(rule.channel.rawValue) marker "
+                + "(expected /\(pattern)/) — the install may be crossing channels"
+
+        case .recipeAnchor(let pattern):
+            let surface = rule.channelAnchorSurface
+            guard surface.range(of: pattern, options: [.regularExpression, .caseInsensitive]) == nil
+            else { return nil }
+            return "rule is no longer anchored on /\(pattern)/ — nothing ties its "
+                + "\(rule.channel.rawValue) install to that channel"
         }
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -53,6 +53,51 @@ public struct GitHubReleaseRule: Sendable {
         self.installerKind = installerKind
     }
 
+    /// Field labels deliberately kept OUT of `channelAnchorSurface` — the ones
+    /// that LABEL a rule rather than decide what it reads or accepts.
+    ///
+    /// Same reasoning as `VendorProbeRecipe.nonAnchorFields`, and the same trap:
+    /// a `.beta` rule carries the literal string "beta" in `channel`, so an
+    /// anchor of `beta` would be satisfied by the mere fact it is a beta rule,
+    /// forever, whatever happened upstream. `bundleID` is the same shape of
+    /// tautology. Everything else is in, including fields added after this list
+    /// was written — see `channelAnchorSurface`.
+    static let nonAnchorFields: Set<String> = ["bundleID", "channel"]
+
+    /// Everything this rule says about WHICH repository it reads and WHICH
+    /// releases and assets it will accept — the text a
+    /// `ChannelArtifactProof.recipeAnchor` is matched against.
+    ///
+    /// Derived by reflection rather than hand-listed, for the reason the vendor
+    /// side learned the hard way: a hand-written surface goes on passing while
+    /// inspecting less, so nothing anywhere reads as broken the day a new field
+    /// arrives and nobody adds it. `channelAnchorSurfaceCoversEveryGitHubRuleField`
+    /// makes adding one a decision somebody states out loud.
+    ///
+    /// One line per field, so an anchor written with `.*` cannot straddle two
+    /// unrelated fields and match something nobody meant.
+    public var channelAnchorSurface: String {
+        Mirror(reflecting: self).children
+            .filter { child in
+                guard let label = child.label else { return false }
+                return !Self.nonAnchorFields.contains(label)
+            }
+            .flatMap { Self.anchorLines(of: $0.value) }
+            .joined(separator: "\n")
+    }
+
+    /// One line per string a value contains, walking into optionals and enum
+    /// payloads. Never `String(describing:)` on a field that holds a string: it
+    /// renders nested strings through their DEBUG description, so quotes come
+    /// back escaped and an anchor written to match the real text stops matching.
+    private static func anchorLines(of value: Any) -> [String] {
+        if let text = value as? String { return [text] }
+        if let url = value as? URL { return [url.absoluteString] }
+        let mirror = Mirror(reflecting: value)
+        guard !mirror.children.isEmpty else { return [String(describing: value)] }
+        return mirror.children.flatMap { anchorLines(of: $0.value) }
+    }
+
     /// First release asset whose filename matches `installAssetPattern`, with
     /// its declared byte size (for shortest-first "Update All" ordering). Pure
     /// and static so the arch/format selection is unit-testable without a fetch.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -1178,13 +1178,33 @@ public enum VendorProbeRegistry {
         // The channel gate still routes each pkg to its own bundle id. (Edge Canary
         // isn't carried by this enterprise API, so it stays "unknown" rather than
         // mis-served.)
+        //
+        // Release notes: Microsoft renamed the PER-CHANNEL enterprise docs pages
+        // from `microsoft-edge-relnotes-<channel>` to
+        // `microsoft-edge-relnote-<channel>` (singular) and the old spellings now
+        // 404 — see issue #107. Not a blanket rename, and worth knowing before
+        // guessing at any other page in that section: the security notes are still
+        // `microsoft-edge-relnotes-security`, plural.
+        //
+        // Dev gets NO `changelogURL` at all, and that is the measured answer
+        // rather than a guess. `learn.microsoft.com/en-us/deployedge/toc.json`
+        // (2026-08-28) carries eight `relnote*` paths — Beta, Stable, Mobile Beta,
+        // Mobile Stable, three `-archive-` companions, and the security page — and
+        // not one of them is Dev. Four plausible Dev spellings all 404
+        // (`…relnote-dev-channel`, `…relnotes-dev-channel`, `…relnote-dev`,
+        // `…relnote-archive-dev-channel`), and Learn's own search API returns Beta,
+        // Security and the release schedule for "Edge Dev channel release notes".
+        // Microsoft stopped publishing Dev channel notes; pointing the button at
+        // Beta's or Stable's page would show a Dev user another train's changes,
+        // which is worse than showing none (same call as Thunderbird Daily below).
         VendorProbeRecipe(
             bundleID: "com.microsoft.edgemac",
             url: URL(string: "https://edgeupdates.microsoft.com/api/products?view=enterprise")!,
             mode: .responseBody,
             versionPattern: #"(?s)"Product"\s*:\s*"Stable".*?"Platform"\s*:\s*"MacOS".*?"ProductVersion"\s*:\s*"([0-9]+(?:\.[0-9]+){3})""#,
             downloadURL: URL(string: "https://www.microsoft.com/edge/download"),
-            changelogURL: URL(string: "https://learn.microsoft.com/deployedge/microsoft-edge-relnotes"),
+            changelogURL: URL(
+                string: "https://learn.microsoft.com/deployedge/microsoft-edge-relnote-stable-channel"),
             install: VendorInstallSpec(
                 urlSource: .redirect(URL(string: "https://go.microsoft.com/fwlink/?linkid=2093504")!),
                 kind: .pkg)),
@@ -1194,7 +1214,8 @@ public enum VendorProbeRegistry {
             mode: .responseBody,
             versionPattern: #"(?s)"Product"\s*:\s*"Beta".*?"Platform"\s*:\s*"MacOS".*?"ProductVersion"\s*:\s*"([0-9]+(?:\.[0-9]+){3})""#,
             downloadURL: URL(string: "https://www.microsoftedgeinsider.com/download"),
-            changelogURL: URL(string: "https://learn.microsoft.com/deployedge/microsoft-edge-relnotes-beta-channel"),
+            changelogURL: URL(
+                string: "https://learn.microsoft.com/deployedge/microsoft-edge-relnote-beta-channel"),
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(
                     #"(?s)"Product"\s*:\s*"Beta".*?"Platform"\s*:\s*"MacOS".*?"Location"\s*:\s*"(https://[^"]+\.pkg)""#),
@@ -1206,7 +1227,6 @@ public enum VendorProbeRegistry {
             mode: .responseBody,
             versionPattern: #"(?s)"Product"\s*:\s*"Dev".*?"Platform"\s*:\s*"MacOS".*?"ProductVersion"\s*:\s*"([0-9]+(?:\.[0-9]+){3})""#,
             downloadURL: URL(string: "https://www.microsoftedgeinsider.com/download"),
-            changelogURL: URL(string: "https://learn.microsoft.com/deployedge/microsoft-edge-relnotes-dev-channel"),
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(
                     #"(?s)"Product"\s*:\s*"Dev".*?"Platform"\s*:\s*"MacOS".*?"Location"\s*:\s*"(https://[^"]+\.pkg)""#),

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubChannelProofTests.swift
@@ -1,0 +1,233 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Issue #101 — the gate the GitHub registry did not have.
+///
+/// `ChannelProofRegistry` exists so a non-stable install-carrying recipe has to
+/// state how it knows the artifact it resolves belongs to its own channel. It
+/// read `VendorProbeRegistry` only, and `crossChannelArtifact` was typed on
+/// `VendorProbeRecipe`, so a GitHub rule could not reach it even in principle:
+/// a vendor recipe that skipped its proof got a hard finding, and a GitHub rule
+/// in the same situation got silence.
+///
+/// The live sweep the issue asked for found nothing misresolving — all three
+/// rules gate the channel in their `versionPattern` — so what these tests guard
+/// is the NEXT rule, written with the registry's default loose pattern and no
+/// discriminator at all.
+struct GitHubChannelProofTests {
+
+    // MARK: exhaustiveness
+
+    /// Derived from the registry, never a hand-written list: a rule added
+    /// tomorrow is covered by construction, which is the whole point.
+    @Test func githubProofsCoverEveryChannelRule() {
+        let needed = Set(ChannelProofRegistry.channelGitHubRulesWithInstall)
+        let have = Set(ChannelProofRegistry.githubProofs.keys)
+        let unproven = needed.subtracting(have).map(\.description).sorted()
+        let orphaned = have.subtracting(needed).map(\.description).sorted()
+        #expect(unproven.isEmpty,
+                "non-stable GitHub rules with an install spec but no ChannelProof: \(unproven)")
+        #expect(orphaned.isEmpty,
+                "ChannelProof entries for GitHub rules that no longer carry a non-stable install spec: \(orphaned)")
+    }
+
+    /// The open question the issue raised about reusing `ChannelProofKey`, turned
+    /// into a measurement.
+    ///
+    /// The key is `(bundleID, channel)` and carries no registry, so two rules
+    /// from different registries sharing a pair would collide on one entry — and
+    /// the exhaustiveness test above would still pass, while checking one
+    /// registry's artifact against the other's proof. Two maps make that
+    /// impossible; this fails the day the ambiguity becomes real, so nobody has
+    /// to rediscover why they are separate.
+    @Test func channelProofMapsDoNotCollide() {
+        let vendor = Set(ChannelProofRegistry.channelRecipesWithInstall)
+        let github = Set(ChannelProofRegistry.channelGitHubRulesWithInstall)
+        let shared = vendor.intersection(github).map(\.description).sorted()
+        #expect(shared.isEmpty,
+                "\(shared) is served by BOTH registries on the same channel — the two proof maps are now genuinely ambiguous and the key needs a registry component")
+    }
+
+    // MARK: the check itself
+
+    /// A rule whose asset URL carries its channel token passes.
+    ///
+    /// The URLs are the real ones (Releases API, 2026-08-28). GitHub builds an
+    /// asset URL as `…/releases/download/<tag>/<name>`, so the tag the
+    /// `versionPattern` matched is in the path — which is what makes an
+    /// `.artifact` proof possible for rules whose asset FILENAME is identical to
+    /// stable's (`Zed-aarch64.dmg`, `GitHub.Desktop-arm64.zip`).
+    @Test func aChannelTaggedArtifactSatisfiesItsProof() {
+        let cases: [(String, String)] = [
+            ("dev.zed.Zed-Preview",
+             "https://github.com/zed-industries/zed/releases/download/v1.18.0-pre/Zed-aarch64.dmg"),
+            ("com.github.GitHubClient",
+             "https://github.com/desktop/desktop/releases/download/release-3.6.5-beta1/GitHub.Desktop-arm64.zip"),
+            ("com.vscodium.VSCodiumInsiders",
+             "https://github.com/VSCodium/vscodium-insiders/releases/download/1.126.04518-insider/VSCodium-darwin-arm64-1.126.04518-insider.zip"),
+        ]
+        for (bundleID, asset) in cases {
+            let rule = try! #require(nonStableRule(bundleID))
+            let complaint = RecipeSanity.crossChannelArtifact(
+                rule: rule, remote: remote(asset))
+            #expect(complaint == nil, "\(bundleID): \(complaint ?? "")")
+        }
+    }
+
+    /// The failure this whole mechanism exists for: the rule still resolves, the
+    /// asset is a real notarized build from the same vendor with the same Team
+    /// ID — and it is stable's. Every one of these is the SAME repository and the
+    /// SAME asset filename as the passing case above; only the tag differs.
+    @Test func stablesArtifactUnderAChannelRuleIsCaughtEveryTime() {
+        let cases: [(String, String)] = [
+            ("dev.zed.Zed-Preview",
+             "https://github.com/zed-industries/zed/releases/download/v1.17.2/Zed-aarch64.dmg"),
+            ("com.github.GitHubClient",
+             "https://github.com/desktop/desktop/releases/download/release-3.6.4/GitHub.Desktop-arm64.zip"),
+            ("com.vscodium.VSCodiumInsiders",
+             "https://github.com/VSCodium/vscodium/releases/download/1.126.04518/VSCodium-darwin-arm64-1.126.04518.zip"),
+        ]
+        for (bundleID, asset) in cases {
+            let rule = try! #require(nonStableRule(bundleID))
+            #expect(RecipeSanity.crossChannelArtifact(rule: rule, remote: remote(asset)) != nil,
+                    "\(bundleID) resolved stable's artifact and nothing complained")
+        }
+    }
+
+    /// A proof must be able to FAIL. The one that could not.
+    ///
+    /// Every GitHub asset URL carries `owner/repo` in its path, so for
+    /// `VSCodium/vscodium-insiders` a bare `-insider` pattern matched the
+    /// repository name and therefore matched every URL the rule could ever
+    /// resolve — a proof that acquits unconditionally. No amount of live data
+    /// shows this, because every real tag in that repo also carries `-insider`;
+    /// only an artifact that is wrong in the way the proof exists to catch
+    /// separates the two patterns.
+    ///
+    /// Written per-registry rather than as a loop over `githubProofs`, because
+    /// the falsifying URL is different for each proof — a generic "does some
+    /// string fail" test would be its own tautology.
+    @Test func aProofMustBeAbleToFailOnItsOwnRepository() {
+        let rule = try! #require(nonStableRule("com.vscodium.VSCodiumInsiders"))
+        // Same repository, same host, a tag with no channel token: the shape a
+        // vendor reorganising their tags would produce.
+        let stableShaped = remote(
+            "https://github.com/VSCodium/vscodium-insiders/releases/download/1.126.04518/VSCodium-darwin-arm64-1.126.04518.zip")
+        #expect(RecipeSanity.crossChannelArtifact(rule: rule, remote: stableShaped) != nil,
+                "the proof matched the repository name rather than the artifact — it can never fail")
+    }
+
+    /// The shape the issue's revised reading named: the registry's DEFAULT
+    /// version pattern, `usePrereleases: true`, a non-stable channel, and no
+    /// discriminator anywhere. Before this, that rule shipped in silence.
+    @Test func anUnregisteredChannelRuleIsAHardFinding() {
+        let loose = GitHubReleaseRule(
+            bundleID: "com.example.SomethingBeta",
+            owner: "example", repo: "something",
+            usePrereleases: true,
+            installAssetPattern: #"^Something-arm64\.zip$"#,
+            installerKind: .zip,
+            channel: .beta)
+        let complaint = RecipeSanity.crossChannelArtifact(
+            rule: loose,
+            remote: remote("https://github.com/example/something/releases/download/v4.1.0/Something-arm64.zip"))
+        let text = try! #require(complaint)
+        #expect(text.contains("no channel proof registered"))
+    }
+
+    /// Two ways to have nothing to judge, and both must stay quiet rather than
+    /// accumulate a streak against a rule that resolves no artifact at all.
+    @Test func thereIsNothingToJudgeWithoutAnInstallSpec() {
+        // Detection-only: `downloadURL` is the releases PAGE, not a build.
+        let detectionOnly = GitHubReleaseRule(
+            bundleID: "com.example.SomethingNightly",
+            owner: "example", repo: "something",
+            usePrereleases: true,
+            channel: .nightly)
+        #expect(RecipeSanity.crossChannelArtifact(
+            rule: detectionOnly,
+            remote: remote("https://github.com/example/something/releases")) == nil)
+
+        // Stable: `/releases/latest` is computed by GitHub with prereleases
+        // excluded, and the mirror check the vendor side runs cannot be run here
+        // — see the comment in `crossChannelArtifact(rule:remote:)`.
+        let stable = GitHubReleaseRule(
+            bundleID: "com.example.Something",
+            owner: "example", repo: "something-beta-tools",
+            installAssetPattern: #"^Something-arm64\.zip$"#,
+            installerKind: .zip)
+        #expect(RecipeSanity.crossChannelArtifact(
+            rule: stable,
+            remote: remote("https://github.com/example/something-beta-tools/releases/download/v4.1.0/Something-arm64.zip")) == nil,
+            "a stable rule in a repo whose NAME contains a pre-release word must not be accused")
+    }
+
+    // MARK: the `.recipeAnchor` surface
+
+    /// Adding a field to `GitHubReleaseRule` must be a decision, not an omission
+    /// — the same guard the vendor side has, for the same reason: a hand-written
+    /// surface goes on passing while inspecting less, so nothing reads as broken.
+    /// The fix on failure is one line either way — bump the count (the field is
+    /// part of what the rule reads) or add the label to `nonAnchorFields` (it
+    /// only labels the rule).
+    @Test func channelAnchorSurfaceCoversEveryGitHubRuleField() {
+        let rule = GitHubReleaseRegistry.rules[0]
+        let labels = Mirror(reflecting: rule).children.compactMap(\.label)
+        #expect(labels.count == 8,
+                "GitHubReleaseRule gained or lost a field (now \(labels.count): \(labels.sorted())) — decide whether it belongs in the .recipeAnchor surface or in nonAnchorFields, then update this count")
+        for excluded in GitHubReleaseRule.nonAnchorFields {
+            #expect(labels.contains(excluded),
+                    "nonAnchorFields names '\(excluded)', which is not a field of GitHubReleaseRule any more")
+        }
+    }
+
+    /// The tautology `nonAnchorFields` exists to prevent: a `.beta` rule carries
+    /// the literal string "beta" in `channel`, so an anchor of `beta` must NOT be
+    /// satisfied by the mere fact that it is a beta rule.
+    @Test func theChannelLabelItselfCannotSatisfyAnAnchor() {
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.SomethingBeta",
+            owner: "example", repo: "something",
+            usePrereleases: true,
+            channel: .beta)
+        #expect(!rule.channelAnchorSurface.contains("beta"),
+                "the surface leaks the channel label, which would make every .recipeAnchor(\"beta\") vacuous")
+    }
+
+    /// And the surface does see the fields that carry a real discriminator.
+    ///
+    /// Zed is the honest witness: `repo` is `"zed"`, so `-pre` can only have come
+    /// from `versionPattern`. VSCodium is asserted against the FIELD rather than
+    /// the joined surface, because its `repo` and `installAssetPattern` both
+    /// contain `insider` — a `surface.contains("insider")` check passes even with
+    /// the discriminator deleted from the version pattern, which is the same
+    /// vacuous shape as the proof in `aProofMustBeAbleToFailOnItsOwnRepository`.
+    @Test func theAnchorSurfaceSeesTheVersionAndAssetPatterns() {
+        let zed = try! #require(nonStableRule("dev.zed.Zed-Preview"))
+        #expect(!zed.repo.contains("-pre"), "this rule is only a witness while its repo name is not")
+        #expect(zed.channelAnchorSurface.contains("-pre"))
+        let codium = try! #require(nonStableRule("com.vscodium.VSCodiumInsiders"))
+        #expect(codium.versionPattern.contains("insider"))
+        #expect(codium.channelAnchorSurface.contains(codium.versionPattern))
+    }
+
+    /// Select by bundle id AND non-stable channel, never by bundle id alone.
+    ///
+    /// GitHub Desktop ships two rules under `com.github.GitHubClient` — stable
+    /// and beta — and `first(where: bundleID)` returns the stable one, whose
+    /// channel makes `crossChannelArtifact` return nil before it checks
+    /// anything. Written the lazy way, the positive test above passed while
+    /// asserting nothing at all; the negative test is what caught it.
+    private func nonStableRule(_ bundleID: String) -> GitHubReleaseRule? {
+        GitHubReleaseRegistry.rules.first {
+            $0.bundleID == bundleID && $0.channel != .stable
+        }
+    }
+
+    private func remote(_ url: String) -> RemoteVersion {
+        RemoteVersion(
+            shortVersion: "1.0.0", version: "1.0.0",
+            downloadURL: URL(string: url)!, sourceName: "GitHub")
+    }
+}

--- a/docs/app-audits/com-microsoft-edgemac.md
+++ b/docs/app-audits/com-microsoft-edgemac.md
@@ -39,10 +39,29 @@
 - 版本方案: 4 段 `ProductVersion` = 安装包 `CFBundleShortVersionString`，无 `versionIsBuild` 风险
 
 ## Changelog
-- stable: changelogURL `https://learn.microsoft.com/deployedge/microsoft-edge-relnotes` (WebView)
-- beta: `https://learn.microsoft.com/deployedge/microsoft-edge-relnotes-beta-channel`
-- dev: `https://learn.microsoft.com/deployedge/microsoft-edge-relnotes-dev-channel`
+- stable: changelogURL `https://learn.microsoft.com/deployedge/microsoft-edge-relnote-stable-channel` (WebView)
+- beta: `https://learn.microsoft.com/deployedge/microsoft-edge-relnote-beta-channel`
+- dev: **无 changelogURL**
 - 无 ChangelogRecipe（均为 WebView 内嵌官网页）
+
+2026-08-28（issue #107）：Microsoft 把**按 channel 分的**页面从 `…-relnotes-<channel>`
+改成 `…-relnote-<channel>`（单数），旧拼法全部 404。stable / beta 按新拼法重指即可。
+
+**注意这不是一次全局重命名**：安全公告页至今仍是 `microsoft-edge-relnotes-security`，
+复数。要猜这个 section 里别的页面之前先看这条。
+
+**dev 则是彻底没有了。** `learn.microsoft.com/en-us/deployedge/toc.json`（2026-08-28）
+一共 8 条 `relnote*` 路径 —— Beta / Stable / Mobile Beta / Mobile Stable、
+对应的三条 `-archive-`、外加上面那条 security —— 没有一条是 Dev；
+`…relnote-dev-channel`、`…relnotes-dev-channel`、`…relnote-dev`、
+`…relnote-archive-dev-channel` 四种拼法实测都 404；Learn 自己的搜索 API 查
+"Edge Dev channel release notes" 返回的是 Beta / Security / release schedule。
+Dev 因此留空：把按钮指到 Beta 或 Stable 的页面，等于给 Dev 用户看另一条 train
+的改动，比不给更糟（与 Thunderbird Daily 同一判断）。
+
+下游安全：`changelogURL` 为 nil 时 `WorkbenchWindowView` 回落到
+`ChangelogCatalog.url(forBundleID:)`，而 `ChangelogCatalog.pages` 没有 Edge 条目，
+所以结果是「不显示 notes」，不会显示成另一条 train 的。
 
 ## 一键安装
 - stable: ✓ `fwlink/?linkid=2093504` → `MicrosoftEdge-<ver>.pkg`，走系统 pkg 安装


### PR DESCRIPTION
Closes #107, closes #101, closes #88.

Three issues that share one shape: a check that cannot fail, or does not exist, on a path where nothing else is looking.

## #107 — Edge's release-notes links, and why nothing noticed

Microsoft renamed the per-channel enterprise docs pages from `microsoft-edge-relnotes-<channel>` to `microsoft-edge-relnote-<channel>` (**singular**). Stable and Beta are live under the new spelling.

The issue concluded the pages were "genuinely gone" after trying `-relnotes-stable-channel`, `-release-notes` and `-relnotes-archive` — all three *plural*. Two of the three needed one letter.

Dev really is gone, measured rather than assumed: `toc.json` carries eight `relnote*` paths (Beta, Stable, Mobile Beta, Mobile Stable, three `-archive-` companions, the security page) and none is Dev; four Dev spellings 404; Learn's search API returns Beta, Security and the release schedule. So Dev gets no `changelogURL` — pointing it at Beta's or Stable's page shows a Dev user another train's changes, which is the call Thunderbird Daily already gets. With it nil the detail view falls through to `ChangelogCatalog`, which has no Edge entry, so the result is no notes rather than the wrong ones.

**The rename is not global** — `microsoft-edge-relnotes-security` is still plural. In the audit doc, because the next person guessing at a page in that section will need it.

### The half that stops it recurring

`ChangelogURLPolicyTests` asserts a `changelogURL`'s *shape*, and a shape stays valid forever after the page behind it is retired. Nothing fetched them. `duo verify` now HEADs every distinct one.

Advisory by construction: only **404 and 410** warn. A 403 is more often a bot wall, a 429/5xx a bad minute, a dropped connection this machine — those are machine notes, which never promote a finding or accumulate a streak.

Two things the first live run taught:

- **A HEAD may only ever confirm a page ALIVE.** `www.workbuddy.ai` and `www.codebuddy.cn` answer HEAD **404** and GET **200** with a full page — a static host with no HEAD route. The first draft retried only on 403/405/400 and accused both by name. Anything but a 2xx is now re-asked with GET, and the GET decides.
- **Running on URLSession is the point.** #107 measured with curl and reported AnyDesk as 403; through URLSession it is **200**, because the wall reads the client. The app opens these in a WebView on the same stack, so asking the way the app asks measures what the user will see.

17 of the 87 pages are also a `ChangelogRecipe.source` that `sweepChangelog` GETs and parses in the same run — those are skipped, so one report cannot say a recipe parsed a page *and* that the page is gone. The sweep gets its own cacheless session: this is the only place issuing a HEAD and a GET for one URL, and a zero-length HEAD in the shared `URLCache` is the kind of thing that becomes an empty body and a false "recipe broken".

## #101 — the proof GitHub rules could not reach

`ChannelProofRegistry` read `VendorProbeRegistry` only, and `crossChannelArtifact` was typed on `VendorProbeRecipe`; the GitHub sweep passed `sanity: { _, _ in [] }`. A vendor recipe that skipped its proof got a hard finding, a GitHub rule got silence — and the asymmetry was invisible exactly where it mattered, at the point where somebody adds a rule.

The live sweep the issue asked for found nothing misresolving: all three rules gate the channel in their `versionPattern`. What was missing is any statement that this is **required** — the registry's default `v?([0-9]+(?:\.[0-9]+)+)` plus `usePrereleases: true` plus a non-stable channel has no discriminator at all.

`githubProofs` is a **separate map**, not extra keys in `proofs`: `ChannelProofKey` is `(bundleID, channel)` and names no registry, so one map would silently collide the day a bundle id appears in both. No such pair exists today, and `channelProofMapsDoNotCollide` measures that rather than assuming it.

### The proof that could not fail

The VSCodium proof started as a bare `-insider`. Every GitHub asset URL carries `owner/repo` in its path, and the repo **is** `vscodium-insiders` — so it matched the repository name and could never fail for any input. The mirror of the fact the stable branch already declines to check on, applied to one direction and not the other.

No amount of live data shows this: every real tag in that repo also carries `-insider`, so loose and anchored agree on all 57 and differ only on the artifact the proof exists to catch. Anchored to `/download/[^/]*-insider`, pinned by a test that feeds it a stable-shaped URL from that same repository.

## #88 — a complaint that could never clear

The lag check assumes a trailing changelog means the pattern is reading a stale section. Here the pattern is perfect and the **vendor** is stale: WorkBuddy's international site carries two entries and stops at 5.2.7 while its own endpoint ships 5.4.2, and the identical pattern returns 58 entries from the Chinese site. Nothing to fix means it filed a "recipe degraded" issue every sweep against working code.

`acknowledgedStaleEntry` is a **version, not a boolean**, and that is the design. A `true` would switch the check off forever, silencing the one detector that would notice the day the pattern really does break. Naming the version means it holds only while the page still says exactly that — the complaint returns if the pattern slips backward, returns once if the vendor publishes, and the field can be deleted once the vendor catches up.

## Verification

`make test` — **1300** core / 102 suites and **141** CLI / 20 suites, 1 pre-existing known issue (Anki).

Full `duo verify` against live endpoints after `make cli`:

```
vendor probe  ✓ 135  ⚠ 1  ✗ 0
GitHub rule   ✓ 69   ⚠ 0  ✗ 0
changelog     ✓ 68   ⚠ 0  ✗ 0
total         ✓ 272  ⚠ 1  ✗ 0        111s
```

The one warning is LibreOffice's pre-existing `remoteBehindInstalled`. One machine note (SourceForge 403), correctly non-actionable.

**Red→green on the real URL**, not a fixture: restoring the dead Edge link produced `⚠ WARN … returns HTTP 404 — the button in the app opens a dead page`; restoring the fix returned it to ✓.

**Independent recomputation** of the #101 proofs — ported to Python, run against the live Releases API: 129 channel artifacts all accepted, 107 stable artifacts all rejected, across the full release histories of all three repos.

## Not covered

- **Soft 404s** — a 200 page whose body says "not found". #107 lists this as unverified too; detecting it means reading and judging 87 vendor pages, a different and much noisier check.
- **`.infra`/`.skipped` findings discard the verdict.** `adding(warning:)` promotes only `ok → warn`, so a vendor whose probe endpoint has a bad minute loses its changelog verdict that run. Documented at the fold site; it delays one page by one nightly sweep.
- `ChangelogLinkSweep.statuses` duplicates `Verify.byHost`'s pacing loop. `byHost` returns `[Finding]`, so genericising it is a separate change.

## Review

Went through an adversarial review pass. Beyond the VSCodium proof above, it caught three of my own tests passing vacuously — including one where `first { $0.bundleID == ... }` returned GitHub Desktop's *stable* rule, because two rules share that bundle id — the `Redactor` eating Notion's 32-hex page id out of a warning that claimed to name the URL, and an audit-doc count that was wrong. All fixed.

No overlap with #108: disjoint file sets.
