### PR TITLE
fix(core): a vendor probe that failed is an error, not an unsupported app

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -146,9 +146,29 @@ public struct UpdateChecker: Sendable {
             }
         }
 
-        if let lastError {
+        // A Toolbox-managed row outranks a failed read, and only this one does.
+        //
+        // Toolbox is the *installer* for these apps; the only reason a source ran at
+        // all is `prefersVendorProbeOverToolbox` — Android Studio Canary/Beta, where
+        // we borrow the vendor probe for a version Toolbox's own cache reports
+        // unreliably. The action is "open Toolbox" either way, and it is valid
+        // whether or not that borrowed read came back. Reporting `.error` instead
+        // takes the Toolbox button off the row and offers a Retry for a version
+        // number, which is the one thing the user does not need in order to act.
+        // (Before vendor probes threw, this arrived as a nil and landed on
+        // `.toolboxManaged` below — this keeps that.)
+        //
+        // Deliberately NOT extended to `.appStoreManaged`/`.testFlightManaged`: a
+        // MAS row reaches `.error` when `MacAppStoreSource` itself threw — the
+        // lookup for the app the store *does* own failed — and that is worth
+        // surfacing as a failed check, not papering over with "managed by the App
+        // Store". TestFlight returns before the loop and never gets here.
+        if let lastError, !app.isToolboxManaged {
             Log.check.error("\(label, privacy: .public): all sources exhausted, last error → .error(\(lastError, privacy: .public))")
             return UpdateResult(app: app, remote: nil, status: .error(lastError))
+        }
+        if let lastError {
+            Log.check.error("\(label, privacy: .public): \(lastError, privacy: .public) — Toolbox owns this app, reporting it as managed")
         }
         // Apps whose updates a known channel already owns aren't "unknown" —
         // they're managed elsewhere. Toolbox takes precedence over the store flag

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -384,7 +384,12 @@ public enum UpdateStatus: Sendable, Equatable {
     case upToDate
     /// A newer version exists. `latest` is the display string.
     case updateAvailable(latest: String)
-    /// No source could answer for this app (no feed, not on MAS, no cask).
+    /// No source *covers* this app — no feed, not on MAS, no cask, no recipe.
+    /// Nothing was tried and failed here: a source that applied and then couldn't
+    /// answer is `.error(_)`, which is retryable and says so. Keeping the two
+    /// apart is the whole point of the distinction — the row renders this one as
+    /// a dead "—", and a transient timeout wearing that badge reads as a
+    /// permanent verdict the user has no way to act on.
     case unknown
     /// The app came from the Mac App Store, which manages its updates. We can't
     /// read a trustworthy Mac version (the public lookup reports the iOS track

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -9,10 +9,14 @@ import Foundation
 /// standard sources have all missed — vendor probes are slow, fragile, and
 /// should never pre-empt a reliable source.
 ///
-/// Best-effort by design: any failure (network, redirect, parse) degrades
-/// silently to "unknown". It never throws to the engine and never reports a
-/// version it isn't confident about, so it can't produce a false "update
-/// available" or a spurious error.
+/// Never reports a version it isn't confident about, so it can't produce a
+/// false "update available". What it does NOT do is stay quiet about failing:
+/// a recipe that applied and could not answer throws ``ProbeFailed``, which
+/// `UpdateChecker` turns into an `.error` row (a retryable "Failed" badge)
+/// rather than the dead "—" that means *no source covers this app at all*.
+/// Only `.notApplicable` — no recipe, wrong channel, wrong host, no device
+/// identity on this Mac — still degrades to nil, because there is nothing there
+/// to retry.
 public struct VendorProbeSource: UpdateSource {
     static let sourceName = "Vendor"
     public let name = VendorProbeSource.sourceName
@@ -115,23 +119,78 @@ public struct VendorProbeSource: UpdateSource {
             }
             return nil
         }
-        // Swallow every failure: a probe that can't answer must look like "this
-        // source doesn't apply", not like an error or a confident result.
+        // nil here is the ONE thing the row's "—" is allowed to mean: no recipe for
+        // this bundle id, none for its channel, none this host can use, or the app
+        // is Toolbox-managed. `probeDiagnostic` decides that before any request.
         guard let bundleID = app.bundleID,
               let outcome = await probeDiagnostic(for: app) else { return nil }
-        // Record recipe health so a vendor changing their page surfaces in
-        // diagnostics rather than silently degrading the app to "unknown". A
-        // transient miss is cleared by the next successful check (success/miss are
-        // compared by recency), so this only flags consistently-broken recipes.
-        if outcome.remote != nil {
-            await RecipeHealth.shared.recordSuccess(id: bundleID, source: name)
-        } else {
-            await RecipeHealth.shared.recordMiss(
-                id: bundleID, source: name,
-                detail: outcome.failure.map { "\($0.kind): \($0.detail)" }
-                    ?? "probe resolved no version")
+        guard let remote = outcome.remote else {
+            let detail = outcome.failure.map { "\($0.kind): \($0.detail)" }
+                ?? "probe resolved no version"
+            // Record recipe health so a vendor changing their page is attributable
+            // in diagnostics and not just a row that went quiet. A transient miss is
+            // cleared by the next successful check (success/miss are compared by
+            // recency), so this only flags consistently-broken recipes. Recorded for
+            // the `.notApplicable` case below too: "this Mac has no such identity"
+            // is exactly the kind of standing miss the sweep wants to see.
+            await RecipeHealth.shared.recordMiss(id: bundleID, source: name, detail: detail)
+
+            // A recipe that cannot apply on THIS machine is not a failure and has
+            // nothing to retry: the device-identity and rollout-track selectors
+            // answer `.notApplicable` when this Mac has no such identity, which is
+            // the same "this source doesn't cover you" the gates above return nil
+            // for. Everything else — a timeout, a 404, a pattern that stopped
+            // matching — is a check that FAILED, and a failed check is not an
+            // unsupported app.
+            guard outcome.failure?.classification != .notApplicable else {
+                Log.source.info(
+                    "vendor probe not applicable \(bundleID, privacy: .public): \(detail, privacy: .public)")
+                return nil
+            }
+            // `.notice`, not `.info`: `.info` from a third-party subsystem is never
+            // written to disk, so the one line explaining why a row stopped
+            // answering would not survive to be read afterwards.
+            Log.source.notice(
+                "vendor probe failed \(outcome.recipeID, privacy: .public): \(detail, privacy: .public)")
+            throw ProbeFailed(bundleID: bundleID, failure: outcome.failure)
         }
-        return outcome.remote
+        // The recipe answered — clears any standing miss on the next comparison.
+        await RecipeHealth.shared.recordSuccess(id: bundleID, source: name)
+        return remote
+    }
+
+    /// A recipe applied to this app and could not produce a version.
+    ///
+    /// Exists so `UpdateChecker` can tell a *failed check* from an *unsupported
+    /// app*. Both used to arrive as nil, and the row rendered the same dead "—"
+    /// for "nothing here covers this app" and "the vendor's endpoint timed out" —
+    /// the second reads as the first, so a fixable outage looked like a permanent
+    /// verdict with no retry offered. Thrown, it becomes `.error(_)`: a retryable
+    /// badge, a row in the failed-check banner, and a `duo check` status that says
+    /// what went wrong.
+    ///
+    /// Throwing does not change which source answers. `UpdateChecker` continues to
+    /// the next source on a throw exactly as it does on a nil, and this source is
+    /// last in the stack — the error only surfaces when nothing else answered.
+    public struct ProbeFailed: LocalizedError {
+        public let bundleID: String
+        public let failure: ProbeFailure?
+
+        /// The cause, never the app. `AppListModel.failedCheckSummary` groups
+        /// failed rows by identical text to name one reason for a whole cluster
+        /// ("The request timed out." across every row behind one dead network),
+        /// and a message carrying the bundle id can never group with anything.
+        /// The row already says which app it is.
+        ///
+        /// `.transport` unwraps to the bare `URLError` message so it groups with
+        /// the other sources, which throw the `URLError` itself.
+        public var errorDescription: String? {
+            switch failure {
+            case .transport(_, let message): return message
+            case .some(let failure): return failure.detail
+            case nil: return "the vendor probe resolved no version"
+            }
+        }
     }
 
     /// Everything that happened probing `app`, or nil when this source does not

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Log.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Log.swift
@@ -18,6 +18,12 @@ import os
 ///                 the breadcrumbs you want when reconstructing one check).
 ///   • `.info`   — milestones: a scan finished, an update found, an install
 ///                 stage advanced.
+///   • `.notice` — the default level, and the lowest one the unified log keeps
+///                 ON DISK for a third-party subsystem: `.debug` and `.info` are
+///                 memory-only and gone by the time anyone goes looking. Use it
+///                 for the handful of lines that have to survive to explain a
+///                 state the user can still see — why a row stopped answering,
+///                 say — without being an `.error` in their face.
 ///   • `.error`  — a source threw, an install failed: the things that turn into
 ///                 an `.error` row or a swallowed surprise.
 ///

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeFailureIsNotUnsupportedTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeFailureIsNotUnsupportedTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A failed check is not an unsupported app.
+///
+/// `VendorProbeSource` used to return nil for both, and `UpdateChecker` renders
+/// nil-from-everything as `.unknown` — the row's dead "—". So WeChat, whose
+/// recipe reads `dldir1.qq.com` and whose only problem was that this Mac's proxy
+/// bypass list sent that host down a dead direct path, sat next to a hand-built
+/// app that genuinely has no source at all and looked identical: no reason, no
+/// retry, nothing to act on. (Found 2026-08-29; the endpoint was serving 200s to
+/// anything that went through the proxy the whole time.)
+///
+/// The split these pin: a recipe that APPLIED and could not answer throws, and
+/// only "nothing here covers this app" stays nil.
+@Suite struct ProbeFailureIsNotUnsupportedTests {
+
+    private static func app(
+        bundleID: String, channel: ReleaseChannel = .stable, isMASApp: Bool = false
+    ) -> InstalledApp {
+        InstalledApp(
+            name: bundleID, bundleID: bundleID,
+            shortVersion: "1.0.0", buildVersion: "1",
+            path: URL(fileURLWithPath: "/Applications/\(bundleID).app"),
+            isMASApp: isMASApp, sparkleFeedURL: nil, releaseChannel: channel)
+    }
+
+    private static func recipe(
+        bundleID: String = "com.example.subject",
+        url: URL,
+        pattern: String = #"<version>([0-9.]+)</version>"#,
+        identities: [ProbeIdentity] = []
+    ) -> VendorProbeRecipe {
+        VendorProbeRecipe(
+            bundleID: bundleID, url: url, mode: .responseBody,
+            versionPattern: pattern, identities: identities)
+    }
+
+    /// Nothing is listening, so the fetch fails at the transport — the shape of
+    /// the WeChat case, and of every "the network went away" round.
+    private static let unreachable = URL(string: "http://127.0.0.1:1/feed")!
+
+    // MARK: - a recipe that applied and could not answer
+
+    @Test func anUnreachableEndpointThrowsInsteadOfReadingAsUnsupported() async {
+        let source = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        await #expect(throws: VendorProbeSource.ProbeFailed.self) {
+            try await source.latestVersion(for: Self.app(bundleID: "com.example.subject"))
+        }
+    }
+
+    /// The thrown message must be the CAUSE, with no app identity in it:
+    /// `AppListModel.failedCheckSummary` groups failed rows by identical text to
+    /// name one reason for the whole cluster, and a per-app string never groups.
+    @Test func theThrownMessageNamesTheCauseAndNotTheApp() async throws {
+        let source = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        do {
+            _ = try await source.latestVersion(for: Self.app(bundleID: "com.example.subject"))
+            Issue.record("expected the probe to throw")
+        } catch let failure as VendorProbeSource.ProbeFailed {
+            let message = try #require(failure.errorDescription)
+            #expect(!message.isEmpty)
+            #expect(!message.contains("com.example.subject"))
+            // The bare `URLError` message — what the other sources throw, so rows
+            // behind one outage carry identical text and group. Specifically NOT
+            // the diagnostic `detail`, which prefixes the numeric code and would
+            // split one outage into a cluster per code.
+            guard case .transport(let code, let carried)? = failure.failure else {
+                Issue.record("expected a transport failure, got \(String(describing: failure.failure))")
+                return
+            }
+            #expect(message == carried)
+            #expect(failure.failure?.detail == "URLError \(code): \(message)")
+        }
+    }
+
+    /// The other half of "the recipe applied": the endpoint answered fine and the
+    /// pattern matched nothing — a vendor rewriting their page. Also a failed
+    /// check, also not an unsupported app.
+    @Test func aPatternThatStoppedMatchingThrows() async throws {
+        let server = try RecipeVerificationTests.StubServer(
+            body: #"{"latest":"2026.2.0.1"}"#)
+        defer { server.stop() }
+        let source = VendorProbeSource(recipes: [Self.recipe(url: server.url)])
+
+        do {
+            _ = try await source.latestVersion(for: Self.app(bundleID: "com.example.subject"))
+            Issue.record("expected the probe to throw")
+        } catch let failure as VendorProbeSource.ProbeFailed {
+            #expect(failure.failure?.kind == "versionPatternNoMatch")
+        }
+    }
+
+    @Test func aBadStatusThrows() async throws {
+        let server = try RecipeVerificationTests.StubServer(status: 404, body: "not found")
+        defer { server.stop() }
+        let source = VendorProbeSource(recipes: [Self.recipe(url: server.url)])
+
+        do {
+            _ = try await source.latestVersion(for: Self.app(bundleID: "com.example.subject"))
+            Issue.record("expected the probe to throw")
+        } catch let failure as VendorProbeSource.ProbeFailed {
+            #expect(failure.failure?.kind == "httpStatus404")
+        }
+    }
+
+    // MARK: - the cases that still mean "unsupported", and must stay nil
+
+    @Test func noRecipeForTheBundleIDStaysNil() async throws {
+        let source = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        #expect(try await source.latestVersion(for: Self.app(bundleID: "com.example.other")) == nil)
+    }
+
+    @Test func aChannelWithNoRecipeStaysNil() async throws {
+        let source = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        let canary = Self.app(bundleID: "com.example.subject", channel: .canary)
+        #expect(try await source.latestVersion(for: canary) == nil)
+    }
+
+    @Test func anAppStoreCopyStaysNil() async throws {
+        let source = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        let storeCopy = Self.app(bundleID: "com.example.subject", isMASApp: true)
+        #expect(try await source.latestVersion(for: storeCopy) == nil)
+    }
+
+    /// The subtle one, and the reason this isn't simply "any nil outcome throws":
+    /// a recipe keyed to a per-machine identity answers `.notApplicable` when
+    /// this Mac has no such file. That IS "this source doesn't cover you" — there
+    /// is no endpoint to retry — so it must keep the dash, not become a Failed
+    /// badge that re-runs the same missing file forever.
+    @Test func anIdentityThisMacDoesNotHaveStaysNil() async throws {
+        let identity = ProbeIdentity(
+            location: .home(".duo-updater-absent-by-design/identity.json"),
+            encoding: .plain,
+            validationPattern: #"[a-z0-9-]{1,64}"#,
+            placeholder: "__IDENTITY__",
+            fallback: nil)  // no fallback: unresolvable, so the recipe cannot apply
+        let source = VendorProbeSource(recipes: [
+            Self.recipe(
+                url: URL(string: "http://127.0.0.1:1/feed?id=__IDENTITY__")!,
+                identities: [identity])
+        ])
+
+        let outcome = await source.probeDiagnostic(for: Self.app(bundleID: "com.example.subject"))
+        // The recipe was selected (an outcome exists) but declined itself.
+        #expect(outcome?.failure?.classification == .notApplicable)
+        #expect(try await source.latestVersion(for: Self.app(bundleID: "com.example.subject")) == nil)
+    }
+
+    // MARK: - what the engine makes of each
+
+    /// End to end: the two halves must reach the UI as DIFFERENT statuses, or
+    /// none of the above bought anything.
+    @Test func theEngineSeparatesAFailedCheckFromAnUnsupportedApp() async {
+        let source = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        let checker = UpdateChecker(sources: [source])
+
+        let failed = await checker.check(Self.app(bundleID: "com.example.subject"))
+        guard case .error(let message) = failed.status else {
+            Issue.record("a reachable recipe that failed must be .error, got \(failed.status)")
+            return
+        }
+        #expect(!message.isEmpty)
+
+        let uncovered = await checker.check(Self.app(bundleID: "com.example.uncovered"))
+        #expect(uncovered.status == .unknown)
+    }
+
+    /// Throwing must not change WHICH source answers. The checker continues past
+    /// a throw exactly as it does past a nil, so a working source ahead of (or
+    /// behind) a failing probe still wins, and no error is reported.
+    @Test func aFailingProbeDoesNotSuppressASourceThatAnswers() async throws {
+        let server = try RecipeVerificationTests.StubServer(body: "<version>9.9.9</version>")
+        defer { server.stop() }
+        let failing = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        let working = VendorProbeSource(recipes: [Self.recipe(url: server.url)])
+
+        let result = await UpdateChecker(sources: [failing, working])
+            .check(Self.app(bundleID: "com.example.subject"))
+
+        #expect(result.status == .updateAvailable(latest: "9.9.9"))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeFailureIsNotUnsupportedTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ProbeFailureIsNotUnsupportedTests.swift
@@ -167,6 +167,47 @@ import Foundation
         #expect(uncovered.status == .unknown)
     }
 
+    /// The row Toolbox owns must stay Toolbox's, even when the borrowed probe
+    /// fails.
+    ///
+    /// Android Studio Canary/Beta are the one case where a Toolbox-managed app is
+    /// still routed through a `VendorProbeRecipe`: we borrow it for a version
+    /// Toolbox's own cache reports unreliably, and the install goes through
+    /// Toolbox regardless. Before probes threw, a failed borrow arrived as nil and
+    /// the row landed on `.toolboxManaged` — the "open Toolbox" button, which is
+    /// valid whether or not the version read came back. Letting the throw win
+    /// instead replaced it with a Failed/Retry badge, taking away the only action
+    /// the row had in order to offer a retry of a version number.
+    @Test func aToolboxOwnedRowSurvivesItsBorrowedProbeFailing() async {
+        let recipe = VendorProbeRecipe(
+            bundleID: "com.google.android.studio", url: Self.unreachable,
+            mode: .responseBody, versionPattern: #"([0-9.]+)"#, channel: .canary)
+        let app = InstalledApp(
+            name: "Android Studio", bundleID: "com.google.android.studio",
+            shortVersion: "2025.2", buildVersion: "AI-252.0.0",
+            path: URL(fileURLWithPath: "/Applications/Android Studio Preview.app"),
+            isMASApp: false, isToolboxManaged: true, sparkleFeedURL: nil,
+            releaseChannel: .canary)
+        #expect(app.prefersVendorProbeOverToolbox)  // linchpin: this app reaches the loop
+
+        let result = await UpdateChecker(sources: [VendorProbeSource(recipes: [recipe])])
+            .check(app)
+
+        #expect(result.status == .toolboxManaged)
+    }
+
+    /// The other side of that guard: an app NO channel owns still reports the
+    /// failure, so the narrowing above cannot quietly swallow every error.
+    @Test func anUnmanagedRowStillReportsTheFailure() async {
+        let source = VendorProbeSource(recipes: [Self.recipe(url: Self.unreachable)])
+        let result = await UpdateChecker(sources: [source])
+            .check(Self.app(bundleID: "com.example.subject"))
+        guard case .error = result.status else {
+            Issue.record("expected .error, got \(result.status)")
+            return
+        }
+    }
+
     /// Throwing must not change WHICH source answers. The checker continues past
     /// a throw exactly as it does past a nil, so a working source ahead of (or
     /// behind) a failing probe still wins, and no error is reported.


### PR DESCRIPTION
## 起因

WeChat 那行显示 `—`。查下来端点没坏、recipe 没坏 —— `dldir1.qq.com` 落在本机系统代理的 bypass 列表里，URLSession 走直连，而这台机器的直连路径是死的，13 秒超时 ×3。走代理时同一个 URL 一直在返 200。

问题在于：**这个失败在 UI 上和「这个 app 根本没有任何更新源」长得一模一样**。两者都是那个死掉的横杠，没有理由、没有重试、没有任何可操作的东西。

## 为什么会这样

`VendorProbeSource` 把所有失败吞成 `nil`，而 `UpdateChecker` 只在源 **throw** 时才会走到 `.error`（[UpdateChecker.swift:149](https://github.com/jizhi0v0/duo-updater/blob/main/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift#L149)）。于是「超时」和「没有 recipe」殊途同归，都变成 `.unknown`。

这也违反了 `UpdateSource` 协议自己写的约定：

> Return the latest version this source knows about for `app`, or nil if this source doesn't apply to the app. **Throw on a real failure (network/parse) so the engine can surface an error rather than silently treating it as "not applicable".**

其他源都守着这条；`VendorProbeSource` 是唯一的例外。

## 改动

recipe **应用了但答不上来** → 抛 `ProbeFailed` → `.error(_)`：可点重试的 Failed 徽标、进 failed-check banner、`duo check` 给出原因。

错误文案刻意是**裸的原因、不含 bundle id** —— `AppListModel.failedCheckSummary` 靠文案完全相同来把一次断网的一簇行归成一条 banner 理由，带 app 身份的字符串永远归不了组。`.transport` 剥掉 `URLError -1001:` 前缀，跟其他源直接抛 `URLError` 的文案对齐。

### `.notApplicable` 这条例外是承重的

`resolveEndpoint` 在本机没有对应设备身份文件 / rollout track 时也报 `ProbeFailure`（[VendorProbeSource.swift:595](https://github.com/jizhi0v0/duo-updater/blob/main/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift#L595)）。那是真的「这条 recipe 不覆盖你」，没有端点可重试。registry 里 5 条带 `identities`、3 条带 `track` —— 一刀切成 error 会让这些行在没有身份文件的机器上永远亮红，反复重试一个不存在的文件。所以判据是 `classification != .notApplicable`，不是「outcome 为 nil 就抛」。

### 不改变哪个源作答

`UpdateChecker` 遇到 throw 和遇到 nil 一样继续往下走，而 vendor probe 是 source stack 的最后一个 —— 错误只在**没有任何源作答**时才浮出来。有专门一条用例钉这点。

### 日志用 `.notice` 不用 `.info`

`.info` 对第三方 subsystem 完全不落盘，事后 `log show` 查不到。解释「这行为什么不作答」的那一句必须活到被人读到的时候。`Log.swift` 的级别表里补了这一档。

## 验证

**先复现红**：把 throw 换回 `return nil`，5 条钉新行为的用例全红；5 条钉「仍是 nil」的守卫两边都绿 —— 那是无回归的一半。

```
✔ Test run with 1428 tests in 121 suites passed after 65.032 seconds with 1 known issue.
✔ Test run with 161 tests in 22 suites passed
✓ localizable keys agree — 413 in the catalog, all reachable
✓ version comparisons discriminate — 181 files
```

（known issue 是既有的 Anki tag 补零，与本次无关。）

**真机全量 `duo check`，改前 → 改后**：

```
改前  up-to-date 122   unknown 17   app-store 1   update 1
改后  up-to-date 122   unknown 15   error 2      app-store 1   update 1
```

翻过去的正好是有 recipe 的那两个。动手前先量过覆盖面：17 个 unknown 里只有 WeChat 和 WeType 在 registry 里，其余 15 个（DuoShot、KeyRemap、EasyConnect…）确实没有任何源，横杠留给它们是对的。

```
error: The request timed out.   WeChat   /Applications/WeChat-vendor.app
error: The request timed out.   WeType   /Library/Input Methods/WeType.app
```

两行文案相同 → 归成一条 banner 理由，符合设计。

**notice 落盘**（下面这条是**不带** `--info --debug` 查出来的）：

```
2026-08-29 02:57:30.071 Df duo[93651] [com.duoupdater.app:source] vendor probe failed vendor:com.tencent.xinWeChat:stable: transport: URLError -1001: The request timed out.
```

## 用户会看到的变化

菜单头部会说「2 of 141 apps not checked」而不是「141 apps · up to date」，并带一条 Retry banner。这是既有的 `.error` 处理链，本次只是把 vendor probe 的失败接了进去。连续失败 3 轮后判为 chronic，自动退出 banner，只留给 `RecipeHealth` 和 `duo verify` —— 所以一条永久坏掉的 recipe 不会把 banner 钉死。

菜单栏角标和通知不受影响：两者都走 `isActionableUpdate`，要求 `hasUpdate`。`duo check` 的退出码只看 `hasUpdate`，脚本行为不变。

## 没做的

- **没给横杠加 tooltip**。`.unknown` 同时是每轮 refresh 的**检查中占位状态**，此时提示「此 app 不受支持」是假话；要加得先 gate 在 `!isChecking` 上，且是 7 种语言的新字符串。
- **没动 CHANGELOG**。这是面向用户的改动，值得写，但目前没有未发布小节，开 0.3.71 等于起一次发版 —— 留给发版时一并写。


---

## Code review 查出的回归（已修，commit `827f153`）

**让 vendor probe 抛错，把 Toolbox 行的按钮弄没了。**

Android Studio Canary/Beta 是唯一「既由 Toolbox 托管、又仍然走 `VendorProbeRecipe`」的 app（`prefersVendorProbeOverToolbox` —— Toolbox 自己的缓存对它报的版本不可靠）。我们只是**借**这个 probe 读版本，安装永远走 Toolbox。

probe 返回 nil 的年代，这行落到 `UpdateChecker` 底部的托管渠道分类 → `.toolboxManaged` → 显示「打开 Toolbox」按钮。改成抛错之后，`if let lastError` 抢在那个分类**之前**命中 → 变成 `.error` → 橙色 Failed/Retry 徽标，把这行**唯一有效的操作**换成了「重试一个版本号」—— 而那个版本号恰恰是用户不需要它就能行动的东西。

实测，同一个 app、同一条 recipe、端点不可达：

```
throwing vendor probe  =>  error("Could not connect to the server.")
nil-returning probe    =>  toolboxManaged
```

修法：`lastError` 那条分支加 `!app.isToolboxManaged`。

**只给 Toolbox 这个特权，刻意没给 `.appStoreManaged`**：MAS 行走到 `.error` 意味着 `MacAppStoreSource` 自己抛了 —— 商店拥有的那个 app、查询它的请求失败了 —— 那个该老实报成一次失败的检查，不该用「由 App Store 管理」糊过去。TestFlight 在进循环前就 return，到不了这里。

补两条用例：Toolbox 行在借来的 probe 失败时活下来；以及 —— 防止这个收窄把所有错误都吞掉 —— 无托管的行仍然报错。同样先复现红：去掉守卫后**只有**新加的那条红，其余全绿。

## 复查过、确认不是问题的

- **cancellation 污染**：`UpdateChecker.check` 被取消时仍会为每行返回结果，其中在途的 probe 会拿到 `URLError(.cancelled)` → 现在变成 `.error`。但 `runChannelSwitchRecheck` 已有 await 前后**双重** `Task.isCancelled` 守卫，注释里写明就是防这个（「a cancellation that lands *during* the await poisons the answer」）。其余调用 `UpdateChecker` 的路径没有人取消它。
- **`lastError` 被后来的源覆盖**：vendor probe 是 stack 最后一个，它的错误会盖掉前面源的。担心的是 GitHub 限流被盖掉后 `isRateLimitError` 失效、限流 banner 少算一行 —— 但 GitHub 规则和 vendor recipe 的 bundle id **零重叠**（118 vs 68，交集 0），够不着。
- **`RecipeHealth` 测试污染**：纯内存无持久化，且 `RecipeHealthTests` 一直用独立实例而非 `.shared`。
- **`ProbeOutcome` 的 `remote == nil && failure == nil`**：`fail()` 恒带 failure，成功路径的 `var remote: RemoteVersion` 是非可选 —— 不可达，`errorDescription` 里那条 `case nil` 是安全兜底而非活代码。

## 最终验证

```
✔ Test run with 1430 tests in 121 suites passed   (原 1428，+2)
✔ Test run with 161 tests in 22 suites passed
✓ localizable keys agree — 413 in the catalog, all reachable
✓ version comparisons discriminate — 181 files
exit=0，零失败
```
