### PR TITLE
fix(core): 三条改名的 GitHub 仓库钉回真名，并加一个能看见改名的守卫

### DIFF
--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -451,9 +451,8 @@ public enum Verify {
                 + "the redirect is not permanent (GitHub drops it if the old name "
                 + "is ever reused) and, until then, following it costs the request "
                 + "its Authorization header")
-        }
-        else if observations.contains(where: \.redirectedButUnnamed),
-                let requested = observations.first?.requestedSlug {
+        } else if observations.contains(where: \.redirectedButUnnamed),
+                  let requested = observations.first?.requestedSlug {
             // The redirect happened but nothing in the answer could name the
             // canonical repo — no release to read `html_url` from, which is every
             // non-2xx response and any empty release list. Say the weaker thing

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -378,16 +378,25 @@ public enum Verify {
             if index > 0 { try? await Task.sleep(for: options.perHostDelay) }
             // See the vendor sweep: counts requests, not probes.
             let tally = GatewayRetry.Tally()
+            // What the endpoint answered, as opposed to what we asked it. This is
+            // the only check here that can see an UPSTREAM rename: the redirect
+            // makes detection keep working, so every other signal stays green while
+            // the request quietly loses its token. See ``GitHubEndpointAudit``.
+            let audit = GitHubEndpointAudit.Ledger()
             var attempt = 0
-            var outcome = await GatewayRetry.$tally.withValue(tally) {
-                await source.resolveDiagnostic(rule)
+            var outcome = await GitHubEndpointAudit.$ledger.withValue(audit) {
+                await GatewayRetry.$tally.withValue(tally) {
+                    await source.resolveDiagnostic(rule)
+                }
             }
             while attempt < options.infraRetries,
                   outcome.failure?.classification == .infra {
                 attempt += 1
                 try? await Task.sleep(for: .seconds(attempt))
-                outcome = await GatewayRetry.$tally.withValue(tally) {
-                    await source.resolveDiagnostic(rule)
+                outcome = await GitHubEndpointAudit.$ledger.withValue(audit) {
+                    await GatewayRetry.$tally.withValue(tally) {
+                        await source.resolveDiagnostic(rule)
+                    }
                 }
             }
             var finding = classify(
@@ -415,9 +424,42 @@ public enum Verify {
                    publishedAt: outcome.remote?.publishedAt) {
                 finding = finding.adding(warning: complaint)
             }
+            for complaint in Self.endpointComplaints(audit.observations) {
+                finding = finding.adding(warning: complaint)
+            }
             out.append(finding)
         }
         return out
+    }
+
+    /// Turn what the endpoint answered into findings. Both of these are `.warn`
+    /// rather than `.broken` on purpose: the rule still returns the right version
+    /// today, so calling it broken would be wrong and would spend the streak
+    /// machinery on something that is not an outage.
+    ///
+    /// One rule can produce several observations (`/releases/latest` plus the list
+    /// fallback), so each complaint is emitted once however many requests it took.
+    static func endpointComplaints(
+        _ observations: [GitHubEndpointAudit.Observation]
+    ) -> [String] {
+        var complaints: [String] = []
+        if let stale = observations.compactMap(\.staleSlug).first,
+           let requested = observations.first?.requestedSlug {
+            complaints.append(
+                "staleSlug: the registry says \(requested), GitHub answers as "
+                + "\(stale) — the rule is riding a rename redirect. Repoint it: "
+                + "the redirect is not permanent (GitHub drops it if the old name "
+                + "is ever reused) and, until then, following it costs the request "
+                + "its Authorization header")
+        }
+        if observations.contains(where: \.authSilentlyDropped) {
+            complaints.append(
+                "anonymousDespiteToken: this request carried a token and came back "
+                + "x-ratelimit-limit: 60, the anonymous ceiling — the token is not "
+                + "reaching the endpoint that answered, so this rule is competing "
+                + "for the shared 60/hour per-IP budget")
+        }
+        return complaints
     }
 
     // MARK: - changelog recipes

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -452,6 +452,19 @@ public enum Verify {
                 + "is ever reused) and, until then, following it costs the request "
                 + "its Authorization header")
         }
+        else if observations.contains(where: \.redirectedButUnnamed),
+                let requested = observations.first?.requestedSlug {
+            // The redirect happened but nothing in the answer could name the
+            // canonical repo — no release to read `html_url` from, which is every
+            // non-2xx response and any empty release list. Say the weaker thing
+            // rather than nothing: this is the case with the least information and
+            // it must not also be the case with the least output.
+            complaints.append(
+                "staleSlugUnnamed: GitHub redirected this request away from "
+                + "\(requested), so the registry's slug is out of date, but the "
+                + "answer carried no release to name the repo it really is. "
+                + "Resolve it with `gh api repos/\(requested) -q .full_name`")
+        }
         if observations.contains(where: \.authSilentlyDropped) {
             complaints.append(
                 "anonymousDespiteToken: this request carried a token and came back "

--- a/CLI/Tests/DuoKitTests/GitHubEndpointAuditTests.swift
+++ b/CLI/Tests/DuoKitTests/GitHubEndpointAuditTests.swift
@@ -88,12 +88,37 @@ struct GitHubEndpointAuditTests {
             .contains { $0.hasPrefix("anonymousDespiteToken:") })
     }
 
-    /// A redirect we cannot name is still worth nothing to report *as a rename*:
-    /// without the canonical slug there is no actionable fix to state, and the
-    /// anonymous-ceiling complaint already covers the consequence.
-    @Test func aRedirectWithNoReleaseToNameItReportsNoRename() {
-        #expect(!Verify.endpointComplaints([Self.observation(canonical: nil)])
-            .contains { $0.hasPrefix("staleSlug:") })
+    // MARK: - a redirect nobody can name
+
+    /// A redirect we cannot name is not reported as a rename — there is no
+    /// canonical slug to put in the message — but it must not be reported as
+    /// *nothing* either. Every non-2xx answer arrives this way (no body, so no
+    /// `html_url`), and a 403 from an exhausted anonymous budget is the loudest
+    /// form of the problem this whole audit exists to explain.
+    @Test func aRedirectWithNoReleaseToNameItFallsBackToTheWeakerComplaint() {
+        let complaints = Verify.endpointComplaints([Self.observation(canonical: nil)])
+        #expect(!complaints.contains { $0.hasPrefix("staleSlug:") })
+        let unnamed = complaints.first { $0.hasPrefix("staleSlugUnnamed:") }
+        #expect(unnamed != nil, "a redirect with no name must still be reported")
+        #expect(unnamed?.contains("block/goose") == true, "it has to name what we asked for")
+    }
+
+    /// The 403 shape end to end: no token would have helped, because the token
+    /// never reached the endpoint that answered. Both halves have to speak.
+    @Test func anExhaustedBudgetBehindARenameReportsBothHalves() {
+        let complaints = Verify.endpointComplaints([Self.observation(
+            requested: "block/goose", canonical: nil, redirected: true,
+            ceiling: 60, sentToken: true)])
+        #expect(complaints.contains { $0.hasPrefix("staleSlugUnnamed:") })
+        #expect(complaints.contains { $0.hasPrefix("anonymousDespiteToken:") })
+    }
+
+    /// Named and unnamed are alternatives, never both — two lines describing one
+    /// redirect would read as two problems.
+    @Test func aNamedRenameSuppressesTheWeakerLine() {
+        let complaints = Verify.endpointComplaints([Self.observation()])
+        #expect(complaints.contains { $0.hasPrefix("staleSlug:") })
+        #expect(!complaints.contains { $0.hasPrefix("staleSlugUnnamed:") })
     }
 
     // MARK: - one rule, several requests

--- a/CLI/Tests/DuoKitTests/GitHubEndpointAuditTests.swift
+++ b/CLI/Tests/DuoKitTests/GitHubEndpointAuditTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import Foundation
+import DuoUpdaterCore
+@testable import DuoKit
+
+/// The one check that can see an UPSTREAM rename.
+///
+/// Everything else in the sweep goes green while a renamed slug rides GitHub's
+/// 301: detection returns the right version, the pattern fixtures pass, and
+/// `batchRuleSlugsArePinned` compares our slug to our own pinned copy of it, so
+/// it agrees with itself. Three rules drifted that way unnoticed. What the
+/// redirect actually costs is the request's `Authorization` header — measured
+/// 2026-08-29: the same URLSession answered `x-ratelimit-limit: 5000` on the
+/// canonical name and `60` (the anonymous ceiling) through the redirect. See #135.
+struct GitHubEndpointAuditTests {
+
+    private static func observation(
+        requested: String = "block/goose",
+        canonical: String? = "aaif-goose/goose",
+        redirected: Bool = true,
+        ceiling: Int? = 60,
+        sentToken: Bool = true
+    ) -> GitHubEndpointAudit.Observation {
+        GitHubEndpointAudit.Observation(
+            requestedSlug: requested, canonicalSlug: canonical,
+            redirected: redirected, rateLimitCeiling: ceiling, sentToken: sentToken)
+    }
+
+    // MARK: - the two conditions
+
+    @Test func aRenamedSlugIsNamedWithWhatItShouldBe() throws {
+        let complaints = Verify.endpointComplaints([Self.observation()])
+        let stale = try #require(complaints.first { $0.hasPrefix("staleSlug:") })
+        #expect(stale.contains("block/goose"))
+        #expect(stale.contains("aaif-goose/goose"))
+    }
+
+    /// The vacuity guard. Every other test here asserts that some shape produces
+    /// NO complaint, and all of those keep passing if `endpointComplaints` is
+    /// gutted to `return []`. This one pins the shape that actually happened —
+    /// redirected, token sent, answered on the anonymous ceiling — and fails if
+    /// the check ever stops firing.
+    @Test func theShapeThatActuallyHappenedProducesBothComplaints() {
+        let complaints = Verify.endpointComplaints([Self.observation()])
+        #expect(complaints.contains { $0.hasPrefix("staleSlug:") })
+        #expect(complaints.contains { $0.hasPrefix("anonymousDespiteToken:") })
+    }
+
+    @Test func aHealthyRuleSaysNothing() {
+        #expect(Verify.endpointComplaints([Self.observation(
+            requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
+            redirected: false, ceiling: 5000)]).isEmpty)
+    }
+
+    @Test func slugComparisonIgnoresCase() {
+        // GitHub is case-insensitive about owner/repo and will happily answer
+        // `AAIF-Goose/goose`; that is not a rename and must not be reported as one.
+        #expect(Verify.endpointComplaints([Self.observation(
+            requested: "AAIF-Goose/Goose", canonical: "aaif-goose/goose",
+            redirected: false, ceiling: 5000)]).isEmpty)
+    }
+
+    // MARK: - what must NOT be reported
+
+    /// The whole point of gating on `sentToken`. A user with no token is answered
+    /// `60` on every one of the 69 rules; complaining there would bury the signal
+    /// under 69 copies of "you have no token", which is not what this check is for.
+    @Test func noTokenMeansSixtyIsSimplyTheTruth() {
+        let complaints = Verify.endpointComplaints([Self.observation(
+            requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
+            redirected: false, ceiling: 60, sentToken: false)])
+        #expect(!complaints.contains { $0.hasPrefix("anonymousDespiteToken:") })
+    }
+
+    @Test func anAuthenticatedCeilingIsNotAComplaint() {
+        #expect(!Verify.endpointComplaints([Self.observation(
+            requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
+            redirected: false, ceiling: 5000)])
+            .contains { $0.hasPrefix("anonymousDespiteToken:") })
+    }
+
+    @Test func aMissingCeilingHeaderIsNotReadAsAnonymous() {
+        // A response with no `x-ratelimit-limit` says nothing either way, and
+        // guessing would turn every proxy that strips headers into a false alarm.
+        #expect(!Verify.endpointComplaints([Self.observation(
+            requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
+            redirected: false, ceiling: nil)])
+            .contains { $0.hasPrefix("anonymousDespiteToken:") })
+    }
+
+    /// A redirect we cannot name is still worth nothing to report *as a rename*:
+    /// without the canonical slug there is no actionable fix to state, and the
+    /// anonymous-ceiling complaint already covers the consequence.
+    @Test func aRedirectWithNoReleaseToNameItReportsNoRename() {
+        #expect(!Verify.endpointComplaints([Self.observation(canonical: nil)])
+            .contains { $0.hasPrefix("staleSlug:") })
+    }
+
+    // MARK: - one rule, several requests
+
+    /// `/releases/latest` then the list fallback is two observations of one rule.
+    /// The reader gets one line per problem, not one per HTTP request.
+    @Test func twoRequestsForOneRuleStillComplainOnce() {
+        let complaints = Verify.endpointComplaints([Self.observation(), Self.observation()])
+        #expect(complaints.filter { $0.hasPrefix("staleSlug:") }.count == 1)
+        #expect(complaints.filter { $0.hasPrefix("anonymousDespiteToken:") }.count == 1)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubEndpointAudit.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubEndpointAudit.swift
@@ -34,8 +34,9 @@ public enum GitHubEndpointAudit {
         public let requestedSlug: String
         /// The repo's real `owner/repo`, when the answer let us name it — read
         /// out of the release's own `html_url`, which GitHub writes with the
-        /// canonical name. Nil when a redirect happened but no release came back
-        /// to name it, in which case `redirected` still says it happened.
+        /// canonical name. Nil whenever no release came back to name it, which
+        /// includes every non-2xx response; `redirected` and
+        /// ``redirectedButUnnamed`` are what still speak in that case.
         public let canonicalSlug: String?
         /// True when the response's final URL is not the one we requested.
         public let redirected: Bool
@@ -64,6 +65,16 @@ public enum GitHubEndpointAudit {
             guard let canonicalSlug, canonicalSlug.lowercased() != requestedSlug.lowercased()
             else { return nil }
             return canonicalSlug
+        }
+
+        /// GitHub sent us somewhere else and we could not name where. Worth
+        /// reporting on its own: with no release in the answer there is nothing
+        /// to read `html_url` from, and on a 403 there is no body at all — but
+        /// the redirect still happened and still cost the request its token.
+        /// Without this, the case with the least information available would be
+        /// the case the sweep says nothing about.
+        public var redirectedButUnnamed: Bool {
+            redirected && staleSlug == nil
         }
 
         /// We authenticated and were answered on the anonymous budget anyway.
@@ -101,8 +112,15 @@ public enum GitHubEndpointAudit {
     /// `https://github.com/aaif-goose/goose/releases/tag/v1.48.0` -> `aaif-goose/goose`.
     /// Nil for anything that isn't a github.com URL with at least two path
     /// components, so a vendor-hosted `html_url` can never be mistaken for a slug.
+    ///
+    /// The host test is an exact match or a real subdomain, deliberately NOT
+    /// `hasSuffix("github.com")`: that also accepts `mygithub.com` and
+    /// `evil-github.com`, and GitHub Enterprise instances on custom domains are
+    /// routinely named that way. A false slug here is worse than none — it makes
+    /// the sweep tell a maintainer to repoint a rule at a repo that does not exist.
     static func slug(fromHTMLURL url: URL?) -> String? {
-        guard let url, url.host?.hasSuffix("github.com") == true else { return nil }
+        guard let url, let host = url.host,
+              host == "github.com" || host.hasSuffix(".github.com") else { return nil }
         let parts = url.pathComponents.filter { $0 != "/" }
         guard parts.count >= 2 else { return nil }
         return "\(parts[0])/\(parts[1])"

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubEndpointAudit.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubEndpointAudit.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// What the GitHub endpoint actually answered, as opposed to what we asked it.
+///
+/// Exists because of a failure that every other check in this codebase is blind
+/// to. When a repo is renamed, `api.github.com/repos/<old>/…` answers 301 to
+/// `/repositories/<id>/…`, URLSession follows it, and the release data comes back
+/// correct — so detection works, `duo verify` reports ✓, and
+/// `GitHubReleaseRuleTests.batchRuleSlugsArePinned` stays green because it
+/// compares our slug against our own pinned copy of it. Three rules
+/// (`block/goose`, `containers/podman-desktop`, `headlamp-k8s/headlamp`) drifted
+/// that way with nothing noticing.
+///
+/// The cost is not cosmetic: **URLSession drops `Authorization` while following
+/// that redirect.** Measured 2026-08-29 on the same session, same request, the
+/// only difference being whether a redirect was involved:
+///
+///     …/repos/aaif-goose/goose/releases/latest   → x-ratelimit-limit: 5000
+///     …/repos/block/goose/releases/latest        → x-ratelimit-limit: 60
+///
+/// 60 is the anonymous ceiling. Those rules were checking on the shared
+/// per-IP budget no matter what token the user had configured, and nothing said
+/// so. See issue #135.
+///
+/// Nothing in the app sets this — the task-local is nil there, so the shipping
+/// check path pays one optional read per request and records nothing. It is the
+/// verification sweep that opts in.
+public enum GitHubEndpointAudit {
+
+    /// One request's worth of "what came back", recorded where the
+    /// `HTTPURLResponse` is still in hand.
+    public struct Observation: Sendable, Equatable {
+        /// The `owner/repo` the rule asked for.
+        public let requestedSlug: String
+        /// The repo's real `owner/repo`, when the answer let us name it — read
+        /// out of the release's own `html_url`, which GitHub writes with the
+        /// canonical name. Nil when a redirect happened but no release came back
+        /// to name it, in which case `redirected` still says it happened.
+        public let canonicalSlug: String?
+        /// True when the response's final URL is not the one we requested.
+        public let redirected: Bool
+        /// `x-ratelimit-limit` off the response that actually carried the data.
+        /// 60 is GitHub's anonymous ceiling, 5000 the authenticated one.
+        public let rateLimitCeiling: Int?
+        /// Whether this request went out carrying an `Authorization` header.
+        /// Without it, a ceiling of 60 is simply the truth rather than a fault.
+        public let sentToken: Bool
+
+        /// Public so the sweep's own tests can state a shape without going
+        /// through a live response; nothing in production builds one by hand.
+        public init(
+            requestedSlug: String, canonicalSlug: String?, redirected: Bool,
+            rateLimitCeiling: Int?, sentToken: Bool
+        ) {
+            self.requestedSlug = requestedSlug
+            self.canonicalSlug = canonicalSlug
+            self.redirected = redirected
+            self.rateLimitCeiling = rateLimitCeiling
+            self.sentToken = sentToken
+        }
+
+        /// The slug drifted and we can name what it should be.
+        public var staleSlug: String? {
+            guard let canonicalSlug, canonicalSlug.lowercased() != requestedSlug.lowercased()
+            else { return nil }
+            return canonicalSlug
+        }
+
+        /// We authenticated and were answered on the anonymous budget anyway.
+        /// Deliberately requires `sentToken`: for a user with no token every
+        /// response says 60, and warning about that would be noise on all 69
+        /// rules rather than a signal on the broken ones.
+        public var authSilentlyDropped: Bool {
+            sentToken && rateLimitCeiling == 60
+        }
+    }
+
+    /// A sweep unit's observations. A class so they survive the `withValue`
+    /// scope; locked because one rule can issue two requests (`/releases/latest`
+    /// then the list fallback).
+    public final class Ledger: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [Observation] = []
+
+        public init() {}
+
+        public var observations: [Observation] {
+            lock.lock(); defer { lock.unlock() }
+            return storage
+        }
+
+        func record(_ observation: Observation) {
+            lock.lock(); storage.append(observation); lock.unlock()
+        }
+    }
+
+    /// Set by a caller that wants the observations; nil everywhere else, which is
+    /// why the app pays nothing for this.
+    @TaskLocal public static var ledger: Ledger?
+
+    /// `https://github.com/aaif-goose/goose/releases/tag/v1.48.0` -> `aaif-goose/goose`.
+    /// Nil for anything that isn't a github.com URL with at least two path
+    /// components, so a vendor-hosted `html_url` can never be mistaken for a slug.
+    static func slug(fromHTMLURL url: URL?) -> String? {
+        guard let url, url.host?.hasSuffix("github.com") == true else { return nil }
+        let parts = url.pathComponents.filter { $0 != "/" }
+        guard parts.count >= 2 else { return nil }
+        return "\(parts[0])/\(parts[1])"
+    }
+
+    /// Record one response. No-op when no ledger is installed.
+    static func record(
+        requestedSlug: String, requestedURL: URL, response: HTTPURLResponse,
+        firstReleaseHTMLURL: URL?, sentToken: Bool
+    ) {
+        guard let ledger else { return }
+        let ceiling = (response.value(forHTTPHeaderField: "x-ratelimit-limit"))
+            .flatMap(Int.init)
+        ledger.record(Observation(
+            requestedSlug: requestedSlug,
+            canonicalSlug: slug(fromHTMLURL: firstReleaseHTMLURL),
+            // Compare the final URL to the one we asked for. A rename lands on
+            // `/repositories/<id>/…`, which never equals the `/repos/<slug>/…` we
+            // built, so this is true exactly when GitHub redirected us.
+            redirected: response.url.map { $0 != requestedURL } ?? false,
+            rateLimitCeiling: ceiling,
+            sentToken: sentToken))
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -457,7 +457,16 @@ public struct GitHubReleasesSource: UpdateSource {
         // Walk releases in document order (GitHub returns newest first) and take
         // the first whose tag the pattern matches — for prerelease channels this
         // skips interleaved stable releases.
-        return Self.releases(from: data, list: list)
+        let decoded = Self.releases(from: data, list: list)
+        // Verification-only bookkeeping: notice a slug that GitHub had to redirect,
+        // and an authenticated request that came back on the anonymous budget
+        // anyway. Recorded here because this is the last place the response and the
+        // decoded body are both in hand. No-op when no ledger is installed, which
+        // is every path except `duo verify`. See ``GitHubEndpointAudit``.
+        GitHubEndpointAudit.record(
+            requestedSlug: rule.slug, requestedURL: url, response: http,
+            firstReleaseHTMLURL: decoded.first?.htmlURL, sentToken: token != nil)
+        return decoded
     }
 
     private struct Resolution {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1170,9 +1170,18 @@ public enum GitHubReleaseRegistry {
         // anchor keeps the airgap variant out; without it a substring match would
         // hand the user a gigabyte download for the same app.
         // One-click: io.podmandesktop.PodmanDesktop, Team HYSCB8KRL2, notarized.
+        //
+        // ⚠️ Renamed containers/podman-desktop
+        // -> podman-desktop/podman-desktop (measured 2026-08-29). The canonical
+        // name is pinned here on purpose, and it is not cosmetic: GitHub answers the
+        // old slug with a 301 to `/repositories/<id>/…`, and URLSession drops
+        // `Authorization` while following it — the fetch that actually returns
+        // the releases came back `x-ratelimit-limit: 60`, i.e. ANONYMOUS,
+        // whatever token the user configured. Three rules were quietly doing
+        // that. See #135.
         GitHubReleaseRule(
             bundleID: "io.podmandesktop.PodmanDesktop",
-            owner: "containers", repo: "podman-desktop",
+            owner: "podman-desktop", repo: "podman-desktop",
             installAssetPattern: #"^podman-desktop-[0-9.]+-arm64\.dmg$"#,
             installerKind: .dmg),
 
@@ -1386,9 +1395,18 @@ public enum GitHubReleaseRegistry {
         // APP tag instead. (No prereleases in this repo, so the list can't hand back
         // a preview build.) One-click: com.microsoft.Headlamp, Team 5N2JF58U87,
         // notarized.
+        //
+        // ⚠️ Renamed headlamp-k8s/headlamp
+        // -> kubernetes-sigs/headlamp (measured 2026-08-29). The canonical name
+        // is pinned here on purpose, and it is not cosmetic: GitHub answers the
+        // old slug with a 301 to `/repositories/<id>/…`, and URLSession drops
+        // `Authorization` while following it — the fetch that actually returns
+        // the releases came back `x-ratelimit-limit: 60`, i.e. ANONYMOUS,
+        // whatever token the user configured. Three rules were quietly doing
+        // that. See #135.
         GitHubReleaseRule(
             bundleID: "com.microsoft.Headlamp",
-            owner: "headlamp-k8s", repo: "headlamp",
+            owner: "kubernetes-sigs", repo: "headlamp",
             usePrereleases: true,
             versionPattern: #"^v([0-9]+(?:\.[0-9]+)+)$"#,
             installAssetPattern: #"^Headlamp-[0-9.]+-mac-arm64\.dmg$"#,
@@ -1518,8 +1536,8 @@ public enum GitHubReleaseRegistry {
             installAssetPattern: #"^Another-Redis-Desktop-Manager-mac-[0-9.]+-arm64\.dmg$"#,
             installerKind: .dmg),
 
-        // Goose (block/goose) — the `goose-*-apple-darwin.tar.gz` assets beside the
-        // app are the CLI and `goose-source-*.zip` is a source drop, so the app is
+        // Goose (aaif-goose/goose) — the `goose-*-apple-darwin.tar.gz` assets beside
+        // the app are the CLI and `goose-source-*.zip` is a source drop, so the app is
         // anchored by literal name. BOTH macOS builds are matched: `Goose.zip` is
         // arm64-ONLY (checked with `file`: a single arm64 slice, not a universal
         // binary) and `Goose_intel_mac.zip` is the Intel build. Matching only
@@ -1532,9 +1550,18 @@ public enum GitHubReleaseRegistry {
         // token-free `Goose.zip`.
         // One-click: com.electron.goose, Team 5N2JF58U87, notarized — verified on
         // BOTH assets.
+        //
+        // ⚠️ Renamed block/goose
+        // -> aaif-goose/goose (measured 2026-08-29). The canonical name
+        // is pinned here on purpose, and it is not cosmetic: GitHub answers the
+        // old slug with a 301 to `/repositories/<id>/…`, and URLSession drops
+        // `Authorization` while following it — the fetch that actually returns
+        // the releases came back `x-ratelimit-limit: 60`, i.e. ANONYMOUS,
+        // whatever token the user configured. Three rules were quietly doing
+        // that. See #135.
         GitHubReleaseRule(
             bundleID: "com.electron.goose",
-            owner: "block", repo: "goose",
+            owner: "aaif-goose", repo: "goose",
             installAssetPattern: #"^Goose(_intel_mac)?\.zip$"#,
             installerKind: .zip),
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -452,6 +452,16 @@ public struct GitHubReleasesSource: UpdateSource {
         guard (200..<300).contains(http.statusCode) else {
             let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"
             Log.source.error("GitHub \(rule.slug, privacy: .public): HTTP \(http.statusCode, privacy: .public) (ratelimit-remaining=\(remaining, privacy: .public))")
+            // Record the failure too, and record it BEFORE throwing. A 403 is the
+            // loudest form of the very problem this audit exists to explain — the
+            // anonymous budget running out under a rule that lost its token to a
+            // rename redirect — so skipping the bad-status path would leave the
+            // sweep silent exactly when it matters most. There is no body to name
+            // the canonical repo from, but the final URL and the rate-limit ceiling
+            // are both on this response.
+            GitHubEndpointAudit.record(
+                requestedSlug: rule.slug, requestedURL: url, response: http,
+                firstReleaseHTMLURL: nil, sentToken: token != nil)
             throw GitHubError.badStatus(http.statusCode)
         }
         // Walk releases in document order (GitHub returns newest first) and take

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubEndpointAuditTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubEndpointAuditTests.swift
@@ -27,6 +27,25 @@ struct GitHubEndpointAuditTests {
             URL(string: "https://example.com/aaif-goose/goose")) == nil)
     }
 
+    /// The host test is an exact match or a real subdomain. `hasSuffix` is the
+    /// obvious way to write it and it is wrong: these three all end in
+    /// "github.com" without being it, and GitHub Enterprise instances on custom
+    /// domains are named exactly like this. A false slug is worse than no slug —
+    /// it makes the sweep tell someone to repoint a rule at a repo that does not
+    /// exist, which kills detection for that app outright.
+    @Test func aHostThatMerelyEndsInGitHubDotComIsNotGitHub() {
+        for host in ["mygithub.com", "evil-github.com", "notgithub.com"] {
+            #expect(GitHubEndpointAudit.slug(fromHTMLURL:
+                URL(string: "https://\(host)/aaif-goose/goose")) == nil,
+                "\(host) must not be read as github.com")
+        }
+    }
+
+    @Test func arealGitHubSubdomainIsStillGitHub() {
+        #expect(GitHubEndpointAudit.slug(fromHTMLURL:
+            URL(string: "https://api.github.com/aaif-goose/goose")) == "aaif-goose/goose")
+    }
+
     @Test func aURLTooShortToCarryASlugYieldsNothing() {
         #expect(GitHubEndpointAudit.slug(fromHTMLURL:
             URL(string: "https://github.com/aaif-goose")) == nil)
@@ -86,6 +105,67 @@ struct GitHubEndpointAuditTests {
         #expect(!Self.observation(
             requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
             ceiling: nil, sentToken: true).authSilentlyDropped)
+    }
+
+    // MARK: - a redirect nobody can name
+
+    /// Every non-2xx answer lands here: no body, so no `html_url`, so no
+    /// canonical name — but the redirect still happened and still cost the
+    /// request its token. Without `redirectedButUnnamed` the case carrying the
+    /// least information would also be the case the sweep says nothing about.
+    @Test func aRedirectWithNothingToNameItStillSpeaks() {
+        let observed = GitHubEndpointAudit.Observation(
+            requestedSlug: "block/goose", canonicalSlug: nil, redirected: true,
+            rateLimitCeiling: 60, sentToken: false)
+        #expect(observed.staleSlug == nil, "there is no name to give")
+        #expect(observed.redirectedButUnnamed)
+    }
+
+    @Test func aNamedRedirectIsNotAlsoReportedAsUnnamed() {
+        let observed = GitHubEndpointAudit.Observation(
+            requestedSlug: "block/goose", canonicalSlug: "aaif-goose/goose",
+            redirected: true, rateLimitCeiling: 60, sentToken: true)
+        #expect(!observed.redirectedButUnnamed, "the named complaint covers it")
+    }
+
+    @Test func noRedirectIsNeverUnnamed() {
+        let url = "https://github.com/aaif-goose/goose/releases/tag/v1"
+        let observed = GitHubEndpointAudit.Observation(
+            requestedSlug: "aaif-goose/goose",
+            canonicalSlug: GitHubEndpointAudit.slug(fromHTMLURL: URL(string: url)),
+            redirected: false, rateLimitCeiling: 5000, sentToken: true)
+        #expect(!observed.redirectedButUnnamed)
+    }
+
+    // MARK: - the failure path really does record (network)
+
+    /// The finding this test exists for: `record` used to sit *after* the
+    /// `guard (200..<300)` in `fetchReleases`, so a non-2xx threw before anything
+    /// was written and the ledger came back empty. That is the 403 case — an
+    /// exhausted anonymous budget under a rule that lost its token to a rename
+    /// redirect — i.e. the audit was blind in precisely the situation it was
+    /// built to explain.
+    ///
+    /// Asserting on `endpointComplaints` cannot catch that: it takes observations
+    /// as input, so it passes whether or not any were ever recorded. The only
+    /// thing that pins it is driving a real non-2xx through the real source and
+    /// looking at the ledger. Hits the network; 404 is stable and costs one
+    /// request.
+    @Test func aNonSuccessResponseIsStillRecorded() async throws {
+        let source = GitHubReleasesSource(token: GitHubToken.resolve())
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.nonexistent",
+            owner: "jizhi0v0", repo: "duo-updater-no-such-repo-135")
+        let ledger = GitHubEndpointAudit.Ledger()
+        let outcome = await GitHubEndpointAudit.$ledger.withValue(ledger) {
+            await source.resolveDiagnostic(rule)
+        }
+        #expect(outcome.failure?.kind == "httpStatus404", "expected the 404 path")
+        let observed = try #require(
+            ledger.observations.first,
+            "a non-2xx must still be recorded — this is the whole finding")
+        #expect(observed.requestedSlug == "jizhi0v0/duo-updater-no-such-repo-135")
+        #expect(observed.canonicalSlug == nil, "no body, so nothing to name it with")
     }
 
     // MARK: - the app pays nothing

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubEndpointAuditTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubEndpointAuditTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The Core half of the rename guard: reading a repo's real name out of the
+/// answer, and deciding what counts as a fault.
+///
+/// The complaint text and the once-per-rule reduction live in `DuoKit`
+/// (`GitHubEndpointAuditTests` there). Split because `slug(fromHTMLURL:)` is an
+/// implementation detail of this module and testing it from the CLI would mean
+/// making it public for no other reason. See #135.
+struct GitHubEndpointAuditTests {
+
+    // MARK: - reading the canonical name out of html_url
+
+    @Test func aReleaseURLNamesTheRepoItReallyCameFrom() {
+        #expect(GitHubEndpointAudit.slug(fromHTMLURL:
+            URL(string: "https://github.com/aaif-goose/goose/releases/tag/v1.48.0"))
+            == "aaif-goose/goose")
+    }
+
+    @Test func aNonGitHubHostIsNeverReadAsASlug() {
+        // `html_url` is GitHub's own field today, but two path components on some
+        // other host must never be mistaken for owner/repo and reported as a
+        // rename — that would name a "canonical slug" that does not exist.
+        #expect(GitHubEndpointAudit.slug(fromHTMLURL:
+            URL(string: "https://example.com/aaif-goose/goose")) == nil)
+    }
+
+    @Test func aURLTooShortToCarryASlugYieldsNothing() {
+        #expect(GitHubEndpointAudit.slug(fromHTMLURL:
+            URL(string: "https://github.com/aaif-goose")) == nil)
+        #expect(GitHubEndpointAudit.slug(fromHTMLURL: nil) == nil)
+    }
+
+    // MARK: - what the observation itself concludes
+
+    private static func observation(
+        requested: String, canonical: String?, ceiling: Int?, sentToken: Bool
+    ) -> GitHubEndpointAudit.Observation {
+        GitHubEndpointAudit.Observation(
+            requestedSlug: requested, canonicalSlug: canonical,
+            redirected: canonical.map { $0 != requested } ?? false,
+            rateLimitCeiling: ceiling, sentToken: sentToken)
+    }
+
+    @Test func aDifferentCanonicalNameIsAStaleSlug() {
+        #expect(Self.observation(
+            requested: "block/goose", canonical: "aaif-goose/goose",
+            ceiling: 60, sentToken: true).staleSlug == "aaif-goose/goose")
+    }
+
+    @Test func theSameNameInDifferentCaseIsNotARename() {
+        // GitHub answers `AAIF-Goose/Goose` as happily as the lowercase form.
+        #expect(Self.observation(
+            requested: "AAIF-Goose/Goose", canonical: "aaif-goose/goose",
+            ceiling: 5000, sentToken: true).staleSlug == nil)
+    }
+
+    /// The measured shape from #135: we sent a token and were answered on the
+    /// anonymous ceiling, because URLSession dropped `Authorization` following
+    /// GitHub's rename redirect. This is the assertion that fails if the check
+    /// ever stops noticing.
+    @Test func aTokenAnsweredOnTheAnonymousCeilingIsAFault() {
+        #expect(Self.observation(
+            requested: "block/goose", canonical: "aaif-goose/goose",
+            ceiling: 60, sentToken: true).authSilentlyDropped)
+    }
+
+    @Test func sixtyWithoutATokenIsSimplyTheTruth() {
+        // A user with no token is answered 60 on all 69 rules. Reporting that
+        // would bury the real signal under 69 copies of "you have no token".
+        #expect(!Self.observation(
+            requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
+            ceiling: 60, sentToken: false).authSilentlyDropped)
+    }
+
+    @Test func anAuthenticatedCeilingIsNotAFault() {
+        #expect(!Self.observation(
+            requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
+            ceiling: 5000, sentToken: true).authSilentlyDropped)
+    }
+
+    @Test func aMissingCeilingHeaderIsNotReadAsAnonymous() {
+        // Guessing would turn any proxy that strips the header into a false alarm.
+        #expect(!Self.observation(
+            requested: "aaif-goose/goose", canonical: "aaif-goose/goose",
+            ceiling: nil, sentToken: true).authSilentlyDropped)
+    }
+
+    // MARK: - the app pays nothing
+
+    /// `record` is a no-op with no ledger installed — that is what keeps this
+    /// verification-only machinery out of the shipping check path.
+    @Test func withNoLedgerInstalledNothingIsRecorded() {
+        #expect(GitHubEndpointAudit.ledger == nil)
+        GitHubEndpointAudit.record(
+            requestedSlug: "block/goose",
+            requestedURL: URL(string: "https://api.github.com/repos/block/goose/releases/latest")!,
+            response: HTTPURLResponse(
+                url: URL(string: "https://api.github.com/repositories/846698999/releases/latest")!,
+                statusCode: 200, httpVersion: nil,
+                headerFields: ["x-ratelimit-limit": "60"])!,
+            firstReleaseHTMLURL: URL(string: "https://github.com/aaif-goose/goose/releases/tag/v1"),
+            sentToken: true)
+        // Nothing to assert beyond "this did not trap"; the ledger it would have
+        // written to does not exist.
+        #expect(GitHubEndpointAudit.ledger == nil)
+    }
+
+    @Test func aLedgerRecordsWhatTheResponseSaid() throws {
+        let ledger = GitHubEndpointAudit.Ledger()
+        GitHubEndpointAudit.$ledger.withValue(ledger) {
+            GitHubEndpointAudit.record(
+                requestedSlug: "block/goose",
+                requestedURL: URL(string: "https://api.github.com/repos/block/goose/releases/latest")!,
+                response: HTTPURLResponse(
+                    url: URL(string: "https://api.github.com/repositories/846698999/releases/latest")!,
+                    statusCode: 200, httpVersion: nil,
+                    headerFields: ["x-ratelimit-limit": "60"])!,
+                firstReleaseHTMLURL: URL(string: "https://github.com/aaif-goose/goose/releases/tag/v1.48.0"),
+                sentToken: true)
+        }
+        let observed = try #require(ledger.observations.first)
+        #expect(observed.redirected, "the final URL differs from the one we asked for")
+        #expect(observed.staleSlug == "aaif-goose/goose")
+        #expect(observed.authSilentlyDropped)
+    }
+
+    @Test func aResponseThatDidNotRedirectSaysSo() throws {
+        let url = URL(string: "https://api.github.com/repos/aaif-goose/goose/releases/latest")!
+        let ledger = GitHubEndpointAudit.Ledger()
+        GitHubEndpointAudit.$ledger.withValue(ledger) {
+            GitHubEndpointAudit.record(
+                requestedSlug: "aaif-goose/goose", requestedURL: url,
+                response: HTTPURLResponse(
+                    url: url, statusCode: 200, httpVersion: nil,
+                    headerFields: ["x-ratelimit-limit": "5000"])!,
+                firstReleaseHTMLURL: URL(string: "https://github.com/aaif-goose/goose/releases/tag/v1.48.0"),
+                sentToken: true)
+        }
+        let observed = try #require(ledger.observations.first)
+        #expect(!observed.redirected)
+        #expect(observed.staleSlug == nil)
+        #expect(!observed.authSilentlyDropped)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubEndpointAuditTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubEndpointAuditTests.swift
@@ -41,7 +41,7 @@ struct GitHubEndpointAuditTests {
         }
     }
 
-    @Test func arealGitHubSubdomainIsStillGitHub() {
+    @Test func aRealGitHubSubdomainIsStillGitHub() {
         #expect(GitHubEndpointAudit.slug(fromHTMLURL:
             URL(string: "https://api.github.com/aaif-goose/goose")) == "aaif-goose/goose")
     }
@@ -160,7 +160,12 @@ struct GitHubEndpointAuditTests {
         let outcome = await GitHubEndpointAudit.$ledger.withValue(ledger) {
             await source.resolveDiagnostic(rule)
         }
-        #expect(outcome.failure?.kind == "httpStatus404", "expected the 404 path")
+        // Any non-2xx exercises the path; deliberately NOT pinned to 404. On a
+        // machine whose anonymous GitHub budget is spent this comes back 403
+        // instead, and a test that insisted on 404 would fail for a reason that
+        // has nothing to do with what it is checking.
+        let kind = try #require(outcome.failure?.kind)
+        #expect(kind.hasPrefix("httpStatus"), "expected a status failure, got \(kind)")
         let observed = try #require(
             ledger.observations.first,
             "a non-2xx must still be recorded — this is the whole finding")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -596,9 +596,19 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
     #expect(picked("net.ankiweb.anki", anki, .x86_64) == "anki-26.08.1-mac-intel.dmg")
 }
 
-/// The repo slug is the one part of a rule no other test touches: a typo or an
-/// upstream rename leaves every pattern fixture green while detection is dead in
-/// production. Pinned against the slugs verified live on 2026-08-16.
+/// The repo slug is the one part of a rule no other test touches: a typo leaves
+/// every pattern fixture green while detection is dead in production. Pinned
+/// against the slugs verified live on 2026-08-16, re-pinned 2026-08-29.
+///
+/// ⚠️ **This does NOT catch an upstream rename, and the comment used to claim it
+/// did.** It compares our string to our own pinned copy, so a repo renamed on
+/// GitHub's side leaves both sides equal and this test green — which is exactly
+/// what happened: `block/goose`, `containers/podman-desktop` and
+/// `headlamp-k8s/headlamp` were all renamed with nothing here noticing, and each
+/// one silently dropped to the anonymous rate-limit budget because URLSession
+/// drops `Authorization` while following GitHub's 301. What this test does catch
+/// is *us* changing a slug without meaning to. Catching the other direction
+/// needs a live comparison against the repo's `full_name`; see #135.
 @Test func batchRuleSlugsArePinned() {
     let expected: [String: String] = [
         "com.ccswitch.desktop": "farion1231/cc-switch",
@@ -608,7 +618,8 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
         "net.kovidgoyal.kitty": "kovidgoyal/kitty",
         "net.sourceforge.sqlitebrowser": "sqlitebrowser/sqlitebrowser",
         "com.jgraph.drawio.desktop": "jgraph/drawio-desktop",
-        "io.podmandesktop.PodmanDesktop": "containers/podman-desktop",
+        // Renamed upstream; re-pinned 2026-08-29 (was containers/podman-desktop). #135
+        "io.podmandesktop.PodmanDesktop": "podman-desktop/podman-desktop",
         "com.bitwarden.desktop": "bitwarden/clients",
         "com.vscodium": "VSCodium/vscodium",
         "com.vscodium.VSCodiumInsiders": "VSCodium/vscodium-insiders",
@@ -619,7 +630,8 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
         "com.sequel-ace.sequel-ace": "Sequel-Ace/Sequel-Ace",
         "com.ameba.SwiftBar": "swiftbar/SwiftBar",
         "io.ganeshrvel.openmtp": "ganeshrvel/openmtp",
-        "com.microsoft.Headlamp": "headlamp-k8s/headlamp",
+        // Renamed upstream; re-pinned 2026-08-29 (was headlamp-k8s/headlamp). #135
+        "com.microsoft.Headlamp": "kubernetes-sigs/headlamp",
         "com.objective-see.lulu.app": "objective-see/LuLu",
         "digital.twisted.noTunes": "tombonez/noTunes",
         "app.cyan.markedit": "MarkEdit-app/MarkEdit",
@@ -632,7 +644,8 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
         "com.pais.handy": "cjpais/Handy",
         "co.palokaj.battery": "actuallymentor/battery",
         "me.qii404.another-redis-desktop-manager": "qishibo/AnotherRedisDesktopManager",
-        "com.electron.goose": "block/goose",
+        // Renamed upstream; re-pinned 2026-08-29 (was block/goose). #135
+        "com.electron.goose": "aaif-goose/goose",
         "com.puremac.app": "momenbasel/PureMac",
         "art.ginzburg.MiddleClick": "artginzburg/MiddleClick",
         "com.theron.UnnaturalScrollWheels": "ther0n/UnnaturalScrollWheels",

--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -4,7 +4,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -12,7 +12,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.18.25",
       "sweepsSinceComment" : 0
     },
@@ -20,7 +20,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -28,7 +28,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -36,7 +36,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.69",
       "sweepsSinceComment" : 0
     },
@@ -53,7 +53,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.40609.0",
       "sweepsSinceComment" : 0
     },
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -69,7 +69,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -77,7 +77,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -85,7 +85,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.83.0",
       "sweepsSinceComment" : 0
     },
@@ -93,7 +93,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -101,7 +101,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.88.1",
       "sweepsSinceComment" : 0
     },
@@ -109,7 +109,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.33.2",
       "sweepsSinceComment" : 0
     },
@@ -117,7 +117,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "Open the agent chat panel in a new window",
       "sweepsSinceComment" : 0
     },
@@ -125,7 +125,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.6.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -133,7 +133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.6.4",
       "sweepsSinceComment" : 0
     },
@@ -141,7 +141,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "152.0.7977.64",
       "sweepsSinceComment" : 0
     },
@@ -149,7 +149,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -157,7 +157,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
     },
@@ -165,7 +165,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026.2.1",
       "sweepsSinceComment" : 0
     },
@@ -173,7 +173,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
     },
@@ -181,7 +181,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -189,7 +189,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -197,7 +197,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.135",
       "sweepsSinceComment" : 0
     },
@@ -205,7 +205,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
     },
@@ -215,7 +215,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (26.727) trails t"
@@ -224,7 +224,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "135.0.5973.66",
       "sweepsSinceComment" : 0
     },
@@ -232,7 +232,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -240,7 +240,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "12.25.7",
       "sweepsSinceComment" : 0
     },
@@ -248,7 +248,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.1",
       "sweepsSinceComment" : 0
     },
@@ -256,7 +256,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.1",
       "sweepsSinceComment" : 0
     },
@@ -264,7 +264,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.3.2",
       "sweepsSinceComment" : 0
     },
@@ -272,7 +272,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
     },
@@ -280,7 +280,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -288,7 +288,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.02.2608272",
       "sweepsSinceComment" : 0
     },
@@ -296,7 +296,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -304,7 +304,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -312,7 +312,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -320,7 +320,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.9.12",
       "sweepsSinceComment" : 0
     },
@@ -328,7 +328,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.51.191",
       "sweepsSinceComment" : 0
     },
@@ -336,7 +336,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "Aug 27, 2026",
       "sweepsSinceComment" : 0
     },
@@ -346,7 +346,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (5.2.7) trails th"
@@ -355,7 +355,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -363,7 +363,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -371,7 +371,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
     },
@@ -379,7 +379,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.2026.08.26.17.59.01",
       "sweepsSinceComment" : 0
     },
@@ -387,7 +387,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.2026.08.26.17.59.01",
       "sweepsSinceComment" : 0
     },
@@ -403,7 +403,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.18.0",
       "sweepsSinceComment" : 0
     },
@@ -419,7 +419,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.17.2",
       "sweepsSinceComment" : 0
     },
@@ -427,7 +427,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -435,7 +435,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.23.2026080313-alpha",
       "sweepsSinceComment" : 0
     },
@@ -443,7 +443,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -451,7 +451,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -459,7 +459,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
     },
@@ -467,7 +467,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
@@ -475,7 +475,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "7.31.2",
       "sweepsSinceComment" : 0
     },
@@ -483,7 +483,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.4.0",
       "sweepsSinceComment" : 0
     },
@@ -491,7 +491,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.7.8",
       "sweepsSinceComment" : 0
     },
@@ -499,7 +499,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
     },
@@ -507,7 +507,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
     },
@@ -515,7 +515,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "140.14.1esr",
       "sweepsSinceComment" : 0
     },
@@ -523,7 +523,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "154.0",
       "sweepsSinceComment" : 0
     },
@@ -531,7 +531,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "155.0beta",
       "sweepsSinceComment" : 0
     },
@@ -539,7 +539,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -547,7 +547,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.8.10",
       "sweepsSinceComment" : 0
     },
@@ -555,7 +555,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.0.3",
       "sweepsSinceComment" : 0
     },
@@ -563,7 +563,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
     },
@@ -571,7 +571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.0.3",
       "sweepsSinceComment" : 0
     },
@@ -579,7 +579,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.1.15",
       "sweepsSinceComment" : 0
     },
@@ -587,7 +587,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -595,7 +595,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -603,7 +603,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -611,7 +611,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -619,7 +619,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -627,7 +627,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -635,7 +635,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.34.0",
       "sweepsSinceComment" : 0
     },
@@ -643,7 +643,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -651,7 +651,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -659,7 +659,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.135.05777-insider",
       "sweepsSinceComment" : 0
     },
@@ -667,7 +667,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.126.04524",
       "sweepsSinceComment" : 0
     },
@@ -675,15 +675,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.8.6",
+      "sweepsSinceComment" : 0
+    },
+    "github:aaif-goose\/goose:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
+      "lastGoodVersion" : "1.48.0",
       "sweepsSinceComment" : 0
     },
     "github:actuallymentor\/battery:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -691,7 +699,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -699,7 +707,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -707,7 +715,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -715,7 +723,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.18.25",
       "sweepsSinceComment" : 0
     },
@@ -723,7 +731,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.2.0",
       "sweepsSinceComment" : 0
     },
@@ -731,7 +739,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -739,7 +747,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -747,7 +755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -763,7 +771,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -771,7 +779,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -787,7 +795,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -795,7 +803,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -803,7 +811,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.1.5",
       "sweepsSinceComment" : 0
     },
@@ -811,7 +819,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.6.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -819,7 +827,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.6.4",
       "sweepsSinceComment" : 0
     },
@@ -827,7 +835,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -835,7 +843,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.4.0",
       "sweepsSinceComment" : 0
     },
@@ -843,7 +851,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.0.13",
       "sweepsSinceComment" : 0
     },
@@ -851,7 +859,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.20.1",
       "sweepsSinceComment" : 0
     },
@@ -859,7 +867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -867,7 +875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -875,7 +883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -883,7 +891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -899,7 +907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -907,7 +915,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "31.3.2",
       "sweepsSinceComment" : 0
     },
@@ -915,7 +923,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -923,15 +931,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.48.2",
+      "sweepsSinceComment" : 0
+    },
+    "github:kubernetes-sigs\/headlamp:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
+      "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
     "github:localsend\/localsend:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -939,7 +955,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -947,7 +963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -955,7 +971,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -963,7 +979,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -971,7 +987,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -979,7 +995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.33.2",
       "sweepsSinceComment" : 0
     },
@@ -987,15 +1003,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.21.0",
+      "sweepsSinceComment" : 0
+    },
+    "github:podman-desktop\/podman-desktop:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
+      "lastGoodVersion" : "1.29.1",
       "sweepsSinceComment" : 0
     },
     "github:qbittorrent\/qBittorrent:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1003,7 +1027,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1011,7 +1035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1019,7 +1043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1027,7 +1051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1035,7 +1059,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1043,7 +1067,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1051,7 +1075,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1059,7 +1083,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1067,7 +1091,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1075,7 +1099,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1083,7 +1107,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1091,7 +1115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1099,7 +1123,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.11.0",
       "sweepsSinceComment" : 0
     },
@@ -1107,7 +1131,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1115,7 +1139,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.18.0",
       "sweepsSinceComment" : 0
     },
@@ -1123,7 +1147,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.17.2",
       "sweepsSinceComment" : 0
     },
@@ -1131,7 +1155,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.21.15b",
       "sweepsSinceComment" : 0
     },
@@ -1139,7 +1163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1147,7 +1171,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -1155,7 +1179,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "151.0.7922.247",
       "sweepsSinceComment" : 0
     },
@@ -1163,7 +1187,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1171,7 +1195,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1179,7 +1203,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -1187,7 +1211,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.1.61",
       "sweepsSinceComment" : 0
     },
@@ -1203,7 +1227,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.40609.0",
       "sweepsSinceComment" : 0
     },
@@ -1211,7 +1235,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.40609.0",
       "sweepsSinceComment" : 0
     },
@@ -1219,7 +1243,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1227,7 +1251,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1235,7 +1259,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.95.92.0",
       "sweepsSinceComment" : 0
     },
@@ -1243,7 +1267,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.96.27.0",
       "sweepsSinceComment" : 0
     },
@@ -1251,7 +1275,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -1259,7 +1283,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.124.1",
       "sweepsSinceComment" : 0
     },
@@ -1267,7 +1291,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.83.1",
       "sweepsSinceComment" : 0
     },
@@ -1275,7 +1299,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1283,7 +1307,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.88.1",
       "sweepsSinceComment" : 0
     },
@@ -1291,7 +1315,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026.8.270956-latest",
       "sweepsSinceComment" : 0
     },
@@ -1299,7 +1323,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.6.721",
       "sweepsSinceComment" : 0
     },
@@ -1307,7 +1331,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.8.20",
       "sweepsSinceComment" : 0
     },
@@ -1315,7 +1339,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "126.8.16",
       "sweepsSinceComment" : 0
     },
@@ -1323,7 +1347,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "126.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1331,7 +1355,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "266.4.3911",
       "sweepsSinceComment" : 0
     },
@@ -1339,7 +1363,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "153.0.8010.12",
       "sweepsSinceComment" : 0
     },
@@ -1347,7 +1371,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "154.0.8030.0",
       "sweepsSinceComment" : 0
     },
@@ -1355,7 +1379,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "154.0.8025.0",
       "sweepsSinceComment" : 0
     },
@@ -1363,7 +1387,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "152.0.7977.65",
       "sweepsSinceComment" : 0
     },
@@ -1371,7 +1395,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.99.2.791",
       "sweepsSinceComment" : 0
     },
@@ -1379,7 +1403,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -1387,7 +1411,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026.2.1 Canary 3",
       "sweepsSinceComment" : 0
     },
@@ -1395,7 +1419,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026.1.3",
       "sweepsSinceComment" : 0
     },
@@ -1403,7 +1427,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -1411,7 +1435,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.11.0",
       "sweepsSinceComment" : 0
     },
@@ -1419,7 +1443,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "7.515.1",
       "sweepsSinceComment" : 0
     },
@@ -1427,7 +1451,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1435,7 +1459,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.0.409",
       "sweepsSinceComment" : 0
     },
@@ -1443,7 +1467,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.0.1296",
       "sweepsSinceComment" : 0
     },
@@ -1451,7 +1475,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.0.257",
       "sweepsSinceComment" : 0
     },
@@ -1459,7 +1483,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "262.10315.19",
       "sweepsSinceComment" : 0
     },
@@ -1467,7 +1491,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026.2.1",
       "sweepsSinceComment" : 0
     },
@@ -1475,7 +1499,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -1483,7 +1507,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -1491,7 +1515,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "9.4.0-beta5",
       "sweepsSinceComment" : 0
     },
@@ -1499,7 +1523,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "9.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1507,7 +1531,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -1515,7 +1539,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1523,7 +1547,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -1531,7 +1555,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "16.112.26082125",
       "sweepsSinceComment" : 0
     },
@@ -1539,7 +1563,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.145.0728",
       "sweepsSinceComment" : 0
     },
@@ -1547,7 +1571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -1555,7 +1579,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "16.112.26082125",
       "sweepsSinceComment" : 0
     },
@@ -1563,7 +1587,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.135.0",
       "sweepsSinceComment" : 0
     },
@@ -1571,7 +1595,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.136.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -1579,7 +1603,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "16.112.26082125",
       "sweepsSinceComment" : 0
     },
@@ -1587,7 +1611,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "153.0.4234.8",
       "sweepsSinceComment" : 0
     },
@@ -1595,7 +1619,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "154.0.4238.0",
       "sweepsSinceComment" : 0
     },
@@ -1603,7 +1627,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "152.0.4191.53",
       "sweepsSinceComment" : 0
     },
@@ -1611,7 +1635,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -1619,7 +1643,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -1627,7 +1651,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.49.15",
       "sweepsSinceComment" : 0
     },
@@ -1635,7 +1659,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.38.0",
       "sweepsSinceComment" : 0
     },
@@ -1643,7 +1667,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.825.32147",
       "sweepsSinceComment" : 0
     },
@@ -1651,7 +1675,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "135.0.5973.66",
       "sweepsSinceComment" : 0
     },
@@ -1659,7 +1683,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -1667,7 +1691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -1675,7 +1699,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "12.25.7",
       "sweepsSinceComment" : 0
     },
@@ -1683,7 +1707,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.104.25",
       "sweepsSinceComment" : 0
     },
@@ -1691,7 +1715,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.1.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1699,7 +1723,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -1707,7 +1731,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -1715,7 +1739,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -1723,7 +1747,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.2.98.301",
       "sweepsSinceComment" : 0
     },
@@ -1731,7 +1755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -1739,7 +1763,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -1747,7 +1771,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -1755,7 +1779,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "7.1.3",
       "sweepsSinceComment" : 0
     },
@@ -1765,7 +1789,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -1774,7 +1798,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.02.2608272",
       "sweepsSinceComment" : 0
     },
@@ -1782,7 +1806,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -1790,7 +1814,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -1798,7 +1822,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1806,7 +1830,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -1814,7 +1838,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -1822,7 +1846,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -1830,7 +1854,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.51.191",
       "sweepsSinceComment" : 0
     },
@@ -1838,7 +1862,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.18.9",
       "sweepsSinceComment" : 0
     },
@@ -1846,7 +1870,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.21.0",
       "sweepsSinceComment" : 0
     },
@@ -1854,7 +1878,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "8.2.4133.31",
       "sweepsSinceComment" : 0
     },
@@ -1862,7 +1886,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1870,7 +1894,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1878,7 +1902,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -1886,7 +1910,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -1894,7 +1918,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "4.10.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1902,7 +1926,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -1910,7 +1934,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1918,7 +1942,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1926,7 +1950,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1934,7 +1958,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.0.395",
       "sweepsSinceComment" : 0
     },
@@ -1942,7 +1966,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.2026.08.28.12.02.00",
       "sweepsSinceComment" : 0
     },
@@ -1950,7 +1974,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.2026.08.26.17.59.01",
       "sweepsSinceComment" : 0
     },
@@ -1958,7 +1982,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "0.2026.08.26.17.59.01",
       "sweepsSinceComment" : 0
     },
@@ -1966,7 +1990,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.12.26",
       "sweepsSinceComment" : 0
     },
@@ -1974,7 +1998,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2026082801",
       "sweepsSinceComment" : 0
     },
@@ -1982,7 +2006,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -1990,7 +2014,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.23.2026080313-alpha",
       "sweepsSinceComment" : 0
     },
@@ -1998,7 +2022,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2006,7 +2030,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2014,7 +2038,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.103.156",
       "sweepsSinceComment" : 0
     },
@@ -2022,7 +2046,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2030,7 +2054,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "154.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2038,7 +2062,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2046,7 +2070,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2054,7 +2078,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.34.24",
       "sweepsSinceComment" : 0
     },
@@ -2062,7 +2086,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "7.31.3",
       "sweepsSinceComment" : 0
     },
@@ -2070,7 +2094,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "2.4.0",
       "sweepsSinceComment" : 0
     },
@@ -2078,7 +2102,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2086,7 +2110,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2094,7 +2118,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2102,7 +2126,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
@@ -2110,24 +2134,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
     },
     "vendor:org.libreoffice.script:stable" : {
-      "consecutiveActionable" : 1,
+      "consecutiveActionable" : 2,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "26.8.0",
       "lastSignature" : "remote is BEHIND the installed copy (26.",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 2
     },
     "vendor:org.mozilla.firefox:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "155.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2135,7 +2159,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "140.14.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2143,7 +2167,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "154.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2151,7 +2175,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "155.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2159,7 +2183,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2167,7 +2191,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2175,7 +2199,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "140.14.1esr",
       "sweepsSinceComment" : 0
     },
@@ -2183,7 +2207,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "154.0",
       "sweepsSinceComment" : 0
     },
@@ -2191,7 +2215,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "155.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2199,7 +2223,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -2207,7 +2231,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "15.0.20",
       "sweepsSinceComment" : 0
     },
@@ -2215,7 +2239,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -2223,7 +2247,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "8.26.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -2231,7 +2255,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "8.25.0",
       "sweepsSinceComment" : 0
     },
@@ -2241,7 +2265,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "10.0.1",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2250,11 +2274,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-08-29T05:17:20Z",
+      "lastGoodAt" : "2026-08-29T05:55:48Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-08-29T05:17:20Z"
+  "updatedAt" : "2026-08-29T05:55:48Z"
 }


### PR DESCRIPTION
三条 GitHub rule 的 `owner/repo` 已经不是仓库真名了，靠 GitHub 的 301 撑着。功能一直没坏——
所以也一直没人发现。**坏的是别的东西：跟重定向时 `Authorization` 被丢掉了。**

Closes #135

## 根因（实测，不是推断）

同一个 URLSession、同一个请求，唯一区别是走不走重定向。读响应的 `x-ratelimit-limit`
（60 = 匿名天花板，5000 = 已认证）：

```
.../repos/aaif-goose/goose/releases/latest   → limit=5000   redirected=false
.../repos/block/goose/releases/latest        → limit=60     redirected=true
                                                (final: /repositories/846698999/…)
```

请求**发出去时**是带认证的（`Log.source.debug` 里 `auth=true`）。重定向落在**同一个 host**
的 `/repositories/<id>/` 上，所以这不是「跨域剥离」那条常见规则能解释的。

逐条量两个限流桶也对得上（`/rate_limit` 自己不计数，可以当免费尺子）：

| rule | token 桶 Δ | 匿名桶 Δ |
|---|---|---|
| goose（改名） | 0 | **+1** |
| podman（改名） | 0 | **+1** |
| headlamp（改名） | +1 | **+1** |
| PureMac（没改名） | 0 | 0 |

**后果**：这三个 app 的检查一直在 60 次/小时的匿名预算里排队，用户配没配 token 都一样——
而配 token 的全部意义就是躲开这个预算。

## 改了什么

**1. 三条 slug 钉回真名**（`GitHubReleasesSource.swift`）

```
block/goose                 -> aaif-goose/goose
containers/podman-desktop   -> podman-desktop/podman-desktop
headlamp-k8s/headlamp       -> kubernetes-sigs/headlamp
```

改完三条都是 `limit=5000`、匿名桶消耗 0。

**2. 加一个朝外看的守卫**（`GitHubEndpointAudit` + `duo verify` 的 GitHub 分支）

这件事能漂到今天，是因为**每一个现有信号都是绿的**：301 兜着，版本读得对，pattern fixture
全过，而 `batchRuleSlugsArePinned` 拿我们的字符串和我们自己钉的副本比——当然相等。
它的文档注释还写着自己防的是 "a typo **or an upstream rename**"，后半句做不到，
三次改名它一次都没响。这条注释也一并改成如实描述。

新增的是一个 task-local 账本，记下**响应实际说了什么**：最终 URL 有没有变、
`x-ratelimit-limit` 是多少、这次请求带没带 token。记录点在 `fetchReleases` 里响应和
解码后的 body 都还在手上的地方；仓库真名从 release 自己的 `html_url` 读，**不额外花请求**。
app 侧 task-local 是 nil，什么都不记。

产出两条 warning：

- `staleSlug` —— registry 写的和 GitHub 答的不是一个名字，并直接给出该改成什么
- `anonymousDespiteToken` —— 带了 token 却被按 60 答复，认证没到达真正回答的端点

两条都是 `.warn` 不是 `.broken`：规则今天确实返回正确版本。

## 刻意的边界（都有测试钉住）

- **`anonymousDespiteToken` 必须带 token 才报。** 没配 token 的用户 69 条全是 60，
  报了就是 69 条噪音把真信号埋掉。
- **缺 `x-ratelimit-limit` 头不算匿名**——猜的话，任何剥头的代理都成假警报。
- **只认 github.com 的 `html_url`**，别的 host 上凑巧两段路径不能被当成 slug，
  否则会报出一个不存在的"真名"。
- slug 比较不分大小写（GitHub 对 owner/repo 大小写不敏感，那不是改名）。
- 一条 rule 可能发两次请求（latest + list 回落），每条 warning 只报一次。

## 验证

**红→绿走的是真实端点，不是只跑单测。** 把 goose 临时改回 `block/goose`、`make cli`、
`duo verify --only goose`：

```
⚠ WARN  github:block/goose:stable
    resolved  1.48.0
    warning   staleSlug: the registry says block/goose, GitHub answers as
              aaif-goose/goose — the rule is riding a rename redirect. …
    warning   anonymousDespiteToken: this request carried a token and came back
              x-ratelimit-limit: 60, the anonymous ceiling — …
```

改回真名后同一条 ✓。

全量 sweep（带 token）：

```
138 vendor probes  69 GitHub rules  69 changelogs
vendor probe  ✓137 ⚠1 ✗0
GitHub rule   ✓ 69 ⚠0 ✗0      ← 守卫开着，零误报
changelog     ✓ 69 ⚠0 ✗0
total         ✓275 ⚠1 ✗0    112s
```

唯一的 ⚠ 是 LibreOffice「26.8.0 落后于装的 26.8.0.3」的三段 vs 四段版本方案，长期存在，
与本 PR 无关。（`duo verify` 只要有任何 `.warn` 就 exit 1，所以退出码是 1 而不是 0。）

`make test`：**1467** passed（+12 Core）+ **170** CLI passed（+9），1 个已知 issue
（Anki 零填充 tag，与本 PR 无关）。

## 已知未做

`verify/baseline.json` 的 key 是按 slug 拼的，改名后旧的三条 key
（`github:block/goose:stable` 等）成了孤儿，那三个 recipe 的 streak 历史等于清零。
本次无害（三条刚重新绿），孤儿 key 的清理没做。

---

## 自审（fix loop）后又改了三处

对这个 PR 自己跑了一轮 review，抓到三条，都在 `5e8343a` / `175e242` 里改了。

**1. 守卫在 403 上是瞎的，而 403 正是它要解释的那件事。**
`record` 原来放在 `guard (200..<300)` 之后，非 2xx 在写入任何东西之前就抛掉了，账本是空的。
而 403 恰恰是这套东西要解释的场景——匿名预算被耗尽。2026-08-29 那次三条 rule 全是 403，
装上这个守卫也会一个字都不说。现在 bad-status 分支先记录再抛。

这条**光测 `endpointComplaints` 抓不到**：它拿 observation 当输入，不管有没有被记录过都会通过。
所以补的是一条打真实网络的用例，拿不存在的 repo 走真的 `resolveDiagnostic`，断言账本非空。
把 record 那几行删掉它会红：

```
✘ a non-2xx must still be recorded — this is the whole finding
↳ ledger.observations → []
```

（`.broken` 的 finding 也会带着 warning 一起打印——`Report.text` 的循环是
`where finding.status.isActionable`，broken 在内，所以 403 的行会同时给出解释。）

**2. `hasSuffix("github.com")` 也匹配 `mygithub.com`。**
实测 `mygithub.com` / `evil-github.com` / `notgithub.com` 全过，而 GitHub Enterprise
的自定义域名就长这样。**假的真名比没有真名更坏**——它会让 sweep 叫人把 rule 指向一个
不存在的 repo，直接把那个 app 的检测搞死。改成精确匹配或真子域。

**3. `redirected` 记了、写了文档、测了，但没有任何地方读它。**
后果是信息最少的那个 case 输出也最少：改名 + 拿不到 release（每个非 2xx 都这样）+ 用户没配
token，三条 warning 一条都不出。新增 `redirectedButUnnamed` 和 `staleSlugUnnamed`，
给出 `gh api repos/<slug> -q .full_name` 让人自己解析；命名版与未命名版互斥。

顺带收尾：括号风格、一个测试名拼写，以及把那条网络用例里钉死 `httpStatus404` 的断言放宽成
`httpStatus*`——匿名预算用完的机器上它会回 403，那会为一个与它无关的理由红掉。

改完复测：`make test` **1473** passed（+18 over main）+ **172** CLI passed（+11）；
真实端点红→绿仍然成立；全量 sweep 69 条 GitHub rule 全绿、零误报。
