### PR TITLE
WeChat: tie the version and the download URL to one feed item

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2204,8 +2204,31 @@ public enum VendorProbeRegistry {
         // One-click dmg: the enclosure is on Tencent's own CDN, same channel, signed
         // by the same Team `5A4RE8SF68` (Tencent Mobile International) as the installed
         // app — the VendorInstaller signature gate enforces it. `.bodyPattern` takes
-        // the FIRST `<enclosure>` (newest item, listed first); its `?t=<token>` query
-        // is read fresh from each probe's feed. Structured notes come from a
+        // the FIRST `<enclosure>` in whatever text it is handed; its `?t=<token>`
+        // query is read fresh from each probe's feed.
+        //
+        // `entryStartPattern` is what makes that safe. Without it the two readers
+        // select INDEPENDENTLY over the whole body — the version is the highest
+        // found anywhere (`selectHighest`), the download URL is the first enclosure
+        // found anywhere — and this feed carries 7 items spanning four generations
+        // (4.1.13.11 down to 2.3.31.22, read live 2026-08-30). They coincide only
+        // because Tencent happens to list newest first; a reordering that put the
+        // legacy `WeChatMac_10_15.dmg` item first would report "4.1.13" while
+        // installing a 3.8 build, silently. That is the #76 shape exactly, and an
+        // ordering argument is not a guard. `<item>` occurs 7 times in the body and
+        // never nested, so it slices between releases and not inside one.
+        //
+        // Tencent also buckets ONE version by OS across three of those items
+        // (`min12.0` with no max, `min12.0/max14.3`, and `min14.3/max15.0` which
+        // carries NO enclosure at all and tells the user to visit the website).
+        // Nothing here reads those bounds — `VendorProbeSource` consults neither,
+        // unlike `SparkleAppcastSource`. What keeps this correct is the tie-break in
+        // `highestVersionEntry`: `best` is replaced only on a STRICTLY newer
+        // version, so among the three items that all read "4.1.13" the FIRST wins —
+        // the no-max bucket carrying the universal dmg. If Tencent ever reorders
+        // those three, the enclosure-less bucket could win and one-click would go
+        // quiet: visible in the nightly sweep, and strictly better than the silent
+        // wrong-artifact install the un-sliced version risks. Structured notes come from a
         // ChangelogRecipe over the official per-version updates page; changelogURL is
         // the webview fallback.
         VendorProbeRecipe(
@@ -2216,6 +2239,7 @@ public enum VendorProbeRegistry {
             downloadURL: URL(string: "https://mac.weixin.qq.com/"),
             changelogURL: URL(string: "https://weixin.qq.com/updates?platform=mac"),
             selectHighest: true,
+            entryStartPattern: #"<item>"#,
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(#"<enclosure url="(https://[^"]+\.dmg[^"]*)""#),
                 kind: .dmg)),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2228,7 +2228,22 @@ public enum VendorProbeRegistry {
         // the no-max bucket carrying the universal dmg. If Tencent ever reorders
         // those three, the enclosure-less bucket could win and one-click would go
         // quiet: visible in the nightly sweep, and strictly better than the silent
-        // wrong-artifact install the un-sliced version risks. Structured notes come from a
+        // wrong-artifact install the un-sliced version risks.
+        //
+        // The pattern is `<item[\s>]`, not the literal `<item>` the feed uses
+        // today, because the literal form fails OPEN in the worst way: an
+        // attribute on the tag (`<item id="269579">`) would match zero times,
+        // `highestVersionEntry` would return nil for having fewer than two
+        // entries, and every reader would revert to whole-body first-match —
+        // this bug, back, behind nothing but a `entryPatternNoMatch` warning
+        // nobody reads until the nightly sweep. The character class costs
+        // nothing and cannot match `<items>`.
+        //
+        // One property worth knowing before reading a sweep report: slicing
+        // needs at least TWO matches to mean anything, so if Tencent ever trims
+        // the feed to a single item this recipe still answers correctly (the
+        // whole body IS that item) while reporting `entryPatternNoMatch`. That
+        // warning would be a false alarm, not a regression. Structured notes come from a
         // ChangelogRecipe over the official per-version updates page; changelogURL is
         // the webview fallback.
         VendorProbeRecipe(
@@ -2239,7 +2254,7 @@ public enum VendorProbeRegistry {
             downloadURL: URL(string: "https://mac.weixin.qq.com/"),
             changelogURL: URL(string: "https://weixin.qq.com/updates?platform=mac"),
             selectHighest: true,
-            entryStartPattern: #"<item>"#,
+            entryStartPattern: #"<item[\s>]"#,
             install: VendorInstallSpec(
                 urlSource: .bodyPattern(#"<enclosure url="(https://[^"]+\.dmg[^"]*)""#),
                 kind: .dmg)),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -600,9 +600,16 @@ public struct VendorProbeSource: UpdateSource {
                     // fragment would not parse as XML at all. It is safe on its own
                     // terms regardless of scoping — it re-matches `version` against
                     // the parsed items itself and returns `[]` on anything but
-                    // exactly one match — and today's `entryStartPattern` recipes
-                    // (Android Studio's JSON feed) have no `sparkle:deltas` to find,
-                    // so this never fires for them either way.
+                    // exactly one match.
+                    //
+                    // Do not read the `entryStartPattern` population as "JSON
+                    // feeds that could never parse as an appcast anyway": WeChat's
+                    // is a real Sparkle appcast, sliced at `<item>`, so this line
+                    // now hands a parseable document to a parser that will parse
+                    // it. That is still correct — whole-body is exactly what this
+                    // call wants, and the feed carries no `sparkle:deltas` at all
+                    // (measured 2026-08-30) — but it holds for the reason stated
+                    // above, not because nothing here could parse.
                     deltas: VendorAppcastDeltas.patches(
                         inBody: body.text, forVersion: version))
                 // A recipe that names a checksum pattern but no longer matches one

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatEntryScopingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatEntryScopingTests.swift
@@ -1,0 +1,164 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// WeChat's feed lists 7 releases spanning four generations, and the recipe reads
+/// two different things out of it with two different rules: the version is the
+/// HIGHEST match anywhere (`selectHighest`), the download URL is the FIRST
+/// `<enclosure>` anywhere. Un-sliced, those are independent selections over the
+/// same body — they agree today only because Tencent lists newest first.
+///
+/// `entryStartPattern` ties them to one item. This suite pins that, against the
+/// real response body (`dldir1.qq.com/weixin/mac/mac-release.xml`, captured
+/// 2026-08-30, trimmed to the fields these rules read and with the volatile
+/// `?t=<token>` query stripped so the fixture cannot rot).
+@Suite struct WeChatEntryScopingTests {
+
+    /// The real body. Note item 2 carries `sparkle:shortVersionString` as an
+    /// ATTRIBUTE on the enclosure rather than an element — which is why the
+    /// recipe's pattern accepts both forms, and why a fixture that normalised
+    /// that away would stop testing the pattern that ships.
+    static let feed = #"""
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <title>4.1.13.11</title>
+      <sparkle:shortVersionString>4.1.13.11</sparkle:shortVersionString>
+      <sparkle:version>269579</sparkle:version>
+      <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://dldir1v6.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.13.11_269579.dmg" length="521477708" type="application/octet-stream" sparkle:edSignature="haHkQfkun3E/sbD4kj0tqleyQXa3aojYKDQw8G+GRU/013bVl1oP0JPmQ9Dtt8jGkxpuS7qLUYDogu19nx/oAg=="/>
+    </item>
+    <item>
+      <title>4.1.13.11</title>
+      <sparkle:version>269579</sparkle:version>
+      <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      <sparkle:maximumSystemVersion>14.3</sparkle:maximumSystemVersion>
+      <enclosure url="https://dldir1v6.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.13.11_269579.dmg" sparkle:shortVersionString="4.1.13.11" type="application/octet-stream" sparkle:edSignature="haHkQfkun3E/sbD4kj0tqleyQXa3aojYKDQw8G+GRU/013bVl1oP0JPmQ9Dtt8jGkxpuS7qLUYDogu19nx/oAg=="/>
+    </item>
+    <item>
+      <title>4.1.13.11</title>
+      <sparkle:shortVersionString>4.1.13.11</sparkle:shortVersionString>
+      <sparkle:version>269579</sparkle:version>
+      <sparkle:minimumSystemVersion>14.3</sparkle:minimumSystemVersion>
+      <sparkle:maximumSystemVersion>15.0</sparkle:maximumSystemVersion>
+    </item>
+    <item>
+      <title>3.8.10.17</title>
+      <sparkle:version>28632</sparkle:version>
+      <sparkle:minimumSystemVersion>10.13</sparkle:minimumSystemVersion>
+      <enclosure url="https://dldir1.qq.com/weixin/mac/WeChatMac_10_15.dmg" sparkle:version="28632" sparkle:shortVersionString="3.8.10.17" length="370570664" type="application/octet-stream" sparkle:dsaSignature="MC0CFQDQt42HUBrBXN8fP7AAZsITuIgrWwIUb3nhJLkVqnIn73ZrGNJO9ezN6bQ=" sparkle:edSignature="vnxq+yKHT7wtRZKz5clxP/6fKM5ng7of8dSZwuayHqbVTueREDTRRPtwltKAU1zW4mqVzApy1FmU0toaVtmpAg==" sparkle:md5="f2d068df06390024415b5a402ad34478"/>
+    </item>
+    <item>
+      <title>3.8.2.21</title>
+      <sparkle:version>27317</sparkle:version>
+      <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>
+      <enclosure url="https://dldir1.qq.com/weixin/mac/WeChatMac_382.dmg" sparkle:version="27317" sparkle:shortVersionString="3.8.2.21" length="352516168" type="application/octet-stream" sparkle:dsaSignature="MC0CFBrYEPv5JuSiPHM+57PV17xJSotlAhUA8Fd15e0jfeTJXcIqRC0C/jCgrIE=" sparkle:md5="0cfc2e9306f44de8d40c1d9bfd69ce0a"/>
+    </item>
+    <item>
+      <title>3.4.1.17</title>
+      <sparkle:minimumSystemVersion>10.11</sparkle:minimumSystemVersion>
+      <enclosure url="https://dldir1.qq.com/weixin/mac/WeChatMac_10_11.dmg" sparkle:version="21938" sparkle:shortVersionString="3.4.1.17" length="169643054" type="application/octet-stream" sparkle:dsaSignature="MCwCFBCz91aF8uBSK7AA+yew2Oh5giOuAhQ6bnb0SRsIm+Q4DJYn/NuHVSzVGA==" sparkle:md5="86619de1d7571014a65c4e5f37462d72"/>
+    </item>
+    <item>
+      <title>2.3.31.22</title>
+      <sparkle:maximumSystemVersion>10.10.6</sparkle:maximumSystemVersion>
+      <enclosure url="https://dldir1.qq.com/weixin/mac/WeChatMac_10_10.dmg" sparkle:version="13425" sparkle:shortVersionString="2.3.31.22" length="33457380" type="application/octet-stream" sparkle:dsaSignature="MCwCFEsn/7iLKqYAcVbAKVhMlm8fJnNAAhQK7Bm3Yy6YcZzfmivf/aNR8clpkQ==" sparkle:md5="f1dcdcef40bd9c05a5ac4bd5f8760d84"/>
+    </item>
+  </channel>
+</rss>
+"""#
+
+    private func recipe() throws -> VendorProbeRecipe {
+        try #require(VendorProbeRegistry.recipes.first { $0.bundleID == "com.tencent.xinWeChat" })
+    }
+
+    /// Every item's own enclosure, in document order — derived from the fixture
+    /// rather than hand-listed, so a re-capture cannot leave a stale copy behind.
+    private static func enclosures(in body: String) -> [String] {
+        body.components(separatedBy: "<item>").dropFirst().map { item in
+            guard let r = item.range(of: #"<enclosure url="[^"]+""#, options: .regularExpression)
+            else { return "NONE" }
+            return String(item[r]).replacingOccurrences(of: #"<enclosure url=""#, with: "")
+                .replacingOccurrences(of: "\"", with: "")
+                .components(separatedBy: "/").last ?? "NONE"
+        }
+    }
+
+    /// The premise the whole suite rests on: this really is a multi-generation
+    /// feed whose items disagree about which artifact they name. If Tencent ever
+    /// collapses it to one item, these tests stop testing anything and should be
+    /// re-derived rather than left passing vacuously.
+    @Test func theFixtureReallyIsAMultiGenerationFeed() {
+        let encs = Self.enclosures(in: Self.feed)
+        #expect(encs.count == 7)
+        #expect(encs[0] == "xWeChatMac_universal_4.1.13.11_269579.dmg")
+        #expect(encs[2] == "NONE", "the min14.3/max15.0 bucket ships no enclosure at all")
+        #expect(encs[3] == "WeChatMac_10_15.dmg", "a 3.8-generation artifact lives in the same feed")
+        #expect(Set(encs).count > 1, "items must not all name the same file")
+    }
+
+    @Test func theRecipeSlicesTheFeedIntoItems() throws {
+        #expect(try recipe().entryStartPattern == "<item>")
+        #expect(try recipe().selectHighest)
+    }
+
+    /// Against the real body as Tencent orders it today: version and download URL
+    /// both come from item 1.
+    @Test func versionAndDownloadBothComeFromTheWinningItem() async throws {
+        let server = try RecipeVerificationTests.StubServer(
+            body: Self.feed, contentType: "application/xml")
+        defer { server.stop() }
+        let outcome = await VendorProbeSource().probeDiagnostic(try recipe().with(url: server.url))
+        #expect(outcome.remote?.shortVersion == "4.1.13")
+        #expect(outcome.remote?.downloadURL?.lastPathComponent
+            == "xWeChatMac_universal_4.1.13.11_269579.dmg")
+    }
+
+    /// THE REGRESSION. Same body, items reordered so the 3.8-generation item is
+    /// listed first — the one thing standing between today's correct answer and a
+    /// wrong one, since document order is the vendor's to change and not ours.
+    ///
+    /// Un-sliced, this pairs the highest version found anywhere ("4.1.13") with
+    /// the first enclosure found anywhere (`WeChatMac_10_15.dmg`, a 3.8 build):
+    /// the user is told 4.1.13 and handed a three-generation-old artifact, with
+    /// nothing failing and nothing to notice. Sliced, both readers land in the
+    /// same item and the pairing holds.
+    @Test func aReorderedFeedCannotPairTheNewVersionWithALegacyArtifact() async throws {
+        let items = Self.feed.components(separatedBy: "<item>")
+        let head = items[0]
+        var rest = Array(items.dropFirst())
+        rest.insert(rest.remove(at: 3), at: 0)   // the WeChatMac_10_15.dmg item, first
+        let reordered = head + rest.map { "<item>" + $0 }.joined()
+
+        // Premise: the reorder really did put the legacy artifact first, so the
+        // un-sliced first-match rule would now select it.
+        #expect(Self.enclosures(in: reordered).first == "WeChatMac_10_15.dmg")
+
+        let server = try RecipeVerificationTests.StubServer(
+            body: reordered, contentType: "application/xml")
+        defer { server.stop() }
+        let outcome = await VendorProbeSource().probeDiagnostic(try recipe().with(url: server.url))
+
+        #expect(outcome.remote?.shortVersion == "4.1.13")
+        #expect(outcome.remote?.downloadURL?.lastPathComponent
+            == "xWeChatMac_universal_4.1.13.11_269579.dmg",
+            "the version and the artifact must come from the same item")
+        #expect(outcome.remote?.downloadURL?.lastPathComponent != "WeChatMac_10_15.dmg")
+    }
+
+    /// Three items all read "4.1.13"; only the first of them carries the universal
+    /// dmg (the second names the same file but is capped at macOS 14.3, the third
+    /// ships no enclosure). `highestVersionEntry` replaces its running best only
+    /// on a STRICTLY newer version, so the first of a tie wins — which is the
+    /// bucket we want. Pinned because it is load-bearing and invisible: flip that
+    /// comparison to `>=` and one-click would silently go away for every WeChat
+    /// user, with detection still working.
+    @Test func theFirstOfTheTiedItemsWinsWhichIsTheOneCarryingTheArtifact() async throws {
+        let sliced = try #require(VendorProbeRecipe.highestVersionEntry(
+            in: Self.feed, entryStartPattern: "<item>",
+            versionPattern: try recipe().versionPattern, selectHighest: true))
+        #expect(sliced.contains("xWeChatMac_universal_4.1.13.11_269579.dmg"))
+        #expect(!sliced.contains("maximumSystemVersion"), "the winner is the uncapped bucket")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatEntryScopingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatEntryScopingTests.swift
@@ -75,8 +75,8 @@ import Foundation
 
     /// Every item's own enclosure, in document order — derived from the fixture
     /// rather than hand-listed, so a re-capture cannot leave a stale copy behind.
-    private static func enclosures(in body: String) -> [String] {
-        body.components(separatedBy: "<item>").dropFirst().map { item in
+    private static func enclosures(in body: String, tag: String = "<item>") -> [String] {
+        body.components(separatedBy: tag).dropFirst().map { item in
             guard let r = item.range(of: #"<enclosure url="[^"]+""#, options: .regularExpression)
             else { return "NONE" }
             return String(item[r]).replacingOccurrences(of: #"<enclosure url=""#, with: "")
@@ -99,8 +99,35 @@ import Foundation
     }
 
     @Test func theRecipeSlicesTheFeedIntoItems() throws {
-        #expect(try recipe().entryStartPattern == "<item>")
+        #expect(try recipe().entryStartPattern == #"<item[\s>]"#)
         #expect(try recipe().selectHighest)
+    }
+
+    /// The slicer must survive an attribute on the tag. A literal `<item>`
+    /// pattern fails OPEN in the worst possible way: zero matches means
+    /// `highestVersionEntry` sees fewer than two entries, returns nil, and every
+    /// reader reverts to whole-body first-match — this PR's bug, restored,
+    /// behind nothing but a warning in the nightly sweep.
+    ///
+    /// Same body as the regression above (legacy item first), only with an
+    /// attribute added to every tag, so the assertion is the same pairing.
+    @Test func anAttributeOnTheItemTagDoesNotDisableTheSlicing() async throws {
+        let items = Self.feed.components(separatedBy: "<item>")
+        var rest = Array(items.dropFirst())
+        rest.insert(rest.remove(at: 3), at: 0)
+        let attributed = items[0] + rest.map { #"<item xml:lang="zh">"# + $0 }.joined()
+        #expect(!attributed.contains("<item>"), "premise: no bare tag is left to match")
+        #expect(Self.enclosures(in: attributed, tag: #"<item xml:lang="zh">"#).first
+            == "WeChatMac_10_15.dmg", "premise: the legacy artifact leads")
+
+        let server = try RecipeVerificationTests.StubServer(
+            body: attributed, contentType: "application/xml")
+        defer { server.stop() }
+        let outcome = await VendorProbeSource().probeDiagnostic(try recipe().with(url: server.url))
+
+        #expect(outcome.remote?.shortVersion == "4.1.13")
+        #expect(outcome.remote?.downloadURL?.lastPathComponent
+            == "xWeChatMac_universal_4.1.13.11_269579.dmg")
     }
 
     /// Against the real body as Tencent orders it today: version and download URL


### PR DESCRIPTION
## The bug shape

The recipe reads two things out of one body with two different rules:

| reads | rule | lands on today |
|---|---|---|
| version | `selectHighest` — **highest** match anywhere | item 1 (`4.1.13`) |
| download URL | `.bodyPattern` — **first** `<enclosure>` anywhere | item 1 |

Those are independent selections. The feed has **7 items spanning four generations** (`4.1.13.11` down to `2.3.31.22`, read live 2026-08-30). They agree only because Tencent happens to list newest first — the vendor's call, not ours.

Reorder so the legacy item leads and the probe reports **`4.1.13`** while handing the installer **`WeChatMac_10_15.dmg`**, a 3.8-generation artifact. Nothing fails. That is the #76 shape, and `entryStartPattern` is what it was built for. `<item>` occurs 7 times in the body and never nested, so it slices between releases rather than inside one.

## The OS buckets, and what actually keeps this right

Tencent buckets **one version** by OS across three items: `min12.0` uncapped, `min12.0/max14.3`, and `min14.3/max15.0` which carries **no enclosure at all**. Nothing in `VendorProbeSource` reads either bound — unlike `SparkleAppcastSource`, which filters both.

What keeps the correct bucket winning is the tie-break in `highestVersionEntry`: `best` is replaced only on a **strictly newer** version, so among the three items that all read `4.1.13` the first wins — the uncapped one carrying the universal dmg. Recorded in the recipe comment because it is load-bearing and invisible: flipping that comparison to `>=` would take one-click away from every WeChat user while detection stayed green.

## Test plan

- [x] Red before green: `aReorderedFeedCannotPairTheNewVersionWithALegacyArtifact` fails without the fix, pairing `4.1.13` with `WeChatMac_10_15.dmg`
- [x] Against the **real response body** (captured 2026-08-30, trimmed to the fields these rules read, volatile `?t=<token>` stripped so it cannot rot). Item 2 keeps `sparkle:shortVersionString` as an enclosure **attribute** — the shape the pattern accepts both forms for, so normalising it would have stopped testing what ships
- [x] Every test asserts its own premise first (`theFixtureReallyIsAMultiGenerationFeed`), so a fixture that stopped containing a legacy artifact fails rather than passing vacuously
- [x] `make cli && duo verify --only xinWeChat` — `vendor ✓ 1, changelog ✓ 1`, version `4.1.13`, **no warnings** (an `entryPatternNoMatch` would mean the slicing silently fell back)
- [x] `swift test` (Core) 1527 tests — one unrelated pre-existing failure (`everyShippedLanguageHasANotesFileMatchingEnglishParagraphForParagraph`, fails on `origin/main` too)