### PR TITLE
fix(cli): document `--budget`, correct `--max-calls`, and guard the usage text

### DIFF
--- a/CLI/Sources/DuoKit/ArgParser.swift
+++ b/CLI/Sources/DuoKit/ArgParser.swift
@@ -5,8 +5,9 @@ import Foundation
 /// Hand-rolled rather than swift-argument-parser because the shipping binary is
 /// built by XcodeGen, where an SPM dependency means threading a third remote
 /// package through `App/project.yml` — and because the core package's
-/// zero-dependency stance is deliberate. The cost is that `--help` is written by
-/// hand in `Usage.swift`.
+/// zero-dependency stance is deliberate. The cost is that `--help` is written
+/// by hand — the `usage` literal at the top of `main.swift`, which
+/// `ArgParserTests` checks against the flags this actually reads.
 public struct Args {
     public let subcommand: String
     /// `--flag` (value `""`) and `--flag value` / `--flag=value`.

--- a/CLI/Sources/DuoKit/Triage.swift
+++ b/CLI/Sources/DuoKit/Triage.swift
@@ -123,6 +123,18 @@ public enum Triage {
     /// with room to spare while still bounding a hang.
     public static let callTimeout: TimeInterval = 360
 
+    /// The budget as a phrase. Whole minutes only: `--budget` used to be a flag
+    /// nobody could find, so dividing by 60 and truncating was always "15";
+    /// documented, it is a number a user picks, and `--budget 90` reading as
+    /// "1-minute" or `--budget 30` as "0-minute" makes the one message that
+    /// mentions the budget the one message worth not believing.
+    static func budgetLabel(_ budget: TimeInterval) -> String {
+        let seconds = Int(budget.rounded())
+        return seconds >= 60 && seconds % 60 == 0
+            ? "\(seconds / 60)-minute"
+            : "\(seconds)-second"
+    }
+
     public static func run(_ options: TriageOptions) -> Int32 {
         guard let data = try? Data(contentsOf: options.reportPath),
               let document = decodeReport(data) else {
@@ -182,7 +194,7 @@ public enum Triage {
             }
         }
         if skippedForTime > 0 {
-            print("  · \(skippedForTime) left unanalysed — the \(Int(options.budget / 60))-minute "
+            print("  · \(skippedForTime) left unanalysed — the \(budgetLabel(options.budget)) "
                 + "budget ran out. They stay flagged and will be picked up next sweep.")
         }
         if eligible.count > options.maxCalls {

--- a/CLI/Sources/DuoKit/Triage.swift
+++ b/CLI/Sources/DuoKit/Triage.swift
@@ -30,9 +30,13 @@ public struct TriageOptions: Sendable {
     /// minutes and 21k output tokens, so the old cap of 20 was three hours of
     /// wall clock against a thirty-minute job. Six calls fit the budget below.
     public var maxCalls = 6
-    /// Wall-clock ceiling for the whole step. No new call is started past it —
-    /// triage is the optional part of the sweep and must never be the reason a
-    /// scheduled run is killed halfway through.
+    /// Deadline for *starting* a call, counted from the first one — not a
+    /// ceiling on the step, which it was called until the flag became
+    /// documented and the claim had to be true: a call begun just inside it
+    /// still runs to `callTimeout`, and the report decode, the baseline load
+    /// and the opencode probe all happen before the clock starts. Triage is
+    /// the optional part of the sweep and must never be the reason a scheduled
+    /// run is killed halfway through, which is what the deadline is for.
     public var budget: TimeInterval = 900
     public var dryRun = false
 
@@ -129,7 +133,10 @@ public enum Triage {
     /// "1-minute" or `--budget 30` as "0-minute" makes the one message that
     /// mentions the budget the one message worth not believing.
     static func budgetLabel(_ budget: TimeInterval) -> String {
-        let seconds = Int(budget.rounded())
+        // Clamped here rather than at the call site in `main.swift`, which no
+        // test can reach: a budget below zero means the same "analyse nothing"
+        // a budget of zero does, and `Int(_:)` traps on a non-finite one.
+        let seconds = budget.isFinite ? Int(max(0, budget).rounded()) : 0
         return seconds >= 60 && seconds % 60 == 0
             ? "\(seconds / 60)-minute"
             : "\(seconds)-second"

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -290,10 +290,7 @@ case "triage":
     triage.model = args.value("model")
     if let variant = args.value("variant") { triage.variant = variant }
     if let cap = args.int("max-calls") { triage.maxCalls = max(0, cap) }
-    // Clamped like `--max-calls` on the line above, and for the same reason: a
-    // negative cap means "analyse nothing", which both of them already do, but
-    // unclamped it also reaches the one message that quotes the budget back.
-    if let budget = args.int("budget") { triage.budget = TimeInterval(max(0, budget)) }
+    if let budget = args.int("budget") { triage.budget = TimeInterval(budget) }
     triage.dryRun = args.has("dry-run")
     run = { Triage.run(triage) }
 

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -27,7 +27,7 @@ commands:
                 against the captured response before anyone reads it.
   reconcile     Turn a verify report into GitHub issues — one per broken recipe,
                 closed automatically when it heals.
-  help          Show this message. So does --help after any command.
+  help          Show this message. So do --help and -h after any command.
 
 list / check options:
   [<app>…]            Which apps, resolved as an install path, then a bundle id,
@@ -133,9 +133,10 @@ triage options:
                       .opencode/agent/duo-triage.md).
   --variant <effort>  Provider reasoning effort, e.g. max, high, minimal.
   --max-calls N       Hard cap on model calls in one run (default 6).
-  --budget N          Wall-clock ceiling for the whole step, in seconds
-                      (default 900). No new call is started past it; findings
-                      it did not reach stay flagged for the next sweep.
+  --budget N          Seconds after which no new call is started (default 900).
+                      A call already under way is left to finish, so the step
+                      can overrun by up to one call. Findings it never reached
+                      stay flagged and are picked up next sweep.
   --dry-run           List what would be asked about, call nothing.
 
   Runs opencode with no tools, in an empty temporary directory, and re-runs every
@@ -289,7 +290,10 @@ case "triage":
     triage.model = args.value("model")
     if let variant = args.value("variant") { triage.variant = variant }
     if let cap = args.int("max-calls") { triage.maxCalls = max(0, cap) }
-    if let budget = args.int("budget") { triage.budget = TimeInterval(budget) }
+    // Clamped like `--max-calls` on the line above, and for the same reason: a
+    // negative cap means "analyse nothing", which both of them already do, but
+    // unclamped it also reaches the one message that quotes the budget back.
+    if let budget = args.int("budget") { triage.budget = TimeInterval(max(0, budget)) }
     triage.dryRun = args.has("dry-run")
     run = { Triage.run(triage) }
 

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -132,7 +132,10 @@ triage options:
   --model <id>        Overrides the agent's model (default is declared in
                       .opencode/agent/duo-triage.md).
   --variant <effort>  Provider reasoning effort, e.g. max, high, minimal.
-  --max-calls N       Hard cap on model calls in one run (default 20).
+  --max-calls N       Hard cap on model calls in one run (default 6).
+  --budget N          Wall-clock ceiling for the whole step, in seconds
+                      (default 900). No new call is started past it; findings
+                      it did not reach stay flagged for the next sweep.
   --dry-run           List what would be asked about, call nothing.
 
   Runs opencode with no tools, in an empty temporary directory, and re-runs every

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -153,8 +153,10 @@ import Testing
     /// leaves `-h` outside it; it cannot check a *default* stated in the
     /// prose, which is what `--max-calls` got wrong; it reads flags out of
     /// `main.swift` alone, so moving a branch's option-building into `DuoKit`
-    /// fails it on a legitimate change; and a read whose name is not a literal
-    /// is invisible to it, which is why the registries come from the enum.
+    /// fails it on a legitimate change; a read whose name is not a literal is
+    /// invisible to it, which is why the registries come from the enum; and it
+    /// strips `//` comments only, so a read commented out inside `/* */` still
+    /// counts as a read.
     @Test func theUsageTextAndTheFlagsArgsReadsAgree() throws {
         let main = try String(
             contentsOf: Self.sources.appendingPathComponent("duo/main.swift"), encoding: .utf8)

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -94,8 +94,8 @@ import Testing
         #expect(args.unrecognised()?.description.contains("`duo restart` takes no flags") == true)
     }
 
-    /// `CLI/Sources`, so the two tests below can read what the CLI actually
-    /// does rather than a copy of it kept here.
+    /// `CLI/Sources`, so the tests below can read what the CLI actually does
+    /// rather than a copy of it kept here.
     private static let sources = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()   // DuoKitTests
         .deletingLastPathComponent()   // Tests
@@ -112,14 +112,13 @@ import Testing
     /// flag nobody reads is refused. `--timeout` sat here unread from the first
     /// commit and turned into `unknown flag '--timeout'` in 0.3.68 (#114).
     @Test func valueFlagsMatchesTheFlagsReadAsValues() throws {
-        let sources = Self.sources
         // Tolerant of a wrapped call and of a camelCase name, so a read the
         // scan cannot see stays rare — an invisible read reports as a declared
         // flag nobody reads, which is a nudge to delete a needed entry.
         let asValue = /\.(?:value|int|list)\(\s*"([A-Za-z0-9-]+)"\s*\)/
 
         let files = try #require(
-            FileManager.default.enumerator(at: sources, includingPropertiesForKeys: nil))
+            FileManager.default.enumerator(at: Self.sources, includingPropertiesForKeys: nil))
         var read: Set<String> = []
         for case let file as URL in files where file.pathExtension == "swift" {
             for match in try String(contentsOf: file, encoding: .utf8).matches(of: asValue) {
@@ -130,7 +129,7 @@ import Testing
         // A regex or a layout that stopped matching would satisfy the
         // comparison below by making it vacuous, which is the same silent
         // drift this test exists to catch.
-        #expect(read.count > 5, "only \(read.count) flag reads found under \(sources.path)")
+        #expect(read.count > 5, "only \(read.count) flag reads found under \(Self.sources.path)")
         #expect(Args.valueFlags == read, """
             valueFlags and the flags read as values have drifted.
             declared, no read found (unrecognised() refuses it): \(Args.valueFlags.subtracting(read).sorted())
@@ -145,28 +144,47 @@ import Testing
     /// advertised a default of 20 that was 6 in that same commit. The mirror
     /// case is worse now: a flag that stays documented after its reader goes
     /// away is one `unrecognised()` refuses while `--help` still offers it.
-    @Test func everyFlagTheCLIReadsIsInTheUsageTextAndBack() throws {
+    ///
+    /// Three things it deliberately does not see, so nobody reads it as more:
+    /// it compares the two sets whole rather than section by section, so a
+    /// flag documented under the wrong subcommand passes; it only knows `--`
+    /// spellings, because a single dash matched in prose picks up the tail of
+    /// every hyphenated word; and it cannot check a *default* stated in the
+    /// prose, which is what `--max-calls` got wrong.
+    @Test func theUsageTextAndTheFlagsArgsReadsAgree() throws {
         let main = try String(
             contentsOf: Self.sources.appendingPathComponent("duo/main.swift"), encoding: .utf8)
-        let usage = try #require(
-            main.split(separator: "let usage = \"\"\"", maxSplits: 1).last?
-                .split(separator: "\n\"\"\"", maxSplits: 1).first,
-            "the usage literal has moved — this test reads it out of main.swift")
+        // Located rather than split on: `split` with no separator found hands
+        // back the whole file, which would compare the flags against a superset
+        // of the usage text and pass while seeing nothing.
+        let opening = try #require(main.firstRange(of: "let usage = \"\"\""),
+                                   "the usage literal has moved out of main.swift")
+        let closing = try #require(
+            main.range(of: "\n\"\"\"", range: opening.upperBound..<main.endIndex),
+            "the usage literal no longer ends at the start of a line")
+        let usage = main[opening.upperBound..<closing.lowerBound]
 
         let documented = Set(usage.matches(of: /--([a-z][a-z0-9-]*)/).map { String($0.1) })
-        // `verify` names the registries from the enum rather than one call per
-        // flag, so the literal scan cannot see them; take them from the enum
-        // too rather than writing the three of them down here.
-        let read = Set(main.matches(of: /\.(?:value|int|list|has)\(\s*"([A-Za-z0-9-]+)"\s*\)/)
-            .map { String($0.1) })
-            .union(Registry.allCases.map(\.rawValue))
+        let readInMain = Set(
+            main.matches(of: /\.(?:value|int|list|has)\(\s*"([A-Za-z0-9-]+)"\s*\)/)
+                .map { String($0.1) })
+        // Both sides are scanned, so both sides need a floor: a regex that
+        // stopped matching would otherwise agree with anything.
+        #expect(readInMain.count > 15, "only \(readInMain.count) flag reads found in main.swift")
+        #expect(documented.count > 15, "only \(documented.count) flags found in the usage text")
 
-        #expect(read.count > 5, "only \(read.count) flag reads found in main.swift")
+        // `verify` names the registries from the enum rather than one call per
+        // flag, so the scan cannot see them; take them from the enum too.
+        let read = readInMain.union(Registry.allCases.map(\.rawValue))
+        // `--help` and `-h` are answered off `CommandLine.arguments` before
+        // `Args` exists, so no scan of flag reads can find them. Derived from
+        // the line that answers them rather than written down here.
+        let answeredBeforeParsing = Set(
+            main.matches(of: /== "-{1,2}([a-z][a-z0-9-]*)"/).map { String($0.1) })
+
         #expect(read.subtracting(documented).isEmpty,
                 "flags the CLI reads that `--help` never mentions: \(read.subtracting(documented).sorted())")
-        // `--help` is answered before `Args` is built, so it is the one flag
-        // documented that no branch can be seen reading.
-        let orphanedDocs = documented.subtracting(read).subtracting(["help"])
+        let orphanedDocs = documented.subtracting(read).subtracting(answeredBeforeParsing)
         #expect(orphanedDocs.isEmpty,
                 "flags `--help` offers that no branch reads, so unrecognised() refuses them: \(orphanedDocs.sorted())")
     }

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -145,12 +145,16 @@ import Testing
     /// case is worse now: a flag that stays documented after its reader goes
     /// away is one `unrecognised()` refuses while `--help` still offers it.
     ///
-    /// Three things it deliberately does not see, so nobody reads it as more:
-    /// it compares the two sets whole rather than section by section, so a
-    /// flag documented under the wrong subcommand passes; it only knows `--`
-    /// spellings, because a single dash matched in prose picks up the tail of
-    /// every hyphenated word; and it cannot check a *default* stated in the
-    /// prose, which is what `--max-calls` got wrong.
+    /// What it does not see, listed rather than counted, since the next blind
+    /// spot belongs on this list too: it compares the two sets whole rather
+    /// than section by section, so a flag documented under the wrong
+    /// subcommand passes; it only knows `--` spellings, because a single dash
+    /// matched in prose picks up the tail of every hyphenated word, which
+    /// leaves `-h` outside it; it cannot check a *default* stated in the
+    /// prose, which is what `--max-calls` got wrong; it reads flags out of
+    /// `main.swift` alone, so moving a branch's option-building into `DuoKit`
+    /// fails it on a legitimate change; and a read whose name is not a literal
+    /// is invisible to it, which is why the registries come from the enum.
     @Test func theUsageTextAndTheFlagsArgsReadsAgree() throws {
         let main = try String(
             contentsOf: Self.sources.appendingPathComponent("duo/main.swift"), encoding: .utf8)
@@ -165,8 +169,17 @@ import Testing
         let usage = main[opening.upperBound..<closing.lowerBound]
 
         let documented = Set(usage.matches(of: /--([a-z][a-z0-9-]*)/).map { String($0.1) })
+        // The read side gets sliced too, and for the reason the documented side
+        // did: a flag named only in a comment — or in the usage text itself —
+        // would count as read, and a reader deleted while its comment survived
+        // is exactly the drift being looked for. Whole-line comments only, so
+        // this can never truncate a line that carries code.
+        let code = main.replacingCharacters(in: opening.lowerBound..<closing.upperBound, with: "")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
         let readInMain = Set(
-            main.matches(of: /\.(?:value|int|list|has)\(\s*"([A-Za-z0-9-]+)"\s*\)/)
+            code.matches(of: /\.(?:value|int|list|has)\(\s*"([A-Za-z0-9-]+)"\s*\)/)
                 .map { String($0.1) })
         // Both sides are scanned, so both sides need a floor: a regex that
         // stopped matching would otherwise agree with anything.
@@ -177,10 +190,15 @@ import Testing
         // flag, so the scan cannot see them; take them from the enum too.
         let read = readInMain.union(Registry.allCases.map(\.rawValue))
         // `--help` and `-h` are answered off `CommandLine.arguments` before
-        // `Args` exists, so no scan of flag reads can find them. Derived from
-        // the line that answers them rather than written down here.
+        // `Args` exists, so no scan of flag reads can find them. Read off that
+        // line rather than written down here — and off that line only, so a
+        // `== "--all"` written somewhere else later cannot quietly excuse a
+        // flag from the check below.
+        let shortCircuit = try #require(
+            code.split(separator: "\n").first { $0.contains("CommandLine.arguments") },
+            "the pre-parse --help short-circuit has moved")
         let answeredBeforeParsing = Set(
-            main.matches(of: /== "-{1,2}([a-z][a-z0-9-]*)"/).map { String($0.1) })
+            shortCircuit.matches(of: /"-{1,2}([a-z][a-z0-9-]*)"/).map { String($0.1) })
 
         #expect(read.subtracting(documented).isEmpty,
                 "flags the CLI reads that `--help` never mentions: \(read.subtracting(documented).sorted())")

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -94,6 +94,14 @@ import Testing
         #expect(args.unrecognised()?.description.contains("`duo restart` takes no flags") == true)
     }
 
+    /// `CLI/Sources`, so the two tests below can read what the CLI actually
+    /// does rather than a copy of it kept here.
+    private static let sources = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()   // DuoKitTests
+        .deletingLastPathComponent()   // Tests
+        .deletingLastPathComponent()   // CLI
+        .appendingPathComponent("Sources")
+
     /// `valueFlags` is the one hand-maintained list left in the parser, and it
     /// fails quietly in both directions — so read the truth out of the sources
     /// rather than restating it here, where the restatement would drift too.
@@ -104,11 +112,7 @@ import Testing
     /// flag nobody reads is refused. `--timeout` sat here unread from the first
     /// commit and turned into `unknown flag '--timeout'` in 0.3.68 (#114).
     @Test func valueFlagsMatchesTheFlagsReadAsValues() throws {
-        let sources = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()   // DuoKitTests
-            .deletingLastPathComponent()   // Tests
-            .deletingLastPathComponent()   // CLI
-            .appendingPathComponent("Sources")
+        let sources = Self.sources
         // Tolerant of a wrapped call and of a camelCase name, so a read the
         // scan cannot see stays rare — an invisible read reports as a declared
         // flag nobody reads, which is a nudge to delete a needed entry.
@@ -132,5 +136,38 @@ import Testing
             declared, no read found (unrecognised() refuses it): \(Args.valueFlags.subtracting(read).sorted())
             read, not declared (the value lands in operands): \(read.subtracting(Args.valueFlags).sorted())
             """)
+    }
+
+    /// The usage text is the CLI's other hand-maintained list, and the one
+    /// users actually read — so it drifts the same two ways, and until this
+    /// test nothing looked at it. `--budget` bounded a triage run from the
+    /// commit that added it and was named nowhere in `--help`; `--max-calls`
+    /// advertised a default of 20 that was 6 in that same commit. The mirror
+    /// case is worse now: a flag that stays documented after its reader goes
+    /// away is one `unrecognised()` refuses while `--help` still offers it.
+    @Test func everyFlagTheCLIReadsIsInTheUsageTextAndBack() throws {
+        let main = try String(
+            contentsOf: Self.sources.appendingPathComponent("duo/main.swift"), encoding: .utf8)
+        let usage = try #require(
+            main.split(separator: "let usage = \"\"\"", maxSplits: 1).last?
+                .split(separator: "\n\"\"\"", maxSplits: 1).first,
+            "the usage literal has moved — this test reads it out of main.swift")
+
+        let documented = Set(usage.matches(of: /--([a-z][a-z0-9-]*)/).map { String($0.1) })
+        // `verify` names the registries from the enum rather than one call per
+        // flag, so the literal scan cannot see them; take them from the enum
+        // too rather than writing the three of them down here.
+        let read = Set(main.matches(of: /\.(?:value|int|list|has)\(\s*"([A-Za-z0-9-]+)"\s*\)/)
+            .map { String($0.1) })
+            .union(Registry.allCases.map(\.rawValue))
+
+        #expect(read.count > 5, "only \(read.count) flag reads found in main.swift")
+        #expect(read.subtracting(documented).isEmpty,
+                "flags the CLI reads that `--help` never mentions: \(read.subtracting(documented).sorted())")
+        // `--help` is answered before `Args` is built, so it is the one flag
+        // documented that no branch can be seen reading.
+        let orphanedDocs = documented.subtracting(read).subtracting(["help"])
+        #expect(orphanedDocs.isEmpty,
+                "flags `--help` offers that no branch reads, so unrecognised() refuses them: \(orphanedDocs.sorted())")
     }
 }

--- a/CLI/Tests/DuoKitTests/TriageTests.swift
+++ b/CLI/Tests/DuoKitTests/TriageTests.swift
@@ -259,4 +259,17 @@ import DuoUpdaterCore
             projectDir: URL(fileURLWithPath: "/nonexistent"))
         #expect(Triage.resolvedModel(options).contains("unknown"))
     }
+
+    /// The only line that quotes the budget back. It read `Int(budget / 60)`,
+    /// which was always "15" while `--budget` was a flag nobody could find and
+    /// starts lying the moment one is documented — the default's own transcript
+    /// (`--budget 60`) is fine, `--budget 90` truncates to "1-minute", and
+    /// anything under a minute reads "0-minute budget ran out".
+    @Test func theBudgetIsQuotedBackInAUnitItFitsIn() {
+        #expect(Triage.budgetLabel(900) == "15-minute")
+        #expect(Triage.budgetLabel(60) == "1-minute")
+        #expect(Triage.budgetLabel(90) == "90-second")
+        #expect(Triage.budgetLabel(30) == "30-second")
+        #expect(Triage.budgetLabel(0) == "0-second")
+    }
 }

--- a/CLI/Tests/DuoKitTests/TriageTests.swift
+++ b/CLI/Tests/DuoKitTests/TriageTests.swift
@@ -271,5 +271,10 @@ import DuoUpdaterCore
         #expect(Triage.budgetLabel(90) == "90-second")
         #expect(Triage.budgetLabel(30) == "30-second")
         #expect(Triage.budgetLabel(0) == "0-second")
+        // The clamp lives in `budgetLabel` because the call site that used to
+        // hold it is top-level code in `main.swift` that no test can reach, so
+        // deleting it there was green everywhere.
+        #expect(Triage.budgetLabel(-30) == "0-second")
+        #expect(Triage.budgetLabel(.nan) == "0-second")
     }
 }


### PR DESCRIPTION
Follow-up to #116. Same defect family, other list.

## What was wrong

Two lines apart in the `triage options:` block of `--help`:

- **`--budget N` was documented nowhere.** It is read in `main.swift` (`if let budget = args.int("budget") { triage.budget = TimeInterval(budget) }`), it is declared in `Args.valueFlags`, and it has a real effect — `TriageOptions.budget` (default 900s) is the deadline in `Triage.run`. It appears in no help text and no workflow. `git log -S` puts both the reader and the usage block in the same commit `5dd4a0c`, so it has been invisible since the day it landed. The exact mirror of #114: there the parser declared a flag nobody read, here the CLI reads a flag nobody documented.
- **`--max-calls` advertised the wrong default.** The help said `(default 20)`; `TriageOptions.maxCalls` has been `6` since `5dd4a0c`, with a comment above it explaining that 20 was three hours of wall clock against a thirty-minute job. Also stale on arrival.

## What three review rounds added

The first pass documented `--budget` as a "wall-clock ceiling for the whole step". That is not what the code does, and shipping a *wrong* help line while fixing a missing one is the same bug twice:

- The deadline gates the **start** of a call. One begun a second before it runs to `Triage.callTimeout` (360s), so the default 900 can finish around 21 minutes.
- It is armed after the report decode, the baseline load and the `opencode --version` probe, so "the whole step" was wrong at both ends.
- The false sentence was **copied from `TriageOptions.budget`'s own doc comment**, which the first fix left in place — the version the next author would have copied again. Corrected there too.

Three things the flag's own path was hiding, all of which matter only because it is now discoverable:

- **The one message that quotes the budget back was `Int(budget / 60)`-minute.** Always "15" while nothing could set the flag; with a flag, `--budget 90` reads "1-minute" and `--budget 30` reads "**0-minute** budget ran out". Whole minutes when it divides, seconds otherwise, cases pinned in `TriageTests`.
- **A negative budget printed a negative phrase.** The clamp first went next to the reader in `main.swift` — top-level code no test can call, so deleting it again would have been green everywhere. It lives in `budgetLabel` now, where the value is consumed and a test reaches it, and it covers the non-finite input `Int(_:)` traps on. Behaviour is unchanged either way: a past deadline and a zero deadline both skip every finding.
- **`-h` is a second undocumented flag**, read alongside `--help` in `main.swift` while the usage said only "So does `--help` after any command". The first pass's "`--budget` was the only gap" was wrong; both are named now. `ArgParser`'s header also pointed at a `Usage.swift` that has never existed — the literal is in `main.swift`.

## The audit

Derived, both directions, per section as well as globally — a flag documented under `triage options:` but read only by `verify` would pass a whole-file comparison and still lie. Every section's documented set equals its branch's read set. `--all` inside the `restart` section reads as documented to a naive scan, but the sentence is "There is no --all". The only gaps were `budget` (read, undocumented) and `-h` (read outside `Args`, undocumented).

## The guard

The usage text is the third hand-maintained list in this CLI and the one users actually read — #116 guarded `valueFlags`, nothing guarded this. `ArgParserTests` now reads the `usage` literal out of `main.swift` and compares it with the flags the CLI reads, both directions: read-but-undocumented (a flag that works and nobody can find), and documented-but-unread (since #108, a flag `--help` offers and `unrecognised()` refuses).

Review took three passes at the guard itself, and each one was a hole it claimed not to have:

- `split` on a separator it cannot find returns the whole file, so renaming the literal handed the test a *superset* of the usage text and it passed while seeing nothing. Both delimiters are located and required now — renaming it gives `↳ the usage literal has moved out of main.swift`.
- The documented side was sliced and the read side was not, so a reader deleted with its name left behind in a comment still counted as read. Both sides are sliced now. Reproduced red by replacing the `--budget` reader with a comment naming it: `↳ flags --help offers that no branch reads … ["budget"]`.
- The `--help` exemption said it was read off the line that answers it and was matched against the whole file, so a `== "--all"` written anywhere later would have quietly excused a flag. That line only, now.
- Its blind spots were introduced as "three things", and there were five. Listed rather than counted.

Red both ways on the drift it exists for:

```
# with the new --budget line deleted
↳ flags the CLI reads that `--help` never mentions: ["budget"]
# with a --frobnicate line nobody reads added
↳ flags `--help` offers that no branch reads, so unrecognised() refuses them: ["frobnicate"]
```

## Verification

```
$ duo triage --help
  --max-calls N       Hard cap on model calls in one run (default 6).
  --budget N          Seconds after which no new call is started (default 900).
                      A call already under way is left to finish, so the step
                      can overrun by up to one call. Findings it never reached
                      stay flagged and are picked up next sweep.
$ duo help | grep '^  help'
  help          Show this message. So do --help and -h after any command.
$ duo -h | head -1
usage: duo <command> [options]
$ duo triage --budget --dry-run --report verify/report.json --out /tmp/x.json
--budget needs a value
exit=2
```

The budget's *semantics* are covered by `TriageTests`, not by a transcript: a `--dry-run` invocation `continue`s before the deadline guard is consulted, so the obvious CLI transcript would have proved only that the parser accepts the flag — which was never in doubt, since `budget` has been in `valueFlags` since `5dd4a0c`.

```
$ make test
━ Test run with 1314 tests in 103 suites passed after 44.608 seconds with 1 known issue.
✔ Test run with 158 tests in 22 suites passed after 0.070 seconds.
✓ localizable keys agree — 413 in the catalog, all reachable
make test exit=0
```

Runtime change is confined to one printed phrase; nothing parses it (`Reconcile` reads `triage.json`, never triage's stdout), and no script or workflow passes either flag. No `duo verify` run: no recipe and no endpoint-facing parsing rule is touched. No CHANGELOG entry — help text and one message, and this repo writes release notes at release time (#115 and #116 likewise).