### PR TITLE
test(core): state what a thrown source does to every UpdateChecker exit

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -158,11 +158,20 @@ public struct UpdateChecker: Sendable {
         // (Before vendor probes threw, this arrived as a nil and landed on
         // `.toolboxManaged` below — this keeps that.)
         //
-        // Deliberately NOT extended to `.appStoreManaged`/`.testFlightManaged`: a
-        // MAS row reaches `.error` when `MacAppStoreSource` itself threw — the
-        // lookup for the app the store *does* own failed — and that is worth
-        // surfacing as a failed check, not papering over with "managed by the App
-        // Store". TestFlight returns before the loop and never gets here.
+        // Deliberately NOT extended to `.appStoreManaged`/`.testFlightManaged`.
+        //
+        // A MAS row that reaches `.error` was answered by nobody and failed
+        // somewhere real: three sources can run for a store copy — the store lookup
+        // itself, `XcodeReleasesSource` (bundle-id gate only, and Xcode ships on the
+        // store), and `SparkleAppcastSource` (feed-url gate only; Keka is a store
+        // copy carrying a `SUFeedURL`). Only Homebrew, GitHub and the vendor probe
+        // carry `guard !app.isMASApp`. None of those three is a *borrowed* read the
+        // way Toolbox's is — each one IS this row's update check — so a failure
+        // there has to read as a failed check. Painting it "Managed by the App
+        // Store" would show the user the same row they get when the store is
+        // quietly keeping the app current.
+        //
+        // TestFlight returns before the loop and never gets here at all.
         if let lastError, !app.isToolboxManaged {
             Log.check.error("\(label, privacy: .public): all sources exhausted, last error → .error(\(lastError, privacy: .public))")
             return UpdateResult(app: app, remote: nil, status: .error(lastError))

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
@@ -194,13 +194,19 @@ import Foundation
     /// **The deliberate asymmetry.** A store app looks like it deserves the same
     /// treatment as a Toolbox one, and it does not.
     ///
-    /// Every other source declines a MAS copy outright (`guard !app.isMASApp` in
-    /// the Homebrew, GitHub and vendor-probe sources), so the only thing that can
-    /// throw here is `MacAppStoreSource` — the lookup for the app the store DOES
-    /// own. That is a check that genuinely failed, and hiding it behind "Managed
-    /// by the App Store" would show the user the same row they get when the store
-    /// is quietly keeping the app current. Unlike Toolbox, nothing was borrowed:
-    /// the failed read IS this row's own update check.
+    /// Only three sources carry `guard !app.isMASApp` — Homebrew, GitHub and the
+    /// vendor probe. Three others can still run for a store copy and can still
+    /// throw: `MacAppStoreSource` (the lookup for the app the store DOES own),
+    /// `XcodeReleasesSource` (bundle-id gate only, and Xcode ships on the store),
+    /// and `SparkleAppcastSource` (feed-url gate only — measured 2026-08-29, Keka
+    /// is a store copy carrying `SUFeedURL = https://u.keka.io`, 1 of the 22 store
+    /// apps on this machine).
+    ///
+    /// What none of them is, is a *borrowed* read. Toolbox's probe answers a
+    /// question Toolbox could have answered itself; each of these three IS this
+    /// row's update check. So a failure there has to read as a failed check —
+    /// painting it "Managed by the App Store" would show the user the same row
+    /// they get when the store is quietly keeping the app current.
     ///
     /// If a later change makes this `.appStoreManaged`, that is a decision to
     /// argue for here, not a tidy-up of an inconsistency.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
@@ -1,0 +1,258 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// What `UpdateChecker.check(_:)` settles on when a source **throws**, for every
+/// terminal status it can reach — one row per outcome, no gaps.
+///
+/// This file exists because of a miss. Making `VendorProbeSource` throw (it used
+/// to swallow every failure into nil) silently jumped the queue in front of the
+/// whole tail of `check(_:)`: `if let lastError` sits ABOVE the block that maps
+/// "no source answered" onto `.toolboxManaged` / `.testFlightManaged` /
+/// `.appStoreManaged` / `.unknown`. Only `.unknown` was the one under discussion,
+/// so only `.unknown` got checked; `.toolboxManaged` turned out to be reachable
+/// too, and an Android Studio Canary row lost its "open Toolbox" button — the one
+/// action it had — to a Retry button for a version number. Caught at review, not
+/// by a test.
+///
+/// Nothing owned that intersection, and the three tests that came close all
+/// couldn't see it: `ToolboxInventoryTests.toolboxManagedAppLabelledManaged`
+/// builds its app on the default `.stable` channel, so `check` returns at the
+/// early Toolbox branch and never enters the source loop at all;
+/// `VendorInstallTests.toolboxManagedCopiesResolveDetectionOnly` does use
+/// canary/beta but asserts on `VendorProbeSource` directly, never on the status
+/// the checker derives; and `UnknownAppsTests` runs the whole real stack and only
+/// `log()`s, with no assertion that can fail.
+///
+/// So the rule this file encodes is not "test the vendor probe" but: **every exit
+/// from `check(_:)` states, here, what a thrown source does to it.** A new status,
+/// or a new source that can throw where none could before, has to come add its
+/// row — which is the part that was missing.
+///
+/// The asymmetry between the rows is deliberate and is the whole reason they are
+/// written out one by one rather than folded into a loop. Read the comments.
+@Suite struct UpdateCheckerTerminalStatusTests {
+
+    /// A source under test control: it answers, misses, or throws on command, and
+    /// remembers whether it was consulted at all.
+    ///
+    /// The "was it consulted" half is load-bearing for the early-return rows
+    /// below. Asserting only on the final status would let a regression that
+    /// moves a guard *below* the loop pass unnoticed whenever the source happens
+    /// to miss — this way the test fails on the guard moving, not on the weather.
+    private final class ScriptedSource: UpdateSource, @unchecked Sendable {
+        enum Behaviour {
+            case throwing
+            case missing
+            case answering(String)
+        }
+
+        let name: String
+        private let behaviour: Behaviour
+        private let lock = NSLock()
+        private var consultedCount = 0
+
+        init(_ behaviour: Behaviour, name: String = "Scripted") {
+            self.behaviour = behaviour
+            self.name = name
+        }
+
+        /// The error a real source raises for the failure this stands in for — a
+        /// dropped connection. Its message is what the row would show.
+        static let error = URLError(.networkConnectionLost)
+
+        var consulted: Bool {
+            lock.withLock { consultedCount > 0 }
+        }
+
+        func latestVersion(for app: InstalledApp) async throws -> RemoteVersion? {
+            // `withLock`, not `lock()`/`unlock()`: the bare pair is unavailable in an
+            // async context (nothing stops a suspension between them).
+            lock.withLock { consultedCount += 1 }
+            switch behaviour {
+            case .throwing:
+                throw Self.error
+            case .missing:
+                return nil
+            case .answering(let version):
+                return RemoteVersion(
+                    shortVersion: version, version: nil, downloadURL: nil,
+                    sourceName: name, requiresManualInstaller: true)
+            }
+        }
+    }
+
+    private static func app(
+        bundleID: String = "com.example.subject",
+        isMASApp: Bool = false,
+        isToolboxManaged: Bool = false,
+        isTestFlightApp: Bool = false,
+        channel: ReleaseChannel = .stable
+    ) -> InstalledApp {
+        InstalledApp(
+            name: "Subject", bundleID: bundleID,
+            shortVersion: "1.0.0", buildVersion: "1",
+            path: URL(fileURLWithPath: "/Applications/Subject.app"),
+            isMASApp: isMASApp, isToolboxManaged: isToolboxManaged,
+            isTestFlightApp: isTestFlightApp, sparkleFeedURL: nil,
+            releaseChannel: channel)
+    }
+
+    /// The Toolbox-managed app that still reaches the source loop. Android Studio
+    /// Canary/Beta are the only ones (`prefersVendorProbeOverToolbox`), which is
+    /// why the bug lived exactly here and nowhere else.
+    private static func androidStudioPreview(_ channel: ReleaseChannel) -> InstalledApp {
+        InstalledApp(
+            name: "Android Studio", bundleID: "com.google.android.studio",
+            shortVersion: "2025.2", buildVersion: "AI-252.0.0",
+            path: URL(fileURLWithPath: "/Applications/Android Studio Preview.app"),
+            isMASApp: false, isToolboxManaged: true, sparkleFeedURL: nil,
+            releaseChannel: channel)
+    }
+
+    // MARK: - .unknown — nothing owns this app
+
+    /// The baseline both other rows are measured against: with no channel to fall
+    /// back on, a thrown source is all we know, so it is what the row says.
+    @Test func anUnownedAppReportsAThrownFailure() async {
+        let source = ScriptedSource(.throwing)
+        let result = await UpdateChecker(sources: [source]).check(Self.app())
+
+        #expect(source.consulted)
+        guard case .error(let message) = result.status else {
+            Issue.record("expected .error, got \(result.status)")
+            return
+        }
+        #expect(message == ScriptedSource.error.localizedDescription)
+    }
+
+    /// And a source that simply doesn't apply still means "nothing covers this" —
+    /// the dead "—". This is the pair that gives the dash its meaning: it is the
+    /// *absence* of a source, never the failure of one.
+    @Test func anUnownedAppWithNoApplicableSourceIsUnknown() async {
+        let result = await UpdateChecker(sources: [ScriptedSource(.missing)])
+            .check(Self.app())
+        #expect(result.status == .unknown)
+    }
+
+    // MARK: - .toolboxManaged — Toolbox owns the install
+
+    /// Toolbox is the installer; a source only ran at all because we BORROW a
+    /// version read for the preview channels. "Open Toolbox" is valid whether or
+    /// not that read came back, so a throw must not replace it with Retry.
+    @Test func aToolboxOwnedAppKeepsItsChannelWhenASourceThrows() async {
+        for channel in [ReleaseChannel.canary, .beta] {
+            let app = Self.androidStudioPreview(channel)
+            #expect(app.prefersVendorProbeOverToolbox, "\(channel.rawValue) must reach the loop")
+
+            let source = ScriptedSource(.throwing)
+            let result = await UpdateChecker(sources: [source]).check(app)
+
+            #expect(source.consulted, "\(channel.rawValue) never reached the source")
+            #expect(result.status == .toolboxManaged, "\(channel.rawValue) lost its Toolbox row")
+        }
+    }
+
+    /// A borrowed read that SUCCEEDS still wins — the guard above must not have
+    /// pinned these rows to `.toolboxManaged` unconditionally, which would throw
+    /// away the very version we borrowed the probe to get.
+    @Test func aToolboxOwnedAppStillTakesAVersionWhenTheBorrowedReadWorks() async {
+        let result = await UpdateChecker(sources: [ScriptedSource(.answering("2026.1"))])
+            .check(Self.androidStudioPreview(.canary))
+        #expect(result.status == .updateAvailable(latest: "2026.1"))
+    }
+
+    /// Every other Toolbox app returns before the loop, so no source can throw for
+    /// it in the first place. Pinned on "was it consulted", not on the status: if
+    /// that early branch is ever moved below the loop, this fails immediately
+    /// instead of waiting for a source that happens to throw.
+    @Test func anOrdinaryToolboxAppNeverReachesASourceAtAll() async {
+        let source = ScriptedSource(.throwing)
+        let result = await UpdateChecker(sources: [source])
+            .check(Self.app(bundleID: "com.jetbrains.intellij", isToolboxManaged: true))
+
+        #expect(!source.consulted, "a Toolbox-managed app must not be handed to a source")
+        #expect(result.status == .toolboxManaged)
+    }
+
+    // MARK: - .testFlightManaged — TestFlight owns the beta
+
+    /// Same shape, and unreachable for the same reason: `check` returns above the
+    /// loop. This is what KEEPS `.testFlightManaged` out of the `lastError` race,
+    /// so it is the guard worth pinning, not the status.
+    @Test func aTestFlightAppNeverReachesASourceAtAll() async {
+        let source = ScriptedSource(.throwing)
+        let result = await UpdateChecker(sources: [source])
+            .check(Self.app(isTestFlightApp: true))
+
+        #expect(!source.consulted, "a TestFlight app must not be handed to a source")
+        #expect(result.status == .testFlightManaged)
+    }
+
+    // MARK: - .appStoreManaged — the store owns it, and is the one that failed
+
+    /// **The deliberate asymmetry.** A store app looks like it deserves the same
+    /// treatment as a Toolbox one, and it does not.
+    ///
+    /// Every other source declines a MAS copy outright (`guard !app.isMASApp` in
+    /// the Homebrew, GitHub and vendor-probe sources), so the only thing that can
+    /// throw here is `MacAppStoreSource` — the lookup for the app the store DOES
+    /// own. That is a check that genuinely failed, and hiding it behind "Managed
+    /// by the App Store" would show the user the same row they get when the store
+    /// is quietly keeping the app current. Unlike Toolbox, nothing was borrowed:
+    /// the failed read IS this row's own update check.
+    ///
+    /// If a later change makes this `.appStoreManaged`, that is a decision to
+    /// argue for here, not a tidy-up of an inconsistency.
+    @Test func anAppStoreAppReportsAFailedStoreLookup() async {
+        let source = ScriptedSource(.throwing, name: "App Store")
+        let result = await UpdateChecker(sources: [source])
+            .check(Self.app(isMASApp: true))
+
+        #expect(source.consulted)
+        guard case .error = result.status else {
+            Issue.record("expected .error, got \(result.status)")
+            return
+        }
+    }
+
+    /// A store lookup that merely misses is a different thing from one that
+    /// failed, and keeps the managed label.
+    @Test func anAppStoreAppWithNoAnswerIsManaged() async {
+        let result = await UpdateChecker(sources: [ScriptedSource(.missing)])
+            .check(Self.app(isMASApp: true))
+        #expect(result.status == .appStoreManaged)
+    }
+
+    // MARK: - the gap this file is meant to close
+
+    /// The list above is only a guard while it is COMPLETE. `UpdateStatus` carries
+    /// two more cases (`upToDate`, `updateAvailable`), which `check` reaches from
+    /// a source that answered and never from the "no source answered" tail — so
+    /// the tail's four are all of them, and each has a row above.
+    ///
+    /// Written as an exhaustive `switch` on purpose: adding a case to
+    /// `UpdateStatus` stops compiling here, which is the only mechanism that makes
+    /// someone come back and decide what a thrown source does to it.
+    @Test func everyStatusIsAccountedFor() {
+        for status: UpdateStatus in [
+            .upToDate, .updateAvailable(latest: "1"), .unknown,
+            .appStoreManaged, .toolboxManaged, .testFlightManaged, .error("x"),
+        ] {
+            switch status {
+            case .upToDate, .updateAvailable:
+                break  // a source answered; the tail is never reached
+            case .unknown:
+                break  // anUnownedAppReportsAThrownFailure / …WithNoApplicableSource
+            case .toolboxManaged:
+                break  // aToolboxOwnedAppKeepsItsChannelWhenASourceThrows
+            case .testFlightManaged:
+                break  // aTestFlightAppNeverReachesASourceAtAll
+            case .appStoreManaged:
+                break  // anAppStoreAppReportsAFailedStoreLookup
+            case .error:
+                break  // the outcome under test throughout
+            }
+        }
+    }
+}


### PR DESCRIPTION
补 #131 review 暴露出来的覆盖空洞。纯测试,零生产代码改动。

## 空洞长什么样

`UpdateChecker.check(_:)` 尾部,`if let lastError` 在把「没有源作答」映射到 `.toolboxManaged` / `.testFlightManaged` / `.appStoreManaged` / `.unknown` 的那段**之上**。所以把一个源从「返回 nil」改成「抛错」,等于在这**四个出口前面一起插队**。

#131 讨论的是 `.unknown`,于是只有 `.unknown` 被验了。结果 `.toolboxManaged` 也是可达的 —— Android Studio Canary 那行丢了「打开 Toolbox」按钮,换成一个「重试一个版本号」的红徽标。**Review 抓到的,不是测试抓到的。**

## 三条擦肩而过的既有测试

| 测试 | 为什么看不见 |
|---|---|
| `ToolboxInventoryTests.toolboxManagedAppLabelledManaged` | 形状完全对(同 app、真 checker、断言就是 `== .toolboxManaged`),但 app 建在默认 `.stable` 上 → `prefersVendorProbeOverToolbox` 为假 → `check` 在**顶部分支就 return**,永远进不了 source 循环 |
| `VendorInstallTests.toolboxManagedCopiesResolveDetectionOnly` | **用了** canary/beta,但断言在 `VendorProbeSource` 本身,对「读失败时 checker 判成什么」只字未提 |
| `UnknownAppsTests` | 跑完整真实 stack + Toolbox,会把这行的消失**打印**出来 —— 但整个文件**零断言**,只有 `log()`,不可能失败 |

## 补的是什么

不是「给 vendor probe 多写几条测试」。是 **`check(_:)` 的每一个出口各占一行,写明一个抛错的源对它做了什么**。

驱动用一个受控的 `ScriptedSource`:按指令 answer / miss / throw,并记录**自己有没有被问过**。

| app 形态 | 源 | 期望 | 理由 |
|---|---|---|---|
| 无人托管 | throw | `.error` | 没有渠道可退,抛错就是全部所知 |
| 无人托管 | miss | `.unknown` | 横杠的含义:源的**缺席**,不是源的失败 |
| Toolbox + `prefersVendorProbeOverToolbox` | throw | `.toolboxManaged` | 只是**借**来读版本,安装本就走 Toolbox |
| 同上 | answer | `.updateAvailable` | 守卫不能反过来把这些行钉死成 managed,否则丢掉借来的版本 |
| 普通 Toolbox app | throw | 源**没被问过** | 早返回 |
| TestFlight | throw | 源**没被问过** | 早返回 |
| MAS | throw | `.error` | **刻意的不对称,见下** |
| MAS | miss | `.appStoreManaged` | miss ≠ fail |

**早返回那两行钉的是「有没有被问过」,不是最终状态。** 只断言状态的话,某天有人把守卫挪到循环下面,只要源恰好 miss 就照样绿 —— 这样写则守卫一动就立刻红,不用等一个碰巧抛错的源。

**关于 `.appStoreManaged` 为什么不给 Toolbox 那份优待** —— 这条注释写在测试旁边,免得下一个人当成不一致顺手「修平」:其余每个源都会直接谢绝 MAS 副本(Homebrew / GitHub / vendor probe 都有 `guard !app.isMASApp`),所以能抛的只剩 `MacAppStoreSource` 自己 —— 即「商店拥有的那个 app、查询它失败了」。这里**没有任何东西是借来的**,那次失败就是这行自己的更新检查。用「由 App Store 管理」盖住它,给用户看到的会和「商店正安静地保持它最新」一模一样。

收尾一条对 `UpdateStatus` 的**穷举 switch**:加了新 case 就编译不过,这是唯一能逼人回来补一行的机制。

## 验证

先确认它咬得动 —— 把 #131 的守卫还原,**只有** `aToolboxOwnedAppKeepsItsChannelWhenASourceThrows` 红(两个 channel 各一次),其余 8 条全绿:

```
✘ aToolboxOwnedAppKeepsItsChannelWhenASourceThrows  Expectation failed: result.status == .toolboxManaged
✘ ...failed after 0.005 seconds with 2 issues
✔ 其余 8 条
```

恢复后全量:

```
━ Test run with 1439 tests in 122 suites passed   (原 1430,+9)
✔ Test run with 161 tests in 22 suites passed
✓ localizable keys agree — 413 in the catalog, all reachable
✓ version comparisons discriminate — 181 files
```

新增 9 条全部合成、不打网络,5ms 跑完。

（`make test` 第一次跑挂在 `check_localizable_keys.py` 的 `database is locked` 上 —— 是 CLAUDE.md 记过的那个坑,另一个 worktree `musing-dirac-eb96d9` 在并发 `xcodebuild`。单独重跑两个脚本都是 ✓,如上。）


---

## Code review 查出的一条（已修，commit `38596f7`，仅注释）

**「MAS app 只有 `MacAppStoreSource` 会抛」是错的。** 这句话同时出现在本 PR 的测试注释和 #131 留在 `UpdateChecker.swift` 的注释里 —— 我是读了三个源就写下的,不是七个。

把七个源的入口守卫逐个量了一遍:

| 源 | 对 MAS app | 能抛吗 |
|---|---|---|
| `MacAppStoreSource` | 要求 MAS | ✅ |
| `XcodeReleasesSource` | **只**卡 bundle id,而 Xcode 上架 App Store | ✅ |
| `SparkleAppcastSource` | **只**卡 `sparkleFeedURL` | ✅ |
| `HomebrewCaskSource` | `guard !app.isMASApp` | — |
| `GitHubReleasesSource` | `guard !app.isMASApp` | — |
| `AlcoveUpdateSource` | bundle id + 全 `try?` | — |
| `VendorProbeSource` | `guard !app.isMASApp` | — |

Sparkle 那条不是假想:本机 22 个 MAS app 里,**Keka 就是一个带 `SUFeedURL = https://u.keka.io` 的商店副本**。

**结论没变,反而更硬**:这三个源没有一个是像 Toolbox 那样「借来的读」—— 每一个**就是**这行自己的更新检查,所以那里失败必须读作一次失败的检查。错的只是理由,而这种错会传播:下一个人读到「只有它会抛」会选择相信,而不是去 grep —— 这正是这句话当初被写出来的方式。

顺带核了一条、确认不是问题:商店查询抛错后 `XcodeReleasesSource` 接手一个商店副本**不会跨分发**,它是 detection-only(`downloadURL: nil`),稳定版的 `pageURL` 指向 App Store 页面。

所以本 PR 现在是 2 个 commit,第二个碰了一个生产文件但**只改注释,零行为变化**。全量重跑仍是 1439 + 161 全绿。
