### PR TITLE
fix(core): a .recipeAnchor must name the fields it relies on, and match in each (#110)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -24,9 +24,33 @@ public enum ChannelArtifactProof: Sendable, Hashable {
     /// The vendor ships ONE artifact to several channels, so the URL carries no
     /// channel token and there is nothing to assert on it. The proof is instead
     /// that the recipe reads a channel-dedicated endpoint (or a channel-tagged
-    /// block of a shared feed): the regex must appear in the recipe's endpoint
-    /// URL, version pattern, or install URL source.
-    case recipeAnchor(String)
+    /// block of a shared feed).
+    ///
+    /// `fields` names the recipe fields the channel identity actually lives in
+    /// (their `Mirror` labels — `"url"`, `"versionPattern"`, `"install"`, …),
+    /// and the regex must match in EVERY one of them. That is the whole point:
+    /// matching against the joined surface passes if any single line matches, so
+    /// a token that happens to sit in two fields kept the proof green while
+    /// either one drifted. WeChat DevTools RC is the live case — `"id": "rc"` is
+    /// in both `versionPattern` and the install `bodyPattern`, and only the
+    /// install half picks the artifact (issue #110).
+    ///
+    /// Which fields to name is a per-recipe fact, not a rule to apply uniformly.
+    /// Measured across the five anchors registered on 2026-08-28:
+    ///   * **Endpoint-keyed** (IntelliJ EAP, Alfred beta) — the response body
+    ///     holds only that channel's builds, so `versionPattern` and the install
+    ///     pattern are byte-identical to their stable siblings' and contain no
+    ///     channel token to anchor on. `["url"]` is the whole proof, and naming
+    ///     anything else would be an assertion those recipes cannot satisfy.
+    ///   * **Shared-feed** (WeChat DevTools RC, OrbStack beta/canary) — one
+    ///     endpoint serves every channel, and the per-field patterns are what
+    ///     select. Both the version half and the install half must stay anchored,
+    ///     so both are named.
+    ///
+    /// An empty set, or a name that is not an anchorable field of the recipe, is
+    /// a hard finding rather than a pass — either would be a proof that cannot
+    /// fail. See `RecipeSanity.recipeAnchorFailure`.
+    case recipeAnchor(String, in: Set<String>)
 }
 
 /// A `(bundleID, channel)` pair — the same key `VendorProbeSource` selects a
@@ -58,7 +82,17 @@ public enum ChannelProofRegistry {
         // uses, so the filename proves nothing. The endpoint does: `type=eap` vs
         // stable's `type=release`, and the install pattern reads the dmg out of
         // that response body.
-        ChannelProofKey("com.jetbrains.intellij-EAP", .preview): .recipeAnchor(#"type=eap"#),
+        //
+        // `url` alone, and that is the honest scope rather than a weaker one: the
+        // response to `type=eap` contains ONLY EAP builds, so `versionPattern`
+        // (`"build": "…"`) and the install pattern (`"macM1" … "link"`) carry no
+        // channel token at all — they are what a `type=release` recipe would use
+        // verbatim. Naming them would assert something this recipe cannot satisfy.
+        // What naming `url` buys is that swapping the endpoint back to
+        // `type=release` fails the proof instead of passing on patterns that never
+        // mentioned a channel.
+        ChannelProofKey("com.jetbrains.intellij-EAP", .preview):
+            .recipeAnchor(#"type=eap"#, in: ["url"]),
         // Android Studio: each preview channel accepts builds at its own quality OR
         // MORE STABLE (the stability floor documented on the recipes), so the marker
         // has to be that whole ladder, not just the channel's own name — Canary
@@ -135,7 +169,16 @@ public enum ChannelProofRegistry {
         // if that anchor ever stops being there the recipe would start reading
         // whichever channel `config.json` lists first (Stable).
         ChannelProofKey("com.tencent.wechatdevtools", .nightly): .artifact(#"/WechatWebDev/nightly/"#),
-        ChannelProofKey("com.tencent.wechatdevtools", .rc): .recipeAnchor(#""id":.*"rc""#),
+        // Named on BOTH halves, which is what issue #110 was about. The token sits
+        // in `versionPattern` and in the install `bodyPattern`, and matching the
+        // joined surface passed on either — so if the install regex alone were
+        // rewritten (the vendor renames the block, someone retypes it), the version
+        // pattern would keep this green while the install fell back to whichever
+        // channel `config.json` lists first. Which is Stable, into an RC install,
+        // through every gate we have. Requiring both means the half that picks the
+        // artifact is checked as the half that picks the artifact.
+        ChannelProofKey("com.tencent.wechatdevtools", .rc):
+            .recipeAnchor(#""id":.*"rc""#, in: ["versionPattern", "install"]),
 
         // MARK: Everything else
         ChannelProofKey("dev.warp.Warp-Preview", .preview): .artifact(#"channel=preview"#),
@@ -145,12 +188,25 @@ public enum ChannelProofRegistry {
         // Alfred serves stable and pre-release from two endpoints that frequently
         // carry the SAME build (both were 5.7.3 (2320) on 2026-08-09), and the
         // tarball name never mentions a channel — only the endpoint can prove it.
-        ChannelProofKey("com.runningwithcrayons.Alfred", .beta): .recipeAnchor(#"prerelease\.xml"#),
+        // Endpoint-scoped for the same reason as IntelliJ EAP: this recipe's
+        // `versionPattern` and install `bodyPattern` are byte-identical to the
+        // stable Alfred recipe's (same plist shape, different endpoint), so the
+        // endpoint is not merely the best evidence — it is the only evidence there
+        // is, and the proof says so.
+        ChannelProofKey("com.runningwithcrayons.Alfred", .beta):
+            .recipeAnchor(#"prerelease\.xml"#, in: ["url"]),
         // OrbStack publishes one appcast with a `<sparkle:channel>` tag per item and
         // promotes the same dmg across channels (all three were v2.2.3_20963 on
         // 2026-08-09). The channel tag the patterns are anchored to is the proof.
-        ChannelProofKey("dev.kdrag0n.MacVirt", .beta): .recipeAnchor(#"<sparkle:channel>beta"#),
-        ChannelProofKey("dev.kdrag0n.MacVirt", .canary): .recipeAnchor(#"<sparkle:channel>canary"#),
+        // Both halves named, like WeChat RC and for the same reason: one appcast
+        // serves all three channels, and the `<sparkle:channel>` prefix on the
+        // version pattern and on the install pattern is what confines each to its
+        // own `<item>`. Losing it from the install pattern alone would let the
+        // enclosure match the first item in the feed regardless of channel.
+        ChannelProofKey("dev.kdrag0n.MacVirt", .beta):
+            .recipeAnchor(#"<sparkle:channel>beta"#, in: ["versionPattern", "install"]),
+        ChannelProofKey("dev.kdrag0n.MacVirt", .canary):
+            .recipeAnchor(#"<sparkle:channel>canary"#, in: ["versionPattern", "install"]),
         // Longbridge splits the two trains by CDN path — `/longbridge-desktop/
         // preview/` vs `/stable/` — and the artifact filename carries the
         // `-preview.N` suffix on top of that, so the URL names the channel twice.
@@ -292,15 +348,15 @@ extension RecipeSanity {
             return "resolved \(url), which carries no \(recipe.channel.rawValue) marker "
                 + "(expected /\(pattern)/) — the install may be crossing channels"
 
-        case .recipeAnchor(let pattern):
-            // Derived from the recipe, never hand-listed — see
-            // `VendorProbeRecipe.channelAnchorSurface`. The list this replaced
-            // named three fields and had already missed `entryStartPattern`.
-            let surface = recipe.channelAnchorSurface
-            guard surface.range(of: pattern, options: [.regularExpression, .caseInsensitive]) == nil
-            else { return nil }
-            return "recipe is no longer anchored on /\(pattern)/ — nothing ties its "
-                + "\(recipe.channel.rawValue) install to that channel"
+        case .recipeAnchor(let pattern, let fields):
+            // Each named field's own text, never the join — see
+            // `VendorProbeRecipe.channelAnchorFields`. The fields themselves are
+            // still derived by reflection; the list this replaced named three of
+            // them by hand and had already missed `entryStartPattern`.
+            return recipeAnchorFailure(
+                pattern: pattern, fields: fields, subject: "recipe",
+                channel: recipe.channel, of: "VendorProbeRecipe",
+                surface: recipe.channelAnchorSurface(ofField:))
         }
     }
 
@@ -349,12 +405,56 @@ extension RecipeSanity {
             return "resolved \(url), which carries no \(rule.channel.rawValue) marker "
                 + "(expected /\(pattern)/) — the install may be crossing channels"
 
-        case .recipeAnchor(let pattern):
-            let surface = rule.channelAnchorSurface
-            guard surface.range(of: pattern, options: [.regularExpression, .caseInsensitive]) == nil
-            else { return nil }
-            return "rule is no longer anchored on /\(pattern)/ — nothing ties its "
-                + "\(rule.channel.rawValue) install to that channel"
+        case .recipeAnchor(let pattern, let fields):
+            return recipeAnchorFailure(
+                pattern: pattern, fields: fields, subject: "rule",
+                channel: rule.channel, of: "GitHubReleaseRule",
+                surface: rule.channelAnchorSurface(ofField:))
         }
+    }
+
+    /// Match a field-scoped `.recipeAnchor` and describe the first way it fails.
+    ///
+    /// Shared by both overloads so the two registries cannot drift into different
+    /// notions of what an anchor asserts — the asymmetry issue #101 was filed
+    /// about, in miniature.
+    ///
+    /// EVERY named field must match. An anchor names the fields its channel
+    /// identity lives in, so a field that stopped carrying the token is exactly
+    /// the drift the proof exists to report, even while a sibling field still
+    /// carries it (issue #110).
+    ///
+    /// The two degenerate inputs are findings, not passes. An empty `fields`
+    /// would make the loop vacuous, and a name that is not an anchorable field —
+    /// a typo, a renamed field, or one of the labelling `nonAnchorFields` —
+    /// yields nothing to match against. Both describe a proof that could not have
+    /// failed for any input, which is the one outcome worse than no proof: it
+    /// reads as green forever. `everyRegisteredAnchorNamesRealFields` fails on
+    /// them in a PR; this is the runtime half, for a proof written after it.
+    static func recipeAnchorFailure(
+        pattern: String,
+        fields: Set<String>,
+        subject: String,
+        channel: ReleaseChannel,
+        of typeName: String,
+        surface: (String) -> String?
+    ) -> String? {
+        guard !fields.isEmpty else {
+            return "the anchor /\(pattern)/ names no field of the \(subject), so it "
+                + "cannot fail and proves nothing about which channel it reads — name "
+                + "the field(s) that tie it to \(channel.rawValue)"
+        }
+        for label in fields.sorted() {
+            guard let text = surface(label) else {
+                return "the anchor /\(pattern)/ names '\(label)', which is not an "
+                    + "anchorable field of \(typeName) (no such field, or one that only "
+                    + "labels the \(subject)) — the proof cannot fail as written"
+            }
+            guard text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) == nil
+            else { continue }
+            return "the \(subject)'s \(label) is no longer anchored on /\(pattern)/ — "
+                + "nothing there ties its \(channel.rawValue) install to that channel"
+        }
+        return nil
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -38,10 +38,15 @@ public enum ChannelArtifactProof: Sendable, Hashable {
     /// Which fields to name is a per-recipe fact, not a rule to apply uniformly.
     /// Measured across the five anchors registered on 2026-08-28:
     ///   * **Endpoint-keyed** (IntelliJ EAP, Alfred beta) — the response body
-    ///     holds only that channel's builds, so `versionPattern` and the install
-    ///     pattern are byte-identical to their stable siblings' and contain no
-    ///     channel token to anchor on. `["url"]` is the whole proof, and naming
-    ///     anything else would be an assertion those recipes cannot satisfy.
+    ///     holds only that channel's builds, so neither `versionPattern` nor the
+    ///     install pattern carries a channel token to anchor on. `["url"]` is the
+    ///     whole proof, and naming anything else would be an assertion those
+    ///     recipes cannot satisfy. (Their INSTALL patterns are byte-identical to
+    ///     their stable siblings'; their version patterns are not, and that is not
+    ///     an oversight to normalise away — IntelliJ EAP reads `"build"` where
+    ///     stable reads `"version"` because `versionIsBuild` compares the build,
+    ///     and Alfred beta's is merely written more strictly. Neither difference
+    ///     names a channel, which is the property that matters here.)
     ///   * **Shared-feed** (WeChat DevTools RC, OrbStack beta/canary) — one
     ///     endpoint serves every channel, and the per-field patterns are what
     ///     select. Both the version half and the install half must stay anchored,
@@ -50,6 +55,15 @@ public enum ChannelArtifactProof: Sendable, Hashable {
     /// An empty set, or a name that is not an anchorable field of the recipe, is
     /// a hard finding rather than a pass — either would be a proof that cannot
     /// fail. See `RecipeSanity.recipeAnchorFailure`.
+    ///
+    /// **Granularity is the whole field**, and `install` is one field. Naming it
+    /// asserts the token is somewhere in the install spec — the `urlSource`
+    /// pattern, but also `kind`, `checksumPattern` and `requestHeaders`. So the
+    /// shape this case exists to close survives one level down: a
+    /// `.bodyTemplate(_, fields: [withToken, withoutToken])` would stay green
+    /// while the sub-pattern that actually resolves the URL drifted. Not reachable
+    /// today — no anchored recipe uses `bodyTemplate` — and said out loud rather
+    /// than left for the next person to discover the way #110 was discovered.
     case recipeAnchor(String, in: Set<String>)
 }
 
@@ -86,8 +100,11 @@ public enum ChannelProofRegistry {
         // `url` alone, and that is the honest scope rather than a weaker one: the
         // response to `type=eap` contains ONLY EAP builds, so `versionPattern`
         // (`"build": "…"`) and the install pattern (`"macM1" … "link"`) carry no
-        // channel token at all — they are what a `type=release` recipe would use
-        // verbatim. Naming them would assert something this recipe cannot satisfy.
+        // channel token at all. Naming either would assert something this recipe
+        // cannot satisfy. (The install pattern is byte-identical to the stable
+        // recipe's; the version pattern is NOT — stable reads `"version"` and this
+        // reads `"build"`, because `versionIsBuild` compares the build. That
+        // difference is deliberate and says nothing about the channel.)
         // What naming `url` buys is that swapping the endpoint back to
         // `type=release` fails the proof instead of passing on patterns that never
         // mentioned a channel.
@@ -189,10 +206,11 @@ public enum ChannelProofRegistry {
         // carry the SAME build (both were 5.7.3 (2320) on 2026-08-09), and the
         // tarball name never mentions a channel — only the endpoint can prove it.
         // Endpoint-scoped for the same reason as IntelliJ EAP: this recipe's
-        // `versionPattern` and install `bodyPattern` are byte-identical to the
-        // stable Alfred recipe's (same plist shape, different endpoint), so the
-        // endpoint is not merely the best evidence — it is the only evidence there
-        // is, and the proof says so.
+        // install `bodyPattern` is byte-identical to the stable Alfred recipe's
+        // (same plist shape, different endpoint) and its `versionPattern` differs
+        // only in strictness — neither names a channel. So the endpoint is not
+        // merely the best evidence, it is the only evidence there is, and the
+        // proof says so.
         ChannelProofKey("com.runningwithcrayons.Alfred", .beta):
             .recipeAnchor(#"prerelease\.xml"#, in: ["url"]),
         // OrbStack publishes one appcast with a `<sparkle:channel>` tag per item and
@@ -310,6 +328,34 @@ public enum ChannelProofRegistry {
         #"(?i)(?<![a-z0-9])(beta|canary|nightly|alpha|insider|snapshot|preview|eap|esr|ptb|devedition)(?![a-z0-9])"#
 }
 
+/// What `RecipeSanity.recipeAnchorFailure` needs from whatever it is judging.
+///
+/// The three call sites used to hand it `subject`, a type name, and a surface
+/// closure as three independent strings that had to agree; nothing linked them,
+/// so `subject: "rule", of: "VendorProbeRecipe", surface: recipe…` compiled and
+/// produced a self-contradictory finding. That is the same hand-paired-list shape
+/// this file argues against everywhere else, so it is derived instead: conforming
+/// a type supplies all three at once and a caller cannot mismatch them.
+protocol ChannelAnchorSubject {
+    /// What to call one of these in a finding ("recipe", "rule", "binding").
+    static var anchorSubjectName: String { get }
+    /// The type name to blame when a proof names a field this type does not have.
+    static var anchorTypeName: String { get }
+    /// The text one named field contributes, or nil when there is no ANCHORABLE
+    /// field by that name — see the implementations' own docs.
+    func channelAnchorSurface(ofField label: String) -> String?
+}
+
+extension VendorProbeRecipe: ChannelAnchorSubject {
+    static var anchorSubjectName: String { "recipe" }
+    static var anchorTypeName: String { "VendorProbeRecipe" }
+}
+
+extension GitHubReleaseRule: ChannelAnchorSubject {
+    static var anchorSubjectName: String { "rule" }
+    static var anchorTypeName: String { "GitHubReleaseRule" }
+}
+
 extension RecipeSanity {
 
     /// The check that catches an install spec resolving the WRONG CHANNEL's build.
@@ -354,9 +400,7 @@ extension RecipeSanity {
             // still derived by reflection; the list this replaced named three of
             // them by hand and had already missed `entryStartPattern`.
             return recipeAnchorFailure(
-                pattern: pattern, fields: fields, subject: "recipe",
-                channel: recipe.channel, of: "VendorProbeRecipe",
-                surface: recipe.channelAnchorSurface(ofField:))
+                pattern: pattern, fields: fields, channel: recipe.channel, subject: recipe)
         }
     }
 
@@ -407,9 +451,7 @@ extension RecipeSanity {
 
         case .recipeAnchor(let pattern, let fields):
             return recipeAnchorFailure(
-                pattern: pattern, fields: fields, subject: "rule",
-                channel: rule.channel, of: "GitHubReleaseRule",
-                surface: rule.channelAnchorSurface(ofField:))
+                pattern: pattern, fields: fields, channel: rule.channel, subject: rule)
         }
     }
 
@@ -417,7 +459,9 @@ extension RecipeSanity {
     ///
     /// Shared by both overloads so the two registries cannot drift into different
     /// notions of what an anchor asserts — the asymmetry issue #101 was filed
-    /// about, in miniature.
+    /// about, in miniature. The subject's own name and type name come from
+    /// `ChannelAnchorSubject` rather than from arguments, so a caller cannot pair
+    /// one type's surface with another's label either.
     ///
     /// EVERY named field must match. An anchor names the fields its channel
     /// identity lives in, so a field that stopped carrying the token is exactly
@@ -431,28 +475,27 @@ extension RecipeSanity {
     /// failed for any input, which is the one outcome worse than no proof: it
     /// reads as green forever. `everyRegisteredAnchorNamesRealFields` fails on
     /// them in a PR; this is the runtime half, for a proof written after it.
-    static func recipeAnchorFailure(
+    static func recipeAnchorFailure<Subject: ChannelAnchorSubject>(
         pattern: String,
         fields: Set<String>,
-        subject: String,
         channel: ReleaseChannel,
-        of typeName: String,
-        surface: (String) -> String?
+        subject: Subject
     ) -> String? {
+        let name = Subject.anchorSubjectName
         guard !fields.isEmpty else {
-            return "the anchor /\(pattern)/ names no field of the \(subject), so it "
-                + "cannot fail and proves nothing about which channel it reads — name "
-                + "the field(s) that tie it to \(channel.rawValue)"
+            return "the anchor /\(pattern)/ names no fields at all, so it cannot fail "
+                + "and proves nothing about which channel the \(name) reads — name the "
+                + "field(s) that tie it to \(channel.rawValue)"
         }
         for label in fields.sorted() {
-            guard let text = surface(label) else {
+            guard let text = subject.channelAnchorSurface(ofField: label) else {
                 return "the anchor /\(pattern)/ names '\(label)', which is not an "
-                    + "anchorable field of \(typeName) (no such field, or one that only "
-                    + "labels the \(subject)) — the proof cannot fail as written"
+                    + "anchorable field of \(Subject.anchorTypeName) (no such field, or "
+                    + "one that only labels the \(name)) — the proof cannot fail as written"
             }
             guard text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) == nil
             else { continue }
-            return "the \(subject)'s \(label) is no longer anchored on /\(pattern)/ — "
+            return "the \(name)'s \(label) is no longer anchored on /\(pattern)/ — "
                 + "nothing there ties its \(channel.rawValue) install to that channel"
         }
         return nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -74,16 +74,18 @@ public struct GitHubReleaseRule: Sendable {
     /// arrives and nobody adds it. `channelAnchorSurfaceCoversEveryGitHubRuleField`
     /// makes adding one a decision somebody states out loud.
     ///
-    /// One line per field, so an anchor written with `.*` cannot straddle two
-    /// unrelated fields and match something nobody meant.
+    /// One line per STRING the rule holds — a field contributes as many lines as
+    /// it has strings — so an anchor written with `.*` cannot straddle two
+    /// unrelated values and match something nobody meant.
     ///
-    /// As on the vendor side, the whole surface is no longer what a proof is
+    /// As on the vendor side, this whole-surface join is no longer what a proof is
     /// matched against: a `.recipeAnchor` names the fields it relies on and is
-    /// checked against each (issue #110). This stays as the union those field
-    /// views are cut from. No `githubProofs` entry is an anchor today — every
-    /// one of them is provable from the resolved URL — so this half exists so
-    /// the first rule that needs an anchor cannot get the weaker any-field
-    /// behaviour by default.
+    /// checked against each, via `channelAnchorSurface(ofField:)` below (issue
+    /// #110). This stays as the union those field views are cut from, and as what
+    /// the tests measure. No `githubProofs` entry is an anchor today — every one
+    /// of them is provable from the resolved URL — so the per-field half below
+    /// exists so that the first rule which does need an anchor cannot silently get
+    /// the weaker any-field behaviour.
     public var channelAnchorSurface: String {
         channelAnchorFields.flatMap(\.lines).joined(separator: "\n")
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -76,14 +76,35 @@ public struct GitHubReleaseRule: Sendable {
     ///
     /// One line per field, so an anchor written with `.*` cannot straddle two
     /// unrelated fields and match something nobody meant.
+    ///
+    /// As on the vendor side, the whole surface is no longer what a proof is
+    /// matched against: a `.recipeAnchor` names the fields it relies on and is
+    /// checked against each (issue #110). This stays as the union those field
+    /// views are cut from. No `githubProofs` entry is an anchor today — every
+    /// one of them is provable from the resolved URL — so this half exists so
+    /// the first rule that needs an anchor cannot get the weaker any-field
+    /// behaviour by default.
     public var channelAnchorSurface: String {
-        Mirror(reflecting: self).children
-            .filter { child in
-                guard let label = child.label else { return false }
-                return !Self.nonAnchorFields.contains(label)
-            }
-            .flatMap { Self.anchorLines(of: $0.value) }
-            .joined(separator: "\n")
+        channelAnchorFields.flatMap(\.lines).joined(separator: "\n")
+    }
+
+    /// The anchorable fields, in declaration order, each with the lines it
+    /// contributes. See `VendorProbeRecipe.channelAnchorFields` for why a proof
+    /// is matched per field rather than against the join.
+    public var channelAnchorFields: [(label: String, lines: [String])] {
+        Mirror(reflecting: self).children.compactMap { child in
+            guard let label = child.label,
+                  !Self.nonAnchorFields.contains(label) else { return nil }
+            return (label, Self.anchorLines(of: child.value))
+        }
+    }
+
+    /// The text one named field contributes, or nil when this rule has no
+    /// ANCHORABLE field by that name. Callers must treat nil as a failure: a
+    /// proof pinned to a field that isn't there is a proof that cannot fail.
+    public func channelAnchorSurface(ofField label: String) -> String? {
+        channelAnchorFields.first { $0.label == label }
+            .map { $0.lines.joined(separator: "\n") }
     }
 
     /// One line per string a value contains, walking into optionals and enum

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -301,14 +301,50 @@ public struct VendorProbeRecipe: Sendable {
     /// `NSRegularExpression`'s default mode, and at least one live anchor spans
     /// a gap with `.*` (`"id":.*"rc"`). Per-field lines keep such a pattern from
     /// straddling two unrelated fields and matching something nobody meant.
+    ///
+    /// The WHOLE surface is no longer what a proof is matched against — a
+    /// `.recipeAnchor` names the fields it relies on and is checked against each
+    /// of them (see `channelAnchorFields` and issue #110). This stays as the
+    /// union those field views are cut from, and as what the tests measure.
     public var channelAnchorSurface: String {
-        Mirror(reflecting: self).children
-            .filter { child in
-                guard let label = child.label else { return false }
-                return !Self.nonAnchorFields.contains(label)
-            }
-            .flatMap { Self.anchorLines(of: $0.value) }
-            .joined(separator: "\n")
+        channelAnchorFields.flatMap(\.lines).joined(separator: "\n")
+    }
+
+    /// The anchorable fields, in declaration order, each with the lines it
+    /// contributes to `channelAnchorSurface`.
+    ///
+    /// Split per field because matching an anchor against the joined surface
+    /// passes if ANY line matches, and a token that appears in two fields makes
+    /// the guard survive either one drifting. WeChat DevTools RC is the live
+    /// case: `"id": "rc"` sits in both `versionPattern` and the install
+    /// `bodyPattern`, and the install half is the one that picks the artifact —
+    /// so if that regex alone were rewritten, the version pattern would keep the
+    /// proof green while the install fell back to whichever channel the vendor's
+    /// `config.json` lists first (Stable). Issue #110.
+    ///
+    /// Still derived by reflection: naming a field in a proof is a claim about
+    /// where the recipe's channel identity lives, but WHICH fields exist is not
+    /// something a hand-written list should get to decide — that is the mistake
+    /// `entryStartPattern` exposed. A proof may name any anchorable field,
+    /// including one added after this was written;
+    /// `everyRegisteredAnchorNamesRealFields` fails loudly on a name that is not
+    /// one, so a typo or a rename cannot turn a proof into a silent no-op.
+    public var channelAnchorFields: [(label: String, lines: [String])] {
+        Mirror(reflecting: self).children.compactMap { child in
+            guard let label = child.label,
+                  !Self.nonAnchorFields.contains(label) else { return nil }
+            return (label, Self.anchorLines(of: child.value))
+        }
+    }
+
+    /// The text one named field contributes, or nil when this recipe has no
+    /// ANCHORABLE field by that name — either no such field at all, or one that
+    /// only labels the recipe (`nonAnchorFields`). Callers must treat nil as a
+    /// failure, never as "nothing to check": a proof pinned to a field that
+    /// isn't there is a proof that cannot fail.
+    public func channelAnchorSurface(ofField label: String) -> String? {
+        channelAnchorFields.first { $0.label == label }
+            .map { $0.lines.joined(separator: "\n") }
     }
 
     /// One line per string a value contains, walking into optionals, arrays,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -353,7 +353,7 @@ public struct VendorProbeRecipe: Sendable {
     /// Not `String(describing:)` on the field, because that renders any string
     /// nested inside something else through its DEBUG description — quotes come
     /// back escaped (`Optional("{\"id\":")`) and an anchor written to match the
-    /// vendor's actual text stops matching. Two of the five anchors registered
+    /// vendor's actual text stops matching. Three of the five anchors registered
     /// today contain quotes or angle brackets, so this is not hypothetical: it
     /// is why the old hand-written surface reached into `install?.urlSource`
     /// with `String(describing:)` and quietly could not have matched a quoted

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -195,13 +195,14 @@ import CryptoKit
 
 /// The concrete gap #81 was filed for: an anchor living in `entryStartPattern`.
 ///
-/// Driven through `crossChannelArtifact` itself, on a REGISTERED proof key
-/// (WeChat DevTools RC, whose proof is `.recipeAnchor("id":.*"rc")`), with the
-/// anchor moved out of `versionPattern` and into `entryStartPattern` — the field
-/// the hand-written surface never learned about. Under that surface this recipe
-/// read as un-anchored and the guard fired on a recipe that is correctly tied to
-/// its channel; the negative case below shows the guard has not simply gone
-/// quiet instead.
+/// Still a live property after #110 made anchors name their fields, and this is
+/// the test that says so: the fields a proof may name are DERIVED, so any field
+/// the recipe reads can be named — including the one the old hand-written
+/// surface never learned about. What changed is that naming it is now required
+/// rather than implied, which is why the proof is built here instead of read out
+/// of the registry (the registered WeChat RC proof names `versionPattern` and
+/// `install`, and correctly refuses a recipe anchored only in a third field).
+/// The negative case shows the guard has not simply gone quiet instead.
 @Test func theAnchorSurfaceSeesEntryStartPattern() {
     func wechatRC(versionPattern: String, entryStartPattern: String?) -> VendorProbeRecipe {
         VendorProbeRecipe(
@@ -215,29 +216,161 @@ import CryptoKit
                 kind: .pkg),
             channel: .rc)
     }
-    // The artifact itself proves nothing here — RC and Stable are served from the
-    // same directory with the same filename template, which is why this proof is
-    // an anchor and not an `.artifact` match in the first place.
+    // No `RemoteVersion` here: the artifact proves nothing for this recipe — RC
+    // and Stable are served from the same directory with the same filename
+    // template, which is why this proof is an anchor and not an `.artifact` match
+    // in the first place — so the anchor match IS the whole check.
+    func anchorFailure(_ recipe: VendorProbeRecipe) -> String? {
+        RecipeSanity.recipeAnchorFailure(
+            pattern: #""id":.*"rc""#, fields: ["entryStartPattern"], subject: "recipe",
+            channel: recipe.channel, of: "VendorProbeRecipe",
+            surface: recipe.channelAnchorSurface(ofField:))
+    }
+
+    // Anchored through `entryStartPattern`, and named there: the guard is satisfied.
+    let anchoredInEntryPattern = wechatRC(
+        versionPattern: #""version":\s*"([0-9]+(?:\.[0-9]+)+)""#,
+        entryStartPattern: #"\{"id":\s*"rc""#)
+    #expect(anchorFailure(anchoredInEntryPattern) == nil,
+            "entryStartPattern must be nameable — a derived field list is the point of #81")
+
+    // …and the guard still fires when the anchor is not in the field that named
+    // it, so the line above is the field being reachable, not the guard going quiet.
+    let unanchored = wechatRC(
+        versionPattern: #""version":\s*"([0-9]+(?:\.[0-9]+)+)""#, entryStartPattern: nil)
+    #expect(anchorFailure(unanchored) != nil,
+            "a recipe with its channel anchor removed must still be complained about")
+}
+
+// MARK: - anchors are checked field by field (issue #110)
+
+/// The failure #110 was filed for: one anchored field covering for another.
+///
+/// WeChat DevTools RC is the live case and the sharpest one — its RC artifact is
+/// byte-for-byte shaped like Stable's (same host, same directory, same filename
+/// template), so this anchor is the ONLY thing between an RC user and a Stable
+/// build. `"id": "rc"` sits in both `versionPattern` and the install
+/// `bodyPattern`; matched against the joined surface, either one alone kept the
+/// proof green.
+///
+/// Driven through `crossChannelArtifact` on the REGISTERED proof, so it is the
+/// shipping registry entry under test and not a hand-built stand-in. Each half is
+/// knocked out in turn: under the old any-field surface both of these passed.
+@Test func eachNamedAnchorFieldIsCheckedOnItsOwn() {
+    func wechatRC(versionPattern: String, installPattern: String) -> VendorProbeRecipe {
+        VendorProbeRecipe(
+            bundleID: "com.tencent.wechatdevtools",
+            url: URL(string: "https://devtools.wxqcloud.qq.com.cn/WechatWebDev/nightly/versions/config.json")!,
+            mode: .responseBody,
+            versionPattern: versionPattern,
+            install: VendorInstallSpec(urlSource: .bodyPattern(installPattern), kind: .pkg),
+            channel: .rc)
+    }
+    let anchoredVersion = #""id":\s*"rc"[\s\S]*?"version":\s*"([0-9]+(?:\.[0-9]+)+)""#
+    let anchoredInstall = #""id":\s*"rc"[\s\S]*?"url":\s*"(https://[^"]+_darwin_arm64\.pkg)""#
+    // The same patterns with the channel block dropped — what "someone rewrites
+    // that regex" or "the vendor renames the block" actually looks like.
+    let driftedVersion = #""version":\s*"([0-9]+(?:\.[0-9]+)+)""#
+    let driftedInstall = #""url":\s*"(https://[^"]+_darwin_arm64\.pkg)""#
+
     let remote = RemoteVersion(
         shortVersion: "1.06.2508260", version: "1.06.2508260",
         downloadURL: URL(string: "https://dldir1.qq.com/WechatWebDev/release/abc123/wechat_devtools_1.06.2508260_darwin_arm64.pkg")!,
         sourceName: "Vendor")
 
-    // Anchored ONLY through `entryStartPattern`: the guard must be satisfied.
-    let anchoredInEntryPattern = wechatRC(
-        versionPattern: #""version":\s*"([0-9]+(?:\.[0-9]+)+)""#,
-        entryStartPattern: #"\{"id":\s*"rc""#)
     #expect(
-        RecipeSanity.crossChannelArtifact(recipe: anchoredInEntryPattern, remote: remote) == nil,
-        "an anchor that lives in entryStartPattern must satisfy .recipeAnchor")
+        RecipeSanity.crossChannelArtifact(
+            recipe: wechatRC(versionPattern: anchoredVersion, installPattern: anchoredInstall),
+            remote: remote) == nil,
+        "the recipe as shipped, anchored in both named fields, must pass")
 
-    // …and the guard still fires when the anchor is nowhere at all, so the line
-    // above is the surface widening, not the guard going quiet.
-    let unanchored = wechatRC(
-        versionPattern: #""version":\s*"([0-9]+(?:\.[0-9]+)+)""#, entryStartPattern: nil)
+    let installDrifted = RecipeSanity.crossChannelArtifact(
+        recipe: wechatRC(versionPattern: anchoredVersion, installPattern: driftedInstall),
+        remote: remote)
+    #expect(installDrifted != nil,
+            "the install spec — the half that PICKS the artifact — lost its channel block, and the version pattern must not cover for it")
+    #expect(installDrifted?.contains("install") == true,
+            "the finding must name the field that drifted, not just the recipe: \(installDrifted ?? "nil")")
+
+    let versionDrifted = RecipeSanity.crossChannelArtifact(
+        recipe: wechatRC(versionPattern: driftedVersion, installPattern: anchoredInstall),
+        remote: remote)
+    #expect(versionDrifted != nil,
+            "the version pattern lost its channel block, and the install spec must not cover for it")
+    #expect(versionDrifted?.contains("versionPattern") == true,
+            "the finding must name the field that drifted: \(versionDrifted ?? "nil")")
+}
+
+/// The two ways a field-scoped anchor could be written so that it can never fail
+/// — the outcome worse than having no proof, because it reads as green forever.
+///
+/// Neither is reachable from the registry today (`everyRegisteredAnchorNamesRealFields`
+/// is what holds that line in a PR); this pins the runtime half, for a proof
+/// written after that test was read.
+@Test func anAnchorThatCannotFailIsItselfAFinding() {
+    let recipe = VendorProbeRegistry.recipes.first {
+        $0.bundleID == "com.tencent.wechatdevtools" && $0.channel == .rc
+    }
+    let subject = try! #require(recipe)
+
     #expect(
-        RecipeSanity.crossChannelArtifact(recipe: unanchored, remote: remote) != nil,
-        "a recipe with its channel anchor removed must still be complained about")
+        RecipeSanity.recipeAnchorFailure(
+            pattern: #""id":.*"rc""#, fields: [], subject: "recipe",
+            channel: .rc, of: "VendorProbeRecipe",
+            surface: subject.channelAnchorSurface(ofField:)) != nil,
+        "an anchor naming no field matches vacuously and must be reported")
+
+    #expect(
+        RecipeSanity.recipeAnchorFailure(
+            pattern: #""id":.*"rc""#, fields: ["versionPatern"], subject: "recipe",
+            channel: .rc, of: "VendorProbeRecipe",
+            surface: subject.channelAnchorSurface(ofField:)) != nil,
+        "a typo'd field name has nothing to match against and must be reported, not skipped")
+
+    // A field that exists but only LABELS the recipe is refused for the same
+    // reason `nonAnchorFields` exists: `channel` literally contains "rc".
+    #expect(
+        RecipeSanity.recipeAnchorFailure(
+            pattern: #"rc"#, fields: ["channel"], subject: "recipe",
+            channel: .rc, of: "VendorProbeRecipe",
+            surface: subject.channelAnchorSurface(ofField:)) != nil,
+        "naming a labelling field must be refused, not answered with a tautology")
+}
+
+/// Every registered anchor names at least one field, and every name is a real
+/// anchorable field of the recipe or rule it is registered against.
+///
+/// This is what keeps the field names from being magic strings: a rename, a typo,
+/// or an anchor pinned to a labelling field turns the proof into something that
+/// cannot fail, and that is exactly the silent-no-op shape this file keeps being
+/// bitten by. Covers BOTH registries, so the GitHub side cannot acquire the
+/// weaker behaviour by being written later.
+@Test func everyRegisteredAnchorNamesRealFields() {
+    let recipesByKey = Dictionary(
+        VendorProbeRegistry.recipes.map { (ChannelProofKey($0.bundleID, $0.channel), $0) },
+        uniquingKeysWith: { a, _ in a })
+    for (key, proof) in ChannelProofRegistry.proofs {
+        guard case .recipeAnchor(let pattern, let fields) = proof else { continue }
+        #expect(!fields.isEmpty, "\(key): the anchor /\(pattern)/ names no field, so it cannot fail")
+        guard let recipe = recipesByKey[key] else { continue }
+        for label in fields {
+            #expect(recipe.channelAnchorSurface(ofField: label) != nil,
+                    "\(key): the anchor names '\(label)', which is not an anchorable field of VendorProbeRecipe")
+        }
+    }
+
+    let rulesByKey = Dictionary(
+        GitHubReleaseRegistry.rules.map { (ChannelProofKey($0.bundleID, $0.channel), $0) },
+        uniquingKeysWith: { a, _ in a })
+    for (key, proof) in ChannelProofRegistry.githubProofs {
+        guard case .recipeAnchor(let pattern, let fields) = proof else { continue }
+        #expect(!fields.isEmpty, "\(key): the anchor /\(pattern)/ names no field, so it cannot fail")
+        guard let rule = rulesByKey[key] else { continue }
+        for label in fields {
+            #expect(rule.channelAnchorSurface(ofField: label) != nil,
+                    "\(key): the anchor names '\(label)', which is not an anchorable field of GitHubReleaseRule")
+        }
+    }
 }
 
 /// An anchor that contains quotes must match wherever in the recipe it lives.
@@ -279,7 +412,7 @@ import CryptoKit
         VendorProbeRegistry.recipes.map { (ChannelProofKey($0.bundleID, $0.channel), $0) },
         uniquingKeysWith: { a, _ in a })
     for (key, proof) in ChannelProofRegistry.proofs {
-        guard case .recipeAnchor(let pattern) = proof else { continue }
+        guard case .recipeAnchor(let pattern, _) = proof else { continue }
         guard let recipe = byKey[key] else { continue }
         let labellingOnly = Mirror(reflecting: recipe).children
             .filter { $0.label.map(VendorProbeRecipe.nonAnchorFields.contains) ?? false }
@@ -302,14 +435,19 @@ import CryptoKit
         VendorProbeRegistry.recipes.map { (ChannelProofKey($0.bundleID, $0.channel), $0) },
         uniquingKeysWith: { a, _ in a })
     for (key, proof) in ChannelProofRegistry.proofs {
-        guard case .recipeAnchor(let pattern) = proof else { continue }
+        guard case .recipeAnchor(let pattern, let fields) = proof else { continue }
         let recipe = byKey[key]
         #expect(recipe != nil, "\(key) has a .recipeAnchor proof but no recipe")
         guard let recipe else { continue }
-        #expect(
-            recipe.channelAnchorSurface.range(
-                of: pattern, options: [.regularExpression, .caseInsensitive]) != nil,
-            "\(key): nothing in the recipe matches its anchor /\(pattern)/ any more")
+        // Per named field, not against the join: a proof that names two fields is
+        // asserting the token is in BOTH, and this is where that is checked
+        // offline (issue #110).
+        for label in fields.sorted() {
+            #expect(
+                recipe.channelAnchorSurface(ofField: label)?.range(
+                    of: pattern, options: [.regularExpression, .caseInsensitive]) != nil,
+                "\(key): the recipe's \(label) no longer matches its anchor /\(pattern)/")
+        }
     }
 }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -222,9 +222,8 @@ import CryptoKit
     // in the first place — so the anchor match IS the whole check.
     func anchorFailure(_ recipe: VendorProbeRecipe) -> String? {
         RecipeSanity.recipeAnchorFailure(
-            pattern: #""id":.*"rc""#, fields: ["entryStartPattern"], subject: "recipe",
-            channel: recipe.channel, of: "VendorProbeRecipe",
-            surface: recipe.channelAnchorSurface(ofField:))
+            pattern: #""id":.*"rc""#, fields: ["entryStartPattern"],
+            channel: recipe.channel, subject: recipe)
     }
 
     // Anchored through `entryStartPattern`, and named there: the guard is satisfied.
@@ -236,10 +235,47 @@ import CryptoKit
 
     // …and the guard still fires when the anchor is not in the field that named
     // it, so the line above is the field being reachable, not the guard going quiet.
-    let unanchored = wechatRC(
+    //
+    // `entryStartPattern` is PRESENT here and merely lost its token, rather than
+    // being nil. A nil field's surface is the literal string "nil", which fails to
+    // match for a different reason than a real field that drifted — so testing
+    // only the nil case would not distinguish "the field is checked" from "the
+    // field does not exist", and would pass either way.
+    let driftedInEntryPattern = wechatRC(
+        versionPattern: #""version":\s*"([0-9]+(?:\.[0-9]+)+)""#,
+        entryStartPattern: #"\{"date":""#)
+    #expect(anchorFailure(driftedInEntryPattern) != nil,
+            "a named field that still exists but lost its channel token must be complained about")
+
+    let absentEntryPattern = wechatRC(
         versionPattern: #""version":\s*"([0-9]+(?:\.[0-9]+)+)""#, entryStartPattern: nil)
-    #expect(anchorFailure(unanchored) != nil,
+    #expect(anchorFailure(absentEntryPattern) != nil,
             "a recipe with its channel anchor removed must still be complained about")
+}
+
+/// A `.recipeAnchor` whose PATTERN matches anything is the third way to write a
+/// proof that cannot fail, and the one neither `everyRegisteredAnchorNamesRealFields`
+/// nor the field-scoping closes: `""`, `a?` and `.*` all match every surface, in
+/// every field, forever.
+///
+/// Checked against the empty string, which is the cheapest total discriminator —
+/// a pattern that matches `""` matches every field of every recipe, so it can
+/// never report drift. Covers BOTH registries; the GitHub side has no anchors
+/// today and this is what stops the first one from being written that way.
+@Test func noRegisteredAnchorMatchesEverything() {
+    func vacuous(_ pattern: String) -> Bool {
+        "".range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+    for (key, proof) in ChannelProofRegistry.proofs {
+        guard case .recipeAnchor(let pattern, _) = proof else { continue }
+        #expect(!vacuous(pattern),
+                "\(key): the anchor /\(pattern)/ matches the empty string, so it matches every field of every recipe and can never report drift")
+    }
+    for (key, proof) in ChannelProofRegistry.githubProofs {
+        guard case .recipeAnchor(let pattern, _) = proof else { continue }
+        #expect(!vacuous(pattern),
+                "\(key): the anchor /\(pattern)/ matches the empty string, so it can never report drift")
+    }
 }
 
 // MARK: - anchors are checked field by field (issue #110)
@@ -315,25 +351,22 @@ import CryptoKit
 
     #expect(
         RecipeSanity.recipeAnchorFailure(
-            pattern: #""id":.*"rc""#, fields: [], subject: "recipe",
-            channel: .rc, of: "VendorProbeRecipe",
-            surface: subject.channelAnchorSurface(ofField:)) != nil,
+            pattern: #""id":.*"rc""#, fields: [],
+            channel: .rc, subject: subject) != nil,
         "an anchor naming no field matches vacuously and must be reported")
 
     #expect(
         RecipeSanity.recipeAnchorFailure(
-            pattern: #""id":.*"rc""#, fields: ["versionPatern"], subject: "recipe",
-            channel: .rc, of: "VendorProbeRecipe",
-            surface: subject.channelAnchorSurface(ofField:)) != nil,
+            pattern: #""id":.*"rc""#, fields: ["versionPatern"],
+            channel: .rc, subject: subject) != nil,
         "a typo'd field name has nothing to match against and must be reported, not skipped")
 
     // A field that exists but only LABELS the recipe is refused for the same
     // reason `nonAnchorFields` exists: `channel` literally contains "rc".
     #expect(
         RecipeSanity.recipeAnchorFailure(
-            pattern: #"rc"#, fields: ["channel"], subject: "recipe",
-            channel: .rc, of: "VendorProbeRecipe",
-            surface: subject.channelAnchorSurface(ofField:)) != nil,
+            pattern: #"rc"#, fields: ["channel"],
+            channel: .rc, subject: subject) != nil,
         "naming a labelling field must be refused, not answered with a tautology")
 }
 
@@ -365,6 +398,7 @@ import CryptoKit
     for (key, proof) in ChannelProofRegistry.githubProofs {
         guard case .recipeAnchor(let pattern, let fields) = proof else { continue }
         #expect(!fields.isEmpty, "\(key): the anchor /\(pattern)/ names no field, so it cannot fail")
+        #expect(rulesByKey[key] != nil, "\(key) has a .recipeAnchor proof but no rule")
         guard let rule = rulesByKey[key] else { continue }
         for label in fields {
             #expect(rule.channelAnchorSurface(ofField: label) != nil,

--- a/docs/app-audits/com-tencent-wechatdevtools.md
+++ b/docs/app-audits/com-tencent-wechatdevtools.md
@@ -116,7 +116,7 @@ https://devtools.wxqcloud.qq.com.cn/WechatWebDev/nightly/versions/
 | `Models/ReleaseChannel.swift` | 新增 `.rc`；刻意不进 `nonStable`/`channelWord`（"rc" 太短，泛匹配会误伤） |
 | `Scan/AppScanner.swift` | `weChatDevToolsIdentity` 读 `package.json` → 真版本 + 渠道；bundle id 改写为 `com.tencent.wechatdevtools` |
 | `Sources/VendorProbeRecipe.swift` | 三条 recipe，同一个 `config.json`，各自锚 `"id"`，一键 arm64 pkg |
-| `Sources/ChannelArtifactProof.swift` | nightly = artifact 证明；rc = recipeAnchor（rc 的包和 stable 同目录同命名，URL 证不了） |
+| `Sources/ChannelArtifactProof.swift` | nightly = artifact 证明；rc = recipeAnchor（rc 的包和 stable 同目录同命名，URL 证不了）。**2026-08-28 (#110)**：该 anchor 现在显式限定字段 `in: ["versionPattern", "install"]`，两个字段都必须匹配才算通过——`"id": "rc"` 在这两处都出现过，而旧的"任一字段命中即通过"意味着只改坏 install 那半边（真正挑包的那半边）时 versionPattern 会替它兜住，proof 照样绿。改 recipe 时两处要一起改，只改一处会在 PR 里红。 |
 | `Sources/ChangelogRecipe.swift` + `StructuredChangelogDecoder.swift` | 新增 `.weChatDevToolsLog`，version-templated 到 `logs/<channel>_v<version>.json` |
 | `CLI/Sources/DuoKit/Verify.swift` | changelog sweep 的版本按 (bundleID, channel) 取，不再按 bundleID 一把抓 |
 | `application-test/.../channel-verify` | 支持 `.pkg` 输入；镜像 scanner 的身份改写 |


### PR DESCRIPTION
Closes #110.

## The defect, as measured

`.recipeAnchor` was matched against `channelAnchorSurface` — every anchorable field joined one per line — and passed if **any** line matched.

WeChat DevTools `.rc` is proven by an anchor rather than by its artifact because its RC build is byte-for-byte shaped like Stable's (same host, same directory, same filename template). That anchor is the only thing between an RC user and a Stable build. `"id": "rc"` appears in **both** `versionPattern` and the install `bodyPattern`, so rewriting the install regex left the version pattern satisfying the anchor while the install fell back to whichever channel `config.json` lists first. Which is Stable.

## Where this differs from the issue as filed

The issue proposed checking "an anchor whose job is to prove the install spec against the install spec". I measured all five registered anchors before implementing, and that rule cannot be applied uniformly:

| proof | pattern | fields that actually carry it |
|---|---|---|
| `com.jetbrains.intellij-EAP` `.preview` | `type=eap` | **`url` only** |
| `com.runningwithcrayons.Alfred` `.beta` | `prerelease\.xml` | **`url` only** |
| `com.tencent.wechatdevtools` `.rc` | `"id":.*"rc"` | `versionPattern` + `install` |
| `dev.kdrag0n.MacVirt` `.beta` / `.canary` | `<sparkle:channel>…` | `versionPattern` + `install` |

IntelliJ EAP and Alfred beta have **no channel token in their install spec at all** — their endpoints return only that channel's builds, so their *install* patterns are byte-identical to their stable siblings' and neither their install nor their version pattern names a channel. Requiring an install-spec anchor would have failed the two recipes that are correctly built.

(Corrected after review: an earlier revision of this description said the *version* patterns were byte-identical too. They are not — IntelliJ EAP reads `"build"` where stable reads `"version"`, deliberately, because `versionIsBuild` compares the build; Alfred beta's differs in strictness. Neither difference names a channel, which is the property the scope actually rests on.)

So the shape here is: **the proof names the fields its channel identity lives in, and the regex must match in every one of them.** Endpoint-keyed recipes name `["url"]`; shared-feed recipes name `["versionPattern", "install"]`.

## Also closed

Both degenerate anchors are now findings rather than passes — an empty field set, and a name that is not an anchorable field (typo, rename, or one of the labelling `nonAnchorFields`). Each would be a proof that cannot fail for any input, which reads as green forever. `everyRegisteredAnchorNamesRealFields` catches them in a PR; `recipeAnchorFailure` catches them at runtime.

Both `crossChannelArtifact` overloads share one matcher, so the two registries cannot drift into different notions of what an anchor asserts.

The fields remain **derived by reflection** — a proof may name any field the recipe reads, including one added after this lands. That keeps the `entryStartPattern` property from #81, which now has its own test saying so explicitly.

## Verification

`swift test` — DuoUpdaterCore:
```
Test run with 1317 tests in 103 suites passed after 46.233 seconds with 1 known issue.
```
(the known issue is the pre-existing `GitHubReleaseRuleTests` xfail)

`swift test --package-path CLI`:
```
Test run with 161 tests in 22 suites passed after 0.075 seconds.
```

Live endpoints, with a `duo` built from **this branch** (the installed binary carries the old registry):
```
wechatdevtools       total  ✓ 6  ⚠ 0  ✗ 0
intellij-EAP         total  ✓ 1  ⚠ 0  ✗ 0
Alfred               total  ✓ 2  ⚠ 0  ✗ 0
MacVirt              total  ✓ 4  ⚠ 0  ✗ 0
```

### Red first, then the counterfactual

A green sweep proves nothing on its own, so I drifted the WeChat RC install pattern — dropped its `"id": "rc"` block, left `versionPattern` intact — and ran the live sweep on **this branch**:

```
⚠ WARN  vendor:com.tencent.wechatdevtools:rc
    warning   the recipe's install is no longer anchored on /"id":.*"rc"/ — nothing there ties its rc install to that channel
```

Then applied the **same drift to `main`'s code** and ran the same sweep:

```
vendor probe  ✓ 3  ⚠ 0  ✗ 0  ~ 0  - 0
```

Silent. That is the defect, reproduced end to end and then closed.

No recipe content changed — `git diff main -- VendorProbeRecipe.swift` touches only the anchor-surface block.


---

## Review round 2

An adversarial review of the first pass found a defect in the comments this PR itself added, plus three gaps. All fixed in `6be9…`:

- **DEFECT — the "byte-identical" claim was false**, in three comments and in this description. Measured: IntelliJ EAP `"build"` vs stable `"version"`; Alfred beta `([0-9]+(?:\.[0-9]+)+)` vs stable `([0-9][0-9.]*)`. The conclusion held, the evidence did not. Narrowed to "neither pattern names a channel", which is what is true and what the scope rests on. In a repo where comments are specification this is a defect, not a nit — the next reader trusts "byte-identical" and normalises the two IntelliJ recipes.
- **A third degenerate anchor was still a silent pass.** The description claimed "both" were closed; there are three. A *pattern* matching any text (`""`, `a?`, `.*`) satisfies every field of every recipe forever. `noRegisteredAnchorMatchesEverything` now tests both registries against the empty string. Verified red-first — swapping IntelliJ's anchor to `.*` fails it with the right message.
- **`recipeAnchorFailure` took three hand-paired strings** (`subject`, type name, surface closure) that had to agree, in the function whose stated purpose is preventing exactly that drift. Replaced with a `ChannelAnchorSubject` protocol, so the type supplies all three.
- **Granularity limit now stated:** `install` is anchored as a whole field, so #110's shape survives inside a `.bodyTemplate`'s `fields`. Not reachable today (no anchored recipe uses `bodyTemplate`); documented rather than left to be rediscovered.
- The `entryStartPattern` negative case now drifts a **present** field rather than only nilling it — a nil field's surface is the string `"nil"`, so the old form would have passed whether or not the field was checked. The GitHub half of the field-name check no longer skips silently when a proof has no rule.
- `docs/app-audits/com-tencent-wechatdevtools.md` records the RC proof's new field scope.

Re-verified after the fixes: `swift test` 1318 passing (DuoUpdaterCore) + 161 (CLI), and the four anchored recipes green against live endpoints.
