### PR TITLE
fix(cli): drop `--timeout`, a value flag no subcommand ever read

### DIFF
--- a/CLI/Sources/DuoKit/ArgParser.swift
+++ b/CLI/Sources/DuoKit/ArgParser.swift
@@ -36,9 +36,13 @@ public struct Args {
     /// flag reads as a bare boolean and its value lands in `operands`, so
     /// `--model deepseek` silently runs the default model. `--model=deepseek`
     /// keeps working either way, which is what makes it hard to notice.
+    /// Leaving one here that no subcommand reads is the same drift pointing the
+    /// other way, and since `unrecognised()` it is no longer harmless: the flag
+    /// is declared and then refused. `--timeout` shipped that way in 0.3.68.
+    /// `ArgParserTests` derives both directions from the sources instead.
     static let valueFlags: Set<String> = [
         "triage", "budget",
-        "only", "route", "max-concurrency", "timeout", "source",
+        "only", "route", "max-concurrency", "source",
         "baseline", "report", "markdown", "out", "max-calls",
         "model", "variant",
     ]

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -222,22 +222,32 @@ case "ignore", "unignore", "skip", "unskip":
     run = { await Visibility.run(options) }
 
 case "backups":
-    let operation: Backups.Options.Operation
-    switch args.operands.first {
-    case "list", nil:
-        operation = .list
-    case "restore":
-        guard args.operands.count == 2 else {
-            die("backups restore needs exactly one app\n\n\(usage)", code: 2)
+    // Which operation the operands name is worked out inside `run`, not here.
+    // This is the only branch that can die on an *operand*, and dying here beat
+    // `unrecognised()` to it: a mistyped flag whose value fell through to the
+    // operands got the value blamed for it, so `duo backups --timeout 5` said
+    // "unknown backups operation '5'" about a `5` the user never typed alone.
+    let operands = args.operands
+    let json = args.has("json")
+    let assumeYes = args.has("yes")
+    run = {
+        let operation: Backups.Options.Operation
+        switch operands.first {
+        case "list", nil:
+            operation = .list
+        case "restore":
+            guard operands.count == 2 else {
+                die("backups restore needs exactly one app\n\n\(usage)", code: 2)
+            }
+            operation = .restore(app: operands[1])
+        case let other?:
+            die("unknown backups operation '\(other)'; expected list or restore", code: 2)
         }
-        operation = .restore(app: args.operands[1])
-    case let other?:
-        die("unknown backups operation '\(other)'; expected list or restore", code: 2)
+        var options = Backups.Options(operation: operation)
+        options.json = json
+        options.assumeYes = assumeYes
+        return await Backups.run(options)
     }
-    var options = Backups.Options(operation: operation)
-    options.json = args.has("json")
-    options.assumeYes = args.has("yes")
-    run = { await Backups.run(options) }
 
 case "doctor":
     let json = args.has("json")

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -223,10 +223,12 @@ case "ignore", "unignore", "skip", "unskip":
 
 case "backups":
     // Which operation the operands name is worked out inside `run`, not here.
-    // This is the only branch that can die on an *operand*, and dying here beat
-    // `unrecognised()` to it: a mistyped flag whose value fell through to the
-    // operands got the value blamed for it, so `duo backups --timeout 5` said
-    // "unknown backups operation '5'" about a `5` the user never typed alone.
+    // Other branches also refuse before the gate at the bottom — `--source`,
+    // `--route`, and triage's required flags — but they refuse a value the user
+    // typed after the flag they named. This is the only one that refuses an
+    // *operand*, and an operand is where a mistyped flag's value lands: before
+    // this, `duo backups --timeout 5` answered "unknown backups operation '5'",
+    // blaming a `5` nobody typed on its own and never naming `--timeout`.
     let operands = args.operands
     let json = args.has("json")
     let assumeYes = args.has("yes")

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -109,7 +109,10 @@ import Testing
             .deletingLastPathComponent()   // Tests
             .deletingLastPathComponent()   // CLI
             .appendingPathComponent("Sources")
-        let asValue = /\.(?:value|int|list)\("([a-z0-9-]+)"\)/
+        // Tolerant of a wrapped call and of a camelCase name, so a read the
+        // scan cannot see stays rare — an invisible read reports as a declared
+        // flag nobody reads, which is a nudge to delete a needed entry.
+        let asValue = /\.(?:value|int|list)\(\s*"([A-Za-z0-9-]+)"\s*\)/
 
         let files = try #require(
             FileManager.default.enumerator(at: sources, includingPropertiesForKeys: nil))
@@ -126,8 +129,8 @@ import Testing
         #expect(read.count > 5, "only \(read.count) flag reads found under \(sources.path)")
         #expect(Args.valueFlags == read, """
             valueFlags and the flags read as values have drifted.
-            declared but unread (refused by unrecognised()): \(Args.valueFlags.subtracting(read).sorted())
-            read but undeclared (value lands in operands): \(read.subtracting(Args.valueFlags).sorted())
+            declared, no read found (unrecognised() refuses it): \(Args.valueFlags.subtracting(read).sorted())
+            read, not declared (the value lands in operands): \(read.subtracting(Args.valueFlags).sorted())
             """)
     }
 }

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import DuoKit
 
@@ -91,5 +92,42 @@ import Testing
         let args = self.args("restart", "--json")
         _ = args.operands
         #expect(args.unrecognised()?.description.contains("`duo restart` takes no flags") == true)
+    }
+
+    /// `valueFlags` is the one hand-maintained list left in the parser, and it
+    /// fails quietly in both directions — so read the truth out of the sources
+    /// rather than restating it here, where the restatement would drift too.
+    ///
+    /// Missing an entry swallows the value into `operands` and the reader sees
+    /// its default. A spare entry is worse now than it was: `unrecognised()`
+    /// judges a command line against what the subcommand read, so a declared
+    /// flag nobody reads is refused. `--timeout` sat here unread from the first
+    /// commit and turned into `unknown flag '--timeout'` in 0.3.68 (#114).
+    @Test func valueFlagsMatchesTheFlagsReadAsValues() throws {
+        let sources = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // DuoKitTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // CLI
+            .appendingPathComponent("Sources")
+        let asValue = /\.(?:value|int|list)\("([a-z0-9-]+)"\)/
+
+        let files = try #require(
+            FileManager.default.enumerator(at: sources, includingPropertiesForKeys: nil))
+        var read: Set<String> = []
+        for case let file as URL in files where file.pathExtension == "swift" {
+            for match in try String(contentsOf: file, encoding: .utf8).matches(of: asValue) {
+                read.insert(String(match.1))
+            }
+        }
+
+        // A regex or a layout that stopped matching would satisfy the
+        // comparison below by making it vacuous, which is the same silent
+        // drift this test exists to catch.
+        #expect(read.count > 5, "only \(read.count) flag reads found under \(sources.path)")
+        #expect(Args.valueFlags == read, """
+            valueFlags and the flags read as values have drifted.
+            declared but unread (refused by unrecognised()): \(Args.valueFlags.subtracting(read).sorted())
+            read but undeclared (value lands in operands): \(read.subtracting(Args.valueFlags).sorted())
+            """)
     }
 }


### PR DESCRIPTION
Closes #114.

## Confirmed first

The issue's two claims both hold on `main`:

- `--timeout` appears in `Args.valueFlags` and **nowhere else** in the repo — not in another source file, not in the `--help` text, not in the README, not in any script or workflow. It arrived in the first CLI commit (`dca081d`) and never gained a reader. Every `.value/.int/.list` read in `CLI/Sources` is a string literal (`grep -rnE '\.(value|int|list)\(' CLI/Sources | grep -v '"'` is empty), so there is no computed-name path that could have reached it.
- The installed `duo` refuses it today:

```
$ duo restart --timeout 5
unknown flag '--timeout' for `duo restart`; `duo restart` takes no flags
exit=2
```

I audited the list in both directions rather than only the flag the issue names. Every other `valueFlags` entry has a reader, and every flag read as a value is declared; the boolean-only reads (`json`, `dry-run`, `yes`, `all`, `samples`, `no-installed`, `include-hidden`) are correctly absent. `--timeout` is the sole orphan.

## The decision taken

Dropped, not given a consumer. Nothing in the CLI wants a user-set timeout: `Triage.callTimeout` is a constant with a measured rationale (a real call took 4m56s), and `--budget` already bounds a triage run.

For every subcommand the outcome is unchanged — `--timeout 5` now parses as a boolean plus a stray operand instead of a flag-with-value, and is still refused with the same first line and the same exit 2, because no branch reads it:

```
== duo list --timeout 5
unknown flag '--timeout' for `duo list`; accepted: --all --include-hidden --json --source
exit=2
== duo verify --timeout 5 --only foo
unknown flag '--timeout' for `duo verify`; accepted: --baseline --changelog --github --markdown --max-concurrency --no-installed --only --report --samples --vendor
exit=2
```

**With one exception, which is the second commit.** `backups` is the only branch that dies on an *operand*, and it does so inside the `switch` in `main.swift` — before the `unrecognised()` gate at the bottom ever runs. So once the `5` stops being `--timeout`'s value and becomes an operand:

```
$ duo backups --timeout 5
unknown backups operation '5'; expected list or restore     # ← blames a token nobody typed alone
```

Exit 2 either way, nothing runs, but the message stopped naming the flag the user actually mistyped. The operation the operands name is now worked out inside `run`, which is what the comment above the gate already claims of every branch ("nothing has run yet: every branch above only reads flags and builds options"). After the fix:

```
== duo backups --timeout 5
unknown flag '--timeout' for `duo backups`; accepted: --json --yes
== duo backups restore Zed --timeout 5
unknown flag '--timeout' for `duo backups`; accepted: --json --yes
```

and `backups frobnicate`, `backups restore`, `backups restore A B`, `backups list --json` are byte-identical to a binary built from `main`.

## The regression test

The issue's second half is the real one: `valueFlags` is the last hand-maintained list in the parser and it fails quietly in **both** directions — a missing entry swallows the value into `operands` while the reader sees its default, and a spare entry is now refused. So the new test derives the answer from the sources rather than restating the list in the test file, where the restatement would drift too: it scans every `.value/.int/.list("…")` under `CLI/Sources` and compares that set with `Args.valueFlags`, naming which side each stray name fell on.

Red first — with `"timeout"` put back:

```
↳ valueFlags and the flags read as values have drifted.
  declared, no read found (unrecognised() refuses it): ["timeout"]
  read, not declared (the value lands in operands): []
✘ Test valueFlagsMatchesTheFlagsReadAsValues() failed after 0.009 seconds with 1 issue.
```

A `read.count > 5` guard sits in front of the comparison, because a regex or a layout that stopped matching would otherwise pass it vacuously — the same silent shape the test exists to catch, and the one that actually matters, since `FileManager.enumerator(at:)` hands back an enumerator that yields nothing rather than nil when the directory isn't there. The message says "no read found" rather than "unread" deliberately: the scan sees literal call sites, so a read it cannot see must not read as an instruction to delete a needed entry.

The `backups` ordering is not unit-testable — it lives in `main.swift`, which is the executable target — so it was verified against real binaries built from both sides, transcripts above.

## Verification

```
$ make test
...
━ Test run with 1314 tests in 103 suites passed after 66.957 seconds with 1 known issue.
✔ Test run with 156 tests in 22 suites passed after 0.070 seconds.
✓ localizable keys agree — 413 in the catalog, all reachable
make test exit=0
```

No `duo verify` run: this touches no recipe and no parsing rule that any endpoint sees.