### PR TITLE
Fix four stale comments (#113)

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3130,7 +3130,17 @@ final class AppListModel {
         persistStagedPackages()
         installNotes[result.id] = nil
         inFlightNotes[result.id] = nil
-        installErrors[result.id] = nil
+        // installErrors is deliberately left alone. Any error sitting here did not
+        // come from the package we just threw away: `openStagedPackage`'s own
+        // failure path already clears `stagedPackages[id]` itself (so this
+        // function would have returned above, at the `guard let staged` — there
+        // would be nothing left to discard), and the only other writer that can
+        // reach this row while a staged package still validates is a *separate*
+        // install attempt — e.g. "Update All" re-queues this row (staging doesn't
+        // clear `hasUpdate`, so `installAllTargets` still offers it) and its fresh
+        // download fails before `PackageInstaller.downloadAndOpen` reaches
+        // `beforeOpen`/`retireStagedPackage`. That error describes THAT attempt,
+        // not this discard, and stays on the row for the user to see.
         Log.install.info("package discarded by user: \(result.app.name, privacy: .public) \(staged.version, privacy: .public)")
     }
 

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3106,7 +3106,14 @@ final class AppListModel {
         // Leaving the file is the safe half of the trade and costs nothing: the
         // 24-hour sweep reclaims it. Forgetting the entry below stays
         // unconditional — the user asked, and the row must not go on offering an
-        // Install they have said they don't want.
+        // Install they have said they don't want. The error goes with it for the
+        // same reason: the user is abandoning the update this row was attempting,
+        // and a lingering red error for an attempt they just called off is not
+        // informative, it's noise. Nothing else would ever clear it either — the
+        // row is `.updateAvailable` by construction here (`stagedPackage(for:)`
+        // requires a remote version on offer), and `pruneSettledInstallErrors`
+        // only settles `.upToDate` rows — so without this it would survive every
+        // rescan until the user starts another install on this row.
         if await InstallerWindowCloser.closeWindow(showing: staged.url) {
             _ = PackageInstaller.discardWorkDirectory(containing: staged.url)
         }
@@ -3130,17 +3137,7 @@ final class AppListModel {
         persistStagedPackages()
         installNotes[result.id] = nil
         inFlightNotes[result.id] = nil
-        // installErrors is deliberately left alone. Any error sitting here did not
-        // come from the package we just threw away: `openStagedPackage`'s own
-        // failure path already clears `stagedPackages[id]` itself (so this
-        // function would have returned above, at the `guard let staged` — there
-        // would be nothing left to discard), and the only other writer that can
-        // reach this row while a staged package still validates is a *separate*
-        // install attempt — e.g. "Update All" re-queues this row (staging doesn't
-        // clear `hasUpdate`, so `installAllTargets` still offers it) and its fresh
-        // download fails before `PackageInstaller.downloadAndOpen` reaches
-        // `beforeOpen`/`retireStagedPackage`. That error describes THAT attempt,
-        // not this discard, and stays on the row for the user to see.
+        installErrors[result.id] = nil
         Log.install.info("package discarded by user: \(result.app.name, privacy: .public) \(staged.version, privacy: .public)")
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -101,15 +101,15 @@ public enum AppRestarter {
         // Surge. Nothing of a parent that is not running is stale, so there is
         // nothing for us to put back.
         if main.isEmpty {
-            // Put back the nested apps that were open. `nested` can't be empty
-            // here: `running` (= main + nested) was non-empty and main is, so
-            // something in `nested` was. `nestedBundles` itself CAN still end up
-            // empty — it's `nested.compactMap(\.bundleURL)`, which drops any
-            // instance whose `bundleURL` is nil — but that's harmless: the loop in
-            // `reopenNestedApps` below then does nothing, `allNestedBack([])` is
-            // vacuously true, and the log line after this still reports the
-            // (accurate, if slightly odd for that case) "was not running itself —
-            // only its nested app(s) needed clearing (nested relaunched=true)".
+            // Put back the nested apps that were open. `nestedBundles` can't be
+            // empty here: `running` (= main + nested) was non-empty and main is,
+            // so something in `nested` was — and `nested.compactMap(\.bundleURL)`
+            // can't drop it, because `nestedRunningInstances(of:)` only ever
+            // admits instances with a non-nil `.app` `bundleURL` in the first
+            // place (`isNestedInside` requires one to test containment;
+            // `isStandaloneNestedApp` requires `bundleURL?.pathExtension == "app"`).
+            // So `nestedBundles.count == nested.count` always, and it's non-empty
+            // here too.
             let results = await reopenNestedApps(nestedBundles, frontmostPath: frontmostPath)
             let relaunched = allNestedBack(results)
             Log.install.info(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -101,9 +101,15 @@ public enum AppRestarter {
         // Surge. Nothing of a parent that is not running is stale, so there is
         // nothing for us to put back.
         if main.isEmpty {
-            // Put back the nested apps that were open. `nestedBundles` can't be
-            // empty here: `running` (= main + nested) was non-empty and main is,
-            // so something in `nested` was.
+            // Put back the nested apps that were open. `nested` can't be empty
+            // here: `running` (= main + nested) was non-empty and main is, so
+            // something in `nested` was. `nestedBundles` itself CAN still end up
+            // empty — it's `nested.compactMap(\.bundleURL)`, which drops any
+            // instance whose `bundleURL` is nil — but that's harmless: the loop in
+            // `reopenNestedApps` below then does nothing, `allNestedBack([])` is
+            // vacuously true, and the log line after this still reports the
+            // (accurate, if slightly odd for that case) "was not running itself —
+            // only its nested app(s) needed clearing (nested relaunched=true)".
             let results = await reopenNestedApps(nestedBundles, frontmostPath: frontmostPath)
             let relaunched = allNestedBack(results)
             Log.install.info(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
@@ -60,17 +60,22 @@ public enum ReleaseChannel: String, Codable, Sendable, Hashable, CaseIterable {
     ///      `org.mozilla.firefox` with Stable. Verified against real bundles
     ///      2026-06-04; the version-suffix heuristic below silently misclassified
     ///      them (an ESR install read as `.stable`, then offered the stable build).
-    ///   0.5/0.6. Two more bundle-id-scoped rules, deliberately ahead of Keystone —
-    ///      Android Studio and DB Browser for SQLite, whose only on-disk channel
-    ///      signal is the installed BUNDLE FILENAME (not the display name or
-    ///      version string). See the block comment on each check, below, for why.
+    ///   0.5/0.6. Two more bundle-id-scoped rules, checked ahead of the ones
+    ///      below — Android Studio and DB Browser for SQLite, whose only on-disk
+    ///      channel signal is the installed BUNDLE FILENAME (not the display
+    ///      name or version string). See the block comment on each check, below,
+    ///      for why.
     ///   1. Chrome/Keystone's explicit `KSChannelID` plist key (the cleanest
     ///      signal — empty/`extended` mean stable; `beta`/`dev`/`canary` are
     ///      authoritative).
     ///   2. A channel suffix on the bundle id (`com.google.Chrome.canary`).
     ///   3. A standalone channel word in the display name ("Google Chrome Dev").
-    ///   4. A Mozilla-style pre-release suffix in the version string
-    ///      ("153.0a1" → nightly) — survives only for Nightly; Beta/ESR strip it.
+    ///   4. A pre-release shape in the version string: Mozilla's `b<N>`/`a<N>`/
+    ///      `esr`, GitHub Desktop's full-semver `-beta<N>`, and a prerelease
+    ///      WORD in the version's dash-separated tail (Freelens `-nightly-…`,
+    ///      VLC `-dev`, KeePassXC `-snapshot`) for apps whose bundle id, name,
+    ///      and filename are all silent — see the block comment below for the
+    ///      anchoring that keeps ordinary build-metadata versions out of this.
     /// Nothing matched → `.stable`.
     public static func detect(
         name: String,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/ReleaseChannel.swift
@@ -60,6 +60,10 @@ public enum ReleaseChannel: String, Codable, Sendable, Hashable, CaseIterable {
     ///      `org.mozilla.firefox` with Stable. Verified against real bundles
     ///      2026-06-04; the version-suffix heuristic below silently misclassified
     ///      them (an ESR install read as `.stable`, then offered the stable build).
+    ///   0.5/0.6. Two more bundle-id-scoped rules, deliberately ahead of Keystone —
+    ///      Android Studio and DB Browser for SQLite, whose only on-disk channel
+    ///      signal is the installed BUNDLE FILENAME (not the display name or
+    ///      version string). See the block comment on each check, below, for why.
     ///   1. Chrome/Keystone's explicit `KSChannelID` plist key (the cleanest
     ///      signal — empty/`extended` mean stable; `beta`/`dev`/`canary` are
     ///      authoritative).

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2878,7 +2878,7 @@ public enum VendorProbeRegistry {
         // Toolbox-MANAGED Canary/Beta — that copy stays detection-only and updates
         // through Toolbox. A HAND-INSTALLED Canary/Beta (`isToolboxManaged ==
         // false`) gets `allowInstall = true` and IS offered this one-click, which is
-        // why the dmg patterns above must stay correct and in lockstep with the
+        // why the dmg patterns below must stay correct and in lockstep with the
         // version set, not merely decorative. Team EQHXZ8M8AV.
         VendorProbeRecipe(
             bundleID: "com.google.android.studio",

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2872,10 +2872,14 @@ public enum VendorProbeRegistry {
         // highest, instead of three separate first-matches over the whole feed
         // that could each land on a different entry (flipping `selectHighest` on
         // `versionPattern` alone would have done exactly that — see its doc).
-        // dmg patterns mirror each channel set — though these installs are
-        // Toolbox-managed → detection-only, so the install spec is suppressed at the
-        // source and the user updates through Toolbox; the dmg set just stays in
-        // lockstep with the version set. Team EQHXZ8M8AV.
+        // dmg patterns mirror each channel set. Suppression is conditional, not a
+        // property of this recipe: `VendorProbeSource` sets `allowInstall` from
+        // `InstalledApp.prefersVendorProbeOverToolbox`, which is true only for a
+        // Toolbox-MANAGED Canary/Beta — that copy stays detection-only and updates
+        // through Toolbox. A HAND-INSTALLED Canary/Beta (`isToolboxManaged ==
+        // false`) gets `allowInstall = true` and IS offered this one-click, which is
+        // why the dmg patterns above must stay correct and in lockstep with the
+        // version set, not merely decorative. Team EQHXZ8M8AV.
         VendorProbeRecipe(
             bundleID: "com.google.android.studio",
             url: URL(string: "https://jb.gg/android-studio-releases-list.json")!,


### PR DESCRIPTION
Closes #113.

**Update:** this PR is now comment-only end to end. It originally included a behavior change for item 4 (removing an `installErrors` clear in `discardStagedPackage`); adversarial review found that change was unnecessary and a net regression (a discarded row's error would then survive forever instead of being cleared), so it's been reverted. See item 4 below for the full story, including the reachable sequence I found (still true) and why the fix is a comment, not a behavior change.

Four comments that no longer described what the code does, each verified against the source before touching anything, per this repo's issue-fixing rules. This also went through one round of adversarial review after the first push, which caught real defects — those are folded into the per-item writeups below rather than listed separately.

## 1. `ReleaseChannel.swift` `detect` — numbered summary skipped steps 0.5/0.6, and step 4 itself was stale

**Claimed:** the doc comment enumerated priority steps 0–4 only, and step 4 said "A Mozilla-style pre-release suffix in the version string."
**Code does:** the body has a step 0.5 (Android Studio) and step 0.6 (DB Browser for SQLite), both bundle-filename-scoped rules that run *ahead* of Keystone. Separately, step 4 itself had grown past its own summary: commit `3efeb39` (same v0.3.67→0.3.68 range as the DB Browser commit #113 caught, landed 6 minutes before it) added GitHub Desktop's full-semver `-betaN` rule and the `versionTailChannelWords` loop (Freelens nightly, VLC `-dev`, KeePassXC `-snapshot`) to that same step — I walked past this while fixing the step above it, and review caught it.
**Verified:** read the full `detect` body, confirmed both 0.5/0.6 checks exist and precede Keystone; read `git log` and `git show 3efeb39` to confirm the step-4 drift and its timing relative to the DB Browser commit.
**Fix:** added a 0.5/0.6 line to the summary pointing at the existing block comments (not duplicating them), and expanded step 4's summary to cover all three shapes it now matches. Also dropped an unsupported "deliberately ahead of Keystone" claim I'd first written for 0.5/0.6 — neither block comment mentions Keystone or ordering, and neither app carries a Keystone channel id, so nothing backs that phrasing.

## 2. `VendorProbeRecipe.swift` (~2877) — Android Studio preview install suppression

**Claimed:** "Toolbox-managed → detection-only, so the install spec is suppressed at the source" — phrased as a property of the recipe.
**Code does:** it's a property of the *install*. Confirmed the chain:
- `VendorProbeSource.swift:195`: `let allowInstall = !app.prefersVendorProbeOverToolbox`
- `InstalledApp.swift:164`: `prefersVendorProbeOverToolbox` requires `isToolboxManaged && bundleID == "com.google.android.studio" && (releaseChannel == .canary || .beta)`
- So a hand-installed Canary/Beta (`isToolboxManaged == false`) gets `allowInstall = true` and **is** offered the one-click.
**Verified:** read both call sites directly, quoted above.
**Fix:** rewrote the comment to say suppression is conditional on the copy being Toolbox-managed, and that a hand-installed preview gets the one-click. (Review also caught a leftover directional slip — "the dmg patterns above" — the preview recipes the comment describes follow it, not precede it; fixed to "below".)

## 3. `AppRestarter.swift` (~104–106) — argument didn't reach its conclusion, and my first fix was itself wrong

**Claimed (original comment):** "`nestedBundles` can't be empty here: `running` (= main + nested) was non-empty and main is, so something in `nested` was."
**My first pass:** said `nestedBundles` (`nested.compactMap(\.bundleURL)`) *could* end up empty if a nested instance's `bundleURL` were nil, and documented that as a live degenerate case.
**Review caught:** that's false. `nestedRunningInstances(of:)` only ever admits instances that already have a non-nil `.app` bundleURL — `isNestedInside` requires one to test containment (`guard let candidateBundleURL else { return false }`), and `isStandaloneNestedApp` requires `bundleURL?.pathExtension == "app"`. So every element of `nested` has a non-nil bundleURL by construction, the `compactMap` can't drop anything, and `nestedBundles.count == nested.count` always. Worse, the degenerate case I'd documented as "harmless" would actually have been the issue-#72 failure mode `AppRestarterTests.swift:187-192` exists to guard against (`allNestedBack([])` vacuously `true` → `relaunched=true` logged for nested apps that were terminated and never came back) — so I'd both invented an unreachable branch and mischaracterized what it would do.
**Verified:** re-read `nestedRunningInstances`, `isNestedInside`, `isStandaloneNestedApp` directly (quoted above); this is exactly the failure-mode issue #113's item 3 was about, and I inherited its framing on the first pass instead of checking it myself.
**Fix:** rewrote the argument to go through `nested`'s construction (why it can't have a nil-bundleURL member in the first place), and deleted the degenerate-case paragraph entirely — nothing to document because the branch is unreachable.

## 4. `AppListModel.swift` `discardStagedPackage` (~3133) — clearing `installErrors`

Issue #113 marked this **not verified** and asked for a concrete reachable sequence before changing behavior, or a comment-only fix otherwise.

**I found a concrete reachable sequence** (still true, unchanged by the revert):
1. A row has a valid staged `.pkg` (`stagedPackages[id]` set, version matches offer, file on disk) from an earlier "Update" click.
2. `installAllTargets()` does **not** exclude rows with a staged package — `isActionableUpdate` stays true because staging never touches the on-disk app — so a later "Update All" re-queues the row and starts a **fresh** download/install attempt.
3. That fresh attempt fails **before** `PackageInstaller.downloadAndOpen` reaches `beforeOpen`/`retireStagedPackage` (its own doc: *"Not called when the download or preliminary gate fails."*), so the OLD staged package is left untouched.
4. `performInstall`'s catch sets `installErrors[id]` to this new attempt's error — not caused by the staged package itself.
5. `canDiscardStagedPackage` is still true, so Discard wipes that error along with the (legitimately discarded) package.

**Review found the conclusion I drew from this didn't hold**, on two counts I verified myself before reverting:

- The error is not "unrelated" the way my original PR described it. `stagedPackage(for:)` requires `staged.version == result.remote?.displayVersion`, so any surviving error is necessarily from an attempt to update *this row* to the *same offered version* — not caused by the discarded file, but not unrelated to the row either. I overstated this.
- Removing the clear is a regression, not neutral. `UpdatePolicy.settledRowIDs` (called from `pruneSettledInstallErrors`) only settles `.upToDate` rows, explicitly leaving `.updateAvailable` alone — and a discarded row is `.updateAvailable` by construction (that's what `stagedPackage(for:)` required). So without the clear, the error would survive every rescan/check/refresh forever, until the user happens to start another install on that exact row. Before my change, the very next install click cleared it anyway (`install()`'s own `installErrors[id] = nil`) — so I'd traded a message that was about to be superseded for one that, on many rows, never would be. It was also inconsistent with itself: `installNotes`/`inFlightNotes` two lines above stayed unconditional under the identical "not caused by this discard" reasoning, with no stated reason for the asymmetry.
- Separately, the comment I wrote to justify the change contained a false absolute — "the only other writer that can reach this row … is a separate install attempt" — when `rollback(_:)` (~4085) also sets `installErrors[id]` (on `ProcessInstallLock.claim()` failure and `BackupStore.restore` failure) without touching `stagedPackages`, and is reachable on the same row whenever a backup exists.

**What I did:** reverted the behavior change — restored `installErrors[result.id] = nil` — and instead extended the existing block comment (the one already explaining why forgetting the staged entry is unconditional) to say why the error goes with it: the user is abandoning the operation the error described, and nothing else would ever clear it on a row that stays `.updateAvailable`. This is the comment-only path #113 authorized when a behavior change isn't clearly net-positive.

## Verification

Comment-only end to end, checked mechanically (every line added/removed across all four files, with comment lines filtered out):
```
$ git diff main..HEAD | grep -E "^[+-]" | grep -v "^[+-][+-]" | grep -vE "^[+-]\s*(//|///)"
(prints nothing)
```

```
$ cd DuoUpdaterCore && swift test
...
━ Test run with 1314 tests in 103 suites passed after 45.982 seconds with 1 known issue.
```

`AppRestarterTests` specifically (item 3's file):
```
$ swift test --filter AppRestarterTests
✔ Test run with 17 tests in 1 suite passed after 0.055 seconds.
```

`App/` (no `swift test` coverage — Xcode-only GUI target):
```
$ xcodegen generate --spec App/project.yml --project App
$ xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug \
    CODE_SIGNING_ALLOWED=NO build
** BUILD SUCCEEDED **
```

Per the task instructions, ran `swift test` inside `DuoUpdaterCore` directly rather than full `make test`, to avoid the `scripts/check_localizable_keys.py` shared-cache lock collision with other concurrent worktrees.
