### PR TITLE
发版时点名哪些语言的发布说明还没跟上

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -659,6 +659,64 @@ $(printf '\033[1;32m✓ Published successfully.\033[0m')
    sha256   : $checksum
 EOF
 
+# The "What's New" window reads CHANGELOG.md in English and, for anyone running
+# Duo Updater in another language, substitutes `changelog/<lang>.md` version by
+# version (see SelfChangelogLocalization). A version those files don't cover falls
+# back to English — deliberately, so a translation being behind can never truncate
+# the history or hold up a release. The cost of that choice is that nothing fails
+# when a release ships untranslated: the guard test in DuoUpdaterCore only requires
+# the languages to move TOGETHER over a hole-free run, never that they have caught
+# up to the newest version — requiring that would turn it red on every release day,
+# and a test that is red on release day is a test people disable.
+#
+# So this print is the only thing standing between "translations lag by a release"
+# and "translations stopped a year ago". It lives here rather than in the test
+# suite for the same reason the site-sync note below does: a reminder is worth
+# something only at the moment it is actionable, and that moment is now — the
+# version exists and its English notes are written and published.
+#
+# Mind the apostrophes below: bash 3.2 (what macOS ships) still balances quotes
+# while scanning for the closing paren of a command substitution, even inside a
+# quoted heredoc it will not otherwise expand. A lone `'` in a Python comment in
+# here is a parse error in this whole file, reported at a line hundreds down.
+untranslated="$(
+    ROOT="$REPO_ROOT" VERSION="$version" python3 - <<'I18N_PY'
+import os, pathlib, re
+root = pathlib.Path(os.environ["ROOT"])
+version = os.environ["VERSION"]
+# Derived from what is on disk, never from a list written here — a hand-kept list
+# stops being true the day a language is added. The other half of the question,
+# "does a shipped language have a file at all", belongs to the guard test.
+pat = re.compile(r'^##[ \t]+' + re.escape(version) + r'[ \t]*$', re.MULTILINE)
+missing = []
+for f in sorted((root / "changelog").glob("*.md")):
+    try:
+        if not pat.search(f.read_text(encoding="utf-8")):
+            missing.append(f.stem)
+    except OSError:
+        missing.append(f.stem)
+print(" ".join(missing))
+I18N_PY
+)"
+if [ -n "$untranslated" ]; then
+    cat <<EOF
+
+$(printf '\033[1;33m! %s has no translated release notes yet.\033[0m' "$version") Missing: $untranslated
+
+  Readers in those languages get this one version in English; everything below it
+  stays translated, so it reads as one English entry at the top rather than as
+  breakage. Nothing is broken — it just is not done.
+
+  To finish it, add a "## $version" section to each of:
+$(for l in $untranslated; do printf '    changelog/%s.md\n' "$l"; done)
+
+  One paragraph per English paragraph — one paragraph is one row in the window,
+  and 'make test' checks the counts match.
+EOF
+elif [ -d "$REPO_ROOT/changelog" ]; then
+    printf '\033[1;32m   i18n     : all translations already cover %s\033[0m\n' "$version"
+fi
+
 # duoupdater.app is a separate repo that keeps a COMMITTED COPY of CHANGELOG.md,
 # refreshed by its own `npm run sync` — nothing about publishing here touches it.
 # So the site silently stops at whatever version was last synced, and "remember to


### PR DESCRIPTION
接 #137。那个 PR 的守卫测试**故意不要求**译文覆盖最新版本——要求了的话，它会在每次
发版当天必红，然后变成"发版时先关掉的测试"。代价是：发版时没有任何东西会因为译文
缺失而失败，译文可以一路悄悄落后下去。

这条打印就是"落后一个版本"和"一年前就停了"之间唯一的东西。

放在发版脚本里而不是测试里，理由和它下面那条站点同步提醒一模一样：**提醒只在可执行
的那一刻才有价值**，而那一刻就是发版刚完成时——版本已经存在，英文说明也已经写好发
出去了。（那条站点提醒的注释里记着"remember to sync"失效过两次，这就是前车之鉴。）

## 行为

已全部覆盖：

```
   i18n     : all translations already cover 0.3.71
```

有落后的（部分覆盖时只点名真正落后的那几个）：

```
! 0.3.72 has no translated release notes yet. Missing: es fr ja ru zh-Hans

  Readers in those languages get this one version in English; everything below it
  stays translated, so it reads as one English entry at the top rather than as
  breakage. Nothing is broken — it just is not done.

  To finish it, add a "## 0.3.72" section to each of:
    changelog/es.md
    …
```

**不会让发版失败**——译文落后是设计允许的状态，不是错误。

语言清单从磁盘上的 `changelog/*.md` 推导，不手写。另一半问题（某个已发布的语言压根
没有文件）归 #137 的守卫测试管。

## 验证

三种情形都真跑过，不是只看编译：

| 情形 | 结果 |
|---|---|
| 0.3.71（六语全覆盖） | 报绿确认 |
| 0.3.72（六语全无） | 六个全部点名 |
| 0.3.72 且 de 已补 | 只点名剩下五个，de 正确消失 |

```
make test        # Core 1482 + CLI 172 全过
bash -n scripts/publish-release.sh
```

## 一个记进注释的 shell 陷阱

macOS 的 bash 3.2 在扫描 `$( )` 的右括号时**仍会配平引号**，连它并不展开的带引号
heredoc 里也算。我在内嵌 python 的注释里写了个 `test's`，那个落单的撇号让整个文件
解析失败，报错行号在几百行之外的另一个 heredoc 里。已在代码里留注释，免得下一个人
重新踩一遍。