### PR TITLE
app-audit: make the "按 OS 分轨" row concrete

### DIFF
--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -384,15 +384,27 @@ recipe had already shipped:
 - **WeChat** (`dldir1.qq.com/weixin/mac/mac-release.xml`): 7 items, 3 of them
   capped (`min12.0/max14.3`, `min14.3/max15.0`, `max10.10.6`). The SAME version is
   bucketed by OS into different artifacts, and one bucket carries no enclosure at
-  all. The recipe reads it with a bare regex — those buckets are invisible to the
-  code, and "本机匹配 item 1，安全" is a human conclusion written in prose, not a
-  judgement anything re-evaluates when the vendor reorders the feed.
+  all. The recipe reads it with a bare regex, so **those buckets are invisible to
+  the code** — that part is durable, and it is the point of this section. (The
+  separate hazard the same audit left open, version and download URL selected
+  independently so a vendor reorder could pair "4.1.13" with a 3.8 artifact, was
+  a real bug and has since been closed with `entryStartPattern`. Which is the
+  lesson twice over: the audit doc reasoned about the ordering in prose and
+  moved on, and prose does not re-evaluate itself when the vendor changes the
+  feed.)
 
 ```bash
 # Look for BOTH bounds. Do not grep only for the one you expect to find.
 curl -sS "<feed>" | grep -iE "minimumSystemVersion|maximumSystemVersion|LSMinimum|depends_on|macos"
-# And read the floor off the real artifact, which never lies:
+# And read the floor off the real artifact, which never lies. Mind the layout:
 /usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "<downloaded>.app/Contents/Info.plist"
+# An iPhone/iPad app running on Apple silicon has NO Contents/ — its plist is
+# under Wrapper/<Inner>.app/ and it states an **iOS** floor in a different key.
+# Reading the wrong path returns "Does Not Exist", which is not "no floor".
+/usr/libexec/PlistBuddy -c 'Print :MinimumOSVersion' \
+  "<downloaded>.app/$(readlink "<downloaded>.app/WrappedBundle")/Info.plist"
+# Never compare that number against a macOS version — different namespaces, and
+# it looks fine only while iOS 26 / macOS 26 happen to line up.
 ```
 
 **Write the numbers into the audit doc, not just a yes/no.** A floor the app has
@@ -402,11 +414,15 @@ recipe. If the feed buckets by OS, say explicitly WHICH bucket the recipe's
 pattern lands on and WHY it cannot drift onto another one — an ordering argument
 is not enough on its own, that is what `entryStartPattern` is for.
 
-**Where the answer already gets honoured, and where it does not:** apps read by
-`SparkleAppcastSource` get both bounds filtered in `usableItems` for free. Apps
-read by `VendorProbeSource` do **not** — even when the endpoint is a Sparkle
-appcast, the recipe reads it with regexes and no bound is consulted. WeChat is
-exactly that case. Do not assume "it's an appcast" means "the bounds are handled".
+**Where the answer gets honoured, and where it does not:** `SparkleAppcastSource`
+filters items on the bounds it parses, inside `usableItems` — **go read which
+bounds it parses today** rather than trusting this line, the same way you would
+for `VendorProbeRecipe`'s field list above. `VendorProbeSource` consults
+**neither** bound, and that half does not drift: even when the endpoint is a
+Sparkle appcast, a recipe reads it with regexes and nothing looks at a
+`min`/`maxSystemVersion` anywhere. WeChat is exactly that case. Do not assume
+"it's an appcast" means "the bounds are handled" — the source that reads it
+decides that, not the format it is written in.
 
 **Delta / binary patch — how to actually check:**
 

--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -370,6 +370,44 @@ both from inferring rather than opening the framework sitting in the bundle. The
 same draft said a field was "absent from `update_reminder`" when that key could
 never have lived there.
 
+**按 OS 分轨 — how to actually check, and what to write down:**
+
+The row above is the one most often answered from memory ("probably not") and
+almost never from the response body. Two real cases, both found only after the
+recipe had already shipped:
+
+- **Little Snitch** (`sw-update.obdev.at/update-feeds/littlesnitch6.plist`): every
+  entry carries `MinimumSystemVersion` **and** `MaximumSystemVersion` — the stable
+  entry reads 14.0/**26.99** while the nightly reads 14.0/**27.99**, i.e. obdev
+  routes a macOS 27 Mac away from stable. Those two keys sat verbatim in the
+  audit's own captured fixture and the audit doc never mentioned them.
+- **WeChat** (`dldir1.qq.com/weixin/mac/mac-release.xml`): 7 items, 3 of them
+  capped (`min12.0/max14.3`, `min14.3/max15.0`, `max10.10.6`). The SAME version is
+  bucketed by OS into different artifacts, and one bucket carries no enclosure at
+  all. The recipe reads it with a bare regex — those buckets are invisible to the
+  code, and "本机匹配 item 1，安全" is a human conclusion written in prose, not a
+  judgement anything re-evaluates when the vendor reorders the feed.
+
+```bash
+# Look for BOTH bounds. Do not grep only for the one you expect to find.
+curl -sS "<feed>" | grep -iE "minimumSystemVersion|maximumSystemVersion|LSMinimum|depends_on|macos"
+# And read the floor off the real artifact, which never lies:
+/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "<downloaded>.app/Contents/Info.plist"
+```
+
+**Write the numbers into the audit doc, not just a yes/no.** A floor the app has
+committed to for a whole generation belongs in `hostRequirement`; per-release
+bounds must be read fresh from the feed every time and never frozen into the
+recipe. If the feed buckets by OS, say explicitly WHICH bucket the recipe's
+pattern lands on and WHY it cannot drift onto another one — an ordering argument
+is not enough on its own, that is what `entryStartPattern` is for.
+
+**Where the answer already gets honoured, and where it does not:** apps read by
+`SparkleAppcastSource` get both bounds filtered in `usableItems` for free. Apps
+read by `VendorProbeSource` do **not** — even when the endpoint is a Sparkle
+appcast, the recipe reads it with regexes and no bound is consulted. WeChat is
+exactly that case. Do not assume "it's an appcast" means "the bounds are handled".
+
 **Delta / binary patch — how to actually check:**
 
 ```bash
@@ -459,7 +497,7 @@ An audit that does not know a field exists will report the situation it covers a
 | `entryStartPattern` | multi-entry feed: slice it so version/URL/date all come from ONE entry |
 | `channel` | this endpoint serves a non-stable track (source refuses cross-channel) |
 | `variant` | one channel legitimately has more than one endpoint worth asking |
-| `hostRequirement` | the build only runs on some Macs (arch / OS floor) — **detection half** |
+| `hostRequirement` | the build only runs on some Macs (arch / OS floor) — **detection half**. A STATIC per-generation floor only; a bound that moves release to release must be read from the feed instead, never frozen here |
 | `identities` (`ProbeIdentity`) | the endpoint only answers for a machine id the app already wrote to disk |
 | `track` (`RolloutTrack`) | one URL, several vendor-assigned tracks, picked by a request-borne value |
 | `requestBody` | the service answers nothing to a GET (Omaha-style) |


### PR DESCRIPTION
The row already existed in the Phase 3⅞ table. It was still being answered from memory rather than from a response body — twice, in recipes that shipped.

- **Little Snitch** — `sw-update.obdev.at/update-feeds/littlesnitch6.plist` carries `MinimumSystemVersion` **and** `MaximumSystemVersion` on every entry: stable caps at **26.99**, nightly at **27.99**, i.e. obdev routes a macOS 27 Mac away from stable. Those two keys sit **verbatim in the audit's own captured test fixture** and its audit doc never mentions them.
- **WeChat** — `dldir1.qq.com/weixin/mac/mac-release.xml` has 7 items, 3 capped (`min12.0/max14.3`, `min14.3/max15.0`, `max10.10.6`). The same version is bucketed by OS into different artifacts and one bucket has **no enclosure at all**. The recipe reads it with a bare regex, so those buckets are invisible to the code; "本机匹配 item 1，安全" is a human conclusion in prose, not something re-evaluated when the vendor reorders the feed.

So the row now says where to look, that **both** bounds matter, and that the numbers go into the audit doc rather than a yes/no.

Plus the distinction that made WeChat's case invisible in the first place: `SparkleAppcastSource` filters both bounds for free; `VendorProbeSource` consults **neither** — even when the endpoint it reads *is* a Sparkle appcast, because it reads it with regexes. "It's an appcast" does not mean the bounds are handled.

Also corrects the reference table: `hostRequirement` is a **static per-generation** floor, and a bound that moves release to release must not be frozen into it.

Docs/skill only — no code, no tests affected. Companion to #145, deliberately kept off that branch so its review surface stays stable.