### PR TITLE
docs(audit): CodexBar — Sparkle covers it; Codex→ChatGPT merge recorded

### DIFF
--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -52,7 +52,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 - [x] **VS Code** · `com.microsoft.VSCode` — P C (one-click) · ✓ src=Vendor
 - [x] **Claude Desktop** · `com.anthropic.claudefordesktop` — P (one-click) · ✓ src=Vendor
-- [x] **Codex** · `com.openai.codex` — P C (one-click) · ✓ src=Vendor
+- [x] **Codex → ChatGPT** · `com.openai.codex` — P C (one-click) · ✓ src=Vendor · 独立 Codex 桌面端 2026-07 并入 ChatGPT app（cask `codex-app` 已 `deprecate! … replacement_cask: "chatgpt"`），**bundle id 未变**——真包核实 ChatGPT.app 仍登记 `com.openai.codex` / `26.825.51511`，既有 recipe 全链 ✓（2026-08-30 复验）
 - [x] **Cursor** · `com.todesktop.230313mzl4w4u92` — P · ✓ src=Vendor
 - [x] **Notion** · `notion.id` — P C · ✓ src=Vendor
 - [x] **Obsidian** · `md.obsidian` — P C · ✓ src=Vendor
@@ -118,6 +118,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
+- [x] [**CodexBar**](com-steipete-codexbar.md) · `com.steipete.codexbar` — S · 真包 v0.56.1 验证 ✓（SUFeedURL 指向 repo 内 appcast.xml；ChangelogCatalog 已有 GitHub 兜底条目）· 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 

--- a/docs/app-audits/com-steipete-codexbar.md
+++ b/docs/app-audits/com-steipete-codexbar.md
@@ -1,0 +1,66 @@
+# CodexBar
+
+## 基本信息
+- Bundle ID: `com.steipete.codexbar`
+- Team ID: `Y5PE65HELJ` (Peter Steinberger)
+- 观测版本: `0.56.1` (build `132`)
+- 自更新机制: **Sparkle**（`SUFeedURL = https://raw.githubusercontent.com/steipete/CodexBar/main/appcast.xml`）
+- 分发: GitHub Releases (`steipete/CodexBar`) / Homebrew cask `codexbar`
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|            | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|------------|---------|----------|-----|--------|-------------|
+| **stable** | ✓       | — (`auto_updates`) | — | ○ | —           |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **Sparkle**（泛化 `SparkleAppcastSource`，
+零 recipe）。`ChangelogCatalog` 另有 GitHub releases 页兜底条目。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `com.steipete.codexbar` | 单一渠道 | — | — | ✓ |
+
+单渠道。appcast 6 条（观测 2026-08-30），全部无 `<sparkle:channel>` 标记，
+head = `0.56.1`。GitHub 发 `vX.Y.Z` 稳定 tag + CLI 的 Linux 资产，无 prerelease。
+
+## 更新检测
+- 源: 泛化 Sparkle。
+- 版本方案: short `0.56.1` 与 build `132` 双轨；feed 两个字段都有，比较落在
+  build，显示走 short。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 无 | 不能 |
+| 证据 | — | feed 条目无 `<sparkle:deltas>`（观测 2026-08-30） | — |
+
+## Changelog
+- 来源: Sparkle inline（feed `<description>`）；`ChangelogCatalog` 已另有
+  `github.com/steipete/CodexBar/releases` 兜底条目
+- Recipe 状态: 不需要
+
+## 一键安装
+- 状态: **支持**（Sparkle 原生路径）
+- 格式: feed enclosure 是 `CodexBar-macos-universal-{v}.zip`（universal，真包核实）
+- **读的是**: 人人可手动下载的 GA（feed 条目与 GitHub release 资产同源）
+- 包验（2026-08-30，v0.56.1 解包）: `com.steipete.codexbar` / short `0.56.1` /
+  build `132`，`Developer ID Application: Peter Steinberger (Y5PE65HELJ)`，
+  universal（x86_64+arm64）
+
+## 已知问题
+- 无。feed 未发现 beta 条目裸混（不像 OpenUsage）。
+
+## 如何复验
+```
+# GET https://raw.githubusercontent.com/steipete/CodexBar/main/appcast.xml → 6 条，head=0.56.1/132
+# 解包 CodexBar-macos-universal-0.56.1.zip → com.steipete.codexbar / 0.56.1 / 132
+# channel-verify --check com.steipete.codexbar → winning=Sparkle, up to date
+```
+
+## 建议下一步
+无。检测 + 一键 + changelog 均由泛化 Sparkle 源覆盖，零代码，审计文档即交付物。


### PR DESCRIPTION
## What

Two things, both verified against real artifacts today:

**CodexBar** (`com.steipete.codexbar`, Homebrew 90d 17,742 installs) ships `SUFeedURL` → the generic Sparkle source already covers detection, one-click and the inline changelog. Zero code. The appcast has 6 untagged default-channel items, head `0.56.1/132`; `ChangelogCatalog` already carries the GitHub releases page as a fallback. Verified on the unpacked v0.56.1 zip (Team `Y5PE65HELJ`, universal): `channel-verify --check com.steipete.codexbar` → **Sparkle wins, up to date**.

**Codex → ChatGPT merge** recorded on the existing index line: cask `codex-app` is now `deprecate! … replacement_cask: "chatgpt"` (2026-07-12) and openai.com/codex is titled "Codex in ChatGPT". The bundle id did not change — the real ChatGPT.app still registers `com.openai.codex` (`26.825.51511`), and the existing VendorProbe row (chatgpt.com backend appcast) still tracks it: `duo verify --only com.openai.codex` → probe + changelog ✓.

No registry code changes.