### PR TITLE
fix(app): the relaunch nudge survived the relaunch that answered it

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3013,10 +3013,6 @@ final class AppListModel {
     /// parked Sparkle installers, which is why it does not belong on the main
     /// actor.
     private func computeSelfUpdateStaging() async {
-        // Track which apps were surfacing a *Relaunch* (actionable staged = the
-        // staged build is the latest) so we can clear their banner if they stop —
-        // applied, staging gone, OR a newer release now makes the staged build trail.
-        let previouslyActionable = Set(results.compactMap { actionableStaged($0) != nil ? $0.id : nil })
         let apps = results.map(\.app).filter(SelfUpdaterStaging.mayHaveStaging)
         let staged = await Task.detached(priority: .utility) {
             // Asked once for the whole sweep rather than per app: the answer is a
@@ -3051,23 +3047,37 @@ final class AppListModel {
                 result: handoff.result, landing: landing,
                 activates: handoff.activates, armedAt: handoff.armedAt)
         }
-        // Dismiss delivered "Relaunch to apply it" banners for apps that are no
-        // longer actionable-staged, so a stale one doesn't linger.
+        // Dismiss delivered "Relaunch to apply it" banners for every row that is not
+        // currently offering a Relaunch. The standing question ("who should have a
+        // banner right now?"), NOT the transition one ("who left the set since last
+        // pass?").
         //
-        // The banner goes; the ledger entry stays. Both sets are read against the
-        // same `results` and only `pendingSelfUpdate` is rebuilt between them — so
-        // the ONLY thing that can put an id here is the staging read coming back
-        // empty, and that read is a live process query (the parked Sparkle updater
-        // has to be enumerable) plus an unsynchronised plist read. One blind pass
-        // must not be able to forget that this build was already announced:
-        // `performLocalRescan` runs this on a 180-second backstop, so forgetting
-        // would re-announce the same build faster than the five-minute timer the
-        // ledger exists to delete. (A remote-version flap cannot reach here at all
-        // — it moves both sets together.)
+        // The transition form could never fire for the case it was written for. Its
+        // "previously" set was re-derived from `results` at the top of this function,
+        // and every caller re-reads disk before getting here — `performLocalRescan`
+        // rescans wholesale, `refreshRow` rechecks the one row. So by the time it was
+        // computed, an applied row's on-disk version had already caught up with the
+        // staged build, `actionableStaged` returned nil (it refuses a staged build
+        // that isn't newer than what's installed), and the id was missing from BOTH
+        // sets — `subtracting` yielded nothing. Relaunching Amp left "Amp downloaded
+        // 1.0 (131) on its own. Relaunch to apply it." sitting in Notification Center
+        // under the "Now running 1.0." confirmation, because the applied case is
+        // exactly the case where the two reads move together. Asking the standing
+        // question has no such window, and also covers a build the app applied while
+        // we weren't running.
+        //
+        // The banner goes; the ledger entry stays. The only other thing that can put
+        // an id here is the staging read coming back empty, and that read is a live
+        // process query (the parked Sparkle updater has to be enumerable) plus an
+        // unsynchronised plist read. One blind pass must not be able to forget that
+        // this build was already announced: `performLocalRescan` runs this on a
+        // 180-second backstop, so forgetting would re-announce the same build faster
+        // than the five-minute timer the ledger exists to delete. Withdrawing a banner
+        // that was never posted costs nothing; re-posting one the user already
+        // dismissed does.
         let nowActionable = Set(results.compactMap { actionableStaged($0) != nil ? $0.id : nil })
-        for id in previouslyActionable.subtracting(nowActionable) {
-            UpdateNotifier.clearSelfDownloaded(appID: id)
-        }
+        UpdateNotifier.clearSelfDownloaded(
+            appIDs: results.map(\.id).filter { !nowActionable.contains($0) })
         if !nowActionable.isEmpty {
             let names = results.filter { nowActionable.contains($0.id) }
                 .map { "\($0.app.name)→\(pendingSelfUpdate[$0.id]!.version)" }.joined(separator: ", ")

--- a/App/Sources/UpdateNotifier.swift
+++ b/App/Sources/UpdateNotifier.swift
@@ -93,10 +93,21 @@ enum UpdateNotifier {
     /// has relaunched, so a stale "Relaunch to apply it" banner doesn't linger in
     /// Notification Center after it's been applied.
     static func clearSelfDownloaded(appID: String) {
-        let id = "selfupdate:\(appID)"
+        clearSelfDownloaded(appIDs: [appID])
+    }
+
+    /// The bulk form. `computeSelfUpdateStaging` withdraws the banner for every row
+    /// that is not currently offering a Relaunch — on a normal machine that is very
+    /// nearly the whole list, on every rescan — so it goes out as one withdrawal
+    /// rather than a per-app round trip to the notification server. Withdrawing an
+    /// identifier that was never posted is a no-op, which is what makes asking the
+    /// standing question affordable.
+    static func clearSelfDownloaded(appIDs: [String]) {
+        guard !appIDs.isEmpty else { return }
+        let ids = appIDs.map { "selfupdate:\($0)" }
         let center = UNUserNotificationCenter.current()
-        center.removePendingNotificationRequests(withIdentifiers: [id])
-        center.removeDeliveredNotifications(withIdentifiers: [id])
+        center.removePendingNotificationRequests(withIdentifiers: ids)
+        center.removeDeliveredNotifications(withIdentifiers: ids)
     }
 
     /// The user restarted and the new version is now live. Reuses the same stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ reads the section matching the version being shipped and embeds it in the GitHub
 release and the Sparkle appcast, so this file is the single source of truth for
 "what's new" — keep each version's prose written for users, not commit-speak.
 
+## 0.3.71
+
+**The "relaunch to apply it" reminder now goes away once you have relaunched.** When an app's own updater downloaded a build in the background, Duo Updater told you so and offered a Relaunch button on the notification. Taking it worked — the app came back on the new build and said "Now running 1.0." — but the reminder it replaced stayed in Notification Center underneath, still asking you to relaunch something you had just relaunched. Duo Updater was watching for the reminder to *stop* being relevant, and the moment it checked was the one moment that had already been accounted for. It now takes the reminder down whenever there is no relaunch outstanding, which also clears one left behind by an app that applied its own update while Duo Updater was not running.
+
 ## 0.3.70
 
 **Apps that ship many builds under one version number are handled properly now — everywhere.** A Mac app carries two version strings: the one it shows you ("1.0") and a build number that actually counts up. Most apps move both. Some move only the build: Amp shipped ten builds in a single day, every one of them called 1.0; Surge has shipped four separate releases as 6.9.0; JetBrains' preview builds do the same. Duo Updater decided "has this changed?" by comparing the *shown* version in about a dozen places, and for those apps that comparison can only ever answer "no" — or, where it asked "are these the same?", "yes" — whatever had really happened. What follows is what that broke. It is one mistake, found because Amp made it visible.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
@@ -630,6 +630,22 @@ private func storeAvailability(
         ampRemote(latestBuild: "130", installedBuild: "130"),
         staged: ampStaged("129")) == nil,
         "staged 129 below installed 130 would be a downgrade")
+
+    // The moment the swap lands, installed == staged and this goes nil — the row
+    // has nothing left to offer. Pinned because `AppListModel`'s banner sweep was
+    // built on the opposite assumption: it withdrew "Relaunch to apply it" only for
+    // ids that *left* the actionable set between two passes, and every caller
+    // re-reads disk before that set is taken. So on the one pass where a relaunch
+    // had just succeeded, the id was already absent from both the before and the
+    // after, the difference was empty, and Amp's "downloaded 1.0 (131) on its own"
+    // banner stayed in Notification Center under the "Now running 1.0."
+    // confirmation. The sweep now asks who should have a banner standing, not who
+    // left; if this expectation ever flips, that sweep starts withdrawing banners
+    // for rows that still need them.
+    #expect(UpdatePolicy.actionableStaged(
+        ampRemote(latestBuild: "131", installedBuild: "131"),
+        staged: ampStaged("131")) == nil,
+        "the staged build is on disk — applied, so no Relaunch is outstanding")
 }
 
 // MARK: - runtimeBundlePath


### PR DESCRIPTION
## 症状

Amp 自己下载了 build 131 并暂存，Duo 播报 "Amp downloaded 1.0 (131) on its own. Relaunch to apply it."。点 Relaunch，app 起来了，"Now running 1.0." 也发了 —— 但上一条还留在通知中心底下，仍然让你去 relaunch 一个刚 relaunch 完的 app。

## 根因

两条通知的 identifier 本就不同，互不替换（设计如此）：

| | identifier |
|---|---|
| `selfDownloaded` | `selfupdate:/Applications/Amp.app` |
| `restarted` | `restart:com.ampcode.amp.macos` |

所以撤回只能靠 `computeSelfUpdateStaging` 里那个 sweep。它问的是**变化**：

```swift
let previouslyActionable = Set(results.compactMap { actionableStaged($0) != nil ? $0.id : nil })  // 函数开头
...
for id in previouslyActionable.subtracting(nowActionable) { UpdateNotifier.clearSelfDownloaded(appID: id) }
```

`previouslyActionable` 是**在同一个函数开头从 `results` 现场重算**的，而每个调用方进来之前都已经重读过磁盘：`performLocalRescan` 整盘重扫，`refreshRow` 在 `recheckMany` 里跑完整的 `AppScanner().scan()`。等算到这一行，Amp 磁盘上已经是 1.0 (131)，`UpdatePolicy.actionableStaged` 的第一道闸（staged 必须**严格新于**已装）返回 nil。

于是 id 在前后两个集合里**都不存在**，`subtracting` 是空集，一次都没清。

"已经应用成功"恰恰是这两个读数同步移动的唯一场景 —— 也就是这个 sweep 唯一存在的理由。三条发 `restarted` 的路径（`relaunchStagedUpdate` / `settleQuitHandoffs` / `restart`）都不另外清；`restart(byID:)` 里那个 `clearSelfDownloaded` 只在**一开始就不 actionable** 的 else 分支上。

## 改法

改问**现状**：现在不该有 Relaunch 的行，就不该有横幅。

```swift
let nowActionable = Set(results.compactMap { actionableStaged($0) != nil ? $0.id : nil })
UpdateNotifier.clearSelfDownloaded(
    appIDs: results.map(\.id).filter { !nowActionable.contains($0) })
```

- 没有那个时间窗。
- 顺带覆盖了老写法同样看不见的另一种：app 在 Duo 没运行时自己应用了更新，横幅留到下次也能清掉。
- 撤回一个从没发过的 identifier 是 no-op，所以问现状不比问变化贵；批量成一次撤回，而不是每次 rescan 对每个 app 一次往返。
- **ledger 条目照旧保留**：staging 读取（活进程查询 + 无同步的 plist 读）偶尔会空一拍，不能让一次瞎扫忘记"这个 build 已经播报过"，否则 180 秒的 backstop 会比 ledger 的五分钟计时更快地重播。

## 测试

`computeSelfUpdateStaging` 在 `App/Sources`，那里没有 test target。所以在 Core 里钉住它赖以工作、实际却踩空的那条事实：swap 落地后 `installed == staged`，`actionableStaged` 必须为 nil。放在 Amp 那个 frozen-marketing-version 用例里 —— 只有成对比较才看得见这个相等。

```
make install   # 编过，已部署
make test      # Core 1418 tests + CLI 161 tests 全绿，两个 checker 也过
```

## 未做的事

没有走真实的红→绿：Amp 的 131 已经应用完，ledger 里还记着 `_Applications_Amp.app = 131`，不删它就不会再播报。依据是代码构造上的证明（两个集合同时丢 id）加上面那条测试。通知库里 Amp 的 `selfupdate:` 记录现在确实没了，但库是在 `make install` 之后拷的，证明不了是新版扫掉的 —— 这条不算证据。