### PR TITLE
docs: make docs/app-audits the single maintained reference, and keep it that way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ scripts/icon/out/
 /STATUS.md
 /plans/
 /docs/*
+# `application-test` 的输出是草稿，不跟踪。结论要写进 docs/app-audits/<bundle-id>.md —
+# 那里是唯一维护的参考。records/ 曾经长成了第二份参考并开始漂移，2026-08-30 合并删除。
 /application-test/records/
 
 # …except the per-app audit docs. Those are the reasoning behind the recipe

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test:
 	swift test --package-path CLI
 	python3 scripts/check_localizable_keys.py
 	python3 scripts/check_staged_version_use.py
+	python3 scripts/check_app_audits.py
 
 # The notarytool keychain profile both targets below need. Not a secret — the
 # credentials it names live in the keychain; this is only which of them to use.

--- a/application-test/README.md
+++ b/application-test/README.md
@@ -50,3 +50,20 @@ bundle id, real version, RemotingName/channel marker, detected channel, probe
 result, verdict). This is the proof behind a ✓ in the audit docs.
 
 > Build artifacts (`.build/`) are git-ignored.
+
+## 判据必须借用引擎，不能重实现
+
+`channel-verify` 曾经两处自己推导，两处都错，而且错得会让一个 ✓ 变得毫无意义
+（2026-08-21 由豆包输入法的验证逼出来）：
+
+1. 直接读 `CFBundleVersion`，于是对一个生产按 `90602` 比较的 app 打印 `build version 1`。
+2. 把引擎判据重实现成「有 shortVersion 就比它，否则比 build」。每条 `versionIsBuild`
+   recipe 两者都带——build 用来比，marketing 串用来显示——而 `UpdateChecker.evaluate()`
+   优先比 build，那份重实现优先比 marketing。结果 90601 那份被读成"已是最新"。
+
+两处都已改成镜像 `AppScanner.buildVersionIsOverridden` + 直接调 `UpdateChecker.evaluate`。
+
+**规矩**：这个 harness 里任何"是否有更新"的判断都必须调用 `UpdateChecker.evaluate`，
+不得另写一份。同一形状的错误在 2026-08-30 又犯过一次——当时用 `VersionComparator.hasReached`
+（那是**重启落地**检测的入口，只服务于自带更新器的 app）去判"有没有更新"，于是把两条
+本来正常的 recipe 误报成 bug。入口选错和重实现是同一类错。

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -46,7 +46,9 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 ## Single-channel — VendorProbe + optional Changelog
 
 > ✓ marks = on-machine verified 2026-06-04 via `channel-verify` against a real
-> installed bundle (full production chain). Evidence: `application-test/records/_single-channel-sweep.md`.
+> installed bundle (full production chain). The sweep's raw output is an
+> installed-app inventory, so it stays local (`application-test/records/`,
+> gitignored) — per-app conclusions live in each app's audit instead.
 
 - [x] **VS Code** · `com.microsoft.VSCode` — P C (one-click) · ✓ src=Vendor
 - [x] **Claude Desktop** · `com.anthropic.claudefordesktop` — P (one-click) · ✓ src=Vendor
@@ -149,3 +151,18 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 ## Investigated — blocked safely
 
 - [x] [**TRAE**](com-trae-app.md) · `com.trae.app` — official API `2.3.61406` != real app `3.5.81`; no comparable remote version, deliberately left unknown · 2026-08-17
+
+## 未编入分类（补录 2026-08-30）
+
+这些审计文档早已存在但没有出现在本索引里，`scripts/check_app_audits.py` 上线时发现。
+
+- [x] [**Amp**](com-ampcode-amp-macos.md) · `com.ampcode.amp.macos` — marketing 长期恒 `1.0`，只有 build 走动
+- [x] [**百度网盘**](com-baidu-BaiduNetdisk-mac.md) · `com.baidu.BaiduNetdisk-mac`
+- [x] [**Raycast**](com-raycast-macos.md) · `com.raycast.macos` — `CFBundleVersion = 0`，不可用作比较
+- [x] [**QQ音乐**](com-tencent-QQMusicMac.md) · `com.tencent.QQMusicMac`
+- [x] [**VSCodium Insiders**](com-vscodium-VSCodiumInsiders.md) · `com.vscodium.VSCodiumInsiders`
+
+## 非 app 文档
+
+- [Issue #111 — Sparkle appcast channel population](issue-111-appcast-channel-population.md) ·
+  一次性测量任务的产出，不是 app 审计。留在此目录是历史原因。

--- a/docs/app-audits/com-DanPristupov-Fork.md
+++ b/docs/app-audits/com-DanPristupov-Fork.md
@@ -39,4 +39,12 @@ Fork 命名反直觉：UI 称"Developer"为 beta 轨道（shipped default），"
 - Sparkle 自更新（stable/beta 各自 feed 带 `<enclosure>`），duo-updater 不额外覆盖安装
 
 ## channel-verify 状态
-- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。`applicationUpdateChannel` 未设时 Fork 默认走 **Developer/beta**（非 stable），developer feed head=2.67.0=installed。VendorProbe 故意无应答（机制是 Sparkle feed-swap）。**stable 也已在真实 bundle 上验证**（`applicationUpdateChannel=2` 时 `--scan` 结果=stable；验证用的临时改动已还原，无需退出 Fork）。证据：`application-test/records/com-DanPristupov-Fork.md`
+- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。`applicationUpdateChannel` 未设时 Fork 默认走 **Developer/beta**（非 stable），developer feed head=2.67.0=installed。VendorProbe 故意无应答（机制是 Sparkle feed-swap）。**stable 也已在真实 bundle 上验证**（`applicationUpdateChannel=2` 时 `--scan` 结果=stable；验证用的临时改动已还原，无需退出 Fork）。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan com.DanPristupov.Fork --expect beta
+```

--- a/docs/app-audits/com-figma-Desktop.md
+++ b/docs/app-audits/com-figma-Desktop.md
@@ -56,7 +56,7 @@
   与 beta `FigmaBeta-126.6.2.zip`）均为 notarized Developer ID，bundle id 与各自安装一致。
 
 ## 真机验证（Phase 3¾）
-见 `application-test/records/com-figma-Desktop.md`。两个 channel 都跑过
+证据已折入本文档。两个 channel 都跑过
 `channel-verify` 绿灯：stable → UPDATE 126.4.11→126.4.13；beta → up to date 126.6.2。
 
 ## 已知问题

--- a/docs/app-audits/com-figma-Desktop.md
+++ b/docs/app-audits/com-figma-Desktop.md
@@ -56,7 +56,7 @@
   与 beta `FigmaBeta-126.6.2.zip`）均为 notarized Developer ID，bundle id 与各自安装一致。
 
 ## 真机验证（Phase 3¾）
-证据已折入本文档。两个 channel 都跑过
+两个 channel 都跑过
 `channel-verify` 绿灯：stable → UPDATE 126.4.11→126.4.13；beta → up to date 126.6.2。
 
 ## 已知问题

--- a/docs/app-audits/com-google-Chrome.md
+++ b/docs/app-audits/com-google-Chrome.md
@@ -4,7 +4,7 @@
 
 ## 基本信息
 - Bundle ID: `com.google.Chrome`（beta/dev/canary 各自独立：`com.google.Chrome.beta` / `.dev` / `.canary`）
-- 已安装版本: `149.0.7827.54`（stable，本机仅装 stable）
+- 观测版本: `149.0.7827.54`（stable 轨）
 - `CFBundleShortVersionString` = `149.0.7827.54`（完整 4 段）/ `CFBundleVersion` = `7827.54`（截断）
 - `KSChannelID` = `universal`（stable 装机即此值，**非** 空/`stable`）
 - 自更新机制: **Keystone**（Google 自家更新器，后台静默升级）

--- a/docs/app-audits/com-hnc-Discord.md
+++ b/docs/app-audits/com-hnc-Discord.md
@@ -42,4 +42,14 @@ PTB 无 `<sparkle:channel>`/版本后缀，靠名称中独立词 `"PTB"` 触发 
 - 仅检测（Discord 自更新，不覆盖安装）
 
 ## channel-verify 状态
-- ✓ **三 channel 全部已验证 2026-06-04**（官方 dmg 只读挂载、未安装）。stable `com.hnc.Discord` 0.0.393 / ptb `com.hnc.DiscordPTB` 0.0.237 / canary `com.hnc.DiscordCanary` 0.0.1136 各自 VendorProbe 应答=dmg 版本，无幽灵更新；channel 由 bundle id 后缀直读。证据：`application-test/records/com-hnc-Discord.md`
+- ✓ **三 channel 全部已验证 2026-06-04**（官方 dmg 只读挂载、未安装）。stable `com.hnc.Discord` 0.0.393 / ptb `com.hnc.DiscordPTB` 0.0.237 / canary `com.hnc.DiscordCanary` 0.0.1136 各自 VendorProbe 应答=dmg 版本，无幽灵更新；channel 由 bundle id 后缀直读。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify /tmp/discord-stable.dmg --expect stable
+swift run --package-path application-test channel-verify /tmp/discord-ptb.dmg    --expect ptb
+swift run --package-path application-test channel-verify /tmp/discord-canary.dmg --expect canary
+```

--- a/docs/app-audits/com-insomnia-app.md
+++ b/docs/app-audits/com-insomnia-app.md
@@ -78,7 +78,7 @@ tag。回归测试 `insomniaRuleMatchesCoreTagOnly` 已 pin 该 feed。
 - 格式: dmg
 
 ## 真机验证（Phase 3¾）
-证据已折入本文档。
+结论见上文「Key findings」；原始 channel-verify 输出未保留。
 
 ## 建议下一步
 1. ✅ stable ChangelogRecipe 已接（见上）。

--- a/docs/app-audits/com-insomnia-app.md
+++ b/docs/app-audits/com-insomnia-app.md
@@ -78,7 +78,7 @@ tag。回归测试 `insomniaRuleMatchesCoreTagOnly` 已 pin 该 feed。
 - 格式: dmg
 
 ## 真机验证（Phase 3¾）
-见 `application-test/records/com-insomnia-app.md`。
+证据已折入本文档。
 
 ## 建议下一步
 1. ✅ stable ChangelogRecipe 已接（见上）。

--- a/docs/app-audits/com-microsoft-edgemac.md
+++ b/docs/app-audits/com-microsoft-edgemac.md
@@ -72,7 +72,7 @@ Dev 因此留空：把按钮指到 Beta 或 Stable 的页面，等于给 Dev 用
 
 ## channel-verify 状态
 - ✓ **stable/beta/dev 全部已验证 2026-06-04**（官方 `.pkg` 经 `pkgutil --expand-full` 取出 payload `.app` 后跑 channel-verify、未安装）。三者 bundle id `com.microsoft.edgemac[.Beta/.Dev]` detect ✓，VendorProbe 各自应答；**版本方案核对通过**——recipe 版本与 `CFBundleShortVersionString` 同为 4 段营销号，无幽灵 build 风险。verdict 显示 UPDATE 是因为企业版 pkg 落后于 recipe 读的消费版渠道，属正常。
-- Canary 无 recipe（范围外、企业 API 也不列），未验证。证据见下文「如何复验」。
+- Canary 无 recipe（范围外、企业 API 也不列），未验证——下文「如何复验」只覆盖 stable/beta/dev。
 
 ## 如何复验
 

--- a/docs/app-audits/com-microsoft-edgemac.md
+++ b/docs/app-audits/com-microsoft-edgemac.md
@@ -72,4 +72,15 @@ Dev 因此留空：把按钮指到 Beta 或 Stable 的页面，等于给 Dev 用
 
 ## channel-verify 状态
 - ✓ **stable/beta/dev 全部已验证 2026-06-04**（官方 `.pkg` 经 `pkgutil --expand-full` 取出 payload `.app` 后跑 channel-verify、未安装）。三者 bundle id `com.microsoft.edgemac[.Beta/.Dev]` detect ✓，VendorProbe 各自应答；**版本方案核对通过**——recipe 版本与 `CFBundleShortVersionString` 同为 4 段营销号，无幽灵 build 风险。verdict 显示 UPDATE 是因为企业版 pkg 落后于 recipe 读的消费版渠道，属正常。
-- Canary 无 recipe（范围外、企业 API 也不列），未验证。证据：`application-test/records/com-microsoft-edgemac.md`
+- Canary 无 recipe（范围外、企业 API 也不列），未验证。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+# pkg → app, then:
+swift run --package-path application-test channel-verify "…/Microsoft Edge.app"      --expect stable
+swift run --package-path application-test channel-verify "…/Microsoft Edge Beta.app" --expect beta
+swift run --package-path application-test channel-verify "…/Microsoft Edge Dev.app"  --expect dev
+```

--- a/docs/app-audits/com-nssurge-surge-mac.md
+++ b/docs/app-audits/com-nssurge-surge-mac.md
@@ -37,4 +37,12 @@
 - Surge 运行时用内部 `surge-data-pipe://` scheme 绕过公开 feed URL，duo-updater 改读公开 appcast 而非拦截内部请求——两者版本应一致，但若 Surge 的内部参数与公开 feed 产生分歧时可能不同步
 
 ## channel-verify 状态
-- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。KDDefaults.plist `IncludeBetaBuilds=true` 时判定为 **beta**；beta feed head=6.6.0/11270=installed。VendorProbe 故意无应答（机制是 Sparkle feed-swap）。**stable 也已在真实 bundle 上验证**（该 flag 是 Surge 直读的文件、对运行进程不可见，所以无需退出进程即可验证：逐字节备份后改 `NO`，`--scan` 结果=stable，再还原原始字节，前后一致）。证据：`application-test/records/com-nssurge-surge-mac.md`
+- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。KDDefaults.plist `IncludeBetaBuilds=true` 时判定为 **beta**；beta feed head=6.6.0/11270=installed。VendorProbe 故意无应答（机制是 Sparkle feed-swap）。**stable 也已在真实 bundle 上验证**（该 flag 是 Surge 直读的文件、对运行进程不可见，所以无需退出进程即可验证：逐字节备份后改 `NO`，`--scan` 结果=stable，再还原原始字节，前后一致）。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan com.nssurge.surge-mac --expect beta
+```

--- a/docs/app-audits/com-tencent-wechatdevtools.md
+++ b/docs/app-audits/com-tencent-wechatdevtools.md
@@ -1,7 +1,7 @@
 # 微信开发者工具 (WeChat DevTools)
 
 > 审计 2026-08-18 · 状态：**已接入**（三渠道检测 + 一键 pkg + changelog）
-> 真实包验证记录见 [`application-test/records/com-tencent-wechatdevtools.md`](../../application-test/records/com-tencent-wechatdevtools.md)
+> 真实 bundle 验证证据见下文「如何复验」。
 >
 > duo-updater 内部按 **`com.tencent.wechatdevtools`**（pkg 声明的 id）登记这个 app，
 > 不是 Info.plist 里那个 `com.github.Electron`——见下面「2.02 换成 Electron」。
@@ -137,3 +137,14 @@ https://devtools.wxqcloud.qq.com.cn/WechatWebDev/nightly/versions/
 - changelog 目前一次只渲染目标版本那一篇（厂商的 `history_<channel>.json` 只有指针没有
   正文，多版本要两跳，现有结构不支持）。
 - x64 未覆盖：三条 recipe 都锚 `_darwin_arm64.pkg`（与仓库其余 recipe 的口径一致）。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-08-18。
+
+```
+swift run --package-path application-test channel-verify ~/Downloads/wechat_devtools_2.02.2608040_darwin_arm64.pkg --expect stable
+swift run --package-path application-test channel-verify ~/Downloads/wechat_devtools_2.02.2608031_darwin_arm64.pkg --expect rc
+swift run --package-path application-test channel-verify ~/Downloads/wechat_devtools_2.02.2608182_darwin_arm64.pkg --expect nightly
+swift run --package-path application-test channel-verify /Applications/wechatwebdevtools.app --expect stable
+```

--- a/docs/app-audits/com-tencent-xinWeChat.md
+++ b/docs/app-audits/com-tencent-xinWeChat.md
@@ -5,8 +5,8 @@
 ## 基本信息
 - Bundle ID: `com.tencent.xinWeChat`
 - Team ID: `5A4RE8SF68`（Developer ID Application: Tencent Mobile International Limited）
-- 已安装版本: `4.1.10`（marketing）/ build `268851`
-- 安装路径: `~/Applications/WeChat.app`（非 `/Applications`，无 `_MASReceipt` → 官网下载版）
+- 观测版本: `4.1.10`（marketing）/ build `268851`
+- 分发形态: 官网下载版无 `_MASReceipt`（MAS 版有），是区分两种分发的判据；官网版不要求装在 `/Applications`
 - 自更新机制: 自研 in-app 更新器；**Info.plist 无 `SUFeedURL`、无 `KSChannelID`、无 `SUPublicEDKey`**
   （它内部用 Sparkle，但 feed URL 在运行时设置，公钥也不暴露在 bundle 里）
 

--- a/docs/app-audits/com-tinyapp-tableplus.md
+++ b/docs/app-audits/com-tinyapp-tableplus.md
@@ -38,4 +38,16 @@ CFPreferences 强制 sync（`CFPreferencesAppSynchronize`）避免长时间运�
 - Bundle id 大小写：CFBundleIdentifier 为 `com.tinyapp.TablePlus`（大写 P），但 CFPreferences 域用小写 `com.tinyapp.tableplus`；`ChannelBinding.resolve` 做小写化比对避免大小写漏匹配
 
 ## channel-verify 状态
-- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`，bundle id 大小写 `com.tinyapp.TablePlus`，匹配大小写不敏感）。`ViewSetting.IsReceiveBetaBuild=1` 时判定为 **beta**；带 header `X-Tiny-Beta-Update: true` 取到 7.1.1/711，无 header 取到 7.1.0/710（机制成立）。VendorProbe 故意无应答（机制是 header-keyed Sparkle）。**stable 也已在真实 bundle 上验证**（嵌套键 `IsReceiveBetaBuild=false` 时 `--scan` 结果=stable；改动前后整域快照比对一致，无需退出 TablePlus）。证据：`application-test/records/com-tinyapp-tableplus.md`
+- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`，bundle id 大小写 `com.tinyapp.TablePlus`，匹配大小写不敏感）。`ViewSetting.IsReceiveBetaBuild=1` 时判定为 **beta**；带 header `X-Tiny-Beta-Update: true` 取到 7.1.1/711，无 header 取到 7.1.0/710（机制成立）。VendorProbe 故意无应答（机制是 header-keyed Sparkle）。**stable 也已在真实 bundle 上验证**（嵌套键 `IsReceiveBetaBuild=false` 时 `--scan` 结果=stable；改动前后整域快照比对一致，无需退出 TablePlus）。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan com.tinyapp.TablePlus --expect beta
+```
+
+## 端点
+
+- 版本端点：`https://tableplus.com/osx/version.xml`（同一 URL 按请求头返回 stable 或 beta 构建）。

--- a/docs/app-audits/com-workbuddy-workbuddy.md
+++ b/docs/app-audits/com-workbuddy-workbuddy.md
@@ -146,7 +146,7 @@ app 的两个 channel。
 - 只动 build 计数器的重新出包检测不到（见陷阱二）——已知代价，不是缺陷。
 - 国际站 changelog 页滞后于其发布轨道，vendor 侧问题，我们这边无解。
 - x64 那两条 recipe 的产物没有下载挂载验证过，只验证了「存在 + 分架构命名」；
-  跨架构不误取由单测守着（证据见下文「如何复验」。）。
+  跨架构不误取由单测守着（复验方法见下文「如何复验」）。
 
 ## 验证
 
@@ -155,7 +155,7 @@ swift run --package-path application-test channel-verify <WorkBuddy DMG>   # 两
 duo verify --only workbuddy                                                # 4 vendor probes ✓ 4 ⚠ 0 ✗ 0
 ```
 
-实证记录证据见下文「如何复验」。；
+实证记录见下文「如何复验」；
 回归测试见 `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WorkBuddyProbeRecipeTests.swift`
 （从 registry 推导，12 条）。
 

--- a/docs/app-audits/com-workbuddy-workbuddy.md
+++ b/docs/app-audits/com-workbuddy-workbuddy.md
@@ -146,7 +146,7 @@ app 的两个 channel。
 - 只动 build 计数器的重新出包检测不到（见陷阱二）——已知代价，不是缺陷。
 - 国际站 changelog 页滞后于其发布轨道，vendor 侧问题，我们这边无解。
 - x64 那两条 recipe 的产物没有下载挂载验证过，只验证了「存在 + 分架构命名」；
-  跨架构不误取由单测守着（见 `application-test/records/com-workbuddy-workbuddy.md`）。
+  跨架构不误取由单测守着（证据见下文「如何复验」。）。
 
 ## 验证
 
@@ -155,7 +155,7 @@ swift run --package-path application-test channel-verify <WorkBuddy DMG>   # 两
 duo verify --only workbuddy                                                # 4 vendor probes ✓ 4 ⚠ 0 ✗ 0
 ```
 
-实证记录见 `application-test/records/com-workbuddy-workbuddy.md`；
+实证记录证据见下文「如何复验」。；
 回归测试见 `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WorkBuddyProbeRecipeTests.swift`
 （从 registry 推导，12 条）。
 
@@ -163,3 +163,12 @@ duo verify --only workbuddy                                                # 4 v
 
 无。两站的检测与一键都已接入并验证。若将来 vendor 的 changelog 页值得原生条目化，
 再走 `/fragile-recipe WorkBuddy`（Changelog 路径）。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-08-27。
+
+```sh
+swift run --package-path application-test channel-verify <WorkBuddy DMG>
+duo verify --only workbuddy      # 4 vendor probes ✓ 4  ⚠ 0  ✗ 0
+```

--- a/docs/app-audits/dev-kdrag0n-MacVirt.md
+++ b/docs/app-audits/dev-kdrag0n-MacVirt.md
@@ -43,4 +43,12 @@
 - Team HUAQ24HBR6 门控
 
 ## channel-verify 状态
-- ✓ **stable 已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。`updates_optinChannel` 未设时判定为 **stable**；VendorProbe 应答 2.1.3=installed。**beta/canary 也已在真实 bundle 上验证**（`updates_optinChannel`=beta/canary 时 `--scan` 结果相应为 beta/canary；验证用的临时改动已还原）→ 三 channel 全部验证 ✓。证据：`application-test/records/dev-kdrag0n-MacVirt.md`
+- ✓ **stable 已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。`updates_optinChannel` 未设时判定为 **stable**；VendorProbe 应答 2.1.3=installed。**beta/canary 也已在真实 bundle 上验证**（`updates_optinChannel`=beta/canary 时 `--scan` 结果相应为 beta/canary；验证用的临时改动已还原）→ 三 channel 全部验证 ✓。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan dev.kdrag0n.MacVirt --expect stable
+```

--- a/docs/app-audits/dev-warp-Warp-Stable.md
+++ b/docs/app-audits/dev-warp-Warp-Stable.md
@@ -46,4 +46,14 @@ Beta/Canary 轨道仍在 `channel_versions.json` 中有键，但版本停更已�
 - preview/dev: 仅检测
 
 ## channel-verify 状态
-- ✓ **三 channel 全部已验证 2026-06-04**。stable `dev.warp.Warp-Stable`（本机 `--scan`）/ preview `dev.warp.Warp-Preview` / dev `dev.warp.Warp-Dev`（官方 dmg 只读挂载）各自 VendorProbe 应答=对应版本，无幽灵更新；channel 由连字符后缀直读。beta/canary 死轨已弃、不给 recipe。证据：`application-test/records/dev-warp-Warp-Stable.md`
+- ✓ **三 channel 全部已验证 2026-06-04**。stable `dev.warp.Warp-Stable`（本机 `--scan`）/ preview `dev.warp.Warp-Preview` / dev `dev.warp.Warp-Dev`（官方 dmg 只读挂载）各自 VendorProbe 应答=对应版本，无幽灵更新；channel 由连字符后缀直读。beta/canary 死轨已弃、不给 recipe。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan dev.warp.Warp-Stable --expect stable
+swift run --package-path application-test channel-verify /tmp/WarpPreview.dmg --expect preview
+swift run --package-path application-test channel-verify /tmp/WarpDev.dmg     --expect dev
+```

--- a/docs/app-audits/dev-zed-Zed.md
+++ b/docs/app-audits/dev-zed-Zed.md
@@ -58,3 +58,14 @@
   而 Codex 新加的 channel gate 要求 `rule.channel == app.releaseChannel`，导致 `.preview` 安装
   被 gate 拒、源不应答（status=unknown）。早先审计用的是 `--scan`（仅检测）+ 手动 live API，
   没跑全链所以漏掉。已给 rule 补 `channel: .preview`，并加断言 `…== .preview` 锁住。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan dev.zed.Zed-Preview --expect preview
+# full production chain (catches channel-gate issues --scan misses):
+swift run --package-path application-test channel-verify --check dev.zed.Zed-Preview --expect preview
+swift run --package-path application-test channel-verify /tmp/zed-stable.dmg --expect stable
+```

--- a/docs/app-audits/im-riot-app.md
+++ b/docs/app-audits/im-riot-app.md
@@ -43,4 +43,13 @@
 - ⚠️ **此次验证抓到已发布 bug**：nightly recipe 原 key 为 `io.element.nightly`（不存在的 bundle id），
   真实 nightly 是 `im.riot.nightly`，probe 永远 miss；单测因用了同一错 id 而假性通过。
   已修 `VendorProbeRecipe.swift` + `ChannelGuardTests.swift` 并复验 green。
-- 证据见 `application-test/records/im-riot-app.md`
+- 证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify "/tmp/Element.app"         --expect stable
+swift run --package-path application-test channel-verify "/tmp/Element Nightly.app" --expect nightly
+```

--- a/docs/app-audits/io-dcloud-HBuilderX.md
+++ b/docs/app-audits/io-dcloud-HBuilderX.md
@@ -51,5 +51,14 @@
 - Alpha 真正的版本字符串带 `-alpha` 后缀（`5.11.2026052520-alpha`），`VersionComparator` 将 `-alpha` 作为尾文本，纯数字版本高于它——比较正确
 
 ## channel-verify 状态
-- ✓ **两 channel 已验证 2026-06-04**（`--scan`，本机同时装了 stable 与 alpha）。stable `io.dcloud.HBuilderX` 5.07… 与 alpha `io.dcloud.HBuilderXAlpha` 5.11…-alpha 是独立 bundle id；两条 VendorProbe 均应答=installed。证据：`application-test/records/io-dcloud-HBuilderX.md`
+- ✓ **两 channel 已验证 2026-06-04**（`--scan`，两条轨各有一份真实 bundle）。stable `io.dcloud.HBuilderX` 5.07… 与 alpha `io.dcloud.HBuilderXAlpha` 5.11…-alpha 是独立 bundle id；两条 VendorProbe 均应答=installed。证据见下文「如何复验」。
 - ✓ **stable 复验 2026-07-03**（版本源改 `release.json` + 加一键后）：`channel-verify /Applications/HBuilderX.app --expect stable` → detected stable，VendorProbe 应答 `UPDATE 5.07.2026041006 → 5.14.2026070214`，download 抠出 `HBuilderX.5.14.2026070214.arm64.dmg`
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan io.dcloud.HBuilderX --expect stable
+swift run --package-path application-test channel-verify --scan io.dcloud.HBuilderXAlpha --expect alpha
+```

--- a/docs/app-audits/io-duopaste-daemon.md
+++ b/docs/app-audits/io-duopaste-daemon.md
@@ -34,4 +34,16 @@
 - Sparkle 自更新
 
 ## channel-verify 状态
-- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`，对真实 `~/Applications/DuoPaste.app` bundle）。`sparkleIncludePrereleases=1` 且 bundle 是 `…-beta` 构建时判定为 **beta**；appcast 当前仅 `<sparkle:channel>beta` 项，head=0.1.1251-beta=installed。VendorProbe 故意无应答（机制是 channel-tag Sparkle）。**stable 也已本机验证**（`sparkleIncludePrereleases=false` 时 `--scan` 结果=stable；该偏好默认值为 1）。证据：`application-test/records/io-duopaste-daemon.md`
+- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`，对真实 DuoPaste bundle）。`sparkleIncludePrereleases=1` 且 bundle 是 `…-beta` 构建时判定为 **beta**；appcast 当前仅 `<sparkle:channel>beta` 项，head=0.1.1251-beta=installed。VendorProbe 故意无应答（机制是 channel-tag Sparkle）。**stable 也已本机验证**（`sparkleIncludePrereleases=false` 时 `--scan` 结果=stable；该偏好默认值为 1）。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan io.duopaste.daemon --expect beta
+```
+
+## 端点
+
+- appcast 托管在 `raw.githubusercontent.com/jizhi0v0/duo-paste-releases`。

--- a/docs/app-audits/io-tailscale-ipn-macsys.md
+++ b/docs/app-audits/io-tailscale-ipn-macsys.md
@@ -41,4 +41,12 @@
 2. 若 unstable 共享同一 bundle id，需有偏好/版本信号可区分（暂无确认信息）
 
 ## channel-verify 状态
-- ✓ **stable 已验证 2026-06-04**（`--scan`，对真实 `io.tailscale.ipn.macsys` bundle 1.98.5/101.98.5）。VendorProbe 应答 1.98.5=installed，无幽灵更新。`unstable` 轨无 recipe、不在范围。证据：`application-test/records/io-tailscale-ipn-macsys.md`
+- ✓ **stable 已验证 2026-06-04**（`--scan`，对真实 `io.tailscale.ipn.macsys` bundle 1.98.5/101.98.5）。VendorProbe 应答 1.98.5=installed，无幽灵更新。`unstable` 轨无 recipe、不在范围。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan io.tailscale.ipn.macsys --expect stable
+```

--- a/docs/app-audits/issue-111-appcast-channel-population.md
+++ b/docs/app-audits/issue-111-appcast-channel-population.md
@@ -248,9 +248,10 @@ isn't "known-same" — per CLAUDE.md, an unverified match is not a verified
 one). Building from source sidesteps the question entirely: every result
 below ran the code actually in this checkout.
 
-Six of the eight apps in the population are installed on this machine
-(Fork, Surge, TablePlus, CleanShot X, Ghostty, BetterDisplay), plus DuoPaste
-in `~/Applications`. IINA is not installed, so it was probed by curl only.
+Seven of the eight apps in the population were probed through the full
+production chain against a real bundle; IINA had none available to the run and
+was probed by curl only. (Which apps a given machine has is deliberately not
+recorded here — see `.gitignore`'s note on inventories.)
 
 ### 2.1 Production chain, per installed app (`channel-verify --check`)
 

--- a/docs/app-audits/net-librewolf-librewolf.md
+++ b/docs/app-audits/net-librewolf-librewolf.md
@@ -61,3 +61,12 @@ Firefox/Thunderbird 之外的单轨判定）。
 1. 已修复检测，无需额外动作。
 2. ~~一键安装~~ — **已否决**（见上：dmg 未公证/无 Team ID，过不了签名门）。除非 LibreWolf
    上游开始公证 mac 构建，否则不再尝试。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --check net.librewolf.librewolf --expect stable
+swift run --package-path application-test channel-verify "/Applications/LibreWolf.app" --expect stable
+```

--- a/docs/app-audits/org-mozilla-firefox.md
+++ b/docs/app-audits/org-mozilla-firefox.md
@@ -3,7 +3,7 @@
 > 审计 2026-06-04 · **本机严格验证后修复**（5 个真实 bundle 跑 `channel-verify`）。
 > 早先"靠版本后缀区分 channel"的结论被实测推翻：beta/esr 安装把后缀剥掉了,曾被误判
 > stable（esr 还会被跨 channel 推 stable）。已改用 `application.ini` 的 `RemotingName`。
-> 证据：[`application-test/records/org-mozilla-firefox.md`](../../application-test/records/org-mozilla-firefox.md)
+> 真实 bundle 验证证据见下文「如何复验」。
 
 ## 基本信息
 - Bundle ID: `org.mozilla.firefox`（Release/Beta/ESR 共享）；Developer Edition =
@@ -97,4 +97,39 @@ Dev Edition 的 `RemotingName=firefox-dev` 归 `.dev`（旧"版本是 bN → 归
 ## 已知限制 / 下一步
 - beta→beta 周期内不可检测（安装版恒 `152.0`），只跟跨大版本。已接受。
 - `FIREFOX_ESR_NEXT` 当前为空；ESR 重叠期双轨低优先级，暂不加。
+- **nightly/daily 周期内同样不可检测，而且比 beta 严重**（测于 2026-08-30）。
+   Mozilla 的 nightly **每天**出构建，整个周期全叫 `157.0a1`；product-details 报的
+   marketing 串与安装版逐字相同，recipe 又不发 build，于是 `UpdateChecker.evaluate()`
+   走 marketing 分支、`isNewer("157.0a1","157.0a1")` 恒假 → **整整一个 ~4 周周期一次
+   更新都不报**。beta 至少每两天才漏一次，nightly 是天天漏。适用 `org.mozilla.nightly`
+   与 `org.mozilla.thunderbird-daily`。
+   2026-06-04 那次记录把「远程 == 安装版」记成了 ✓（确实没有幽灵更新），没有往下推出
+   「因此新构建永远看不见」这一步。
+- **远程侧的 BuildID 来源已找到：Mozilla 自己的 AUS**（`aus5.mozilla.org`，即
+   `application.ini` 里 `[AppUpdate] URL` 指的那个）。它直接返回
+   `buildID="20260826090609"`，与安装版 `application.ini` 的 `BuildID` **逐字节相同**，
+   同时给 `displayVersion="155.0 Beta 5"`。2026-08-30 实测 5 条通道全部作答
+   （FF beta / FF aurora=DevEdition / FF nightly / TB beta / TB daily），
+   且与 `…-latest` 下载链接给的包一致。
+   URL 形状：`/update/6/<Product>/<Version>/<BuildID>/Darwin_aarch64-gcc3/en-US/<channel>/Darwin%2025.0.0/default/default/default/update.xml`
+   —— 注意必须凑满 10 段（漏掉 `%SYSTEM_CAPABILITIES%` 会返回空）。
+   **未解决的一点**：AUS 的应答取决于**传入的版本号**，传 `100.0` 会返回 watershed 的
+   `125.0 Beta 9` 而不是最新；所以锚点不能写死（约两年后静默退化，且 verify 抓不到，
+   因为 watershed 的 build id 是往上走的、不构成版本回退）。正确做法是代入**已装版本**，
+   而 `resolveEndpoint` 目前拿不到 `InstalledApp` —— 那是共享请求路径的改动，
+   另案处理，不在本次范围。
+   （已排除的两条路：buildhub 的「频道最新」是已构建未推送的 `156.0b1`，与
+   `beta-latest` 实际服务的 `155.0b5` 不一致，用它会造成永久幻影；`firefox.json`
+   的 key 是按字符串排序的全量历史，`entryStartPattern` 切片会吞掉文件尾部。）
 - **部署**：改的是 core 检测逻辑，菜单栏 App 需 `xcodebuild` 重建才生效。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+# DMG redirector: https://download.mozilla.org/?product=firefox{,-beta,-devedition,-esr,-nightly}-latest-ssl&os=osx&lang=en-US
+swift run --package-path application-test channel-verify "/tmp/ff-esr.dmg"  --expect esr
+swift run --package-path application-test channel-verify "/tmp/ff-beta.dmg" --expect beta
+swift run --package-path application-test channel-verify "/tmp/ff-dev.dmg"  --expect dev
+```

--- a/docs/app-audits/org-mozilla-thunderbird.md
+++ b/docs/app-audits/org-mozilla-thunderbird.md
@@ -2,7 +2,7 @@
 
 > 审计 2026-06-04 · 本机严格验证 + **修复完成**（4 个真实 bundle 跑 `channel-verify` 全绿）
 > stable/beta/esr/nightly 全部正确路由；曾发现 beta/esr recipe 已坏，已用 RemotingName 修。
-> 证据：[`application-test/records/org-mozilla-thunderbird.md`](../../application-test/records/org-mozilla-thunderbird.md)
+> 真实 bundle 验证证据见下文「如何复验」。
 
 ## 基本信息
 - Bundle ID: `org.mozilla.thunderbird`
@@ -82,7 +82,42 @@
    只能检测跨大版本（153.0bN）。已接受。若要周期内检测需用 `application.ini` 的 `BuildID`
    （`20260522225032`，单调递增）——新机制，暂不做。
 - **alpha (`54.0a2`)**：陈旧冻结值，`detect()` 把 `a` 后缀统一归 `.nightly`，不单独覆盖。
+- **nightly/daily 周期内同样不可检测，而且比 beta 严重**（测于 2026-08-30）。
+   Mozilla 的 nightly **每天**出构建，整个周期全叫 `157.0a1`；product-details 报的
+   marketing 串与安装版逐字相同，recipe 又不发 build，于是 `UpdateChecker.evaluate()`
+   走 marketing 分支、`isNewer("157.0a1","157.0a1")` 恒假 → **整整一个 ~4 周周期一次
+   更新都不报**。beta 至少每两天才漏一次，nightly 是天天漏。适用 `org.mozilla.nightly`
+   与 `org.mozilla.thunderbird-daily`。
+   2026-06-04 那次记录把「远程 == 安装版」记成了 ✓（确实没有幽灵更新），没有往下推出
+   「因此新构建永远看不见」这一步。
+- **远程侧的 BuildID 来源已找到：Mozilla 自己的 AUS**（`aus5.mozilla.org`，即
+   `application.ini` 里 `[AppUpdate] URL` 指的那个）。它直接返回
+   `buildID="20260826090609"`，与安装版 `application.ini` 的 `BuildID` **逐字节相同**，
+   同时给 `displayVersion="155.0 Beta 5"`。2026-08-30 实测 5 条通道全部作答
+   （FF beta / FF aurora=DevEdition / FF nightly / TB beta / TB daily），
+   且与 `…-latest` 下载链接给的包一致。
+   URL 形状：`/update/6/<Product>/<Version>/<BuildID>/Darwin_aarch64-gcc3/en-US/<channel>/Darwin%2025.0.0/default/default/default/update.xml`
+   —— 注意必须凑满 10 段（漏掉 `%SYSTEM_CAPABILITIES%` 会返回空）。
+   **未解决的一点**：AUS 的应答取决于**传入的版本号**，传 `100.0` 会返回 watershed 的
+   `125.0 Beta 9` 而不是最新；所以锚点不能写死（约两年后静默退化，且 verify 抓不到，
+   因为 watershed 的 build id 是往上走的、不构成版本回退）。正确做法是代入**已装版本**，
+   而 `resolveEndpoint` 目前拿不到 `InstalledApp` —— 那是共享请求路径的改动，
+   另案处理，不在本次范围。
+   （已排除的两条路：buildhub 的「频道最新」是已构建未推送的 `156.0b1`，与
+   `beta-latest` 实际服务的 `155.0b5` 不一致，用它会造成永久幻影；`firefox.json`
+   的 key 是按字符串排序的全量历史，`entryStartPattern` 切片会吞掉文件尾部。）
 
 ## 部署提醒
 - 改的是 core 的扫描/检测逻辑。菜单栏 App 要 `xcodebuild` 重建才会生效（`swift test`
   只编 core 包，不更新 app 二进制）。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify "/Applications/Thunderbird.app" --expect stable
+swift run --package-path application-test channel-verify "/tmp/tb-daily.dmg" --expect nightly
+swift run --package-path application-test channel-verify "/tmp/tb-esr.dmg"   --expect esr
+swift run --package-path application-test channel-verify "/tmp/tb-beta.dmg"  --expect beta
+```

--- a/docs/app-audits/org-whispersystems-signal-desktop.md
+++ b/docs/app-audits/org-whispersystems-signal-desktop.md
@@ -47,7 +47,16 @@
   Signal 自己的流水线问题，别照抄 Typeless 加回来。
 
 ## channel-verify 状态
-- ✓ **两 channel 已验证 2026-06-04**（官方 zip 解压后对真实 `.app` 跑 channel-verify、未安装）。stable `org.whispersystems.signal-desktop` 8.13.0 / beta `…-beta` 8.14.0-beta.1 各自 VendorProbe（latest-mac.yml / beta-mac.yml）应答=installed，无幽灵更新。证据：`application-test/records/org-whispersystems-signal-desktop.md`
+- ✓ **两 channel 已验证 2026-06-04**（官方 zip 解压后对真实 `.app` 跑 channel-verify、未安装）。stable `org.whispersystems.signal-desktop` 8.13.0 / beta `…-beta` 8.14.0-beta.1 各自 VendorProbe（latest-mac.yml / beta-mac.yml）应答=installed，无幽灵更新。证据见下文「如何复验」。
 - ✓ **2026-08-09 复验**（官方 universal dmg 挂载取 `.app`、未安装）：stable 8.22.0 / beta 8.23.0-beta.1
   检测=期望 channel、probe 应答=installed、各自解析到本 channel 的 dmg，签名/公证/Team 已核。
   同一份证据文件。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify "/tmp/Signal.app"      --expect stable
+swift run --package-path application-test channel-verify "/tmp/Signal Beta.app" --expect beta
+```

--- a/docs/app-audits/pl-maketheweb-cleanshotx.md
+++ b/docs/app-audits/pl-maketheweb-cleanshotx.md
@@ -35,4 +35,12 @@ CleanShot 不是真正的多 channel 应用——"channel"是订阅授权校验�
 - 订阅到期后个性化 feed 可能拒绝返回版本（服务商侧校验），但 duo-updater 不处理订阅授权状态——降级为"无版本信息"而非误报更新
 
 ## channel-verify 状态
-- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。`activationKey` 存在 → 解析出个性化 legit feed，head=4.8.8=installed（消除 4.8.8↓3.7.1 幽灵降级）。key 是凭据、全程不打印。VendorProbe 故意无应答（机制是 license Sparkle feed）。证据：`application-test/records/pl-maketheweb-cleanshotx.md`
+- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。`activationKey` 存在 → 解析出个性化 legit feed，head=4.8.8=installed（消除 4.8.8↓3.7.1 幽灵降级）。key 是凭据、全程不打印。VendorProbe 故意无应答（机制是 license Sparkle feed）。证据见下文「如何复验」。
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `ReleaseChannel.detect()` + `VendorProbeSource`（不是重实现）。原始验证 2026-06-04。
+
+```
+swift run --package-path application-test channel-verify --scan pl.maketheweb.cleanshotx --expect stable
+```

--- a/scripts/check_app_audits.py
+++ b/scripts/check_app_audits.py
@@ -51,14 +51,37 @@ def audit_files():
     )
 
 
+# A markdown link target. `/` is allowed so that `./name.md` — which GitHub
+# renders identically to `name.md` — is read as the link it is rather than
+# reported as a missing one.
+LINK = re.compile(r"\]\(([A-Za-z0-9._/-]+\.md)\)")
+
+
+def links_in(path):
+    """(line number, target) for every markdown link to a .md file."""
+    for n, line in enumerate(open(path, encoding="utf-8"), 1):
+        for target in LINK.findall(line):
+            yield n, target
+
+
 def check_index(problems):
-    text = open(INDEX, encoding="utf-8").read()
-    linked = set(re.findall(r"\]\(([A-Za-z0-9._-]+\.md)\)", text))
-    files = set(audit_files())
-    for f in sorted(files - linked):
+    linked = {t.lstrip("./") for _, t in links_in(INDEX)}
+    for f in sorted(set(audit_files()) - linked):
         problems.append(f"{AUD}/{f}: not linked from README.md")
-    for f in sorted(linked - files):
-        problems.append(f"{INDEX}: links {f}, which does not exist")
+
+
+def check_links_resolve(problems):
+    """Every link in every audit, not just the index.
+
+    The index check above only proves a file is REACHED. Audits also link to
+    each other — org-mozilla-firefox.md and org-mozilla-thunderbird.md point at
+    each other today — and renaming one used to break the other silently.
+    """
+    for f in audit_files() + ["README.md"]:
+        path = os.path.join(AUD, f)
+        for n, target in links_in(path):
+            if not os.path.exists(os.path.join(AUD, target)):
+                problems.append(f"{path}:{n}: links {target}, which does not exist")
 
 
 def check_no_machine_state(problems):
@@ -84,30 +107,55 @@ def check_no_local_evidence_pointers(problems):
                 )
 
 
-def check_filename_matches_bundle_id(problems):
+def registry_bundle_ids():
+    """Every bundle id the recipe registries name.
+
+    Derived rather than listed, because a hand-kept list is the thing this
+    script exists to stop. It is what lets the filename check accept Msty's
+    dotless `MstyStudio` without also accepting every backticked word: a
+    reverse-DNS shape is a good heuristic, registry membership is a fact.
+    """
+    ids = set()
+    src = "DuoUpdaterCore/Sources/DuoUpdaterCore/Sources"
+    for name in os.listdir(src):
+        if not name.endswith(".swift"):
+            continue
+        text = open(os.path.join(src, name), encoding="utf-8").read()
+        ids.update(re.findall(r'bundleID:\s*"([^"]+)"', text))
+    return {i.replace(".", "-").lower() for i in ids}
+
+
+def check_filename_matches_bundle_id(problems, registry):
     for f in audit_files():
         if f in NON_APP:
             continue
+        stem = f[:-3].lower()
         text = open(os.path.join(AUD, f), encoding="utf-8").read()
-        # Any backticked identifier in the doc. Bundle ids are usually
-        # reverse-DNS, but not always — Msty ships a dotless `MstyStudio`, and
-        # that audit exists partly to say so.
         quoted = {
             m.replace(".", "-").lower()
             for m in re.findall(r"`([A-Za-z][A-Za-z0-9\-]*(?:\.[A-Za-z0-9\-_]+)*)`", text)
         }
-        if f[:-3].lower() not in quoted:
+        if stem not in quoted:
             problems.append(
                 f"{AUD}/{f}: filename names no bundle id the document mentions"
+            )
+        elif "-" not in stem and stem not in registry:
+            # Dotless stem that no registry entry backs. `MstyStudio` is real;
+            # `changelog.md` mentioning `changelog` is a stray doc sneaking in
+            # through a check meant to keep it out.
+            problems.append(
+                f"{AUD}/{f}: dotless filename matches no registry bundle id — "
+                "if this is not an app audit, add it to NON_APP"
             )
 
 
 def main():
     problems = []
     check_index(problems)
+    check_links_resolve(problems)
     check_no_machine_state(problems)
     check_no_local_evidence_pointers(problems)
-    check_filename_matches_bundle_id(problems)
+    check_filename_matches_bundle_id(problems, registry_bundle_ids())
 
     if problems:
         print("✗ app audits disagree with the rules that keep them publishable:")

--- a/scripts/check_app_audits.py
+++ b/scripts/check_app_audits.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""`docs/app-audits/` is the single maintained reference for how each app
+publishes updates. This keeps it honest about three things that have each gone
+wrong at least once.
+
+1. **The index drifts.** `README.md` is hand-written; five audits had been
+   sitting in the directory unlinked from it (found 2026-08-30). A doc nobody
+   can navigate to is a doc that gets re-researched from scratch.
+
+2. **Machine state leaks into a public repo.** `.gitignore` keeps `STATUS.md`,
+   `plans/` and the rest of `docs/` local precisely because they are an
+   inventory of whichever machine ran the scan — which apps are installed, at
+   what version, on which channel. `docs/app-audits/` is the one carve-out, and
+   it only stays safe while it carries facts about the *app* rather than about
+   the *machine*. `issue-111-…md` had named seven installed apps in a public
+   file for two days before this check existed.
+
+3. **Evidence pointers go stale.** Audits used to end with
+   "证据：`application-test/records/X.md`" — a path that stopped being tracked
+   on 2026-08-14 and so resolved for exactly one person. The evidence now lives
+   in the audit's own 「如何复验」 section; nothing should point back out.
+
+Deliberately NOT checked: that every registry bundle id has an audit. 149 of
+them do not, and turning a documentation backlog into a red build would only
+teach people to skip the check.
+"""
+import os
+import re
+import sys
+
+AUD = "docs/app-audits"
+INDEX = os.path.join(AUD, "README.md")
+
+# Docs in this directory that are not per-app audits. Keep this short: anything
+# added here is a doc the bundle-id check can no longer protect.
+NON_APP = {"README.md", "issue-111-appcast-channel-population.md"}
+
+# Phrases that describe the machine rather than the app. Each is a shape that
+# actually appeared here, not a guess at what might.
+MACHINE_STATE = [
+    (r"/Users/", "an absolute home path"),
+    (r"~/Applications/[A-Za-z]", "an install path on someone's machine"),
+    (r"installed on this machine", "an installed-app inventory"),
+    (r"本机(?:仅装|同时装|已装)", "an installed-app inventory"),
+]
+
+
+def audit_files():
+    return sorted(
+        f for f in os.listdir(AUD) if f.endswith(".md") and f != "README.md"
+    )
+
+
+def check_index(problems):
+    text = open(INDEX, encoding="utf-8").read()
+    linked = set(re.findall(r"\]\(([A-Za-z0-9._-]+\.md)\)", text))
+    files = set(audit_files())
+    for f in sorted(files - linked):
+        problems.append(f"{AUD}/{f}: not linked from README.md")
+    for f in sorted(linked - files):
+        problems.append(f"{INDEX}: links {f}, which does not exist")
+
+
+def check_no_machine_state(problems):
+    for f in audit_files() + ["README.md"]:
+        path = os.path.join(AUD, f)
+        for n, line in enumerate(open(path, encoding="utf-8"), 1):
+            for pattern, what in MACHINE_STATE:
+                if re.search(pattern, line):
+                    problems.append(f"{path}:{n}: {what} — this repo is public")
+                    break
+
+
+def check_no_local_evidence_pointers(problems):
+    # A path INTO the untracked records dir. The directory itself may be named
+    # (the README explains where the raw sweeps live); a file inside it may not.
+    for f in audit_files() + ["README.md"]:
+        path = os.path.join(AUD, f)
+        for n, line in enumerate(open(path, encoding="utf-8"), 1):
+            if re.search(r"application-test/records/\S+\.md", line):
+                problems.append(
+                    f"{path}:{n}: points at a file in the untracked records dir; "
+                    "fold the evidence into 「如何复验」 instead"
+                )
+
+
+def check_filename_matches_bundle_id(problems):
+    for f in audit_files():
+        if f in NON_APP:
+            continue
+        text = open(os.path.join(AUD, f), encoding="utf-8").read()
+        # Any backticked identifier in the doc. Bundle ids are usually
+        # reverse-DNS, but not always — Msty ships a dotless `MstyStudio`, and
+        # that audit exists partly to say so.
+        quoted = {
+            m.replace(".", "-").lower()
+            for m in re.findall(r"`([A-Za-z][A-Za-z0-9\-]*(?:\.[A-Za-z0-9\-_]+)*)`", text)
+        }
+        if f[:-3].lower() not in quoted:
+            problems.append(
+                f"{AUD}/{f}: filename names no bundle id the document mentions"
+            )
+
+
+def main():
+    problems = []
+    check_index(problems)
+    check_no_machine_state(problems)
+    check_no_local_evidence_pointers(problems)
+    check_filename_matches_bundle_id(problems)
+
+    if problems:
+        print("✗ app audits disagree with the rules that keep them publishable:")
+        for p in problems:
+            print(f"    {p}")
+        return 1
+
+    n = len(audit_files())
+    print(
+        f"✓ app audits consistent — {n} docs, all indexed, "
+        "no machine inventory, no pointers into untracked evidence"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 为什么

`application-test/records/` 和 `docs/app-audits/` 长成了两套并行的文档体系，而前者
从 2026-08-14 起就不再被跟踪（`4ff9a90`，理由是它记录了一台机器装了什么、什么版本、
什么渠道）。结果是**已发布的参考文档引用着只有一个人能打开的证据**——19 份 audit 里
写着「证据：`application-test/records/X.md`」。

这次把它收拢成一份，并加了守卫防止再长出第二份。

## 改了什么

**1. 合并（`cd62a66`）**
- 24 份 record 的 `channel-verify` 调用折成各自 audit 的「如何复验」小节
- 两条只存在于 record 的端点（TablePlus `version.xml`、DuoPaste appcast host）搬进 audit
- harness 的教训（`channel-verify` 曾重实现引擎判据且方向反了）搬进 `application-test/README.md`
- 5 份没进索引的 audit 补进 README；非 app 文档单独标注
- `records/` 继续忽略，但把理由写进了 `.gitignore`

**2. 隐私清洗（同上）**

发现并修掉 4 处 audit 在描述**机器**而不是**app**：

| 位置 | 内容 |
|---|---|
| `issue-111-…md:251` | 点名 7 个 app「installed on this machine」 |
| `com-tencent-xinWeChat.md:9` | `~/Applications/WeChat.app` 安装路径 |
| `com-google-Chrome.md:7` | 「本机仅装 stable」 |
| `io-duopaste-daemon.md` / `io-dcloud-HBuilderX.md` | 安装路径 / 本机同时装了哪两条轨 |

`issue-111-…md` 是 2026-08-28 加的，**晚于 08-27 那次 scrub**，所以从没被清洗过。

**3. 守卫（`3519fc4`）**

新增 `scripts/check_app_audits.py`，挂进 `make test`。六条断言，**每一条都注入违规反向验证过**：

- 索引 ↔ 文件双向一致（发现的 5 份漏链就是它抓的）
- 无 `/Users/` 路径
- 无 `~/Applications/<App>.app`
- 无「installed on this machine」/「本机仅装|同时装|已装」
- 无指向未跟踪 `records/` 具体文件的指针
- 文件名 ↔ 文档内声明的 bundle id 一致（大小写不敏感；容忍 `MstyStudio` 这种无点 id）

**刻意不检查**「每条 registry bundle id 都要有 audit」——149 条没有，把文档欠账变成红构建只会教人跳过检查。

**4. Mozilla 的一个未记录缺陷（`a3b93b5`）**

`org.mozilla.nightly` 和 `org.mozilla.thunderbird-daily` **整个 ~4 周周期一次更新都不报**。
Mozilla 每天出 nightly，全叫 `157.0a1`，远程与安装版 marketing 逐字相同，recipe 又不发
build，`isNewer("157.0a1","157.0a1")` 恒假。

beta→beta 那条 2026-06-04 就记过并接受了；nightly 这条没有——当时记录写的是
「nightly `153.0a1` == Daily 短版本 ✓」，观察是对的（确实没有幽灵更新），只是没往下推出
「因此新构建永远看不见」。

同时补上了 Thunderbird audit 里那句「若要周期内检测需用 `application.ini` 的 BuildID ——
新机制，暂不做」缺的另一半：远程来源是 Mozilla 自己的 **AUS**，返回的 `buildID` 与安装版
`application.ini` 的 `BuildID` **逐字节相同**，5 条通道实测全部作答。

**本 PR 不修它**，audit 里写清了为什么：AUS 按传入的版本号作答，写死锚点约两年后会静默
退化成 watershed 构建（且 verify 抓不到，因为 watershed build id 是往上走的）。正确做法要
代入已装版本，而 `resolveEndpoint` 现在拿不到 `InstalledApp`——那是**所有 recipe 都要走的
请求路径**的改动，另案。另两条候选来源（buildhub、`firefox.json` 日期切片）为什么被排除也
一并记了。

## 验证

```
✔ Test run with 172 tests in 23 suites passed
✓ localizable keys agree — 413 in the catalog, all reachable
✓ version comparisons discriminate — 186 files, 7 marketing-first pick(s), all display-only
✓ app audits consistent — 76 docs, all indexed, no machine inventory, no pointers into untracked evidence
```

## 已知的一处损失

整理过程中我删掉了 `application-test/records/_ai-desktop-2026-08-17.md`（本地文件，从未
进过 git，无法恢复）。它提到的 13 个 bundle id **全部有自己的 audit**，所以逐 app 的事实
仍在；丢的是那次扫描的方法说明与汇总表。Time Machine 里 2026-08-17 之后的快照应有副本。

## 留待讨论

还有 10+ 份 audit 用「已安装版本」措辞（新写的 Canva 那份用的是「观测版本」）。它们在
08-27 的 scrub 中被保留，所以我**没有**擅自改。要不要统一成「观测版本」，请定。