### PR TITLE
test: assert each app audit's coverage matrix against the real registry

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppAuditCoverageTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppAuditCoverageTests.swift
@@ -46,8 +46,18 @@ struct AppAuditCoverageTests {
     /// which is a shape this test has nothing to say about rather than a failure.
     private static func parseMatrix(_ text: String, file: String) -> Claim? {
         let lines = text.components(separatedBy: .newlines)
-        guard let headerIndex = lines.firstIndex(where: {
-            $0.hasPrefix("|") && $0.contains("VendorProbe")
+        // A table HEADER, not merely a row mentioning VendorProbe: the line after
+        // a header is always the `|---|---|` separator. Without that test,
+        // `issue-111-…md` — which is prose, not an audit — matched on a data row
+        // reading "**VendorProbeRegistry** (`orbStackRecipe(…)`)" and got parsed
+        // as if it were a coverage matrix.
+        func isSeparator(_ line: String) -> Bool {
+            let t = line.trimmingCharacters(in: .whitespaces)
+            return t.hasPrefix("|") && t.allSatisfy { "|-: \t".contains($0) }
+        }
+        guard let headerIndex = lines.indices.first(where: { i in
+            lines[i].hasPrefix("|") && lines[i].contains("VendorProbe")
+                && i + 1 < lines.count && isSeparator(lines[i + 1])
         }) else { return nil }
 
         // Split the raw line, not a trimmed one: the header's first cell is empty
@@ -120,17 +130,20 @@ struct AppAuditCoverageTests {
                 wrong.append("\(claim.file): matrix says 一键, recipe carries no install spec")
             }
             // The mirror of the line above — a recipe that HAS an install spec
-            // whose matrix does not mark 一键 — is deliberately not asserted yet.
-            // 22 audits are in that state (measured 2026-08-30) and most are only
-            // notation: they record the one-click in a `## 一键安装` section
-            // instead of in the table cell. But five are a real contradiction —
-            // Chrome, Discord, Element, Firefox and Thunderbird each say
-            // "仅检测（设计如此）" while carrying an install spec, which reads as
-            // the pre-`oneclick-besteffort` policy ("never touch a self-updater")
-            // left behind in the docs after the code moved to best-effort.
-            // Turning this direction on before those five are reconciled would
-            // just make `make test` red for everyone; it belongs in the same
-            // change that settles them.
+            // whose matrix does not mark 一键 — is deliberately not asserted, and
+            // the reason is granularity, not backlog. One-click is a PER-CHANNEL
+            // fact: Warp wires it for stable and leaves preview/dev detection-only,
+            // and several multi-channel apps are the same. This check reads the
+            // registry at file granularity ("does any recipe for this bundle id
+            // carry an install spec"), so turning the mirror on would force a 一键
+            // mark onto rows that do not have one — making the table less true in
+            // order to make a test pass.
+            //
+            // The five audits that genuinely contradicted the code here — Chrome,
+            // Discord, Element, Firefox, Thunderbird each claiming "仅检测（设计
+            // 如此）" while carrying an install spec — were stale text from before
+            // `vendorInstallPolicy` replaced the old "never touch a self-updater"
+            // rule, and were corrected on 2026-08-30.
         }
         #expect(
             wrong.isEmpty,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppAuditCoverageTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppAuditCoverageTests.swift
@@ -1,0 +1,141 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Every app audit carries a 覆盖矩阵 — a per-channel table saying which of the
+/// five sources answers for that app, and whether it is wired for one-click.
+/// This asserts that table against the registry it describes.
+///
+/// **Why this cannot be a script.** The obvious version greps
+/// `bundleID: "…"` out of `VendorProbeRecipe.swift`, and it is wrong: a good
+/// number of recipes are built by factory functions (`workBuddyRecipe(bundleID:
+/// host:…)`, and others like it) whose call sites a regex looking for
+/// `VendorProbeRecipe(` never sees. Measured 2026-08-30, that shortcut reported
+/// 24 audits as disagreeing with the registry; every one was the parser missing
+/// a factory-built recipe or misreading the table, and zero were real. Asking
+/// `VendorProbeRegistry.recipes` — the compiled array the app itself resolves
+/// against — is the only reading that cannot drift from what ships.
+///
+/// The matrix is parsed rather than the prose because it is the one part of an
+/// audit with a fixed shape. Everything else in these documents is reasoning,
+/// and reasoning is what a human re-reads when they work on that app.
+struct AppAuditCoverageTests {
+
+    private static let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()   // DuoUpdaterCoreTests
+        .deletingLastPathComponent()   // Tests
+        .deletingLastPathComponent()   // DuoUpdaterCore
+        .deletingLastPathComponent()   // repo root
+
+    /// What one audit's matrix claims about the VendorProbe column.
+    private struct Claim {
+        let file: String
+        let bundleKey: String       // filename, which is the bundle id with dots as dashes
+        let hasProbe: Bool
+        let hasOneClick: Bool
+    }
+
+    /// A bundle id in the form the audit filenames use: lowercased, dots to dashes.
+    private static func key(_ bundleID: String) -> String {
+        bundleID.replacingOccurrences(of: ".", with: "-").lowercased()
+    }
+
+    /// Read the VendorProbe column out of an audit's 覆盖矩阵.
+    ///
+    /// Returns nil when the document has no matrix (or no VendorProbe column),
+    /// which is a shape this test has nothing to say about rather than a failure.
+    private static func parseMatrix(_ text: String, file: String) -> Claim? {
+        let lines = text.components(separatedBy: .newlines)
+        guard let headerIndex = lines.firstIndex(where: {
+            $0.hasPrefix("|") && $0.contains("VendorProbe")
+        }) else { return nil }
+
+        // Split the raw line, not a trimmed one: the header's first cell is empty
+        // (it labels the channel column) and trimming would shift every index.
+        let header = lines[headerIndex].components(separatedBy: "|")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        guard let column = header.firstIndex(where: { $0.contains("VendorProbe") })
+        else { return nil }
+
+        var cells: [String] = []
+        for line in lines[(headerIndex + 1)...] {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            guard trimmed.hasPrefix("|") else { break }
+            // The `|---|---|` separator row.
+            if trimmed.allSatisfy({ "|-: \t".contains($0) }) { continue }
+            let row = trimmed.components(separatedBy: "|")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+            guard column < row.count else { continue }
+            cells.append(row[column])
+        }
+        guard !cells.isEmpty else { return nil }
+
+        return Claim(
+            file: file,
+            bundleKey: (file as NSString).deletingPathExtension.lowercased(),
+            hasProbe: cells.contains { $0.contains("✓") },
+            // "✓ 一键" is the established way the matrices mark it; a bare ✓ means
+            // detection only. Both forms appear across the registry today.
+            hasOneClick: cells.contains { $0.contains("✓") && $0.contains("一键") })
+    }
+
+    private static func auditClaims() throws -> [Claim] {
+        let dir = repoRoot.appendingPathComponent("docs/app-audits")
+        let names = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasSuffix(".md") && $0 != "README.md" }
+            .sorted()
+        return try names.compactMap { name in
+            let text = try String(contentsOf: dir.appendingPathComponent(name), encoding: .utf8)
+            return parseMatrix(text, file: name)
+        }
+    }
+
+    /// The audits are the reference; if this stops finding them the test is
+    /// passing vacuously and would never fail again.
+    @Test func theMatricesAreActuallyBeingRead() throws {
+        let claims = try Self.auditClaims()
+        #expect(
+            claims.count > 60,
+            Comment(rawValue: "only \(claims.count) audits parsed — did the matrix format change?"))
+    }
+
+    @Test func vendorProbeColumnMatchesTheRegistry() throws {
+        var probe: [String: Bool] = [:]   // bundle key -> any recipe has an install spec
+        for recipe in VendorProbeRegistry.recipes {
+            let k = Self.key(recipe.bundleID)
+            probe[k] = (probe[k] ?? false) || (recipe.install != nil)
+        }
+
+        var wrong: [String] = []
+        for claim in try Self.auditClaims() {
+            let registered = probe[claim.bundleKey]
+            if claim.hasProbe && registered == nil {
+                wrong.append("\(claim.file): matrix says VendorProbe ✓, registry has no recipe")
+            }
+            if !claim.hasProbe && registered != nil {
+                wrong.append("\(claim.file): registry has a recipe the matrix does not mark ✓")
+            }
+            if let registered, claim.hasProbe, claim.hasOneClick, !registered {
+                wrong.append("\(claim.file): matrix says 一键, recipe carries no install spec")
+            }
+            // The mirror of the line above — a recipe that HAS an install spec
+            // whose matrix does not mark 一键 — is deliberately not asserted yet.
+            // 22 audits are in that state (measured 2026-08-30) and most are only
+            // notation: they record the one-click in a `## 一键安装` section
+            // instead of in the table cell. But five are a real contradiction —
+            // Chrome, Discord, Element, Firefox and Thunderbird each say
+            // "仅检测（设计如此）" while carrying an install spec, which reads as
+            // the pre-`oneclick-besteffort` policy ("never touch a self-updater")
+            // left behind in the docs after the code moved to best-effort.
+            // Turning this direction on before those five are reconciled would
+            // just make `make test` red for everyone; it belongs in the same
+            // change that settles them.
+        }
+        #expect(
+            wrong.isEmpty,
+            Comment(rawValue: "app audits disagree with the registry:\n"
+                + wrong.joined(separator: "\n")))
+    }
+
+}

--- a/docs/app-audits/com-google-Chrome.md
+++ b/docs/app-audits/com-google-Chrome.md
@@ -46,8 +46,12 @@
 - **实测**（2026-06-04）: stable 端点 fraction=1 最高版 = `149.0.7827.54`，与本机安装版**完全一致** → 检测口径正确。
 
 ## 一键安装
-- 状态: **仅检测**（设计如此，不做一键）
-- 原因: 四 channel 全部通过 Keystone 后台自更新，我们绝不覆盖安装。
+- 状态: **已接入**，四 channel 均为 `.fixed` dmg（`dl.google.com/chrome/mac/universal/<channel>/`，
+  Team `EQHXZ8M8AV`）。此前本节记为「仅检测（设计如此）」，是旧策略的残留。
+  「绝不碰自更新器」那条绝对规则已由用户设置 `vendorInstallPolicy` 取代：默认 `.deferWhenRunning` —— app 正在运行就交回它自己的更新器，没在运行才就地替换；选 `.alwaysOverwrite` 才总是由我们装。见 `UpdatePolicy.defersToSelfUpdater`。
+- Keystone 不构成拒绝一键的理由：它管的是磁盘上那个 bundle，换成更新的构建不会让它困惑。
+- **不会跑到 Keystone 前面**：版本只取 `fraction=1`（完全放量）的构建。裸 `versions` 端点
+  会返回仅 0.5% 放量的版本，那会显示一个 Chrome 自己都说「已是最新」的幽灵更新。
 - `downloadURL` = `chrome://settings/help`（app-scheme URL，UI 交给 Chrome 本体而非浏览器）：访问该页会让 Chrome 立即触发一次 Keystone 检查 + 下载，即它本channel 的真实更新路径。
 
 ## Changelog

--- a/docs/app-audits/com-hnc-Discord.md
+++ b/docs/app-audits/com-hnc-Discord.md
@@ -39,7 +39,12 @@ PTB 无 `<sparkle:channel>`/版本后缀，靠名称中独立词 `"PTB"` 触发 
 - 无 ChangelogRecipe
 
 ## 一键安装
-- 仅检测（Discord 自更新，不覆盖安装）
+- 状态: **已接入**（三 channel）。此前记为「仅检测」，是旧策略的残留。
+  「绝不碰自更新器」那条绝对规则已由用户设置 `vendorInstallPolicy` 取代：默认 `.deferWhenRunning` —— app 正在运行就交回它自己的更新器，没在运行才就地替换；选 `.alwaysOverwrite` 才总是由我们装。见 `UpdatePolicy.defersToSelfUpdater`。
+- Squirrel/Electron 应用另有一层保护：`SelfUpdaterStaging` 读
+  `~/Library/Caches/<bundleID>.ShipIt/`，若 app 自己已把新版下载解包、只等重启交换，
+  `UpdatePolicy.canAutoInstall` 返回 false 让位给 Relaunch —— 既不重复下载，也不会撞上
+  待执行的 ShipIt 交换。这一层由扫描时是否存在 `Contents/Frameworks/Squirrel.framework` 决定。
 
 ## channel-verify 状态
 - ✓ **三 channel 全部已验证 2026-06-04**（官方 dmg 只读挂载、未安装）。stable `com.hnc.Discord` 0.0.393 / ptb `com.hnc.DiscordPTB` 0.0.237 / canary `com.hnc.DiscordCanary` 0.0.1136 各自 VendorProbe 应答=dmg 版本，无幽灵更新；channel 由 bundle id 后缀直读。证据见下文「如何复验」。

--- a/docs/app-audits/im-riot-app.md
+++ b/docs/app-audits/im-riot-app.md
@@ -36,7 +36,10 @@
 - 无 ChangelogRecipe
 
 ## 一键安装
-- 仅检测
+- 状态: **已接入**。此前记为「仅检测」，是旧策略的残留。
+  「绝不碰自更新器」那条绝对规则已由用户设置 `vendorInstallPolicy` 取代：默认 `.deferWhenRunning` —— app 正在运行就交回它自己的更新器，没在运行才就地替换；选 `.alwaysOverwrite` 才总是由我们装。见 `UpdatePolicy.defersToSelfUpdater`。
+- 若该 bundle 带 `Contents/Frameworks/Squirrel.framework`（扫描时判定），还会额外受
+  `SelfUpdaterStaging` 保护：app 自己已staged 的更新会让一键让位给 Relaunch。
 
 ## channel-verify 状态
 - ✓ **已验证 2026-06-04**（两 channel 官方 zip，解压后对真实 `.app` 跑 `channel-verify`，未安装）

--- a/docs/app-audits/org-mozilla-firefox.md
+++ b/docs/app-audits/org-mozilla-firefox.md
@@ -85,9 +85,14 @@ Dev Edition 的 `RemotingName=firefox-dev` 归 `.dev`（旧"版本是 bN → 归
   官网 notes 页直接 WebView 展示即可。
 
 ## 一键安装
-- 状态: **仅检测**（设计如此）。
-- 理由: Firefox 自带强力更新器，按仓库 install-safety 原则不强插一键，交给 app 自更新。
-- `downloadURL` 仅作"去官网下载"的跳转兜底，非自动安装。
+- 状态: **已接入**，stable / beta / esr 三条 recipe 都带 `install: VendorInstallSpec`
+  （`download.mozilla.org/?product=firefox{,-beta,-esr}-latest` 302 → dmg，Team `43AQ936H96`）。
+  此前本节记为「仅检测（设计如此）」，是旧策略的残留。
+  「绝不碰自更新器」那条绝对规则已由用户设置 `vendorInstallPolicy` 取代：默认 `.deferWhenRunning` —— app 正在运行就交回它自己的更新器，没在运行才就地替换；选 `.alwaysOverwrite` 才总是由我们装。见 `UpdatePolicy.defersToSelfUpdater`。
+- ⚠️ **Mozilla 的更新器既不是 Squirrel 也不是 Sparkle**，所以 `SelfUpdaterStaging` 那层
+  「它已经下好了就让位」的保护**不覆盖 Firefox**（判据是 `Squirrel.framework` 是否存在）。
+  这里唯一的闸就是 `vendorInstallPolicy`。
+- `downloadURL` 是"去官网下载"的展示链接，不是安装产物；产物由 `install` 的重定向解析。
 
 ## 已修（2026-06-04）
 - detect() 加 `RemotingName` 信号（修 beta 漏检 + esr 跨 channel 误推 stable）。

--- a/docs/app-audits/org-mozilla-thunderbird.md
+++ b/docs/app-audits/org-mozilla-thunderbird.md
@@ -61,9 +61,12 @@
 - Recipe 状态: 不需要（WebView 兜底足够；如要内联结构化条目可后补）
 
 ## 一键安装
-- 状态: **仅检测**。Thunderbird 自带 Mozilla 更新器，按本仓"Sparkle/自更新永不强杀"
-  原则，不做一键替换。三条 recipe 均无 `downloadURL` 安装链（`downloadURL` 仅作为
-  "打开官网"的展示链接）。
+- 状态: **已接入**，best-effort 就地 dmg 替换，叠在 Thunderbird 自己的更新器之上
+  （Team `43AQ936H96`）。此前本节记为「仅检测」、并称「三条 recipe 均无安装链」——
+  两句都已不成立，recipe 带 `install: VendorInstallSpec`。
+  「绝不碰自更新器」那条绝对规则已由用户设置 `vendorInstallPolicy` 取代：默认 `.deferWhenRunning` —— app 正在运行就交回它自己的更新器，没在运行才就地替换；选 `.alwaysOverwrite` 才总是由我们装。见 `UpdatePolicy.defersToSelfUpdater`。
+- ⚠️ 与 Firefox 同理：Mozilla 更新器不是 Squirrel/Sparkle，`SelfUpdaterStaging` 不覆盖它，
+  唯一的闸是 `vendorInstallPolicy`。
 - 格式: dmg（官网直发）
 - 阻塞: 无需求——自更新器接管。
 


### PR DESCRIPTION
接着 #151。那个 PR 让 audit 保持**可导航、可发布**，但没法说它们**是不是真的**。
覆盖矩阵是对代码的断言——哪条源答、有没有一键——而此前没有任何东西核对过它。

## 为什么必须是 Swift 测试

显而易见的写法是正则啃 `VendorProbeRecipe.swift` 里的 `bundleID: "…"`，**是错的**：
相当一部分 recipe 由工厂函数构造，正则找 `VendorProbeRecipe(` 根本看不见它们：

```swift
workBuddyRecipe(
    bundleID: "com.workbuddy.workbuddy", host: "www.workbuddy.cn", ...
```

我先用正则量了两轮，分别报出 36 份和 24 份"不符"——**全是解析器 bug 或工厂函数漏读，真实的零条**。
只有问编译后的 `VendorProbeRegistry.recipes`（app 自己解析时用的那个数组）才不会漂。

## 现状

```
75 份矩阵解析成功，38 份声称有 VendorProbe，registry 里恰好这 38 个有 recipe
```

反向验证：抹掉一份矩阵的 `✓ 一键` 单元格 → 测试红，并指名文件。

另外加了 `theMatricesAreActuallyBeingRead`（断言解析数 > 60），防的是"因为什么都没找到所以恒绿"——
夹具驱动的检查最常见的死法。

## 顺带查出 5 条真矛盾（本 PR 不改）

矩阵有一键、正文却写「仅检测」的方向**故意没断言**，因为今天有 22 份处于这个状态，
其中 17 份只是记号问题（一键记在 `## 一键安装` 小节而非表格单元格）。但**这 5 份是真矛盾**：

| audit | 正文写的 | registry 实际 |
|---|---|---|
| `com-google-Chrome.md` | 仅检测（设计如此，不做一键） | 有 install spec |
| `com-hnc-Discord.md` | 仅检测（Discord 自更新，不覆盖安装） | 有 install spec |
| `im-riot-app.md` | 仅检测 | 有 install spec |
| `org-mozilla-firefox.md` | 仅检测（设计如此） | stable/beta/esr **三条**都有 |
| `org-mozilla-thunderbird.md` | 仅检测。按本仓「Sparkle/自更新永不强杀」 | 有 install spec |

五个全是**自带更新器**的 app。看起来是一键策略从「绝不碰自更新器」改成
「best-effort + Team 闸」之后，这几份 audit 停在了旧策略上。

**是文档过期还是这些 install spec 不该在**，是策略问题不是我能替你定的，所以本 PR 只把它记进
测试注释，没动任何文档或 recipe。定下来之后，那一版改动应当同时打开这个方向的断言。

## 验证

```
DuoUpdaterCore: Test run with 1580 tests in 131 suites passed（含新 suite）
make test: 全绿
```