### PR TITLE
fix(core): register channel proofs for the appcast binding population (#111)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -322,12 +322,24 @@ public enum ChannelProofRegistry {
     /// says nothing about which population it came from, so one map would
     /// silently collide the day a bundle id appears in two of them on the same
     /// channel — and the exhaustiveness test would pass while proving the wrong
-    /// thing. `channelProofMapsDoNotCollide` measures that rather than assuming it.
+    /// thing. `channelProofMapsDoNotCollide` measures that for the two recipe
+    /// registries; `bindingProofsDoNotCollideWithTheOtherRegistries` extends it to
+    /// this one, comparing POPULATIONS and not merely the keys somebody happened
+    /// to register — a bundle id that two populations could both serve is the
+    /// ambiguity, whether or not both entries exist yet.
     ///
     /// Every entry is a `.recipeAnchor`, and none of them could honestly be an
-    /// `.artifact`: for all four of these vendors, stable and beta are the same
-    /// filename from the same host, so there is no token in the response to
-    /// anchor on. The channel signal lives entirely in the REQUEST. That is not a
+    /// `.artifact`: none of these vendors puts a CHANNEL TOKEN anywhere in the
+    /// artifact, so there is nothing in the response to anchor on. The channel
+    /// signal lives entirely in the REQUEST.
+    ///
+    /// Not "the same filename from the same host" — that is a stronger claim than
+    /// the measurement supports and it is false for three of the four. Fork serves
+    /// `Fork-2.66.7.dmg` against `Fork-2.69.0.dmg`, Surge puts a per-build hash in
+    /// the name, and only TablePlus reuses one filename (`TablePlus.dmg`, under
+    /// different build-numbered paths). The filenames DIFFER; what none of them
+    /// carries is a token that says which train the build came from — a version
+    /// or a hash is not a channel. That is not a
     /// weaker proof than the recipe population gets — Alfred's registered anchor
     /// is `prerelease\.xml` in its endpoint, which is the same assertion about
     /// the same kind of evidence.
@@ -359,8 +371,29 @@ public enum ChannelProofRegistry {
         // `1`/`yes` as stable (`TablePlusChannel`). So the anchor covers the value,
         // not just the field name, which is why `ResolvedChannel.anchorLines`
         // renders a header as one `key: value` line instead of two.
+        //
+        // Right-anchored, because without the `$` it also accepted `trueX` — a
+        // value this comment's own model of the server says would be treated as
+        // stable. Case is NOT pinned: the shared matcher runs case-insensitively
+        // for every proof, so this asserts the token and its boundary, not the
+        // letter case.
+        // BetterDisplay declares its own tag names because its feed spells them
+        // `pre`/`internal` and no `ReleaseChannel` case does. Anchored on the tag
+        // the resolution actually carries: retype `preTag` and this fails, where
+        // `allowedChannels` would silently build a set matching nothing and drop
+        // the user to stable.
+        //
+        // NOT `^pre$`. `sparkleChannelNames` is a Set rendered one element per
+        // line, and `.unstable` carries two, so `^`/`$` — which match the whole
+        // string in `NSRegularExpression`'s default mode, not each line — would
+        // fail on the two-tag resolution depending on Set order. `\b` bounds the
+        // token without depending on how many tags sit beside it.
+        ChannelProofKey("pro.betterdisplay.BetterDisplay", .beta):
+            .recipeAnchor(#"\bpre\b"#, in: ["sparkleChannelNames"]),
+        ChannelProofKey("pro.betterdisplay.BetterDisplay", .unstable):
+            .recipeAnchor(#"\binternal\b"#, in: ["sparkleChannelNames"]),
         ChannelProofKey("com.tinyapp.tableplus", .beta):
-            .recipeAnchor(#"X-Tiny-Beta-Update:\s*true"#, in: ["feedHTTPHeaders"]),
+            .recipeAnchor(#"X-Tiny-Beta-Update:\s*true\s*$"#, in: ["feedHTTPHeaders"]),
     ]
 
     /// The channel bindings whose non-stable resolution needs a proof (issue #111).
@@ -379,20 +412,31 @@ public enum ChannelProofRegistry {
     ///     have bindings, but the binding only picks which `VendorProbeRecipe`
     ///     runs; the install comes from that recipe and `proofs` already covers it.
     ///     Counting them here would register a second proof for the same artifact.
-    ///  3. **Request-keyed only** — `feedOverride` or `feedHTTPHeaders`. This is
-    ///     the real discriminator. A channel-TAG binding (DuoPaste, BetterDisplay)
-    ///     is already protected structurally: `SparkleAppcastSource.allowedChannels`
-    ///     narrows the feed to the `<sparkle:channel>` values the user opted into,
-    ///     in code that runs for every such app whether or not anyone remembered
-    ///     to register anything — a stronger guarantee than a hand-written regex,
-    ///     and one that would be a literal no-op to restate here.
+    ///  3. **The channel choice is ours to get wrong** — the resolution carries a
+    ///     `feedOverride`, `feedHTTPHeaders`, or hand-declared `sparkleChannelNames`.
     ///
-    /// What is left is exactly the population where the channel signal lives in
-    /// the REQUEST and nothing in the response corroborates it: the feed-swap and
-    /// header-keyed apps. TablePlus is the sharpest — stable and beta come from
-    /// the same host with the same filename, differing only in build number, so
-    /// if the vendor retires `X-Tiny-Beta-Update` a beta user is served the stable
-    /// dmg and every gate we have passes.
+    /// That third predicate is the real discriminator, and it deliberately covers
+    /// two shapes rather than one:
+    ///
+    ///   * **Request-keyed** (Fork, Surge, IINA, TablePlus) — the channel signal
+    ///     is which URL we fetched or which header we sent, and nothing in the
+    ///     response corroborates it. TablePlus is the sharpest: retire
+    ///     `X-Tiny-Beta-Update` and a beta user is served the stable dmg, past
+    ///     every gate we have.
+    ///   * **Hand-declared tags** (BetterDisplay) — `SparkleAppcastSource` filters
+    ///     the feed by `<sparkle:channel>`, but the TAG NAMES come from a per-app
+    ///     constant (`BetterDisplayChannel.preTag`/`internalTag`), because its feed
+    ///     spells them `pre`/`internal` and no `ReleaseChannel` case does. Retype
+    ///     one and `allowedChannels` builds a set matching NOTHING in the feed, so
+    ///     the user matches only untagged items and is silently offered STABLE —
+    ///     the failure `ResolvedChannel.sparkleChannelNames`' own doc warns about.
+    ///     `allowedChannels` cannot validate a name it is handed; an anchor can.
+    ///
+    /// What predicate 3 EXCLUDES is the binding whose tag is derived rather than
+    /// declared: DuoPaste's comes from `ReleaseChannel.rawValue` in shared code,
+    /// so there is no per-app constant to mistype and an entry here would be a
+    /// literal no-op. That is the distinction — not "channel-tag apps are safe",
+    /// which is false, but "a tag nobody hand-wrote has nothing to drift."
     public static var channelBindingsNeedingProof: [ChannelProofKey] {
         ChannelBinding.allResolutions
             .filter { entry in
@@ -400,9 +444,18 @@ public enum ChannelProofRegistry {
                     && !ChannelBinding.vendorProbeBackedBindings
                         .contains(entry.bundleID.lowercased())
                     && (entry.resolved.feedOverride != nil
-                        || !entry.resolved.feedHTTPHeaders.isEmpty)
+                        || !entry.resolved.feedHTTPHeaders.isEmpty
+                        || !entry.resolved.sparkleChannelNames.isEmpty)
             }
             .map { ChannelProofKey($0.bundleID, $0.resolved.channel) }
+            // A binding can produce one resolution from several preference
+            // combinations — BetterDisplay's `internal` toggle subsumes `pre`, so
+            // two of its four reach the same `(bundleID, channel)`. Deduplicated
+            // so the population is a set of keys and not a count of ways to get
+            // there.
+            .reduce(into: [ChannelProofKey]()) { out, key in
+                if !out.contains(key) { out.append(key) }
+            }
     }
 
     /// Pre-release tokens that must never appear in a STABLE recipe's installer
@@ -553,25 +606,42 @@ extension RecipeSanity {
     /// The same check for a `ChannelBinding` resolution (issue #111).
     ///
     /// Deliberately NOT an overload of `crossChannelArtifact`, and not given a
-    /// `RemoteVersion`: there is no artifact to inspect. For every binding in this
-    /// population stable and non-stable resolve the same filename from the same
-    /// host, so a URL check would be the vacuous kind of proof this file exists to
-    /// refuse. What is checked is the request the resolution will make.
+    /// `RemoteVersion`: there is no artifact to inspect. No binding in this
+    /// population resolves an artifact that names its channel — the filenames
+    /// differ, but by version or by build hash, never by train — so a URL check
+    /// would be the vacuous kind of proof this file exists to refuse. What is
+    /// checked is the request the resolution will make.
     ///
     /// Stable resolutions return nil rather than being checked against
-    /// `preReleaseTokens` the way a stable recipe is. That is measured, not lazy:
-    /// two of these four bindings' STABLE feeds would trip a bare token match —
-    /// Surge's `appcast-signed.xml` sits beside `appcast-signed-beta.xml` on the
-    /// same path, and a token scan over a feed URL says nothing about which train
-    /// the server answers with. The stable direction here is protected by the
-    /// resolver returning the stable feed when the preference is unreadable, which
-    /// `everyBindingProofFailsOnItsOwnStableSibling` pins from the other side.
+    /// `preReleaseTokens` the way a stable recipe is, and the honest reason is
+    /// that the check would not mean anything here, NOT that these URLs would
+    /// trip it. (Measured 2026-08-28: none of the four stable feeds contains a
+    /// pre-release token — `feed-stable.xml`, `appcast.xml`, `appcast-signed.xml`,
+    /// and TablePlus has no feed override at all. An earlier revision of this
+    /// comment claimed two of them did; that was wrong.) The reason to skip it is
+    /// that a token scan over a REQUEST says nothing about which train the server
+    /// answers with — Surge's stable and beta feeds differ by a filename we chose
+    /// to fetch, not by anything the vendor asserts. The stable direction is
+    /// protected by each resolver falling back to its stable feed when the
+    /// preference is unreadable, and `everyBindingProofFailsOnItsOwnStableSibling`
+    /// pins it from the other side.
     public static func crossChannelBinding(
         binding: ResolvedChannel, bundleID: String
     ) -> String? {
         guard binding.channel != .stable else { return nil }
         let key = ChannelProofKey(bundleID, binding.channel)
-        guard let proof = ChannelProofRegistry.bindingProofs[key] else {
+        // Matched case-insensitively on the bundle id, like `ChannelBinding.resolve`
+        // and for the same reason it documents: a `CFBundleIdentifier` is
+        // case-insensitive and TablePlus ships `com.tinyapp.TablePlus` while its
+        // prefs (and this registry) use the lower-cased spelling. A case-sensitive
+        // lookup here would tell the first caller that passes a real
+        // `InstalledApp.bundleID` that its sharpest-case proof is unregistered.
+        let proofEntry = ChannelProofRegistry.bindingProofs[key]
+            ?? ChannelProofRegistry.bindingProofs.first {
+                $0.key.bundleID.lowercased() == bundleID.lowercased()
+                    && $0.key.channel == binding.channel
+            }?.value
+        guard let proof = proofEntry else {
             return "no channel proof registered for \(key) — nothing checks that its "
                 + "appcast request is the one that serves its own channel"
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -315,6 +315,96 @@ public enum ChannelProofRegistry {
             .map { ChannelProofKey($0.bundleID, $0.channel) }
     }
 
+    /// Proof of channel identity for the binding population (issue #111).
+    ///
+    /// A third map rather than entries in `proofs`, for exactly the reason
+    /// `githubProofs` is a third: `ChannelProofKey` is `(bundleID, channel)` and
+    /// says nothing about which population it came from, so one map would
+    /// silently collide the day a bundle id appears in two of them on the same
+    /// channel — and the exhaustiveness test would pass while proving the wrong
+    /// thing. `channelProofMapsDoNotCollide` measures that rather than assuming it.
+    ///
+    /// Every entry is a `.recipeAnchor`, and none of them could honestly be an
+    /// `.artifact`: for all four of these vendors, stable and beta are the same
+    /// filename from the same host, so there is no token in the response to
+    /// anchor on. The channel signal lives entirely in the REQUEST. That is not a
+    /// weaker proof than the recipe population gets — Alfred's registered anchor
+    /// is `prerelease\.xml` in its endpoint, which is the same assertion about
+    /// the same kind of evidence.
+    ///
+    /// What these DO buy, and what they do not: an anchor here fails in a PR when
+    /// the discriminator is edited away, which is the drift that would otherwise
+    /// be silent. It cannot notice a vendor retiring the discriminator on their
+    /// side — nothing in the response would change shape. `duo verify` does not
+    /// sweep this population (it sweeps recipes and rules), so enforcement is
+    /// build-time only. Said plainly because the opposite impression is exactly
+    /// the "green check nobody should trust" issue #111 warned about.
+    public static let bindingProofs: [ChannelProofKey: ChannelArtifactProof] = [
+        // Fork ships two entirely separate feed documents. Note which is which:
+        // the BETA train is the unsuffixed `feed.xml` (also the code-signed
+        // `SUFeedURL`, and the shipped default), and stable is the one that had to
+        // be given a suffix. So the anchor is the absence of that suffix, and it
+        // discriminates precisely because `feed-stable.xml` does not contain the
+        // literal `feed.xml`.
+        ChannelProofKey("com.DanPristupov.Fork", .beta):
+            .recipeAnchor(#"/update/feed\.xml"#, in: ["feedOverride"]),
+        ChannelProofKey("com.nssurge.surge-mac", .beta):
+            .recipeAnchor(#"appcast-signed-beta\.xml"#, in: ["feedOverride"]),
+        ChannelProofKey("com.colliderli.iina", .beta):
+            .recipeAnchor(#"appcast-beta\.xml"#, in: ["feedOverride"]),
+        // TablePlus is the sharpest case in the population and the only
+        // header-keyed one. Stable and beta share ONE feed URL; the server decides
+        // which builds to return from a request header, and the VALUE is
+        // load-bearing — the app sends the literal `true` and the server treats
+        // `1`/`yes` as stable (`TablePlusChannel`). So the anchor covers the value,
+        // not just the field name, which is why `ResolvedChannel.anchorLines`
+        // renders a header as one `key: value` line instead of two.
+        ChannelProofKey("com.tinyapp.tableplus", .beta):
+            .recipeAnchor(#"X-Tiny-Beta-Update:\s*true"#, in: ["feedHTTPHeaders"]),
+    ]
+
+    /// The channel bindings whose non-stable resolution needs a proof (issue #111).
+    ///
+    /// The third install-carrying population. `ChannelBinding` + `SparkleAppcastSource`
+    /// reaches an install without passing through either registry above, so neither
+    /// `channelRecipesWithInstall` nor `channelGitHubRulesWithInstall` can see it.
+    ///
+    /// Three predicates, each excluding a group for a DIFFERENT reason — which is
+    /// the point, because issue #111's own warning was that a proof table half
+    /// full of no-ops is worse than none:
+    ///
+    ///  1. **Non-stable only**, as everywhere else: a stable resolution has no
+    ///     other channel to cross into.
+    ///  2. **Not backed by a vendor probe.** OrbStack, Alfred, Tailscale and CapCut
+    ///     have bindings, but the binding only picks which `VendorProbeRecipe`
+    ///     runs; the install comes from that recipe and `proofs` already covers it.
+    ///     Counting them here would register a second proof for the same artifact.
+    ///  3. **Request-keyed only** — `feedOverride` or `feedHTTPHeaders`. This is
+    ///     the real discriminator. A channel-TAG binding (DuoPaste, BetterDisplay)
+    ///     is already protected structurally: `SparkleAppcastSource.allowedChannels`
+    ///     narrows the feed to the `<sparkle:channel>` values the user opted into,
+    ///     in code that runs for every such app whether or not anyone remembered
+    ///     to register anything — a stronger guarantee than a hand-written regex,
+    ///     and one that would be a literal no-op to restate here.
+    ///
+    /// What is left is exactly the population where the channel signal lives in
+    /// the REQUEST and nothing in the response corroborates it: the feed-swap and
+    /// header-keyed apps. TablePlus is the sharpest — stable and beta come from
+    /// the same host with the same filename, differing only in build number, so
+    /// if the vendor retires `X-Tiny-Beta-Update` a beta user is served the stable
+    /// dmg and every gate we have passes.
+    public static var channelBindingsNeedingProof: [ChannelProofKey] {
+        ChannelBinding.allResolutions
+            .filter { entry in
+                entry.resolved.channel != .stable
+                    && !ChannelBinding.vendorProbeBackedBindings
+                        .contains(entry.bundleID.lowercased())
+                    && (entry.resolved.feedOverride != nil
+                        || !entry.resolved.feedHTTPHeaders.isEmpty)
+            }
+            .map { ChannelProofKey($0.bundleID, $0.resolved.channel) }
+    }
+
     /// Pre-release tokens that must never appear in a STABLE recipe's installer
     /// URL — the mirror of the same failure, and the worse direction: pushing a
     /// nightly onto someone who chose stable.
@@ -354,6 +444,11 @@ extension VendorProbeRecipe: ChannelAnchorSubject {
 extension GitHubReleaseRule: ChannelAnchorSubject {
     static var anchorSubjectName: String { "rule" }
     static var anchorTypeName: String { "GitHubReleaseRule" }
+}
+
+extension ResolvedChannel: ChannelAnchorSubject {
+    static var anchorSubjectName: String { "binding" }
+    static var anchorTypeName: String { "ResolvedChannel" }
 }
 
 extension RecipeSanity {
@@ -452,6 +547,42 @@ extension RecipeSanity {
         case .recipeAnchor(let pattern, let fields):
             return recipeAnchorFailure(
                 pattern: pattern, fields: fields, channel: rule.channel, subject: rule)
+        }
+    }
+
+    /// The same check for a `ChannelBinding` resolution (issue #111).
+    ///
+    /// Deliberately NOT an overload of `crossChannelArtifact`, and not given a
+    /// `RemoteVersion`: there is no artifact to inspect. For every binding in this
+    /// population stable and non-stable resolve the same filename from the same
+    /// host, so a URL check would be the vacuous kind of proof this file exists to
+    /// refuse. What is checked is the request the resolution will make.
+    ///
+    /// Stable resolutions return nil rather than being checked against
+    /// `preReleaseTokens` the way a stable recipe is. That is measured, not lazy:
+    /// two of these four bindings' STABLE feeds would trip a bare token match —
+    /// Surge's `appcast-signed.xml` sits beside `appcast-signed-beta.xml` on the
+    /// same path, and a token scan over a feed URL says nothing about which train
+    /// the server answers with. The stable direction here is protected by the
+    /// resolver returning the stable feed when the preference is unreadable, which
+    /// `everyBindingProofFailsOnItsOwnStableSibling` pins from the other side.
+    public static func crossChannelBinding(
+        binding: ResolvedChannel, bundleID: String
+    ) -> String? {
+        guard binding.channel != .stable else { return nil }
+        let key = ChannelProofKey(bundleID, binding.channel)
+        guard let proof = ChannelProofRegistry.bindingProofs[key] else {
+            return "no channel proof registered for \(key) — nothing checks that its "
+                + "appcast request is the one that serves its own channel"
+        }
+        switch proof {
+        case .artifact(let pattern):
+            return "\(key) is proven by .artifact(/\(pattern)/), which cannot hold for a "
+                + "binding: stable and non-stable resolve the same artifact from the same "
+                + "host, so the URL never names the channel — use .recipeAnchor"
+        case .recipeAnchor(let pattern, let fields):
+            return recipeAnchorFailure(
+                pattern: pattern, fields: fields, channel: binding.channel, subject: binding)
         }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -47,6 +47,68 @@ public struct ResolvedChannel: Sendable, Equatable {
         self.feedHTTPHeaders = feedHTTPHeaders
         self.sparkleChannelNames = sparkleChannelNames
     }
+
+    // MARK: - channel-anchor surface (issue #111)
+
+    /// The one field that LABELS a resolution rather than deciding what it asks
+    /// for. Same tautology `VendorProbeRecipe.nonAnchorFields` exists to stop: a
+    /// `.beta` resolution carries the literal string "beta" in `channel`, so an
+    /// anchor of `beta` would be satisfied by the mere fact that it is a beta
+    /// resolution, forever, whatever happened to the feed or the header.
+    static let nonAnchorFields: Set<String> = ["channel"]
+
+    /// The anchorable fields, in declaration order, each with the lines it
+    /// contributes — the binding-population counterpart of
+    /// `VendorProbeRecipe.channelAnchorFields`, and matched the same way (a
+    /// `.recipeAnchor` names the fields it relies on and must match in each).
+    ///
+    /// What is being anchored here is the REQUEST, not the response, and that is
+    /// the whole reason this population needs its own surface. For a feed-swap or
+    /// header-keyed app the vendor puts no channel token in the artifact at all —
+    /// stable and beta are the same filename from the same host — so the only
+    /// thing that ever distinguished them is which URL we asked for or which
+    /// header we sent. That is not a weaker kind of proof than the recipes get:
+    /// Alfred's registered anchor is `prerelease\.xml` in its endpoint, which is
+    /// the same assertion in the same shape.
+    public var channelAnchorFields: [(label: String, lines: [String])] {
+        Mirror(reflecting: self).children.compactMap { child in
+            guard let label = child.label,
+                  !Self.nonAnchorFields.contains(label) else { return nil }
+            return (label, Self.anchorLines(of: child.value))
+        }
+    }
+
+    /// The text one named field contributes, or nil when there is no ANCHORABLE
+    /// field by that name. Callers must treat nil as a failure, never as
+    /// "nothing to check" — see `RecipeSanity.recipeAnchorFailure`.
+    public func channelAnchorSurface(ofField label: String) -> String? {
+        channelAnchorFields.first { $0.label == label }
+            .map { $0.lines.joined(separator: "\n") }
+    }
+
+    /// One line per string a value contains, walking into optionals, collections
+    /// and enum payloads. Never `String(describing:)` on a value that holds a
+    /// string: nested strings come back debug-escaped and an anchor written to
+    /// match the real text stops matching.
+    ///
+    /// **Dictionaries yield `key: value` on ONE line**, which the recipe-side
+    /// versions of this function have no reason to do and this one must. A
+    /// header's value is load-bearing, not decoration: TablePlus's server unlocks
+    /// the beta feed for the literal string `true` and treats `1`/`yes` as stable
+    /// (`TablePlusChannel`). Emitting the field and the value as two lines would
+    /// make `X-Tiny-Beta-Update.*true` unmatchable — `.` does not cross a newline
+    /// — so the only anchor anybody could write would be one that cannot tell the
+    /// working header from a broken one.
+    private static func anchorLines(of value: Any) -> [String] {
+        if let text = value as? String { return [text] }
+        if let url = value as? URL { return [url.absoluteString] }
+        if let headers = value as? [String: String] {
+            return headers.sorted { $0.key < $1.key }.map { "\($0.key): \($0.value)" }
+        }
+        let mirror = Mirror(reflecting: value)
+        guard !mirror.children.isEmpty else { return [String(describing: value)] }
+        return mirror.children.flatMap { anchorLines(of: $0.value) }
+    }
 }
 
 /// Resolves the channel a user chose for apps that hide that choice in a private
@@ -205,4 +267,69 @@ public enum ChannelBinding {
         default:                       return nil
         }
     }
+
+    /// Every resolution a binding can produce, machine-independently (issue #111).
+    ///
+    /// `resolve(bundleID:)` answers for THIS Mac — it reads the user's actual
+    /// preferences — so it cannot tell anyone which channels a binding is capable
+    /// of serving. `ChannelProofRegistry.channelBindingsNeedingProof` needs that
+    /// capability set, because the question it asks is "could this binding ever
+    /// hand someone a build from another channel", not "is it doing so right now
+    /// on this machine".
+    ///
+    /// Built by calling each resolver's PURE function with the opt-in values it
+    /// accepts, so no feed URL, header or channel is restated here — the same
+    /// discipline `preferenceWatchCandidates` uses for paths, and for the same
+    /// reason: a copy drifts, a call cannot.
+    ///
+    /// Kept honest by `everyBindingIsEnumerated`, which pins this against
+    /// `boundBundleIDs`. That is a real but partial guard, and worth stating
+    /// plainly: it catches a binding added to one list and not the other, since
+    /// `boundBundleIDs` is the list somebody already has to touch when they add a
+    /// resolver. It cannot catch a resolver added to the `resolve` switch and to
+    /// neither list — Swift gives no way to reflect over a switch's cases.
+    public static let allResolutions: [(bundleID: String, resolved: ResolvedChannel)] = [
+        (DuoPasteChannel.bundleID, DuoPasteChannel.resolve(includePrereleases: false)),
+        (DuoPasteChannel.bundleID, DuoPasteChannel.resolve(includePrereleases: true)),
+        // Fork's pref is an Int with 2 == stable; anything else (including absent,
+        // the shipped default) is the "Developer" train.
+        (ForkChannel.bundleID, ForkChannel.resolve(channelPref: 2)),
+        (ForkChannel.bundleID, ForkChannel.resolve(channelPref: nil)),
+        (SurgeChannel.bundleID, SurgeChannel.resolve(includeBeta: false)),
+        (SurgeChannel.bundleID, SurgeChannel.resolve(includeBeta: true)),
+        (TablePlusChannel.bundleID, TablePlusChannel.resolve(receiveBeta: false)),
+        (TablePlusChannel.bundleID, TablePlusChannel.resolve(receiveBeta: true)),
+        (IINAChannel.bundleID, IINAChannel.resolve(receiveBeta: false)),
+        (IINAChannel.bundleID, IINAChannel.resolve(receiveBeta: true)),
+        // Both toggles, because "internal" subsumes "pre" — a user with both on is
+        // opted into two tags at once and must be offered whichever is newer.
+        (BetterDisplayChannel.bundleID,
+         BetterDisplayChannel.resolve(preEnabled: false, internalEnabled: false)),
+        (BetterDisplayChannel.bundleID,
+         BetterDisplayChannel.resolve(preEnabled: true, internalEnabled: false)),
+        (BetterDisplayChannel.bundleID,
+         BetterDisplayChannel.resolve(preEnabled: false, internalEnabled: true)),
+        (BetterDisplayChannel.bundleID,
+         BetterDisplayChannel.resolve(preEnabled: true, internalEnabled: true)),
+        // The remaining four have no pure resolver to drive because they have no
+        // user-settable choice to drive it with. Ghostty is a fixed stable-only
+        // feed override; CleanShot keys a personalized feed off the licence and
+        // exposes one channel. `resolveCurrent()` is machine-independent for both.
+        (GhosttyChannel.bundleID, GhosttyChannel.resolveCurrent()),
+    ] + (CleanShotChannel.resolveCurrent().map { [(CleanShotChannel.bundleID, $0)] } ?? [])
+
+    /// The bundle ids `allResolutions` covers, lower-cased for comparison with
+    /// `boundBundleIDs`.
+    ///
+    /// Excludes the four bindings whose channel choice exists only to pick a
+    /// `VendorProbeRecipe` — OrbStack, Alfred, Tailscale and CapCut resolve their
+    /// INSTALL through `VendorProbeRegistry`, so their cross-channel question is
+    /// already answered by `ChannelProofRegistry.proofs` and enumerating them here
+    /// would double-count them into a second registry.
+    public static let vendorProbeBackedBindings: Set<String> = [
+        OrbStackChannel.bundleID.lowercased(),
+        AlfredChannel.bundleID.lowercased(),
+        TailscaleChannel.bundleID.lowercased(),
+        CapCutChannel.bundleID.lowercased(),
+    ]
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -65,7 +65,7 @@ public struct ResolvedChannel: Sendable, Equatable {
     /// What is being anchored here is the REQUEST, not the response, and that is
     /// the whole reason this population needs its own surface. For a feed-swap or
     /// header-keyed app the vendor puts no channel token in the artifact at all —
-    /// stable and beta are the same filename from the same host — so the only
+    /// the filenames differ, but by version or by build hash, never by train — so the only
     /// thing that ever distinguished them is which URL we asked for or which
     /// header we sent. That is not a weaker kind of proof than the recipes get:
     /// Alfred's registered anchor is `prerelease\.xml` in its endpoint, which is
@@ -311,21 +311,38 @@ public enum ChannelBinding {
          BetterDisplayChannel.resolve(preEnabled: false, internalEnabled: true)),
         (BetterDisplayChannel.bundleID,
          BetterDisplayChannel.resolve(preEnabled: true, internalEnabled: true)),
-        // The remaining four have no pure resolver to drive because they have no
-        // user-settable choice to drive it with. Ghostty is a fixed stable-only
-        // feed override; CleanShot keys a personalized feed off the licence and
-        // exposes one channel. `resolveCurrent()` is machine-independent for both.
+        // The remaining two have no user-settable channel choice to drive.
+        // Ghostty is a fixed stable-only feed override, so `resolveCurrent()` is
+        // already a constant.
         (GhosttyChannel.bundleID, GhosttyChannel.resolveCurrent()),
-    ] + (CleanShotChannel.resolveCurrent().map { [(CleanShotChannel.bundleID, $0)] } ?? [])
+    ] + (CleanShotChannel.resolve(activationKey: CleanShotChannel.placeholderActivationKey)
+        .map { [(CleanShotChannel.bundleID, $0)] } ?? [])
 
-    /// The bundle ids `allResolutions` covers, lower-cased for comparison with
-    /// `boundBundleIDs`.
+    // CleanShot is enumerated through its PURE resolver with a placeholder key,
+    // never `resolveCurrent()`. It keys a personalized feed off the licence, so
+    // enumerating the live resolution would have made this list depend on whether
+    // the machine has a licensed CleanShot — present for the author, absent on CI
+    // and on anyone else's Mac, with `everyBindingIsEnumerated` failing there and
+    // only there. It would also have put a real licence key into a public global.
+    // Its channel is `.stable` either way: the key selects an ENTITLEMENT, not a
+    // train, so there is no other channel for it to cross into.
+
+    /// The four bindings `allResolutions` deliberately does NOT cover, lower-cased.
     ///
-    /// Excludes the four bindings whose channel choice exists only to pick a
-    /// `VendorProbeRecipe` — OrbStack, Alfred, Tailscale and CapCut resolve their
-    /// INSTALL through `VendorProbeRegistry`, so their cross-channel question is
-    /// already answered by `ChannelProofRegistry.proofs` and enumerating them here
-    /// would double-count them into a second registry.
+    /// OrbStack, Alfred, Tailscale and CapCut have bindings, but the binding only
+    /// picks which `VendorProbeRecipe` runs; the install comes from that recipe,
+    /// so their cross-channel question is already answered by
+    /// `ChannelProofRegistry.proofs` and enumerating them here would double-count
+    /// them into a second registry.
+    ///
+    /// Used two ways, and honest about the weaker one: it is what
+    /// `everyBindingIsEnumerated` subtracts to compute what SHOULD be enumerated,
+    /// and it is a term in `channelBindingsNeedingProof`'s predicate where it is
+    /// currently INERT — none of these four appears in `allResolutions`, so the
+    /// term never excludes anything. `vendorProbeBackedBindingsAreNotEnumerated`
+    /// measures that inertness rather than leaving it assumed, so the day one of
+    /// them does get enumerated (a binding that both overrides the feed and
+    /// selects a recipe), the term starts doing work and somebody is told.
     public static let vendorProbeBackedBindings: Set<String> = [
         OrbStackChannel.bundleID.lowercased(),
         AlfredChannel.bundleID.lowercased(),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CleanShotChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CleanShotChannel.swift
@@ -35,10 +35,29 @@ enum CleanShotChannel {
     /// fall back to the app's shipped v3 `SUFeedURL` (current behavior), never to
     /// a higher channel. Graceful, non-degrading.
     static func resolveCurrent() -> ResolvedChannel? {
-        guard let key = readActivationKey(), !key.isEmpty,
+        resolve(activationKey: readActivationKey())
+    }
+
+    /// The pure half, so `ChannelBinding.allResolutions` can enumerate what this
+    /// binding is CAPABLE of without depending on whether the machine running the
+    /// tests happens to have a licensed CleanShot on it.
+    ///
+    /// That is not a hypothetical tidy-up: enumerating via `resolveCurrent()`
+    /// made the binding appear on a licensed Mac and vanish on every other one,
+    /// so the enumeration test passed for the author and failed for everybody
+    /// else — and it put a REAL licence key into a public `static let` global, in
+    /// a file whose own header says the key must never be logged or persisted.
+    /// Callers enumerate with a placeholder; only `resolveCurrent()` ever sees the
+    /// real one.
+    static func resolve(activationKey: String?) -> ResolvedChannel? {
+        guard let key = activationKey, !key.isEmpty,
               let feed = feed(forKey: key) else { return nil }
         return ResolvedChannel(channel: .stable, feedOverride: feed)
     }
+
+    /// A syntactically-valid stand-in for the licence key, for enumeration only.
+    /// Never a real key, and never used to build a request.
+    static let placeholderActivationKey = "PLACEHOLDER-NOT-A-REAL-KEY"
 
     /// Read `activationKey` from CleanShot's own defaults via CFPreferences, so
     /// it's authoritative even while CleanShot is running. Plaintext, non-keychain;

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
@@ -1,0 +1,178 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Issue #111 — `ChannelBinding` + `SparkleAppcastSource` is a third
+/// install-carrying population, and neither `channelRecipesWithInstall` nor
+/// `channelGitHubRulesWithInstall` can see it: both read one registry each, and
+/// both `crossChannelArtifact` overloads are typed on a recipe or a rule.
+///
+/// What makes it worth a registry of its own rather than a note: for every app in
+/// it the channel signal lives in the REQUEST — which feed URL was fetched, or
+/// which header was sent — and nothing in the response corroborates it. TablePlus
+/// is the sharpest case. Stable and beta come from the same host with the same
+/// filename; if the vendor retires `X-Tiny-Beta-Update` a beta user is served the
+/// stable dmg, with the same Team ID, notarized, past every gate we have.
+@Suite struct BindingChannelProofTests {
+
+    /// The population is derived, and it is exactly the request-keyed bindings.
+    ///
+    /// Pinned as an exact set rather than a count so that BOTH directions fail
+    /// loudly: a new feed-swap or header-keyed binding appearing here without a
+    /// proof, and an existing one quietly dropping out of the population (which
+    /// would silently retire its proof rather than announce it).
+    @Test func theBindingPopulationIsExactlyTheRequestKeyedOnes() {
+        let needing = Set(ChannelProofRegistry.channelBindingsNeedingProof)
+        #expect(needing == Set([
+            ChannelProofKey("com.DanPristupov.Fork", .beta),
+            ChannelProofKey("com.nssurge.surge-mac", .beta),
+            ChannelProofKey("com.tinyapp.tableplus", .beta),
+            ChannelProofKey("com.colliderli.iina", .beta),
+        ]), "the request-keyed binding population changed: \(needing.map(\.description).sorted())")
+    }
+
+    /// Every member of that population carries a proof, and nothing else does.
+    ///
+    /// The second half is the answer to issue #111's own warning that "a proof
+    /// table that is half no-ops is worse than none": an entry for a channel-TAG
+    /// binding would be exactly such a no-op, because `SparkleAppcastSource`
+    /// already narrows the feed to the tags the user opted into, in code that runs
+    /// for every such app whether or not anyone registered anything.
+    @Test func bindingProofsCoverExactlyThatPopulation() {
+        let needing = Set(ChannelProofRegistry.channelBindingsNeedingProof)
+        for key in needing {
+            #expect(ChannelProofRegistry.bindingProofs[key] != nil,
+                    "\(key) can hand out an install on a channel it chose by request, and nothing states how we know the request is the right one")
+        }
+        for key in ChannelProofRegistry.bindingProofs.keys {
+            #expect(needing.contains(key),
+                    "\(key) has a binding proof but is not in the population — either it is protected some other way (making this a no-op) or the predicate stopped seeing it")
+        }
+    }
+
+    /// Every registered binding anchor matches its own resolution.
+    @Test func everyBindingProofMatchesItsOwnResolution() {
+        for (bundleID, resolved) in ChannelBinding.allResolutions {
+            let key = ChannelProofKey(bundleID, resolved.channel)
+            guard ChannelProofRegistry.bindingProofs[key] != nil else { continue }
+            #expect(
+                RecipeSanity.crossChannelBinding(binding: resolved, bundleID: bundleID) == nil,
+                "\(key): its own resolution no longer satisfies its proof")
+        }
+    }
+
+    /// …and FAILS on the same binding's stable resolution.
+    ///
+    /// The property that makes these proofs worth having, and one the recipe-side
+    /// registry cannot state as directly: an anchor is only evidence if the other
+    /// channel's request would not also satisfy it. `appcast-signed-beta\.xml`
+    /// proves something because `appcast-signed.xml` does not match it; an anchor
+    /// of `appcast` would match both and prove nothing while looking identical in
+    /// a diff. Fork is the case that makes this non-obvious — its BETA feed is the
+    /// unsuffixed `feed.xml` and stable is `feed-stable.xml`, so the anchor is the
+    /// absence of a suffix, and it only discriminates because `feed-stable.xml`
+    /// does not contain the literal `feed.xml`.
+    @Test func everyBindingProofFailsOnItsOwnStableSibling() {
+        let stableByID = Dictionary(
+            ChannelBinding.allResolutions
+                .filter { $0.resolved.channel == .stable }
+                .map { ($0.bundleID, $0.resolved) },
+            uniquingKeysWith: { first, _ in first })
+
+        for (key, proof) in ChannelProofRegistry.bindingProofs {
+            guard case .recipeAnchor(let pattern, let fields) = proof else {
+                Issue.record("\(key): a binding proof must be a .recipeAnchor")
+                continue
+            }
+            let stable = try! #require(stableByID[key.bundleID])
+            // Matched the way the guard matches it — per named field, same options.
+            let matched = fields.contains { label in
+                stable.channelAnchorSurface(ofField: label)?
+                    .range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+            }
+            #expect(!matched,
+                    "\(key): the anchor /\(pattern)/ ALSO matches this app's stable resolution, so it cannot tell the two apart and proves nothing")
+        }
+    }
+
+    /// A header's value is part of the evidence, not decoration.
+    ///
+    /// TablePlus's server unlocks the beta feed for the literal string `true` and
+    /// treats `1`/`yes` as stable, so a proof that only checked the field name
+    /// would stay green through the exact vendor change that would start serving
+    /// beta users stable builds. This is why `ResolvedChannel.anchorLines` renders
+    /// a header as one `key: value` line: emitted as two lines, `.` could not
+    /// cross between them and no anchor covering the value could ever match.
+    @Test func aHeaderProofCoversTheValueNotJustTheFieldName() {
+        let beta = TablePlusChannel.resolve(receiveBeta: true)
+        #expect(RecipeSanity.crossChannelBinding(
+            binding: beta, bundleID: TablePlusChannel.bundleID) == nil,
+            "the shipping beta resolution must satisfy its own proof")
+
+        // The vendor keeps the header but stops honouring this value — the failure
+        // the registered anchor exists to catch.
+        let wrongValue = ResolvedChannel(
+            channel: .beta,
+            feedHTTPHeaders: [TablePlusChannel.betaHeaderField: "1"])
+        #expect(RecipeSanity.crossChannelBinding(
+            binding: wrongValue, bundleID: TablePlusChannel.bundleID) != nil,
+            "a header carrying a value the server treats as STABLE must not satisfy a beta proof")
+
+        // …and dropping the header entirely, which is the resolution a broken
+        // TablePlusChannel would produce.
+        #expect(RecipeSanity.crossChannelBinding(
+            binding: ResolvedChannel(channel: .beta), bundleID: TablePlusChannel.bundleID) != nil,
+            "a beta resolution that sends no header at all must be complained about")
+    }
+
+    /// A binding with no proof is a finding, not a pass — the same stance the two
+    /// recipe registries take, so the third population cannot be the quiet one.
+    @Test func anUnregisteredBindingChannelIsAFinding() {
+        let madeUp = ResolvedChannel(
+            channel: .beta,
+            feedOverride: URL(string: "https://example.invalid/appcast-beta.xml")!)
+        #expect(RecipeSanity.crossChannelBinding(
+            binding: madeUp, bundleID: "com.example.NotRegistered") != nil,
+            "an unregistered binding channel must be reported, not silently allowed")
+
+        // Stable resolutions have no other channel to cross into.
+        #expect(RecipeSanity.crossChannelBinding(
+            binding: ResolvedChannel(channel: .stable), bundleID: "com.example.NotRegistered") == nil,
+            "a stable resolution has nothing to prove here")
+    }
+
+    /// `allResolutions` must not fall behind the resolvers it is derived from.
+    ///
+    /// Partial by construction and worth saying so: this catches a binding added
+    /// to `boundBundleIDs` and not here (the realistic drift, since `boundBundleIDs`
+    /// is what somebody already touches when adding a resolver). It cannot catch a
+    /// resolver added to the `resolve` switch and to neither list — Swift offers no
+    /// way to reflect over a switch's cases.
+    @Test func everyBindingIsEnumerated() {
+        let enumerated = Set(ChannelBinding.allResolutions.map { $0.bundleID.lowercased() })
+        // Ghostty is deliberately outside `boundBundleIDs` (no user-settable
+        // preference to watch) but is still a real binding, so it is enumerated.
+        let expected = ChannelBinding.boundBundleIDs
+            .union([GhosttyChannel.bundleID.lowercased()])
+            .subtracting(ChannelBinding.vendorProbeBackedBindings)
+        #expect(enumerated == expected,
+                "allResolutions drifted from the resolvers: missing \(expected.subtracting(enumerated).sorted()), extra \(enumerated.subtracting(expected).sorted())")
+
+        for id in enumerated {
+            #expect(ChannelBinding.resolve(bundleID: id) != nil,
+                    "\(id) is enumerated but `resolve` has no case for it")
+        }
+    }
+
+    /// The three proof maps must not collide, for the reason `githubProofs`'
+    /// own doc gives: `ChannelProofKey` says nothing about which population it
+    /// came from, so a shared key would be checked against the wrong one while the
+    /// exhaustiveness tests all passed.
+    @Test func bindingProofsDoNotCollideWithTheOtherRegistries() {
+        let binding = Set(ChannelProofRegistry.bindingProofs.keys)
+        #expect(binding.isDisjoint(with: Set(ChannelProofRegistry.proofs.keys)),
+                "a key is in both the vendor and binding proof maps")
+        #expect(binding.isDisjoint(with: Set(ChannelProofRegistry.githubProofs.keys)),
+                "a key is in both the GitHub and binding proof maps")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
@@ -28,7 +28,13 @@ import Foundation
             ChannelProofKey("com.nssurge.surge-mac", .beta),
             ChannelProofKey("com.tinyapp.tableplus", .beta),
             ChannelProofKey("com.colliderli.iina", .beta),
-        ]), "the request-keyed binding population changed: \(needing.map(\.description).sorted())")
+            ChannelProofKey("pro.betterdisplay.BetterDisplay", .beta),
+            ChannelProofKey("pro.betterdisplay.BetterDisplay", .unstable),
+        ]), "the binding population changed: \(needing.map(\.description).sorted())")
+        // Deduplicated: BetterDisplay reaches `.unstable` from two preference
+        // combinations, and the population is a set of keys, not of routes to one.
+        #expect(ChannelProofRegistry.channelBindingsNeedingProof.count == needing.count,
+                "channelBindingsNeedingProof returned duplicate keys")
     }
 
     /// Every member of that population carries a proof, and nothing else does.
@@ -84,7 +90,14 @@ import Foundation
                 Issue.record("\(key): a binding proof must be a .recipeAnchor")
                 continue
             }
-            let stable = try! #require(stableByID[key.bundleID])
+            // `guard`, not `try! #require`: a proof registered for a binding with
+            // no enumerated stable resolution is a real (if unlikely) mistake, and
+            // it should read as one failing test rather than a `fatalError` that
+            // takes the whole test binary down with it.
+            guard let stable = stableByID[key.bundleID] else {
+                Issue.record("\(key): no stable resolution enumerated for this bundle id, so the proof cannot be shown to discriminate")
+                continue
+            }
             // Matched the way the guard matches it — per named field, same options.
             let matched = fields.contains { label in
                 stable.channelAnchorSurface(ofField: label)?
@@ -169,10 +182,37 @@ import Foundation
     /// came from, so a shared key would be checked against the wrong one while the
     /// exhaustiveness tests all passed.
     @Test func bindingProofsDoNotCollideWithTheOtherRegistries() {
+        // POPULATIONS, not just the keys somebody happened to register. A bundle
+        // id that two populations could both serve on one channel is the
+        // ambiguity — `ChannelProofKey` records no population, so the entry
+        // written for one would be checked against the other — and it is ambiguous
+        // whether or not both entries exist yet. Comparing registered keys alone
+        // would pass in exactly the window where the mistake is still invisible.
+        let bindingPopulation = Set(ChannelProofRegistry.channelBindingsNeedingProof)
+        #expect(bindingPopulation.isDisjoint(with: Set(ChannelProofRegistry.channelRecipesWithInstall)),
+                "a (bundleID, channel) is served by both the vendor recipe and binding populations")
+        #expect(bindingPopulation.isDisjoint(with: Set(ChannelProofRegistry.channelGitHubRulesWithInstall)),
+                "a (bundleID, channel) is served by both the GitHub rule and binding populations")
+        // …and the registered maps, which is the weaker statement kept because a
+        // proof can be written before its population entry exists.
         let binding = Set(ChannelProofRegistry.bindingProofs.keys)
         #expect(binding.isDisjoint(with: Set(ChannelProofRegistry.proofs.keys)),
                 "a key is in both the vendor and binding proof maps")
         #expect(binding.isDisjoint(with: Set(ChannelProofRegistry.githubProofs.keys)),
                 "a key is in both the GitHub and binding proof maps")
+    }
+
+    /// The `vendorProbeBackedBindings` term in the population predicate excludes
+    /// nothing today, and that is measured rather than assumed.
+    ///
+    /// It is the one hand-written list in an otherwise derived pipeline, and its
+    /// failure direction is silent narrowing — it can only REMOVE rows. Pinning
+    /// its inertness means the day a binding both overrides a feed and selects a
+    /// recipe, the term starts excluding something and this test says so instead
+    /// of the row quietly leaving the population.
+    @Test func vendorProbeBackedBindingsAreNotEnumerated() {
+        let enumerated = Set(ChannelBinding.allResolutions.map { $0.bundleID.lowercased() })
+        #expect(enumerated.isDisjoint(with: ChannelBinding.vendorProbeBackedBindings),
+                "a vendor-probe-backed binding is now enumerated — the predicate term that excludes it has stopped being inert, so decide out loud whether its install really comes from the recipe")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -255,27 +255,43 @@ import CryptoKit
 
 /// A `.recipeAnchor` whose PATTERN matches anything is the third way to write a
 /// proof that cannot fail, and the one neither `everyRegisteredAnchorNamesRealFields`
-/// nor the field-scoping closes: `""`, `a?` and `.*` all match every surface, in
-/// every field, forever.
+/// nor the field-scoping closes.
 ///
-/// Checked against the empty string, which is the cheapest total discriminator —
-/// a pattern that matches `""` matches every field of every recipe, so it can
-/// never report drift. Covers BOTH registries; the GitHub side has no anchors
-/// today and this is what stops the first one from being written that way.
+/// Probed against several unrelated strings rather than just `""`. The empty
+/// string alone is NOT the total discriminator an earlier version of this claimed:
+/// it catches `""`, `a?` and `.*`, but `.+` and `.` match every real surface while
+/// failing on `""`, so they would have slipped through while asserting nothing
+/// beyond "this field is non-empty". A pattern that matches all of these probes is
+/// not distinguishing anything about a channel.
+///
+/// Covers all THREE registries. The GitHub side has no anchors today, and on the
+/// binding side this is the half `everyBindingProofFailsOnItsOwnStableSibling`
+/// cannot backstop: TablePlus's stable `feedHTTPHeaders` surface is `""`, so `.+`
+/// would pass that test too.
 @Test func noRegisteredAnchorMatchesEverything() {
+    // Deliberately unlike any real feed URL, header or vendor marker.
+    let arbitrary = ["x", "0", "   ", "zzz zzz"]
+    func matches(_ pattern: String, _ text: String) -> Bool {
+        text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+    // Two ways to assert nothing, and they need different probes — which is the
+    // bug an earlier version of this test had, checking only the first:
+    //   * matching `""` means matching every surface there is (`.*`, `a?`, `^`);
+    //   * matching every arbitrary NON-empty string means the anchor only asserts
+    //     "this field is non-empty" (`.+`, `.`), which no channel proof should be.
     func vacuous(_ pattern: String) -> Bool {
-        "".range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+        matches(pattern, "") || arbitrary.allSatisfy { matches(pattern, $0) }
     }
-    for (key, proof) in ChannelProofRegistry.proofs {
-        guard case .recipeAnchor(let pattern, _) = proof else { continue }
-        #expect(!vacuous(pattern),
-                "\(key): the anchor /\(pattern)/ matches the empty string, so it matches every field of every recipe and can never report drift")
+    func check(_ label: String, _ map: [ChannelProofKey: ChannelArtifactProof]) {
+        for (key, proof) in map {
+            guard case .recipeAnchor(let pattern, _) = proof else { continue }
+            #expect(!vacuous(pattern),
+                    "\(label) \(key): the anchor /\(pattern)/ matches arbitrary unrelated text, so it can never report drift")
+        }
     }
-    for (key, proof) in ChannelProofRegistry.githubProofs {
-        guard case .recipeAnchor(let pattern, _) = proof else { continue }
-        #expect(!vacuous(pattern),
-                "\(key): the anchor /\(pattern)/ matches the empty string, so it can never report drift")
-    }
+    check("vendor", ChannelProofRegistry.proofs)
+    check("github", ChannelProofRegistry.githubProofs)
+    check("binding", ChannelProofRegistry.bindingProofs)
 }
 
 // MARK: - anchors are checked field by field (issue #110)

--- a/docs/app-audits/issue-111-appcast-channel-population.md
+++ b/docs/app-audits/issue-111-appcast-channel-population.md
@@ -594,6 +594,30 @@ What shipped:
   machine-independently, built by calling each resolver's own pure function so no
   feed URL or header is restated.
 
+**Correction to an earlier draft of this section.** It said "for all four,
+stable and non-stable are the same filename from the same host". That
+contradicts §1's own raw output and is false for three of the four — Fork serves
+`Fork-2.66.7.dmg` against `Fork-2.69.0.dmg`, Surge puts a per-build hash in the
+name, and only TablePlus reuses `TablePlus.dmg` (under different build-numbered
+paths). The claim §1 actually measured, and the one the conclusion rests on, is
+that **none of these vendors puts a channel TOKEN in the artifact** — a version
+or a hash is not a channel. §4 is preserved as the record of what was checked;
+this section supersedes its conclusion, not its measurements.
+
+**Population widened after review.** §3 called BetterDisplay a no-op because
+`SparkleAppcastSource` filters by `<sparkle:channel>`. That is right about the
+filtering and wrong about the risk: the tag NAMES are a per-app constant
+(`BetterDisplayChannel.preTag`/`internalTag`), because its feed spells them
+`pre`/`internal` and no `ReleaseChannel` case does. Retype one and
+`allowedChannels` builds a set matching nothing in the feed, so the user matches
+only untagged items and is silently offered **stable** — the failure
+`ResolvedChannel.sparkleChannelNames`' own doc warns about, and one
+`allowedChannels` cannot catch because it cannot validate a name it is handed.
+So the predicate covers hand-declared tags too, and BetterDisplay `.beta` and
+`.unstable` carry proofs. DuoPaste stays excluded on the sharper distinction:
+its tag is DERIVED from `ReleaseChannel.rawValue` in shared code, so there is no
+per-app constant to mistype.
+
 Two things this does NOT do, stated plainly because the opposite impression is
 the "green check nobody should trust" §4 rightly worried about:
 
@@ -602,8 +626,8 @@ the "green check nobody should trust" §4 rightly worried about:
    away — not when a vendor retires it. §4's third option (a live differential
    check) remains the answer to the vendor-side failure and is not a substitute
    for this one, nor this for it.
-2. **It cannot see inside the response.** For all four, stable and non-stable are
-   the same filename from the same host.
+2. **It cannot see inside the response.** No binding here resolves an artifact
+   that names its channel.
 
 The strongest property the tests do pin, which the recipe-side registry cannot
 state as directly: `everyBindingProofFailsOnItsOwnStableSibling` asserts each

--- a/docs/app-audits/issue-111-appcast-channel-population.md
+++ b/docs/app-audits/issue-111-appcast-channel-population.md
@@ -1,0 +1,616 @@
+# Issue #111 — the Sparkle-appcast channel population, enumerated and swept
+
+> Measurement task only, no code changes. Produced for issue #111 ("Channel
+> bindings served by Sparkle appcasts are a third install-carrying population
+> no proof registry enumerates"). Branch `audit/111-appcast-channel-population`.
+> All live probes run 2026-08-28 from this worktree; commands and raw output
+> are reproduced verbatim below rather than summarized.
+
+## TL;DR
+
+- The third population is **8 apps**: DuoPaste, Fork, Surge, TablePlus,
+  CleanShot X, IINA, Ghostty, BetterDisplay. Confirmed by grepping both
+  `VendorProbeRecipe.swift` and `GitHubReleasesSource.swift` for each of the
+  12 bundle ids `ChannelBinding.resolve()` switches on — 4 of the 12
+  (OrbStack, Alfred, Tailscale, CapCut) actually resolve through
+  `VendorProbeRegistry` and are **already** covered by
+  `ChannelProofRegistry.channelRecipesWithInstall` / `.proofs`. The issue's
+  own doc comments say this for OrbStack/Alfred/Tailscale but don't say it
+  plainly enough to rule them out of the "third population" headline — worth
+  stating explicitly since it's exactly the kind of undercount CLAUDE.md's
+  "先量一遍" rule warns about.
+- Of the 8, **4 carry no non-stable channel at all** (CleanShot X and
+  Ghostty resolve only `.stable`) or are **structurally protected already**
+  by `SparkleAppcastSource`'s own channel-tag filtering (DuoPaste,
+  BetterDisplay) — a proof-registry entry would be a no-op for all four.
+- The remaining **4 are genuinely unprotected**: Fork, Surge, TablePlus,
+  IINA. All four are feed-swap or header-keyed, and **none of their vendors
+  puts a channel token anywhere in the downloaded artifact** — channel
+  identity is 100% "which URL/header we used to ask," with nothing in the
+  response tying back to that choice. TablePlus's header-flip was
+  live-reproduced today (build 770 stable / 771 beta, see below) — the exact
+  failure mode the issue describes is real and currently silent everywhere
+  in this group.
+- `SparkleInstaller.swift` contains **zero** occurrences of the word
+  "channel" — the actual install pipeline for this population has no
+  channel-awareness of any kind. EdDSA verification (where present) proves
+  authenticity, never channel.
+
+---
+
+## 1. The population table (Q1)
+
+### Reconciling `boundBundleIDs` vs the `resolve()` switch
+
+`ChannelBinding.resolve(bundleID:)`'s switch has **12** cases: DuoPaste,
+Fork, Surge, OrbStack, TablePlus, CleanShot, Tailscale, IINA, Alfred,
+Ghostty, BetterDisplay, CapCut.
+
+`ChannelBinding.boundBundleIDs` has **11** — every one of those *except*
+Ghostty. This is not a bug: the doc comment on `boundBundleIDs` says so
+outright ("Deliberately excludes Ghostty: its binding is a fixed
+stable-only feed override with no user-settable preference, so there is
+nothing to watch"). `boundBundleIDs` feeds the preference-file watcher, not
+channel resolution — Ghostty still resolves through `resolve()`, it just
+has no on-disk toggle worth polling. Stated here because the task asked to
+reconcile the two lists explicitly, but this one turned out to be
+intentional, not a gap.
+
+### Which of the 12 are VendorProbe/GitHub (not the third population) vs pure Sparkle-appcast
+
+Grepped `VendorProbeRecipe.swift` and `GitHubReleasesSource.swift` for each
+of the 12 bundle ids directly (not from doc-comment claims):
+
+| Bundle ID | Reaches install via | Evidence |
+|---|---|---|
+| `dev.kdrag0n.MacVirt` (OrbStack) | **VendorProbeRegistry** (`orbStackRecipe(channel:tag:)`, `VendorProbeRecipe.swift:4971`) | Already in `channelRecipesWithInstall` + `ChannelProofRegistry.proofs` (`.recipeAnchor("<sparkle:channel>beta")` / `"canary"`) |
+| `com.runningwithcrayons.Alfred` | **VendorProbeRegistry** (two recipes, `VendorProbeRecipe.swift:915`, `:3275`) | Already in `channelRecipesWithInstall` + proofs (`.recipeAnchor("prerelease\.xml")`) |
+| `io.tailscale.ipn.macsys` | **VendorProbeRegistry** (three recipes, `VendorProbeRecipe.swift:2616-2663`) | Already in `channelRecipesWithInstall` + proofs (`.artifact("/unstable/")`, `.artifact("/release-candidate/")`) |
+| `com.lemon.lvoverseas` (CapCut) | **VendorProbeRegistry** (`VendorProbeRecipe.swift:4864` area) | Already in `channelRecipesWithInstall` + proofs (`.artifact("_capcutpc_beta_")`) |
+| `io.duopaste.daemon` | **SparkleAppcastSource only** — no hit in either registry | **Third population** |
+| `com.DanPristupov.Fork` | **SparkleAppcastSource only** | **Third population** |
+| `com.nssurge.surge-mac` | **SparkleAppcastSource only** | **Third population** |
+| `com.tinyapp.tableplus` / `TablePlus` | **SparkleAppcastSource only** | **Third population** |
+| `pl.maketheweb.cleanshotx` | **SparkleAppcastSource only** | **Third population** (single-channel) |
+| `com.colliderli.iina` | **SparkleAppcastSource only** | **Third population** |
+| `com.mitchellh.ghostty` | **SparkleAppcastSource only** | **Third population** (single-channel) |
+| `pro.betterdisplay.BetterDisplay` | **SparkleAppcastSource only** | **Third population** |
+
+So the third population is exactly the 8 the TL;DR names — 4 fewer than a
+naive read of `boundBundleIDs` would suggest, because 4 of the 12 bindings
+exist purely to tell `VendorProbeSource` which recipe to pick, not to feed
+`SparkleAppcastSource` at all.
+
+### Per-binding detail
+
+For every row: shape, whether it carries an install (traced
+`ChannelBinding` → `AppScanner.swift:484-490` → `InstalledApp` →
+`SparkleAppcastSource.latestVersion`/`usableItems` → `RemoteVersion.downloadURL`
+→ `UpdatePolicy.canAutoInstall` → `SignatureVerifier`/`SparkleInstaller`),
+and what currently proves the resolved artifact belongs to the resolved
+channel.
+
+#### DuoPaste (`io.duopaste.daemon`) — channel-tag
+
+- Channels: stable / beta. One feed
+  (`raw.githubusercontent.com/jizhi0v0/duo-paste-releases/main/appcast.xml`),
+  no `feedOverride`.
+- Install-carrying: **yes**. `SUPublicEDKey` present on the installed
+  bundle (`5Ws5rSunj3IH4UiP8aN8YFtDni4inudOxMLTgmzhr1s=`); every item in the
+  live feed carries `sparkle:edSignature`; enclosure is a `.dmg`
+  (`sparkleArchiveExtensions`) → `UpdatePolicy.canAutoInstall` returns true
+  once the EdDSA signature verifies.
+- What proves channel: the `<sparkle:channel>beta</sparkle:channel>` tag on
+  each item, enforced **structurally** by
+  `SparkleAppcastSource.allowedChannels`/`usableItems` — not a per-app
+  registry entry, but code that runs identically for every channel-tag app.
+  Belt-and-suspenders: the enclosure filename itself also embeds the
+  literal string `-beta+<hash>` (e.g.
+  `DuoPaste-0.1.1283-beta+dc86f01.dmg`), so even a hypothetical tag-parsing
+  bug would still have a filename token to fall back on.
+
+#### Fork (`com.DanPristupov.Fork`) — feed-swap, **genuinely unprotected**
+
+- Channels: stable / beta ("Developer", the shipped default). Two entirely
+  separate feed documents:
+  `fork.dev/update/feed-stable.xml` (stable) and
+  `fork.dev/update/feed.xml` (beta/Developer, also the code-signed
+  `SUFeedURL`).
+- Install-carrying: **yes**, but **unsigned** — `SUPublicEDKey` is absent
+  from the installed Info.plist. `UpdatePolicy.canAutoInstall`'s unsigned
+  branch applies: "best-effort one-click," gated only by
+  `SparkleInstaller`'s code-signature + Team ID + bundle-id check (the same
+  gate Vendor/GitHub installs use), never by EdDSA. Enclosure is `.dmg`.
+- What proves channel: **nothing in the artifact**. Neither feed's items
+  carry a `<sparkle:channel>` tag (confirmed live, see §2), and the
+  enclosure URL (`https://cdn.fork.dev/mac/Fork-2.66.7.dmg` vs
+  `…Fork-2.69.0.dmg`) carries no channel word — only a version number that
+  happens to differ because the two feeds happen to be at different
+  releases today. The entire trust boundary is "we asked the URL
+  `ForkChannel.resolve(channelPref:)` says to ask" — a pure, tested
+  function, but nothing downstream checks that the *content* returned at
+  that URL is what it claims to be.
+
+#### Surge (`com.nssurge.surge-mac`) — feed-swap, **genuinely unprotected**
+
+- Channels: stable / beta. Two feeds:
+  `nssurge.com/mac/latest/appcast-signed.xml` (stable) and
+  `…appcast-signed-beta.xml` (beta).
+- Install-carrying: **yes**, and **signed** — `SUPublicEDKey` present
+  (`+kybZprlaFQheSwPX2lkSI/zCXrN3uBI2dJDTqM0qlg=`), `edSignature` present on
+  live items, enclosure `.zip`. Full EdDSA gate applies — which is exactly
+  the case `ChannelArtifactProof`'s own doc comment warns about: "the
+  download is a real notarized build from the same vendor … so the
+  signature gate passes too." EdDSA proves the vendor signed it; it says
+  nothing about which channel it belongs to.
+- What proves channel: **nothing in the artifact**, same shape as Fork.
+  Enclosure filenames carry a content hash but no "beta"/"stable" word
+  (`Surge-6.8.1-12030-69f4be88db9663476f31a6b264109f0b.zip`). Note in
+  passing (not part of the channel question, but observed while probing):
+  the *installed* app's own `SUFeedURL` is `https://sgupd.com/latest/…`,
+  a different domain than the `nssurge.com` constant `SurgeChannel` hard-codes
+  — irrelevant to correctness today because `feedOverride` always wins, but
+  worth a note in case `sgupd.com` and `nssurge.com` ever diverge instead of
+  mirroring each other. **Unverified**: whether they are the same origin
+  under the hood.
+
+#### TablePlus (`com.tinyapp.TablePlus`) — header-keyed, **the sharpest case, live-reproduced**
+
+- Channels: stable / beta. **One** feed URL
+  (`https://tableplus.com/osx/version.xml`); the server decides what to
+  return based on the `X-Tiny-Beta-Update: true` request header.
+- Install-carrying: **yes**, and **signed** — `SUPublicEDKey` present
+  (`+SVxmqxTHeb9ZPYezeYQNR48kMq9BEq9fcPHUWQW7Eg=`), `edSignature` present in
+  both responses, enclosure `.dmg`.
+- What proves channel: **nothing in the artifact, and not even a version
+  number by convention** — see the live probe in §2. The bare response and
+  the header'd response return the **same filename**
+  (`TablePlus.dmg`) at the **same host**, differing only by a numeric build
+  folder in the path (`/770/` vs `/771/`) that is higher for beta only
+  because beta happens to be ahead today. If the vendor's header logic
+  broke (ignored the header, or started serving the same build both ways),
+  there would be no way to detect it from the response alone.
+
+#### CleanShot X (`pl.maketheweb.cleanshotx`) — single-channel, no-op
+
+- Channel: **stable only**. `CleanShotChannel.resolveCurrent()` never
+  returns a non-stable `ResolvedChannel` — the personalized, license-keyed
+  feed swap exists to fix a phantom-downgrade bug (frozen legacy v3 feed
+  vs. the real subscription-gated "legit" feed), not to expose a channel
+  choice.
+- Install-carrying: yes (signed, `SUPublicEDKey` present), but there is no
+  cross-channel question to ask: with one channel, there is no wrong train
+  to cross to.
+- What proves channel: N/A. A proof-registry entry would be a no-op.
+
+#### IINA (`com.colliderli.iina`) — feed-swap, **same shape as Fork/Surge, currently dormant**
+
+- Channels: stable / beta. Two feeds: `iina.io/appcast.xml` (stable) and
+  `iina.io/appcast-beta.xml` (beta).
+- Install-carrying: **yes**, signed (`SUPublicEDKey` present), edSignature
+  present, `.dmg`.
+- What proves channel: **nothing in the artifact** — identical risk shape
+  to Fork/Surge. Live-measured 2026-08-28 (§2): the two feeds are currently
+  **byte-identical** (matching md5), i.e. IINA has not shipped a beta build
+  ahead of stable recently, so there is nothing to misresolve *today*. That
+  is a fact about the current vendor state, not a property of the
+  mechanism — the exposure is the same as Fork/Surge and will matter again
+  the moment a beta build diverges.
+
+#### Ghostty (`com.mitchellh.ghostty`) — single-channel, no-op
+
+- Channel: **stable only**, deliberately — the doc comment states tip/nightly
+  builds are on GitHub Releases under a rolling `tip` tag, not this appcast,
+  and a user actually running tip is a documented, accepted blind spot
+  (`CHANNEL_COVERAGE_TODO`), unrelated to this issue.
+- Install-carrying: yes, signed (`SUPublicEDKey` present), edSignature
+  present, `.zip`.
+- What proves channel: N/A, single channel.
+- **Docs finding, unrelated to the proof question**: `docs/app-audits/com-mitchellh-ghostty.md`
+  is stale — it says "当前生效源…unknown", "本机 bundle has no SUFeedURL",
+  and lists both Sparkle and VendorProbe as unimplemented (`○`). That was
+  true before `GhosttyChannel.swift` was added; today the binding is fully
+  wired (`feedOverride`, EdDSA-verified one-click). Flagged separately from
+  the channel-proof question since it's a documentation-drift finding, not
+  a code gap — the audit doc should be updated to match `GhosttyChannel.swift`.
+
+#### BetterDisplay (`pro.betterdisplay.BetterDisplay`) — channel-tag, no-op, **undocumented in `docs/app-audits/`**
+
+- Channels: stable / beta (`pre`) / unstable (`internal`, subsumes `pre`).
+  One appcast, `<sparkle:channel>` tags, `sparkleChannelNames` override
+  (`ReleaseChannel` has no `.pre`/`.internal` case).
+- Install-carrying: **yes** for all three tracks — signed (`SUPublicEDKey`
+  present), edSignature present, `.dmg`/`.zip`.
+- What proves channel: the `<sparkle:channel>` tag, same structural
+  enforcement as DuoPaste. Live-verified 2026-08-28 (§2): `internal` items
+  live under a distinct, rolling `/releases/download/pre/` GitHub tag path
+  (two hash-named `.zip` builds, no per-version tag); `pre` items live under
+  per-version tag paths with `-pre-release` in the filename; stable items
+  are untagged with a plain filename. So for the `pre` and stable tracks the
+  artifact path *also* independently corroborates the tag; only `internal`
+  relies on the tag alone.
+- **No audit doc exists** for BetterDisplay under `docs/app-audits/` at all,
+  despite `BetterDisplayChannel.swift` carrying the most involved binding
+  logic in the whole file (three tracks, a subsuming toggle, an excluded
+  `arm64_pre` fourth tag with its own architecture trap). Worth creating
+  one — flagged as a documentation gap, not part of this task's scope to fix.
+
+---
+
+## 2. Live sweep (Q2) — raw commands and output
+
+Built `channel-verify` fresh from **this worktree's source**
+(`swift build --package-path application-test -c release`) rather than
+relying on the installed `duo` binary, whose exact provenance relative to
+this checkout was not confirmed (its mtime, `Aug 28 14:00`, is close to
+this branch's HEAD commit `0dd7540` at `2026-08-28 14:00:25`, but "close"
+isn't "known-same" — per CLAUDE.md, an unverified match is not a verified
+one). Building from source sidesteps the question entirely: every result
+below ran the code actually in this checkout.
+
+Six of the eight apps in the population are installed on this machine
+(Fork, Surge, TablePlus, CleanShot X, Ghostty, BetterDisplay), plus DuoPaste
+in `~/Applications`. IINA is not installed, so it was probed by curl only.
+
+### 2.1 Production chain, per installed app (`channel-verify --check`)
+
+```
+$ .build/release/channel-verify --check com.DanPristupov.Fork
+  UpdateChecker.check() — full production source chain
+    app             Fork
+    bundle id       com.DanPristupov.Fork
+    short version   2.69.0
+    build version   2.69.0
+    detected channel → beta
+    winning source    → Sparkle
+    latest            → 2.69.0
+    status            → up to date
+
+$ .build/release/channel-verify --check com.nssurge.surge-mac
+    app             Surge
+    short version   6.9.0
+    build version   12230
+    detected channel → beta
+    winning source    → Sparkle
+    latest            → 6.9.0
+    status            → up to date
+
+$ .build/release/channel-verify --check com.tinyapp.TablePlus
+    app             TablePlus
+    short version   26.9.13
+    build version   771
+    detected channel → beta
+    winning source    → Sparkle
+    latest            → 26.9.13
+    status            → up to date
+
+$ .build/release/channel-verify --check pl.maketheweb.cleanshotx
+    app             CleanShot X
+    short version   4.8.10
+    detected channel → stable
+    winning source    → Sparkle
+    latest            → 4.8.10
+    status            → up to date
+
+$ .build/release/channel-verify --check com.mitchellh.ghostty
+    app             Ghostty
+    short version   1.3.1
+    build version   15212
+    detected channel → stable
+    winning source    → Sparkle
+    latest            → 1.3.1
+    status            → up to date
+
+$ .build/release/channel-verify --check pro.betterdisplay.BetterDisplay
+    app             BetterDisplay
+    short version   4.3.6
+    build version   50119
+    detected channel → stable
+    winning source    → Sparkle
+    latest            → 4.3.6
+    status            → up to date
+
+$ .build/release/channel-verify --check io.duopaste.daemon
+    app             DuoPaste
+    short version   0.1.1283-beta+dc86f01
+    build version   1283
+    detected channel → beta
+    winning source    → Sparkle
+    latest            → 0.1.1283-beta+dc86f01
+    status            → up to date
+```
+
+Verdict: **all seven installed apps resolve to the channel their own
+on-disk preference says, and the production chain reports "up to date"
+against the live feed** — i.e. `ChannelBinding` correctly identifies which
+channel each of these real installs is on today. This says nothing about
+artifact-level protection (that's §1) — it confirms the *resolver* half of
+the pipeline works, on real machines, right now.
+
+### 2.2 TablePlus header flip — the issue's exact question, answered
+
+```
+$ curl -s "https://tableplus.com/osx/version.xml" | <extract first item>
+<item><enclosure … sparkle:version="770" sparkle:shortVersionString="26.9.12"
+  sparkle:edSignature="IM+EwfMotkiBPshQkKS4xll4XiIknYo0DBtrbq2H8R3bXapf9OoFWuX2diZ3ZqvfB3CKVVZ5OkzilKJ7GLuvAQ=="
+  url="https://files.tableplus.com/macos/770/TablePlus.dmg"></enclosure>
+<title>Build 770 - Support MacOS 27 Golden Gate</title> …
+
+$ curl -s -H "X-Tiny-Beta-Update: true" "https://tableplus.com/osx/version.xml" | <extract first item>
+<item><enclosure … sparkle:version="771" sparkle:shortVersionString="26.9.13"
+  sparkle:edSignature="gk9xVrej8FTgKZn4TCprvierNQX1s69IjPvXLo9xIEaVdR55h65p9iXW0ddMTKrPbuAWYCU9+dYLbMk1QhgwCg=="
+  url="https://files.tableplus.com/macos/771/TablePlus.dmg"></enclosure>
+<title>Beta Update - Golden Gate - You received this update because you've
+  enabled: Preferences > Receive Beta Updates.</title> …
+```
+
+**Verdict: currently correct.** The header is still load-bearing today —
+bare gets build 770 (stable), the header gets build 771 (beta), and the
+description text in the beta response even states the reason
+("...because you've enabled..."). But per §1, this is entirely
+unprotected: the only thing distinguishing the two responses is a
+build-number path segment, and nothing checks that "the header worked."
+This is a live confirmation of the issue's central claim, not a
+hypothetical.
+
+### 2.3 Fork feed-swap — content check
+
+```
+$ curl -s "https://fork.dev/update/feed-stable.xml" | <first item>
+<title>Fork 2.66</title> … <enclosure url="https://cdn.fork.dev/mac/Fork-2.66.7.dmg"
+  sparkle:version="2.66.7" type="application/octet-stream"/>
+
+$ curl -s "https://fork.dev/update/feed.xml" | <first item>
+<title>Fork 2.69</title> … <enclosure url="https://cdn.fork.dev/mac/Fork-2.69.0.dmg"
+  sparkle:version="2.69.0" type="application/octet-stream"/>
+```
+
+**Verdict: currently correct** (stable trails beta as expected, matching the
+installed Fork's own resolution above). **No `<sparkle:channel>` tag on
+either feed's items** — confirms the channel gate is purely "which URL," not
+anything content-based.
+
+### 2.4 Surge feed-swap — content check
+
+```
+$ curl -s "https://nssurge.com/mac/latest/appcast-signed.xml" | <first item>
+<title>Version 6.8.1</title> … <enclosure
+  url="https://dl.nssurge.com/mac/v6/Surge-6.8.1-12030-69f4be88db9663476f31a6b264109f0b.zip"
+  sparkle:version="12030" sparkle:shortVersionString="6.8.1"
+  sparkle:edSignature="Y20CeDkOVmRqup4Em11hLa/cAghbZp5yc4K2YXv0bMJnwnkfwo27gHeS5gxs8GqOHLl35cUlzXc6WHpD+JeaAg=="/>
+
+$ curl -s "https://nssurge.com/mac/latest/appcast-signed-beta.xml" | <first item>
+<title>Version 6.9.0</title> … (edSignature present, different build)
+```
+
+**Verdict: currently correct** (stable 6.8.1/12030 vs beta 6.9.0, matching
+the installed Surge's own resolution above). No `<sparkle:channel>` tag
+either.
+
+### 2.5 IINA feed-swap — content check
+
+```
+$ curl -s "https://www.iina.io/appcast.xml" | md5
+4baab4045924cc7ee1f34dfba6dad355
+$ curl -s "https://www.iina.io/appcast-beta.xml" | md5
+4baab4045924cc7ee1f34dfba6dad355
+```
+
+**Verdict: could not measure divergence-handling** — the two feeds are
+currently byte-identical (both head at 1.4.4 / build 168), so there is
+nothing to misresolve right now. The mechanism (feed-swap, no artifact
+marker) is structurally identical to Fork/Surge, so the same exposure
+applies whenever IINA next ships a beta ahead of stable — this is a
+statement about current vendor state, not a clean bill of health.
+
+### 2.6 DuoPaste channel-tag — content check
+
+```
+$ curl -s "https://raw.githubusercontent.com/jizhi0v0/duo-paste-releases/main/appcast.xml"
+  | <first 6 items>
+title: Version 0.1.1283-beta+dc86f01   channel: beta
+  url: …/download/v0.1.1283-beta+dc86f01/DuoPaste-0.1.1283-beta+dc86f01.dmg   edSig: True
+title: Version 0.1.1282-beta+5699299   channel: beta
+  url: …/DuoPaste-0.1.1282-beta+5699299.dmg   edSig: True
+… (all 20 items in the head of the feed are tagged `beta` and carry `-beta+`
+   in the filename)
+```
+
+**Verdict: currently correct and structurally protected** — every item is
+both tagged and filename-marked as beta.
+
+### 2.7 BetterDisplay channel-tag — content check
+
+```
+$ curl -s "https://betterdisplay.pro/betterdisplay/sparkle/appcast.xml" | <first 6 items>
+title: 5.0.4   channel: internal
+  url: …/releases/download/pre/BetterDisplay-v5.0.4-b53044.zip
+title: 5.0.4   channel: internal
+  url: …/releases/download/pre/BetterDisplay-v5.0.4-b52989.zip
+title: 5.0.3   channel: pre
+  url: …/releases/download/v5.0.3/BetterDisplay-v5.0.3-pre-release.dmg
+title: 5.0.2   channel: pre
+  url: …/releases/download/v5.0.2/BetterDisplay-v5.0.2-pre-release.dmg
+title: 4.3.6   channel: (untagged/stable)
+  url: …/releases/download/v4.3.6/BetterDisplay-v4.3.6.dmg
+title: 5.0.1   channel: arm64_pre
+  url: …/releases/download/v5.0.1/BetterDisplay-v5.0.1-pre-release.dmg
+```
+
+**Verdict: currently correct and structurally protected** — matches
+`BetterDisplayChannel.swift`'s doc comment exactly (internal under rolling
+`/pre/` tag, pre under per-version tag with `-pre-release` filename token,
+stable untagged, `arm64_pre` present and correctly excluded from every
+allowed set).
+
+### 2.8 CleanShot X — could not measure the channel that actually matters
+
+```
+$ curl -s "https://updates.getcleanshot.com/v3/appcast.xml" | <first item>
+<title>3.7.1</title> … <enclosure url="https://updates.getcleanshot.com/v3/CleanShot-X-3.7.1.dmg" …
+```
+
+This confirms the **legacy, frozen** feed (matches the doc comment: stuck at
+3.7.1). It is **not** the feed `ChannelBinding` actually uses — that's the
+personalized `legit.maketheweb.io/api/v1/appcast?key=<licenseKey>` feed,
+which requires a real license key this session does not have.
+**Could not measure** the feed duo-updater actually reads; relying on the
+prior verification recorded in `docs/app-audits/pl-maketheweb-cleanshotx.md`
+(2026-06-04: personalized feed head = 4.8.8 = installed). Not re-verified
+this session. Moot for the channel-proof question regardless, since
+CleanShot only ever resolves `.stable`.
+
+### 2.9 Ghostty — single channel, sanity only
+
+```
+$ curl -s "https://release.files.ghostty.org/appcast.xml" | <first 3 items>
+title: Build 8343   channel: (untagged/stable)   edSig: True
+title: Build 8346   channel: (untagged/stable)   edSig: True   url: …/0.1.4/ghostty-macos-universal.zip
+title: Build 8347   channel: (untagged/stable)   edSig: True   url: …/0.1.5/ghostty-macos-universal.zip
+```
+
+Confirms stable-only, signed, one-click-eligible — no channel question to
+ask.
+
+---
+
+## 3. Which rows a proof entry would be a no-op for
+
+| Binding | Channel(s) at risk | Structural protection today | Would a proof entry add anything? |
+|---|---|---|---|
+| DuoPaste (beta) | beta | `<sparkle:channel>` tag, enforced in `SparkleAppcastSource.usableItems` for every channel-tag app + filename also carries `-beta+` | **No-op** |
+| BetterDisplay (beta="pre", unstable="internal") | pre / internal | Same tag mechanism + path-level corroboration for pre/stable | **No-op** |
+| CleanShot X | none (stable only) | N/A — no non-stable channel exists | **No-op** |
+| Ghostty | none (stable only) | N/A — no non-stable channel exists | **No-op** |
+| **Fork (beta)** | beta | **None** — feed-swap, zero artifact marker, unsigned | **Real gap** |
+| **Surge (beta)** | beta | **None** — feed-swap, zero artifact marker, signed (over-trust risk) | **Real gap** |
+| **TablePlus (beta)** | beta | **None** — header-keyed, zero artifact marker beyond an incidental build number | **Real gap** |
+| **IINA (beta)** | beta | **None** — feed-swap, zero artifact marker, currently dormant (feeds identical) | **Real gap** |
+
+**Exactly half (4 of 8) are no-ops**, and the other half is the entire
+feed-swap / header-keyed subset. This is precisely the shape the issue
+warned about ("a proof table that is half no-ops is worse than none") —
+except here it isn't a warning about a hypothetical table, it's a
+measured split of the real population.
+
+Worth stating plainly: the 4 "no-op" rows aren't no-ops because nobody
+bothered to protect them — they're no-ops because `SparkleAppcastSource`'s
+channel-tag filtering **already is** an equivalent-strength, code-level
+guarantee that applies uniformly to every channel-tag app, VendorProbe or
+Sparkle-native alike, without anyone having to remember to register
+anything. That's arguably a stronger guarantee than `ChannelProofRegistry`
+gives the VendorProbe population (a regex some author has to write and
+which can silently rot) — it just isn't visible as a "proof" because it was
+never designed as one.
+
+---
+
+## 4. Recommendation (not implemented) — SUPERSEDED, see §5
+
+> Kept verbatim below because the measurement it rests on is sound and still the
+> record of what was checked; the conclusion it reaches was not taken. §5 says why.
+
+
+
+The genuinely exposed rows (Fork, Surge, TablePlus, IINA) share a property
+that makes them harder to close with the *same primitive* the existing
+registry uses: **`ChannelArtifactProof.artifact(pattern)` needs a string in
+the resolved URL to anchor on, and none of these four vendors puts a
+channel token in the artifact at all.** Unlike OrbStack/Alfred/CapCut/
+Tailscale/GitHub-rule cases — where the issue text and `ChannelProofRegistry`
+comments describe a real path segment or filename token to regex against —
+here the entire channel signal lives *outside* the response: in which URL
+was requested, or which header was sent, before the vendor ever answered.
+A regex proof on the *response* literally cannot see that decision.
+
+Trade-offs, stated rather than decided:
+
+- **Extend the two-map pattern with a third `ChannelBinding`-typed overload
+  of `crossChannelArtifact`.** Matches the existing shape and reuses
+  `ChannelProofKey`. But for Fork/Surge/TablePlus/IINA there is nothing
+  honest to write as an `.artifact` pattern — the best available assertion
+  is something weaker than what the type currently promises (e.g. "the
+  beta feed's head version is not older than stable's," which is a
+  staleness heuristic, not a channel proof, and would pass even if the
+  vendor collapsed both feeds to the same content). Writing a proof entry
+  that can't actually prove anything risks the opposite failure the issue
+  is trying to prevent — a green check nobody should trust.
+- **Extend the *exhaustiveness test* only, not a proof registry**, requiring
+  a hand-written, honest note per `(bundleID, channel)` in this population
+  — including "no artifact-level marker exists; protection is entirely
+  'we asked the right URL'" for the four exposed rows. Cheaper, and it
+  makes the real state of things impossible to overlook in a diff, without
+  fabricating a check that would pass unconditionally.
+- **A live differential check** (not a static proof): periodically fetch
+  both feeds/both header states for these four apps and assert they are
+  *not* byte-identical (or, for TablePlus, that the two responses' builds
+  differ) — catching a vendor-side collapse the moment it happens rather
+  than asserting a pattern that can't distinguish "the header worked" from
+  "the header stopped mattering and both requests happen to return the
+  same thing today." This is closest to what would have caught the actual
+  failure mode described in the issue, but it is a monitoring addition, not
+  a build-time guard, and the two kinds of protection are not substitutes
+  for each other.
+
+No implementation attempted per the task's scope. The choice among these
+(or some combination) is the decision this report exists to inform.
+
+
+---
+
+## 5. What was actually implemented (2026-08-28)
+
+§4 concluded that the four exposed rows could not be closed with the existing
+primitive, because `ChannelArtifactProof.artifact(pattern)` needs a token in the
+resolved URL and none of these vendors puts one there. That is true of
+`.artifact`, and it is the reason none of the four gets one.
+
+But it does not hold for `.recipeAnchor`, and that is the primitive these rows
+need. **`.recipeAnchor` never asserted anything about the artifact.** It asserts
+that the recipe reads a channel-dedicated source. Alfred's registered proof is
+`prerelease\.xml`, matched against the recipe's endpoint — literally "we asked
+the right URL", which is exactly the assertion available for Fork, Surge and
+IINA, and the header equivalent is exactly the assertion available for TablePlus.
+So these four are not a weaker class of evidence than the vendor population; they
+are the same class, in a population that had no registry to put it in.
+
+What shipped:
+
+- `ChannelProofRegistry.bindingProofs` — four entries, all `.recipeAnchor`,
+  field-scoped onto `feedOverride` / `feedHTTPHeaders` (the field scoping is
+  issue #110, landed alongside).
+- `ChannelProofRegistry.channelBindingsNeedingProof` — the population, **derived**
+  from three predicates rather than hand-listed: non-stable, not vendor-probe
+  backed, and request-keyed (`feedOverride != nil || !feedHTTPHeaders.isEmpty`).
+  That last predicate is what makes §3's "half the table would be no-ops" not
+  happen: a channel-TAG binding is excluded by construction, because
+  `SparkleAppcastSource.allowedChannels` already narrows the feed to the tags the
+  user opted into. The derived population is exactly the four rows §3 called real
+  gaps — zero no-ops, and it stays exact as bindings are added or removed.
+- `RecipeSanity.crossChannelBinding` — deliberately NOT an overload of
+  `crossChannelArtifact`, and takes no `RemoteVersion`, because there is no
+  artifact to inspect.
+- `ChannelBinding.allResolutions` — every resolution a binding can produce,
+  machine-independently, built by calling each resolver's own pure function so no
+  feed URL or header is restated.
+
+Two things this does NOT do, stated plainly because the opposite impression is
+the "green check nobody should trust" §4 rightly worried about:
+
+1. **It is build-time only.** `duo verify` sweeps recipes and rules, not
+   bindings, so these proofs fail in a PR when someone edits the discriminator
+   away — not when a vendor retires it. §4's third option (a live differential
+   check) remains the answer to the vendor-side failure and is not a substitute
+   for this one, nor this for it.
+2. **It cannot see inside the response.** For all four, stable and non-stable are
+   the same filename from the same host.
+
+The strongest property the tests do pin, which the recipe-side registry cannot
+state as directly: `everyBindingProofFailsOnItsOwnStableSibling` asserts each
+anchor does **not** match the same app's stable resolution. An anchor is only
+evidence if the other channel's request would fail it — `appcast-signed-beta\.xml`
+proves something precisely because `appcast-signed.xml` does not match, whereas
+an anchor of `appcast` would match both, prove nothing, and look identical in a
+diff. Fork is the case that makes this non-obvious: its BETA feed is the
+unsuffixed `feed.xml` and stable is `feed-stable.xml`, so the anchor is the
+absence of a suffix.


### PR DESCRIPTION
Closes #111. **Stacked on #122** (it uses the field-scoped `.recipeAnchor` from #110) — retarget to `main` once that merges.

## The gap

`ChannelBinding` + `SparkleAppcastSource` reaches an install without passing through either registry. `channelRecipesWithInstall` and `channelGitHubRulesWithInstall` read one registry each, and both `crossChannelArtifact` overloads are typed on a `VendorProbeRecipe` / `GitHubReleaseRule`, so nothing could reach this population at all.

TablePlus `.beta` is the sharpest case, and it was live-reproduced during the measurement: bare request → build 770 (stable), `X-Tiny-Beta-Update: true` → build 771 (beta). Same host, same path shape, same filename. Retire that header and a beta user is served the stable dmg with the same Team ID, notarized, past every gate we have.

## The population, measured not assumed

`ChannelBinding.resolve` switches on 12 bundle ids, but 4 of them (OrbStack, Alfred, Tailscale, CapCut) resolve their *install* through `VendorProbeRegistry` and are already covered by `proofs`. Of the remaining 8, only 4 are genuinely unprotected:

| binding | shape | protected today? |
|---|---|---|
| DuoPaste, BetterDisplay | channel-tag | **yes** — `SparkleAppcastSource.allowedChannels` narrows the feed to the opted-in `<sparkle:channel>` tags |
| CleanShot X, Ghostty | single-channel | no non-stable channel exists |
| **Fork, Surge, TablePlus, IINA** | feed-swap / header-keyed | **no** — nothing in the response corroborates the channel |

## Why these are closable, contra the measurement's own recommendation

The audit report (included in this PR, §4) concluded no honest primitive existed, because `.artifact` needs a token in the resolved URL and none of these vendors puts one there. That is true of `.artifact` — and it is why none of the four gets one.

But **`.recipeAnchor` never asserted anything about the artifact.** It asserts the recipe reads a channel-dedicated source. Alfred's registered proof is `prerelease\.xml` matched against its *endpoint* — literally "we asked the right URL", which is exactly the assertion available for Fork/Surge/IINA, and the header equivalent is exactly the assertion available for TablePlus. Same class of evidence, in a population that had nowhere to record it. §5 of the doc states this and marks §4 superseded rather than rewriting it.

## Zero no-ops, by construction

Issue #111's warning was that a table half full of no-ops is worse than none. The population is **derived** from three predicates — non-stable, not vendor-probe backed, and request-keyed (`feedOverride != nil || !feedHTTPHeaders.isEmpty`) — so a channel-tag binding is excluded by construction, and the set is exactly the four real gaps. `bindingProofsCoverExactlyThatPopulation` asserts both directions, so a no-op entry fails just as loudly as a missing one.

## The property worth having

`everyBindingProofFailsOnItsOwnStableSibling`: each anchor must **not** match the same app's stable resolution. An anchor is only evidence if the other channel's request would fail it — `appcast-signed-beta\.xml` proves something precisely because `appcast-signed.xml` does not match, whereas an anchor of `appcast` would match both, prove nothing, and look identical in a diff. Fork makes this non-obvious: its *beta* feed is the unsuffixed `feed.xml` and stable is `feed-stable.xml`, so the anchor is the absence of a suffix.

The TablePlus header value is covered too, not just the field name — the server treats `1`/`yes` as stable, so a proof that only matched `X-Tiny-Beta-Update` would stay green through exactly the vendor change that starts serving beta users stable builds. That is why `ResolvedChannel.anchorLines` renders a header as one `key: value` line.

## What this does NOT do

Stated plainly, because the opposite impression is the green check nobody should trust:

1. **Build-time only.** `duo verify` sweeps recipes and rules, not bindings. These fail in a PR when someone edits the discriminator away — **not** when a vendor retires it. A live differential check (the audit's third option) is the answer to the vendor-side failure and is not a substitute for this, nor this for it.
2. **It cannot see inside the response.** For all four, stable and non-stable are the same filename from the same host.

## Verification

```
swift test (DuoUpdaterCore)  1326 tests in 104 suites passed, 1 known issue
swift test (CLI)              161 tests in 22 suites passed
```
`everyBindingIsEnumerated` pins `allResolutions` against `boundBundleIDs` and is explicit in its own doc about what it cannot catch (a resolver added to the switch and to neither list — Swift can't reflect over a switch).

---

## Review round 2

Adversarial review found six defects. Corrections in `3f241ff`:

- **The enumeration was machine-dependent — it passed on my Mac and would have failed on every other one.** `allResolutions` enumerated CleanShot via `resolveCurrent()`, which returns nil without a licensed CleanShot X on the running machine. Licensed → 8 ids; CI or anyone else → 7, and `everyBindingIsEnumerated` fails there and only there. It also put a **real licence key** into a public `static let`, in a file whose header says the key must never be logged or persisted. Now enumerated through a pure `resolve(activationKey:)` with a placeholder; `resolveCurrent()` is the only path touching the real key.

  **Nothing leaked**: `allResolutions` has never been on `main`, so this never shipped. I re-verified the existing protections and they all hold — `diskCapacity: 0` on the update session (documented as a security boundary, naming this exact key), `ChannelSwitchDetector.fingerprint`'s SHA-256 as the only persisted form, no feed-URL logging anywhere (`SparkleAppcastSource` has none at all), and neither `ResolvedChannel` nor `InstalledApp` is `Codable`.

- **The population was too narrow.** Excluding all channel-tag bindings was wrong for BetterDisplay: the `<sparkle:channel>` filtering is real, but the tag *names* are a per-app constant (`preTag`/`internalTag`), because its feed spells them `pre`/`internal` and no `ReleaseChannel` case does. Retype one and `allowedChannels` builds a set matching nothing, so the user matches only untagged items and is silently offered **stable** — and `allowedChannels` cannot catch it, because it cannot validate a name it is handed. DuoPaste stays excluded on the sharper distinction: its tag is *derived* from `ReleaseChannel.rawValue` in shared code, so there is no constant to mistype. Population is now 6.

- **Three factual claims in my comments were false**, which is the same defect class as #113 and as the previous round on #122:
  - "stable and beta are the same filename from the same host" — false for 3 of 4. Fork serves `Fork-2.66.7.dmg` vs `Fork-2.69.0.dmg`; Surge puts a per-build hash in the name; only TablePlus reuses a filename. The true claim, and the one the design rests on, is that none of them carries a channel **token** — a version or a hash is not a channel. Corrected in source, in the audit doc, and above in this description.
  - "two of these four bindings' stable feeds would trip a bare token match" — measured: **zero** do.
  - `vendorProbeBackedBindings`' summary line described the opposite of the set it holds.

- **The vacuous-anchor test I added in #122 had a hole.** It probed only `""` and claimed that was a total discriminator. `.+` and `.` match every real surface while failing on `""` — so they passed while asserting only "this field is non-empty". Now probes `""` *and* arbitrary non-empty strings, and covers all three registries. This matters most on TablePlus, where `everyBindingProofFailsOnItsOwnStableSibling` cannot backstop it (its stable header surface is `""`). Red-checked on both arms.

  *This fix lives here rather than in #122 because the test now iterates `bindingProofs`, which only exists on this branch. If #122 merges alone, that gap remains until this lands.*

- Smaller: TablePlus's anchor is right-anchored (it accepted `trueX`); `crossChannelBinding` matches the bundle id case-insensitively like `ChannelBinding.resolve` (TablePlus ships `com.tinyapp.TablePlus`); the collision test compares **populations** rather than registered keys; `vendorProbeBackedBindingsAreNotEnumerated` pins that predicate term's inertness rather than assuming it; and `try! #require` no longer risks taking the test binary down.

Re-verified: `swift test` 1327 passing (DuoUpdaterCore) + 161 (CLI).

One flake seen and chased down rather than waved off: `installPipelineDryRun` failed twice on this branch. It picks `candidates.prefix(1)`, which is currently TablePlus. I ran the same test on a clean `main` worktree — same target, and both sides pass on re-run. The failing path is a CDN download, and `crossChannelBinding` has no production caller, so this branch cannot be the differentiator.
