### PR TITLE
feat(app): right-click an app in the workbench sidebar to open it

### DIFF
--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -761,6 +761,17 @@ private struct WorkbenchSidebarRow: View {
             Spacer()
         }
         .padding(.vertical, 2)
+        // The row is name + version with a Spacer holding the rest open; without a
+        // content shape the right-click only lands on the drawn parts, so the empty
+        // stretch beside a short name would come up with no menu.
+        .contentShape(Rectangle())
+        .contextMenu {
+            // The same "Open" the popover row offers, and it goes through
+            // `AppRestarter.launchApp` rather than `NSWorkspace.open` for the same
+            // reason: the latter blocks the main thread until the app has finished
+            // launching.
+            Button("Open") { Task { await AppRestarter.launchApp(result.app.path) } }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
The popover's rows have carried an **Open** in their right-click menu since the menu existed; the workbench sidebar — the roomier list people actually browse 137 apps in — had no context menu at all, so the one gesture that works in every other Mac app list did nothing there.

It runs through `AppRestarter.launchApp` for the same reason the popover's does: `NSWorkspace.open` blocks the main thread until the launch finishes.

The `contentShape` is load-bearing, not decoration. A row is name + version with a Spacer holding the rest open, so without it the right-click only lands on the drawn text and the empty stretch beside a short name comes up with nothing.

Brew casks reuse this row and get it too; CLI formulae keep their own row and don't — a formula has no bundle to open.

## Verification

Against the installed copy, driving real events at `/Applications/DuoUpdater.app` (AX to locate the row's frame, CGEvent for the click):

- The menu opens on the row under the cursor.
- Red → green on the launch itself: `AppCleaner` was not running beforehand; after pressing **Open** on its row, `pgrep` showed `/Applications/AppCleaner.app/Contents/MacOS/AppCleaner` — the bundle the row names, not a neighbour's. Quit again afterwards.
- `make test` green (core + CLI); `✓ localizable keys agree — 413 in the catalog, all reachable`. The `Open` key already exists in all seven languages, so no new translation debt.

No recipe touched, so no `duo verify` run.