### PR TITLE
接入百度网盘：版本探测 + 一键安装 + 原生更新日志

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -2345,8 +2345,12 @@ public enum ChangelogRecipeRegistry {
         //     detail object's `title`.** Those are not note-less releases — 4.54.9's
         //     title is "百度网盘优化了一些已知的体验问题，欢迎升级体验~", the whole note.
         //     So `body` captures the WHOLE detail object and the item patterns are
-        //     ordered: bullets first, the title only when there are none. Capturing
-        //     just the `more` array would have shown eleven empty entries.
+        //     ordered: bullets first, the title only when there are none.
+        //     Capturing just the `more` array would not have shown eleven blank
+        //     entries — `ChangelogExtractor` drops an entry whose item patterns
+        //     yield nothing (`guard !noteHits.isEmpty`), so those eleven releases
+        //     would be MISSING from the changelog entirely, with no blank row to
+        //     notice. The fallback is what keeps them.
         //  2. **The key order inside `detail` is not fixed** — 97 of 100 are
         //     `more, stable, title` and 3 are `feature_tips, more, title` — so
         //     nothing may assume `more` comes first.
@@ -2360,6 +2364,16 @@ public enum ChangelogRecipeRegistry {
         // separates `more`'s elements from the keys and from `title`'s value in
         // the same object (a key is followed by `:`, a value preceded by one).
         //
+        // Its body is `(?:[^"\\]|\\.)+` rather than `[^"]+` so a note containing an
+        // escaped quote stays one element. `[^"]+` stops at the backslash's quote
+        // and the element is then SILENTLY DROPPED, not reported: the array's other
+        // elements still match, so `firstNonEmptyItemHits` is satisfied, never tries
+        // the fallback, and the entry renders with fewer notes than the vendor
+        // published. (Measured on `"more":["say \"hi\" now","b"]`: `[^"]+` yields
+        // `["b"]` alone.) No live item carries a quote today — 0 of 165 — which is
+        // exactly why this would have gone unnoticed; the recipe is `.json` because
+        // this feed's strings are escaped, so the item pattern has to agree.
+        //
         // Verified 2026-08-29 against the live 40-entry response: all 40 entries
         // match, and every version, date and item list is byte-identical to what
         // `json.loads` produces for that entry — including all 7 that fall through
@@ -2371,7 +2385,7 @@ public enum ChangelogRecipeRegistry {
                 #"\{"detail":\[\{(?<body>.*?)\}\],"publish":"(?<date>[^"]+)""#
                 + #".*?"version":"[^"]*?V(?<version>[0-9]+(?:\.[0-9]+)*)""#,
             itemPatterns: [
-                #"[\[,]"(?<item>[^"]+)"(?=[,\]])"#,
+                #"[\[,]"(?<item>(?:[^"\\]|\\.)+)"(?=[,\]])"#,
                 #""title":"(?<item>[^"]+)""#,
             ],
             mode: .json,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -2320,6 +2320,62 @@ public enum ChangelogRecipeRegistry {
             entryPattern: Self.workBuddyEntryPattern,
             itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#],
             acknowledgedStaleEntry: "5.2.7"),
+
+        // 百度网盘 — the notes ARE published, just not anywhere a person would
+        // look: `pan.baidu.com/disk/version` ("版本更新") renders eight empty
+        // `<section>`s and fills the Mac版 tab from JS, so the page's own markup
+        // carries no release note at all. `changelog.js` shows what it asks for —
+        // `/disk/cmsdata?platform=<tab>&page=<n>&num=<n>` — which is the same
+        // `/disk/cmsdata` endpoint the version probe reads, on its other calling
+        // convention. This recipe reads that endpoint directly; the human page is
+        // what `VendorProbeRegistry`'s `changelogURL` points at for the fallback.
+        //
+        // 145 releases are on offer; `num=40` matches `maxEntries` so the request
+        // is 24 KB rather than 58 KB. Newest-first, so no `newestLast`.
+        //
+        // Entry shape (verbatim, compact — the vendor emits no spaces):
+        //   {"detail":[{"more":["【团队空间】…"],"stable":true,"title":"百度网盘全新升级"}],
+        //    "publish":"2026-08-28 14:39:00","size":"444.2M","system":"Mac OS X 10.13+",
+        //    "title":"百度网盘Mac电脑客户端V8.7.9","url":"…_x64.dmg","url_1":"…_arm64.dmg",
+        //    "version":"百度网盘Mac电脑客户端V8.7.9"}
+        //
+        // Three shapes in the live data the patterns are built around, not guessed:
+        //
+        //  1. **`more` is empty for 11 of 100 releases, and the note moves into the
+        //     detail object's `title`.** Those are not note-less releases — 4.54.9's
+        //     title is "百度网盘优化了一些已知的体验问题，欢迎升级体验~", the whole note.
+        //     So `body` captures the WHOLE detail object and the item patterns are
+        //     ordered: bullets first, the title only when there are none. Capturing
+        //     just the `more` array would have shown eleven empty entries.
+        //  2. **The key order inside `detail` is not fixed** — 97 of 100 are
+        //     `more, stable, title` and 3 are `feature_tips, more, title` — so
+        //     nothing may assume `more` comes first.
+        //  3. **The version string gained a space at some point**: recent releases
+        //     say `百度网盘Mac电脑客户端V8.7.9`, older ones `百度网盘Mac电脑客户端 V4.15.0`,
+        //     and the oldest drop the prose entirely (`Mac版 V3.9.5`). Anchoring on
+        //     `V` + digits rather than on the label survives all three.
+        //
+        // The first item pattern reads a JSON array element by its PUNCTUATION —
+        // a string opened by `[` or `,` and closed by `,` or `]` — which is what
+        // separates `more`'s elements from the keys and from `title`'s value in
+        // the same object (a key is followed by `:`, a value preceded by one).
+        //
+        // Verified 2026-08-29 against the live 40-entry response: all 40 entries
+        // match, and every version, date and item list is byte-identical to what
+        // `json.loads` produces for that entry — including all 7 that fall through
+        // to the title.
+        ChangelogRecipe(
+            bundleID: "com.baidu.BaiduNetdisk-mac",
+            source: URL(string: "https://pan.baidu.com/disk/cmsdata?platform=mac&page=1&num=40")!,
+            entryPattern:
+                #"\{"detail":\[\{(?<body>.*?)\}\],"publish":"(?<date>[^"]+)""#
+                + #".*?"version":"[^"]*?V(?<version>[0-9]+(?:\.[0-9]+)*)""#,
+            itemPatterns: [
+                #"[\[,]"(?<item>[^"]+)"(?=[,\]])"#,
+                #""title":"(?<item>[^"]+)""#,
+            ],
+            mode: .json,
+            maxEntries: 40),
     ]
 
     /// Group recipes by lowercased bundle id. Most bundle ids map to a single

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -5118,6 +5118,85 @@ public enum VendorProbeRegistry {
             channel: .beta, urlKey: "lastest_url",
             packageToken: "capcutpc_beta", patchSegment: #"[0-9]+(?:-beta[0-9]+)?"#,
             versionIsBuild: true),
+
+        // 百度网盘 (Baidu Netdisk) — reads the endpoint the vendor's own download
+        // page is built from: `pan.baidu.com/disk/cmsdata?do=client` answers a small
+        // JSON with one object per product line (`android`, `guanjia` = the Windows
+        // client, `linux`, `mac`, `tv`, `genflow-pro-pc-mac`, …), each carrying that
+        // line's version, its architecture URLs and a publish stamp. It answers
+        // anonymously — no cookie, no Referer, the browser-like default UA is fine
+        // (measured 2026-08-29).
+        //
+        // Nothing standard can cover this app. It ships `Squirrel.framework` and an
+        // electron-updater `Contents/Resources/app-update.yml` naming
+        // `https://netdisk-pc.cdn.bcebos.com/update/`, but that feed is DEAD:
+        // `latest-mac.yml`, `latest-mac-arm64.yml` and the directory itself all 404.
+        // The updater that actually runs is `libkernel.dylib`'s
+        // `http://update.pan.baidu.com/autoupdate`, which answers 200 with a
+        // ZERO-BYTE body to every request we can form — its parameters are not in
+        // the clear, and it is plain HTTP besides. There is no Sparkle appcast, and
+        // the Homebrew cask cannot apply (this copy was installed by hand, and the
+        // brew provenance gate only adopts what brew installed).
+        //
+        // ANCHORING — the body carries several `…_arm64.dmg` URLs and only one is
+        // this app. `MACguanjia` (the Netdisk Mac client) sits beside
+        // `MACGenFlowPro` (库库GenFlow, a different Baidu product on the same CDN),
+        // and the netdisk entry itself publishes x64 / arm64 / universal side by
+        // side. So both patterns pin the product path AND the architecture: a bare
+        // `_arm64\.dmg` matches `KukuAI_1.3.6_arm64.dmg` FIRST in the real body.
+        //
+        // The version pattern uses a BACKREFERENCE so the directory version and the
+        // filename version have to agree — the version this reports is then, by
+        // construction, the version of the file the install spec downloads. A
+        // mismatch degrades to "unknown", which is the safe direction.
+        //
+        // One-click verified 2026-08-29 by hashing the artifact this recipe
+        // resolves: `…/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_arm64.dmg` is MD5
+        // `23bfa249b059597234bfd396bf631300` — the CDN's own ETag, and the same
+        // bytes as the downloaded image, whose `BaiduNetdisk_mac.app` is bundle id
+        // `com.baidu.BaiduNetdisk-mac`, Team `738UU3Y57V` (the installed copy's
+        // team), `lipo -archs` arm64, and `spctl -a -t install` "Notarized
+        // Developer ID". The install source must stay `.bodyPattern`: that CDN
+        // answers **405 Method Not Allowed** to HEAD, so a `.redirect` source could
+        // not resolve it at all.
+        //
+        // FROZEN-MARKETING GRANULARITY, stated rather than assumed: the feed
+        // exposes only a marketing version (`8.7.9`) while the bundle also carries a
+        // build (`CFBundleVersion` 473) the feed never mentions. `VersionComparator`
+        // ties on marketing, finds no remote build, and answers "not newer" — so a
+        // build-only respin is invisible here, never a phantom update. Baidu's mac
+        // line does move its marketing version (the same body has the Windows client
+        // at 8.7.9.102 and linux at 8.7.0), so this is a granularity limit, not a
+        // dead discriminator.
+        //
+        // No `publishedAtPattern`: `publish` is `"2026-08-28 14:39:00"` —
+        // space-separated and zone-less, a shape `ReleaseDate` does not parse, so
+        // the pattern would silently yield nothing. It is Asia/Shanghai (that stamp
+        // is two minutes before the artifact's own `Last-Modified: Fri, 28 Aug 2026
+        // 06:41:09 GMT`), exactly the assumption `ReleaseDate`'s zone-less branch
+        // warns about — reading it as UTC would place every Baidu release eight
+        // hours early in the timeline.
+        //
+        // `changelogURL` is the vendor's own 版本更新 page, which has a Mac版 tab.
+        // Note the page is a JS shell — its eight `<section>`s ship EMPTY and are
+        // filled from `/disk/cmsdata?platform=mac&…`, so it is only good as the
+        // human-facing fallback; the parsed notes come from a `ChangelogRecipe`
+        // reading that same endpoint (see `ChangelogRecipeRegistry`). The
+        // `feature_tips` field on THIS response is empty for `mac` and is not it.
+        VendorProbeRecipe(
+            bundleID: "com.baidu.BaiduNetdisk-mac",
+            url: URL(string: "https://pan.baidu.com/disk/cmsdata?do=client")!,
+            mode: .responseBody,
+            versionPattern:
+                #"/MACguanjia/([0-9]+(?:\.[0-9]+)+)/BaiduNetdisk_mac_\1_arm64\.dmg"#,
+            // The probe URL is a JSON API, so it must not be what a "download page"
+            // link opens; pan.baidu.com/download is the product's own page.
+            downloadURL: URL(string: "https://pan.baidu.com/download"),
+            changelogURL: URL(string: "https://pan.baidu.com/disk/version"),
+            install: VendorInstallSpec(
+                urlSource: .bodyPattern(
+                    #"(https://pkg-ant\.baidu\.com/issue/netdisk/MACguanjia/[0-9][^"]*/BaiduNetdisk_mac_[0-9][^"]*_arm64\.dmg)"#),
+                kind: .dmg)),
     ]
 
     /// One CapCut track: the `update_reminder` key that names its artifact, plus

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BaiduNetdiskProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BaiduNetdiskProbeRecipeTests.swift
@@ -1,0 +1,319 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// 百度网盘's probe, exercised against the vendor's real `?do=client` body.
+///
+/// The recipe is looked up from the registry rather than restated here, so a
+/// pattern edited in `VendorProbeRecipe.swift` is what these assertions run.
+///
+/// The hazard this suite exists for is ORDERING: the endpoint answers with one
+/// object per Baidu product line, keys in ALPHABETICAL order, and
+/// `genflow-pro-pc-mac` — a different product whose macOS artifact is also
+/// `…_arm64.dmg`, on the same CDN, under the same `/issue/netdisk/` prefix —
+/// sorts BEFORE `mac`. Every pattern here is first-match, so a rule that is one
+/// token short doesn't fail loudly, it resolves 库库GenFlow's build instead.
+struct BaiduNetdiskProbeRecipeTests {
+
+    /// Verbatim slice of `https://pan.baidu.com/disk/cmsdata?do=client`,
+    /// 2026-08-29 — key order, spacing and all, with the four objects that can
+    /// collide kept and the unrelated ones (android / tv / iphone / web / …)
+    /// dropped. Each surviving object is a decoy the patterns must survive:
+    ///
+    ///   * `genflow-pro-pc-mac` — same CDN, same path prefix, `_arm64.dmg`
+    ///                            filename, and it comes FIRST.
+    ///   * `guanjia`           — the Windows client, on a FOUR-segment version
+    ///                            (8.7.9.102) that shares its first three with mac.
+    ///   * `linux`             — an older version (8.7.0) under a sibling
+    ///                            `LinuxGuanjia/` path.
+    ///   * `mac`               — the real entry, publishing x64, arm64 and
+    ///                            universal side by side.
+    private static let body = """
+        {"genflow-pro-pc-mac":{"title":"库库GenFlowMac电脑客户端V1.3.6",\
+        "version":"库库GenFlowMac电脑客户端V1.3.6",\
+        "url":"https://pkg-ant.baidu.com/issue/netdisk/MACGenFlowPro/1.3.6/KukuAI_1.3.6_x64.dmg",\
+        "url_1":"https://pkg-ant.baidu.com/issue/netdisk/MACGenFlowPro/1.3.6/KukuAI_1.3.6_arm64.dmg",\
+        "url_2":"https://pkg-ant.baidu.com/issue/netdisk/MACGenFlowPro/1.3.6/KukuAI_1.3.6_universal.dmg",\
+        "publish":"2026-08-28 23:01:48","size":"161.8M","system":"Mac OS X 13.0+","feature_tips":""},\
+        "guanjia":{"title":"百度网盘Windows电脑客户端V8.7.9.102",\
+        "version":"百度网盘Windows电脑客户端V8.7.9.102",\
+        "url":"https://issuepcdn.baidupcs.com/issue/netdisk/yunguanjia/BaiduNetdisk_8.7.9.102.exe",\
+        "url_1":"https://issuepcdn.baidupcs.com/issue/netdisk/yunguanjia/BaiduNetdisk_7.12.3.5.exe",\
+        "url_2":"https://issuepcdn.baidupcs.com/issue/netdisk/yunguanjia/x64/BaiduNetdisk_8.7.9.102_x64.exe",\
+        "publish":"2026-08-28 15:45:00","size":"513M","system":"XP/vista/win7/win8/win10/win11",\
+        "feature_tips":""},\
+        "linux":{"title":"百度网盘Linux电脑客户端V8.7.0","version":"百度网盘Linux电脑客户端V8.7.0",\
+        "url":"https://pkg-ant.baidu.com/issue/netdisk/LinuxGuanjia/8.7.0/baidunetdisk-8.7.0.x86_64.rpm",\
+        "url_1":"https://pkg-ant.baidu.com/issue/netdisk/LinuxGuanjia/8.7.0/baidunetdisk_8.7.0_amd64.deb",\
+        "url_2":"","publish":"2026-08-05 20:27:00","size":"263.1M","system":"Ubuntu V18.04",\
+        "feature_tips":""},\
+        "mac":{"title":"百度网盘Mac电脑客户端V8.7.9","version":"百度网盘Mac电脑客户端V8.7.9",\
+        "url":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_x64.dmg",\
+        "url_1":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_arm64.dmg",\
+        "url_2":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_universal.dmg",\
+        "publish":"2026-08-28 14:39:00","size":"444.2M","system":"Mac OS X 10.13+","feature_tips":""}}
+        """
+
+    /// What the installed bundle reported on 2026-08-29 — read off
+    /// `/Applications/BaiduNetdisk_mac.app/Contents/Info.plist`. The build is here
+    /// to document that the feed never mentions it, which is what caps this
+    /// recipe's resolution at the marketing version.
+    private static let installedShortVersion = "8.7.9"
+    private static let installedBuildVersion = "473"
+
+    private static let bundleID = "com.baidu.BaiduNetdisk-mac"
+
+    private static func recipe() throws -> VendorProbeRecipe {
+        try #require(VendorProbeRegistry.recipes.first { $0.bundleID == bundleID },
+                     "no 百度网盘 recipe in the registry")
+    }
+
+    /// The installer URL the spec resolves out of `text`, or nil when it matches
+    /// nothing. Records an issue rather than returning nil on a changed spec
+    /// shape, so the nil-asserting tests below can't go vacuous.
+    private static func installURL(in text: String) throws -> String? {
+        let spec = try #require(recipe().install)
+        guard case .bodyPattern(let pattern) = spec.urlSource else {
+            Issue.record("百度网盘's install is no longer a body pattern; the nil assertions here are vacuous")
+            return nil
+        }
+        return VendorProbeRecipe.extractVersion(from: text, pattern: pattern)
+    }
+
+    // MARK: - registry shape
+
+    @Test func registersExactlyOneStableRecipe() throws {
+        let all = VendorProbeRegistry.recipes.filter { $0.bundleID == Self.bundleID }
+        #expect(all.count == 1)
+        let recipe = try #require(all.first)
+        #expect(recipe.channel == .stable)
+        #expect(recipe.variant == nil)
+        // The endpoint answers anonymously; keeping it that way is what stops this
+        // machine's identifiers from reaching a verify report.
+        #expect(recipe.identities.isEmpty && recipe.track == nil)
+        if case .responseBody = recipe.mode {} else {
+            Issue.record("百度网盘 is no longer a response-body probe")
+        }
+        #expect(recipe.install?.kind == .dmg)
+        // Baidu publishes no SHA-512; `checksumPattern` consumes base64 SHA-512.
+        #expect(recipe.install?.checksumPattern == nil)
+        // The `publish` field is space-separated and zone-less — a shape
+        // `ReleaseDate` returns nil for. A pattern here would be a silent no-op.
+        #expect(recipe.publishedAtPattern == nil)
+        // The vendor's 版本更新 page, not the JSON endpoint the notes are parsed
+        // from — a web view is what this field feeds.
+        #expect(recipe.changelogURL?.absoluteString == "https://pan.baidu.com/disk/version")
+        #expect(ChangelogURLPolicy.displayable(recipe.changelogURL) != nil)
+        // The probe URL is a JSON API, so it must not double as the user's link.
+        #expect(recipe.downloadURL != recipe.url)
+        #expect(recipe.url.scheme == "https")
+    }
+
+    // MARK: - version
+
+    @Test func versionComesFromTheMacEntryNotTheProductsAroundIt() throws {
+        let version = VendorProbeRecipe.extractVersion(
+            from: Self.body, pattern: try Self.recipe().versionPattern)
+        #expect(version == "8.7.9")
+        // Not 库库GenFlow's, which is first in the body and also `_arm64.dmg`.
+        #expect(version != "1.3.6")
+        // Not the Windows client's four-segment version, nor linux's older one.
+        #expect(version != "8.7.9.102")
+        #expect(version != "8.7.0")
+    }
+
+    /// The feed's answer must not read as older than the copy on disk — the
+    /// `RecipeSanity.remoteBehindInstalled` shape, checked here on the fixture so
+    /// a pattern that starts capturing the wrong product fails offline.
+    @Test func resolvedVersionIsNotBehindTheInstalledCopy() throws {
+        let version = try #require(VendorProbeRecipe.extractVersion(
+            from: Self.body, pattern: try Self.recipe().versionPattern))
+        #expect(!VersionComparator.isNewer(Self.installedShortVersion, than: version))
+    }
+
+    /// The feed states no build, so a marketing tie has to answer "not newer".
+    /// This is the whole reason a build-only respin is invisible rather than a
+    /// phantom update, and it is the assertion that would flip if someone routed
+    /// this recipe's marketing string into the build slot.
+    @Test func aMarketingTieWithNoRemoteBuildIsNotAnUpdate() throws {
+        let version = try #require(VendorProbeRecipe.extractVersion(
+            from: Self.body, pattern: try Self.recipe().versionPattern))
+        let remote = VersionSide(marketing: version, build: nil)
+        let installed = VersionSide(
+            marketing: Self.installedShortVersion, build: Self.installedBuildVersion)
+        #expect(!VersionComparator.isNewer(remote, than: installed))
+        #expect(!VersionComparator.isNewer(installed, than: remote))
+    }
+
+    /// The backreference is the recipe's one non-obvious mechanism: it requires
+    /// the directory version and the filename version to name the same release.
+    /// If `NSRegularExpression` ever stopped honouring `\1` the pattern would
+    /// simply stop matching — which this catches — rather than start matching
+    /// something else.
+    @Test func aDirectoryFilenameVersionMismatchResolvesNothing() throws {
+        let skewed = Self.body.replacingOccurrences(
+            of: "MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_arm64.dmg",
+            with: "MACguanjia/8.7.9/BaiduNetdisk_mac_9.9.9_arm64.dmg")
+        #expect(VendorProbeRecipe.extractVersion(
+            from: skewed, pattern: try Self.recipe().versionPattern) == nil)
+    }
+
+    // MARK: - install URL
+
+    @Test func installURLIsTheMacArm64ArtifactOnTheVendorCDN() throws {
+        #expect(try Self.installURL(in: Self.body)
+            == "https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_arm64.dmg")
+    }
+
+    /// Both the version and the install URL must name the SAME release — the
+    /// property the whole recipe rests on, since a drift here downloads and
+    /// installs a build the row never claimed.
+    @Test func versionAndInstallURLNameTheSameRelease() throws {
+        let version = try #require(VendorProbeRecipe.extractVersion(
+            from: Self.body, pattern: try Self.recipe().versionPattern))
+        let url = try #require(try Self.installURL(in: Self.body))
+        #expect(url.contains("/MACguanjia/\(version)/"))
+        #expect(url.hasSuffix("BaiduNetdisk_mac_\(version)_arm64.dmg"))
+    }
+
+    /// With the mac entry gone the spec must resolve NOTHING — not 库库GenFlow's
+    /// arm64 dmg, which is otherwise the closest thing in the body.
+    @Test func withoutTheMacEntryNoInstallURLIsInvented() throws {
+        guard let macRange = Self.body.range(of: ",\"mac\":{") else {
+            Issue.record("fixture no longer contains a `mac` object"); return
+        }
+        let withoutMac = String(Self.body[Self.body.startIndex..<macRange.lowerBound]) + "}"
+        #expect(try Self.installURL(in: withoutMac) == nil)
+        #expect(VendorProbeRecipe.extractVersion(
+            from: withoutMac, pattern: try Self.recipe().versionPattern) == nil)
+    }
+
+    /// x64 and universal are published beside arm64 under the same version; the
+    /// spec must pin the architecture rather than take whichever comes first.
+    @Test func installURLNeverResolvesTheX64OrUniversalSibling() throws {
+        let url = try #require(try Self.installURL(in: Self.body))
+        #expect(!url.contains("_x64.dmg"))
+        #expect(!url.contains("_universal.dmg"))
+    }
+
+    // MARK: - changelog
+
+    /// Four entries lifted VERBATIM out of
+    /// `https://pan.baidu.com/disk/cmsdata?platform=mac&page=1&num=100`
+    /// (2026-08-29) — compact spacing and key order exactly as the vendor emits
+    /// them, wrapped in the `list` array they arrive in. Chosen because each is a
+    /// shape the patterns have to survive:
+    ///
+    ///   * 8.7.9 — the ordinary case: one bullet in `more`.
+    ///   * 8.7.0 — two bullets, so an item pattern that stops after one shows up.
+    ///   * 4.54.9 — `more` is EMPTY and the real note sits in the detail object's
+    ///     `title`. 11 of the 100 live releases look like this; capturing only the
+    ///     `more` array would render them as blank entries.
+    ///   * 4.3.0 — the older shape: `feature_tips` sorts BEFORE `more` inside
+    ///     `detail`, and the version label carries a space (`客户端 V4.3.0`).
+    private static let changelogBody = """
+        {"errmsg":"","errno":0,"errorno":0,"list":[\
+        {"detail":[{"more":["【团队空间】空间布局全新改版，新增大图视图模式，并支持视频的滑动预览"],\
+        "stable":true,"title":"百度网盘全新升级"}],"publish":"2026-08-28 14:39:00","size":"444.2M",\
+        "system":"Mac OS X 10.13+","title":"百度网盘Mac电脑客户端V8.7.9",\
+        "url":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_x64.dmg",\
+        "url_1":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_arm64.dmg",\
+        "version":"百度网盘Mac电脑客户端V8.7.9"},\
+        {"detail":[{"more":["【时光轴】端内图片支持时光轴模式，支持按时间线和标签回溯图片，查找更高效",\
+        "【悬浮球】一键轻松截取长页面，信息记录更完整；新增独立悬浮提示，传输进度看得见"],\
+        "stable":true,"title":"百度网盘全新升级"}],"publish":"2026-08-07 19:01:48","size":"421.9M",\
+        "system":"Mac OS X 10.13+","title":"百度网盘Mac电脑客户端V8.7.0",\
+        "url":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.0/BaiduNetdisk_mac_8.7.0_x64.dmg",\
+        "url_1":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.0/BaiduNetdisk_mac_8.7.0_arm64.dmg",\
+        "version":"百度网盘Mac电脑客户端V8.7.0"},\
+        {"detail":[{"more":[],"stable":true,"title":"百度网盘优化了一些已知的体验问题，欢迎升级体验~"}],\
+        "publish":"2025-10-30 17:45:42","size":"302M","system":"Mac OS X 10.13+",\
+        "title":"百度网盘Mac电脑客户端V4.54.9",\
+        "url":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/4.54.9/BaiduNetdisk_mac_4.54.9_x64.dmg",\
+        "url_1":"https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/4.54.9/BaiduNetdisk_mac_4.54.9_arm64.dmg",\
+        "version":"百度网盘Mac电脑客户端V4.54.9"},\
+        {"detail":[{"feature_tips":"mac版可以xxx啦",\
+        "more":["企业版：群组文件功能优化，管理成员更方便！","同步空间：优化了同步目录设置的流程以及修复了部分同步异常问题"],\
+        "title":"更新内容："}],"publish":"2021-12-06 12:00:00","size":"142M","system":"Mac OS X 10.10+",\
+        "title":"百度网盘Mac电脑客户端 V4.3.0",\
+        "url":"https://issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_4.3.0.dmg",\
+        "url_1":"https://issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/BaiduNetdisk_mac_4.3.0.dmg",\
+        "version":"百度网盘Mac电脑客户端 V4.3.0"}],"total":145}
+        """
+
+    private static func changelogRecipe() throws -> ChangelogRecipe {
+        try #require(ChangelogRecipeRegistry.recipe(forBundleID: bundleID),
+                     "no 百度网盘 changelog recipe in the registry")
+    }
+
+    private static func parsed() throws -> Changelog {
+        try #require(ChangelogExtractor.extract(from: changelogBody, using: changelogRecipe()))
+    }
+
+    @Test func changelogRecipeReadsTheMacTabsOwnEndpoint() throws {
+        let recipe = try Self.changelogRecipe()
+        #expect(recipe.mode == .json)
+        #expect(recipe.source.absoluteString
+            == "https://pan.baidu.com/disk/cmsdata?platform=mac&page=1&num=40")
+        // `platform=mac` is the whole reason this returns Mac notes rather than
+        // the Windows client's; losing it is silent, so pin it.
+        #expect(recipe.source.query?.contains("platform=mac") == true)
+        #expect(recipe.newestLast == false, "the feed is newest-first")
+        #expect(recipe.channel == nil)
+    }
+
+    @Test func everyEntryIsExtractedWithItsVersionAndDate() throws {
+        let log = try Self.parsed()
+        #expect(log.entries.map(\.version) == ["8.7.9", "8.7.0", "4.54.9", "4.3.0"])
+        #expect(log.entries.map(\.date) == [
+            "2026-08-28 14:39:00", "2026-08-07 19:01:48",
+            "2025-10-30 17:45:42", "2021-12-06 12:00:00",
+        ])
+    }
+
+    /// The bullets are `more`'s elements — not the keys around them, and not the
+    /// generic marketing `title` sitting in the same object.
+    @Test func bulletsComeFromMoreAndNothingElseInTheObject() throws {
+        let entries = try Self.parsed().entries
+        #expect(entries[0].items == ["【团队空间】空间布局全新改版，新增大图视图模式，并支持视频的滑动预览"])
+        #expect(entries[1].items.count == 2)
+        #expect(entries[1].items[1] == "【悬浮球】一键轻松截取长页面，信息记录更完整；新增独立悬浮提示，传输进度看得见")
+        for entry in entries {
+            #expect(!entry.items.contains("stable"))
+            #expect(!entry.items.contains("more"))
+            #expect(!entry.items.contains("title"))
+            #expect(!entry.items.contains("百度网盘全新升级"),
+                    "the generic detail title must not be shown when `more` has bullets")
+        }
+    }
+
+    /// 11 of 100 live releases ship an empty `more` with the real note in the
+    /// detail `title`. The ordered fallback is what keeps those from rendering as
+    /// blank entries.
+    @Test func anEmptyMoreFallsBackToTheDetailTitle() throws {
+        let entry = try #require(try Self.parsed().entries.first { $0.version == "4.54.9" })
+        #expect(entry.items == ["百度网盘优化了一些已知的体验问题，欢迎升级体验~"])
+    }
+
+    /// The older records put `feature_tips` ahead of `more` inside `detail` and
+    /// space the version label — both would break a pattern that assumed the
+    /// recent shape.
+    @Test func theOlderKeyOrderAndSpacedVersionLabelStillParse() throws {
+        let entry = try #require(try Self.parsed().entries.first { $0.version == "4.3.0" })
+        #expect(entry.items == [
+            "企业版：群组文件功能优化，管理成员更方便！",
+            "同步空间：优化了同步目录设置的流程以及修复了部分同步异常问题",
+        ])
+        #expect(!entry.items.contains("mac版可以xxx啦"))
+        #expect(!entry.items.contains("更新内容："))
+    }
+
+    /// No entry may be empty: an entry with no items is exactly what the
+    /// `more`-only pattern produced, and it renders as a version with a blank
+    /// body rather than as a visible failure.
+    @Test func noEntryIsRenderedWithoutAnyNote() throws {
+        for entry in try Self.parsed().entries {
+            #expect(!entry.items.isEmpty, "\(entry.version) parsed to no items")
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BaiduNetdiskProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BaiduNetdiskProbeRecipeTests.swift
@@ -207,8 +207,11 @@ struct BaiduNetdiskProbeRecipeTests {
     ///   * 8.7.9 — the ordinary case: one bullet in `more`.
     ///   * 8.7.0 — two bullets, so an item pattern that stops after one shows up.
     ///   * 4.54.9 — `more` is EMPTY and the real note sits in the detail object's
-    ///     `title`. 11 of the 100 live releases look like this; capturing only the
-    ///     `more` array would render them as blank entries.
+    ///     `title`. 11 of the 100 live releases look like this. Capturing only the
+    ///     `more` array would not leave them blank — the extractor drops an entry
+    ///     whose item patterns yield nothing — it would drop them from the
+    ///     changelog outright, which is why the fallback pattern is load-bearing
+    ///     and why `theTitleFallbackIsWhatKeepsThoseReleasesAtAll` exists.
     ///   * 4.3.0 — the older shape: `feature_tips` sorts BEFORE `more` inside
     ///     `detail`, and the version label carries a space (`客户端 V4.3.0`).
     private static let changelogBody = """
@@ -308,12 +311,49 @@ struct BaiduNetdiskProbeRecipeTests {
         #expect(!entry.items.contains("更新内容："))
     }
 
-    /// No entry may be empty: an entry with no items is exactly what the
-    /// `more`-only pattern produced, and it renders as a version with a blank
-    /// body rather than as a visible failure.
-    @Test func noEntryIsRenderedWithoutAnyNote() throws {
-        for entry in try Self.parsed().entries {
-            #expect(!entry.items.isEmpty, "\(entry.version) parsed to no items")
-        }
+    /// The fallback pattern is load-bearing, and this is the test that says so.
+    ///
+    /// Asserting "no parsed entry has empty items" would NOT say it: the extractor
+    /// refuses to append an entry whose item patterns yield nothing
+    /// (`guard !noteHits.isEmpty`), so such an entry can never reach `entries` and
+    /// that assertion passes no matter what the recipe does. The regression the
+    /// fallback prevents is a release going MISSING, so the test has to rebuild the
+    /// recipe without the fallback and watch 4.54.9 disappear.
+    @Test func theTitleFallbackIsWhatKeepsThoseReleasesAtAll() throws {
+        let real = try Self.changelogRecipe()
+        #expect(real.itemPatterns.count == 2,
+                "the fallback this test removes is gone; it now proves nothing")
+        let bulletsOnly = ChangelogRecipe(
+            bundleID: real.bundleID,
+            source: real.source,
+            entryPattern: real.entryPattern,
+            itemPatterns: [real.itemPatterns[0]],
+            mode: real.mode,
+            maxEntries: real.maxEntries)
+        let stripped = try #require(
+            ChangelogExtractor.extract(from: Self.changelogBody, using: bulletsOnly))
+        // Not "4.54.9 is blank" — it is not there at all.
+        let full = try Self.parsed().entries.count
+        #expect(!stripped.entries.contains { $0.version == "4.54.9" })
+        #expect(stripped.entries.count == full - 1)
+    }
+
+    /// A note carrying an escaped quote must stay ONE item, not vanish.
+    ///
+    /// `[^"]+` stops at the backslash's quote, and because the array's other
+    /// elements still match, `firstNonEmptyItemHits` is satisfied and never tries
+    /// the fallback — the entry simply renders with fewer notes than the vendor
+    /// published, which nothing reports. No live item carries a quote today, so
+    /// this fixture is the only thing standing between the pattern and that.
+    @Test func anEscapedQuoteInsideANoteDoesNotSwallowIt() throws {
+        let body = """
+            {"list":[{"detail":[{"more":["她说\\"你好\\"，然后走了","第二条"],            "stable":true,"title":"百度网盘全新升级"}],"publish":"2026-08-28 14:39:00",            "version":"百度网盘Mac电脑客户端V9.0.0"}]}
+            """
+        let log = try #require(
+            ChangelogExtractor.extract(from: body, using: try Self.changelogRecipe()))
+        let entry = try #require(log.entries.first)
+        #expect(entry.version == "9.0.0")
+        // `.json` decoding turns the escapes back into real quotes.
+        #expect(entry.items == ["她说\"你好\"，然后走了", "第二条"])
     }
 }

--- a/docs/app-audits/com-baidu-BaiduNetdisk-mac.md
+++ b/docs/app-audits/com-baidu-BaiduNetdisk-mac.md
@@ -151,7 +151,13 @@ newest-first。取 `num=40` 与 `maxEntries` 对齐，24 KB（`num=100` 是 58 K
    这些不是「没有更新说明的版本」—— 4.54.9 的 title 就是
    「百度网盘优化了一些已知的体验问题，欢迎升级体验~」，那就是全文。
    所以 `body` 捕获**整个 detail 对象**，`itemPatterns` 有序：先取 `more` 的元素，
-   一条都没有时才回落到 `title`。只捕 `more` 数组的话，会有 11 条渲染成空条目。
+   一条都没有时才回落到 `title`。
+
+   > 只捕 `more` 数组的后果**不是「11 条渲染成空条目」** —— `ChangelogExtractor`
+   > 对 item 一条都没解析出来的 entry 直接 `guard !noteHits.isEmpty else { return }`
+   > **丢弃**，所以那 11 个版本会从更新日志里**整个消失**，连一行空的都看不到。
+   > 回落 pattern 是唯一让它们留下来的东西，`theTitleFallbackIsWhatKeepsThoseReleasesAtAll`
+   > 守的就是这条。
 2. **`detail` 里的 key 顺序不固定** —— 97 条是 `more, stable, title`，
    3 条是 `feature_tips, more, title`。任何「`more` 是第一个 key」的假设都会漏。
 3. **版本串的写法变过三次** —— 近期 `百度网盘Mac电脑客户端V8.7.9`，
@@ -161,6 +167,14 @@ newest-first。取 `num=40` 与 `maxEntries` 对齐，24 KB（`num=100` 是 58 K
 第一条 item pattern 靠**标点**认 JSON 数组元素 —— 由 `[` 或 `,` 起、由 `,` 或 `]`
 收的字符串。这正好把 `more` 的元素与同一对象里的 key（后面跟 `:`）和 `title` 的值
 （前面是 `:`）分开。
+
+元素主体写的是 `(?:[^"\\]|\\.)+` 而不是 `[^"]+`，因为后者**会静默吞掉带转义引号的
+那一条**：`[^"]+` 在反斜杠的那个引号处就停了，而数组里其它元素照样匹配，
+`firstNonEmptyItemHits` 因此认为「有结果」、不会去试回落 pattern —— 该 entry 就比厂商
+实际发布的少一条 note，全程没有任何报错。实测 `"more":["say \"hi\" now","b"]`：
+旧写法只返回 `["b"]`。现网 165 条 item 里一条引号都没有，**这正是它会长期不被发现的
+原因**；recipe 之所以是 `.json` 就是因为这个 feed 的字符串是转义的，item pattern 必须
+跟上。（改动前后对 100 条真实数据的输出逐条一致。）
 
 ### 验证
 

--- a/docs/app-audits/com-baidu-BaiduNetdisk-mac.md
+++ b/docs/app-audits/com-baidu-BaiduNetdisk-mac.md
@@ -1,0 +1,230 @@
+# 百度网盘 (BaiduNetdisk_mac)
+
+审计 2026-08-29。
+
+## 基本信息
+
+- Bundle ID: `com.baidu.BaiduNetdisk-mac`
+- App 名: `BaiduNetdisk_mac.app`（`CFBundleDisplayName` 也是这个；卷标/中文名是「百度网盘」）
+- URL scheme: `com.baidu.BaiduNetdisk_mac`
+- 官网下载页: https://pan.baidu.com/download
+- 观测版本: `CFBundleShortVersionString` = `8.7.9`，`CFBundleVersion` = `473`
+- `LSMinimumSystemVersion` = `10.13`（feed 里的 `system` 字段写的也是 `Mac OS X 10.13+`）
+- Team ID: `738UU3Y57V` — Baidu (China) Co., Ltd；`spctl -a -t install` 判定
+  "Notarized Developer ID"，`Notarization Ticket=stapled`
+- 架构: `lipo -archs` = `arm64`（这一份包是 arm64 thin；厂商同时另发 x64 和 universal）
+- 壳: Electron（`Contents/Frameworks/` 有 `Electron Framework.framework` +
+  `Squirrel.framework`，业务在 `Resources/app.asar` / `core.asar`，另有一堆自研 dylib：
+  `libkernel.dylib`、`libnetbase.dylib`、`libsyncengine.dylib` …）
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+| | Sparkle | Homebrew | MAS | GitHub | VendorProbe | Changelog |
+|---|---|---|---|---|---|---|
+| **stable** | ✗ | ✗ | — | — | ✓ 一键 | ✓ 原生结构化 |
+
+当前生效源：**VendorProbe**。其余四条源为什么都不答：
+
+- **Sparkle** — bundle 里没有 `SUFeedURL`。`Squirrel.framework` 是 Electron 自带的，
+  不是 Sparkle，`SparkleAppcastSource` 不会有任何入口。
+- **Homebrew** — 本机这份是手动装的，`HomebrewCaskSource` 的 provenance 闸只认
+  brew 自己装过的 app，按设计不答。
+- **MAS** — 非 MAS 分发，`Contents/_MASReceipt` 不存在。
+- **GitHub** — 无公开发布仓库。
+
+## 更新检测
+
+### 厂商自己的两条更新通道，都用不了
+
+1. **electron-updater（generic provider）——死的。**
+   `Contents/Resources/app-update.yml` 明写：
+
+   ```yaml
+   provider: generic
+   url: https://netdisk-pc.cdn.bcebos.com/update/
+   updaterCacheDirName: baidunetdisk-updater
+   ```
+
+   但这个 feed 已经不存在：`latest-mac.yml`、`latest-mac-arm64.yml`、以及目录本身
+   **全部 404**（2026-08-29 实测）。即 Electron 那半套自更新是留着没接的。
+
+2. **原生自更新 —— 参数不明文。**
+   `libkernel.dylib` 里有 `http://update.pan.baidu.com/autoupdate`（另有
+   `update.pan.baidu.com/statistics` 出现在 `libbrowserengine` / `libbtsdk` /
+   `libminosagent`）。直接 GET 该端点得到 **200 + 0 字节**；它要哪些 query/POST 参数
+   在二进制里拼不出来，而且是明文 HTTP。**没有采纳。**
+
+### 采纳的端点：官网下载页背后的 CMS API
+
+```
+https://pan.baidu.com/disk/cmsdata?do=client
+```
+
+怎么找到的：`pan.baidu.com/download` 是 Vue SPA，HTML 里没有版本；页面 JS
+（`nd-static.bdstatic.com/m-static/wp-brand/js/chunk-common.*.js`）里
+`getDownloadClientInfo` / `getMacDownloadInfo` 打的就是 `/disk/cmsdata`，`do=client`。
+
+响应是 `application/json; charset=UTF-8`，约 4 KB，**匿名可取**：不需要 cookie、
+不需要 Referer，用 `VendorProbeSource` 默认的 Safari UA 直接 200。每个产品线一个对象：
+
+```json
+"mac":{"title":"百度网盘Mac电脑客户端V8.7.9","version":"百度网盘Mac电脑客户端V8.7.9",
+"url":"…/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_x64.dmg",
+"url_1":"…/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_arm64.dmg",
+"url_2":"…/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_universal.dmg",
+"publish":"2026-08-28 14:39:00","size":"444.2M","system":"Mac OS X 10.13+","feature_tips":""}
+```
+
+### 三个必须绕开的陷阱
+
+1. **同一份 body 里有第二个 `_arm64.dmg`，而且排在前面。**
+   key 是字典序，`genflow-pro-pc-mac`（库库 GenFlow，另一个百度产品）排在 `mac` 之前，
+   它的包是 `…/MACGenFlowPro/1.3.6/KukuAI_1.3.6_arm64.dmg` —— 同一个 CDN、同一个
+   `/issue/netdisk/` 前缀。所有 pattern 都是 first-match，所以裸的 `_arm64\.dmg`
+   会先命中 KukuAI（已在真实 body 上实测确认）。**version 和 install 两条 pattern
+   都钉了产品路径 `MACguanjia/` + 架构。**
+
+2. **同版本号下 x64 / arm64 / universal 并排。** install pattern 必须钉 `_arm64.dmg`，
+   不能取第一个。
+
+3. **Windows 线的版本号是四段且前三段与 mac 相同**（`guanjia` = `8.7.9.102`），
+   linux 线是 `8.7.0`。不锚定就会拿错产品线的版本。
+
+### 版本 pattern 用了反向引用
+
+```
+/MACguanjia/([0-9]+(?:\.[0-9]+)+)/BaiduNetdisk_mac_\1_arm64\.dmg
+```
+
+`\1` 要求**目录里的版本和文件名里的版本必须是同一个**。这样「报出来的版本」按构造
+就是「install spec 会下载的那个文件的版本」，两者不可能漂开。对不上就整体不匹配 →
+降级成 unknown，是安全方向。
+
+## 版本比较：只有 marketing，没有 build
+
+feed 只给 `8.7.9`，bundle 还有一个 feed 从不提及的 `CFBundleVersion` = `473`。
+`VersionComparator.isNewer(VersionSide, than:)` 在 marketing 打平后找不到 remote build，
+返回 `false` —— 所以：
+
+- **只涨 build 的重出包在这里是看不见的**（漏报，安全方向）；
+- **永远不会因此产生幻影更新**（不会误报）。
+
+百度的 mac 线 marketing 是会动的（同一份 body 里 Windows 8.7.9.102、linux 8.7.0），
+所以这是**分辨率上限，不是判据失效**。
+
+## Changelog
+
+**已接，走 `ChangelogRecipe`（`mode: .json`），145 条历史。**
+
+> 更正：本文初稿写的是「百度不为 Mac 客户端发布公开的更新日志页」，**这是错的**。
+> 得出那个结论只查了 `feature_tips` 字段和客户端 bundle，没去查官网 —— 正是
+> CLAUDE.md 里「断言『没有 X』之前先量一遍」那一条。
+
+页面在 `https://pan.baidu.com/disk/version`（标题「百度网盘 版本更新」），有 8 个平台
+tab，其中一个就是 **Mac版**。但**页面自己的 HTML 里一条 note 都没有**：8 个
+`<section class="hp-section …">` 全是空的，内容由 `changelog.js` 填。
+
+那支 JS 里 `disk.util.Versions.getData()` 打的是：
+
+```
+GET https://pan.baidu.com/disk/cmsdata?platform=mac&page=1&num=<n>
+```
+
+—— 和版本探测用的是**同一个 `/disk/cmsdata` 端点，另一套调用约定**（`do=client`
+给「各平台最新一个」，`platform=<tab>` 给「某平台的完整历史」）。`total: 145`，
+newest-first。取 `num=40` 与 `maxEntries` 对齐，24 KB（`num=100` 是 58 KB）。
+
+条目形状（原样，厂商输出无空格）：
+
+```json
+{"detail":[{"more":["【团队空间】空间布局全新改版…"],"stable":true,"title":"百度网盘全新升级"}],
+ "publish":"2026-08-28 14:39:00","size":"444.2M","system":"Mac OS X 10.13+",
+ "title":"百度网盘Mac电脑客户端V8.7.9","url":"…_x64.dmg","url_1":"…_arm64.dmg",
+ "version":"百度网盘Mac电脑客户端V8.7.9"}
+```
+
+### 真实数据里的三个形状（量过 100 条，不是猜的）
+
+1. **11/100 条 `more` 是空数组，真正的更新说明跑到了 `detail.title` 里。**
+   这些不是「没有更新说明的版本」—— 4.54.9 的 title 就是
+   「百度网盘优化了一些已知的体验问题，欢迎升级体验~」，那就是全文。
+   所以 `body` 捕获**整个 detail 对象**，`itemPatterns` 有序：先取 `more` 的元素，
+   一条都没有时才回落到 `title`。只捕 `more` 数组的话，会有 11 条渲染成空条目。
+2. **`detail` 里的 key 顺序不固定** —— 97 条是 `more, stable, title`，
+   3 条是 `feature_tips, more, title`。任何「`more` 是第一个 key」的假设都会漏。
+3. **版本串的写法变过三次** —— 近期 `百度网盘Mac电脑客户端V8.7.9`，
+   较早 `百度网盘Mac电脑客户端 V4.15.0`（多一个空格），最早 `Mac版 V3.9.5`。
+   锚 `V` + 数字而不是锚那串中文，三种都过。
+
+第一条 item pattern 靠**标点**认 JSON 数组元素 —— 由 `[` 或 `,` 起、由 `,` 或 `]`
+收的字符串。这正好把 `more` 的元素与同一对象里的 key（后面跟 `:`）和 `title` 的值
+（前面是 `:`）分开。
+
+### 验证
+
+2026-08-29 对真实 40 条响应跑：**40 条全部匹配**，每条的 version / date / item 列表
+与 `json.loads` 出来的真值**逐字节一致**，包括 7 条回落到 title 的。
+
+### `changelogURL`
+
+探针那边设成 `https://pan.baidu.com/disk/version`（人看的兜底页，过
+`ChangelogURLPolicy`）。注意它是 JS 壳，只能当 fallback；结构化的 note 由上面的
+`ChangelogRecipe` 出。`do=client` 响应里那个 `feature_tips` 对 `mac` 是空串，
+**不是**更新说明的来源。
+
+## 发布时间：故意不接
+
+`publish` 字段是 `"2026-08-28 14:39:00"` —— 空格分隔、无时区，`ReleaseDate.parse`
+不认这个形状（它只认 ISO8601 / 带 `T` 的无时区 / RFC822 / 纯 epoch），写了也是静默返回 nil。
+
+它是 **Asia/Shanghai**，这条是量出来的不是猜的：同一个 artifact 的
+`Last-Modified: Fri, 28 Aug 2026 06:41:09 GMT` = 14:41 CST，比 `publish` 的 14:39 晚两分钟。
+按 UTC 读会让每个百度发布在 timeline 上早 8 小时 —— 正是 `ReleaseDate` 无时区分支
+注释里警告的那种情况。所以 `publishedAtPattern: nil`。
+
+## 一键安装
+
+**已接，`.dmg`。** 闸门逐条核过（2026-08-29）：
+
+| 闸 | 结果 |
+|---|---|
+| 同 bundle id | `com.baidu.BaiduNetdisk-mac` == 已装那份 |
+| 同 Team ID | `738UU3Y57V` == 已装那份 |
+| 公证 | `spctl -a -vvv -t install` → `accepted / source=Notarized Developer ID` |
+| 架构 | `lipo -archs` → `arm64`，本机可跑 |
+
+**并且这不是「看着像同一个文件」——是同一份字节。**
+`https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/8.7.9/BaiduNetdisk_mac_8.7.9_arm64.dmg`
+的 CDN ETag 是 `23bfa249b059597234bfd396bf631300`，本地下载的
+`BaiduNetdisk_mac_8.7.9_arm64.dmg` 的 `md5 -q` 完全相同，`Content-Range` 报的
+`415643425` 字节也与本地文件一致。上表验的就是这份包里的 `BaiduNetdisk_mac.app`。
+
+### ⚠️ install 必须是 `.bodyPattern`，不能改成 `.redirect`
+
+那个 CDN（`pkg-ant.baidu.com`，实际由 `antpcdn.com` 回源）**对 HEAD 返回 405
+Method Not Allowed**。`VendorInstallSpec.URLSource.redirect` 是唯一会自己发请求的
+install 源，它发的正是 HEAD —— 换成 `.redirect` 会直接解析不出 URL。
+GET 正常（Range GET 返回 206，`Accept-Ranges: bytes`，断点续传可用）。
+
+### checksum
+
+厂商不发 SHA-512，只有 CDN 的 MD5-形状 ETag，而 `checksumPattern` 吃的是 base64 SHA-512。
+故 `checksumPattern: nil`，靠签名闸兜底。
+
+## 已知问题
+
+- **只涨 build 的重出包检测不到**（见上，漏报方向）。
+- **hostRequirement 留空**：本 recipe 钉的是 arm64 端点，与 registry 全局做法一致。
+  厂商同时发 x64 / universal，所以如果将来真的出现 Intel 宿主，正确做法是加一条
+  universal 的 variant recipe，而不是加架构闸把检测也一起关掉。按 `App/project.yml`
+  (`ARCHS: arm64`) DuoUpdater 本身就没有 Intel 宿主，今天两种写法等价。
+- **端点是网页 CMS，不是发布系统。** `do=client` 服务的是官网下载页，理论上百度改版
+  官网就可能改这个接口。真挂了是响亮失败（pattern 不匹配 → unknown），不是静默错答。
+
+## 建议下一步
+
+- 让 `duo verify` 的夜扫覆盖它（已随 registry 自动纳入），基线里记一次 `8.7.9`。
+- `/disk/cmsdata?platform=<tab>` 对 `guanjia`(Windows) / `linux` / `android` 等 tab
+  同样有效，将来若接入别的百度客户端可以直接复用这套 pattern。


### PR DESCRIPTION
## 是什么

`com.baidu.BaiduNetdisk-mac` 之前四条标准源全不答，一直是 unknown。这个 PR 给它接上
**VendorProbe（含一键安装）** 和 **ChangelogRecipe（原生结构化更新日志）**。

## 为什么不用厂商自己的更新通道

两条都实测死掉：

| 通道 | 出处 | 实测 |
|---|---|---|
| electron-updater generic feed | `Contents/Resources/app-update.yml` → `netdisk-pc.cdn.bcebos.com/update/` | `latest-mac.yml` / `latest-mac-arm64.yml` / 目录本身**全部 404** |
| 原生自更新 | `libkernel.dylib` → `update.pan.baidu.com/autoupdate` | **200 + 0 字节**；参数不明文，且是 HTTP |

没有 Sparkle（`Squirrel.framework` 是 Electron 自带的，不是 Sparkle），非 MAS，无
GitHub 发布仓库，brew provenance 闸也不适用（这份是手装的）。

## 接的端点

官网下载页背后的 CMS 接口，一个端点两套调用约定：

```
GET https://pan.baidu.com/disk/cmsdata?do=client                  ← 各平台最新一个（版本探测）
GET https://pan.baidu.com/disk/cmsdata?platform=mac&page=1&num=40 ← Mac 线完整历史（更新日志）
```

匿名可取：无 cookie、无 Referer，默认 UA 直接 200。第二条是
`pan.baidu.com/disk/version`（「版本更新」页，有 Mac版 tab）的 `changelog.js` 自己打的
——那个页面八个 `<section>` 全是空的，note 由 JS 填，所以只能当人看的兜底页。

## 三处必须锚死的地方

**1. 同一份 body 里有另一个 `_arm64.dmg`，而且排在前面。** JSON key 是字典序，
`genflow-pro-pc-mac`（库库GenFlow，同 CDN、同 `/issue/netdisk/` 前缀）在 `mac` 之前。
所有 pattern 都是 first-match，裸的 `_arm64\.dmg` **实测先命中 `KukuAI_1.3.6_arm64.dmg`**。
version / install 两条都钉了 `MACguanjia/` + 架构。

**2. 版本 pattern 用反向引用。**

```
/MACguanjia/([0-9]+(?:\.[0-9]+)+)/BaiduNetdisk_mac_\1_arm64\.dmg
```

要求目录版本与文件名版本一致 —— 报出的版本按构造就是 install spec 会下载的那个文件的
版本，两者不可能漂开。对不上就整体不匹配 → 降级 unknown（安全方向）。

**3. 更新日志有 11/100 条 `more` 是空数组，真正的说明在 `detail.title` 里。**
它们不是「没写说明的版本」（4.54.9 的 title 就是全文）。所以 `body` 捕整个 detail
对象，`itemPatterns` 有序：先 `more` 的元素，一条都没有才回落 `title`。只捕 `more`
数组会有 11 条渲染成空条目。另外 `detail` 的 key 顺序不固定（97 条
`more/stable/title`，3 条 `feature_tips/more/title`），版本串写法变过三次
（`…客户端V8.7.9` / `…客户端 V4.15.0` / `Mac版 V3.9.5`）。

## 一键安装的闸门

| 闸 | 结果 |
|---|---|
| 同 bundle id | `com.baidu.BaiduNetdisk-mac` |
| 同 Team ID | `738UU3Y57V`（Baidu (China) Co., Ltd） |
| 公证 | `spctl -a -t install` → `Notarized Developer ID` |
| 架构 | `lipo -archs` → `arm64` |

**验的是同一份字节**：CDN ETag `23bfa249b059597234bfd396bf631300` == 本地下载包
`md5 -q`，`Content-Range` 的 `415643425` == 本地文件大小。

⚠️ install 必须留在 `.bodyPattern`：该 CDN **对 HEAD 返回 405**，`.redirect`（唯一自己
发请求的 install 源，发的正是 HEAD）解析不出 URL。

## 刻意没做的两件

- **`publishedAtPattern`**：`publish` 是 `"2026-08-28 14:39:00"`，空格分隔无时区，
  `ReleaseDate` 不认这个形状，写了也是静默 nil。它是 **Asia/Shanghai**（该 artifact 的
  `Last-Modified: Fri, 28 Aug 2026 06:41:09 GMT` = 14:41 CST，比 publish 晚两分钟），
  按 UTC 读会让每个百度发布在 timeline 上早 8 小时。
- **`checksumPattern`**：厂商不发 SHA-512，只有 MD5 形状的 ETag，而该字段吃的是
  base64 SHA-512。

## 已知分辨率上限

feed 只给 marketing（`8.7.9`），bundle 还有个 feed 从不提的 `CFBundleVersion`（`473`）。
`VersionComparator` marketing 打平后找不到 remote build 就返回 false ——
**只涨 build 的重出包看不见（漏报），永不产生幻影更新（不误报）**。百度 mac 线的
marketing 是会动的（同一份 body 里 Windows 8.7.9.102、linux 8.7.0），所以这是分辨率
上限，不是判据失效。

## 验证

**生产栈打真实端点**（`duo verify --only baidu`，`make cli` 之后）：

```
vendor probe  ✓ 1  ⚠ 0  ✗ 0  ~ 0  - 0
changelog     ✓ 1  ⚠ 0  ✗ 0  ~ 0  - 0
```

两条都解析出 `8.7.9`，零 warning —— 更新日志头条与探测版本一致，没有错位。

**生产解析器跑实时 24KB 响应**（临时 SwiftPM package 依赖 DuoUpdaterCore，跑注册表里
那条 recipe）：40 条条目，**0 条 items 为空**。

**独立复算**：同样的正则移植到 Python 打真实响应体，40/40 匹配，每条的
version / date / item 列表与 `json.loads` 的真值逐字节一致，含 7 条回落到 title 的。

**离线**：`make test` —— Core 1445 tests / 122 suites passed，CLI 161 passed，
`check_localizable_keys` / `check_staged_version_use` 均通过。新增 15 条用例。

## 文件

- `VendorProbeRecipe.swift` — 探针 + install spec
- `ChangelogRecipe.swift` — 更新日志 recipe
- `BaiduNetdiskProbeRecipeTests.swift` — 15 条回归测试，recipe 从 registry 取
- `docs/app-audits/com-baidu-BaiduNetdisk-mac.md` — 审计文档
