### PR TITLE
fix(changelog): stamp disk-cached entries with a parser generation

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
@@ -6,7 +6,7 @@ import Foundation
 /// the release tag. From that we fetch the GitHub release body and parse it into the
 /// same structured `Changelog` the app rows render, so formula notes look native.
 /// Non-GitHub formulae (Go, GNU tools) fall back to their homepage.
-public struct FormulaRelease: Sendable, Codable {
+public struct FormulaRelease: Sendable, Codable, Hashable {
     /// Structured notes, when a GitHub release body was found and parsed. nil falls
     /// the UI back to `pageURL` (rendered in a web view).
     public let changelog: Changelog?
@@ -28,6 +28,14 @@ public struct FormulaRelease: Sendable, Codable {
 /// the GitHub Releases API for the body. Lazy by design — the UI calls this only
 /// when a formula is selected, so a screenful of outdated formulae never burns the
 /// GitHub rate limit up front.
+///
+/// This is the SECOND cross-launch disk cache whose content comes from
+/// `GitHubMarkdownParser` — `ChangelogDiskCache` is the other, and issue #112 was
+/// filed against exactly this failure mode: a version's notes cached under an
+/// older parser get served forever, because a released version's notes never
+/// change but what THIS APP extracts from them can. `cached`/`persist` below stamp
+/// and check `Changelog.parserGeneration` for the same reason and by the same
+/// rule as `ChangelogDiskCache` — see its doc comment and `Changelog.parserGeneration`'s.
 public actor BrewFormulaReleaseService {
     private let session: URLSession
     private let directory: URL
@@ -45,14 +53,36 @@ public actor BrewFormulaReleaseService {
         }
     }
 
+    /// Wraps `FormulaRelease` with the parser generation that produced it, mirroring
+    /// `ChangelogDiskCache.Stored` — kept OUT of `FormulaRelease` itself because that
+    /// type is also what the UI holds in `AppListModel.formulaReleaseStates`, and a
+    /// caching concern has no business riding along on a domain value passed around
+    /// the app. Non-optional and undefaulted for the same reason as
+    /// `ChangelogDiskCache.Stored`: an entry written before this field existed has
+    /// no honest generation to compare against, so it can't be assigned one — it can
+    /// only be unknown, and decoding it here throws, which `cached` below already
+    /// turns into a miss (same as any other corrupt/unreadable file). `persist`
+    /// still overwrites this exact key's file on the next fetch, and the sibling
+    /// prune below deletes every *other*-version file for the formula on each
+    /// successful write regardless of decodability, so this doesn't accumulate
+    /// unbounded undecodable files — same ~one-file-per-formula bound as before.
+    private struct Stored: Codable {
+        let release: FormulaRelease
+        let parserGeneration: Int
+    }
+
     /// The cross-launch disk-cached notes for a formula version, with NO `brew info`
     /// spawn and NO GitHub call. Used by the pre-warm probe and as the fast path in
-    /// `release(for:…)`. A formula version's notes are immutable, so a hit is final.
+    /// `release(for:…)`. A formula version's notes are immutable, so a hit is final
+    /// PROVIDED it was written under the running build's `Changelog.parserGeneration`
+    /// — a mismatch (or a pre-generation file with no such field at all) is treated
+    /// as a miss, same as `ChangelogDiskCache.get`.
     public func cached(for name: String, version: String) -> FormulaRelease? {
         guard let data = try? Data(contentsOf: fileURL(name: name, version: version)),
-              let release = try? JSONDecoder().decode(FormulaRelease.self, from: data)
+              let stored = try? JSONDecoder().decode(Stored.self, from: data),
+              stored.parserGeneration == Changelog.parserGeneration
         else { return nil }
-        return release
+        return stored.release
     }
 
     public func release(for name: String, version: String, token: String?) async -> FormulaRelease {
@@ -93,13 +123,24 @@ public actor BrewFormulaReleaseService {
         directory.appendingPathComponent(prefix(name: name) + sanitize(version) + ".json")
     }
 
-    /// Persist a formula version's notes, pruning any older-version file for the same
+    /// Persist a formula version's notes, stamped with the running build's
+    /// `Changelog.parserGeneration`, and prune any older-version file for the same
     /// formula (only the current version is ever shown). Best-effort.
-    private func persist(_ release: FormulaRelease, name: String, version: String) {
+    ///
+    /// Internal, not `private`: `compute` above spawns a real `brew info` `Process`
+    /// and a real GitHub request, so exercising the disk-write path (does `persist`
+    /// stamp the running generation?) through the public `release(for:…)` API would
+    /// make that test dependent on Homebrew being installed and reachable over the
+    /// network — exactly the kind of test this codebase avoids for its cache layers.
+    /// `BrewFormulaReleaseServiceTests` calls this directly instead, the same
+    /// reasoning `ChangelogDiskCache.directory` documents for its own test-only
+    /// internal visibility.
+    func persist(_ release: FormulaRelease, name: String, version: String) {
         let keep = fileURL(name: name, version: version).lastPathComponent
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-            try JSONEncoder().encode(release).write(
+            let stored = Stored(release: release, parserGeneration: Changelog.parserGeneration)
+            try JSONEncoder().encode(stored).write(
                 to: directory.appendingPathComponent(keep), options: .atomic)
         } catch {
             Log.app.debug("formula release disk write failed: \(error.localizedDescription, privacy: .public)")

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
@@ -6,7 +6,11 @@ import Foundation
 /// the release tag. From that we fetch the GitHub release body and parse it into the
 /// same structured `Changelog` the app rows render, so formula notes look native.
 /// Non-GitHub formulae (Go, GNU tools) fall back to their homepage.
-public struct FormulaRelease: Sendable, Codable, Hashable {
+// `Equatable` (not `Hashable`) because that is all anything needs: the cache
+// round-trip test compares two values. Nothing hashes a `FormulaRelease` — it is
+// never a dictionary key or a Set member — and widening a public type further
+// than its use requires is API surface nobody asked for.
+public struct FormulaRelease: Sendable, Codable, Equatable {
     /// Structured notes, when a GitHub release body was found and parsed. nil falls
     /// the UI back to `pageURL` (rendered in a web view).
     public let changelog: Changelog?

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
@@ -11,6 +11,33 @@ import Foundation
 /// (later) ship in a remote catalog, and it's also what `ChangelogExtractor`
 /// produces on-device. Either way the renderer only ever sees this struct.
 public struct Changelog: Codable, Sendable, Hashable {
+
+    /// The extraction logic's generation. `ChangelogDiskCache` stamps every entry
+    /// it writes with this number and treats a stored entry whose number doesn't
+    /// match the running build's as a miss — falls through to the network, exactly
+    /// like a cold cache (see `ChangelogDiskCache`). That's what lets a parser fix
+    /// reach a version whose notes were already cached under the OLD logic: without
+    /// this, an entry written by an older build is served forever for that exact
+    /// version, no matter what `ChangelogExtractor`, `StructuredChangelogDecoder`,
+    /// or `GitHubMarkdownParser` have learned since (issue #112).
+    ///
+    /// **Bump this whenever a change to any of those three files could change what
+    /// a PREVIOUSLY-parsed version's `Changelog` would come out as** — a change to
+    /// parsing/extraction *rules*, not merely support for a newly-encountered vendor
+    /// shape that no cached entry could have hit. Each of those files carries a
+    /// pointer comment back here for exactly this reason: the constant living only
+    /// in the cache file, which a parser author has no reason to ever open, is the
+    /// same hand-maintained-list failure this codebase has already been bitten by
+    /// (see `VendorProbeRecipe.channelAnchorSurface`'s doc comment).
+    ///
+    /// One line per bump — what changed and why:
+    /// - 1: baseline. Introduced with the generation field itself (issue #112); no
+    ///   prior bump history exists because the field didn't. Ships as of this
+    ///   commit already carrying the `GitHubMarkdownParser.isImageOnly` HTML `<img>`
+    ///   arm (`9963e3e`), so that fix is folded into generation 1 rather than
+    ///   triggering a bump on its own.
+    public static let parserGeneration = 1
+
     public let entries: [Entry]
 
     /// What the change lines in `items` are written in, so the renderer knows

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
@@ -8,34 +8,59 @@ import Foundation
 /// `WKWebView`.
 ///
 /// `Codable` on purpose: this is the shape an offline pipeline can pre-compute and
-/// (later) ship in a remote catalog, and it's also what `ChangelogExtractor`
-/// produces on-device. Either way the renderer only ever sees this struct.
+/// (later) ship in a remote catalog, and it's also what `ChangelogExtractor`,
+/// `StructuredChangelogDecoder`, and `GitHubMarkdownParser` produce on-device —
+/// the last of those directly for Homebrew formula release notes too, not only
+/// for app changelogs. Either way the renderer only ever sees this struct.
 public struct Changelog: Codable, Sendable, Hashable {
 
-    /// The extraction logic's generation. `ChangelogDiskCache` stamps every entry
-    /// it writes with this number and treats a stored entry whose number doesn't
-    /// match the running build's as a miss — falls through to the network, exactly
-    /// like a cold cache (see `ChangelogDiskCache`). That's what lets a parser fix
-    /// reach a version whose notes were already cached under the OLD logic: without
-    /// this, an entry written by an older build is served forever for that exact
-    /// version, no matter what `ChangelogExtractor`, `StructuredChangelogDecoder`,
-    /// or `GitHubMarkdownParser` have learned since (issue #112).
+    /// The extraction logic's generation. TWO cross-launch disk caches stamp every
+    /// entry they write with this number and treat a stored entry whose number
+    /// doesn't match the running build's as a miss — falls through to the network,
+    /// exactly like a cold cache: `ChangelogDiskCache` (app changelogs) and
+    /// `BrewFormulaReleaseService`'s own on-disk cache (Homebrew formula release
+    /// notes, which are also parsed by `GitHubMarkdownParser` — same generation,
+    /// same rule, separate store — see both types' doc comments). That's what lets
+    /// a parser fix reach a version whose notes were already cached under the OLD
+    /// logic: without this, an entry written by an older build is served forever
+    /// for that exact version, no matter what extraction has learned since
+    /// (issue #112).
     ///
-    /// **Bump this whenever a change to any of those three files could change what
-    /// a PREVIOUSLY-parsed version's `Changelog` would come out as** — a change to
-    /// parsing/extraction *rules*, not merely support for a newly-encountered vendor
-    /// shape that no cached entry could have hit. Each of those files carries a
-    /// pointer comment back here for exactly this reason: the constant living only
-    /// in the cache file, which a parser author has no reason to ever open, is the
-    /// same hand-maintained-list failure this codebase has already been bitten by
-    /// (see `VendorProbeRecipe.channelAnchorSurface`'s doc comment).
+    /// **Bump this whenever a change could alter what a PREVIOUSLY-parsed version's
+    /// `Changelog` would come out as** — a change to parsing/extraction *rules*, not
+    /// merely support for a newly-encountered vendor shape that no cached entry
+    /// could have hit. That covers two different kinds of change, both of which
+    /// need a bump:
+    /// - the extraction CODE: `ChangelogExtractor`, `StructuredChangelogDecoder`,
+    ///   `GitHubMarkdownParser`;
+    /// - the per-recipe DATA in `ChangelogRecipeRegistry` (`ChangelogRecipe.swift`)
+    ///   that's threaded into that code and changes its output just as directly —
+    ///   `entryPattern`, `itemPatterns`, `skipSections`, `stripTags`,
+    ///   `escapedMarkup`, `markdownSource`, `minItemLength`, `newestLast`,
+    ///   `maxEntries`, `source` itself, and so on. A recipe edit that changes what
+    ///   an EXISTING cached version's notes would parse to (not just what a *new*
+    ///   release's notes will) is exactly as invalidating as a code change; two
+    ///   already-merged commits prove it — `0d9d424` (Figma moved to a different
+    ///   feed with a different `entryPattern`, same bundle id) and `a6ac16b`
+    ///   (`skipSections` added, changing BetterDisplay's existing releases' output).
+    ///
+    /// Each of the four files above carries a pointer comment back here for exactly
+    /// this reason: the constant living only in the cache file, which a parser
+    /// author has no reason to ever open, is the same hand-maintained-list failure
+    /// this codebase has already been bitten by (see
+    /// `VendorProbeRecipe.channelAnchorSurface`'s doc comment). Unlike that surface,
+    /// there is no mechanical derivation for "did extraction's output change" —
+    /// parsing is a function from (recipe data, page bytes) to `Changelog`, not a
+    /// field list reflection can enumerate — so the closest available mechanical
+    /// guard is `ChangelogParserGenerationGuardTests`, which pins the actual parsed
+    /// output of two registry-driven fixtures and fails when either moves.
     ///
     /// One line per bump — what changed and why:
     /// - 1: baseline. Introduced with the generation field itself (issue #112); no
     ///   prior bump history exists because the field didn't. Ships as of this
     ///   commit already carrying the `GitHubMarkdownParser.isImageOnly` HTML `<img>`
-    ///   arm (`9963e3e`), so that fix is folded into generation 1 rather than
-    ///   triggering a bump on its own.
+    ///   arm (`9963e3e`) and `ChangelogRecipe.skipSections` (`a6ac16b`), so those are
+    ///   folded into generation 1 rather than triggering a bump on their own.
     public static let parserGeneration = 1
 
     public let entries: [Entry]
@@ -56,8 +81,18 @@ public struct Changelog: Codable, Sendable, Hashable {
     }
 
     /// Defaults to `.plain`: every producer except the GitHub one strips markup
-    /// before it gets here, and an older cached `Changelog` (this type is
-    /// `Codable` and lands on disk) decodes without the key.
+    /// before it gets here, and a `Changelog` encoded before this field existed
+    /// decodes without the key. NO LONGER the path that protects either on-disk
+    /// changelog cache, though: `ChangelogDiskCache.Stored` and
+    /// `BrewFormulaReleaseService`'s own `Stored` wrapper both carry a
+    /// `parserGeneration` (see `Changelog.parserGeneration`) that fails to decode
+    /// FIRST for an entry old enough to predate this field — by the time
+    /// `parserGeneration` existed, `itemSyntax` already did, so nothing reaches this
+    /// default through either cache any more. What still needs it: the "shape an
+    /// offline pipeline can pre-compute and ship in a remote catalog" this type is
+    /// also `Codable` for (see the type's own doc comment), which carries no
+    /// generation wrapper at all — exercised directly (bypassing both caches) by
+    /// `ChangelogItemSyntaxTests.syntaxSurvivesTheDiskCacheAndOldPayloadsDecode`.
     public let itemSyntax: ItemSyntax
 
     public init(entries: [Entry], itemSyntax: ItemSyntax = .plain) {
@@ -113,8 +148,13 @@ public struct Changelog: Codable, Sendable, Hashable {
             self.content = content
         }
 
-        // Custom decode so entries cached before `content` existed still decode —
-        // a missing key falls back to empty rather than throwing.
+        // Custom decode so an `Entry` encoded before `content` existed still
+        // decodes — a missing key falls back to empty rather than throwing. As with
+        // `itemSyntax` above, this is no longer what protects either on-disk
+        // changelog cache (both wrap `Changelog` in a `Stored` type whose own
+        // `parserGeneration` fails to decode first for an entry this old — see
+        // `Changelog.parserGeneration`'s doc comment); it remains live for the
+        // generation-less remote-catalog path this type is also `Codable` for.
         public init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             title = try c.decodeIfPresent(String.self, forKey: .title)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogDiskCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogDiskCache.swift
@@ -16,6 +16,12 @@ import Foundation
 /// the "open window" stale-while-revalidate path is driven by the model + the
 /// in-memory cache, not by a TTL here.
 ///
+/// A released version's *notes* never change, but what THIS APP extracts from them
+/// can — a parser fix. `Stored.parserGeneration` (below) is what that side of
+/// invalidation runs on: not a TTL (which would either miss entries a parser
+/// change never touched, or fail to catch ones it did), but an exact match against
+/// `Changelog.parserGeneration`, treating any mismatch as a miss.
+///
 /// Thread-safe via actor isolation. Best-effort throughout: any I/O failure is
 /// swallowed (a miss just falls through to the network), never thrown.
 public actor ChangelogDiskCache {
@@ -37,9 +43,26 @@ public actor ChangelogDiskCache {
         }
     }
 
+    /// Non-optional and undefaulted on purpose. An entry written before this field
+    /// existed has no `parserGeneration` key at all, and there is no "generation
+    /// zero" that would honestly describe what parsed it — so it can't be assigned
+    /// one and compared; it can only be treated as unknown. Decoding it as `Stored`
+    /// throws, `get` below already turns that throw into a miss (same as any other
+    /// corrupt/unreadable file), and a miss is exactly the outcome we want for a
+    /// pre-generation entry: we have no idea whether it matches current output, so
+    /// don't serve it. See `ChangelogDiskCache` and `Changelog.parserGeneration`'s
+    /// doc comments for why a mismatch is a miss rather than a TTL.
+    ///
+    /// This doesn't leak an unbounded pile of undecodable files: `set` still
+    /// overwrites this exact key's file the next time this version is fetched, and
+    /// `pruneSiblings` deletes every *other*-version file for the app+channel on
+    /// every successful write regardless of whether it was decodable — the on-disk
+    /// footprint stays bounded to ~one file per channel, same as before this field
+    /// existed.
     private struct Stored: Codable {
         let changelog: Changelog
         let fetchedAt: Date
+        let parserGeneration: Int
     }
 
     let directory: URL   // internal: asserted by DuoStateDirectoryTests
@@ -61,26 +84,36 @@ public actor ChangelogDiskCache {
     // MARK: - Public interface
 
     /// The cached changelog for `key`, or nil if we've never stored this exact
-    /// version's notes. Checks the in-memory mirror first, then the file.
+    /// version's notes UNDER THE RUNNING BUILD'S PARSER GENERATION. Checks the
+    /// in-memory mirror first (which — see `set` and the generation check below —
+    /// can only ever hold current-generation entries, so it needs no check of its
+    /// own), then the file, where a generation mismatch is a miss: same treatment
+    /// as a missing or corrupt file, never written into `memory`. See
+    /// `Changelog.parserGeneration`'s doc comment for why this exists.
     public func get(for key: Key) -> Changelog? {
         if let hit = memory[key] { return hit }
         guard let data = try? Data(contentsOf: fileURL(for: key)),
-              let stored = try? JSONDecoder().decode(Stored.self, from: data)
+              let stored = try? JSONDecoder().decode(Stored.self, from: data),
+              stored.parserGeneration == Changelog.parserGeneration
         else { return nil }
         memory[key] = stored.changelog
         return stored.changelog
     }
 
-    /// Persist `changelog` as the notes for `key` and drop any older-version files
-    /// for the same app+channel (only the newest version is ever displayed, so a
-    /// stale sibling is dead weight). Best-effort; a write failure is logged and
-    /// otherwise ignored — the network path still served the caller.
+    /// Persist `changelog` as the notes for `key`, stamped with the running build's
+    /// `Changelog.parserGeneration`, and drop any older-version files for the same
+    /// app+channel (only the newest version is ever displayed, so a stale sibling
+    /// is dead weight — this also bounds the on-disk footprint when it deletes a
+    /// sibling written by an older, undecodable generation; see `Stored`'s doc
+    /// comment). Best-effort; a write failure is logged and otherwise ignored — the
+    /// network path still served the caller.
     public func set(_ changelog: Changelog, for key: Key) {
         memory[key] = changelog
         do {
             try FileManager.default.createDirectory(
                 at: directory, withIntermediateDirectories: true)
-            let data = try JSONEncoder().encode(Stored(changelog: changelog, fetchedAt: .now))
+            let data = try JSONEncoder().encode(
+                Stored(changelog: changelog, fetchedAt: .now, parserGeneration: Changelog.parserGeneration))
             try data.write(to: fileURL(for: key), options: .atomic)
             pruneSiblings(of: key)
         } catch {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogDiskCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogDiskCache.swift
@@ -12,9 +12,15 @@ import Foundation
 /// version ships the *key* changes, so the new notes are fetched fresh; the prior
 /// version's entry stays valid (and is pruned, since only the newest is shown).
 ///
-/// `fetchedAt` is recorded for diagnostics / future age-based policy; freshness of
-/// the "open window" stale-while-revalidate path is driven by the model + the
-/// in-memory cache, not by a TTL here.
+/// `fetchedAt` is recorded for diagnostics only — nothing in this type reads it
+/// back. It is NOT the seed of a future age-based policy: freshness of the "open
+/// window" stale-while-revalidate path is driven by the model + the in-memory
+/// cache, and the invalidation problem an age policy would otherwise be reached
+/// for is `parserGeneration`'s job (below), which is the exact-match answer
+/// rather than the approximate one — see its doc comment for why a TTL was
+/// rejected. Kept for the same reason a log line carries a timestamp: reading a
+/// support bundle's cache directory and seeing how old an entry is remains
+/// useful on its own, independent of any invalidation this cache performs.
 ///
 /// A released version's *notes* never change, but what THIS APP extracts from them
 /// can — a parser fix. `Stored.parserGeneration` (below) is what that side of

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
@@ -10,10 +10,12 @@ import Foundation
 /// result is the caller's signal to fall back to the embedded web page.
 ///
 /// If you're changing what this file extracts (not just adding support for a
-/// new recipe shape), bump `Changelog.parserGeneration` — see its doc comment.
-/// A `Changelog` this produces can be written to `ChangelogDiskCache` and served,
-/// unre-parsed, to a user on a version their notes were already cached for;
-/// without the bump, this fix never reaches them.
+/// new recipe shape) — including a `ChangelogRecipe` field edit in the registry
+/// (`ChangelogRecipe.swift`) that changes what an EXISTING cached version parses
+/// to, not just new releases — bump `Changelog.parserGeneration`; see its doc
+/// comment. A `Changelog` this produces can be written to `ChangelogDiskCache` and
+/// served, unre-parsed, to a user on a version their notes were already cached
+/// for; without the bump, this fix never reaches them.
 public enum ChangelogExtractor {
 
     /// Parse `text` into a `Changelog` per `recipe`, or nil when nothing usable

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
@@ -8,6 +8,12 @@ import Foundation
 /// Totally defensive: an invalid pattern, a no-match, or an entry with no items
 /// yields fewer entries (or nil), never a throw and never a crash. A nil/empty
 /// result is the caller's signal to fall back to the embedded web page.
+///
+/// If you're changing what this file extracts (not just adding support for a
+/// new recipe shape), bump `Changelog.parserGeneration` — see its doc comment.
+/// A `Changelog` this produces can be written to `ChangelogDiskCache` and served,
+/// unre-parsed, to a user on a version their notes were already cached for;
+/// without the bump, this fix never reaches them.
 public enum ChangelogExtractor {
 
     /// Parse `text` into a `Changelog` per `recipe`, or nil when nothing usable

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -16,6 +16,16 @@ import Foundation
 ///     page's variants (old vs new markup) without branching code.
 ///   - **Serializable.** Every field is plain data, so a recipe can later live in
 ///     a remote catalog and be fixed without shipping a new app build.
+///
+/// A field here is not just config — it's an input to `ChangelogExtractor` /
+/// `StructuredChangelogDecoder` exactly like their own source code is, and an edit
+/// that changes what an EXISTING cached version's notes parse to (`entryPattern`,
+/// `itemPatterns`, `skipSections`, `stripTags`, `escapedMarkup`, `markdownSource`,
+/// `minItemLength`, `newestLast`, `maxEntries`, `source`, …) needs the same
+/// `Changelog.parserGeneration` bump a parser-code change does — see its doc
+/// comment. Two already-merged recipe-only edits prove this isn't hypothetical:
+/// `0d9d424` (Figma's `entryPattern`/`source` moved to a different feed) and
+/// `a6ac16b` (`skipSections` added, below).
 public struct ChangelogRecipe: Codable, Sendable {
     /// `CFBundleIdentifier` (lowercased by convention) of the app this targets.
     public let bundleID: String

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -17,9 +17,13 @@ import Foundation
 ///
 /// If you're changing what this file extracts (not just adding support for a
 /// new vendor shape), bump `Changelog.parserGeneration` — see its doc comment.
-/// A `Changelog` this parser produces can be written to `ChangelogDiskCache` and
-/// served, unre-parsed, to a user on a version their notes were already cached
-/// for; without the bump, this fix never reaches them.
+/// A `Changelog` this parser produces can be written to EITHER of the two
+/// cross-launch disk caches that persist one — `ChangelogDiskCache` (via
+/// `StructuredChangelogDecoder`, for the `.gitHubReleases`/`.zedGitHubReleases`
+/// recipe formats) and `BrewFormulaReleaseService`'s own on-disk cache (this file
+/// called directly, for Homebrew formula release notes) — and served, unre-parsed,
+/// to a user on a version their notes were already cached for; without the bump,
+/// this fix never reaches them.
 public enum GitHubMarkdownParser {
 
     /// Parse a single release body into a `Changelog` with one entry, or nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -14,6 +14,12 @@ import Foundation
 /// Hand-written bodies use arbitrary section headings and bullet styles.
 /// Both go through the same pipeline — bullets are extracted, contributor-
 /// noise sections are skipped, and the "by @user in URL" suffix is stripped.
+///
+/// If you're changing what this file extracts (not just adding support for a
+/// new vendor shape), bump `Changelog.parserGeneration` — see its doc comment.
+/// A `Changelog` this parser produces can be written to `ChangelogDiskCache` and
+/// served, unre-parsed, to a user on a version their notes were already cached
+/// for; without the bump, this fix never reaches them.
 public enum GitHubMarkdownParser {
 
     /// Parse a single release body into a `Changelog` with one entry, or nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -9,6 +9,12 @@ import Foundation
 /// Totally defensive: malformed JSON, a missing channel, or an entry with no usable
 /// notes yields fewer entries (or nil), never a throw — a nil/empty result is the
 /// caller's signal to fall back to the embedded web page.
+///
+/// If you're changing what this file extracts (not just adding support for a new
+/// vendor's structured format), bump `Changelog.parserGeneration` — see its doc
+/// comment. A `Changelog` this produces can be written to `ChangelogDiskCache` and
+/// served, unre-parsed, to a user on a version their notes were already cached
+/// for; without the bump, this fix never reaches them.
 public enum StructuredChangelogDecoder {
 
     /// Dispatch on the recipe's structured format. nil when the body can't be parsed

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -11,10 +11,13 @@ import Foundation
 /// caller's signal to fall back to the embedded web page.
 ///
 /// If you're changing what this file extracts (not just adding support for a new
-/// vendor's structured format), bump `Changelog.parserGeneration` — see its doc
-/// comment. A `Changelog` this produces can be written to `ChangelogDiskCache` and
-/// served, unre-parsed, to a user on a version their notes were already cached
-/// for; without the bump, this fix never reaches them.
+/// vendor's structured format) — including a `ChangelogRecipe` field edit in the
+/// registry (`ChangelogRecipe.swift`, e.g. `skipSections`) that changes what an
+/// EXISTING cached version parses to, not just new releases — bump
+/// `Changelog.parserGeneration`; see its doc comment. A `Changelog` this produces
+/// can be written to `ChangelogDiskCache` and served, unre-parsed, to a user on a
+/// version their notes were already cached for; without the bump, this fix never
+/// reaches them.
 public enum StructuredChangelogDecoder {
 
     /// Dispatch on the recipe's structured format. nil when the body can't be parsed

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BetterDisplayChangelogRecipeTests.swift
@@ -10,7 +10,12 @@ import Testing
 /// line and the download button are what the parser has to make decisions about;
 /// the other five change bullets add nothing to the test. Everything kept is
 /// verbatim. v5.0.2's body is whole.
-private let betterDisplayReleasesFixture = #"""
+// Not `private`: reused by ChangelogParserGenerationGuardTests (issue #112) — it
+// is the one fixture in this test target whose parse depends on BOTH
+// `GitHubMarkdownParser.isImageOnly` (the download button) AND
+// `ChangelogRecipe.skipSections` (the contributor roster), so pinning its output
+// there catches a regression to either without a second fixture.
+let betterDisplayReleasesFixture = #"""
 [
  {
   "tag_name": "v5.0.2",

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseServiceTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseServiceTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Regression coverage for issue #112's DEFECT 1 (adversarial review of PR #120):
+/// `BrewFormulaReleaseService` is the SECOND cross-launch disk cache holding a
+/// `Changelog` produced by `GitHubMarkdownParser` — `ChangelogDiskCache` is the
+/// other — and needed the same `Changelog.parserGeneration` stamp-and-check the
+/// first PR only applied to `ChangelogDiskCache`. See both types' doc comments.
+///
+/// Mirrors `ChangelogDiskCacheTests`'s idiom and its use of `persist` — internal
+/// here, not `private`, specifically so this file doesn't need Homebrew installed
+/// or a network connection to exercise the write path; see `persist`'s doc
+/// comment for why.
+struct BrewFormulaReleaseServiceTests {
+
+    private static func makeRelease(itemText: String = "Fixed a thing") -> FormulaRelease {
+        FormulaRelease(
+            changelog: Changelog(entries: [
+                Changelog.Entry(version: "1.0", date: "2026-01-01", items: [itemText]),
+            ]),
+            pageURL: URL(string: "https://github.com/example/example/releases/tag/v1.0"))
+    }
+
+    /// Fresh scratch directory per test.
+    private func withScratchDirectory<T>(_ body: (URL) async throws -> T) async rethrows -> T {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewFormulaReleaseServiceTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        return try await body(dir)
+    }
+
+    /// The single file `persist` wrote, so a test can corrupt/rewrite it without
+    /// reimplementing the service's private filename scheme.
+    private func onDiskFileURL(in dir: URL) throws -> URL {
+        let names = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+        #expect(names.count == 1, "expected exactly one file after a single persist(); found \(names)")
+        return dir.appendingPathComponent(names[0])
+    }
+
+    // MARK: - Same generation: hit
+
+    @Test func sameGenerationEntryIsServed() async {
+        await withScratchDirectory { dir in
+            let service = BrewFormulaReleaseService(cacheDirectory: dir)
+            let release = Self.makeRelease()
+            await service.persist(release, name: "azure-cli", version: "1.0")
+            #expect(await service.cached(for: "azure-cli", version: "1.0") == release)
+        }
+    }
+
+    // MARK: - Older generation on disk: miss
+
+    /// An entry written at generation N-1 must be a miss at generation N. There is
+    /// no way to *produce* an N-1 file through the current build (`persist` always
+    /// writes `Changelog.parserGeneration`), so this rewrites the JSON `persist`
+    /// wrote, simulating a build this process was never compiled as — same
+    /// technique `ChangelogDiskCacheTests.staleGenerationOnDiskIsAMiss` uses.
+    @Test func staleGenerationOnDiskIsAMiss() async throws {
+        try await withScratchDirectory { dir in
+            let service = BrewFormulaReleaseService(cacheDirectory: dir)
+            await service.persist(Self.makeRelease(), name: "azure-cli", version: "1.0")
+            let fileURL = try onDiskFileURL(in: dir)
+
+            var data = try Data(contentsOf: fileURL)
+            var json = try #require(
+                try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let staleGeneration = Changelog.parserGeneration - 1
+            #expect(staleGeneration >= 0, "parserGeneration must start at 1 or higher for this test to mean anything")
+            json["parserGeneration"] = staleGeneration
+            data = try JSONSerialization.data(withJSONObject: json)
+            try data.write(to: fileURL)
+
+            // Fresh instance: there is no in-memory mirror in this actor (unlike
+            // `ChangelogDiskCache`, `cached` always reads the file), so this is
+            // already a real disk-level check without needing a second instance —
+            // kept anyway to match the sibling test's shape and rule out any future
+            // memoization being added without a matching generation check.
+            let reopened = BrewFormulaReleaseService(cacheDirectory: dir)
+            #expect(await reopened.cached(for: "azure-cli", version: "1.0") == nil)
+        }
+    }
+
+    // MARK: - Pre-generation (old-schema) file: miss, not a crash
+
+    /// A file written before `parserGeneration` existed at all (no such key, and
+    /// the bare `FormulaRelease` shape rather than the `Stored` wrapper — what
+    /// `persist` wrote before this fix) must be treated as a miss.
+    @Test func preGenerationSchemaFileIsAMissNotACrash() async throws {
+        try await withScratchDirectory { dir in
+            let service = BrewFormulaReleaseService(cacheDirectory: dir)
+            await service.persist(Self.makeRelease(), name: "azure-cli", version: "1.0")
+            let fileURL = try onDiskFileURL(in: dir)
+
+            // Old shape: `FormulaRelease` encoded bare, not wrapped in `Stored`.
+            let legacy = try JSONEncoder().encode(Self.makeRelease())
+            try legacy.write(to: fileURL)
+
+            let reopened = BrewFormulaReleaseService(cacheDirectory: dir)
+            #expect(await reopened.cached(for: "azure-cli", version: "1.0") == nil)
+        }
+    }
+
+    // MARK: - persist() always stamps the current generation
+
+    @Test func persistStampsRunningGeneration() async throws {
+        try await withScratchDirectory { dir in
+            let service = BrewFormulaReleaseService(cacheDirectory: dir)
+            await service.persist(Self.makeRelease(), name: "azure-cli", version: "1.0")
+            let fileURL = try onDiskFileURL(in: dir)
+            let json = try #require(
+                try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any])
+            #expect(json["parserGeneration"] as? Int == Changelog.parserGeneration)
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogDiskCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogDiskCacheTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Regression coverage for issue #112: a `ChangelogDiskCache` entry written by an
+/// older build's parser must not be served to a newer build whose extraction logic
+/// has since changed for the same version. See `Changelog.parserGeneration` and
+/// `ChangelogDiskCache`'s doc comments for the design (a generation mismatch is a
+/// miss, not a TTL).
+struct ChangelogDiskCacheTests {
+
+    private static let key = ChangelogDiskCache.Key(
+        bundleID: "com.example.app", channel: "stable", version: "1.0")
+
+    private static func makeChangelog(version: String = "1.0") -> Changelog {
+        Changelog(entries: [
+            Changelog.Entry(version: version, date: "2026-01-01", items: ["Fixed a thing"])
+        ])
+    }
+
+    /// Fresh scratch directory per test so runs never share on-disk state.
+    private func withScratchDirectory<T>(_ body: (URL) async throws -> T) async rethrows -> T {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChangelogDiskCacheTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        return try await body(dir)
+    }
+
+    /// The single file `set` wrote for `key`, so a test can corrupt/rewrite it
+    /// without reimplementing `ChangelogDiskCache`'s private filename scheme.
+    private func onDiskFileURL(in dir: URL) throws -> URL {
+        let names = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+        #expect(names.count == 1, "expected exactly one file after a single set(); found \(names)")
+        return dir.appendingPathComponent(names[0])
+    }
+
+    // MARK: - Same generation: hit
+
+    @Test func sameGenerationEntryIsServed() async {
+        await withScratchDirectory { dir in
+            let cache = ChangelogDiskCache(directory: dir)
+            let changelog = Self.makeChangelog()
+            await cache.set(changelog, for: Self.key)
+            #expect(await cache.get(for: Self.key) == changelog)
+        }
+    }
+
+    // MARK: - Older generation on disk: miss, not poisoned
+
+    /// An entry written at generation N-1 must be a miss at generation N. There is
+    /// no way to *produce* an N-1 file through the current build (it always writes
+    /// `Changelog.parserGeneration`), so this reaches into the file `set` wrote and
+    /// rewrites its `parserGeneration` field directly, simulating a build this
+    /// process was never compiled as.
+    @Test func staleGenerationOnDiskIsAMiss() async throws {
+        try await withScratchDirectory { dir in
+            let cache = ChangelogDiskCache(directory: dir)
+            await cache.set(Self.makeChangelog(), for: Self.key)
+            let fileURL = try onDiskFileURL(in: dir)
+
+            // Rewrite the stored JSON with a generation older than the running
+            // build's, exactly like a file a previous release wrote to this
+            // machine and never revisited.
+            var data = try Data(contentsOf: fileURL)
+            var json = try #require(
+                try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let staleGeneration = Changelog.parserGeneration - 1
+            #expect(staleGeneration >= 0, "parserGeneration must start at 1 or higher for this test to mean anything")
+            json["parserGeneration"] = staleGeneration
+            data = try JSONSerialization.data(withJSONObject: json)
+            try data.write(to: fileURL)
+
+            // A fresh cache instance so nothing survives in the in-memory mirror
+            // from the `set` above — this must be a disk-level miss, not an
+            // artifact of skipping the file read entirely.
+            let reopened = ChangelogDiskCache(directory: dir)
+            #expect(await reopened.get(for: Self.key) == nil)
+        }
+    }
+
+    /// A miss on a stale-generation file must not leave the in-memory mirror
+    /// serving that same stale content afterwards — i.e. the miss really is a
+    /// miss, not a one-time hiccup papered over by a cache the next call reads
+    /// through.
+    @Test func staleGenerationMissDoesNotPoisonMemory() async throws {
+        try await withScratchDirectory { dir in
+            let cache = ChangelogDiskCache(directory: dir)
+            await cache.set(Self.makeChangelog(), for: Self.key)
+            let fileURL = try onDiskFileURL(in: dir)
+            var data = try Data(contentsOf: fileURL)
+            var json = try #require(
+                try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            json["parserGeneration"] = Changelog.parserGeneration - 1
+            data = try JSONSerialization.data(withJSONObject: json)
+            try data.write(to: fileURL)
+
+            let reopened = ChangelogDiskCache(directory: dir)
+            #expect(await reopened.get(for: Self.key) == nil)
+            // Ask again: if the first miss had wrongly cached the stale changelog
+            // into `memory`, this second call would return it instead of nil.
+            #expect(await reopened.get(for: Self.key) == nil)
+        }
+    }
+
+    // MARK: - Pre-generation (old-schema) file: miss, not a crash
+
+    /// A file written before `parserGeneration` existed at all (no such key in the
+    /// JSON) must be treated as a miss — `Stored.parserGeneration` is non-optional,
+    /// so this exercises the decode-failure path `get` already swallows, per the
+    /// deliberate migration decision documented on `Stored`.
+    @Test func preGenerationSchemaFileIsAMissNotACrash() async throws {
+        try await withScratchDirectory { dir in
+            let cache = ChangelogDiskCache(directory: dir)
+            await cache.set(Self.makeChangelog(), for: Self.key)
+            let fileURL = try onDiskFileURL(in: dir)
+
+            // Old shape: only `changelog` + `fetchedAt`, exactly what `Stored`
+            // looked like before this field was added.
+            var data = try Data(contentsOf: fileURL)
+            var json = try #require(
+                try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            json.removeValue(forKey: "parserGeneration")
+            data = try JSONSerialization.data(withJSONObject: json)
+            try data.write(to: fileURL)
+
+            let reopened = ChangelogDiskCache(directory: dir)
+            #expect(await reopened.get(for: Self.key) == nil)
+        }
+    }
+
+    // MARK: - set() always stamps the current generation
+
+    @Test func setStampsRunningGeneration() async throws {
+        try await withScratchDirectory { dir in
+            let cache = ChangelogDiskCache(directory: dir)
+            await cache.set(Self.makeChangelog(), for: Self.key)
+            let fileURL = try onDiskFileURL(in: dir)
+            let json = try #require(
+                try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any])
+            #expect(json["parserGeneration"] as? Int == Changelog.parserGeneration)
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -1622,7 +1622,13 @@ private let obsidianFixture = #"""
 // `<[^>]*>` strip run before the CDATA is pulled out eats the whole
 // `<![CDATA[…]]>` construct (`[^>]*` reads through to the `>` that closes
 // `]]>`), which would otherwise corrupt exactly this kind of entry.
-private let figmaFixture = #"""
+// Not `private`: reused by ChangelogParserGenerationGuardTests as one of the
+// anchor fixtures for the mechanical parser-generation guard (issue #112) — a
+// registry-driven fixture whose parse depends on the LIVE `ChangelogRecipe`
+// for this bundle id, so a future recipe-data edit (entryPattern, itemPatterns,
+// source) moves the guard's pinned output exactly the way a parser-code change
+// does.
+let figmaFixture = #"""
     <entry>
         <title type="html"><![CDATA[Recommend resources you want users to discover and use]]></title>
         <id>dece0d00-5f03-4a5d-aa04-3b0fad21b5eb</id>

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogItemSyntaxTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogItemSyntaxTests.swift
@@ -32,8 +32,15 @@ import Foundation
         #expect(log.entries.first?.items.first == "a * b and _c_")
     }
 
-    /// The flag rides along in the on-disk cache, and a `Changelog` written
-    /// before the flag existed must still decode (as plain).
+    /// The flag rides along in `Changelog`'s own `Codable` conformance, and a
+    /// `Changelog` written before the flag existed must still decode (as plain).
+    /// Decoded here directly, NOT through either on-disk changelog cache: as of
+    /// issue #112 both `ChangelogDiskCache` and `BrewFormulaReleaseService` wrap
+    /// `Changelog` in a `Stored` type carrying `parserGeneration`, whose own
+    /// decode fails first for a payload this old (see
+    /// `Changelog.parserGeneration`'s doc comment) — so this tolerance is no
+    /// longer reachable via either cache, only via the generation-less
+    /// remote-catalog path `Changelog` is also `Codable` for.
     @Test func syntaxSurvivesTheDiskCacheAndOldPayloadsDecode() throws {
         let log = Changelog(
             entries: [.init(title: nil, version: "1.0", date: nil, items: ["x"], content: [])],

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The mechanical guard `Changelog.parserGeneration` needed but didn't have: a
+/// hand-maintained comment "bump this when extraction changes" is exactly the
+/// failure mode `VendorProbeRecipe.channelAnchorSurface`'s doc comment already
+/// argues against — a guard that goes on passing while inspecting nothing is
+/// worse than no guard, because it *looks* covered. `channelAnchorSurface` fixed
+/// that for its own surface by deriving mechanically AND pinning a count that
+/// forces a human decision on every new field
+/// (`channelAnchorSurfaceCoversEveryRecipeField`). There is no equivalent
+/// mechanical derivation for "did extraction's output change" — parsing isn't a
+/// field list, it's a function from (recipe data, page bytes) to `Changelog` — so
+/// this pins the ACTUAL parsed output of two fixtures already carried by other
+/// test files, run through the exact registered recipe (not a hand-built one, so
+/// a recipe-data edit — `entryPattern`, `skipSections`, `source`, … — moves this
+/// test exactly the way a parser-code edit does). A change to `ChangelogExtractor`,
+/// `StructuredChangelogDecoder`, `GitHubMarkdownParser`, or `ChangelogRecipeRegistry`
+/// that alters what either fixture parses to fails HERE, and the fix is always the
+/// same two-part edit: bump `Changelog.parserGeneration` (with a one-line log entry
+/// on its doc comment) and update the expected value below to match.
+///
+/// Two fixtures, chosen to jointly cover every trigger this generation exists for:
+/// - `betterDisplayReleasesFixture` (`BetterDisplayChangelogRecipeTests.swift`)
+///   depends on BOTH `GitHubMarkdownParser.isImageOnly` (the HTML `<img>` download
+///   button — the fix issue #112 itself was filed over) AND
+///   `ChangelogRecipe.skipSections` (the contributor-roster drop) — the two
+///   already-merged commits (`9963e3e`, `a6ac16b`) that would have needed a
+///   generation bump had this field existed at the time.
+/// - `figmaFixture` (`ChangelogExtractorTests.swift`) depends on the registered
+///   recipe's `entryPattern`/`itemPatterns`/`source` for a regex-recipe (not
+///   structured-decoder) path — covers the third already-merged commit
+///   (`0d9d424`, the Atom-feed migration) via the same mechanism: this recipe's
+///   `entryPattern` only matches Atom `<entry>` blocks, so reverting to the old
+///   HTML-page pattern changes (empties) the parsed result.
+///
+/// Deliberately NOT a hash of the JSON encoding: `Changelog`/`Entry` are already
+/// `Equatable`, so direct struct equality is strictly stronger than a digest (no
+/// serialization-format sensitivity to worry about, e.g. key ordering or a future
+/// `Codable` key rename that changes JSON bytes without changing meaning) and
+/// gives a real diff in the failure message instead of two opaque hex strings.
+/// Both fixtures are static string literals with no dates, UUIDs, or network
+/// calls, so this cannot be flaky.
+@Suite struct ChangelogParserGenerationGuardTests {
+
+    /// Pinned alongside the two fixture checks below on purpose: bumping the
+    /// generation without touching this file is still *possible* (nothing forces
+    /// them to be edited in the same commit), but the two are next to each other
+    /// so a reviewer scanning this file sees both move together, and a bump that
+    /// changes NEITHER fixture's output (a bump "just in case") is caught here for
+    /// the opposite reason — it's a signal the bump might be unnecessary, worth a
+    /// second look rather than a silent no-op.
+    @Test func pinnedGeneration() {
+        #expect(Changelog.parserGeneration == 1)
+    }
+
+    /// Stable (v4.3.6, bulleted): exercises `skipSections` — the `### Included
+    /// Localizations` roster is a whole section, not a bullet-shaped item, so this
+    /// path never calls `isImageOnly` at all (the trailing download button here
+    /// isn't a bullet either; the bullet passes never look at a non-bullet line in
+    /// the first place). That is the OTHER fixture's job, right below.
+    @Test func betterDisplayStableFixtureOutputIsPinned() throws {
+        let recipe = try #require(
+            ChangelogRecipeRegistry.recipe(forBundleID: BetterDisplayChannel.bundleID, channel: .stable))
+        let format = try #require(recipe.structuredFormat)
+        let changelog = try #require(StructuredChangelogDecoder.decode(
+            betterDisplayReleasesFixture, format: format, channel: recipe.channel,
+            maxEntries: recipe.maxEntries, skipSections: recipe.skipSections))
+
+        let expected = Changelog(entries: [
+            Changelog.Entry(
+                version: "4.3.6",
+                date: "2026-08-11",
+                items: [
+                    "Fixed DDC capability retrieval through the console potentially hanging indefinitely - #5674",
+                    "Improved default nits values for built-in displays on Intel Macs - #5684",
+                ]),
+        ], itemSyntax: .markdown)
+        #expect(changelog == expected)
+    }
+
+    /// Beta (v5.0.2, bullet-less pre-release): the one that actually exercises
+    /// `isImageOnly` — no bullets anywhere in the body, so this goes through the
+    /// prose pass, which is the ONLY pass that ever looks at the trailing
+    /// `<a href=…><img …/></a>` download-button line. This is the fixture that
+    /// fails if `isImageOnly` regresses.
+    @Test func betterDisplayBetaFixtureOutputIsPinned() throws {
+        let recipe = try #require(
+            ChangelogRecipeRegistry.recipe(forBundleID: BetterDisplayChannel.bundleID, channel: .beta))
+        let format = try #require(recipe.structuredFormat)
+        let changelog = try #require(StructuredChangelogDecoder.decode(
+            betterDisplayReleasesFixture, format: format, channel: recipe.channel,
+            maxEntries: recipe.maxEntries, skipSections: recipe.skipSections))
+
+        let expected = Changelog(entries: [
+            Changelog.Entry(
+                version: "5.0.2",
+                date: "2026-08-11",
+                items: [
+                    "This updated BetterDisplay 5 pre-release adds improved soft-disconnected display handling, direct display connection controls in Settings, new display-group actions, and better touch compatibility on macOS 27 Golden Gate. Additionally, this version reintroduces Intel support for macOS 26 Tahoe. Other highlights in BetterDisplay 5 include advanced compositor filters, expanded display reporting and integration capabilities, HDMI-CEC control, improved per-display automation, app menu and OSD refinements, performance improvements, custom 3D LUT filters, a built-in app console, and compatibility updates for the latest macOS versions.",
+                    "_Please note that this pre-release was tested with macOS 27 Golden Gate public beta 3 (developer beta 5) and may not be fully compatible with earlier or later macOS 27 versions - an [updated release](https://github.com/waydabber/BetterDisplay/releases) is available._",
+                ]),
+        ], itemSyntax: .markdown)
+        #expect(changelog == expected)
+    }
+
+    @Test func figmaFixtureOutputIsPinned() throws {
+        let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.figma.Desktop"))
+        let changelog = try #require(ChangelogExtractor.extract(from: figmaFixture, using: recipe))
+
+        let expected = Changelog(entries: [
+            Changelog.Entry(
+                version: "Recommend resources you want users to discover and use",
+                date: "2026-08-17",
+                items: [
+                    "Admins can now choose which resources (skills, templates, libraries, and Make kits) are recommended to your organization or workspace.",
+                ]),
+            Changelog.Entry(
+                version: "Get responsive text across screens with text wrap",
+                date: "2026-08-14",
+                items: [
+                    "Text wrap makes your text responsive with two new options: Balance and Pretty. Set either on a text layer, a text style, or an individual paragraph in text settings.",
+                ]),
+            Changelog.Entry(
+                version: "Try skills from the Community and make your own with the Figma agent",
+                date: "2026-08-13",
+                items: [
+                    "We've added more ways to discover, create, and share skills for the Figma agent.",
+                ]),
+        ], itemSyntax: .plain)
+        #expect(changelog == expected)
+    }
+}


### PR DESCRIPTION
Fixes #112.

## The gap

`ChangelogDiskCache` keys on `(bundleID, channel, version)` and `get(for:)` returned whatever decoded, with no schema/parser field and no TTL (`ChangelogDiskCache.swift`, pre-change). `Stored` carried a `fetchedAt` that `get` never consulted. So an entry written by an older build was served forever for that exact version, no matter what the parser learned since. `GitHubMarkdownParser.isImageOnly` gained an HTML `<img>` arm in the 0.3.67→0.3.68 range (`9963e3e`), and a version whose notes were cached by 0.3.67 kept rendering the old broken output after the user updated.

## Verified before writing code

- Read `ChangelogDiskCache.swift` end to end and confirmed the above.
- Enumerated every writer/reader by grep, not by trust: `ChangelogService.load` is the only writer (`ChangelogDiskCache.shared.set`, inside the network-fetch closure, never on an in-memory hit), and `ChangelogService.diskCached` is the only reader (used by the workbench for instant first paint). Tests are the only other caller (`DuoStateDirectoryTests`).
- Traced the full extraction surface whose output actually lands in the cache: `ChangelogService.parse()` calls either `StructuredChangelogDecoder.decode` (structured-format recipes) or `ChangelogExtractor.extract` (regex recipes) — and `StructuredChangelogDecoder` itself delegates to `GitHubMarkdownParser.parse` for the GitHub-shaped formats. The issue's own example (`isImageOnly`) only covers one of these three files; a generation bump needs to cover a change to any of them, not just `GitHubMarkdownParser`.

## Shape chosen: generation integer, not a TTL

`Changelog.parserGeneration` (in `Changelog.swift`, the shared output type all three extraction paths produce) is a manually-bumped `Int`. `ChangelogDiskCache.Stored` now stamps every entry with the generation that wrote it; `get(for:)` treats a mismatch as a miss — falls through to the network exactly like a cold cache. A TTL was rejected per the issue's own reasoning: it would either miss entries a parser change never touched, or fail to invalidate ones it did. The generation invalidates exactly what a parser change invalidates.

**Discoverability**: the constant's doc comment carries the "bump this + why" instructions and a one-line log per bump (starts at `1`, this PR). Each of the three extraction files (`GitHubMarkdownParser.swift`, `ChangelogExtractor.swift`, `StructuredChangelogDecoder.swift`) carries a short pointer comment back to it, so whoever is actually editing extraction logic sees the reminder at the point of change — a constant that only lived inside `ChangelogDiskCache.swift`, which a parser author has no reason to ever open, would be the same hand-maintained-list failure `VendorProbeRecipe.channelAnchorSurface`'s doc comment already argues against.

## Migration decision for pre-existing entries (stated explicitly, not left implicit)

`Stored.parserGeneration` is **non-optional and undefaulted**. An entry written before this field existed has no honest generation to compare against — there's no "generation zero" that correctly describes what parsed it — so it can't be assigned one; it can only be unknown. Decoding such a file as `Stored` throws, and `get(for:)` already swallows any decode throw into a miss (same path as a corrupt/missing file today). That is the invalidation I want for the first release carrying this field: every disk-cached entry that predates it is treated as unknown and re-fetched once.

This doesn't leave undecodable files piling up: `set()` overwrites the exact file for a re-fetched version, and `pruneSiblings` already deletes every *other*-version file for an app+channel on every successful write, decodable or not — so the on-disk footprint stays bounded to ~one file per channel, same invariant as before this field existed.

The in-memory `memory` mirror can't serve a stale-generation entry either: within one running process `Changelog.parserGeneration` is a fixed compile-time constant, `set()` always stamps the current one, and `get()` only writes into `memory` *after* confirming the on-disk generation matches — so `memory` can never hold anything but current-generation content.

## Tests (`DuoUpdaterCoreTests/ChangelogDiskCacheTests.swift`)

New file, following `ChangelogCacheTests.swift`'s swift-testing idiom and `ChangelogDiskCache.init(directory:)`'s test seam (same pattern `DuoStateDirectoryTests` uses):

- `sameGenerationEntryIsServed` — a generation-N entry is a hit at generation N.
- `staleGenerationOnDiskIsAMiss` — an entry written at generation N-1 (simulated by rewriting the JSON `set()` wrote) is a miss at generation N, from a fresh cache instance (a real disk-level miss, not an in-memory pass-through).
- `staleGenerationMissDoesNotPoisonMemory` — querying the same stale entry twice returns `nil` both times; the miss never got cached into `memory`.
- `preGenerationSchemaFileIsAMissNotACrash` — a file missing the `parserGeneration` key entirely (the pre-this-PR shape) is a miss, not a crash.
- `setStampsRunningGeneration` — `set()` always writes `Changelog.parserGeneration` into the stored JSON.

## Verification

Compiling is not verification, so:

```
$ cd DuoUpdaterCore && swift test --filter ChangelogDiskCacheTests
...
✔ Test run with 5 tests in 1 suite passed after 0.005 seconds.
```

Then the full suite (not `make test` — a concurrent worktree is running it and would collide on `scripts/check_localizable_keys.py`'s shared `/tmp/duo-loc-check` lock; `swift test` inside `DuoUpdaterCore` avoids that entirely and is what CLAUDE.md asks for anyway):

```
$ cd DuoUpdaterCore && swift test
...
━ Test run with 1319 tests in 104 suites passed after 72.642 seconds with 1 known issue.
```

The "1 known issue" is `GitHubReleaseRuleTests`' pre-existing `withKnownIssue` xfail, unrelated to this change (confirmed by grep — it predates this branch).

No parser/recipe logic was touched — this PR is the cache layer only, per the issue's framing.

---

## Update: adversarial re-review found 2 defects + 2 concerns — all addressed, same branch

An independent adversarial pass (coordinator verified DEFECT 1 personally before forwarding) found real gaps in the first version of this PR. Fixed in three follow-up commits on this branch (`0e4c4f8`, `316b6ce`, `1f2e1e0`); nothing here changed the shape of the original fix, only its completeness.

### DEFECT 1 — a second disk cache was missed: `BrewFormulaReleaseService`

Confirmed by reading the file: `FormulaRelease` (holding `changelog: Changelog?`) is written straight to disk by `BrewFormulaReleaseService.persist`/`cached`, content produced by `GitHubMarkdownParser.parse` at line ~81 — the exact same parser `ChangelogDiskCache` guards, and a live path (`AppListModel.prewarmFormulaReleases`, called after every brew refresh). It had no generation field, so the fix in the first commit reached app changelogs but not formula release notes.

**Fixed**: `BrewFormulaReleaseService` now wraps `FormulaRelease` in a private `Stored { release, parserGeneration }` on disk (kept out of `FormulaRelease` itself since that's also the type the UI holds directly in `AppListModel.formulaReleaseStates`), with the same mismatch-is-a-miss rule as `ChangelogDiskCache`. `persist` moved from `private` to internal so tests can exercise the write path without Homebrew installed or a network connection — `compute` spawns a real `brew info` Process and a real GitHub request, which is not something a cache-layer unit test should depend on. The `GitHubMarkdownParser.swift` pointer comment now names both cache consumers instead of just `ChangelogDiskCache`.

### DEFECT 2 — the bump trigger excluded the most-edited surface: recipe data

Verified both cited commits myself (`git show`) before writing anything:
- `0d9d424` — Figma's `entryPattern` AND `source` both changed (HTML page → Atom feed), same `bundleID`. A version cached under the old page-scrape pattern would have kept serving stale-shaped notes.
- `a6ac16b` — `ChangelogRecipe.skipSections` added and populated for BetterDisplay, which measurably changes what an *already-cached* release's parsed output looks like (the contributor roster stops appearing).

Both are real; the original trigger definition ("any of those three files") only covered extraction *code*, not the per-recipe *data* threaded into it, which changes output identically. `Changelog.parserGeneration`'s doc comment, `ChangelogExtractor.swift`'s and `StructuredChangelogDecoder.swift`'s pointer comments, and a new fourth pointer comment in `ChangelogRecipe.swift` now all name the registry explicitly, with both commits cited as proof this isn't hypothetical.

### CONCERN 3 — no mechanical guard; my honest verdict

Re-read `VendorProbeRecipe.channelAnchorSurface`'s doc comment in full, as asked. It's right: three unenforced comments are the same failure shape as a hand-maintained list nobody re-checks. Unlike `channelAnchorSurface`, though, there's no mechanical *derivation* available here — `channelAnchorSurface` can reflect over a struct's fields; "did extraction's output change" is a question about a function's behavior (recipe data × page bytes → `Changelog`), which reflection can't enumerate.

**What I built instead**: `ChangelogParserGenerationGuardTests` pins the exact parsed `Changelog` for two fixtures already living in other test files, run through their *live registered* `ChangelogRecipe` (not a hand-built one, so a recipe-data edit moves this test the same way a parser-code edit does):
- `BetterDisplayChangelogRecipeTests.betterDisplayReleasesFixture` — the one fixture in the whole test target that depends on BOTH `isImageOnly` (the HTML `<img>` download button, stable channel has no bullet for it so the beta/prose-pass entry is the one that actually exercises this) AND `skipSections` (the roster drop, exercised on the stable/bulleted entry).
- `ChangelogExtractorTests.figmaFixture` — depends on the registered `entryPattern`/`source` for a regex-recipe path.

Both fixtures were widened from `private` to internal visibility in their home files (not duplicated, not invented) so the guard file can reuse them verbatim.

**On the digest question specifically**: I did not build a JSON-hash digest. `Changelog`/`Entry` are already `Equatable`, so direct struct equality is strictly *stronger* than a hash (no serialization-format sensitivity — e.g. a future `Codable` key rename that changes JSON bytes without changing meaning would false-positive a hash but not a struct comparison) and gives a real diff in the failure output instead of two opaque hex strings. I judged this the better mechanical guard, not a fallback for an infeasible one — the direct approach was cheaply achievable and I didn't hit the flakiness risk that would have pushed me toward proposing something else.

**Verified the guard actually guards**, not just that it passes: temporarily reverted the `isImageOnly` HTML-`<img>` arm locally and reran — `betterDisplayBetaFixtureOutputIsPinned` failed with a full expected-vs-actual diff naming the leaked `<img>` markup. Separately reverted `skipSections` (emptied `betterDisplayContributorRosters`) — `betterDisplayStableFixtureOutputIsPinned` failed the same way. Restored both, confirmed clean, before committing.

### CONCERN 4 — two comments this change silently falsified

Both `Changelog.itemSyntax`'s and `Entry.content`'s decode-tolerance comments claimed to protect "an older cached `Changelog`... on disk." Traced why that's no longer true: both on-disk stores now wrap `Changelog` in a `Stored` type whose own `parserGeneration` field is non-optional, so decoding an entry old enough to lack `itemSyntax`/`content` already fails at the OUTER `Stored` decode — it never reaches `Changelog`'s own tolerant decoder. (Confirmed this isn't reachable any other way inside the two caches: `grep`'d for every `decode(Changelog...)`/`Changelog.self` call site in the codebase — the only *direct* decode of a bare `Changelog`, bypassing both `Stored` wrappers, is `ChangelogItemSyntaxTests.syntaxSurvivesTheDiskCacheAndOldPayloadsDecode`, whose own comment made the identical now-false claim and got updated too.) The tolerance itself is still correct and still needed — for `Changelog`'s other declared purpose, a remote catalog with no generation wrapper at all — so it stays; only the comments describing *why* it exists were wrong now, and are fixed.

### The "Also" ask: what this migration does to existing entries, in numbers

This turns the issue's "some entries" into every disk-cached changelog and formula-release entry, on every machine, becoming a miss exactly once (the first read after upgrading to a build carrying this PR), because generation 1 is a new field with no prior value to match.

For **app changelogs**: re-fetch fan-out is bounded — `AppListModel.prewarmChangelogs` gates genuine network fetches (disk hits skip the gate entirely) through `prewarmNetworkGate = AsyncSemaphore(value: 4)`, so at most 4 concurrent requests regardless of how many of the ~68 changelog-recipe-backed apps are installed.

For **Homebrew formula release notes** — the cache DEFECT 1 added generation-stamping to — I checked whether the same claim holds and it does **not**: `AppListModel.prewarmFormulaReleases` has no equivalent semaphore. It fetches eagerly (unbounded concurrent Tasks, one per outdated formula) whenever a GitHub token is present, gated only by "is there a token" — not "how many at once." This isn't a regression this PR introduces (the exact same unbounded fan-out already fires today on a machine's very first brew refresh, before any formula has a cached entry) — but this migration does mean a machine with many outdated formulae, a token configured, and a warm formula-release cache built up over time will see that same unbounded burst recur once, on the next refresh after upgrading. In practice this is `brew info` local Process spawns (cheap) plus GitHub API calls (rate-limited but token-authenticated, 5000/hr), and formula counts are typically small (tens, not the ~68 changelog recipe count) — so I judge the actual risk low, but it is a real, pre-existing gap, not something I fixed here (out of scope for a cache-generation PR), and I don't want to carry forward the "checked, bounded, acceptable" framing as if it applies uniformly to both caches when it only holds for one. Flagged separately (not fixed) via a spawned task — see below.

### Test output (actual commands, actual results)

```
$ cd DuoUpdaterCore && swift test --filter "BrewFormulaReleaseServiceTests|ChangelogDiskCacheTests|ChangelogParserGenerationGuardTests|ChangelogItemSyntaxTests|BetterDisplayChangelogRecipeTests|ChangelogExtractorTests"
...
✔ Test run with 119 tests in 6 suites passed after 0.014 seconds.

$ cd DuoUpdaterCore && swift test
...
━ Test run with 1327 tests in 106 suites passed after 46.610 seconds with 1 known issue.
```

The "1 known issue" is the same pre-existing `GitHubReleaseRuleTests` `withKnownIssue` xfail from the original PR description, unrelated to any of this. 1327 vs. the original PR's 1319: +5 (original `ChangelogDiskCacheTests`, already counted) +4 (`ChangelogParserGenerationGuardTests`) +4 (`BrewFormulaReleaseServiceTests`) = +8, matches.

No parser/recipe logic was touched in either round — this PR remains cache-layer + coverage only.
