### PR TITLE
fix(cli): refuse a number flag whose value is not a number

### DIFF
--- a/CLI/Sources/DuoKit/ArgParser.swift
+++ b/CLI/Sources/DuoKit/ArgParser.swift
@@ -114,10 +114,12 @@ public struct Args {
     /// sweep instead of the one recipe `--only` was meant to name, and `--githubb`
     /// spends the unauthenticated GitHub rate limit on the way past.
     ///
-    /// The corollary for whoever adds the next flag: read it unconditionally. A
-    /// flag read only inside an `if` is a flag this refuses whenever that `if`
-    /// is false, because from here "never asked about" and "not accepted" are
-    /// the same thing.
+    /// The corollary for whoever adds the next flag: read it unconditionally,
+    /// and read it before this runs. A flag read only inside an `if` is a flag
+    /// this refuses whenever that `if` is false, because from here "never asked
+    /// about" and "not accepted" are the same thing — and a number flag read
+    /// lazily, inside the `run` closure, opts itself out of the check below
+    /// the same way.
     public func unrecognised() -> UsageError? {
         let accepted = seen.flags.isEmpty
             ? "`duo \(subcommand)` takes no flags"
@@ -135,16 +137,16 @@ public struct Args {
         }
         // A number flag holding something that is not a number. `Int.init` fails,
         // `int()` hands back nil, and nil is what "not given at all" looks like
-        // from every call site — so `duo triage --max-calls 2.5` ran the default
-        // cap of 6, and `--max-concurrency 8x` kept probing four hosts at once
-        // while the person who typed it believed they had slowed the sweep down.
-        // An empty value is left to the loop above, whose message fits it better.
-        for name in flags.keys.sorted() where seen.integerFlags.contains(name) {
-            guard let raw = flags[name], !raw.isEmpty, Int(raw) == nil else { continue }
+        // from every call site: `duo verify --max-concurrency 8x` swept with the
+        // default of four hosts in flight, which is the wrong way round for
+        // someone narrowing it to spare an endpoint. An empty value belongs to
+        // the loop above, whose message fits it better.
+        for (name, raw) in flags.sorted(by: { $0.key < $1.key })
+        where seen.integerFlags.contains(name) && !raw.isEmpty && Int(raw) == nil {
             return UsageError("--\(name) needs a whole number, got '\(raw)'")
         }
         // No operand in this CLI is an app named `-something`, so a leading dash
-        // here is a misspelled flag that the loop above never saw.
+        // here is a misspelled flag that the unknown-flag loop never saw.
         if let stray = positional.first(where: { $0.hasPrefix("-") }) {
             return UsageError("unknown flag '\(stray)' for `duo \(subcommand)`; \(accepted)")
         }

--- a/CLI/Sources/DuoKit/ArgParser.swift
+++ b/CLI/Sources/DuoKit/ArgParser.swift
@@ -137,10 +137,11 @@ public struct Args {
         }
         // A number flag holding something that is not a number. `Int.init` fails,
         // `int()` hands back nil, and nil is what "not given at all" looks like
-        // from every call site: `duo verify --max-concurrency 8x` swept with the
-        // default of four hosts in flight, which is the wrong way round for
-        // someone narrowing it to spare an endpoint. An empty value belongs to
-        // the loop above, whose message fits it better.
+        // from every call site: `duo verify --max-concurrency 1x` swept with the
+        // default of four hosts in flight rather than the one asked for, which
+        // is the wrong way round for someone slowing a sweep to spare an
+        // endpoint. An empty value belongs to the loop above, whose message
+        // fits it better.
         for (name, raw) in flags.sorted(by: { $0.key < $1.key })
         where seen.integerFlags.contains(name) && !raw.isEmpty && Int(raw) == nil {
             return UsageError("--\(name) needs a whole number, got '\(raw)'")

--- a/CLI/Sources/DuoKit/ArgParser.swift
+++ b/CLI/Sources/DuoKit/ArgParser.swift
@@ -27,6 +27,9 @@ public struct Args {
     /// the drift only shows up as a flag nobody validates.
     private final class Seen {
         var flags: Set<String> = []
+        /// The subset read as numbers, so `unrecognised()` can refuse a value
+        /// that is not one instead of letting it read as absent.
+        var integerFlags: Set<String> = []
         var readOperands = false
     }
 
@@ -97,7 +100,10 @@ public struct Args {
         guard let raw = flags[name], !raw.isEmpty else { return nil }
         return raw
     }
-    public func int(_ name: String) -> Int? { value(name).flatMap(Int.init) }
+    public func int(_ name: String) -> Int? {
+        seen.integerFlags.insert(name)
+        return value(name).flatMap(Int.init)
+    }
 
     /// The first token this invocation can't account for, or nil if it is clean.
     ///
@@ -126,6 +132,16 @@ public struct Args {
         for name in flags.keys.sorted()
         where Self.valueFlags.contains(name) && flags[name]?.isEmpty == true {
             return UsageError("--\(name) needs a value")
+        }
+        // A number flag holding something that is not a number. `Int.init` fails,
+        // `int()` hands back nil, and nil is what "not given at all" looks like
+        // from every call site — so `duo triage --max-calls 2.5` ran the default
+        // cap of 6, and `--max-concurrency 8x` kept probing four hosts at once
+        // while the person who typed it believed they had slowed the sweep down.
+        // An empty value is left to the loop above, whose message fits it better.
+        for name in flags.keys.sorted() where seen.integerFlags.contains(name) {
+            guard let raw = flags[name], !raw.isEmpty, Int(raw) == nil else { continue }
+            return UsageError("--\(name) needs a whole number, got '\(raw)'")
         }
         // No operand in this CLI is an app named `-something`, so a leading dash
         // here is a misspelled flag that the loop above never saw.

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -208,4 +208,46 @@ import Testing
         #expect(orphanedDocs.isEmpty,
                 "flags `--help` offers that no branch reads, so unrecognised() refuses them: \(orphanedDocs.sorted())")
     }
+
+    /// `int()` turns a value it cannot parse into nil, and nil is what "not
+    /// given at all" looks like from every call site — the same shape #108 was
+    /// written to stop, hiding inside a flag that *is* accepted. Measured on
+    /// the shipped binary before this: `duo triage --max-calls 2.5` analysed
+    /// five findings, exit 0, saying nothing, because the cap fell back to its
+    /// default of 6. `--max-concurrency 8x` keeps four hosts in flight while
+    /// the person who typed it believes they slowed the sweep down.
+    ///
+    /// Derived from `main.swift` rather than listing the three flags here: a
+    /// fourth number flag should not have to remember to be tested.
+    @Test func aNumberFlagRefusesAValueThatIsNotOne() throws {
+        let main = try String(
+            contentsOf: Self.sources.appendingPathComponent("duo/main.swift"), encoding: .utf8)
+        let numeric = Set(main.matches(of: /\.int\(\s*"([A-Za-z0-9-]+)"\s*\)/).map { String($0.1) })
+        #expect(numeric.count >= 3, "only \(numeric.count) number flags found in main.swift")
+
+        for name in numeric.sorted() {
+            for bad in ["2.5", "8x", "abc", "1e3", "1_000"] {
+                let args = Args(["duo", "verify", "--\(name)", bad])!
+                _ = args.int(name)
+                #expect(args.unrecognised()?.description
+                        == "--\(name) needs a whole number, got '\(bad)'")
+            }
+            // What it must not start refusing: the values that always worked.
+            // `-3` reaches its reader, which is where the clamping lives.
+            for good in ["2", "0", "-3"] {
+                let args = Args(["duo", "verify", "--\(name)", good])!
+                #expect(args.int(name) == Int(good))
+                #expect(args.unrecognised() == nil)
+            }
+        }
+    }
+
+    /// The empty case belongs to the older message, which fits it better —
+    /// `--max-calls` with nothing after it is not a number that failed to
+    /// parse, it is a flag missing its value.
+    @Test func aNumberFlagWithNothingAfterItStillSaysItNeedsAValue() {
+        let args = Args(["duo", "triage", "--max-calls"])!
+        _ = args.int("max-calls")
+        #expect(args.unrecognised()?.description == "--max-calls needs a value")
+    }
 }

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -217,9 +217,11 @@ import Testing
     /// findings: `duo triage --dry-run --max-calls 2 …` analysed two and
     /// `--max-calls 2.5` analysed five, exit 0, saying nothing — the cap had
     /// fallen back to its default of 6. Not measured, read off the same code
-    /// path: `--max-concurrency 8x` leaves the sweep on its default of four
-    /// hosts in flight, which is the wrong way round for someone narrowing it
-    /// to spare an endpoint that just rate-limited them.
+    /// path: `--max-concurrency 1x` leaves the sweep on its default of four
+    /// hosts in flight instead of the one asked for — the wrong way round for
+    /// someone slowing a sweep to spare an endpoint that just rate-limited
+    /// them, and the reason a value silently ignored is not a value ignored
+    /// safely.
     ///
     /// The flags come from `main.swift` rather than being listed here. Two
     /// things that leaves uncovered: it reads that one file, so moving a
@@ -265,10 +267,18 @@ import Testing
     /// the likelier root cause, and the number may well have been meant for it.
     /// A missing value outranks an unparseable one for the same reason.
     @Test func aMistypedFlagIsReportedBeforeABadNumber() {
-        let args = Args(["duo", "verify", "--githubb", "--max-concurrency", "2.5"])!
-        _ = args.has("github")
-        _ = args.int("max-concurrency")
-        #expect(args.unrecognised()?.description.contains("unknown flag '--githubb'") == true)
+        let mistyped = Args(["duo", "verify", "--githubb", "--max-concurrency", "2.5"])!
+        _ = mistyped.has("github")
+        _ = mistyped.int("max-concurrency")
+        #expect(mistyped.unrecognised()?.description.contains("unknown flag '--githubb'") == true)
+
+        // The empty flag sorts after the bad number, so this passes only
+        // because the missing-value loop drains every flag before the number
+        // loop begins — not because of where the two happen to appear.
+        let valueless = Args(["duo", "verify", "--budget", "9x", "--only"])!
+        _ = valueless.int("budget")
+        _ = valueless.value("only")
+        #expect(valueless.unrecognised()?.description == "--only needs a value")
     }
 
     /// The empty case belongs to the older message, which fits it better —

--- a/CLI/Tests/DuoKitTests/ArgParserTests.swift
+++ b/CLI/Tests/DuoKitTests/ArgParserTests.swift
@@ -211,20 +211,37 @@ import Testing
 
     /// `int()` turns a value it cannot parse into nil, and nil is what "not
     /// given at all" looks like from every call site — the same shape #108 was
-    /// written to stop, hiding inside a flag that *is* accepted. Measured on
-    /// the shipped binary before this: `duo triage --max-calls 2.5` analysed
-    /// five findings, exit 0, saying nothing, because the cap fell back to its
-    /// default of 6. `--max-concurrency 8x` keeps four hosts in flight while
-    /// the person who typed it believes they slowed the sweep down.
+    /// written to stop, hiding inside a flag that *is* accepted.
     ///
-    /// Derived from `main.swift` rather than listing the three flags here: a
-    /// fourth number flag should not have to remember to be tested.
+    /// Measured on the shipped binary, against a report with five eligible
+    /// findings: `duo triage --dry-run --max-calls 2 …` analysed two and
+    /// `--max-calls 2.5` analysed five, exit 0, saying nothing — the cap had
+    /// fallen back to its default of 6. Not measured, read off the same code
+    /// path: `--max-concurrency 8x` leaves the sweep on its default of four
+    /// hosts in flight, which is the wrong way round for someone narrowing it
+    /// to spare an endpoint that just rate-limited them.
+    ///
+    /// The flags come from `main.swift` rather than being listed here. Two
+    /// things that leaves uncovered: it reads that one file, so moving a
+    /// branch's option-building into `DuoKit` empties the set; and it calls
+    /// `int()` itself, so it cannot see whether the branch that owns the flag
+    /// still calls `int()` before `unrecognised()` — which is what makes the
+    /// check fire at all.
     @Test func aNumberFlagRefusesAValueThatIsNotOne() throws {
         let main = try String(
             contentsOf: Self.sources.appendingPathComponent("duo/main.swift"), encoding: .utf8)
         let numeric = Set(main.matches(of: /\.int\(\s*"([A-Za-z0-9-]+)"\s*\)/).map { String($0.1) })
-        #expect(numeric.count >= 3, "only \(numeric.count) number flags found in main.swift")
+        // No count to keep in step with the code: empty would make the loop
+        // below vacuous, and completeness is `valueFlagsMatchesTheFlagsReadAsValues`'s
+        // job. A number flag that takes no value would be a contradiction, so
+        // that much is worth asserting here.
+        #expect(!numeric.isEmpty, "no number flags found in main.swift")
+        #expect(numeric.isSubset(of: Args.valueFlags),
+                "number flags that do not take a value: \(numeric.subtracting(Args.valueFlags).sorted())")
 
+        // The subcommand is immaterial: `unrecognised()` judges an invocation by
+        // what it asked the parser for, never by a table per command, so reading
+        // the flag here is what makes it accepted here.
         for name in numeric.sorted() {
             for bad in ["2.5", "8x", "abc", "1e3", "1_000"] {
                 let args = Args(["duo", "verify", "--\(name)", bad])!
@@ -232,14 +249,26 @@ import Testing
                 #expect(args.unrecognised()?.description
                         == "--\(name) needs a whole number, got '\(bad)'")
             }
-            // What it must not start refusing: the values that always worked.
-            // `-3` reaches its reader, which is where the clamping lives.
+            // What it must not start refusing: the values that always parsed.
+            // Zero and negatives are handed to the branch unchanged — what each
+            // does with them is its own business, and not all of them clamp.
             for good in ["2", "0", "-3"] {
                 let args = Args(["duo", "verify", "--\(name)", good])!
                 #expect(args.int(name) == Int(good))
                 #expect(args.unrecognised() == nil)
             }
         }
+    }
+
+    /// Only one problem is ever reported, so the order matters. A flag the
+    /// command never heard of outranks a bad value on one it did: the typo is
+    /// the likelier root cause, and the number may well have been meant for it.
+    /// A missing value outranks an unparseable one for the same reason.
+    @Test func aMistypedFlagIsReportedBeforeABadNumber() {
+        let args = Args(["duo", "verify", "--githubb", "--max-concurrency", "2.5"])!
+        _ = args.has("github")
+        _ = args.int("max-concurrency")
+        #expect(args.unrecognised()?.description.contains("unknown flag '--githubb'") == true)
     }
 
     /// The empty case belongs to the older message, which fits it better —


### PR DESCRIPTION
Found while answering "what does that actually break?" about a line in #117's review notes. Third instance of the family as #114 and #116, and the one with teeth: the flag is *accepted*, and its value is silently discarded.

## Reproduced first, on the shipped binary

A crafted report with five eligible findings, so the cap is observable:

```
$ duo triage --dry-run --max-calls 2    --report fake-report.json …   → 2 analysed
$ duo triage --dry-run --max-calls 2.5  --report fake-report.json …   → 5 analysed, exit 0
$ duo triage --dry-run --max-calls abc  --report fake-report.json …   → 5 analysed, exit 0
$ duo triage --dry-run --max-calls '2 ' --report fake-report.json …   → 5 analysed, exit 0
```

Not one of them said anything. The cap fell back to its default of 6.

## Why the gate missed it

`int()` was `value(name).flatMap(Int.init)` — `Int.init` fails, `int()` returns nil, and every call site is `if let cap = args.int(…)`, so nil reads as "the flag was never passed". `unrecognised()` could not catch it either: `value()` marks the flag seen, and the raw string is non-empty, so neither the unknown-flag loop nor the needs-a-value loop applies.

That is exactly the failure #108 was written to end — "an unrecognised flag reads as absent, and absent is rarely harmless" — reappearing inside a flag that *is* recognised.

## What it costs, per reader

- **`--max-calls`** — the cap is on real model calls, each bounded by `callTimeout` (360s; a dense page measured 4m56s). Asking for 2 and getting 6 is the intent inverted where it costs money.
- **`--budget`** — a run bounded at the default 900s instead of the 300 asked for, plus one call's overrun on top. Inside CI's 60-minute job timeout, so it burns time and calls rather than failing.
- **`--max-concurrency`** — the one that points the wrong way. `--max-concurrency 1x` from someone slowing a sweep to spare an endpoint that just rate-limited them leaves it on the default of four hosts in flight, and gives them no reason to doubt it.

Blast radius today is whoever types these by hand: `.github/workflows/recipe-verify.yml` passes none of the three (`--report/--baseline/--out/--only/--dry-run` only), and no script does either.

## The fix

`int()` records the flag as one read as a number; `unrecognised()` refuses a non-empty value that will not parse. Same place, same moment, same shape as the existing `--only needs a value`:

```
$ duo verify --max-concurrency 8x
--max-concurrency needs a whole number, got '8x'

try `duo verify --help`
exit=2
$ duo verify --max-concurrency=1e3 --only zzznomatch
--max-concurrency needs a whole number, got '1e3'
exit=2
$ duo triage --dry-run --max-calls 2 --report fake-report.json …
  [dry-run] would ask about vendor:com.example.app0:stable
  [dry-run] would ask about vendor:com.example.app1:stable
  · 3 more eligible, over the --max-calls cap of 2
exit=0
```

Only one problem is ever reported, so the priority is deliberate and pinned by tests: an **unknown flag** outranks a bad number (the typo is the likelier root cause, and the number may have been meant for it), and a **missing value** outranks an unparseable one. The number check therefore sits between the needs-a-value loop and the stray-dash/stray-operand checks, which it now preempts — `duo verify workbuddy --max-concurrency 2.5` reports the number rather than the stray word. Both are real; the CLI reports one.

An **empty** value stays with the older message — `--max-calls` with nothing after it is not a number that failed to parse, it is a flag missing its value.

The test derives the flags from `main.swift` (`.int("…")`) instead of naming the three, so a fourth does not have to remember to be tested, and checks both directions: `2.5`, `8x`, `abc`, `1e3`, `1_000` refused with the value echoed back; `2`, `0`, `-3` still parsing and reaching the branch unchanged (what each does with a zero or a negative is its own business — `max(1,·)`, `max(0,·)`, and for `--budget` nothing until `Triage.budgetLabel`). It also asserts an invariant worth having on its own: a flag read as a number must be one that takes a value, or its value lands in `operands` and the needs-a-value loop — which gates on `valueFlags` — never sees it.

## What review corrected in the PR itself

Three rounds, all of it in the comments and the test, none in the gate:

- The repro written into two comments, bare `duo triage --max-calls 2.5`, dies on `triage needs --report <path> and --out <path>` before `int()` is called. The examples use `duo verify --max-concurrency …`, which reaches the check.
- A paragraph opening "Measured on the shipped binary" covered two claims and only one was measured; the derived one says so now.
- "`-3` reaches its reader, which is where the clamping lives" is false for `--budget`, whose reader clamps nothing — `Triage.budgetLabel` does, deliberately, three files away and documented there.
- `numeric.count >= 3` was a hand-maintained count of today's three flags with no slack: removing one would have failed with "only 2 number flags found", blaming the regex for a deliberate change.
- The worked example argued the opposite of what it demonstrated: typing `8x` means you wanted **8** and silently got **4**, so it could not illustrate "narrowing it to spare an endpoint". That is `1x`.
- Two blind spots are named rather than implied: the scan reads `main.swift` alone, and since the test calls `int()` itself it cannot see whether the branch owning the flag still calls it before the gate.

## Verification

```
$ make test
━ Test run with 1314 tests in 103 suites passed after 47.345 seconds with 1 known issue.
✔ Test run with 161 tests in 22 suites passed after 0.070 seconds.
✓ localizable keys agree — 413 in the catalog, all reachable
make test exit=0
```

No `duo verify` run: no recipe and no endpoint-facing parsing rule is touched. No CHANGELOG entry — release notes are written at release time here (#115, #116, #117 likewise).