### PR TITLE
chore: delete the retired Actions workflow, and say where the sweep runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,18 @@ verify/report.json
 verify/report.md
 verify/triage.json
 
-# Nightly recipe sweep. Kept local: it targets a self-hosted runner that runs as
-# the desktop user, which is not a safe thing to expose from a public repo.
+# The recipe sweep does NOT run on GitHub Actions. It was moved to a launchd
+# agent on the machine that owns the checkout (2026-08-14, 4ff9a90) because the
+# workflow targeted a self-hosted runner running as the desktop user, which is
+# not a safe thing to expose from a public repo — a public repo is where someone
+# eventually adds a `pull_request` trigger, and the blast radius is a login
+# session rather than a sandbox.
+#
+# The stale workflow file outlived the move and kept being read as evidence that
+# Actions still ran the sweep — it does not, and has not since 2026-08-13. The
+# file is deleted; this line stays so a `gh workflow`-shaped habit cannot quietly
+# reintroduce it. Where the agent lives and how it is scheduled is machine
+# topology and stays off this repo, same rule as the rest of /docs/.
 /.github/workflows/recipe-verify.yml
 
 # Python bytecode from the release scripts


### PR DESCRIPTION
## 为什么

`.github/workflows/recipe-verify.yml` 从 2026-08-14 起就不再是跑扫描的东西了（`4ff9a90` 转 public 时把它从 git 里删掉：它指向一个**以桌面用户身份运行**的 self-hosted runner，而公开仓库迟早有人加 `pull_request` 触发器）。但文件留在磁盘上、被 gitignore 忽略着，于是**一直被当成「Actions 还在跑扫描」的证据**。

它没在跑，从 2026-08-13 起就没跑过：`gh run list` 对所有 workflow 都是空的，`actions/runners` 返回 0。**这个空值这周被误读成「夜间扫描死了」两次**——扫描活得好好的，只是搬家了。

## 改动

- 删掉磁盘上那份 workflow（本地和 mini 都已清）
- ignore 那行保留，防止 `gh workflow` 之类的习惯把它悄悄带回来，并在旁边写清原因和「扫描在别处」的指向
- **具体在哪、怎么调度，不写进这个仓库**——那是机器拓扑，和 `/docs/` 其余部分同一条规则。判断扫描跑没跑，看 baseline 自己的提交（作者 `duo-verify`），不要看 GitHub 的 run list

## 顺带（本 PR 之外，已完成的运维动作）

扫描机的 checkout 之前冻在 `a473b4b`（08-29），落后 54 个提交、积压 3 个未推送的 baseline 提交，死锁形状是「推送失败 → 攒下本地提交 → `git pull --ff-only` 拉不动」。已于 15:15 手工解冻并触发一次扫描验证：

```
2026-08-30 15:15:54  at 5d1bdaf   ← pull 恢复正常，WARN 消失
  baseline: dropped changelog:com.TablePro:- — no recipe produces this id any more
  …（共 7 条孤儿，#153 的 prune 在生产上首次生效）
  total          ✓ 286  ⚠ 0  ✗ 0  ~ 0  - 0      121s
2026-08-30 15:21:06  baseline pushed
```

扫描覆盖从 **277 → 286**（此前 9 条新 recipe 因 checkout 冻结从未被扫过），远端 baseline 现在 286 条，与 registry 完全吻合。

死锁的**成因未修**，连同「陈旧时 reconcile 没被守住」一起记在 #156；安装 dry-run 空过报绿记在 #155。

## 验证

```
make test 全绿
```