### PR TITLE
Show which build a staged relaunch will apply, and notify per build

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2301,7 +2301,7 @@ final class AppListModel {
             staged: SelfUpdaterStaging.staged(
                 for: result.app, requireNewerThanInstalled: false)) {
             Log.install.info("install yielded to staged self-update: \(result.app.name, privacy: .public) has \(staged.version, privacy: .public) waiting for a quit")
-            let note = String(localized: "\(result.app.name) has already downloaded \(staged.version) and will apply it when you quit it — installing now would be undone.")
+            let note = String(localized: "\(result.app.name) has already downloaded \(result.stagedRelaunchLine(staged).to) and will apply it when you quit it — installing now would be undone.")
             installNotes[id] = note
             inFlightNotes[id] = note
             installing[id] = nil
@@ -3365,11 +3365,18 @@ final class AppListModel {
             // ignored the app or skipped that version.
             guard let staged = nudgeableStaged(result) else { continue }
             let key = prefs.key(for: result.app)
-            guard ledger.isNew(key: key, version: staged.version) else { continue }
-            ledger.record(key: key, version: staged.version)
+            // `buildIdentity`, NOT `staged.version`: the latter is a marketing
+            // string an app may leave unchanged across many builds, and keying the
+            // ledger on it announces the first of them and silently swallows every
+            // one after — Amp shipped ten builds as "1.0" in a day. See
+            // `StagedSelfUpdate.buildIdentity`. Entries persisted by an older build
+            // hold a marketing version, so the first pass after this ships may
+            // re-announce one staged build per app; it self-heals on that write.
+            guard ledger.isNew(key: key, version: staged.buildIdentity) else { continue }
+            ledger.record(key: key, version: staged.buildIdentity)
             Log.app.info("notify: \(result.app.name, privacy: .public) staged \(staged.version, privacy: .public) — relaunch nudge")
             UpdateNotifier.selfDownloaded(
-                app: result.app.name, version: staged.version, appID: result.id)
+                app: result.app.name, version: result.stagedRelaunchLine(staged).to, appID: result.id)
         }
         // Only on a real change: this runs on every local rescan (the directory
         // watcher and its 180s backstop), and the neighbouring bookkeeping passes

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1192,12 +1192,19 @@ private struct AppRow: View {
 
     /// The staged-relaunch version line: installed → staged. `actionableStaged`
     /// guarantees the staged build is the latest, so there's nothing newer to note.
+    ///
+    /// Formatted by `UpdateResult.stagedRelaunchLine`, which keeps the build
+    /// numbers when the marketing versions do not tell the two apart — the same
+    /// rule `restartVersionLine` above gets from `relaunchLine`, which this line
+    /// went without until an app that ships every build as "1.0" made it read
+    /// "1.0 → 1.0".
     @ViewBuilder
     private func stagedVersionLine(_ staged: StagedSelfUpdate) -> some View {
+        let line = result.stagedRelaunchLine(staged)
         HStack(spacing: 4) {
-            Text(result.app.shortVersion ?? "?")
+            Text(line.from)
             Image(systemName: "arrow.right").font(.caption2)
-            Text(staged.version).fontWeight(.semibold).foregroundStyle(.tint)
+            Text(line.to).fontWeight(.semibold).foregroundStyle(.tint)
         }
         .font(.caption)
         .lineLimit(1)

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1481,7 +1481,7 @@ private struct AppRow: View {
             .controlSize(.small)
             .buttonStyle(.bordered)
             .tint(.orange)
-            .help("\(result.app.name) already downloaded \(staged.version) — relaunch to apply it (no extra download; a large app may take a minute to swap & reopen)")
+            .help("\(result.app.name) already downloaded \(result.stagedRelaunchLine(staged).to) — relaunch to apply it (no extra download; a large app may take a minute to swap & reopen)")
     }
 
     /// An incremental App Store update is downloaded but the app is running, so the

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -585,7 +585,7 @@ private struct WorkbenchActionView: View {
             Button("Relaunch") { Task { await model.relaunchStagedUpdate(result) } }
                 .buttonStyle(.bordered)
                 .tint(.orange)
-                .help("\(result.app.name) already downloaded \(staged.version) — relaunch to apply it")
+                .help("\(result.app.name) already downloaded \(result.stagedRelaunchLine(staged).to) — relaunch to apply it")
         } else if model.needsRestart.contains(result.id) && !result.hasUpdate {
             Button("Relaunch") { Task { await model.restart(result) } }
                 .buttonStyle(.bordered)

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -235,7 +235,7 @@ public enum Install {
             result,
             staged: SelfUpdaterStaging.staged(
                 for: result.app, requireNewerThanInstalled: false)) {
-            return .refuse("its own updater has \(staged.version) staged for the next quit "
+            return .refuse("its own updater has \(result.stagedRelaunchLine(staged).to) staged for the next quit "
                 + "— installing now would be undone (quit it to apply)")
         }
         if let inFlight = SelfUpdaterStaging.inFlightDownload(for: result.app) {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -352,6 +352,32 @@ extension UpdateResult {
         return (from.text(withBuild: withBuild), to.text(withBuild: withBuild))
     }
 
+    /// Both ends of the *staged* relaunch line: the bundle installed now on the
+    /// left, the build a relaunch would install on the right.
+    ///
+    /// The sibling of `relaunchLine(from:to:)`'s other caller, and it exists
+    /// because that rule reached only one of the two relaunch lines. The staged
+    /// line formatted each side as a bare `CFBundleShortVersionString`, so an app
+    /// whose marketing version does not move rendered as "1.0 → 1.0" — a line
+    /// that names no difference at all. Amp is the extreme case: it stayed on
+    /// "1.0" through ten builds in the six hours after it shipped, and every one
+    /// of them offered a relaunch that said nothing.
+    ///
+    /// Both sides come from a bundle's own `Info.plist` — `staged.buildVersion`
+    /// is read from the staged bundle by `SelfUpdaterStaging`, which already
+    /// compares it against the installed build to decide the row is offerable at
+    /// all — so the number was on hand the whole time; only this line did not ask
+    /// for it. `strippingBuildPrefix` on both, matching `relaunchTargetSide`, so a
+    /// vendor that prefixes its build (`v1234`) is compared and shown in one
+    /// namespace.
+    public func stagedRelaunchLine(_ staged: StagedSelfUpdate) -> (from: String, to: String) {
+        Self.relaunchLine(
+            from: VersionSide(marketing: app.shortVersion,
+                              build: app.buildVersion.map(Self.strippingBuildPrefix)),
+            to: VersionSide(marketing: staged.version,
+                            build: staged.buildVersion.map(Self.strippingBuildPrefix)))
+    }
+
 }
 
 public enum UpdateStatus: Sendable, Equatable {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
@@ -20,6 +20,24 @@ public struct StagedSelfUpdate: Sendable, Hashable {
         self.buildVersion = buildVersion
         self.stagedBundlePath = stagedBundlePath
     }
+
+    /// What identifies this staged build when the question is "is this a
+    /// different build from the one we last saw" — newness comparisons and the
+    /// announce-once ledger.
+    ///
+    /// The build number first, because `version` is a *marketing* string an app
+    /// is free to leave alone across any number of builds: Amp shipped ten builds
+    /// as "1.0" in one day, Surge shipped four releases as "6.9.0". Keyed on
+    /// `version`, an announce-once ledger announces the first of those and then
+    /// treats all nine of the rest as already-seen — quiet becoming silence,
+    /// which is the exact failure `StagedNudgeLedger` documents itself as
+    /// avoiding. Falls back to `version` for a staged bundle with no
+    /// `CFBundleVersion`, where it is the only string there is.
+    ///
+    /// NOT for display: it is a bare build number with no marketing version in
+    /// front of it. `UpdateResult.stagedRelaunchLine` is what a row or a
+    /// notification should show.
+    public var buildIdentity: String { buildVersion ?? version }
 }
 
 /// Detects updates that an app's *own* Squirrel updater (Electron's
@@ -102,7 +120,7 @@ public enum SelfUpdaterStaging {
             // Offering Relaunch for an older staged build would be offering a
             // downgrade, which is exactly the ChatGPT case.
             if requireNewerThanInstalled {
-                let stagedV = staged.buildVersion ?? staged.version
+                let stagedV = staged.buildIdentity
                 guard let installedV = app.buildVersion ?? app.shortVersion,
                       VersionComparator.isNewer(stagedV, than: installedV) else { return nil }
             }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RelaunchLineTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RelaunchLineTests.swift
@@ -118,4 +118,66 @@ import Testing
                     "one end kept its build and the other dropped it: \(line)")
         }
     }
+
+    // MARK: - The staged relaunch line
+
+    private func staged(version: String, build: String?) -> StagedSelfUpdate {
+        StagedSelfUpdate(
+            version: version, buildVersion: build,
+            stagedBundlePath: URL(fileURLWithPath: "/tmp/staged/Amp.app"))
+    }
+
+    /// The bug this pair exists for: `stagedVersionLine` formatted each side as a
+    /// bare `CFBundleShortVersionString`, so the rule above reached only ONE of the
+    /// two relaunch lines. Amp ships every build as "1.0" — the row read
+    /// "1.0 → 1.0" and named no difference at all, while both build numbers were
+    /// already in hand (`SelfUpdaterStaging` compares them to decide the row is
+    /// offerable).
+    @Test func stagedLineKeepsTheBuildsWhenTheMarketingVersionDoesNotMove() {
+        let line = result(short: "1.0", build: "128")
+            .stagedRelaunchLine(staged(version: "1.0", build: "130"))
+        #expect(line.from == "1.0 (128)")
+        #expect(line.to == "1.0 (130)")
+    }
+
+    /// The other half of the same rule, so the fix cannot be "always show builds":
+    /// when the marketing versions already differ, the build is noise.
+    @Test func stagedLineDropsTheBuildsWhenTheMarketingVersionsAlreadyDiffer() {
+        let line = result(short: "1.7.3", build: "194")
+            .stagedRelaunchLine(staged(version: "1.8.0", build: "201"))
+        #expect(line.from == "1.7.3")
+        #expect(line.to == "1.8.0")
+    }
+
+    /// Both ends are put through `strippingBuildPrefix`, matching
+    /// `relaunchTargetSide` — a vendor that prefixes its build must not end up with
+    /// one side stripped and the other not, which would read as two namespaces.
+    ///
+    /// The prefix it strips is a letters-then-dash one (`nightly-1234`); a bare
+    /// `v1234` has no dash and is left alone, which is the existing contract and is
+    /// asserted here so this test cannot be read as claiming more than it does.
+    @Test func stagedLineStripsBuildPrefixesOnBothEnds() {
+        let line = result(short: "2.0", build: "nightly-1234")
+            .stagedRelaunchLine(staged(version: "2.0", build: "nightly-1235"))
+        #expect(line.from == "2.0 (1234)")
+        #expect(line.to == "2.0 (1235)")
+
+        let undashed = result(short: "2.0", build: "v1234")
+            .stagedRelaunchLine(staged(version: "2.0", build: "v1235"))
+        #expect(undashed.from == "2.0 (v1234)")
+        #expect(undashed.to == "2.0 (v1235)")
+    }
+
+    /// A staged bundle with no `CFBundleVersion` leaves the installed side showing
+    /// its build against a bare target. That asymmetry is the established format,
+    /// not a bug: `neitherEndSuppressesABuildTheOtherIsShowing` above judges only
+    /// the sides that COULD carry a parenthesised build, because a side with no
+    /// build has nothing to put in parentheses. Pinned here so the staged line is
+    /// held to the same reading as the restart line rather than quietly diverging.
+    @Test func stagedLineWithNoStagedBuildKeepsTheInstalledBuildAsIs() {
+        let line = result(short: "1.0", build: "128")
+            .stagedRelaunchLine(staged(version: "1.0", build: nil))
+        #expect(line.from == "1.0 (128)")
+        #expect(line.to == "1.0")
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedNudgeLedgerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedNudgeLedgerTests.swift
@@ -79,4 +79,32 @@ struct StagedNudgeLedgerTests {
         #expect(StagedNudgeLedger(ledger.entries) == ledger)
         #expect(!StagedNudgeLedger(ledger.entries).isNew(key: chatGPT, version: "1.2026.238"))
     }
+
+    /// The ledger's stated invariant — "when the app stages a different build,
+    /// that is a new pair and it is announced again" — held only for apps whose
+    /// marketing version moves. The caller keyed on `staged.version`, so an app
+    /// shipping many builds under one marketing string was announced once and then
+    /// silenced: quiet becoming silence, the exact failure the type documents
+    /// itself as avoiding. `buildIdentity` is what the caller keys on now.
+    @Test func buildIdentityDistinguishesBuildsSharingOneMarketingVersion() {
+        func amp(_ build: String?) -> StagedSelfUpdate {
+            StagedSelfUpdate(version: "1.0", buildVersion: build,
+                             stagedBundlePath: URL(fileURLWithPath: "/tmp/Amp.app"))
+        }
+        var ledger = StagedNudgeLedger()
+        let key = "/Applications/Amp.app"
+
+        // Ten builds, one marketing version — every one is its own announcement.
+        for build in ["121", "122", "130"] {
+            #expect(ledger.isNew(key: key, version: amp(build).buildIdentity),
+                    "build \(build) shares \"1.0\" with the last one and was swallowed")
+            ledger.record(key: key, version: amp(build).buildIdentity)
+        }
+        // ...and the same build still announces only once.
+        #expect(!ledger.isNew(key: key, version: amp("130").buildIdentity))
+
+        // A staged bundle with no CFBundleVersion falls back to the marketing
+        // string, which is the only identity it has.
+        #expect(amp(nil).buildIdentity == "1.0")
+    }
 }


### PR DESCRIPTION
The row for an app waiting to be relaunched read `1.0 → 1.0` — Amp ships every build as `1.0`, and `stagedVersionLine` formatted each side as a bare `CFBundleShortVersionString`. That is `UpdateResult.relaunchLine`'s rule reaching the second of the two relaunch lines; `restartVersionLine` has had it since 0.3.66.

A review of that fix found the same defect at six more sites. Five are display (both Relaunch tooltips, the relaunch notification, the install-yield note, `duo install`'s refusal) — each named a version identical to the one running.

The sixth loses information: `StagedNudgeLedger`, new in 0.3.69, keyed on the marketing version, so Amp's build 121 was announced and builds 122–130 were all read as already-seen. The nudge went silent exactly where it had the most to say. Now keyed on `buildIdentity` (`buildVersion ?? version`), which `SelfUpdaterStaging` already used one layer down for the same question.

The `staged.version` reads that are *logic* — `actionableStaged`'s exact-string gate, the skip-version comparison, the relaunch handoff — are deliberately untouched.

Verified: `make test` 1386 core + 161 CLI, localizable keys 413; app builds via `make install`. New regression tests cover both halves of the build-number rule on the staged line and the ledger distinguishing builds that share one marketing version.