### PR TITLE
包装的 iPhone/iPad app 走 AX 路线可以一键更新，外加它带出的三个 bug

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -826,10 +826,8 @@ final class AppListModel {
     /// is genuinely warranted (vs. nagging users who don't use that route).
     var needsAccessibilitySetup: Bool {
         guard prefs.appStoreUpdateStrategy == .incremental, !accessibilityTrusted else { return false }
-        // iOS-on-Mac apps redirect to the App Store (no AX), so they don't justify
-        // an Accessibility nudge on their own.
         return results.contains {
-            isActionableUpdate($0) && $0.remote?.appStore?.trackID != nil && !$0.app.isiOSAppOnMac
+            isActionableUpdate($0) && $0.remote?.appStore?.trackID != nil
         }
     }
 
@@ -1570,6 +1568,12 @@ final class AppListModel {
             vendorInstallPolicy: prefs.vendorInstallPolicy,
             declinedElevationKeys: prefs.declinedElevationKeys)
     }
+    /// Whether App Store updates take the mas route. Read by the row views: a
+    /// wrapped iPhone/iPad app is a store redirect there and a one-click on the
+    /// incremental route, and "`canAutoInstall` is false" alone does not say which
+    /// (a declined elevation reaches the same branch).
+    var appStoreStrategyIsFullDownload: Bool { prefs.appStoreUpdateStrategy == .full }
+
     private var policyEnvironment: InstallEnvironment {
         InstallEnvironment(
             isHelperEnabled: helperEnabled,
@@ -2383,12 +2387,23 @@ final class AppListModel {
                     return true
                 }
             case .appStore:
-                // iOS-on-Mac apps can only be updated by the App Store app itself
-                // (mas has no Mac-store entry; the AX route is unreliable for them).
-                // `canAutoInstall` already keeps them out of the one-click button and
-                // Install-All, but guard here too so any other caller redirects to the
-                // store instead of firing a doomed `mas` install.
-                if result.app.isiOSAppOnMac {
+                // On the mas route a wrapped iPhone/iPad app can only be updated by
+                // the App Store app itself: mas has no Mac-store entry for it and
+                // errors "No apps found for ADAM ID". `canAutoInstall` already keeps
+                // these out of the one-click and Install-All there, but guard here
+                // too so any other caller redirects rather than firing a doomed
+                // install. The AX route handles them and is not redirected.
+                //
+                // Region-locked apps are excluded from the redirect on BOTH routes:
+                // their product page reads "App Not Available", so sending anyone
+                // there is a dead end. They belong to the `isRegionMismatch` branch
+                // below, which drives App Store's Updates list instead — the one
+                // place an installed region-locked app can still update. (Before this
+                // ordering, a wrapped region-locked app on the mas route got the dead
+                // deep link; the branch below was unreachable for it.)
+                if result.app.isiOSAppOnMac,
+                   prefs.appStoreUpdateStrategy == .full,
+                   result.remote?.appStore?.isRegionMismatch != true {
                     installing[id] = nil
                     if let url = result.remote?.appStore?.deepLink { NSWorkspace.shared.open(url) }
                     return false
@@ -2526,7 +2541,11 @@ final class AppListModel {
                         } confirmQuit: { [weak self] appName in
                             await self?.requestQuitConfirmation(id: id, appName: appName) ?? false
                         }
-                    case .incremental where MASInstaller.isAvailable:
+                    // Not for a wrapped iPhone/iPad app: mas cannot install one at
+                    // all, so falling back to it would trade a fixable permission
+                    // prompt for a guaranteed "No apps found for ADAM ID". Those fall
+                    // to the case below, which asks for the grant the AX route needs.
+                    case .incremental where MASInstaller.isAvailable && !result.app.isiOSAppOnMac:
                         // Incremental is selected but Accessibility isn't granted (the
                         // user declined the opt-in prompt, or revoked it later). There's
                         // no "denied" callback from the TCC flow, so we resolve it here,
@@ -4198,8 +4217,12 @@ final class AppListModel {
     /// pre-flight is not mirrored here — it costs a subprocess, which is the
     /// thing this is trying to avoid spending.
     private func appStoreRouteWillNotInstall(_ result: UpdateResult) -> Bool {
-        // Store-managed by the App Store app itself; we only open the deep link.
-        if result.app.isiOSAppOnMac { return true }
+        // On the mas route these are store-managed by the App Store app itself and
+        // we only open a deep link, so there is nothing to roll back from. The AX
+        // route installs them like any other store app — and does take a backup,
+        // which is why this cannot stay an unconditional true: `BackupStore` would
+        // otherwise never have been asked to read a wrapped bundle.
+        if result.app.isiOSAppOnMac, prefs.appStoreUpdateStrategy == .full { return true }
         // Nothing to install against.
         if result.remote?.appStore?.trackID == nil { return true }
         // Region-locked apps are AX-only, and the AX route needs the grant first.

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3944,7 +3944,7 @@ final class AppListModel {
     nonisolated private static func readBundleVersions(
         _ bundle: URL
     ) -> (short: String?, build: String?) {
-        let info = bundle.appendingPathComponent("Contents/Info.plist")
+        let info = BundleLayout.infoPlistURL(for: bundle)
         guard let data = try? Data(contentsOf: info),
               let dict = (try? PropertyListSerialization.propertyList(
                 from: data, options: [], format: nil)) as? [String: Any]

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -312,6 +312,10 @@ final class AppListModel {
     /// (e.g. two Android Studio versions side by side) sharing one bundle id, and
     /// only the install whose bundle is actually executing should light up.
     private(set) var runningAppPaths: Set<String> = []
+    /// The identifiers behind the same processes, read in the same pass. Carries
+    /// the running answer for bundles no path can match — see
+    /// `InstallEnvironment.runningBundleIDs`.
+    private(set) var runningBundleIDs: Set<String> = []
 
     /// Whether *this exact install* currently has a running process — drives the
     /// green "live" dot in the menu and workbench. Matched on the bundle path so a
@@ -1571,7 +1575,8 @@ final class AppListModel {
             isHelperEnabled: helperEnabled,
             runningAppPaths: runningAppPaths,
             stagedSelfUpdates: pendingSelfUpdate,
-            elevationRequiredPaths: elevationRequiredPaths)
+            elevationRequiredPaths: elevationRequiredPaths,
+            runningBundleIDs: runningBundleIDs)
     }
 
     /// The install paths that need an administrator prompt to replace.
@@ -5057,10 +5062,12 @@ final class AppListModel {
     /// match how `AppScanner` records `InstalledApp.path` (it resolves symlinks too),
     /// so the comparison in `isRunning` lines up.
     private func refreshRunningApps() {
+        // One snapshot, both readings: a second `runningApplications` call could
+        // straddle an app launching or quitting and leave the two disagreeing.
+        let running = NSWorkspace.shared.runningApplications
         runningAppPaths = Set(
-            NSWorkspace.shared.runningApplications.compactMap {
-                $0.bundleURL.map(UpdatePolicy.runtimeBundlePath)
-            })
+            running.compactMap { $0.bundleURL.map(UpdatePolicy.runtimeBundlePath) })
+        runningBundleIDs = Set(running.compactMap(\.bundleIdentifier))
     }
 
     /// Post a "new updates available" banner for actionable updates the user hasn't

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1695,11 +1695,17 @@ private struct AppRow: View {
             .popover(isPresented: $showRegionHint, arrowEdge: .bottom) {
                 regionHintPopover(info)
             }
-        } else if result.app.isiOSAppOnMac {
-            // Wrapped iPhone/iPad app: mas can't update it and the AX route is
-            // unreliable for these, so the dependable path is the App Store app
-            // itself. Send the user to its product page, where an available update
-            // shows an "Update" button — rather than offering a one-click that fails.
+        } else if result.app.isiOSAppOnMac, model.appStoreStrategyIsFullDownload {
+            // Wrapped iPhone/iPad app on the mas route: mas has no Mac-store entry
+            // for it, so a one-click here would always fail. Send the user to its
+            // product page, where an available update shows an "Update" button.
+            //
+            // Conditioned on the route rather than inferred from it: this branch is
+            // reached whenever `canAutoInstall` is false, which has causes other than
+            // the strategy — a declined elevation most of all, and every wrapped app
+            // qualifies for one (they sit in a root-owned `/Applications`). Without
+            // the check, the button and its "can’t be updated from here" help text
+            // would say that on a route where they can.
             Button("App Store") { openInAppStore(info) }
                 .controlSize(.small)
                 .buttonStyle(.bordered)

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -633,16 +633,19 @@ private struct WorkbenchActionView: View {
                     .help("Downloads the official installer and opens it (asks for admin)")
             }
         } else if let info = result.remote?.appStore, !info.isRegionMismatch, !info.isLatestMacIncompatible {
-            // iOS-on-Mac apps: only the App Store app can update them (mas can't,
-            // AX is unreliable), so this is a redirect to the store rather than a
-            // one-click. A Mac App Store app lands here when the privileged helper
-            // isn't approved yet — still an installed app with a pending update, so
-            // it says **Update** (what the store calls it), never "Get".
-            Button(result.app.isiOSAppOnMac ? String(localized: "App Store") : String(localized: "Update")) {
+            // A wrapped iPhone/iPad app on the mas route: mas has no Mac-store entry
+            // for it, so this is a redirect rather than a one-click. Conditioned on
+            // the route, not inferred from it — this branch is reached whenever
+            // `canAutoInstall` is false, which has other causes (a declined
+            // elevation), and on the incremental route these do install from here.
+            // A Mac App Store app lands here when the privileged helper isn't
+            // approved yet — still an installed app with a pending update, so it
+            // says **Update** (what the store calls it), never "Get".
+            Button(storeManagedHere ? String(localized: "App Store") : String(localized: "Update")) {
                 if let url = info.deepLink ?? result.remote?.pageURL { NSWorkspace.shared.open(url) }
             }
             .buttonStyle(.bordered)
-            .help(result.app.isiOSAppOnMac
+            .help(storeManagedHere
                   ? String(localized: "Update \(result.app.name) in the App Store — iPhone/iPad apps can’t be updated from here")
                   : appStoreRedirectHelp)
         } else if let url = result.remote?.pageURL {
@@ -655,6 +658,13 @@ private struct WorkbenchActionView: View {
     /// Why this row hands off to the App Store instead of installing in place —
     /// same reasoning as the popover's: approving the helper is the one lever the
     /// user has, so say so when that's what's missing.
+    /// This row hands off to the App Store because the store app is the only
+    /// thing that can update it — as opposed to handing off because a permission
+    /// is missing, which is what every other path through this branch means.
+    private var storeManagedHere: Bool {
+        result.app.isiOSAppOnMac && model.appStoreStrategyIsFullDownload
+    }
+
     private var appStoreRedirectHelp: String {
         if !model.helperEnabled {
             return String(localized: "Opens \(result.app.name) in the App Store. Turn on the background helper in Settings to install App Store updates in one click.")

--- a/CLI/Sources/DuoKit/Check.swift
+++ b/CLI/Sources/DuoKit/Check.swift
@@ -90,7 +90,8 @@ public enum Check {
             runningAppPaths: runningBundlePaths(),
             stagedSelfUpdates: [:],
             elevationRequiredPaths: InPlaceSwap.elevationRequiredPaths(
-                for: results.map(\.app.path)))
+                for: results.map(\.app.path)),
+            runningBundleIDs: runningBundleIDs())
 
         var rows: [Row] = []
         for result in results.sorted(by: { $0.app.name.localizedCaseInsensitiveCompare($1.app.name) == .orderedAscending }) {
@@ -161,6 +162,8 @@ public enum Check {
     static func runningBundlePaths() -> Set<String> {
         Set(RunningApps.bundleURLs().map(UpdatePolicy.runtimeBundlePath))
     }
+
+    static func runningBundleIDs() -> Set<String> { RunningApps.bundleIDs() }
 
     static func describe(_ status: UpdateStatus) -> String {
         switch status {

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -82,7 +82,8 @@ public enum Install {
             runningAppPaths: Check.runningBundlePaths(),
             stagedSelfUpdates: staged,
             elevationRequiredPaths: InPlaceSwap.elevationRequiredPaths(
-                for: results.map(\.app.path)))
+                for: results.map(\.app.path)),
+            runningBundleIDs: Check.runningBundleIDs())
 
         var plan: [Planned] = []
         var refusals: [(UpdateResult, String)] = []
@@ -129,7 +130,8 @@ public enum Install {
                 isHelperEnabled: false,
                 runningAppPaths: Check.runningBundlePaths(),
                 stagedSelfUpdates: stagedSelfUpdates(for: plan.map(\.result)),
-                elevationRequiredPaths: environment.elevationRequiredPaths)
+                elevationRequiredPaths: environment.elevationRequiredPaths,
+                runningBundleIDs: Check.runningBundleIDs())
             let started = plan.filter {
                 UpdatePolicy.defersToSelfUpdater(
                     $0.result, settings: settings.updateSettings, environment: live)

--- a/CLI/Sources/DuoKit/RunningApps.swift
+++ b/CLI/Sources/DuoKit/RunningApps.swift
@@ -11,4 +11,10 @@ enum RunningApps {
     static func bundleURLs() -> [URL] {
         NSWorkspace.shared.runningApplications.compactMap(\.bundleURL)
     }
+
+    /// The identifiers behind those processes. Needed for bundles whose running
+    /// copy cannot be recognised by path — see `InstallEnvironment.runningBundleIDs`.
+    static func bundleIDs() -> Set<String> {
+        Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+    }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -25,17 +25,31 @@ public struct InstallEnvironment: Sendable {
     /// by the host — via `InPlaceSwap.needsElevatedReplace`, the same predicate
     /// the swap itself branches on — and handed in, keeping the policy pure.
     public var elevationRequiredPaths: Set<String>
+    /// Bundle identifiers with at least one live process — the running side for
+    /// bundles whose running copy cannot be recognised by path.
+    ///
+    /// A wrapped iPhone/iPad app is the case that needs this. Its process reports
+    /// a per-launch shadow container as its `bundleURL`, not the bundle the user
+    /// installed: measured on macOS 26 (2026-08-29) for Aqara Home, `bundleURL`
+    /// was `/private/var/folders/…/X/<uuid>/d/Wrapper/AqaraHome.app` while the
+    /// install lives at `/Applications/Aqara Home.app`. No amount of symlink
+    /// resolution turns one into the other, so `runningAppPaths` cannot contain
+    /// a running wrapped app and every path-keyed "is it running?" answers no.
+    /// The identifier is unaffected (`com.lumiunited.pre.homekit` either way).
+    public var runningBundleIDs: Set<String>
 
     public init(
         isHelperEnabled: Bool,
         runningAppPaths: Set<String>,
         stagedSelfUpdates: [String: StagedSelfUpdate],
-        elevationRequiredPaths: Set<String> = []
+        elevationRequiredPaths: Set<String> = [],
+        runningBundleIDs: Set<String> = []
     ) {
         self.isHelperEnabled = isHelperEnabled
         self.runningAppPaths = runningAppPaths
         self.stagedSelfUpdates = stagedSelfUpdates
         self.elevationRequiredPaths = elevationRequiredPaths
+        self.runningBundleIDs = runningBundleIDs
     }
 }
 
@@ -315,7 +329,19 @@ public enum UpdatePolicy {
     /// (same bundle id, different path) doesn't falsely light up when only the
     /// other copy is open.
     public static func isRunning(_ result: UpdateResult, environment: InstallEnvironment) -> Bool {
-        environment.runningAppPaths.contains(runtimeBundlePath(result.app.path))
+        // Path is the discriminator everywhere it can be: two copies of the same
+        // app in different places are different installs, and only the one being
+        // replaced should read as running.
+        //
+        // A wrapped iPhone/iPad app is the exception, and not by preference — its
+        // running process reports a shadow container path that can never equal the
+        // installed bundle (see `InstallEnvironment.runningBundleIDs`). Falling
+        // back to the identifier costs nothing here: these are store-installed and
+        // singular, so "another copy elsewhere" is not a state that arises.
+        if result.app.isiOSAppOnMac, let bundleID = result.app.bundleID {
+            return environment.runningBundleIDs.contains(bundleID)
+        }
+        return environment.runningAppPaths.contains(runtimeBundlePath(result.app.path))
     }
 
     /// The vendor's advertised version when it is strictly *older* than what is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -152,19 +152,28 @@ public enum UpdatePolicy {
             //   • incremental → AX-driven; needs no mas. Accessibility is requested
             //     on demand at install time (mirroring App Management), so we don't
             //     gate the offer on it here.
-            // iOS-on-Mac apps (wrapped iPhone/iPad bundles) are never a one-click:
-            // `mas` has no Mac-store entry to install (it errors "No apps found for
-            // ADAM ID"), and the AX route is too unreliable for them. Only the App
-            // Store app itself updates these, so the row offers an "Open in App
-            // Store" redirect instead (see the App Store branch in both row views).
             guard let info = result.remote?.appStore,
-                  !info.isRegionMismatch, !info.isLatestMacIncompatible,
-                  !result.app.isiOSAppOnMac else { return false }
+                  !info.isRegionMismatch, !info.isLatestMacIncompatible else { return false }
             switch settings.appStoreUpdateStrategy {
-            // `.full` now routes mas through the privileged helper — offered only
-            // once the helper is approved (else the row falls back to App Store "Get").
-            // Reads the observable mirror so rows re-render the moment it's approved.
-            case .full:        return environment.isHelperEnabled
+            // `.full` routes mas through the privileged helper — offered only once
+            // the helper is approved (else the row falls back to an App Store
+            // redirect). Reads the observable mirror so rows re-render the moment
+            // it's approved.
+            //
+            // iOS-on-Mac apps (wrapped iPhone/iPad bundles) are excluded from *this*
+            // route only: `mas` has no Mac-store entry for them and errors "No apps
+            // found for ADAM ID".
+            case .full:        return environment.isHelperEnabled && !result.app.isiOSAppOnMac
+            // The AX route presses the product page's own Update button, and that
+            // page is structurally what a native Mac app gets: one
+            // `AppStore.productPage`, one `AppStore.shelfItem.ProductLockup…` hero
+            // naming the app, one `AppStore.offerButton` titled "Update" inside it.
+            // Probed live on macOS 26 (Nowdex, 2026-08-29): `heroOwnsPage` true and
+            // `ownButtonCount` 1 — the pair `AppStoreAXInstaller.shouldPress`
+            // requires — and driving it installed the update. "Designed for iPad.
+            // Not verified for macOS." is a subtitle in that hero, not a barrier;
+            // the developer-opted-out case is `isLatestMacIncompatible`, guarded
+            // above for both routes.
             case .incremental: return true
             }
         default:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -237,6 +237,14 @@ public enum AppRestarter {
         let candidates = app.bundleID.map {
             NSRunningApplication.runningApplications(withBundleIdentifier: $0)
         } ?? NSWorkspace.shared.runningApplications
+        // A wrapped iPhone/iPad app runs out of a per-launch shadow container, so
+        // its `bundleURL` never resolves to the installed bundle and this filter
+        // would drop every live instance (measured — see
+        // `InstallEnvironment.runningBundleIDs`). The identifier query above has
+        // already narrowed to this app, and a second copy of a store-installed
+        // wrapped app is not a state that arises, so the path filter has nothing
+        // left to disambiguate.
+        guard !app.isiOSAppOnMac else { return candidates }
         return candidates.filter { matchesBundlePath($0.bundleURL, target: target) }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -341,7 +341,7 @@ public actor AppStoreAXInstaller {
     /// `fallbackShort` (the caller's known current version) is used only if the
     /// Info.plist can't be read at that instant.
     private func installedVersions(_ appPath: URL, fallbackShort: String? = nil) -> (short: String?, build: String?) {
-        let plist = appPath.appendingPathComponent("Contents/Info.plist")
+        let plist = BundleLayout.infoPlistURL(for: appPath)
         let dict = NSDictionary(contentsOf: plist)
         let short = (dict?["CFBundleShortVersionString"] as? String) ?? fallbackShort
         let build = dict?["CFBundleVersion"] as? String

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -181,7 +181,7 @@ public actor AppStoreAXInstaller {
         // update usually bumps the short version, but a build-only re-release bumps
         // only CFBundleVersion — keying completion on the short version alone would
         // miss that and falsely "time out" on a successful install.
-        let baseline = installedVersions(appPath, fallbackShort: currentShortVersion)
+        let baseline = Self.installedVersions(at: appPath, fallbackShort: currentShortVersion)
 
         // Press Update *with the app still running*. App Store downloads the delta in
         // the background while the user keeps working — it only raises the "Close this
@@ -340,7 +340,13 @@ public actor AppStoreAXInstaller {
     /// used to detect when storedownloadd has finished swapping the new build in.
     /// `fallbackShort` (the caller's known current version) is used only if the
     /// Info.plist can't be read at that instant.
-    private func installedVersions(_ appPath: URL, fallbackShort: String? = nil) -> (short: String?, build: String?) {
+    ///
+    /// Static and internal so the completion rule can be asserted against a real
+    /// bundle on disk without a live App Store. It was private, and the tests that
+    /// stood in for it re-implemented the read — which is how a hardcoded
+    /// `Contents/Info.plist` here survived a green suite while making
+    /// `versionChanged` permanently false for a wrapped iPhone/iPad bundle.
+    static func installedVersions(at appPath: URL, fallbackShort: String? = nil) -> (short: String?, build: String?) {
         let plist = BundleLayout.infoPlistURL(for: appPath)
         let dict = NSDictionary(contentsOf: plist)
         let short = (dict?["CFBundleShortVersionString"] as? String) ?? fallbackShort
@@ -352,8 +358,8 @@ public actor AppStoreAXInstaller {
     /// EITHER the short or build key. A `nil` baseline value can't trigger
     /// completion, so a transiently unreadable Info.plist at baseline time can't be
     /// misread as "updated" the instant it becomes readable again.
-    private func versionChanged(from baseline: (short: String?, build: String?), appPath: URL) -> Bool {
-        let now = installedVersions(appPath)
+    static func versionChanged(from baseline: (short: String?, build: String?), appPath: URL) -> Bool {
+        let now = installedVersions(at: appPath)
         if let b = baseline.short, let n = now.short, n != b { return true }
         if let b = baseline.build, let n = now.build, n != b { return true }
         return false
@@ -482,7 +488,7 @@ public actor AppStoreAXInstaller {
             // 1. Completion: the bundle on disk has been swapped for the new build.
             // Covers both the app-not-running case (installs directly, no sheet) and
             // the post-Continue swap. Keyed on short OR build version changing.
-            if versionChanged(from: baseline, appPath: appPath) {
+            if Self.versionChanged(from: baseline, appPath: appPath) {
                 Log.install.info("appstore-ax: \(appName, privacy: .public) install complete — bundle version changed on disk")
                 onStage(.done)
                 return

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupManifest.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupManifest.swift
@@ -49,6 +49,11 @@ public struct BackupManifest: Codable, Equatable, Sendable {
         // nil means there was no seal to consult; then every unreadable file
         // counts as payload, because we cannot tell payload from droppings.
         let sealedPaths = sealedEntries(of: bundle)
+        // Where this bundle keeps its interior — `Contents/` normally, but a
+        // wrapped iPhone/iPad app has no `Contents/` at all and holds both its
+        // plist and its seal under `Wrapper/<Inner>.app/`. Read from the bundle
+        // rather than assumed, so the seal keys below line up with the walk.
+        let interior = BundleLayout.interiorPrefix(for: bundle, fileManager: fm)
         let base = bundle.standardizedFileURL.path
         var sealed: [String] = []
         var unsealed: [String] = []
@@ -60,10 +65,10 @@ public struct BackupManifest: Codable, Equatable, Sendable {
             guard values?.isRegularFile == true,
                   !fm.isReadableFile(atPath: item.path) else { continue }
             let relative = String(item.standardizedFileURL.path.dropFirst(base.count + 1))
-            // `CodeResources` keys are relative to `Contents/`, the tree we walk
-            // is relative to the bundle root.
-            let sealKey = relative.hasPrefix("Contents/")
-                ? String(relative.dropFirst("Contents/".count)) : relative
+            // `CodeResources` keys are relative to the bundle's interior, the
+            // tree we walk is relative to the bundle root.
+            let sealKey = relative.hasPrefix(interior)
+                ? String(relative.dropFirst(interior.count)) : relative
             guard let sealedPaths else { sealed.append(relative); continue }
             if sealedPaths.contains(sealKey) { sealed.append(relative) } else { unsealed.append(relative) }
         }
@@ -76,7 +81,7 @@ public struct BackupManifest: Codable, Equatable, Sendable {
     /// and quietly store a partial copy of an unsigned app, which is the
     /// opposite of the cautious reading.
     private static func sealedEntries(of bundle: URL) -> Set<String>? {
-        let url = bundle.appendingPathComponent("Contents/_CodeSignature/CodeResources")
+        let url = BundleLayout.codeResourcesURL(for: bundle)
         guard let data = try? Data(contentsOf: url),
               let plist = try? PropertyListSerialization.propertyList(
                 from: data, options: [], format: nil) as? [String: Any]

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupStore.swift
@@ -540,7 +540,7 @@ public enum BackupStore {
     /// `CFBundleShortVersionString` of the app currently at `path`, or nil if it
     /// isn't there or has no readable plist.
     private static func installedShortVersion(atPath path: String) -> String? {
-        let plist = URL(fileURLWithPath: path).appendingPathComponent("Contents/Info.plist")
+        let plist = BundleLayout.infoPlistURL(for: URL(fileURLWithPath: path))
         guard let data = try? Data(contentsOf: plist),
               let info = try? PropertyListSerialization.propertyList(
                 from: data, options: [], format: nil) as? [String: Any]

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -275,11 +275,7 @@ public struct AppScanner: Sendable {
         // bundle has no readable Info.plist and the app is silently dropped.
         let wrappedBundle = bundleURL.appendingPathComponent("WrappedBundle")
         let isiOSAppOnMac = fm.fileExists(atPath: wrappedBundle.path)
-        let infoURL: URL = isiOSAppOnMac
-            ? wrappedBundle.appendingPathComponent("Info.plist")
-            : bundleURL
-                .appendingPathComponent("Contents", isDirectory: true)
-                .appendingPathComponent("Info.plist")
+        let infoURL = BundleLayout.infoPlistURL(for: bundleURL, fileManager: fm)
 
         guard
             let data = try? Data(contentsOf: infoURL),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/BundleLayout.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/BundleLayout.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Where a bundle's `Info.plist` actually lives.
+///
+/// A normal macOS app keeps it at `Contents/Info.plist`. An iPhone/iPad app
+/// running on Apple Silicon is *wrapped*: the outer `.app` has no `Contents/` at
+/// all — the real bundle sits at `Wrapper/<Inner>.app` (a flat iOS layout) behind
+/// a `WrappedBundle` symlink, with its plist at that bundle's root.
+///
+/// Reading the wrong path doesn't fail loudly, it reads **nothing**: the file
+/// isn't there, both version fields come back nil, and every caller that asks
+/// "has the version changed?" answers "no" — forever, not once. That is how a
+/// wrapped app's App Store update landed correctly and then spun out the
+/// installer's full six-minute poll before reporting a timeout (Nowdex on
+/// macOS 26, 2026-08-29: the bytes were on disk 15 seconds in, `versionChanged`
+/// could never observe it). `AppScanner` has resolved this layout since wrapped
+/// apps were first scanned; the readers on the install path had not, so the rule
+/// lives here where all of them can share it rather than in any one of them.
+public enum BundleLayout {
+
+    /// The `Info.plist` inside `bundleURL`, wherever this bundle keeps it.
+    ///
+    /// Presence of the `WrappedBundle` symlink is the discriminator — the same one
+    /// `AppScanner` derives `isiOSAppOnMac` from, and it is a fact about the
+    /// bundle on disk rather than anything we were told about it, so a reader that
+    /// only has a path can still get this right.
+    public static func infoPlistURL(
+        for bundleURL: URL, fileManager: FileManager = .default
+    ) -> URL {
+        let wrapped = bundleURL.appendingPathComponent("WrappedBundle")
+        guard fileManager.fileExists(atPath: wrapped.path) else {
+            return bundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("Info.plist")
+        }
+        return wrapped.appendingPathComponent("Info.plist")
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/BundleLayout.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/BundleLayout.swift
@@ -18,21 +18,58 @@ import Foundation
 /// lives here where all of them can share it rather than in any one of them.
 public enum BundleLayout {
 
-    /// The `Info.plist` inside `bundleURL`, wherever this bundle keeps it.
+    /// The path, relative to the bundle root and ending in `/`, of the directory
+    /// holding `Info.plist` and `_CodeSignature` — `Contents/` for a normal app,
+    /// `Wrapper/<Inner>.app/` for a wrapped one.
     ///
     /// Presence of the `WrappedBundle` symlink is the discriminator — the same one
-    /// `AppScanner` derives `isiOSAppOnMac` from, and it is a fact about the
-    /// bundle on disk rather than anything we were told about it, so a reader that
-    /// only has a path can still get this right.
+    /// `AppScanner` derives `isiOSAppOnMac` from, and a fact about the bundle on
+    /// disk rather than anything we were told about it, so a reader holding only a
+    /// path can still get this right.
+    ///
+    /// Returned relative, and resolved through the symlink's *destination* rather
+    /// than the symlink itself, because one caller (`BackupManifest`) needs it to
+    /// line up with a directory walk of the same bundle. That walk yields real
+    /// paths (`Wrapper/<Inner>.app/…`) and never the `WrappedBundle` alias, so a
+    /// prefix naming the alias would match none of them.
+    public static func interiorPrefix(
+        for bundleURL: URL, fileManager: FileManager = .default
+    ) -> String {
+        let wrapped = bundleURL.appendingPathComponent("WrappedBundle")
+        guard fileManager.fileExists(atPath: wrapped.path) else { return "Contents/" }
+        // The link's own text is the answer and costs no directory scan; it is
+        // written relative to the bundle root ("Wrapper/Amp.app"). Fall back to
+        // finding the single `.app` under `Wrapper/` if it can't be read, and to
+        // the alias itself if even that fails — reading through the alias still
+        // works, and only the seal-key mapping loses precision.
+        if let destination = try? fileManager.destinationOfSymbolicLink(atPath: wrapped.path),
+           !destination.hasPrefix("/") {
+            return destination.hasSuffix("/") ? destination : destination + "/"
+        }
+        let wrapperDir = bundleURL.appendingPathComponent("Wrapper", isDirectory: true)
+        if let inner = try? fileManager.contentsOfDirectory(atPath: wrapperDir.path)
+            .first(where: { $0.hasSuffix(".app") }) {
+            return "Wrapper/\(inner)/"
+        }
+        return "WrappedBundle/"
+    }
+
+    /// The `Info.plist` inside `bundleURL`, wherever this bundle keeps it.
     public static func infoPlistURL(
         for bundleURL: URL, fileManager: FileManager = .default
     ) -> URL {
-        let wrapped = bundleURL.appendingPathComponent("WrappedBundle")
-        guard fileManager.fileExists(atPath: wrapped.path) else {
-            return bundleURL
-                .appendingPathComponent("Contents", isDirectory: true)
-                .appendingPathComponent("Info.plist")
-        }
-        return wrapped.appendingPathComponent("Info.plist")
+        bundleURL.appendingPathComponent(
+            interiorPrefix(for: bundleURL, fileManager: fileManager) + "Info.plist")
+    }
+
+    /// The bundle's `_CodeSignature/CodeResources` — the seal `BackupManifest`
+    /// consults to tell shipped payload from runtime droppings. Absent for an
+    /// unsigned bundle, which that caller already treats as "no seal to consult".
+    public static func codeResourcesURL(
+        for bundleURL: URL, fileManager: FileManager = .default
+    ) -> URL {
+        bundleURL.appendingPathComponent(
+            interiorPrefix(for: bundleURL, fileManager: fileManager)
+                + "_CodeSignature/CodeResources")
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Traffic/InstalledBuild.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Traffic/InstalledBuild.swift
@@ -21,7 +21,7 @@ public enum InstalledBuild {
     /// Returns nil when the bundle is unreadable or declares no build, so callers
     /// fall back rather than record a wrong value.
     public static func read(at bundleURL: URL) -> String? {
-        let plist = bundleURL.appendingPathComponent("Contents/Info.plist")
+        let plist = BundleLayout.infoPlistURL(for: bundleURL)
         guard let data = try? Data(contentsOf: plist),
               let object = try? PropertyListSerialization.propertyList(
                   from: data, format: nil),

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BundleLayoutTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BundleLayoutTests.swift
@@ -73,28 +73,71 @@ private func makeBundle(wrapped: Bool, short: String, build: String) throws -> U
     #expect(InstalledBuild.read(at: iosOnMac) == "48")
 }
 
-/// The exact shape of the six-minute spin: baseline is read before the store
-/// swaps the bundle, the swap lands, and the installer asks whether the on-disk
+/// The exact shape of the six-minute spin, asserted through the installer's own
+/// rule rather than a stand-in: baseline is read before the store swaps the
+/// bundle, the swap lands, and `versionChanged` is asked whether the on-disk
 /// version moved. With the plist unreadable both readings are nil and the answer
-/// is "no" no matter how long it waits — the poll can only end in a timeout on an
-/// update that already succeeded. Exercised through the same reader the installer
-/// uses, one layout each, so a regression in either direction fails here.
-@Test func aWrappedBundleSwapIsObservable() throws {
+/// is "no" however long it waits, so the poll can only end in a timeout on an
+/// update that already succeeded.
+///
+/// An earlier version of this test re-implemented the read with `NSDictionary`
+/// and could not fail for any mutation of the installer — the same "守卫在、判据废了"
+/// shape as the bug it was meant to pin.
+@Test func theInstallerObservesAWrappedBundleSwap() throws {
     let app = try makeBundle(wrapped: true, short: "1.0.6", build: "47")
     defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
 
-    let before = NSDictionary(contentsOf: BundleLayout.infoPlistURL(for: app))
-    #expect(before?["CFBundleShortVersionString"] as? String == "1.0.6")
+    let baseline = AppStoreAXInstaller.installedVersions(at: app, fallbackShort: "1.0.6")
+    #expect(baseline.short == "1.0.6")
+    #expect(baseline.build == "47")   // nil here is the pre-fix reading
+    #expect(!AppStoreAXInstaller.versionChanged(from: baseline, appPath: app))
 
     // Stand in for storedownloadd replacing the wrapped bundle in place.
     let inner = app.appendingPathComponent("Wrapper/Sample.app/Info.plist")
-    let updated = try PropertyListSerialization.data(
+    try PropertyListSerialization.data(
         fromPropertyList: ["CFBundleShortVersionString": "1.0.7",
                            "CFBundleVersion": "48"] as [String: Any],
-        format: .xml, options: 0)
-    try updated.write(to: inner)
+        format: .xml, options: 0).write(to: inner)
 
-    let after = NSDictionary(contentsOf: BundleLayout.infoPlistURL(for: app))
-    #expect(after?["CFBundleShortVersionString"] as? String == "1.0.7")
-    #expect(after?["CFBundleVersion"] as? String == "48")
+    #expect(AppStoreAXInstaller.versionChanged(from: baseline, appPath: app))
+}
+
+/// A build-only bump is the case marketing strings cannot see, and wrapped apps
+/// hit it (Amp ships many builds under a frozen "1.0"). The completion rule has
+/// to settle on the build alone.
+@Test func theInstallerObservesABuildOnlySwap() throws {
+    let app = try makeBundle(wrapped: true, short: "1.0", build: "47")
+    defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+
+    let baseline = AppStoreAXInstaller.installedVersions(at: app)
+    let inner = app.appendingPathComponent("Wrapper/Sample.app/Info.plist")
+    try PropertyListSerialization.data(
+        fromPropertyList: ["CFBundleShortVersionString": "1.0",
+                           "CFBundleVersion": "48"] as [String: Any],
+        format: .xml, options: 0).write(to: inner)
+
+    #expect(AppStoreAXInstaller.versionChanged(from: baseline, appPath: app))
+}
+
+/// `BackupManifest` walks the bundle from its root and looks each unreadable file
+/// up in the seal, whose keys are relative to the bundle's interior. For a
+/// wrapped app that interior is `Wrapper/<Inner>.app/`, not `Contents/`, and both
+/// the seal's location and the prefix to strip move with it — get either wrong
+/// and every shipped file reads as an unsealed dropping (or the reverse).
+@Test func theSealIsFoundWhereAWrappedBundleKeepsIt() throws {
+    let classic = try makeBundle(wrapped: false, short: "3.1", build: "310")
+    defer { try? FileManager.default.removeItem(at: classic.deletingLastPathComponent()) }
+    let iosOnMac = try makeBundle(wrapped: true, short: "1.0.7", build: "48")
+    defer { try? FileManager.default.removeItem(at: iosOnMac.deletingLastPathComponent()) }
+
+    #expect(BundleLayout.interiorPrefix(for: classic) == "Contents/")
+    #expect(BundleLayout.codeResourcesURL(for: classic).path
+            == classic.appendingPathComponent("Contents/_CodeSignature/CodeResources").path)
+
+    // Read from the symlink's destination, so it lines up with a directory walk
+    // of the same bundle — which yields Wrapper/…, never the WrappedBundle alias.
+    #expect(BundleLayout.interiorPrefix(for: iosOnMac) == "Wrapper/Sample.app/")
+    #expect(BundleLayout.codeResourcesURL(for: iosOnMac).path
+            == iosOnMac.appendingPathComponent(
+                "Wrapper/Sample.app/_CodeSignature/CodeResources").path)
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BundleLayoutTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BundleLayoutTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Build the two bundle layouts on disk. A wrapped iPhone/iPad app has no
+/// `Contents/` at all: `Wrapper/<Inner>.app` holds a flat iOS bundle and
+/// `WrappedBundle` is a symlink to it. Built rather than mocked because the
+/// discriminator being tested is a filesystem fact.
+private func makeBundle(wrapped: Bool, short: String, build: String) throws -> URL {
+    let fm = FileManager.default
+    let root = fm.temporaryDirectory
+        .appendingPathComponent("bundle-layout-\(UUID().uuidString)", isDirectory: true)
+    let app = root.appendingPathComponent("Sample.app", isDirectory: true)
+    let plist: [String: Any] = [
+        "CFBundleShortVersionString": short,
+        "CFBundleVersion": build,
+        "CFBundleIdentifier": "com.example.sample",
+        "CFBundleName": "Sample",
+    ]
+    let data = try PropertyListSerialization.data(
+        fromPropertyList: plist, format: .xml, options: 0)
+    if wrapped {
+        let inner = app.appendingPathComponent("Wrapper/Sample.app", isDirectory: true)
+        try fm.createDirectory(at: inner, withIntermediateDirectories: true)
+        try data.write(to: inner.appendingPathComponent("Info.plist"))
+        try fm.createSymbolicLink(
+            at: app.appendingPathComponent("WrappedBundle"),
+            withDestinationURL: inner)
+    } else {
+        let contents = app.appendingPathComponent("Contents", isDirectory: true)
+        try fm.createDirectory(at: contents, withIntermediateDirectories: true)
+        try data.write(to: contents.appendingPathComponent("Info.plist"))
+    }
+    return app
+}
+
+@Test func resolvesTheClassicLayout() throws {
+    let app = try makeBundle(wrapped: false, short: "3.1", build: "310")
+    defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+
+    #expect(BundleLayout.infoPlistURL(for: app).path
+            == app.appendingPathComponent("Contents/Info.plist").path)
+}
+
+/// The regression this exists for: the outer `.app` of a wrapped iPhone/iPad app
+/// has no `Contents/Info.plist`, so the classic path reads *nothing* — not a
+/// wrong version, an absent one. Assert the file we resolve to is actually
+/// readable, since "returns a URL" was never the failure.
+@Test func resolvesTheWrappediOSLayout() throws {
+    let app = try makeBundle(wrapped: true, short: "1.0.7", build: "48")
+    defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+
+    let classic = app.appendingPathComponent("Contents/Info.plist")
+    #expect(!FileManager.default.fileExists(atPath: classic.path))
+
+    let resolved = BundleLayout.infoPlistURL(for: app)
+    let dict = NSDictionary(contentsOf: resolved)
+    #expect(dict?["CFBundleShortVersionString"] as? String == "1.0.7")
+    #expect(dict?["CFBundleVersion"] as? String == "48")
+}
+
+/// `InstalledBuild.read` is what records which build landed after a swap, and
+/// what `DeltaApplier` checks a delta against. On the classic layout it always
+/// worked; on a wrapped one it returned nil, which reads downstream as "couldn't
+/// tell" and silently disables every build-based comparison.
+@Test func readsTheBuildFromEitherLayout() throws {
+    let classic = try makeBundle(wrapped: false, short: "3.1", build: "310")
+    defer { try? FileManager.default.removeItem(at: classic.deletingLastPathComponent()) }
+    let iosOnMac = try makeBundle(wrapped: true, short: "1.0.7", build: "48")
+    defer { try? FileManager.default.removeItem(at: iosOnMac.deletingLastPathComponent()) }
+
+    #expect(InstalledBuild.read(at: classic) == "310")
+    #expect(InstalledBuild.read(at: iosOnMac) == "48")
+}
+
+/// The exact shape of the six-minute spin: baseline is read before the store
+/// swaps the bundle, the swap lands, and the installer asks whether the on-disk
+/// version moved. With the plist unreadable both readings are nil and the answer
+/// is "no" no matter how long it waits — the poll can only end in a timeout on an
+/// update that already succeeded. Exercised through the same reader the installer
+/// uses, one layout each, so a regression in either direction fails here.
+@Test func aWrappedBundleSwapIsObservable() throws {
+    let app = try makeBundle(wrapped: true, short: "1.0.6", build: "47")
+    defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+
+    let before = NSDictionary(contentsOf: BundleLayout.infoPlistURL(for: app))
+    #expect(before?["CFBundleShortVersionString"] as? String == "1.0.6")
+
+    // Stand in for storedownloadd replacing the wrapped bundle in place.
+    let inner = app.appendingPathComponent("Wrapper/Sample.app/Info.plist")
+    let updated = try PropertyListSerialization.data(
+        fromPropertyList: ["CFBundleShortVersionString": "1.0.7",
+                           "CFBundleVersion": "48"] as [String: Any],
+        format: .xml, options: 0)
+    try updated.write(to: inner)
+
+    let after = NSDictionary(contentsOf: BundleLayout.infoPlistURL(for: app))
+    #expect(after?["CFBundleShortVersionString"] as? String == "1.0.7")
+    #expect(after?["CFBundleVersion"] as? String == "48")
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
@@ -70,10 +70,12 @@ private func environment(
     helperEnabled: Bool = false,
     running: Set<String> = [],
     staged: [String: StagedSelfUpdate] = [:],
-    elevationRequired: Set<String> = []
+    elevationRequired: Set<String> = [],
+    runningIDs: Set<String> = []
 ) -> InstallEnvironment {
     InstallEnvironment(isHelperEnabled: helperEnabled, runningAppPaths: running,
-                       stagedSelfUpdates: staged, elevationRequiredPaths: elevationRequired)
+                       stagedSelfUpdates: staged, elevationRequiredPaths: elevationRequired,
+                       runningBundleIDs: runningIDs)
 }
 
 private func staged(_ version: String) -> StagedSelfUpdate {
@@ -239,10 +241,41 @@ private func storeAvailability(
             expected: false
         ),
         (
-            name: "iOS-on-Mac app is not auto-installable",
+            // The mas route cannot install one at all — no Mac-store entry, so
+            // `mas install` errors "No apps found for ADAM ID".
+            name: "iOS-on-Mac app is not auto-installable on the mas route",
             result: fixtureResult(
                 source: "App Store", appStore: storeAvailability(), app: fixtureApp(isiOSAppOnMac: true)),
             settings: defaultSettings(), environment: environment(helperEnabled: true),
+            expected: false
+        ),
+        (
+            // The AX route presses the product page's own Update button, and that
+            // page is the same for a wrapped iPad app as for a native Mac one
+            // (probed live, macOS 26, 2026-08-29). This row is the whole point of
+            // the split: without it, restoring the blanket exclusion passes.
+            name: "iOS-on-Mac app IS auto-installable on the AX route",
+            result: fixtureResult(
+                source: "App Store", appStore: storeAvailability(), app: fixtureApp(isiOSAppOnMac: true)),
+            settings: defaultSettings(strategy: .incremental), environment: environment(),
+            expected: true
+        ),
+        (
+            // …and the split must not have flipped the ordinary case with it.
+            name: "native Mac App Store app is auto-installable on the AX route",
+            result: fixtureResult(source: "App Store", appStore: storeAvailability()),
+            settings: defaultSettings(strategy: .incremental), environment: environment(),
+            expected: true
+        ),
+        (
+            // The developer-opted-out flag guards BOTH routes, so lifting the
+            // iOS-on-Mac exclusion must not let this one through.
+            name: "iOS-on-Mac app Apple marks Mac-incompatible stays out on the AX route",
+            result: fixtureResult(
+                source: "App Store",
+                appStore: storeAvailability(latestMacCompatible: false),
+                app: fixtureApp(isiOSAppOnMac: true)),
+            settings: defaultSettings(strategy: .incremental), environment: environment(),
             expected: false
         ),
         (
@@ -1063,4 +1096,44 @@ struct LaggingRemoteVersionTests {
     #expect(UpdatePolicy.canAutoInstall(
         fixtureResult(source: "Vendor", vendorInstallerKind: .zip, app: app),
         settings: defaultSettings(), environment: environment()))
+}
+
+
+// MARK: - Running detection
+
+/// A wrapped iPhone/iPad app runs out of a per-launch shadow container, so its
+/// process reports a `bundleURL` that can never equal the installed bundle —
+/// measured on macOS 26 (2026-08-29): Aqara Home reported
+/// `/private/var/folders/…/X/<uuid>/d/Wrapper/AqaraHome.app` while installed at
+/// `/Applications/Aqara Home.app`. Path matching therefore answers "not running"
+/// for a live wrapped app, which silently disarms the reopen after the store
+/// quits it (`AppStoreQuitPolicy.armsReopen` keys on exactly this) and hides the
+/// "App Store can't replace it while it's open" note.
+@Test func aWrappedAppIsRecognisedAsRunningByIdentifier() {
+    let app = fixtureApp(isiOSAppOnMac: true)
+    let result = UpdateResult(app: app, remote: nil, status: .unknown)
+
+    // What the host can actually observe for a running wrapped app: the shadow
+    // path (which matches nothing) plus the identifier (which does).
+    let shadow: Set<String> = ["/private/var/folders/x/y/d/Wrapper/Inner.app"]
+    #expect(UpdatePolicy.isRunning(
+        result, environment: environment(running: shadow, runningIDs: ["com.example.fixture"])))
+
+    // Same observation without the identifier set is the pre-fix behaviour, and
+    // it is wrong — kept as a row so the fix cannot be quietly reverted.
+    #expect(!UpdatePolicy.isRunning(result, environment: environment(running: shadow)))
+}
+
+/// Path stays the discriminator for every other app: two copies in different
+/// places are different installs, and only the one being replaced reads as
+/// running. Sharing an identifier must not make the other copy count.
+@Test func aNormalAppIsStillMatchedByPathNotIdentifier() {
+    let result = UpdateResult(app: fixtureApp(), remote: nil, status: .unknown)
+
+    #expect(UpdatePolicy.isRunning(result, environment: environment(running: [fixturePath])))
+    #expect(!UpdatePolicy.isRunning(
+        result,
+        environment: environment(
+            running: ["/Users/someone/Applications/Fixture.app"],
+            runningIDs: ["com.example.fixture"])))
 }


### PR DESCRIPTION
起因是一个问题：mini 上的 App Store 更新为什么不能一键了。答案是"它从来不能"——Nowdex 是包装的 iPad app，`canAutoInstall` 里有一条 0.1.7 加的排除。但那条排除的理由只说对了一半，查下去还带出三个更深的问题。

## 那半句错在哪

0.1.7 的原话是"mas 装不了，而且 AX 路线对它们不可靠"。前半句是真的：Mac 商店里没有这些 app 的条目，`mas install` 必然报 "No apps found for ADAM ID"。后半句没有任何依据——仓库里找不到测试、审计文档或 issue 支撑它。

实测（macOS 26，Nowdex，2026-08-29，只读遍历 App Store 的辅助功能树）：包装 iPad app 的产品页跟原生 Mac app **结构完全一样**——一个 `AppStore.productPage`，一个 `AppStore.shelfItem.ProductLockup…` hero，里面一个标题为 "Update" 的 `AppStore.offerButton`；`heroOwnsPage` 为真、`ownButtonCount` 为 1，正是 `shouldPress` 要求的那一对。真驱动一遍，更新装上了。

"Designed for iPad. Not verified for macOS." 只是 hero 里的一行副标题，不是门槛；开发者明确关掉 macOS 的那种是另一个字段（`isIOSBinaryMacOSCompatible` → `isLatestMacIncompatible`），本 PR 一个字没动，两条路上都照旧拦住。

## 顺带挖出来的三个 bug

**1. 完成检测对包装 bundle 恒假**（`813491c`）
包装 app 的外层 `.app` 里没有 `Contents/`，真正的 bundle 在 `Wrapper/<Inner>.app/`。`AppStoreAXInstaller` 的完成检测硬编码了 `Contents/Info.plist`，于是两个版本字段永远读回 nil，`versionChanged` 恒假。实测时间线：

| 时刻 | 事实 |
|---|---|
| 18:28:17 | 按下 Update（baseline `short=1.0.6 build=?`，`?` 就是读回 nil 的痕迹） |
| 18:28:34 | 磁盘已经是 1.0.7 |
| 18:35:44 | 报 `timed out — 6-min poll cap reached`，红字 "Timed out waiting for the App Store" |

更新 7 分钟前就成功了。守卫在，判据废了——跟 CLAUDE.md 里记的 Word 那次同一个形状。这条独立于本 PR 的其余部分成立。

**2. 运行中的包装 app，我们判"它在运行"恒为假**（`49869c8`）
它跑在每次启动新建的影子容器里：

```
NSRunningApplication.bundleURL = /private/var/folders/…/X/<uuid>/d/Wrapper/AqaraHome.app
installed at                   = /Applications/Aqara Home.app
```

路径永远对不上。而 `AppStoreQuitPolicy.armsReopen` 正是 `route == .appStore && wasRunningBeforeInstall`——商店为了换包把 app 杀掉之后**我们不会把它拉回来**；同一个判据还管那条"App Store 正等你点 Continue"的提示，也不会显示，用户会撞上一个没人知道存在的模态框。改动前不可能发生（这些 app 根本进不了安装路径），是放行带出来的。现在只对包装 app 按 bundleID 认，其它一律仍按路径。

**3. 备份读了两个不存在的文件**（`aaef141`）
放行之后包装 app 第一次会被备份，而 `BackupStore.installedShortVersion` 和 `BackupManifest.sealedEntries` 都假设 `Contents/`。前者让备份列表的版本列空掉；后者读不到 seal，而那段代码把"读不到 seal"**刻意**当成"每个读不了的文件都算 payload"，于是会用一句讲 root-owned `.pkg` 的话拒绝备份——对商店 app 是错的故事。

## 对现有用户的影响

**默认路线（`.full`）上，一键的可用性没有任何变化。** `.full` 现在读 `isHelperEnabled && !isiOSAppOnMac`，跟"先排除再返回 `isHelperEnabled`"真值表相同。增量档仍然不在 Settings 里列出（`visibleCases` 只给 `.full`），只能手工 `defaults write` 打开。

用 141 个和 56 个真实 bundle 做过 A/B：改动前后的 `duo list --json` 输出**逐字节一致**，两台机器都包含真实的包装 bundle。

**有一处默认路线也会变，说清楚**：运行判据修好之后，一个**正在运行的包装 app**，它的行现在会显示绿色运行指示点，以前不会（`isRunning` 恒假）。`isRunning` 的消费方全部在 UI——两处 `RunningIndicator` 和一处 12pt 行宽预留；`defersToSelfUpdater` 也读它，但 App Store 源落到 `default:` 返回 false，不受影响。这个点是**对的**（它确实在运行），属于修好了一个一直在说假话的指示器，但它确实是默认路线上肉眼可见的变化，不是零影响。

## 验证

```
make test → 1490 tests / 124 suites passed（1 known issue）+ CLI 172/172 + 两个 lint 脚本
```

**每条新测试都做了变异验证**——把对应修复倒回去，测试必须变红：

| 变异 | 结果 |
|---|---|
| `case .incremental: return true` → `!isiOSAppOnMac` | RED |
| 完成检测的 plist → `Contents/Info.plist` | RED |
| `isRunning` 去掉 bundleID 分支 | RED |
| `interiorPrefix` 包装时返回 `WrappedBundle/` | RED |

这条标准是有来由的：**上一轮不是这么做的**，结果整套套件在核心改动被倒回的情况下依然全绿，而其中一条测试根本不可能失败（它 `NSDictionary` 重写了一遍读取逻辑，等于在断言"写进 plist 的东西读出来还是那个"）。那一版的两个 commit 已经从历史里摘掉重做，本 PR 是重做后的版本。

## 还没实测的

1. **完成检测的修复没跑过真实的包装 app 安装**——Nowdex 那次更新已经用掉了，单元测试和变异都到位，端到端要等下一个 iOS-on-Mac 更新。
2. **reopen 那条新修的路径同样没跑过真实场景**——需要"包装 app 正在运行时点一键"。
3. **区域锁 + 包装 app 走 Updates list** 纯属推理，手上没有区域锁的包装 app 可测。

## 没写 CHANGELOG

默认路线的用户没有任何可见变化，而 CHANGELOG 会进 GitHub Release 和 appcast 推给全量用户——写一条等于在发布说明里宣传一个还没开放的档。等增量正式放开时一起写。
