### PR TITLE
Add OpenLogi update detection

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1061,6 +1061,20 @@ public enum GitHubReleaseRegistry {
             installAssetPattern: #"^bruno_[0-9.]+_arm64_mac\.dmg$"#,
             installerKind: .dmg),
 
+        // OpenLogi — fast-moving native Logitech utility. The real 0.8.1 bundle
+        // is `org.openlogi.openlogi` and carries neither Sparkle nor another
+        // standard update feed in Info.plist; its Homebrew cask is
+        // `auto_updates: true`, so Homebrew correctly defers to the app updater.
+        // That updater's compiled-in stable manifest and release workflow both
+        // point at AprilNEA/OpenLogi, where stable tags are exactly `vX.Y.Z` and
+        // publishing is gated on both macOS DMGs existing. The anchored pattern
+        // rejects prerelease suffixes rather than truncating one onto stable.
+        // Detection-only until one-click is approved and separately verified.
+        GitHubReleaseRule(
+            bundleID: "org.openlogi.openlogi",
+            owner: "AprilNEA", repo: "OpenLogi",
+            versionPattern: #"^v([0-9]+(?:\.[0-9]+)+)$"#),
+
         // LocalSend — the reason `installAssetPattern` doubles as the macOS-release
         // gate. Upstream builds Windows/Linux/Android on CI but the dmg by hand
         // (`support/scripts/compile_mac_dmg.sh`, one maintainer, Developer ID +

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -130,6 +130,16 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
     #expect(!matches("bruno_4.0.0_arm64_win.zip", "com.usebruno.app"))
 }
 
+@Test func openLogiRuleReadsStableTagsOnlyAndStaysDetectionOnly() {
+    #expect(extract("v0.8.2", "org.openlogi.openlogi") == "0.8.2")
+    // A prerelease must not be truncated and served to a stable install.
+    #expect(extract("v0.8.3-rc.1", "org.openlogi.openlogi") == nil)
+    #expect(rule("org.openlogi.openlogi").usePrereleases == false)
+    // One-click is a separate, explicitly approved capability.
+    #expect(rule("org.openlogi.openlogi").installAssetPattern == nil)
+    #expect(rule("org.openlogi.openlogi").installerKind == nil)
+}
+
 /// PureMac ships a second product out of the same releases: `cli-v1.0.0`
 /// (2026-08-17) carries only `puremac-cli-1.0.0.tar.gz` and GitHub marks it
 /// latest. Unanchored, the default pattern read that as 1.0.0 — and a remote
@@ -613,6 +623,7 @@ private func matches(_ name: String, _ bundleID: String) -> Bool {
     let expected: [String: String] = [
         "com.ccswitch.desktop": "farion1231/cc-switch",
         "com.usebruno.app": "usebruno/bruno",
+        "org.openlogi.openlogi": "AprilNEA/OpenLogi",
         "org.localsend.localsendApp": "localsend/localsend",
         "com.utmapp.UTM": "utmapp/UTM",
         "net.kovidgoyal.kitty": "kovidgoyal/kitty",

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -112,6 +112,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**KeePassXC**](org-keepassxc-keepassxc.md) · `org.keepassxc.keepassxc` — G (one-click) · ✓ src=GitHub · snapshot 共享 bundle id，完全无签名 → **一键永久不可**，检测已可行（#93 已解决），尚未接 recipe（issue #95）
 - [x] [**Insomnia**](com-insomnia-app.md) · `com.insomnia.app` — G C (one-click) · ✓ src=GitHub · changelog=insomnia.rest(`__NEXT_DATA__` JSON) · 修 stable 跨渠道误推（pattern 加 `$` 锚，2026-06-06）· beta/alpha 受阻于 detect() 不解析 `-beta.N` 后缀
 - [x] **Pearcleaner** · `com.alienator88.Pearcleaner` — G · ✓ src=GitHub
+- [x] [**OpenLogi**](org-openlogi-openlogi.md) · `org.openlogi.openlogi` — G (detection-only) · Homebrew `auto_updates:true` 会让位；真包 0.8.1 → GitHub stable 0.8.2 全链验证 ✓ · 2026-08-30
 - [x] **Macs Fan Control** · `com.crystalidea.macsfancontrol` — G · ✓ src=GitHub
 - [x] **Alcove** · `com.henrikruscon.Alcove` — P(stable, detection-only) · ✓ src=Vendor `download.tryalcove.com/latest`（GitHub 镜像滞后已删；`update.tryalcove.com` 2026-07-29 起 NXDOMAIN，recipe 已改指 `/latest`）· 公开下载是滞后的 trial 构建（metadata 1.7.9 时 dmg 仍 1.7.7）故**不给一键** · 授权用户走 `AlcoveUpdateSource`（changelog + published_at + 一键）· 2026-07-29
 - [ ] **Zen Browser** · `app.zen-browser.zen` — G C · (not installed; prerelease-tag channel, not a pure single-channel sweep target)

--- a/docs/app-audits/org-openlogi-openlogi.md
+++ b/docs/app-audits/org-openlogi-openlogi.md
@@ -1,0 +1,83 @@
+# OpenLogi
+
+## 基本信息
+
+- Bundle ID: `org.openlogi.openlogi`
+- Team ID: `8U3ZJ258K9`
+- 已安装验证版本: `0.8.1`（build `20260826.132846`）
+- 自更新机制: 自研 `gpui-updater`，release build 内写死官方 stable manifest
+  `https://updates.openlogi.org/channels/stable/latest.json`
+- 分发: 官网 / GitHub Releases / Homebrew cask `openlogi`
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|              | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|--------------|---------|----------|-----|--------|-------------|
+| **stable**   | —       | — (`auto_updates`) | — | ✓ | ○（官方 manifest，未采用） |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **GitHub**。
+
+`auto_updates: true` 的含义是 Homebrew 把更新责任交回应用自身；即使这份 app
+由 brew 安装，`HomebrewCaskSource` 也会按设计返回 nil。接入前对真实 brew 安装
+运行 `channel-verify --check`，结果为 `winning source <none>` / `unknown`。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|-----------|----------|----------|------|
+| stable | `org.openlogi.openlogi` | 单一渠道 | 默认 `.stable` | GitHub tag 必须完整匹配 `vX.Y.Z` | ✓ |
+
+官方 updater 源码与 release workflow 都把 channel 固定为 `stable`；没有发现
+beta/nightly 构建或本机需要辨识的 channel 偏好。
+
+## 更新检测
+
+- 源: `GitHubReleasesSource`
+- Repo: `AprilNEA/OpenLogi`
+- Tag pattern: `^v([0-9]+(?:\.[0-9]+)+)$`
+- 版本方案: GitHub `v0.8.2` → `0.8.2`，与真实 bundle 的
+  `CFBundleShortVersionString` `0.8.1` 同构；不比较时间型 build
+  `20260826.132846`
+- 交叉验证: 真包二进制内的 manifest URL 在 2026-08-30 返回 `version: 0.8.2`、
+  `app_id: org.openlogi.openlogi`、`channel: stable`；同一版本的 GitHub Release
+  同时发布 arm64/x86_64 DMG
+- 防跨渠道: pattern 锚定两端，`v0.8.3-rc.1` 不会被截成 stable `0.8.3`
+
+## Changelog
+
+- 来源: GitHub Release body（由 `GitHubReleasesSource` 原生带回）
+- 跟随 channel: 是，仅 stable release
+- Recipe 状态: 不需要单独 `ChangelogRecipe`
+
+## 一键安装
+
+- 状态: **仅检测**
+- 官方格式: 分架构 DMG
+- 当前阻塞: 尚未获得将一键能力纳入本 PR 的明确确认，因此规则不登记
+  `installAssetPattern`；检测与 release notes 不受影响
+
+## 本机验证
+
+2026-08-30 使用 Homebrew 安装官方 cask，真实读取：
+
+| 项目 | 结果 |
+|------|------|
+| App | `/Applications/OpenLogi.app` |
+| Bundle / version | `org.openlogi.openlogi` / `0.8.1` / build `20260826.132846` |
+| Team / notarization | `8U3ZJ258K9` / stapled ticket |
+| 接入前全链 | `unknown` |
+| 接入后全链 | `GitHub` / `UPDATE 0.8.1 → 0.8.2` ✓ |
+
+## 已知问题
+
+- `spctl -a -vv` 在本机 macOS 27 beta 对该 bundle 返回 Code Signing subsystem
+  internal error；`codesign -dvvv` 能读取 Developer ID Team 与 stapled ticket。
+  这不影响 detection-only 路径。
+
+## 建议下一步
+
+1. 保持当前 detection-only GitHub rule，合并后由 verify 监控 repo slug 与 latest tag。
+2. 若批准一键，再单独核对 0.8.2 DMG 的 Team、签名、公证、架构选择和 bundle-only
+   安装边界，然后在本 app PR 内或后续 OpenLogi 专属 PR 打开资产规则。


### PR DESCRIPTION
## Summary
- add a stable GitHub release rule for `org.openlogi.openlogi`
- anchor tags to full `vX.Y.Z` releases so prereleases cannot leak into stable
- keep the integration detection-only pending explicit one-click approval
- document the real bundle, Homebrew provenance behavior, channel, and on-machine evidence

## Verification
- installed official Homebrew cask `openlogi` 0.8.1 and read bundle/version/Team ID
- before: full production chain returned `unknown`
- after: `GitHub`, update `0.8.1 -> 0.8.2`
- `swift test --package-path DuoUpdaterCore`: 1612 tests passed, 1 existing known issue
- `swift run --package-path CLI duo verify --only openlogi --github`: 1 passed, 0 warnings, 0 failures
- `python3 scripts/check_app_audits.py`: 77 docs consistent

The temporary local install was removed after verification.