### PR TITLE
fix: a single gateway 5xx no longer strands an update check

### DIFF
--- a/CLI/Sources/DuoKit/Finding.swift
+++ b/CLI/Sources/DuoKit/Finding.swift
@@ -60,7 +60,17 @@ public struct Finding: Codable, Sendable {
     /// Host only — never a resolved URL, which can carry an identifier.
     public let endpointHost: String
     public let pattern: String?
+    /// HTTP requests the sweep actually spent on this recipe — the outer
+    /// `infraRetries` probes plus any gateway retry inside them. A request count,
+    /// not a probe count, so it cannot understate what an endpoint cost.
     public let attempts: Int
+    /// How many of `attempts` were `URLSession.versionFeedData`'s single retry on a
+    /// 502/503/504. Non-zero on an otherwise `ok` finding is the signal worth
+    /// having: the endpoint flapped and recovered, which no other field records.
+    ///
+    /// Optional so a `report.json` written before this existed still decodes — nil
+    /// means "not recorded", which is not the same claim as zero.
+    public let gatewayRetries: Int?
     public let elapsedMs: Int
     /// Redacted and capped. Present only for actionable findings, since this is
     /// the one field that carries arbitrary vendor content.
@@ -84,7 +94,8 @@ public struct Finding: Codable, Sendable {
         status: FindingStatus, version: String? = nil,
         failureKind: String? = nil, failureDetail: String? = nil,
         warnings: [String] = [], endpointHost: String, pattern: String? = nil,
-        attempts: Int = 1, elapsedMs: Int = 0, bodySample: String? = nil
+        attempts: Int = 1, gatewayRetries: Int? = nil,
+        elapsedMs: Int = 0, bodySample: String? = nil
     ) {
         self.recipeID = recipeID
         self.registry = registry
@@ -98,6 +109,7 @@ public struct Finding: Codable, Sendable {
         self.endpointHost = endpointHost
         self.pattern = pattern
         self.attempts = attempts
+        self.gatewayRetries = gatewayRetries
         self.elapsedMs = elapsedMs
         // Condense before redacting: the changelog path hands over a whole raw
         // HTML page, and a report full of `<link rel="preload">` is a report

--- a/CLI/Sources/DuoKit/Report.swift
+++ b/CLI/Sources/DuoKit/Report.swift
@@ -75,6 +75,23 @@ public enum Report {
             }
         }
 
+        // A gateway 5xx that succeeded on retry leaves no other trace: the status
+        // is `ok`, no warning is raised, and the loop above prints only actionable
+        // findings. That is the flap worth seeing early — an endpoint answering
+        // 502 to one request in N is degrading, and by the time it fails outright
+        // it is no longer news. Printed for every status, since a finding that
+        // retried and then failed anyway cost those requests too.
+        let retried = findings.filter { ($0.gatewayRetries ?? 0) > 0 }
+        if !retried.isEmpty {
+            print("\n  \u{27F3} GATEWAY RETRIES (endpoint 5xx'd, request was repeated once)")
+            for finding in retried {
+                let n = finding.gatewayRetries ?? 0
+                print("      \(finding.recipeID) — \(finding.endpointHost) "
+                    + "\u{00B7} \(n) retr\(n == 1 ? "y" : "ies") of \(finding.attempts) "
+                    + "request\(finding.attempts == 1 ? "" : "s") \u{00B7} settled \(finding.status)")
+            }
+        }
+
         let infra = findings.filter { $0.status == .infra }
         if !infra.isEmpty {
             print("\n  ~ INFRA (transient by default — reported once persistent)")

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -245,17 +245,28 @@ public enum Verify {
                     endpointHost: recipe.url.host ?? "-")
             }
             let source = VendorProbeSource()
+            // One tally spanning every attempt, so `attempts` below counts the
+            // requests this recipe actually cost rather than the probes we chose to
+            // run. Without it a probe that 502s and recovers inside
+            // `versionFeedData` reports one attempt for two requests — and reports
+            // `ok`, hiding exactly the kind of flap this sweep exists to catch.
+            let tally = GatewayRetry.Tally()
             var attempt = 0
-            var outcome = await source.probeDiagnostic(recipe)
+            var outcome = await GatewayRetry.$tally.withValue(tally) {
+                await source.probeDiagnostic(recipe)
+            }
             while attempt < options.infraRetries,
                   outcome.failure?.classification == .infra {
                 attempt += 1
                 try? await Task.sleep(for: .seconds(attempt))
-                outcome = await source.probeDiagnostic(recipe)
+                outcome = await GatewayRetry.$tally.withValue(tally) {
+                    await source.probeDiagnostic(recipe)
+                }
             }
             var finding = classify(
                 outcome, registry: .vendor, host: recipe.url.host ?? "-",
-                pattern: recipe.versionPattern, attempts: attempt + 1,
+                pattern: recipe.versionPattern,
+                attempts: attempt + 1 + tally.count, gatewayRetries: tally.count,
                 installed: installed[recipe.recipeID],
                 sanity: { version, remote in
                     RecipeSanity.complaints(version: version, recipe: recipe)
@@ -365,17 +376,24 @@ public enum Verify {
         var out: [Finding] = []
         for (index, rule) in rules.enumerated() {
             if index > 0 { try? await Task.sleep(for: options.perHostDelay) }
+            // See the vendor sweep: counts requests, not probes.
+            let tally = GatewayRetry.Tally()
             var attempt = 0
-            var outcome = await source.resolveDiagnostic(rule)
+            var outcome = await GatewayRetry.$tally.withValue(tally) {
+                await source.resolveDiagnostic(rule)
+            }
             while attempt < options.infraRetries,
                   outcome.failure?.classification == .infra {
                 attempt += 1
                 try? await Task.sleep(for: .seconds(attempt))
-                outcome = await source.resolveDiagnostic(rule)
+                outcome = await GatewayRetry.$tally.withValue(tally) {
+                    await source.resolveDiagnostic(rule)
+                }
             }
             var finding = classify(
                 outcome, registry: .github, host: "api.github.com",
-                pattern: rule.versionPattern, attempts: attempt + 1,
+                pattern: rule.versionPattern,
+                attempts: attempt + 1 + tally.count, gatewayRetries: tally.count,
                 installed: installed["vendor:\(rule.bundleID):\(rule.channel.rawValue)"],
                 // Issue #101: this used to pass `{ _, _ in [] }`. The vendor
                 // sweep asked "did this install spec resolve its OWN channel's
@@ -700,7 +718,7 @@ public enum Verify {
     /// sweeps so both are judged by identical rules.
     static func classify(
         _ outcome: ProbeOutcome, registry: Registry, host: String, pattern: String?,
-        attempts: Int, installed: InstalledVersion?,
+        attempts: Int, gatewayRetries: Int, installed: InstalledVersion?,
         sanity: (String, RemoteVersion) -> [String]
     ) -> Finding {
         func make(
@@ -711,8 +729,8 @@ public enum Verify {
                 channel: outcome.channel.rawValue, status: status, version: version,
                 failureKind: outcome.failure?.kind, failureDetail: outcome.failure?.detail,
                 warnings: warnings, endpointHost: host, pattern: pattern,
-                attempts: attempts, elapsedMs: outcome.elapsedMs,
-                bodySample: outcome.bodySample)
+                attempts: attempts, gatewayRetries: gatewayRetries,
+                elapsedMs: outcome.elapsedMs, bodySample: outcome.bodySample)
         }
 
         if let failure = outcome.failure {
@@ -848,7 +866,8 @@ extension Finding {
             status: status, version: version,
             failureKind: failureKind, failureDetail: failureDetail,
             warnings: warnings + [note], endpointHost: endpointHost, pattern: pattern,
-            attempts: attempts, elapsedMs: elapsedMs, bodySample: bodySample)
+            attempts: attempts, gatewayRetries: gatewayRetries,
+            elapsedMs: elapsedMs, bodySample: bodySample)
     }
 
     /// Attach a warning discovered after the fact (the baseline's history checks
@@ -859,6 +878,7 @@ extension Finding {
             status: status == .ok ? .warn : status, version: version,
             failureKind: failureKind, failureDetail: failureDetail,
             warnings: warnings + [warning], endpointHost: endpointHost, pattern: pattern,
-            attempts: attempts, elapsedMs: elapsedMs, bodySample: bodySample)
+            attempts: attempts, gatewayRetries: gatewayRetries,
+            elapsedMs: elapsedMs, bodySample: bodySample)
     }
 }

--- a/CLI/Tests/DuoKitTests/GatewayRetryReportingTests.swift
+++ b/CLI/Tests/DuoKitTests/GatewayRetryReportingTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import DuoKit
+
+/// `attempts` is what a reader uses to judge how much an endpoint cost, and
+/// `gatewayRetries` is the only record that a flap happened at all — an endpoint
+/// that 502s and recovers still reports `ok`.
+struct GatewayRetryReportingTests {
+
+    private static func finding(attempts: Int, retries: Int?) -> Finding {
+        Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable", status: .ok,
+            endpointHost: "example.com", attempts: attempts, gatewayRetries: retries)
+    }
+
+    @Test func aRetryIsRecordedEvenWhenTheFindingIsOtherwiseFine() {
+        let f = Self.finding(attempts: 2, retries: 1)
+        #expect(f.status == .ok)
+        #expect(f.gatewayRetries == 1)
+        // The whole point: two requests were spent, and the report says two.
+        #expect(f.attempts == 2)
+    }
+
+    /// `observing` and `adding` rebuild the whole struct field by field, so a new
+    /// field is exactly the kind that gets silently dropped there.
+    @Test func annotatingAFindingKeepsItsRequestAccounting() {
+        let base = Self.finding(attempts: 3, retries: 1)
+        #expect(base.observing("\(Finding.machineNotePrefix)note").gatewayRetries == 1)
+        #expect(base.observing("\(Finding.machineNotePrefix)note").attempts == 3)
+        #expect(base.adding(warning: "w").gatewayRetries == 1)
+        #expect(base.adding(warning: "w").attempts == 3)
+    }
+
+    /// `report.json` files written before this field existed are still read by
+    /// `Reconcile` and `Triage`. Decoding must not start failing on them, and a
+    /// missing key must not be reported as a confident zero.
+    @Test func anOlderReportWithoutTheFieldStillDecodes() throws {
+        let json = """
+        {
+          "recipeID": "vendor:com.example.app:stable",
+          "registry": "vendor",
+          "bundleID": "com.example.app",
+          "channel": "stable",
+          "status": "ok",
+          "warnings": [],
+          "endpointHost": "example.com",
+          "attempts": 1,
+          "elapsedMs": 12
+        }
+        """
+        let decoded = try JSONDecoder().decode(Finding.self, from: Data(json.utf8))
+        #expect(decoded.recipeID == "vendor:com.example.app:stable")
+        #expect(decoded.gatewayRetries == nil)   // "not recorded", not "zero"
+    }
+
+    @Test func aFreshFindingRoundTripsTheField() throws {
+        let data = try JSONEncoder().encode(Self.finding(attempts: 2, retries: 1))
+        #expect(try JSONDecoder().decode(Finding.self, from: data).gatewayRetries == 1)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AlcoveUpdateSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AlcoveUpdateSource.swift
@@ -142,7 +142,8 @@ public struct AlcoveUpdateSource: UpdateSource {
         if let b = app.buildVersion { request.setValue(b, forHTTPHeaderField: "x-app-build") }
         request.setValue(Self.osVersion, forHTTPHeaderField: "x-macos-version")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "Alcove updates/latest")
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             return nil
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -423,7 +423,8 @@ public struct GitHubReleasesSource: UpdateSource {
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
 
         Log.source.debug("GitHub GET \(endpoint, privacy: .public) (auth=\(self.token != nil, privacy: .public))")
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "GitHub \(rule.slug)")
         guard let http = response as? HTTPURLResponse else { return nil }
         guard (200..<300).contains(http.statusCode) else {
             let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/HomebrewCaskCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/HomebrewCaskCatalog.swift
@@ -138,7 +138,8 @@ public actor HomebrewCaskCatalog {
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "Homebrew cask catalog")
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             throw CaskError.badStatus(http.statusCode)
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -187,7 +187,8 @@ public struct MacAppStoreSource: UpdateSource {
             forHTTPHeaderField: "User-Agent"
         )
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "App Store page id\(trackId)")
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
               let html = String(data: data, encoding: .utf8) else { return nil }
         return extractMacVersionInfo(from: html)
@@ -261,7 +262,8 @@ public struct MacAppStoreSource: UpdateSource {
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
             forHTTPHeaderField: "User-Agent"
         )
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "App Store compat id\(trackId)")
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
               let html = String(data: data, encoding: .utf8) else { return nil }
         return extractMacCompatible(from: html)
@@ -340,7 +342,8 @@ public struct MacAppStoreSource: UpdateSource {
         request.timeoutInterval = 15
         request.cachePolicy = URLRequest.versionFeedCachePolicy
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "App Store lookup \(bundleID)")
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             throw MASError.badStatus(http.statusCode)
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -40,7 +40,8 @@ public struct SparkleAppcastSource: UpdateSource {
             request.setValue(value, forHTTPHeaderField: field)
         }
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "Sparkle \(app.name)")
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             throw SparkleError.badStatus(http.statusCode)
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ToolboxSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ToolboxSource.swift
@@ -123,7 +123,8 @@ public struct ToolboxSource: Sendable {
         request.timeoutInterval = 15
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "Toolbox sparkle feed")
         guard let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode) else { return nil }
         let body = String(decoding: data, as: UTF8.self)
@@ -172,7 +173,8 @@ public struct ToolboxSource: Sendable {
         request.timeoutInterval = 15
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "Android Studio updates.xml")
         guard let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode) else { return nil }
         let body = String(decoding: data, as: UTF8.self)
@@ -208,7 +210,8 @@ public struct ToolboxSource: Sendable {
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "Toolbox feed")
         guard let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -705,7 +705,8 @@ public struct VendorProbeSource: UpdateSource {
             let okRange = recipe.followRedirects ? (200..<300) : (200..<400)
             let data: Data
             let response: URLResponse
-            do { (data, response) = try await activeSession.data(for: request) }
+            do { (data, response) = try await activeSession.versionFeedData(
+                for: request, label: "VendorProbe \(recipe.bundleID)") }
             catch { return .failure(Self.transportFailure(error)) }
             guard let http = response as? HTTPURLResponse else {
                 return .failure(.nonHTTPResponse)
@@ -922,7 +923,8 @@ public struct VendorProbeSource: UpdateSource {
         request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
         let data: Data
         let response: URLResponse
-        do { (data, response) = try await session.data(for: request) }
+        do { (data, response) = try await session.versionFeedData(
+            for: request, label: "VendorProbe zip \(url.host ?? "?")") }
         catch { return .failure(Self.transportFailure(error)) }
         guard let http = response as? HTTPURLResponse else {
             return .failure(.nonHTTPResponse)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -645,7 +645,8 @@ public struct VendorProbeSource: UpdateSource {
                 // filename (e.g. "ToDesk_4.7.6.0.dmg").
                 request.httpMethod = "HEAD"
                 let response: URLResponse
-                do { (_, response) = try await session.data(for: request) }
+                do { (_, response) = try await session.versionFeedData(
+                    for: request, label: "VendorProbe HEAD \(recipe.bundleID)") }
                 catch { return .failure(Self.transportFailure(error)) }
                 guard let http = response as? HTTPURLResponse else {
                     return .failure(.nonHTTPResponse)
@@ -667,7 +668,8 @@ public struct VendorProbeSource: UpdateSource {
                 // the Location path, so `text` is the full redirect target.
                 request.httpMethod = "GET"
                 let response: URLResponse
-                do { (_, response) = try await Self.noRedirectSession.data(for: request) }
+                do { (_, response) = try await Self.noRedirectSession.versionFeedData(
+                    for: request, label: "VendorProbe redirect \(recipe.bundleID)") }
                 catch { return .failure(Self.transportFailure(error)) }
                 guard let http = response as? HTTPURLResponse else {
                     return .failure(.nonHTTPResponse)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/XcodeReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/XcodeReleasesSource.swift
@@ -134,7 +134,8 @@ public struct XcodeReleasesSource: UpdateSource {
         // Same reason every other version feed sets this: a long max-age would
         // otherwise let a stale copy hide a release for days.
         request.cachePolicy = URLRequest.versionFeedCachePolicy
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "XcodeReleases")
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw URLError(.badServerResponse)
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
@@ -72,6 +72,7 @@ public extension URLSession {
         // trace anywhere.
         Log.source.info(
             "\(label, privacy: .public): HTTP \(http.statusCode, privacy: .public) — retrying once")
+        GatewayRetry.tally?.record()
         // Cancellation must not change the *shape* of the failure a caller sees.
         // `Task.sleep` throws `CancellationError`, which is not a `URLError`, and
         // `VendorProbeSource.transportFailure` would render it as "URLError 1" — a
@@ -85,4 +86,45 @@ public extension URLSession {
             "\(label, privacy: .public): gateway retry → \(status.map(String.init) ?? "non-HTTP", privacy: .public)")
         return second
     }
+}
+
+/// Makes the retry in ``URLSession/versionFeedData(for:label:retryDelay:)``
+/// countable by whoever asked for the fetch.
+///
+/// The retry is deliberately invisible to callers — that is what keeps every
+/// existing status guard meaning what it meant. But `duo verify` exists to notice
+/// an endpoint degrading, and an endpoint that 502s and then succeeds is exactly
+/// the early, cheap-to-catch kind of degradation: without a count it reports `ok`
+/// with no trace that anything happened, while quietly making two requests where
+/// the report claims one.
+///
+/// A task-local rather than a return value because the retry happens several
+/// layers below anyone who cares — threading a count up through every source's
+/// signature would touch a dozen call sites to serve one tool. Task-locals also
+/// scope themselves to a task tree, so a concurrent sweep's recipes cannot
+/// contaminate each other's counts.
+public enum GatewayRetry {
+
+    /// One sweep unit's tally. A class so the value survives being read back after
+    /// the `withValue` scope ends; locked because a probe may fan out internally.
+    public final class Tally: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+
+        public init() {}
+
+        /// How many *extra* requests the gateway retry cost. Zero is the norm.
+        public var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+
+        func record() {
+            lock.lock(); value += 1; lock.unlock()
+        }
+    }
+
+    /// Set by a caller that wants the count; nil everywhere else, which is why the
+    /// app pays nothing for this.
+    @TaskLocal public static var tally: Tally?
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public extension URLSession {
+
+    /// The HTTP statuses a *version feed* request retries once, and nothing else.
+    ///
+    /// All three mean "an intermediary could not reach the origin right now" —
+    /// they carry no claim about the request itself, so the same bytes sent a
+    /// moment later routinely succeed. Headlamp's check died on exactly this:
+    /// `api.github.com` answered 504 with no `X-RateLimit-Remaining` header at
+    /// all, i.e. the request never reached GitHub's application layer.
+    ///
+    /// What is deliberately *not* here matters more than what is:
+    ///
+    /// - **500** — an origin that did reach the application and threw. Repeating
+    ///   it usually reproduces it, and a vendor whose feed 500s consistently is a
+    ///   broken recipe we want to see reported, not smoothed over.
+    /// - **403 / 429** — GitHub's unauthenticated 60/hour limit. Retrying a rate
+    ///   limit spends the budget it is complaining about and brings the reset
+    ///   nearer; `UpdateStatus.isRateLimitError` already drives a proper UI nudge.
+    /// - **4xx generally** — a definitive answer about *this* request.
+    static let retryableGatewayStatuses: Set<Int> = [502, 503, 504]
+
+    /// How long to wait before the single retry.
+    ///
+    /// Long enough that we are not re-asking the same wedged edge node in the
+    /// same instant, short enough to stay inside one update-check round rather
+    /// than stretching a 130-app fan-out. It is a fixed pause, not a growing
+    /// backoff, because there is only ever one retry to schedule.
+    static let gatewayRetryDelay: Duration = .milliseconds(800)
+
+    /// GET a version feed, retrying **exactly once** when the answer is a
+    /// gateway 5xx (see ``retryableGatewayStatuses``).
+    ///
+    /// The retry is invisible to the caller: this returns whatever the second
+    /// attempt produced, so every existing status guard keeps its own meaning —
+    /// a source that throws on non-2xx still throws, one that returns nil still
+    /// returns nil. On any other status (including a 5xx not in the set) the
+    /// first response is handed back untouched and no second request is made.
+    ///
+    /// Only for **idempotent GETs on the update-check path**. A POST that
+    /// mints a token or otherwise changes server state must not go through here.
+    ///
+    /// A transport-level failure (`URLError`) is not retried: `Downloader` owns
+    /// that policy for the bytes that matter, and a source that cannot connect
+    /// at all is already reported as a retryable row.
+    func versionFeedData(
+        for request: URLRequest,
+        label: String,
+        retryDelay: Duration = URLSession.gatewayRetryDelay
+    ) async throws -> (Data, URLResponse) {
+        let first = try await data(for: request)
+        guard let http = first.1 as? HTTPURLResponse,
+              Self.retryableGatewayStatuses.contains(http.statusCode)
+        else { return first }
+        // Safe by construction rather than by every caller remembering: a body-carrying
+        // method is not ours to send twice. `VendorProbeSource` builds GET and POST
+        // probes through one code path (`recipe.requestBody` decides), so the guard has
+        // to live here — a call site that "knows" it is a GET is one recipe away from
+        // being wrong. nil means GET.
+        let method = (request.httpMethod ?? "GET").uppercased()
+        guard method == "GET" || method == "HEAD" else {
+            Log.source.info(
+                "\(label, privacy: .public): HTTP \(http.statusCode, privacy: .public) on \(method, privacy: .public) — not retried")
+            return first
+        }
+
+        Log.source.info(
+            "\(label, privacy: .public): HTTP \(http.statusCode, privacy: .public) — retrying once")
+        try await Task.sleep(for: retryDelay)
+        let second = try await data(for: request)
+        let status = (second.1 as? HTTPURLResponse)?.statusCode
+        Log.source.info(
+            "\(label, privacy: .public): gateway retry → \(status.map(String.init) ?? "non-HTTP", privacy: .public)")
+        return second
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
@@ -65,9 +65,20 @@ public extension URLSession {
             return first
         }
 
+        // `.info` rather than the `.debug` this file's own convention gives HTTP
+        // statuses: this is not a status, it is us deciding to send a second
+        // request. When the retry succeeds nothing else logs at all — the source's
+        // `.error` never fires — so at `.debug` a gateway hiccup would leave no
+        // trace anywhere.
         Log.source.info(
             "\(label, privacy: .public): HTTP \(http.statusCode, privacy: .public) — retrying once")
-        try await Task.sleep(for: retryDelay)
+        // Cancellation must not change the *shape* of the failure a caller sees.
+        // `Task.sleep` throws `CancellationError`, which is not a `URLError`, and
+        // `VendorProbeSource.transportFailure` would render it as "URLError 1" — a
+        // code that does not exist. Cancelling a `data(for:)` has always produced
+        // `URLError(.cancelled)`; keep that, so every existing catch stays honest.
+        do { try await Task.sleep(for: retryDelay) }
+        catch { throw URLError(.cancelled) }
         let second = try await data(for: request)
         let status = (second.1 as? HTTPURLResponse)?.statusCode
         Log.source.info(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GatewayRetryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GatewayRetryTests.swift
@@ -150,6 +150,43 @@ struct GatewayRetryTests {
         #expect(URLSession.retryableGatewayStatuses == [502, 503, 504])
     }
 
+    /// Every other test injects a 1 ms delay, so without this the production
+    /// constant is pinned by nothing: raising it to 30 s would keep the whole
+    /// suite green while melting a 130-app fan-out.
+    @Test func theProductionDelayIsPinned() {
+        #expect(URLSession.gatewayRetryDelay == .milliseconds(800))
+    }
+
+    /// `.redirectFilename` recipes read the version from a HEAD's resolved URL, so
+    /// HEAD is a real version-read path here, not just a permitted method.
+    @Test func headIsRetriedLikeAnyOtherIdempotentRead() async throws {
+        let result = try await Self.fetch(scripting: [503, 200], method: "HEAD")
+        #expect(result.status == 200)
+        #expect(result.requests == ["HEAD", "HEAD"])
+    }
+
+    /// Cancelling during the wait must not invent a failure shape no caller knows.
+    /// `VendorProbeSource.transportFailure` renders a non-`URLError` through
+    /// `NSError.code`, which would print a nonexistent "URLError 1"; cancelling a
+    /// plain `data(for:)` has always yielded `URLError(.cancelled)`.
+    @Test func cancellationDuringTheWaitSurfacesAsACancelledURLError() async throws {
+        ScriptedProtocol.script.load([504, 200])
+        let session = Self.session()
+        let task = Task {
+            try await session.versionFeedData(
+                for: URLRequest(url: Self.url), label: "test", retryDelay: .seconds(30))
+        }
+        // Let the first attempt land and the sleep begin.
+        try await Task.sleep(for: .milliseconds(150))
+        task.cancel()
+
+        await #expect(throws: URLError.self) { try await task.value }
+        do { _ = try await task.value }
+        catch let error as URLError { #expect(error.code == .cancelled) }
+        // The retry never went out.
+        #expect(ScriptedProtocol.script.requests == ["GET"])
+    }
+
     /// The reported case, end to end: Headlamp's check died because one
     /// `api.github.com` 504 was a terminal answer. Through the real source, the
     /// same 504 now resolves to a version.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GatewayRetryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GatewayRetryTests.swift
@@ -187,6 +187,41 @@ struct GatewayRetryTests {
         #expect(ScriptedProtocol.script.requests == ["GET"])
     }
 
+    /// `duo verify` reports how many requests a recipe cost. The retry happens far
+    /// below it, so without this the report understates the cost and — worse — a
+    /// probe that 502s and recovers reports `ok` with no trace at all.
+    @Test func aCallerThatAsksCanCountTheRetries() async throws {
+        ScriptedProtocol.script.load([504, 200])
+        let tally = GatewayRetry.Tally()
+        let session = Self.session()
+        _ = try await GatewayRetry.$tally.withValue(tally) {
+            try await session.versionFeedData(
+                for: URLRequest(url: Self.url), label: "test", retryDelay: Self.fastDelay)
+        }
+        #expect(tally.count == 1)
+        #expect(ScriptedProtocol.script.requests.count == 2)
+    }
+
+    /// The count must track retries, not failures: a gateway that never recovers
+    /// still only earns one extra request.
+    @Test func aPersistentFailureCountsOneRetryNotOnePerAttempt() async throws {
+        ScriptedProtocol.script.load([503, 503, 200])
+        let tally = GatewayRetry.Tally()
+        let session = Self.session()
+        _ = try await GatewayRetry.$tally.withValue(tally) {
+            try await session.versionFeedData(
+                for: URLRequest(url: Self.url), label: "test", retryDelay: Self.fastDelay)
+        }
+        #expect(tally.count == 1)
+    }
+
+    /// Nobody outside `duo verify` sets a tally, and the app must not pay for it.
+    @Test func noTallyIsTheNormalCaseAndCostsNothing() async throws {
+        let result = try await Self.fetch(scripting: [502, 200])
+        #expect(result.status == 200)
+        #expect(GatewayRetry.tally == nil)
+    }
+
     /// The reported case, end to end: Headlamp's check died because one
     /// `api.github.com` 504 was a terminal answer. Through the real source, the
     /// same 504 now resolves to a version.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GatewayRetryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GatewayRetryTests.swift
@@ -1,0 +1,177 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A gateway 5xx (502/503/504) says an intermediary could not reach the origin —
+/// it carries no verdict on the request, so the same bytes a moment later usually
+/// work. These pin the *shape* of that one retry: which statuses earn it, that it
+/// happens exactly once, and that nothing else changed.
+@Suite(.serialized)
+struct GatewayRetryTests {
+
+    /// Serves a scripted list of statuses in order, recording every request it saw.
+    /// The body is GitHub-release shaped and *versioned by attempt number*, so a
+    /// test can prove which response the caller ended up with rather than merely
+    /// that some 200 arrived.
+    private final class ScriptedProtocol: URLProtocol, @unchecked Sendable {
+        final class Script: @unchecked Sendable {
+            private let lock = NSLock()
+            private var queue: [Int] = []
+            private var seen: [String] = []
+
+            func load(_ statuses: [Int]) {
+                lock.lock(); queue = statuses; seen = []; lock.unlock()
+            }
+
+            func next(method: String) -> (status: Int, attempt: Int) {
+                lock.lock(); defer { lock.unlock() }
+                seen.append(method)
+                let status = queue.isEmpty ? 200 : queue.removeFirst()
+                return (status, seen.count)
+            }
+
+            var requests: [String] { lock.lock(); defer { lock.unlock() }; return seen }
+        }
+
+        static let script = Script()
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            let (status, attempt) = Self.script.next(method: request.httpMethod ?? "GET")
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status,
+                httpVersion: "HTTP/1.1", headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(Self.body(attempt: attempt).utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+
+        /// A minimal but real `/releases/latest` payload — `GitHubReleasesSource`
+        /// parses this one for the end-to-end test, and the plain helper tests read
+        /// the tag out of it as an attempt marker.
+        static func body(attempt: Int) -> String {
+            """
+            {
+              "tag_name": "v0.0.\(attempt)",
+              "assets": [
+                {
+                  "name": "Example-0.0.\(attempt)-arm64.dmg",
+                  "browser_download_url": "https://example.com/Example-0.0.\(attempt)-arm64.dmg",
+                  "size": 42
+                }
+              ],
+              "prerelease": false,
+              "draft": false
+            }
+            """
+        }
+    }
+
+    private static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ScriptedProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private static let url = URL(string: "https://example.com/feed.json")!
+
+    /// Tests never wait the production 800 ms; the delay is a parameter for exactly
+    /// this reason.
+    private static let fastDelay: Duration = .milliseconds(1)
+
+    private static func fetch(
+        scripting statuses: [Int], method: String? = nil
+    ) async throws -> (status: Int?, body: String, requests: [String]) {
+        ScriptedProtocol.script.load(statuses)
+        var request = URLRequest(url: url)
+        if let method { request.httpMethod = method }
+        let (data, response) = try await session().versionFeedData(
+            for: request, label: "test", retryDelay: fastDelay)
+        return (
+            (response as? HTTPURLResponse)?.statusCode,
+            String(decoding: data, as: UTF8.self),
+            ScriptedProtocol.script.requests)
+    }
+
+    @Test(arguments: [502, 503, 504])
+    func gatewayStatusIsRetriedOnceAndTheSecondAnswerWins(status: Int) async throws {
+        let result = try await Self.fetch(scripting: [status, 200])
+        #expect(result.status == 200)
+        // Not just "a 200": the tag proves the caller got attempt 2, not a
+        // cached or replayed first response.
+        #expect(result.body.contains("\"tag_name\": \"v0.0.2\""))
+        #expect(result.requests.count == 2)
+    }
+
+    /// "Once" is the whole contract. A wedged gateway must not turn one check into
+    /// an open-ended retry loop across a 130-app fan-out.
+    @Test func aPersistentGatewayFailureIsRetriedExactlyOnce() async throws {
+        let result = try await Self.fetch(scripting: [504, 504, 200])
+        #expect(result.status == 504)
+        #expect(result.requests.count == 2)  // the scripted 200 is never reached
+    }
+
+    /// 500 is the origin answering and throwing — repeating it reproduces it, and a
+    /// recipe whose feed 500s consistently should be *reported*, not smoothed over.
+    @Test func plainServerErrorIsNotRetried() async throws {
+        let result = try await Self.fetch(scripting: [500, 200])
+        #expect(result.status == 500)
+        #expect(result.requests.count == 1)
+    }
+
+    /// Retrying a rate limit spends the budget it is complaining about.
+    @Test(arguments: [403, 429])
+    func rateLimitIsNotRetried(status: Int) async throws {
+        let result = try await Self.fetch(scripting: [status, 200])
+        #expect(result.status == status)
+        #expect(result.requests.count == 1)
+    }
+
+    @Test(arguments: [200, 304, 404])
+    func settledStatusesCostExactlyOneRequest(status: Int) async throws {
+        let result = try await Self.fetch(scripting: [status])
+        #expect(result.status == status)
+        #expect(result.requests.count == 1)
+    }
+
+    /// `VendorProbeSource` builds GET and POST probes through one code path, so the
+    /// method guard lives in the helper rather than in each caller's head.
+    @Test func aBodyCarryingMethodIsNeverRetried() async throws {
+        let result = try await Self.fetch(scripting: [503, 200], method: "POST")
+        #expect(result.status == 503)
+        #expect(result.requests == ["POST"])
+    }
+
+    @Test func onlyGatewayStatusesAreEligible() {
+        #expect(URLSession.retryableGatewayStatuses == [502, 503, 504])
+    }
+
+    /// The reported case, end to end: Headlamp's check died because one
+    /// `api.github.com` 504 was a terminal answer. Through the real source, the
+    /// same 504 now resolves to a version.
+    @Test func aGitHubGatewayFailureNoLongerStrandsTheCheck() async throws {
+        ScriptedProtocol.script.load([504])   // then the stub's 200 for attempt 2
+        let source = GitHubReleasesSource(rules: [], session: Self.session())
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#,
+            installAssetPattern: #"^Example-[0-9.]+-arm64\.dmg$"#,
+            installerKind: .dmg)
+
+        let outcome = await source.resolveDiagnostic(
+            rule, preferring: .arm64, allowingIntelTranslation: false)
+
+        // Before this change the 504 was terminal: one request, a thrown
+        // `badStatus(504)`, and the row read "GitHub returned HTTP 504". Resolving
+        // to `0.0.2` — the *second* attempt's tag — is the proof the retry happens
+        // inside the source, not only in the helper's own unit tests.
+        #expect(outcome.remote?.shortVersion == "0.0.2")
+        #expect(outcome.remote?.downloadURL?.lastPathComponent == "Example-0.0.2-arm64.dmg")
+        #expect(outcome.failure == nil)
+        #expect(ScriptedProtocol.script.requests == ["GET", "GET"])
+    }
+}


### PR DESCRIPTION
Headlamp's check failed on 2026-08-28 with `GitHub returned HTTP 504`, and the banner asked the user to click Retry. The endpoint was fine minutes later.

```
10:10:12 [source] GitHub headlamp-k8s/headlamp: HTTP 504 (ratelimit-remaining=?)
10:10:12 [check]  Headlamp v0.45.0: all sources exhausted, last error → GitHub returned HTTP 504
```

`ratelimit-remaining=?` is the tell: GitHub did not return a rate-limit header at all, so the request never reached its application layer. That is an intermediary failing, not an answer about the request.

## What there was before

Nothing. `UpdateChecker`'s loop catches a source failure and moves to the **next source** — it never re-asks the one that failed. For an app with a single source, one HTTP hiccup is the whole check. `Downloader` does retry, but its `isTransient` gate is `guard let urlError = error as? URLError`, and an HTTP 5xx is thrown as `DownloadError.httpStatus`, so it never qualified there either. The only 5xx handling anywhere was `duo verify`'s baseline, which classifies a vendor 5xx as transient infra for **reporting**.

## What this does

`URLSession.versionFeedData(for:label:retryDelay:)` — retry **exactly once**, after 800 ms, **only** on 502/503/504, **only** for GET/HEAD.

What it excludes is the load-bearing part:

- **500** is the origin answering and throwing. Repeating it reproduces it, and a feed that 500s consistently should be reported, not smoothed over.
- **403/429** is GitHub's 60/hour limit. Retrying a rate limit spends the budget it is complaining about; `UpdateStatus.isRateLimitError` already drives a proper UI nudge.
- **Body-carrying methods.** The guard lives in the helper, not at each call site, because `VendorProbeSource` builds GET and POST probes through one code path (`recipe.requestBody` decides) — a caller that "knows" it is a GET is one recipe away from being wrong. Alcove's token POST and `AlcoveLicenseService` stay on plain `data(for:)`.

The retry is invisible to callers: the second response is returned as-is, so every existing status guard keeps its meaning. A source that throws on non-2xx still throws; one that returns nil still returns nil. A 3xx — which `VendorProbeSource` treats as *success* on its no-redirect session — is handed back untouched with no second request.

Wired into 12 idempotent version reads: GitHub, Sparkle, XcodeReleases, the Homebrew cask catalog, App Store (3), Toolbox (3), Alcove's `updates/latest`, and all four `VendorProbeSource` version paths (`.responseBody`, both `.redirectFilename` arms, and the zip probe).

Deliberately **not** wired, in three categories:

- **POSTs** — Alcove's token, `AlcoveLicenseService`. Non-idempotent.
- **Status is the data** — VendorProbe's install-URL reachability probes. Their 5xx feeds `duo verify`'s infra classification and its ageing window; retrying would sand off the signal. That path also already has its own 3× backoff, so wiring it would mean 6 requests.
- **Cosmetic** — changelog fetches, self-update notes, image cache. Already `try?`; a user sees no difference.

## Verification

| | |
|---|---|
| `make test` | 1311 tests / 103 suites ✔, CLI 151 / 21 ✔ (1 pre-existing known issue) |
| red → green | reverting the GitHub wiring fails the end-to-end test on all four expectations |
| `duo verify` (real endpoints, 272 checks) | ✓ 272 ⚠ 1 ✗ 0, 104s — the ⚠ is LibreOffice's known version-scheme mismatch, `lastGoodVersion` 26.8.0 in the 08-27 baseline |

## Adversarial review

Ran one and it found a real omission, fixed in 218f5a7: `.redirectFilename` (14 recipes, Telegram Desktop among them) had been skipped, which also left the helper's HEAD branch as dead code. Notably, the one endpoint in this repo with *measured* bursty 502s — `td.telegram.org`, "verified by interleaving it with curl" — is that mode. It also caught that `CancellationError` from the sleep would render as a nonexistent `"URLError 1"` through `ProbeFailure.detail`; the wait now throws `URLError(.cancelled)`, which is what cancelling `data(for:)` always produced.

## `duo verify` counts requests now, not probes

Surfacing the retry was necessary, not optional: `attempts` counted only the outer `infraRetries` loop, so a probe that 502s and recovers inside the helper reported `(1 attempt)` with `status: ok` and left no trace at all. An endpoint answering 502 to one request in N is degrading, and by the time it fails outright it is no longer news — noticing that early is what the sweep is for.

`GatewayRetry.tally` is a task-local counter the helper increments. A task-local rather than a return value because the retry happens several layers below anyone who cares (threading a count up through every source's signature would touch a dozen call sites to serve one tool), and because task-locals scope to a task tree, so a concurrent sweep's recipes cannot contaminate each other's counts. Nothing outside `duo verify` sets one, so the app pays nothing.

`attempts` is now outer probes + inner retries. `Finding` also carries `gatewayRetries`, so an otherwise-`ok` finding still records the flap, and `Report` gains a section:

```
  ⟳ GATEWAY RETRIES (endpoint 5xx'd, request was repeated once)
      vendor:com.tdesktop.Telegram:stable — telegram.org · 1 retry of 2 requests · settled ok
```

`gatewayRetries` is `Int?` rather than `Int` because `Reconcile` and `Triage` decode `report.json` files written before it existed: a missing key means "not recorded", which is not the same claim as zero. The 68 changelog findings carry nil for the same honest reason — that sweep has no retry at any layer.

Re-verified after this: `make test` 1314 / 103 suites + CLI 155 / 22 ✔, and a live `duo verify` at ✓ 272 ⚠ 1 ✗ 0 with the new field present on all 205 findings whose path can produce it. The rendered section was confirmed by relaxing its filter against a live vendor probe and reading the output, then reverting.
