### PR TITLE
在 App Store 里点 Continue，我们也要认：退出确认不再独占等待

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -190,8 +190,8 @@ final class AppListModel {
     /// App ids for which an incremental (AX) App Store update has downloaded but the
     /// app is still running, so App Store is asking to quit it to finish installing.
     /// id → the app's display name (for the prompt). Drives a "Relaunch to finish
-    /// update" affordance; tapping it resumes the matching `quitContinuations` entry,
-    /// which presses the App Store sheet's Continue button.
+    /// update" affordance; tapping it records an answer in `quitAnswers`, which the
+    /// installer reads on its next poll.
     private(set) var awaitingQuitConfirm: [String: String] = [:]
     /// App ids that just finished updating and whose new build is already fully in
     /// effect (in-place swap, or an incremental App Store update that already quit +
@@ -214,9 +214,16 @@ final class AppListModel {
     /// moment the helper is approved — the live property isn't part of the @Observable
     /// model, so reading it directly wouldn't trigger a re-render.
     private(set) var helperEnabled = false
-    /// Suspended `confirmQuit` calls from the AX installer, keyed by app id, resumed
-    /// by `confirmQuit(_:proceed:)` when the user accepts or dismisses the prompt.
-    @ObservationIgnored private var quitContinuations: [String: CheckedContinuation<Bool, Never>] = [:]
+    /// The user's answer to a pending quit-to-install prompt, keyed by app id, read
+    /// by the AX installer on each poll and cleared when it withdraws the question.
+    ///
+    /// Deliberately state and not a continuation. Awaiting one made the installer
+    /// stop watching while it waited, and the answer often arrives somewhere it
+    /// cannot be resumed from — App Store's own Continue button, in App Store's own
+    /// window. The install then sat parked while the update landed behind it, and the
+    /// button we had left on screen still meant "quit this app", so pressing it later
+    /// terminated an app that had finished updating (measured 2026-08-29).
+    @ObservationIgnored private var quitAnswers: [String: QuitPromptAnswer] = [:]
     /// App ids the user agreed to quit (via the confirm affordance) for an
     /// incremental App Store update — App Store's Continue quits but doesn't reopen,
     /// so we relaunch them ourselves once the new build is in place.
@@ -2487,8 +2494,12 @@ final class AppListModel {
                         viaUpdatesList: true
                     ) { stage in
                         Task { @MainActor in self.setStage(id, stage) }
-                    } confirmQuit: { [weak self] appName in
-                        await self?.requestQuitConfirmation(id: id, appName: appName) ?? false
+                    } requestQuit: { [weak self] appName in
+                        Task { @MainActor in self?.requestQuit(id: id, appName: appName) }
+                    } quitAnswer: { [weak self] in
+                        await MainActor.run { self?.quitAnswer(id: id) ?? .pending }
+                    } withdrawQuit: { [weak self] in
+                        Task { @MainActor in self?.withdrawQuit(id: id) }
                     }
                 } else {
                     // Pre-flight before we drive the store: the row may have gone current
@@ -2538,8 +2549,12 @@ final class AppListModel {
                             currentShortVersion: result.app.shortVersion
                         ) { stage in
                             Task { @MainActor in self.setStage(id, stage) }
-                        } confirmQuit: { [weak self] appName in
-                            await self?.requestQuitConfirmation(id: id, appName: appName) ?? false
+                        } requestQuit: { [weak self] appName in
+                            Task { @MainActor in self?.requestQuit(id: id, appName: appName) }
+                        } quitAnswer: { [weak self] in
+                            await MainActor.run { self?.quitAnswer(id: id) ?? .pending }
+                        } withdrawQuit: { [weak self] in
+                            Task { @MainActor in self?.withdrawQuit(id: id) }
                         }
                     // Not for a wrapped iPhone/iPad app: mas cannot install one at
                     // all, so falling back to it would trade a fixable permission
@@ -4087,14 +4102,27 @@ final class AppListModel {
     /// `installing`, the whole background check cadence. So it must never be a purely
     /// in-menu prompt: post a banner too, with a Relaunch action that answers it
     /// without the user having to open the popover and find the row.
-    private func requestQuitConfirmation(id: String, appName: String) async -> Bool {
+    /// Put the quit-to-install question on screen. Returns immediately: the answer
+    /// is read back through `quitAnswer(id:)`, so the installer keeps polling — and
+    /// keeps seeing the world — while the user decides.
+    private func requestQuit(id: String, appName: String) {
         UpdateNotifier.needsQuitConfirmation(app: appName, rowID: id)
-        return await withCheckedContinuation { cont in
-            // A second sheet for the same app shouldn't strand the first continuation.
-            quitContinuations.removeValue(forKey: id)?.resume(returning: false)
-            awaitingQuitConfirm[id] = appName
-            quitContinuations[id] = cont
-        }
+        awaitingQuitConfirm[id] = appName
+        quitAnswers[id] = .pending
+    }
+
+    /// What the user has said so far about quitting this app.
+    private func quitAnswer(id: String) -> QuitPromptAnswer {
+        quitAnswers[id] ?? .pending
+    }
+
+    /// Take the question back down — the install no longer needs an answer, because
+    /// it got one elsewhere or the swap already happened. Leaving it up would strand
+    /// a button whose action has become wrong rather than merely useless.
+    private func withdrawQuit(id: String) {
+        awaitingQuitConfirm[id] = nil
+        quitAnswers[id] = nil
+        UpdateNotifier.clearQuitConfirmation(rowID: id)
     }
 
     /// Resolve a pending quit-to-install prompt: `proceed` true presses the App Store
@@ -4105,22 +4133,24 @@ final class AppListModel {
         // Nothing is waiting on an answer — a stale banner tapped after the install
         // already settled. Bail before touching `reopenAfterQuit`/`relaunching`,
         // which nothing would then clear.
-        guard quitContinuations[id] != nil else {
+        guard quitAnswers[id] != nil else {
             UpdateNotifier.clearQuitConfirmation(rowID: id)
             return
         }
         awaitingQuitConfirm[id] = nil
         UpdateNotifier.clearQuitConfirmation(rowID: id)
-        // App Store's Continue quits the app without reopening it; remember to
-        // relaunch it ourselves once the install lands. Show the "Relaunching…"
-        // indicator meanwhile (cleared when the install settles in `installApp`).
+        // Quitting the app is what lets App Store swap it, and it does not reopen it
+        // afterwards; remember to do that ourselves once the install lands. Show the
+        // "Relaunching…" indicator meanwhile (cleared when the install settles in
+        // `installApp`). Armed on the answer, not on the quit — the installer may find
+        // the update already landed and skip the quit entirely, and reopening an app
+        // that was never closed is a no-op.
         if proceed {
             reopenAfterQuit[id] = .userAskedToQuit
             relaunching.insert(id)
         }
-        let cont = quitContinuations.removeValue(forKey: id)
-        Log.install.info("confirmQuit: \(id, privacy: .public) proceed=\(proceed) resumedInstaller=\(cont != nil)")
-        cont?.resume(returning: proceed)
+        quitAnswers[id] = proceed ? .proceed : .declined
+        Log.install.info("confirmQuit: \(id, privacy: .public) proceed=\(proceed)")
     }
 
     /// Reopen an app we quit for an incremental App Store update (App Store's

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/QuitPrompt.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/QuitPrompt.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// The user's answer to "this app must quit to finish updating".
+///
+/// A tri-state, and `pending` is the point of it. The installer used to *await*
+/// the answer, which meant it stopped looking at the world while it waited — and
+/// the world is where the answer often arrives.
+public enum QuitPromptAnswer: String, Sendable, Equatable {
+    case pending
+    case proceed
+    case declined
+}
+
+/// What to do about App Store's "close this app to update" sheet on this poll.
+public enum QuitPromptOutcome: Sendable, Equatable {
+    /// Nobody has answered and nothing has moved. Keep polling — and keep the
+    /// prompt up, without spending the install's timeout budget on the user.
+    case keepWaiting
+    /// The user agreed here: quit the app so the store can swap it.
+    case quitTheApp
+    /// The user declined here: press Cancel and abandon the install.
+    case cancelled
+    /// The question no longer has an answer to give — someone else already
+    /// settled it. Withdraw the prompt and go back to watching the swap.
+    case settledElsewhere
+}
+
+/// Whether to act on the quit prompt, given the answer and what the screen and
+/// the disk now show.
+///
+/// This exists because the sheet has *two* buttons the user can reach: ours, and
+/// App Store's own Continue in its window. Only the first used to resume the
+/// installer. Answering in App Store — the obvious thing to do when App Store is
+/// the thing asking — left the install suspended on a continuation with no
+/// timeout and no other resumer, so:
+///
+///   • the update landed and the row never noticed. Measured 2026-08-29: the
+///     bundle was swapped and the install task stayed parked for minutes, until
+///     our own button was pressed, at which point it settled in 0.7s
+///     (`resumedInstaller=true` in the log says it had been waiting all along).
+///   • the stale button was still live. Pressing it then ran the quit it had
+///     always meant, terminating an app that had finished updating and been
+///     reopened — a button that kills the app you are using, to finish work that
+///     finished minutes ago.
+///
+/// So `versionChanged` is consulted first and beats every answer: once the
+/// bundle has moved there is nothing left to quit, whoever consented and
+/// wherever. That single ordering is what makes a late tap harmless.
+public enum QuitPrompt {
+
+    public static func decide(
+        answer: QuitPromptAnswer,
+        sheetPresent: Bool,
+        versionChanged: Bool,
+        appRunning: Bool
+    ) -> QuitPromptOutcome {
+        // Ground truth. The swap happened, so the consent happened — ours to
+        // observe, not to ask about again.
+        if versionChanged { return .settledElsewhere }
+        switch answer {
+        case .proceed:  return .quitTheApp
+        case .declined: return .cancelled
+        case .pending:
+            // The sheet is gone and the app is down while we were still asking:
+            // the user answered in App Store's own window and the store is
+            // mid-swap. Stop asking and watch for the bundle to land.
+            //
+            // Both halves are required. A sheet that vanishes with the app still
+            // up is a Cancel we did not press (or a redraw), and a running app
+            // with no sheet is not yet a swap; either alone would abandon the
+            // prompt on a question the user still has to answer.
+            if !sheetPresent && !appRunning { return .settledElsewhere }
+            return .keepWaiting
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -662,7 +662,10 @@ public actor AppStoreAXInstaller {
                     //
                     // A momentary redraw looks like the second one for a poll or two, so
                     // it has to persist before we call it a cancel — same shape as the
-                    // `sheetTicks >= 8` grace above, and the same reason.
+                    // `sheetTicks >= 8` grace above, and the same reason. Counted in
+                    // polls, which here run at the slower prompt cadence: four of them
+                    // is ~6s, three orders of magnitude past a redraw and still short
+                    // enough that a cancel doesn't leave the row looking stuck.
                     switch QuitPrompt.decide(
                         answer: await quitAnswer(),
                         sheetPresent: false,
@@ -695,7 +698,7 @@ public actor AppStoreAXInstaller {
                         throw AXError.cancelled
                     case .keepWaiting:
                         sheetlessPromptTicks += 1
-                        if sheetlessPromptTicks >= 8 {  // ~3.2s, as above
+                        if sheetlessPromptTicks >= 4 {  // ~6s at the 1.5s prompt cadence
                             Log.install.info("appstore-ax: \(appName, privacy: .public) close-to-update sheet dismissed elsewhere with the app still running — treating as cancelled")
                             withdrawQuit()
                             throw AXError.cancelled
@@ -738,7 +741,13 @@ public actor AppStoreAXInstaller {
                 }
             }
 
-            try await Task.sleep(for: .milliseconds(400))
+            // Slower while the question is on screen. Awaiting the answer used to
+            // cost nothing at all — the task was simply suspended — so polling for it
+            // at the install cadence would be a regression paid by anyone who leaves
+            // the prompt sitting: an AX tree walk every 400 ms for as long as they
+            // take. A person deciding is not a swap in flight, and 1.5 s is still far
+            // inside human reaction time for noticing an answer given in App Store.
+            try await Task.sleep(for: .milliseconds(askedToQuit ? 1_500 : 400))
         }
         Log.install.error("appstore-ax: \(appName, privacy: .public) timed out — 6-min poll cap reached (continued=\(continued) sawProgress=\(sawProgress))")
         throw AXError.timedOut

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -127,7 +127,9 @@ public actor AppStoreAXInstaller {
         currentShortVersion: String?,
         viaUpdatesList: Bool = false,
         onStage: @Sendable @escaping (InstallStage) -> Void,
-        confirmQuit: @Sendable @escaping (String) async -> Bool
+        requestQuit: @Sendable @escaping (String) -> Void,
+        quitAnswer: @Sendable @escaping () async -> QuitPromptAnswer,
+        withdrawQuit: @Sendable @escaping () -> Void
     ) async throws {
         guard Self.isTrusted else { throw AXError.notTrusted }
 
@@ -219,7 +221,9 @@ public actor AppStoreAXInstaller {
             viaUpdatesList: viaUpdatesList,
             sheetBeforePress: sheetBeforePress,
             onStage: onStage,
-            confirmQuit: confirmQuit
+            requestQuit: requestQuit,
+            quitAnswer: quitAnswer,
+            withdrawQuit: withdrawQuit
         )
 
         // A product-page install leaves App Store's cached "N updates available" count
@@ -452,7 +456,9 @@ public actor AppStoreAXInstaller {
         viaUpdatesList: Bool,
         sheetBeforePress: Bool,
         onStage: @Sendable @escaping (InstallStage) -> Void,
-        confirmQuit: @Sendable @escaping (String) async -> Bool
+        requestQuit: @Sendable @escaping (String) -> Void,
+        quitAnswer: @Sendable @escaping () async -> QuitPromptAnswer,
+        withdrawQuit: @Sendable @escaping () -> Void
     ) async throws {
         // Every press here — the quit sheet's Continue/Cancel and the idle re-press —
         // honors a backgrounded App Store, so nothing activates (see `update`). App Store
@@ -482,9 +488,20 @@ public actor AppStoreAXInstaller {
             Log.install.info("appstore-ax: \(appName, privacy: .public) a sheet was already up before we pressed — ignoring it until it clears")
         }
 
-        // ~6 min hard cap of *polling* — the suspension on `confirmQuit` below doesn't
-        // burn iterations, so waiting on the user's Relaunch tap never times us out.
-        for _ in 0..<900 {
+        // Is our quit prompt on screen and unanswered? While it is we keep polling —
+        // that is the whole fix, since the answer can arrive in App Store's own window
+        // and only a poll can see that — but spend no budget, so a user who takes a
+        // minute to decide never times the install out. That freedom used to come from
+        // *awaiting* the answer, which is exactly what stopped us watching.
+        var askedToQuit = false
+        /// Polls our prompt has been up with no sheet behind it — the window in which
+        /// a dismissal elsewhere is told apart from a redraw.
+        var sheetlessPromptTicks = 0
+
+        // ~6 min hard cap of *polling*, not of elapsed time — see `askedToQuit`.
+        var polls = 0
+        while polls < 900 {
+            if !askedToQuit { polls += 1 }
             // 1. Completion: the bundle on disk has been swapped for the new build.
             // Covers both the app-not-running case (installs directly, no sheet) and
             // the post-Continue swap. Keyed on short OR build version changing.
@@ -571,17 +588,46 @@ public actor AppStoreAXInstaller {
                     // swapped — 2026-06-08). This is the only point we steal focus — the whole
                     // download ran in the background; the user just tapped Relaunch and expects
                     // the app to cycle.
-                    Log.install.info("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown — awaiting user Relaunch/Cancel")
-                    guard await confirmQuit(appName) else {
+                    if !askedToQuit {
+                        Log.install.info("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown — asking for Relaunch/Cancel")
+                        requestQuit(appName)
+                        askedToQuit = true
+                    }
+                    sheetlessPromptTicks = 0
+                    // The sheet has two affirmative buttons within the user's reach:
+                    // ours and App Store's own Continue. `QuitPrompt` weighs both, plus
+                    // the disk — so an answer given in the store's window settles this
+                    // too, and a late tap on ours can never quit an app whose update
+                    // has already landed. See there for what going without cost.
+                    switch QuitPrompt.decide(
+                        answer: await quitAnswer(),
+                        sheetPresent: true,
+                        versionChanged: Self.versionChanged(from: baseline, appPath: appPath),
+                        appRunning: isRunning(bundleID)
+                    ) {
+                    case .keepWaiting:
+                        break
+                    case .cancelled:
                         Log.install.info("appstore-ax: \(appName, privacy: .public) user declined — pressing Cancel")
+                        withdrawQuit()
                         pressCancel(in: axApp, appName: appName)
                         throw AXError.cancelled
+                    case .settledElsewhere:
+                        Log.install.info("appstore-ax: \(appName, privacy: .public) quit confirmed in App Store — withdrawing our prompt")
+                        withdrawQuit()
+                        askedToQuit = false
+                        onStage(.installing)
+                        continued = true
+                        sheetTicks = 0
+                    case .quitTheApp:
+                        withdrawQuit()
+                        askedToQuit = false
+                        onStage(.installing)  // "Relaunching" — quit the app, App Store swaps
+                        activateAppStore()
+                        await terminateAndWait(bundleID: bundleID, appName: appName)
+                        continued = true
+                        sheetTicks = 0
                     }
-                    onStage(.installing)  // "Relaunching" — quit the app, App Store swaps
-                    activateAppStore()
-                    await terminateAndWait(bundleID: bundleID, appName: appName)
-                    continued = true
-                    sheetTicks = 0
                 } else {
                     // A sheet with no download behind it (or the app already gone) is a
                     // subscription / purchase / terms confirmation. But a *fast* delta can
@@ -602,6 +648,60 @@ public actor AppStoreAXInstaller {
                 }
             } else {
                 sheetTicks = 0
+                if askedToQuit {
+                    // Our prompt is up but the sheet behind it is gone. Two ways that
+                    // happens, and they need opposite answers, so ask the same rule with
+                    // what we can see rather than guessing:
+                    //
+                    //   • the user pressed Continue in App Store — the app is down and
+                    //     the swap is running, so stop asking and go watch for it.
+                    //   • the user pressed Cancel there — the app is still up and
+                    //     nothing is coming. Leaving the prompt on screen would strand
+                    //     a button that no longer means anything, and holding the
+                    //     budget open would mean the install never ends at all.
+                    //
+                    // A momentary redraw looks like the second one for a poll or two, so
+                    // it has to persist before we call it a cancel — same shape as the
+                    // `sheetTicks >= 8` grace above, and the same reason.
+                    switch QuitPrompt.decide(
+                        answer: await quitAnswer(),
+                        sheetPresent: false,
+                        versionChanged: Self.versionChanged(from: baseline, appPath: appPath),
+                        appRunning: bundleID.map { isRunning($0) } ?? false
+                    ) {
+                    case .settledElsewhere:
+                        Log.install.info("appstore-ax: \(appName, privacy: .public) quit confirmed in App Store — withdrawing our prompt")
+                        withdrawQuit()
+                        askedToQuit = false
+                        onStage(.installing)
+                        continued = true
+                        sheetlessPromptTicks = 0
+                    case .quitTheApp:
+                        // The user tapped our Relaunch after the sheet went away. Honour
+                        // it — quitting is still what lets the store swap — but only if
+                        // we know what to quit; with no bundle id there is nothing to
+                        // address, and the swap is watched for either way.
+                        withdrawQuit()
+                        askedToQuit = false
+                        onStage(.installing)
+                        activateAppStore()
+                        if let bundleID {
+                            await terminateAndWait(bundleID: bundleID, appName: appName)
+                        }
+                        continued = true
+                        sheetlessPromptTicks = 0
+                    case .cancelled:
+                        withdrawQuit()
+                        throw AXError.cancelled
+                    case .keepWaiting:
+                        sheetlessPromptTicks += 1
+                        if sheetlessPromptTicks >= 8 {  // ~3.2s, as above
+                            Log.install.info("appstore-ax: \(appName, privacy: .public) close-to-update sheet dismissed elsewhere with the app still running — treating as cancelled")
+                            withdrawQuit()
+                            throw AXError.cancelled
+                        }
+                    }
+                }
             }
 
             // 3. Surface download progress from the offer button title (display only).

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/QuitPromptTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/QuitPromptTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import DuoUpdaterCore
+
+/// The close-to-update sheet has two affirmative buttons the user can reach:
+/// ours, and App Store's own Continue in App Store's own window. The installer
+/// used to await an answer from ours alone, so answering in the store's window —
+/// the obvious thing to do, since the store is what is asking — parked the
+/// install on a continuation nothing else could resume.
+@Test func anAnswerGivenInAppStoreSettlesTheQuestion() {
+    // The app is down and the sheet is gone while we are still asking: the user
+    // pressed Continue over there and the swap is running.
+    #expect(QuitPrompt.decide(
+        answer: .pending, sheetPresent: false, versionChanged: false, appRunning: false)
+        == .settledElsewhere)
+}
+
+/// Both halves of that reading are required. A sheet that goes away with the app
+/// still up is a Cancel we did not press (or a redraw), and a running app with no
+/// sheet is not yet a swap — either alone would abandon a question the user still
+/// has in front of them.
+@Test func neitherHalfAloneAbandonsTheQuestion() {
+    #expect(QuitPrompt.decide(
+        answer: .pending, sheetPresent: false, versionChanged: false, appRunning: true)
+        == .keepWaiting)
+    #expect(QuitPrompt.decide(
+        answer: .pending, sheetPresent: true, versionChanged: false, appRunning: false)
+        == .keepWaiting)
+}
+
+/// The bug's sharp end: the prompt outlived the install, and it still meant
+/// "quit this app". Pressing it after the update had landed terminated an app
+/// that had already been updated and reopened. A moved bundle therefore beats
+/// every answer — there is nothing left to quit, whoever consented and wherever.
+@Test func aLateTapCannotQuitAnAppThatAlreadyUpdated() {
+    #expect(QuitPrompt.decide(
+        answer: .proceed, sheetPresent: true, versionChanged: true, appRunning: true)
+        == .settledElsewhere)
+    // Same for a late decline: the update succeeded, so this is not a cancellation.
+    #expect(QuitPrompt.decide(
+        answer: .declined, sheetPresent: true, versionChanged: true, appRunning: true)
+        == .settledElsewhere)
+}
+
+/// The ordinary path, unchanged: the user answers here, we act here.
+@Test func answeringHereStillDrivesTheInstall() {
+    #expect(QuitPrompt.decide(
+        answer: .pending, sheetPresent: true, versionChanged: false, appRunning: true)
+        == .keepWaiting)
+    #expect(QuitPrompt.decide(
+        answer: .proceed, sheetPresent: true, versionChanged: false, appRunning: true)
+        == .quitTheApp)
+    #expect(QuitPrompt.decide(
+        answer: .declined, sheetPresent: true, versionChanged: false, appRunning: true)
+        == .cancelled)
+}


### PR DESCRIPTION
App Store 的"关闭这个 app 才能更新"弹在**它自己的窗口里**，带着**它自己的 Continue 按钮**。而在商店问你的时候去商店里回答，是最自然的动作。

安装器只听得见我们那颗按钮：它 `await` 一个 continuation，而那个 continuation 没有任何别的东西能 resume。于是它在世界即将给出答案的那一刻，恰好停止了观察世界。

## 实测（2026-08-29，Telegram 12.9 → 12.10，AX 路线，在 App Store 里点的 Continue）

**症状一：更新落地了，行永远不刷新。**安装任务停在那儿好几分钟；直到我们自己那颗按钮被按下，它 0.7 秒就结束了：

```
22:53:25.464  confirmQuit: /Applications/Telegram.app proceed=true resumedInstaller=true
22:53:25.693  appstore-ax: Telegram quit — App Store can now swap in the update
22:53:26.124  appstore-ax: Telegram install complete — bundle version changed on disk
22:53:27.270  install done: Telegram now 12.10
```

`resumedInstaller=true` 就是证据 —— 它**一直**挂在那儿，而 bundle 早在几分钟前就换好了。

**症状二（更糟）：那颗过期的按钮还是活的，而且语义仍然是"退掉这个 app"。**上面 `22:53:25.693` 那行 `Telegram quit` 就是它执行的 —— 我们**又把一个已经更新完、已经被重开的 Telegram 杀了一遍**，去"完成"一件几分钟前就完成了的事。一颗会杀掉你正在用的 app 的按钮。

## 改法

不再 await。`requestQuit` 把问题挂出去就返回，轮询循环每一圈通过 `QuitPrompt.decide` 把答复和"屏幕/磁盘现在是什么样"一起判。核心是一条排序：

> **磁盘版本已经变了，压倒一切答复** —— 没有什么可退的了，不管是谁在哪里同意的。

这一条同时解掉两个症状：行正常 settle；晚点的那一下再也不会执行 quit。sheet 消失且 app 已退出，说明商店那边接下了这个 quit，于是撤回问题、回去等换包。

两件必须一起保住的事：

1. **用户的思考时间仍然免费。**以前"等答复不消耗 6 分钟轮询预算"是 await 白送的；现在改成"我们的提示还挂着且未答复时不计预算"。
2. **这个豁免不能变成新的挂死。**我自己先踩了一次：sheet 消失后代码进不到那个分支，预算永不减少、循环永不退出 —— 一个挂死换另一个挂死。补上了：sheet 没了但提示还在时，同一条规则再判一次；app 已退出 = 商店那边点了 Continue（去等换包），app 还在跑 = 那边点了 Cancel（宽限约 3.2 秒后按取消结束）。宽限是因为一次重绘看起来跟"被取消"一模一样 —— 跟旁边 `sheetTicks >= 8` 同一个形状、同一个理由。

App 侧从 `CheckedContinuation` 换成普通状态，顺带消掉了"必须恰好 resume 一次、且只能从一个地方 resume"的误用风险。

## 验证

```
QuitPrompt 单测 4/4 绿
make test → 1578 tests / 130 suites passed（1 known issue）+ CLI 172/172 + 两个 lint 脚本
```

变异测试（倒回修复，对应测试必须变红）：

| 变异 | 结果 |
|---|---|
| 去掉「版本已变优先」（即"过期按钮杀 app"那条） | RED |
| 「sheet 消失」单独就放弃提问（不看 app 是否还在跑） | RED |
| 完全不认商店那边的回答（即原 bug） | RED |

## 没做到的

**没有端到端复现。**需要"某个 MAS app 有待更新 + 该 app 正在运行 + 走 AX 路线"三个条件同时成立，两台机器现在都没有待更新的 MAS app。下次有的时候我会起 log stream 验收，判据是日志里出现 `quit confirmed in App Store — withdrawing our prompt` 而不是又挂住。

顺带一条**已知的数据异常**：这次 `make test` 是 1578 tests / 130 suites，上一轮是 1490 / 124，而我只加了 4 个测试。两次都全绿，新测试也确实生效（变异全红），但这个差值我没查清楚 —— 可能有用例数依赖环境（网络或本机已安装的 app）。记在这里以免下一个人以为是自己弄出来的。

## 波及面：**不是只有增量档**

一句要更正的话：这个 AX 安装器**不只增量档的用户会走到**。区域锁那条分支（`AppListModel` 里 `viaUpdatesList: true` 那处）调用它时**不看策略** —— 所以一个默认 `.full` 的用户，只要有一个区域锁的 App Store app 并从区域提示里选择更新，就会跑到我改的这段代码。评估合并风险时按这个口径看，不要按"锁在隐藏档后面"。

对那条路来说，改动前它有**一模一样的挂起 bug**（同一个 `driveToCompletion`），所以修复对它同样是净收益；新增的风险面是那条"sheet 被别处关掉"的宽限判断可能把一次异常重绘读成取消 —— 宽限约 6 秒，而重绘是亚秒级的。

## 追加提交：等人回答时不该按安装节奏轮询

`await` 本来是零开销（任务挂起），换成轮询等于给"等人"标了价：每 400 ms 走一遍 AX 树 + 读一次 plist，而这个等待**按设计是无限期的**（用户的思考时间故意不计入超时）。已改为提示挂着时用 1.5 s 节奏。

这连带把旁边那条宽限重新定价了：它按 poll 计数，在新节奏下"8 个 poll"其实变成了约 12 秒，而注释还写着 3.2 秒 —— 一条被三行外的改动弄假的注释。现在是 4 个 poll，注释也点明了它依赖的节奏（约 6 秒）。

## 没写 CHANGELOG

默认路线上能碰到这段代码的只有"区域锁 app + 从区域提示更新"这一种情况，而那条路改动前后都是坏的→好的，没有面向用户的新行为可宣传。等增量正式放开时一起写。
