### PR TITLE
fix(core): brew info no longer occupies the formula-release actor

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
@@ -100,7 +100,7 @@ public actor BrewFormulaReleaseService {
     }
 
     private func compute(name: String, version: String, token: String?) async -> FormulaRelease {
-        guard let info = Self.brewInfo(name: name) else {
+        guard let info = await Self.brewInfoOffActor(name: name) else {
             return FormulaRelease(changelog: nil, pageURL: nil)
         }
         guard let gh = Self.deriveGitHub(fromStableURL: info.stableURL) else {
@@ -165,7 +165,29 @@ public actor BrewFormulaReleaseService {
 
     // MARK: - brew info (local)
 
-    private struct Info { let homepage: URL?; let stableURL: String? }
+    private struct Info: Sendable { let homepage: URL?; let stableURL: String? }
+
+    /// `brewInfo` on a detached task, so the ~0.5s subprocess never occupies this
+    /// actor. Load-bearing: `brewInfo` is already effectively non-isolated (it's
+    /// `static`), but that alone changes nothing — a *synchronous* call has no
+    /// ability to switch executors, so it runs to completion on whatever executor
+    /// calls it. Called synchronously from `compute`, that executor is this actor,
+    /// and the actor stays occupied for the whole subprocess.
+    ///
+    /// That serialized every client behind every other: `prewarmFormulaReleases`
+    /// enqueues one task per outdated formula, so selecting a formula whose notes
+    /// were ALREADY on disk still spun for N x 0.5s — its cheap `cached(...)` hop
+    /// queued behind the whole blocking chain (23 outdated formulae here = ~10s).
+    /// Awaiting a detached task hops off, leaving the actor holding only the cache
+    /// and bookkeeping work it's actually for.
+    ///
+    /// Deliberately unthrottled: measured on a 14-core machine, 23 concurrent
+    /// `brew info` calls finish in ~0.8s (vs ~10.3s serialized) and cost an
+    /// unrelated cooperative-pool consumer ~0.01s of added stall. A concurrency
+    /// limit here would buy nothing and read as load-bearing.
+    private static func brewInfoOffActor(name: String) async -> Info? {
+        await Task.detached(priority: .utility) { Self.brewInfo(name: name) }.value
+    }
 
     /// Read `homepage` + `urls.stable.url` for one formula from `brew info
     /// --json=v2` — local, no network, authoritative for the installed formula.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
@@ -165,28 +165,54 @@ public actor BrewFormulaReleaseService {
 
     // MARK: - brew info (local)
 
+    /// `Sendable` because `brewInfoOffActor` resumes a continuation with it from a
+    /// Dispatch thread — it crosses a concurrency domain, it isn't decoration.
     private struct Info: Sendable { let homepage: URL?; let stableURL: String? }
 
-    /// `brewInfo` on a detached task, so the ~0.5s subprocess never occupies this
-    /// actor. Load-bearing: `brewInfo` is already effectively non-isolated (it's
-    /// `static`), but that alone changes nothing — a *synchronous* call has no
-    /// ability to switch executors, so it runs to completion on whatever executor
-    /// calls it. Called synchronously from `compute`, that executor is this actor,
-    /// and the actor stays occupied for the whole subprocess.
+    /// Runs `brewInfo` on a Dispatch thread, so the ~0.5s subprocess never occupies
+    /// this actor. The hop is load-bearing: `brewInfo` is already effectively
+    /// non-isolated (it's `static`), but that alone changes nothing — a *synchronous*
+    /// call has no ability to switch executors (SE-0338), so it runs to completion on
+    /// whatever executor calls it. Called synchronously from `compute`, that executor
+    /// is this actor, and the actor stays occupied for the whole subprocess.
     ///
-    /// That serialized every client behind every other: `prewarmFormulaReleases`
-    /// enqueues one task per outdated formula, so selecting a formula whose notes
-    /// were ALREADY on disk still spun for N x 0.5s — its cheap `cached(...)` hop
-    /// queued behind the whole blocking chain (23 outdated formulae here = ~10s).
-    /// Awaiting a detached task hops off, leaving the actor holding only the cache
-    /// and bookkeeping work it's actually for.
+    /// That serialized every client behind every other. With a GitHub token configured
+    /// `prewarmFormulaReleases` calls `release(...)` for each uncached outdated formula
+    /// — without a token it only reads the disk cache and never spawns a subprocess at
+    /// all, so the storm below is token-gated — and the interactive path
+    /// (`ensureFormulaReleaseLoading`, on user select) shares this actor. So selecting
+    /// a formula whose notes were ALREADY on disk still spun for N x 0.5s: its cheap
+    /// `cached(...)` hop queued behind the whole blocking chain. #112's parser
+    /// generation invalidates every entry once after an upgrade, which is exactly when
+    /// N is largest (11 of 23 outdated formulae on the author's machine, ~7s).
     ///
-    /// Deliberately unthrottled: measured on a 14-core machine, 23 concurrent
-    /// `brew info` calls finish in ~0.8s (vs ~10.3s serialized) and cost an
-    /// unrelated cooperative-pool consumer ~0.01s of added stall. A concurrency
-    /// limit here would buy nothing and read as load-bearing.
+    /// Dispatch, NOT `Task.detached`: a detached task still runs on the *cooperative*
+    /// pool, which is width-capped near the core count and does not overcommit when one
+    /// of its threads blocks. Fanning out N blocking `waitUntilExit()` calls there
+    /// saturates the `.utility` band and stalls unrelated `.utility` work — this repo
+    /// puts `BackupStore.pruneOrphans`, `runChannelSwitchRecheck` and the `lsappinfo`
+    /// probe in that band, and they overlap the very refresh that triggers this.
+    /// Measured 23-wide on a 14-core M3 Max, worst added stall for an unrelated,
+    /// freshly-enqueued `.utility` task:
+    ///
+    ///     Task.detached          0.95 - 1.07s     fan-out wall 2.34s
+    ///     DispatchQueue.global   0.02 - 0.06s     fan-out wall 2.36s
+    ///
+    /// Same wall clock, ~25x less collateral, because Dispatch grows its pool when a
+    /// thread blocks. That is why there is no concurrency limit here: a bound would be
+    /// treating a symptom of the wrong vehicle.
+    ///
+    /// If you re-measure, probe in the SAME QoS band as the blocked threads. Darwin
+    /// pools per-QoS, so a probe on `.medium` (or any other band) reports ~0.01s and
+    /// looks perfectly healthy while `.utility` is fully saturated. An earlier revision
+    /// of this comment shipped that ~0.01s figure and concluded, wrongly, that the
+    /// vehicle didn't matter.
     private static func brewInfoOffActor(name: String) async -> Info? {
-        await Task.detached(priority: .utility) { Self.brewInfo(name: name) }.value
+        await withCheckedContinuation { (continuation: CheckedContinuation<Info?, Never>) in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: Self.brewInfo(name: name))
+            }
+        }
     }
 
     /// Read `homepage` + `urls.stable.url` for one formula from `brew info

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
@@ -9,7 +9,13 @@ import Foundation
 /// subprocess is called synchronously from an actor-isolated method it holds the
 /// actor for its whole duration, so the chain serializes and a formula whose notes
 /// are ALREADY on disk still spins for N x 0.5s behind it.
-@Suite(.serialized)
+/// Gated, not `#require`d: a `#require` failure is a test FAILURE, and this is the
+/// only test in the repo that needs Homebrew installed — the sibling
+/// `BrewFormulaReleaseServiceTests` goes out of its way to avoid that. On a
+/// brew-less runner there is no subprocess to serialize behind, so the right
+/// outcome is "not applicable", not "broken".
+@Suite(.serialized, .enabled(if: HomebrewInstaller.brewPath() != nil,
+                             "needs Homebrew: the premise is that `brew info` is slow"))
 struct BrewFormulaReleaseActorTests {
     /// Fails instantly, so `fetchRelease` can never reach the real GitHub API — this
     /// test is about the local subprocess, and must not spend rate limit to say so.
@@ -33,10 +39,6 @@ struct BrewFormulaReleaseActorTests {
     /// `brewInfoOffActor`: revert it to a synchronous `Self.brewInfo(name:)` and the
     /// `cached(...)` below queues behind every subprocess in the batch instead.
     @Test func cachedStaysResponsiveWhileUncachedFormulaeAreComputing() async throws {
-        // `brew info` is what blocks; with no brew there is no subprocess to serialize
-        // behind and the test would pass vacuously.
-        try #require(HomebrewInstaller.brewPath() != nil, "needs Homebrew installed")
-
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("BrewFormulaReleaseActorTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -60,6 +62,7 @@ struct BrewFormulaReleaseActorTests {
 
         // A prewarm-sized batch of uncached formulae, each paying a full `brew info`.
         let batch = 4
+        let batchStart = Date()
         let inFlight = (0..<batch).map { i in
             Task {
                 _ = await service.release(
@@ -71,16 +74,31 @@ struct BrewFormulaReleaseActorTests {
         // Let the batch enter the actor before timing the interactive read.
         try await Task.sleep(nanoseconds: 100_000_000)
 
+        let bound = 0.2
         let start = Date()
         let hit = await service.cached(for: cachedName, version: cachedVersion)
         let elapsed = Date().timeIntervalSince(start)
 
         #expect(hit == seeded)
-        // Each `brew info` costs ~0.5s+, so the serialized form would take multiple
-        // seconds to answer here. Generous bound: this is about seconds-vs-instant,
-        // not about measuring the disk read.
-        #expect(elapsed < 0.5, "cached() waited \(elapsed)s behind the brew info batch")
+        // Under ONE subprocess (~0.55s), not under the whole batch. Actors make no FIFO
+        // admission promise, so a bound of 4x-a-subprocess would still pass if `cached`
+        // happened to be admitted after only one `brewInfo` — which is the bug.
+        #expect(elapsed < bound, "cached() waited \(elapsed)s behind the brew info batch")
 
         for task in inFlight { await task.value }
+        let batchElapsed = Date().timeIntervalSince(batchStart)
+
+        // Vacuity guard on this test's own premise. It can only tell "actor held" from
+        // "actor free" while `brew info` is genuinely slow; if it ever gets fast, the
+        // serialized form drops under `bound` and this test passes while proving
+        // nothing. The batch runs concurrently, so its wall clock ~= one subprocess and
+        // the serialized cost ~= batch x that. Fail loudly the day that stops being
+        // true, rather than going quietly green.
+        let serializedEstimate = Double(batch) * batchElapsed
+        #expect(serializedEstimate > 3 * bound, """
+            premise gone: `brew info` is now fast enough that the serialized form \
+            (~\(serializedEstimate)s) no longer clears the \(bound)s bound, so a pass \
+            here proves nothing. Re-tune or delete this test.
+            """)
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `BrewFormulaReleaseService` runs `brew info` (a ~0.5s subprocess) on the way to
+/// a formula's notes. That work must never occupy the actor: `prewarmFormulaReleases`
+/// enqueues one `release(...)` per outdated formula, and the interactive path
+/// (`ensureFormulaReleaseLoading`, on user select) shares the same actor. When the
+/// subprocess is called synchronously from an actor-isolated method it holds the
+/// actor for its whole duration, so the chain serializes and a formula whose notes
+/// are ALREADY on disk still spins for N x 0.5s behind it.
+@Suite(.serialized)
+struct BrewFormulaReleaseActorTests {
+    /// Fails instantly, so `fetchRelease` can never reach the real GitHub API — this
+    /// test is about the local subprocess, and must not spend rate limit to say so.
+    private final class OfflineProtocol: URLProtocol, @unchecked Sendable {
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+        }
+        override func stopLoading() {}
+    }
+
+    private static func offlineSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OfflineProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    /// A disk-cached formula must stay instantly readable while a prewarm-sized batch
+    /// of uncached `release(...)` calls is in flight. Guards the executor hop in
+    /// `brewInfoOffActor`: revert it to a synchronous `Self.brewInfo(name:)` and the
+    /// `cached(...)` below queues behind every subprocess in the batch instead.
+    @Test func cachedStaysResponsiveWhileUncachedFormulaeAreComputing() async throws {
+        // `brew info` is what blocks; with no brew there is no subprocess to serialize
+        // behind and the test would pass vacuously.
+        try #require(HomebrewInstaller.brewPath() != nil, "needs Homebrew installed")
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewFormulaReleaseActorTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let service = BrewFormulaReleaseService(session: Self.offlineSession(), cacheDirectory: dir)
+
+        // Seeded through `persist` rather than a hand-written file: it stamps the
+        // running `Changelog.parserGeneration`, so this can't drift from the on-disk
+        // format the way a literal fixture does. Same reason
+        // `BrewFormulaReleaseServiceTests` uses it — see `persist`'s doc comment.
+        let cachedName = "duocachedformula"
+        let cachedVersion = "1.0.0"
+        let seeded = FormulaRelease(
+            changelog: nil, pageURL: URL(string: "https://example.com/notes"))
+        await service.persist(seeded, name: cachedName, version: cachedVersion)
+
+        // Guard against a vacuous pass: a `cached` that misses returns nil instantly,
+        // and the timing assertion below would then prove nothing.
+        #expect(await service.cached(for: cachedName, version: cachedVersion) == seeded,
+                "seeded entry must be readable before timing it")
+
+        // A prewarm-sized batch of uncached formulae, each paying a full `brew info`.
+        let batch = 4
+        let inFlight = (0..<batch).map { i in
+            Task {
+                _ = await service.release(
+                    for: "duo-uncached-formula-\(i)", version: "9.9.9", token: nil)
+            }
+        }
+        defer { for task in inFlight { task.cancel() } }
+
+        // Let the batch enter the actor before timing the interactive read.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let start = Date()
+        let hit = await service.cached(for: cachedName, version: cachedVersion)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(hit == seeded)
+        // Each `brew info` costs ~0.5s+, so the serialized form would take multiple
+        // seconds to answer here. Generous bound: this is about seconds-vs-instant,
+        // not about measuring the disk read.
+        #expect(elapsed < 0.5, "cached() waited \(elapsed)s behind the brew info batch")
+
+        for task in inFlight { await task.value }
+    }
+}


### PR DESCRIPTION
## The bug

`BrewFormulaReleaseService.compute` called `Self.brewInfo(name:)` synchronously. A synchronous call cannot switch executors, so the `brew info` subprocess — measured at **~0.55s** — ran to completion *on the actor*, holding it the whole time.

Every client of the actor therefore serialized behind every other. `prewarmFormulaReleases` enqueues one task per outdated formula, and the interactive path (`ensureFormulaReleaseLoading`, on user select) shares that actor. So selecting a formula whose notes were **already on disk** still spun for N × 0.55s — its cheap `cached(...)` call queued behind the entire blocking chain.

The counter-intuitive part: the formulae that are *uncached* spin for a good reason. The bug is that the **cached** ones spin too, and longest, because they queue last.

**Token-gated** (this was missing from the first draft): prewarm only calls `release(...)` — hence `brew info` — in its `else if await tokenTask.value != nil` branch. Without a GitHub token configured it reads the disk cache and never spawns a subprocess at all.

Pre-existing, but #112's parser generation invalidates every cached entry once after upgrade, which is exactly when the miss count peaks. On the author's machine at the time of writing: 23 outdated formulae, 11 of them missing → ~7s.

## One correction to the original diagnosis

The suggested direction was "mark `brewInfo` `nonisolated` and run it off the actor's executor". The first half is a **no-op**:

- `brewInfo` is already `static`, and static members of an actor are already non-isolated.
- Per [SE-0338](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0338-clarify-execution-non-actor-async.md), synchronous functions *"'inherit' their executor because they have no ability to change it."*

Only the actual executor hop is load-bearing. That reasoning is in the comment so the next reader does not "simplify" it back into a sync call.

## The fix — and a correction to the first cut of this PR

The first revision used `Task.detached(priority: .utility)` and argued from a measurement that **was wrong by ~100×**. Review caught it, and it was precisely the number that justified the vehicle.

`Task.detached` still runs on the **cooperative** pool, which is width-capped near the core count and does **not** overcommit when one of its threads blocks. Fanning N blocking `waitUntilExit()` calls out there saturates the `.utility` band. Re-measured 23-wide, worst added stall for an unrelated, freshly-enqueued `.utility` task:

| | added stall on unrelated `.utility` work | fan-out wall |
|---|---|---|
| `Task.detached` (first cut) | **0.95 – 1.07s** | 2.34s |
| `DispatchQueue.global(qos:)` (now) | **0.02 – 0.06s** | 2.36s |

So the detach did not reduce a stall — it **created** one, ~1s of collateral on a band this repo uses for `BackupStore.pruneOrphans`, `runChannelSwitchRecheck` and the `lsappinfo` probe, all of which overlap the very refresh that triggers this. Dispatch is the same wall clock with ~25× less collateral, because it grows its pool when a thread blocks.

**Why the original ~0.012s figure was wrong:** it probed a *different QoS band* than the one being saturated. Darwin pools per-QoS, so a `.medium` probe reports ~0.01s and looks perfectly healthy while `.utility` is fully saturated. The comment now says this explicitly, because the mistake is easy to repeat. This was reproduced independently twice.

**No throttle**, but for a corrected reason: with the right vehicle a bound is unnecessary. The first draft's claim that a limit "would buy nothing" rested on the bad measurement and is gone.

**Dedup invariant preserved**: `AppListModel` is untouched. The `.loading` slot is still claimed synchronously on the main actor before any suspension, one layer above the service actor, keyed by name — independently verified, so widening the suspension window cannot cause same-name double-fetch or a `persist` sibling-prune race. Note `compute` was *already* `async` (`await fetchRelease` sat between the `cached()` miss and `persist`), so this PR widens a pre-existing window rather than opening one.

## Test

`BrewFormulaReleaseActorTests` fires a prewarm-sized batch of uncached `release(...)` calls and times a `cached(...)` read against them. Three defects in the first cut, all found in review:

- `try #require(brewPath() != nil)` is a **failure**, not a skip — and this is the only test in the repo needing Homebrew (the sibling `BrewFormulaReleaseServiceTests` deliberately avoids it). Now `.enabled(if:)`.
- The bound was 0.5s against a ~2.3s serialized cost, i.e. under **four** subprocesses. Actors promise no FIFO admission, so `cached` admitted after only **one** `brewInfo` would still have passed with the bug present. Tightened to **0.2s** — under a single subprocess.
- **No guard on its own premise.** The test only distinguishes held-from-free while `brew info` is slow; if it ever got fast, the serialized form would drop under the bound and the test would pass while proving nothing. It now estimates the serialized cost from the batch's own wall clock and fails loudly if it stops clearing the bound by 3×.

Both directions verified, not just asserted:

- revert the executor hop → fails, `cached() waited 2.42s` against the 0.2s bound
- raise the vacuity threshold → that guard fires with its own message
- 5/5 consecutive green runs, 0.72–0.89s

It seeds through `persist` (internal for exactly this reason) so it cannot drift from the on-disk format, and asserts the seeded entry reads back **before** timing it.

## Verification

```
swift test DuoUpdaterCore  ━ 1341 tests in 108 suites passed with 1 known issue
swift test CLI             ✔ 161 tests in 22 suites passed
```

## Spun out, not fixed here

`AppListModel.formulaReleaseStates` is keyed by formula **name only**, carries no version, and is never cleared. After `brew upgrade` → `refreshBrewFormulae()`, both guards see the previous version's `.loaded` and skip, so the workbench renders the **old version's release notes against the new version**. Pre-existing and unrelated to the executor question, so deliberately not fixed here — spun out as a separate task.
