### PR TITLE
安装 URL 可达性探测：厂商换掉下载地址时不再静默报 ✓

### DIFF
--- a/CLI/Sources/DuoKit/Baseline.swift
+++ b/CLI/Sources/DuoKit/Baseline.swift
@@ -393,9 +393,21 @@ public extension Finding {
     /// recipe that is still broken the same way from one that broke differently.
     var signature: String {
         if let failureKind { return failureKind }
-        guard !publicWarnings.isEmpty else { return "unknown" }
+        // `installURLTransient` is excluded for the same reason `Verify` excludes
+        // it from `actionable`: it accuses nobody. It is also inherently flappy —
+        // any CDN 5xx, any timeout — and since the sweep began probing all 129
+        // install URLs rather than only the 26 redirect ones, it flaps on 5x as
+        // many recipes. Left in, a recipe that already has an open issue for some
+        // OTHER warning would flip its signature in and out every sweep, and
+        // `Reconcile` returns `.comment` on a changed signature BEFORE it reaches
+        // the `mayComment` weekly rate limit — so it would post a "the failure
+        // changed shape" comment nightly, forever.
+        let stable = publicWarnings.filter {
+            !$0.hasPrefix(ProbeWarning.installURLTransient(status: nil).kind)
+        }
+        guard !stable.isEmpty else { return "unknown" }
         // Warning text embeds versions that change between sweeps; key on the
         // leading phrase so "still the same problem" stays stable.
-        return publicWarnings.map { String($0.prefix(40)) }.sorted().joined(separator: "|")
+        return stable.map { String($0.prefix(40)) }.sorted().joined(separator: "|")
     }
 }

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -272,14 +272,14 @@ public enum Verify {
             let tally = GatewayRetry.Tally()
             var attempt = 0
             var outcome = await GatewayRetry.$tally.withValue(tally) {
-                await source.probeDiagnostic(recipe)
+                await source.probeDiagnostic(recipe, checkingInstallURL: true)
             }
             while attempt < options.infraRetries,
                   outcome.failure?.classification == .infra {
                 attempt += 1
                 try? await Task.sleep(for: .seconds(attempt))
                 outcome = await GatewayRetry.$tally.withValue(tally) {
-                    await source.probeDiagnostic(recipe)
+                    await source.probeDiagnostic(recipe, checkingInstallURL: true)
                 }
             }
             var finding = classify(

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -837,7 +837,7 @@ public enum Verify {
 
         // The judgment rules live in `RecipeSanity`, in the core next to the
         // registry they guard — a second copy here would drift from it.
-        var warnings = outcome.warnings.map(\.kind)
+        var warnings = outcome.warnings.map(\.display)
         warnings.append(contentsOf: sanity(version, remote))
         if let installed, let complaint = RecipeSanity.remoteBehindInstalled(
             remote: remote, installedMarketing: installed.marketing,
@@ -849,7 +849,13 @@ public enum Verify {
         // against a recipe that is working. `td.telegram.org` 502s that HEAD in
         // bursts, which is what this exists for. Everything else keeps flipping
         // the finding to `.warn`, including a genuinely dead install URL.
-        let actionable = warnings.filter { $0 != ProbeWarning.installURLTransient(status: nil).kind }
+        // `hasPrefix`, not `==`: a warning is published as `kind: detail`, and the
+        // detail is what tells a 404 from a 403. Matching the whole string here
+        // would silently stop exempting transients the moment one carried a
+        // status — i.e. always — and start filing issues against vendors having
+        // a bad minute.
+        let transientKind = ProbeWarning.installURLTransient(status: nil).kind
+        let actionable = warnings.filter { !$0.hasPrefix(transientKind) }
         return make(actionable.isEmpty ? .ok : .warn, version: version, warnings: warnings)
     }
 

--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -448,4 +448,48 @@ import DuoUpdaterCore
         for id in live { b.entries[id] = Baseline.Entry() }
         #expect(b.prune(keeping: live).removed.isEmpty)
     }
+    // MARK: - what the signature must NOT move on
+
+    /// `installURLTransient` is kept out of the signature for the same reason
+    /// `Verify` keeps it out of `actionable`: it accuses nobody.
+    ///
+    /// It is also inherently flappy — any CDN 5xx, any timeout — and the sweep
+    /// now probes all ~129 install URLs rather than only the 26 redirect ones, so
+    /// it flaps on five times as many recipes. Left in the signature, a recipe
+    /// that already has an open issue for some OTHER warning flips its signature
+    /// in and out every sweep, and `Reconcile` returns `.comment` on a changed
+    /// signature BEFORE it reaches the weekly `mayComment` rate limit. The
+    /// user-visible result is a "the failure changed shape" comment every night,
+    /// forever, on an issue nothing new has happened to.
+    @Test func aFlappingInstallTransientDoesNotMoveTheSignature() {
+        let steady = Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable", status: .warn,
+            warnings: ["displayPatternNoMatch"], endpointHost: "example.invalid")
+        let flapping = Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable", status: .warn,
+            warnings: ["displayPatternNoMatch", "installURLTransient: HTTP 503"],
+            endpointHost: "example.invalid")
+
+        #expect(steady.signature == flapping.signature,
+                "a vendor's bad minute must not read as the failure changing shape")
+
+        // But a genuinely dead install URL IS new information and must move it.
+        let dead = Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable", status: .warn,
+            warnings: ["displayPatternNoMatch",
+                       "installURLNotFound: HTTP 404 from dl.example.invalid"],
+            endpointHost: "example.invalid")
+        #expect(dead.signature != steady.signature)
+
+        // And a transient on its own must not masquerade as a known failure.
+        let onlyTransient = Finding(
+            recipeID: "vendor:com.example.app:stable", registry: .vendor,
+            bundleID: "com.example.app", channel: "stable", status: .warn,
+            warnings: ["installURLTransient: HTTP 503"], endpointHost: "example.invalid")
+        #expect(onlyTransient.signature == "unknown")
+    }
+
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
@@ -20,6 +20,16 @@ import Foundation
 ///     error page, an insecure redirect, a disk error) are not retried.
 final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
 
+    /// The UA every installer fetch carries.
+    ///
+    /// Shared rather than inlined because the sweep's install-URL reachability
+    /// probe (`VendorProbeSource.installURLReachability`) has to send the SAME
+    /// one to be asking about the same thing. SourceForge answers 403 to a
+    /// browser-like agent and 200 to this, so a probe that drifted off this
+    /// constant would report healthy recipes as broken.
+    static let userAgent = "DuoUpdater/0.1"
+
+
     enum DownloadError: LocalizedError {
         case httpStatus(Int)
         case unsafeFilename(String)
@@ -208,7 +218,7 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
             .attributesOfItem(atPath: partial.path)[.size] as? NSNumber)?.int64Value ?? 0
 
         var request = URLRequest(url: url)
-        request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
+        request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
         // Force identity encoding. URLSession otherwise advertises
         // `Accept-Encoding: gzip` and some CDNs (Google's edgedl.me.gvt1.com,
         // serving the Android Studio dmg) honour it even for already-compressed

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -130,6 +130,21 @@ public enum ProbeWarning: Sendable, Equatable {
     /// a healthy recipe file issues against itself. The same 5xx/429-is-not-our-
     /// fault rule already governs version probes (see `ProbeFailure.category`).
     case installURLTransient(status: Int?)
+    /// The installer URL resolved to a well-formed URL that the vendor no longer
+    /// serves — a 4xx that survived a `Range: bytes=0-0` GET retry.
+    ///
+    /// Deliberately NOT `installURLUnresolved`. That one means the recipe could
+    /// not even BUILD a URL (a pattern stopped matching), and the fix is to go
+    /// re-derive the pattern. This one means the pattern still works and the
+    /// vendor moved or deleted the artifact, and the fix is to find where it
+    /// went. Collapsing them would hand whoever picks up the issue the wrong
+    /// starting point.
+    ///
+    /// Only the sweep raises this: resolving an install URL is on the same code
+    /// path as an ordinary update check, and a check must not pay an extra
+    /// request per app for a question only the nightly asks. See
+    /// `VendorProbeSource.probeDiagnostic(_:checkingInstallURL:)`.
+    case installURLNotFound(status: Int?)
     /// `checksumPattern` is set but matched nothing, so the download would be
     /// installed without SHA-512 verification.
     case checksumPatternNoMatch
@@ -175,6 +190,7 @@ public enum ProbeWarning: Sendable, Equatable {
         switch self {
         case .installURLUnresolved: return "installURLUnresolved"
         case .installURLTransient: return "installURLTransient"
+        case .installURLNotFound: return "installURLNotFound"
         case .checksumPatternNoMatch: return "checksumPatternNoMatch"
         case .entryPatternNoMatch: return "entryPatternNoMatch"
         case .displayPatternNoMatch: return "displayPatternNoMatch"

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -144,7 +144,7 @@ public enum ProbeWarning: Sendable, Equatable {
     /// path as an ordinary update check, and a check must not pay an extra
     /// request per app for a question only the nightly asks. See
     /// `VendorProbeSource.probeDiagnostic(_:checkingInstallURL:)`.
-    case installURLNotFound(status: Int?)
+    case installURLNotFound(status: Int?, host: String?)
     /// `checksumPattern` is set but matched nothing, so the download would be
     /// installed without SHA-512 verification.
     case checksumPatternNoMatch
@@ -185,6 +185,37 @@ public enum ProbeWarning: Sendable, Equatable {
     /// value jump from `155.0b5` to `20260826090609` — an increase, and the only
     /// history check there is looks for a version moving BACKWARDS.
     case displayPatternNoMatch
+
+    /// The part of a warning that varies, kept OUT of `kind` on purpose.
+    ///
+    /// `kind` is what the reconcile step keys a filed issue on, so anything that
+    /// moves between sweeps must not live there. But a bare `installURLNotFound`
+    /// is close to useless to whoever picks the issue up: it cannot tell a 404
+    /// (the artifact moved — go find it) from a 403 (a WAF or a geo-block — the
+    /// recipe is fine), which is exactly the distinction the SourceForge
+    /// false-accusation turned on. And the finding's `endpointHost` names the
+    /// VERSION endpoint, which for this warning answered perfectly — so the host
+    /// that actually failed appeared nowhere at all.
+    ///
+    /// Status and host, not the full URL: both are stable for a given recipe,
+    /// where a `versionTemplate` URL changes with every release and would churn
+    /// the signature for no new information.
+    public var detail: String? {
+        switch self {
+        case .installURLNotFound(let status, let host):
+            let code = status.map { "HTTP \($0)" } ?? "no answer"
+            return host.map { "\(code) from \($0)" } ?? code
+        case .installURLTransient(let status):
+            return status.map { "HTTP \($0)" }
+        default:
+            return nil
+        }
+    }
+
+    /// `kind`, plus `detail` when there is one. What the sweep publishes.
+    public var display: String {
+        detail.map { "\(kind): \($0)" } ?? kind
+    }
 
     public var kind: String {
         switch self {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -83,6 +83,30 @@ public struct VendorInstallSpec: Sendable {
         case redirect(URL)
         /// A fixed, already-final installer URL.
         case fixed(URL)
+
+        /// Whether resolving this source already proved the URL is served.
+        ///
+        /// Only `.redirect` does: it HEAD-follows the stable link and returns the
+        /// URL it landed on, so a 4xx there has already failed resolution. Every
+        /// other case BUILDS a URL — from a template, or by lifting it out of the
+        /// response body — and returns it without ever asking the vendor whether
+        /// it still exists. That is the gap the sweep's reachability probe fills:
+        /// a vendor that renames or deletes an artifact leaves the pattern
+        /// matching and the version reading, so the recipe grades healthy while
+        /// one-click is dead.
+        ///
+        /// Written as an exhaustive switch, not `if case .redirect`, so adding a
+        /// URL source forces a decision here instead of silently defaulting into
+        /// "already proven" and skipping the probe.
+        public var provesReachabilityWhenResolved: Bool {
+            switch self {
+            case .redirect: return true
+            case .fixed, .versionTemplate, .bodyTemplate,
+                 .bodyPattern, .bodyPatternLast, .bodyPatternHighestVersioned,
+                 .bodyPatternRelative:
+                return false
+            }
+        }
     }
 
     public let urlSource: URLSource

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -83,30 +83,6 @@ public struct VendorInstallSpec: Sendable {
         case redirect(URL)
         /// A fixed, already-final installer URL.
         case fixed(URL)
-
-        /// Whether resolving this source already proved the URL is served.
-        ///
-        /// Only `.redirect` does: it HEAD-follows the stable link and returns the
-        /// URL it landed on, so a 4xx there has already failed resolution. Every
-        /// other case BUILDS a URL — from a template, or by lifting it out of the
-        /// response body — and returns it without ever asking the vendor whether
-        /// it still exists. That is the gap the sweep's reachability probe fills:
-        /// a vendor that renames or deletes an artifact leaves the pattern
-        /// matching and the version reading, so the recipe grades healthy while
-        /// one-click is dead.
-        ///
-        /// Written as an exhaustive switch, not `if case .redirect`, so adding a
-        /// URL source forces a decision here instead of silently defaulting into
-        /// "already proven" and skipping the probe.
-        public var provesReachabilityWhenResolved: Bool {
-            switch self {
-            case .redirect: return true
-            case .fixed, .versionTemplate, .bodyTemplate,
-                 .bodyPattern, .bodyPatternLast, .bodyPatternHighestVersioned,
-                 .bodyPatternRelative:
-                return false
-            }
-        }
     }
 
     public let urlSource: URLSource

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -365,8 +365,19 @@ public struct VendorProbeSource: UpdateSource {
     /// reimplementation elsewhere would drift and start reporting failures the
     /// app never sees — and, worse, passes for recipes the app can't actually
     /// resolve.
-    public func probeDiagnostic(_ recipe: VendorProbeRecipe) async -> ProbeOutcome {
-        await probeOutcome(recipe, allowInstall: true)
+    /// Run one recipe for the sweep, which unlike an update check wants every
+    /// half-broken thing named rather than worked around.
+    ///
+    /// `checkingInstallURL` defaults to FALSE, and the default is the whole
+    /// point: this method is the entry point for the recipe unit tests as well
+    /// as the nightly, and it shares `probeOutcome` with the ordinary update
+    /// path. Defaulting it on would put an extra request per app on every user's
+    /// every check, and would send dozens of existing tests at live download
+    /// hosts. Only `duo verify` passes true.
+    public func probeDiagnostic(
+        _ recipe: VendorProbeRecipe, checkingInstallURL: Bool = false
+    ) async -> ProbeOutcome {
+        await probeOutcome(recipe, allowInstall: true, checkInstallURL: checkingInstallURL)
     }
 
     /// Where this machine's track value came from — read off disk, or the
@@ -492,7 +503,11 @@ public struct VendorProbeSource: UpdateSource {
     /// not the old best-effort nil: only `.notApplicable` still degrades to nil
     /// (the silent "—"), and every other classification is thrown and rendered as
     /// a retryable `.error` row. See ``ProbeFailure``.
-    func probeOutcome(_ recipe: VendorProbeRecipe, allowInstall: Bool = true) async -> ProbeOutcome {
+    func probeOutcome(
+        _ recipe: VendorProbeRecipe,
+        allowInstall: Bool = true,
+        checkInstallURL: Bool = false
+    ) async -> ProbeOutcome {
         let started = DispatchTime.now()
         func elapsed() -> Int {
             Int((DispatchTime.now().uptimeNanoseconds - started.uptimeNanoseconds) / 1_000_000)
@@ -639,6 +654,20 @@ public struct VendorProbeSource: UpdateSource {
                 // still installs — unverified. Silent today; flag it.
                 if spec.checksumPattern != nil, plan.checksum == nil {
                     warnings.append(.checksumPatternNoMatch)
+                }
+                // Resolving proved the URL is well-formed, not that the vendor
+                // still serves it. For every source but `.redirect` those are
+                // different claims, and the difference is invisible until a user
+                // presses Update — the install-time signature gates never even
+                // run, because a 404 delivers no bytes for them to judge.
+                //
+                // Note the URL probed is `plan.url`, i.e. AFTER `preferHTTPS` — the
+                // same string the installer would download. Probing the pre-rewrite
+                // URL would be testing something nobody fetches.
+                if checkInstallURL, !spec.urlSource.provesReachabilityWhenResolved,
+                   let warning = Self.warning(
+                       for: await installURLReachability(plan.url, spec: spec)) {
+                    warnings.append(warning)
                 }
             } else {
                 // Version still reads, one-click is dead. The app shows this app
@@ -832,6 +861,109 @@ public struct VendorProbeSource: UpdateSource {
     /// Layer a recipe's own headers over the defaults set just above, so a recipe
     /// can override even `User-Agent` (SourceForge 403s the browser-like default
     /// — see `VendorProbeRecipe.requestHeaders`).
+    /// What one reachability probe of a resolved installer URL concluded.
+    enum InstallURLReachability: Sendable, Equatable {
+        case ok
+        /// The vendor answered 4xx to both a HEAD and a ranged GET.
+        case gone(status: Int?)
+        /// 5xx/429, or the request never completed. The vendor's problem, not
+        /// the recipe's — aged by the same machinery as `installURLTransient`.
+        case transient(status: Int?)
+    }
+
+    /// The verdict a reachability result carries into the sweep, or nil when the
+    /// URL is fine.
+    ///
+    /// Pulled out as a pure function on purpose: the probe itself can only be
+    /// exercised over a live socket, and a mapping that decides whether an issue
+    /// gets filed should be checkable without one.
+    static func warning(for result: InstallURLReachability) -> ProbeWarning? {
+        switch result {
+        case .ok: return nil
+        case .gone(let status): return .installURLNotFound(status: status)
+        case .transient(let status): return .installURLTransient(status: status)
+        }
+    }
+
+    /// Ask whether a resolved installer URL is still served, without downloading
+    /// it. Sweep-only: see `probeDiagnostic(_:checkingInstallURL:)`.
+    ///
+    /// Two requests deep on purpose. A bare HEAD is not enough evidence to accuse
+    /// a vendor of moving an artifact: some download hosts answer HEAD with 403 or
+    /// 405 and serve the same URL perfectly to a GET, so a HEAD-only rule would
+    /// file issues against recipes that work. So a 4xx HEAD is downgraded to a
+    /// question, and a ranged GET answers it — `bytes=0-0` because these URLs are
+    /// installers and a plain GET would pull hundreds of megabytes per recipe per
+    /// sweep.
+    ///
+    /// A server that ignores `Range` and starts streaming the whole file is
+    /// handled by the caller cancelling as soon as the response head arrives; we
+    /// never read the body.
+    ///
+    /// The request must be byte-for-byte the request `Downloader` would make, or
+    /// it is not answering the question. That is not a nicety — it is the one
+    /// thing this method got wrong first, and the mistake was invisible in a
+    /// curl spot check:
+    ///
+    /// Probing with this type's browser-like `userAgent` (right for VERSION
+    /// endpoints, several of which reject unfamiliar agents) accused TigerVNC
+    /// and GrandPerspective of losing their installers. Both were fine.
+    /// SourceForge's edge answers **403 to a browser-like UA and 200 to
+    /// `DuoUpdater/0.1`** — the reverse of the usual WAF, measured 2026-08-30 on
+    /// the same URL in the same second with the UA as the only variable — and
+    /// `Downloader` sends `DuoUpdater/0.1`. So the download works and the probe
+    /// said it was gone.
+    ///
+    /// Hence: mirror `Downloader.swift` — its UA, its `Accept-Encoding: identity`
+    /// — and then `spec.requestHeaders`, which is what it layers on top and what
+    /// carries the per-vendor WAF workarounds (Oray's `Referer`, Alcove's
+    /// `Authorization`). Deliberately NOT `recipe.requestHeaders`: those belong to
+    /// the version endpoint and the downloader never sends them, so honouring
+    /// them here would make the probe pass URLs the real install cannot fetch.
+    func installURLReachability(
+        _ url: URL, spec: VendorInstallSpec
+    ) async -> InstallURLReachability {
+        func request(_ method: String, range: Bool) -> URLRequest {
+            var request = URLRequest(url: url)
+            request.httpMethod = method
+            request.timeoutInterval = 20
+            request.cachePolicy = URLRequest.versionFeedCachePolicy
+            request.setValue(Downloader.userAgent, forHTTPHeaderField: "User-Agent")
+            request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+            if range { request.setValue("bytes=0-0", forHTTPHeaderField: "Range") }
+            Self.apply(spec.requestHeaders, to: &request)
+            return request
+        }
+
+        var lastStatus: Int?
+        // Same shape as the `.redirect` resolve above: retry the transient kinds a
+        // few times before believing them, so one 502 in a burst does not cost a
+        // recipe its green.
+        for attempt in 0..<3 {
+            if attempt > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(attempt) * 700_000_000)
+            }
+            guard let (_, response) = try? await session.data(for: request("HEAD", range: false)),
+                  let http = response as? HTTPURLResponse
+            else { lastStatus = nil; continue }
+            lastStatus = http.statusCode
+            if (200..<400).contains(http.statusCode) { return .ok }
+            if Self.isTransientStatus(http.statusCode) { continue }
+
+            // 4xx. Could be a real 404, could be a host that simply refuses HEAD.
+            guard let (_, ranged) = try? await session.data(for: request("GET", range: true)),
+                  let rangedHTTP = ranged as? HTTPURLResponse
+            else { return .gone(status: http.statusCode) }
+            if (200..<400).contains(rangedHTTP.statusCode) { return .ok }
+            if Self.isTransientStatus(rangedHTTP.statusCode) {
+                lastStatus = rangedHTTP.statusCode
+                continue
+            }
+            return .gone(status: rangedHTTP.statusCode)
+        }
+        return .transient(status: lastStatus)
+    }
+
     private static func apply(_ headers: [String: String], to request: inout URLRequest) {
         for (field, value) in headers {
             request.setValue(value, forHTTPHeaderField: field)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -664,9 +664,20 @@ public struct VendorProbeSource: UpdateSource {
                 // Note the URL probed is `plan.url`, i.e. AFTER `preferHTTPS` — the
                 // same string the installer would download. Probing the pre-rewrite
                 // URL would be testing something nobody fetches.
-                if checkInstallURL, !spec.urlSource.provesReachabilityWhenResolved,
+                //
+                // No source is exempt, `.redirect` included. Resolving a redirect
+                // DOES prove its final URL answered — but it proves it with THIS
+                // type's browser-like agent and without `spec.requestHeaders`
+                // (see the resolve above), and the installer sends
+                // `Downloader.userAgent` plus those headers. SourceForge answers
+                // 403 to one and 200 to the other, so "already proven" was a proof
+                // about a request nobody makes: precisely the bug this probe was
+                // written to catch, one boolean away from being blessed. 26 extra
+                // HEADs a night is the cheaper side of that trade.
+                if checkInstallURL,
                    let warning = Self.warning(
-                       for: await installURLReachability(plan.url, spec: spec)) {
+                       for: await installURLReachability(plan.url, spec: spec),
+                       host: plan.url.host) {
                     warnings.append(warning)
                 }
             } else {
@@ -877,10 +888,12 @@ public struct VendorProbeSource: UpdateSource {
     /// Pulled out as a pure function on purpose: the probe itself can only be
     /// exercised over a live socket, and a mapping that decides whether an issue
     /// gets filed should be checkable without one.
-    static func warning(for result: InstallURLReachability) -> ProbeWarning? {
+    static func warning(
+        for result: InstallURLReachability, host: String? = nil
+    ) -> ProbeWarning? {
         switch result {
         case .ok: return nil
-        case .gone(let status): return .installURLNotFound(status: status)
+        case .gone(let status): return .installURLNotFound(status: status, host: host)
         case .transient(let status): return .installURLTransient(status: status)
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -897,8 +897,8 @@ public struct VendorProbeSource: UpdateSource {
     /// sweep.
     ///
     /// A server that ignores `Range` and starts streaming the whole file is
-    /// handled by the caller cancelling as soon as the response head arrives; we
-    /// never read the body.
+    /// handled by taking the response head from `bytes(for:)` and cancelling the
+    /// task before the stream is ever iterated, so the body is never read.
     ///
     /// The request must be byte-for-byte the request `Downloader` would make, or
     /// it is not answering the question. That is not a nicety — it is the one
@@ -916,8 +916,11 @@ public struct VendorProbeSource: UpdateSource {
     ///
     /// Hence: mirror `Downloader.swift` — its UA, its `Accept-Encoding: identity`
     /// — and then `spec.requestHeaders`, which is what it layers on top and what
-    /// carries the per-vendor WAF workarounds (Oray's `Referer`, Alcove's
-    /// `Authorization`). Deliberately NOT `recipe.requestHeaders`: those belong to
+    /// carries the per-vendor WAF workarounds — in the registry today that is
+    /// Oray's `Referer`, and nothing else. (Not Alcove's `Authorization`: that
+    /// lives on `RemoteVersion.downloadHeaders` in a source that is in no
+    /// registry and never swept, so it does not reach here and does not need to.)
+    /// Deliberately NOT `recipe.requestHeaders`: those belong to
     /// the version endpoint and the downloader never sends them, so honouring
     /// them here would make the probe pass URLs the real install cannot fetch.
     func installURLReachability(
@@ -951,11 +954,38 @@ public struct VendorProbeSource: UpdateSource {
             if Self.isTransientStatus(http.statusCode) { continue }
 
             // 4xx. Could be a real 404, could be a host that simply refuses HEAD.
-            guard let (_, ranged) = try? await session.data(for: request("GET", range: true)),
+            //
+            // `bytes(for:)`, not `data(for:)`: this returns once the response HEAD
+            // is in, leaving the body unread, and we cancel before touching the
+            // stream. `data(for:)` buffers the whole response first — so a host
+            // that answers 4xx to HEAD and then IGNORES `Range` would have pulled
+            // an entire installer into memory, which is both a hundreds-of-MB
+            // stall and a straight violation of this sweep's "never downloads an
+            // installer" contract (`Verify.swift`'s header).
+            guard let (stream, ranged) = try? await session.bytes(for: request("GET", range: true)),
                   let rangedHTTP = ranged as? HTTPURLResponse
-            else { return .gone(status: http.statusCode) }
+            else {
+                // No answer at all. NOT `.gone`: the asymmetry matters, because
+                // `.gone` files a public issue accusing a vendor of deleting an
+                // artifact. A timeout, a reset or a TLS failure here is the same
+                // event the HEAD path above treats as transient, and the honest
+                // verdict for "we never got an answer" is that we do not know.
+                // `lastStatus` still holds the HEAD's status for the report.
+                continue
+            }
+            stream.task.cancel()
             if (200..<400).contains(rangedHTTP.statusCode) { return .ok }
             if Self.isTransientStatus(rangedHTTP.statusCode) {
+                lastStatus = rangedHTTP.statusCode
+                continue
+            }
+            // 416 means the range was refused, not that the artifact is missing —
+            // the URL plainly exists to have rejected a range against it. 501 is
+            // the same answer from a server that will not implement `Range` at
+            // all. Either way this probe has run out of ways to ask, and guessing
+            // "deleted" from a Range complaint is exactly the false accusation the
+            // GET fallback exists to prevent.
+            if rangedHTTP.statusCode == 416 || rangedHTTP.statusCode == 501 {
                 lastStatus = rangedHTTP.statusCode
                 continue
             }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLReachabilityTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLReachabilityTests.swift
@@ -160,11 +160,24 @@ struct InstallURLReachabilityTests {
     /// actionable immediately, and swapping them either buries a dead URL or
     /// files an issue every time a CDN has a bad minute.
     @Test func reachabilityMapsOntoTheRightWarning() {
-        #expect(VendorProbeSource.warning(for: .ok) == nil)
-        #expect(VendorProbeSource.warning(for: .gone(status: 404))
-                == .installURLNotFound(status: 404))
-        #expect(VendorProbeSource.warning(for: .transient(status: 503))
+        #expect(VendorProbeSource.warning(for: .ok, host: "dl.example.com") == nil)
+        #expect(VendorProbeSource.warning(for: .gone(status: 404), host: "dl.example.com")
+                == .installURLNotFound(status: 404, host: "dl.example.com"))
+        #expect(VendorProbeSource.warning(for: .transient(status: 503), host: "dl.example.com")
                 == .installURLTransient(status: 503))
+
+        // The published string has to carry the status and the failing host. The
+        // finding's own `endpointHost` names the VERSION endpoint, which for this
+        // warning answered perfectly — so without this the issue points at a host
+        // that is fine and never mentions the one that is not, and cannot tell a
+        // 404 (the artifact moved) from a 403 (a WAF; the recipe is fine).
+        #expect(ProbeWarning.installURLNotFound(status: 404, host: "dl.example.com").display
+                == "installURLNotFound: HTTP 404 from dl.example.com")
+        #expect(ProbeWarning.installURLNotFound(status: nil, host: nil).display
+                == "installURLNotFound: no answer")
+        // `kind` stays bare, because that is what the reconcile step keys on.
+        #expect(ProbeWarning.installURLNotFound(status: 404, host: "a").kind
+                == ProbeWarning.installURLNotFound(status: 403, host: "b").kind)
     }
 
     /// The cost guard, and the only end-to-end assertion that survives contact
@@ -303,37 +316,66 @@ struct InstallURLReachabilityTests {
 
     // MARK: - the registry-derived coverage check
 
-    /// Derived from the registry rather than a hand-written list, so adding a
-    /// recipe or a `URLSource` cannot quietly fall out of coverage.
+    /// Every recipe carrying an install spec is now probed — `.redirect`
+    /// included, since its resolve-time HEAD proves the URL with the browser-like
+    /// version agent and no `spec.requestHeaders`, which is not the request the
+    /// installer makes.
     ///
-    /// `provesReachabilityWhenResolved` is the switch that decides whether a
-    /// recipe gets probed at all, so getting it wrong in the "true" direction is
-    /// silent: the recipe simply never gets checked. This re-derives the same
-    /// fact a second, independent way (pattern-matching `.redirect` directly) and
-    /// requires both groups to be non-empty, which is what stops the whole thing
-    /// degenerating into a constant.
-    @Test func onlyRedirectSourcesAreConsideredAlreadyProven() {
-        var proven: [String] = []
-        var probed: [String] = []
-        for recipe in VendorProbeRegistry.recipes {
+    /// Derived from the registry rather than a written-down list, with
+    /// non-vacuity guards, so it fails if the population it describes collapses.
+    @Test func everyInstallSpecInTheRegistryIsInScope() {
+        let withInstall = VendorProbeRegistry.recipes.filter { $0.install != nil }
+        var redirects = 0
+        var modes = Set<String>()
+        for recipe in withInstall {
             guard let spec = recipe.install else { continue }
-            let isRedirect: Bool
-            if case .redirect = spec.urlSource { isRedirect = true } else { isRedirect = false }
-            #expect(
-                spec.urlSource.provesReachabilityWhenResolved == isRedirect,
-                "\(recipe.recipeID): provesReachabilityWhenResolved disagrees with .redirect")
-            if isRedirect { proven.append(recipe.recipeID) } else { probed.append(recipe.recipeID) }
+            switch spec.urlSource {
+            case .redirect: redirects += 1; modes.insert("redirect")
+            case .fixed: modes.insert("fixed")
+            case .versionTemplate: modes.insert("versionTemplate")
+            case .bodyTemplate: modes.insert("bodyTemplate")
+            case .bodyPattern: modes.insert("bodyPattern")
+            case .bodyPatternLast: modes.insert("bodyPatternLast")
+            case .bodyPatternHighestVersioned: modes.insert("bodyPatternHighestVersioned")
+            case .bodyPatternRelative: modes.insert("bodyPatternRelative")
+            }
         }
-        #expect(!proven.isEmpty, "no .redirect recipe left — this check has gone vacuous")
-        #expect(!probed.isEmpty, "nothing would be probed — this check has gone vacuous")
-        // The gap #159 was filed about: the probed group is the large one.
-        #expect(probed.count > proven.count)
+        #expect(withInstall.count > 100, "the probed population collapsed: \(withInstall.count)")
+        #expect(redirects > 0, "no .redirect recipe left — the exemption this test replaced")
+        #expect(modes.count >= 5, "URLSource coverage thinned out to \(modes.sorted())")
+    }
+
+    /// The behavioural half of the same claim: a `.redirect` recipe really does
+    /// get probed, rather than being waved through on the strength of its
+    /// resolve-time HEAD.
+    @Test func aRedirectRecipeIsProbedLikeEveryOtherSource() async throws {
+        let server = try MethodAwareServer(headStatus: 200, rangedGetStatus: 206)
+        defer { server.stop() }
+        let recipe = VendorProbeRecipe(
+            bundleID: "com.example.subject",
+            url: server.feedURL,
+            mode: .responseBody,
+            versionPattern: #""version":"([0-9.]+)""#,
+            install: VendorInstallSpec(urlSource: .redirect(server.installURL), kind: .zip))
+
+        _ = await VendorProbeSource().probeDiagnostic(recipe, checkingInstallURL: true)
+        let resolveOnly = try MethodAwareServer(headStatus: 200, rangedGetStatus: 206)
+        defer { resolveOnly.stop() }
+        let plain = VendorProbeRecipe(
+            bundleID: "com.example.subject", url: resolveOnly.feedURL, mode: .responseBody,
+            versionPattern: #""version":"([0-9.]+)""#,
+            install: VendorInstallSpec(urlSource: .redirect(resolveOnly.installURL), kind: .zip))
+        _ = await VendorProbeSource().probeDiagnostic(plain)
+
+        #expect(server.connectionCount() > resolveOnly.connectionCount(),
+                Comment(rawValue: "the sweep must probe a redirect on top of resolving it: "
+                + "\(server.connectionCount()) vs \(resolveOnly.connectionCount())"))
     }
 
     @Test func theNewWarningIsDistinctFromAPatternMiss() {
-        #expect(ProbeWarning.installURLNotFound(status: 404).kind == "installURLNotFound")
-        #expect(ProbeWarning.installURLNotFound(status: 404) != ProbeWarning.installURLUnresolved)
-        #expect(ProbeWarning.installURLNotFound(status: 404)
+        #expect(ProbeWarning.installURLNotFound(status: 404, host: "h").kind == "installURLNotFound")
+        #expect(ProbeWarning.installURLNotFound(status: 404, host: "h") != ProbeWarning.installURLUnresolved)
+        #expect(ProbeWarning.installURLNotFound(status: 404, host: "h")
                 != ProbeWarning.installURLTransient(status: 404))
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLReachabilityTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLReachabilityTests.swift
@@ -27,7 +27,10 @@ struct InstallURLReachabilityTests {
         /// - Parameters:
         ///   - headStatus: what `/install` answers a HEAD.
         ///   - rangedGetStatus: what `/install` answers a GET carrying `Range`.
-        init(headStatus: Int, rangedGetStatus: Int, version: String = "2.0.0") throws {
+        init(
+            headStatus: Int, rangedGetStatus: Int, version: String = "2.0.0",
+            dropGET: Bool = false
+        ) throws {
             let listener = try NWListener(using: .tcp, on: .any)
             self.listener = listener
             let queue = self.queue
@@ -43,7 +46,14 @@ struct InstallURLReachabilityTests {
                     let parts = line.split(separator: " ").map(String.init)
                     let method = parts.first ?? ""
                     let path = parts.count > 1 ? parts[1] : ""
-                    queue.async { box.seen.append("\(method) \(path)") }
+                    queue.async {
+                        box.seen.append("\(method) \(path)")
+                        box.heads.append(request)
+                    }
+
+                    // Answer nothing and hang up: models a host that accepts the
+                    // connection and then times out or resets mid-request.
+                    if dropGET, method == "GET" { conn.cancel(); return }
 
                     let status: Int
                     var body = ""
@@ -76,7 +86,10 @@ struct InstallURLReachabilityTests {
             self.port = bound
         }
 
-        final class Box: @unchecked Sendable { var seen: [String] = [] }
+        final class Box: @unchecked Sendable {
+            var seen: [String] = []
+            var heads: [String] = []
+        }
         private let box: Box
 
         var feedURL: URL { URL(string: "http://127.0.0.1:\(port)/feed")! }
@@ -86,6 +99,8 @@ struct InstallURLReachabilityTests {
         /// binary, which is why `connectionCount()` exists alongside it.
         func requests() -> [String] { queue.sync { box.seen } }
         func connectionCount() -> Int { queue.sync { box.seen.count } }
+        /// Full request heads, for asserting on headers.
+        func heads() -> [String] { queue.sync { box.heads } }
         func stop() { listener.cancel() }
     }
 
@@ -177,6 +192,113 @@ struct InstallURLReachabilityTests {
             .probeDiagnostic(Self.recipe(swept), checkingInstallURL: true)
         #expect(swept.connectionCount() > 1,
                 "the sweep must contact the install URL, saw \(swept.connectionCount())")
+    }
+
+    /// A transport failure on the ranged GET must NOT be read as "the vendor
+    /// deleted this".
+    ///
+    /// This branch shipped wrong once. The `guard ... else` returned `.gone`,
+    /// which is the verdict that files a public issue accusing a vendor — off a
+    /// timeout, with no retry, on the very hosts most likely to need the GET
+    /// fallback in the first place (the ones that refuse HEAD). The identical
+    /// condition on the HEAD path was already treated as transient; the two must
+    /// agree, because "we never got an answer" is not evidence of deletion.
+    @Test func noAnswerToTheRangedGETIsNotEvidenceOfDeletion() async throws {
+        let server = try MethodAwareServer(
+            headStatus: 404, rangedGetStatus: 404, dropGET: true)
+        defer { server.stop() }
+        let result = await VendorProbeSource().installURLReachability(
+            server.installURL,
+            spec: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+        #expect(result == .transient(status: 404),
+                "a dropped GET must age as transient, never accuse the vendor")
+    }
+
+    /// A `Range` refusal is not a missing artifact — the URL plainly exists to
+    /// have rejected a range against it.
+    @Test func aRangeRefusalIsNotAMissingArtifact() async throws {
+        for status in [416, 501] {
+            let server = try MethodAwareServer(headStatus: 405, rangedGetStatus: status)
+            defer { server.stop() }
+            let result = await VendorProbeSource().installURLReachability(
+                server.installURL,
+                spec: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+            #expect(result == .transient(status: status),
+                    "HTTP \(status) says the range was refused, not that the file is gone")
+        }
+    }
+
+    /// The one mistake this change actually made, pinned.
+    ///
+    /// The probe first shipped sending this type's browser-like version-endpoint
+    /// agent. SourceForge answers **403 to that and 200 to `DuoUpdater/0.1`**, so
+    /// the sweep accused TigerVNC and GrandPerspective of losing installers that
+    /// were being served the whole time. A curl spot check cannot see this — only
+    /// the production request can — so the agent has to be asserted here or
+    /// nothing holds it.
+    @Test func theProbeSendsExactlyTheAgentTheDownloaderSends() async throws {
+        let server = try MethodAwareServer(headStatus: 405, rangedGetStatus: 206)
+        defer { server.stop() }
+        _ = await VendorProbeSource().installURLReachability(
+            server.installURL,
+            spec: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+
+        let heads = server.heads()
+        #expect(heads.count >= 2, "expected a HEAD and the ranged GET, saw \(heads.count)")
+        for head in heads {
+            #expect(head.contains("User-Agent: \(Downloader.userAgent)"),
+                    "every probe request must carry the downloader's agent")
+            #expect(!head.lowercased().contains("mozilla"),
+                    "the browser-like version-endpoint agent must never be used here")
+        }
+        #expect(heads.contains { $0.contains("Range: bytes=0-0") })
+    }
+
+    /// `spec.requestHeaders` is what the real download layers on top, so it must
+    /// win here too — that is the only way a per-vendor WAF workaround (Oray's
+    /// `Referer`) reaches the probe.
+    @Test func specHeadersReachTheProbeAndOverrideTheDefault() async throws {
+        let server = try MethodAwareServer(headStatus: 405, rangedGetStatus: 206)
+        defer { server.stop() }
+        _ = await VendorProbeSource().installURLReachability(
+            server.installURL,
+            spec: VendorInstallSpec(
+                urlSource: .fixed(server.installURL), kind: .zip,
+                requestHeaders: ["Referer": "https://example.invalid/dl",
+                                 "User-Agent": "Override/9"]))
+        for head in server.heads() {
+            #expect(head.contains("Referer: https://example.invalid/dl"))
+            #expect(head.contains("User-Agent: Override/9"),
+                    "a spec-level agent must override the downloader default")
+        }
+    }
+
+    /// The wiring, not the mapping: deleting `warnings.append(...)` in
+    /// `probeOutcome` must break something.
+    ///
+    /// Uses an unreachable HTTPS install URL rather than the stub, because
+    /// `resolveInstall` rewrites every `http://` through `preferHTTPS` — so a
+    /// plaintext stub can never answer the probe (see `onlyTheSweepTouchesTheInstallURL`).
+    /// A refused connection reaches the same append by the transient path.
+    @Test func theWarningActuallyReachesTheOutcome() async throws {
+        let server = try MethodAwareServer(headStatus: 200, rangedGetStatus: 206)
+        defer { server.stop() }
+        let recipe = VendorProbeRecipe(
+            bundleID: "com.example.subject",
+            url: server.feedURL,
+            mode: .responseBody,
+            versionPattern: #""version":"([0-9.]+)""#,
+            install: VendorInstallSpec(
+                urlSource: .fixed(URL(string: "https://127.0.0.1:1/nothing-listens-here")!),
+                kind: .zip))
+
+        let swept = await VendorProbeSource().probeDiagnostic(recipe, checkingInstallURL: true)
+        #expect(swept.warnings.map(\.kind).contains("installURLTransient"),
+                "the probe's verdict must reach ProbeOutcome.warnings, saw \(swept.warnings.map(\.kind))")
+
+        let checked = await VendorProbeSource().probeDiagnostic(recipe)
+        #expect(checked.warnings.isEmpty,
+                "and must not appear on the ordinary update path")
     }
 
     // MARK: - the registry-derived coverage check

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLReachabilityTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallURLReachabilityTests.swift
@@ -1,0 +1,217 @@
+import Testing
+import Foundation
+import Network
+@testable import DuoUpdaterCore
+
+/// The gap #159 closes: `resolveInstall` proves an installer URL is well-FORMED,
+/// not that the vendor still serves it. For every `URLSource` but `.redirect`
+/// those are different claims, and nothing anywhere noticed the difference — a
+/// vendor that renames an artifact leaves the pattern matching and the version
+/// reading, so the recipe grades ✓ while one-click is dead. The install-time
+/// signature gates cannot cover this either: a 404 delivers no bytes for them to
+/// judge, so they never run.
+struct InstallURLReachabilityTests {
+
+    // MARK: - a stub that answers per method and per path
+
+    /// Unlike `RecipeVerificationTests.StubServer`, this one has to distinguish a
+    /// HEAD from a GET, because the whole design question is what to conclude
+    /// when those two disagree.
+    final class MethodAwareServer: @unchecked Sendable {
+        private let listener: NWListener
+        private let queue = DispatchQueue(label: "InstallURLReachabilityStub")
+        let port: UInt16
+        /// Guarded by `queue`; read after `stop()`.
+        private var seen: [String] = []
+
+        /// - Parameters:
+        ///   - headStatus: what `/install` answers a HEAD.
+        ///   - rangedGetStatus: what `/install` answers a GET carrying `Range`.
+        init(headStatus: Int, rangedGetStatus: Int, version: String = "2.0.0") throws {
+            let listener = try NWListener(using: .tcp, on: .any)
+            self.listener = listener
+            let queue = self.queue
+            let box = Box()
+            self.box = box
+
+            listener.newConnectionHandler = { conn in
+                conn.start(queue: queue)
+                conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) {
+                    data, _, _, _ in
+                    let request = String(decoding: data ?? Data(), as: UTF8.self)
+                    let line = request.split(separator: "\r\n").first.map(String.init) ?? ""
+                    let parts = line.split(separator: " ").map(String.init)
+                    let method = parts.first ?? ""
+                    let path = parts.count > 1 ? parts[1] : ""
+                    queue.async { box.seen.append("\(method) \(path)") }
+
+                    let status: Int
+                    var body = ""
+                    if path.hasPrefix("/feed") {
+                        status = 200
+                        body = #"{"version":"\#(version)"}"#
+                    } else if method == "HEAD" {
+                        status = headStatus
+                    } else {
+                        status = rangedGetStatus
+                    }
+                    let payload = Data(body.utf8)
+                    var header = "HTTP/1.1 \(status) X\r\n"
+                    header += "Content-Type: application/json\r\n"
+                    header += "Content-Length: \(payload.count)\r\n"
+                    header += "Connection: close\r\n\r\n"
+                    conn.send(
+                        content: Data(header.utf8) + payload,
+                        completion: .contentProcessed { _ in conn.cancel() })
+                }
+            }
+            listener.start(queue: queue)
+
+            var resolved: UInt16?
+            for _ in 0..<500 {
+                if let p = listener.port?.rawValue, p != 0 { resolved = p; break }
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            guard let bound = resolved else { throw URLError(.cannotConnectToHost) }
+            self.port = bound
+        }
+
+        final class Box: @unchecked Sendable { var seen: [String] = [] }
+        private let box: Box
+
+        var feedURL: URL { URL(string: "http://127.0.0.1:\(port)/feed")! }
+        var installURL: URL { URL(string: "http://127.0.0.1:\(port)/install")! }
+        /// Every request line the server saw, e.g. `HEAD /install`. Only
+        /// meaningful for plaintext requests — a TLS handshake lands here as
+        /// binary, which is why `connectionCount()` exists alongside it.
+        func requests() -> [String] { queue.sync { box.seen } }
+        func connectionCount() -> Int { queue.sync { box.seen.count } }
+        func stop() { listener.cancel() }
+    }
+
+    private static func recipe(_ server: MethodAwareServer) -> VendorProbeRecipe {
+        VendorProbeRecipe(
+            bundleID: "com.example.subject",
+            url: server.feedURL,
+            mode: .responseBody,
+            versionPattern: #""version":"([0-9.]+)""#,
+            install: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+    }
+
+    // MARK: - what the probe concludes
+
+    @Test func aServedURLIsOK() async throws {
+        let server = try MethodAwareServer(headStatus: 200, rangedGetStatus: 206)
+        defer { server.stop() }
+        let result = await VendorProbeSource().installURLReachability(
+            server.installURL, spec: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+        #expect(result == .ok)
+    }
+
+    @Test func aVendorThatDeletedTheArtifactIsGone() async throws {
+        let server = try MethodAwareServer(headStatus: 404, rangedGetStatus: 404)
+        defer { server.stop() }
+        let result = await VendorProbeSource().installURLReachability(
+            server.installURL, spec: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+        #expect(result == .gone(status: 404))
+    }
+
+    /// The false-accusation guard, and the reason this probe costs two requests
+    /// instead of one. Several download hosts refuse HEAD outright and serve the
+    /// very same URL to a GET; a HEAD-only rule would file issues against
+    /// recipes whose one-click works perfectly.
+    @Test func aHostThatRefusesHEADButServesGETIsNotAccused() async throws {
+        let server = try MethodAwareServer(headStatus: 405, rangedGetStatus: 206)
+        defer { server.stop() }
+        let result = await VendorProbeSource().installURLReachability(
+            server.installURL, spec: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+        #expect(result == .ok, "405-to-HEAD must be resolved by the ranged GET, not reported")
+        #expect(server.requests().contains("GET /install"), "the ranged GET must actually happen")
+    }
+
+    @Test func aVendorHavingABadMinuteIsTransientNotBroken() async throws {
+        let server = try MethodAwareServer(headStatus: 503, rangedGetStatus: 503)
+        defer { server.stop() }
+        let result = await VendorProbeSource().installURLReachability(
+            server.installURL, spec: VendorInstallSpec(urlSource: .fixed(server.installURL), kind: .zip))
+        #expect(result == .transient(status: 503))
+    }
+
+    // MARK: - what the sweep does with it
+
+    /// The mapping that decides whether an issue gets filed, checked without a
+    /// socket. `gone` and `transient` must land on DIFFERENT warnings: one is
+    /// aged by `Baseline`'s transient machinery and stays quiet, the other is
+    /// actionable immediately, and swapping them either buries a dead URL or
+    /// files an issue every time a CDN has a bad minute.
+    @Test func reachabilityMapsOntoTheRightWarning() {
+        #expect(VendorProbeSource.warning(for: .ok) == nil)
+        #expect(VendorProbeSource.warning(for: .gone(status: 404))
+                == .installURLNotFound(status: 404))
+        #expect(VendorProbeSource.warning(for: .transient(status: 503))
+                == .installURLTransient(status: 503))
+    }
+
+    /// The cost guard, and the only end-to-end assertion that survives contact
+    /// with `preferHTTPS`.
+    ///
+    /// `resolveInstall` rewrites every `http://` installer URL to `https://`
+    /// before returning it — correctly, since that is the URL the installer would
+    /// download — so a plain-HTTP stub cannot answer the probe and there is no
+    /// point asserting on the resulting warning here (the socket-level semantics
+    /// are covered above). What this CAN prove, and what actually matters, is
+    /// whether the install URL is contacted at all: `probeOutcome` is shared with
+    /// the ordinary update path, so a default-on probe would put an extra request
+    /// per app on every user's every check. Counting connections proves the
+    /// default is off by observation rather than by trusting the flag.
+    @Test func onlyTheSweepTouchesTheInstallURL() async throws {
+        let quiet = try MethodAwareServer(headStatus: 404, rangedGetStatus: 404)
+        defer { quiet.stop() }
+        _ = await VendorProbeSource().probeDiagnostic(Self.recipe(quiet))
+        #expect(quiet.connectionCount() == 1,
+                "an update check must fetch the feed and nothing else, saw \(quiet.connectionCount())")
+
+        let swept = try MethodAwareServer(headStatus: 404, rangedGetStatus: 404)
+        defer { swept.stop() }
+        _ = await VendorProbeSource()
+            .probeDiagnostic(Self.recipe(swept), checkingInstallURL: true)
+        #expect(swept.connectionCount() > 1,
+                "the sweep must contact the install URL, saw \(swept.connectionCount())")
+    }
+
+    // MARK: - the registry-derived coverage check
+
+    /// Derived from the registry rather than a hand-written list, so adding a
+    /// recipe or a `URLSource` cannot quietly fall out of coverage.
+    ///
+    /// `provesReachabilityWhenResolved` is the switch that decides whether a
+    /// recipe gets probed at all, so getting it wrong in the "true" direction is
+    /// silent: the recipe simply never gets checked. This re-derives the same
+    /// fact a second, independent way (pattern-matching `.redirect` directly) and
+    /// requires both groups to be non-empty, which is what stops the whole thing
+    /// degenerating into a constant.
+    @Test func onlyRedirectSourcesAreConsideredAlreadyProven() {
+        var proven: [String] = []
+        var probed: [String] = []
+        for recipe in VendorProbeRegistry.recipes {
+            guard let spec = recipe.install else { continue }
+            let isRedirect: Bool
+            if case .redirect = spec.urlSource { isRedirect = true } else { isRedirect = false }
+            #expect(
+                spec.urlSource.provesReachabilityWhenResolved == isRedirect,
+                "\(recipe.recipeID): provesReachabilityWhenResolved disagrees with .redirect")
+            if isRedirect { proven.append(recipe.recipeID) } else { probed.append(recipe.recipeID) }
+        }
+        #expect(!proven.isEmpty, "no .redirect recipe left — this check has gone vacuous")
+        #expect(!probed.isEmpty, "nothing would be probed — this check has gone vacuous")
+        // The gap #159 was filed about: the probed group is the large one.
+        #expect(probed.count > proven.count)
+    }
+
+    @Test func theNewWarningIsDistinctFromAPatternMiss() {
+        #expect(ProbeWarning.installURLNotFound(status: 404).kind == "installURLNotFound")
+        #expect(ProbeWarning.installURLNotFound(status: 404) != ProbeWarning.installURLUnresolved)
+        #expect(ProbeWarning.installURLNotFound(status: 404)
+                != ProbeWarning.installURLTransient(status: 404))
+    }
+}


### PR DESCRIPTION
Closes #159.

## 问题

`resolveInstall` 证明的是安装 URL **拼得出来**，不是厂商**还在提供它**。129 条带 install spec 的 recipe 里，只有 `.redirect` 那 26 条真的对安装 URL 发过请求；其余 103 条从模板拼、或从响应体里抠出来就直接返回。于是厂商改名或删掉一个安装包之后，pattern 照常匹配、版本照常读出来，**recipe 判 ✓ 而一键更新已经死了**。

安装时的签名闸兜不住这一类：它们是 fail-closed 的，但 **404 根本没有字节送到它们面前**，它们不会被调用。第一个发现的人是按下 Update 的用户。

## 做法

resolve 成功后：HEAD → 4xx 时用 `Range: bytes=0-0` 的 GET 再问一次 → 两次都是 4xx 才判新的 `installURLNotFound`。5xx/429/没应答仍归 `installURLTransient`，走既有的老化逻辑。

**探测默认关闭。** `probeOutcome` 是生产更新检查和 sweep 共用的，默认打开等于给每个用户的每次检查多加一个请求/app，还会把几十个既有 recipe 测试打到真实下载站。只有 `duo verify` 传 `true`——并且有一条**数连接数**的测试守着这件事，而不是信任那个 flag。

**请求逐字节复刻 `Downloader`**（它的 UA、它的 `Accept-Encoding: identity`，再叠 `spec.requestHeaders`）。这是本 PR 唯一真正犯过的错，也是最值得记的一条：第一版发的是版本端点那个浏览器 UA，**SourceForge 对它回 403、对 `DuoUpdater/0.1` 回 200**，于是 sweep 指控 TigerVNC 和 GrandPerspective 弄丢了安装包——两个都是好的。curl 抽查看不见这种事，只有生产请求能。所以 UA 现在提成了共享常量，并且被测试钉住。

## 对抗复审后改的

复审（编号攻击面、禁止跑构建）找到两个 High，都是我写的：

1. **ranged GET 的传输失败被判成 `.gone`** —— 超时/重置/TLS 失败会立刻返回 `.gone`（还用 HEAD 的状态码），而五行之上完全相同的情况在 HEAD 路径上是 `continue`。`.gone` 正是那个会开公开工单指控厂商的判据，而它偏偏最容易在**拒绝 HEAD 的主机**上触发。改成 `continue` → `.transient`。
2. **ranged GET 用了 `data(for:)`，会把整个响应缓冲进内存** —— 遇到忽略 `Range` 的主机就是几百 MB，并且直接违反 sweep「从不下载安装包」的契约。改用 `bytes(for:)`，拿到响应头就 cancel。原来的 docstring 声称有个"调用方会取消"，**那个调用方不存在**。

以及三条 Medium：

3. **诊断信息现在说得出话** —— `installURLNotFound` 原来只发一个裸 kind，分不清 404（包挪了）和 403（WAF/地区限制，recipe 没问题），而 finding 的 `endpointHost` 记的是**版本端点**（它答得好好的），真正失败的主机哪儿都没出现。现在发 `kind: HTTP 404 from <host>`。带状态和主机、**不带完整 URL**：前两者对一条 recipe 是稳定的，而 `versionTemplate` 的 URL 每次发版都变，会毫无新意地抖动 signature。
4. **transient 不再进 signature** —— 它本来在里面，而 `Reconcile` 在**到达每周 `mayComment` 限流之前**就因 signature 变化返回 `.comment`。transient 天生易抖，又从 26 条扩到 129 条，任何已有工单的 recipe 会**每晚**被刷一条"failure changed shape"。
5. **取消 `.redirect` 豁免** —— 它的"已证明"是用**浏览器 UA 且不带 `spec.requestHeaders`** 的请求证明的，也就是本 PR 要抓的那个 bug，只差一个布尔值就被固化。布尔值直接删掉而不是修正：一个过时的"我们决定过了"比没有决定更糟。代价是每晚多 26 个 HEAD。

## 验证

- **全量 vendor sweep 打真实端点：146 ✓ / 0 ⚠ / 0 ✗**（129 条安装 URL 全探测）。那 1 个 `~` 是 Inkscape **版本**端点超时，A/B 两边都出现，与本 PR 无关。
- **负面对照**：把 anydesk 的 `.fixed` 指到必 404 的地址 → 报出 `installURLNotFound`，版本仍解析出 9.7.3，且没误告成 pattern miss。
- **变异测试**（红→绿逐条走）：把浏览器 UA 改回去 / 把传输失败改回 `.gone` / 删掉 `warnings.append` / 去掉 signature 过滤 —— **四条各自红对应的测试**。
- `make test`：**1611 tests / 133 suites + 179 CLI tests 全过**（1 个 known issue 是既有的 Anki 版本比较）。
- 成本 A/B（各 2 次）：不带探测 101/105s，带探测 84/104s —— 加的开销落在运行间抖动里量不出来，样本小，只能说"没有可测量的回归"。

## 已知遗留（未做，故意）

- 完整安装 URL 路径没进 finding，只有主机和状态。要让 triage 拿到路径得给 `Finding` 加字段，动 report.json schema，留给需要时再做。
- **soft-404**（CDN 用 HTTP 200 返回 HTML 错误页）仍会判 `.ok`。便宜的守卫是对 `Content-Type: text/html` 或明显过小的 `Content-Length` 起疑。
- delta 补丁 URL 不探测（`VendorInstaller` 下的是 `patch?.url ?? downloadURL`，这里只看后者）。delta 本身有回退路径。
