### PR TITLE
fix(verify): drop baseline rows for recipes that no longer exist

### DIFF
--- a/CLI/Sources/DuoKit/Baseline.swift
+++ b/CLI/Sources/DuoKit/Baseline.swift
@@ -321,6 +321,49 @@ public struct Baseline: Codable, Sendable {
 
     /// Whether this recipe has been actionable often enough to be worth
     /// reporting.
+    /// Drop rows whose recipe no longer exists in any registry.
+    ///
+    /// The file only ever grew: `reconcile` writes `entries[finding.recipeID]`
+    /// and nothing removes. A recipe that is deleted, renamed, or re-keyed
+    /// therefore leaves its last state behind forever, and that state reads as a
+    /// live signal — `changelog:com.TablePro:-` sat at `consecutiveActionable: 1`
+    /// for nine days after its recipe was deliberately removed, looking exactly
+    /// like an unattended finding. Re-keying is the common case, not deletion:
+    /// Claude Desktop's recipe split into `:ga` + `:rollout`, Zed's changelog
+    /// recipes gained a `channel:`, and three GitHub slugs were repointed at
+    /// renamed repos — seven stale rows on 2026-08-30, none of them a real
+    /// problem and all of them looking like one.
+    ///
+    /// Two guards, both load-bearing:
+    ///
+    /// - **An empty `live` prunes nothing.** The caller builds that set from the
+    ///   registries; if it ever hands over an empty one, the bug must not be a
+    ///   wiped baseline.
+    /// - **A row with an OPEN issue stays**, even when orphaned. The issue number
+    ///   is the only handle reconciliation has, and issues close on a clean
+    ///   verify — which a removed recipe never produces again. Dropping the row
+    ///   would strand an issue nothing can close. Kept rows are returned to the
+    ///   caller separately so a human can see them.
+    ///
+    /// Returns the ids removed, and the orphaned ids kept for an open issue.
+    @discardableResult
+    public mutating func prune(
+        keeping live: Set<String>
+    ) -> (removed: [String], keptWithOpenIssue: [String]) {
+        guard !live.isEmpty else { return ([], []) }
+        var removed: [String] = []
+        var kept: [String] = []
+        for (id, entry) in entries where !live.contains(id) {
+            if entry.issueNumber != nil, entry.closedAt == nil {
+                kept.append(id)
+            } else {
+                entries.removeValue(forKey: id)
+                removed.append(id)
+            }
+        }
+        return (removed.sorted(), kept.sorted())
+    }
+
     public func isReportable(_ recipeID: String) -> Bool {
         (entries[recipeID]?.consecutiveActionable ?? 0) >= Self.actionableThreshold
     }

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -136,6 +136,22 @@ public enum Verify {
         }
         baseline.updatedAt = Date()
 
+        // Drop rows for recipes that no longer exist. Deliberately keyed on the
+        // REGISTRIES rather than on what this run swept: `--only` and
+        // `--changelog` narrow the sweep, and pruning against a narrowed run
+        // would delete every row the filter excluded.
+        let live = Set(
+            VendorProbeRegistry.recipes.map(\.recipeID)
+                + ChangelogRecipeRegistry.recipes.map(\.recipeID)
+                + GitHubReleaseRegistry.rules.map(\.recipeID))
+        let pruned = baseline.prune(keeping: live)
+        for id in pruned.removed {
+            print("  baseline: dropped \(id) — no recipe produces this id any more")
+        }
+        for id in pruned.keptWithOpenIssue {
+            print("  baseline: \(id) has no recipe but its issue is still open — kept")
+        }
+
         Report.text(findings, elapsed: Int(Date().timeIntervalSince(started)),
                     baseline: baseline, showSamples: options.showSamples)
         writeArtifacts(findings, baseline: baseline, options: options)

--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -371,3 +371,81 @@ import DuoUpdaterCore
         #expect(Verify.buildDate("3.6.4") == nil)
     }
 }
+
+/// Pruning is the only operation that DELETES from the baseline, and it runs
+/// unattended on every sweep, so each guard on it is pinned rather than trusted.
+@Suite struct BaselinePruneTests {
+
+    private func baseline(_ ids: [String]) -> Baseline {
+        var b = Baseline()
+        for id in ids { b.entries[id] = Baseline.Entry() }
+        return b
+    }
+
+    @Test func dropsRowsNoRecipeProducesAnyMore() {
+        var b = baseline(["vendor:a:stable", "changelog:gone:-", "github:o/r:stable"])
+        let out = b.prune(keeping: ["vendor:a:stable", "github:o/r:stable"])
+        #expect(out.removed == ["changelog:gone:-"])
+        #expect(b.entries.keys.sorted() == ["github:o/r:stable", "vendor:a:stable"])
+    }
+
+    /// The real shape this exists for: a recipe that was re-keyed rather than
+    /// deleted. Claude Desktop's split into `:ga` + `:rollout` left the bare
+    /// `:stable` row behind reading as nine-days-stale.
+    @Test func dropsTheOldKeyWhenARecipeIsReKeyed() {
+        var b = baseline([
+            "vendor:com.anthropic.claudefordesktop:stable",
+            "vendor:com.anthropic.claudefordesktop:stable:ga",
+            "vendor:com.anthropic.claudefordesktop:stable:rollout",
+        ])
+        let out = b.prune(keeping: [
+            "vendor:com.anthropic.claudefordesktop:stable:ga",
+            "vendor:com.anthropic.claudefordesktop:stable:rollout",
+        ])
+        #expect(out.removed == ["vendor:com.anthropic.claudefordesktop:stable"])
+        #expect(b.entries.count == 2)
+    }
+
+    /// Issues close when a recipe verifies clean. A removed recipe never
+    /// verifies again, so dropping its row would strand the issue with nothing
+    /// left that could ever close it.
+    @Test func keepsAnOrphanWhoseIssueIsStillOpen() {
+        var b = baseline(["changelog:gone:-"])
+        b.entries["changelog:gone:-"]?.issueNumber = 42
+        let out = b.prune(keeping: ["vendor:other:stable"])
+        #expect(out.removed.isEmpty)
+        #expect(out.keptWithOpenIssue == ["changelog:gone:-"])
+        #expect(b.entries["changelog:gone:-"] != nil)
+    }
+
+    @Test func dropsAnOrphanWhoseIssueWasAlreadyClosed() {
+        var b = baseline(["changelog:gone:-"])
+        b.entries["changelog:gone:-"]?.issueNumber = 42
+        b.entries["changelog:gone:-"]?.closedAt = Date()
+        #expect(b.prune(keeping: ["vendor:other:stable"]).removed == ["changelog:gone:-"])
+        #expect(b.entries.isEmpty)
+    }
+
+    /// A caller that fails to build the live set must not wipe the file. This is
+    /// the difference between a bug and a data loss.
+    @Test func anEmptyLiveSetPrunesNothing() {
+        var b = baseline(["vendor:a:stable", "changelog:b:-"])
+        let out = b.prune(keeping: [])
+        #expect(out.removed.isEmpty)
+        #expect(b.entries.count == 2)
+    }
+
+    /// The set the sweep actually passes has to cover every row the sweep writes,
+    /// or the next run deletes what this one recorded. Derived from the
+    /// registries, never a literal list.
+    @Test func everyRegistryRecipeIDIsInTheLiveSet() {
+        let live = Set(
+            VendorProbeRegistry.recipes.map(\.recipeID)
+                + ChangelogRecipeRegistry.recipes.map(\.recipeID)
+                + GitHubReleaseRegistry.rules.map(\.recipeID))
+        #expect(live.count > 250, "only \(live.count) ids — a registry stopped contributing?")
+        var b = Baseline()
+        for id in live { b.entries[id] = Baseline.Entry() }
+        #expect(b.prune(keeping: live).removed.isEmpty)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -257,6 +257,17 @@ public struct GitHubReleaseRule: Sendable {
     var slug: String { "\(owner)/\(repo)" }
 }
 
+public extension GitHubReleaseRule {
+    /// Stable sweep key for this rule — the id the baseline files it under.
+    ///
+    /// Public and defined once because two callers need to agree on it: the
+    /// sweep, which writes rows under this key, and `Baseline.prune`, which
+    /// decides a row is orphaned when no rule produces its key. A second,
+    /// separately-maintained spelling of this string would make the prune delete
+    /// live rows the first time the two drifted.
+    var recipeID: String { "github:\(slug):\(channel.rawValue)" }
+}
+
 /// Resolves updates for apps distributed through GitHub Releases. Kept separate
 /// from `VendorProbeSource` because GitHub is one uniform mechanism (one API,
 /// shared rate limit, tag-name parsing) rather than a pile of bespoke endpoints.
@@ -375,7 +386,7 @@ public struct GitHubReleasesSource: UpdateSource {
             remote: RemoteVersion?, failure: ProbeFailure?, tags: [String] = [], status: Int? = nil
         ) -> ProbeOutcome {
             ProbeOutcome(
-                recipeID: "github:\(rule.slug):\(rule.channel.rawValue)",
+                recipeID: rule.recipeID,
                 bundleID: rule.bundleID, channel: rule.channel,
                 remote: remote, failure: failure, httpStatus: status,
                 bodySample: tags.isEmpty ? nil : tags.joined(separator: "\n"),


### PR DESCRIPTION
## 起因

在核对「有多少 recipe 处于被静默跳过的状态」时发现：答案是 **0 条**，但 baseline 里有 **7 行孤儿**，每一行都长得像有问题。

它们把我误导了两次——我先断言「Claude Desktop 16 天没验过」，又断言「Zed 陈旧」，**两次都错**。

## 根因

`verify/baseline.json` 只增不减。`Baseline.reconcile` 写 `entries[finding.recipeID]`，全文件没有任何删除路径。于是 recipe 一旦被删除、改名或**换 key**，它最后的状态就永远留在那里。

**换 key 才是常态，不是删除。** 2026-08-30 实测的 7 行：

| 孤儿行 | 看起来像 | 实际 |
|---|---|---|
| `changelog:com.TablePro:-` | `consecutiveActionable: 1` 挂了 9 天，像一条无人处理的工单 | recipe 是**有意移除**的（TablePro 的 Sparkle feed 内联带说明，单独 recipe 只会抢在前面并多打一次请求） |
| `vendor:com.anthropic.claudefordesktop:stable` | 16 天陈旧 | recipe 拆成 `:ga` + `:rollout`，两条**每天都在验** |
| `changelog:dev.zed.Zed:-` / `:Zed-Preview:-` | 9 天陈旧 | recipe 加了 `channel:` 换了 key；写这段时直接打了一遍：**✓ 2 全过** |
| `github:block/goose:stable` 等 3 条 | — | `3034e3f` 把改名的仓库钉回真名后留下的旧 slug |

## 改动

`Baseline.prune(keeping:)`，每次扫描都跑。两条守卫都写了测试：

- **live 集合来自 registry，不是"本次扫到的"**。`--only` / `--changelog` 会收窄一次运行，按收窄后的结果清理会删光被过滤掉的所有行。
- **空 live 集合什么都不删**。调用方万一没构造出集合，后果不能是清空文件。
- **孤儿但工单still开着的行保留**。工单只在 recipe 验证通过时自动关闭，而被移除的 recipe 永远不会再验证通过——删了那行就等于留下一个永远关不掉的 GitHub issue。保留的行会单独打印出来让人看见。

`GitHubReleaseRule.recipeID` 改为 public，并让扫描的调用点也改用它——**baseline 归档用的 id 和清理时查找的 id 必须是同一个定义**。两份各自维护的拼法，第一次漂移时就会让清理删掉活的行。

## 验证

对**真实 baseline 的副本**端到端跑过：

```
$ duo verify --only org.gnome.Meld --baseline <copy>
  baseline: dropped changelog:com.TablePro:- — no recipe produces this id any more
  baseline: dropped changelog:dev.zed.Zed-Preview:- …
  （共 7 条）

283 行 → 276 行，删的正好是这 7 条，无新增，
且只有 --only 真正扫到的 Meld 那一行内容有变化。
```

单元测试 6 条，含一条从 registry 推导的：`everyRegistryRecipeIDIsInTheLiveSet` 断言 live 集合覆盖每一条 recipe 的 id 且 > 250——防的是"某个 registry 不再贡献 id 导致清理误删"。

```
DuoUpdaterCore: 1580 tests in 131 suites passed
CLI:            178 tests in 24 suites passed（原 172）
make test:      全绿
```

## 没做的事

**没有手改 `verify/baseline.json`。** 我试过，但按自己的格式重写会造成 2224 行插入的假 diff，既掩盖真实改动也可能和扫描器的写入格式冲突。它是扫描的产物，下一次扫描会用它自己的 writer 清掉那 7 行。