### PR TITLE
docs(audit): VoiceInk — Sparkle covers it, verified on the real build

### DIFF
--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,7 +118,6 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
-- [x] [**VoiceInk**](com-prakashjoshipax-VoiceInk.md) · `com.prakashjoshipax.VoiceInk` — S · 真包 v2.13 挂载验证 ✓ · 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 
@@ -150,6 +149,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**Dia Browser**](company-thebrowser-dia.md) · `company.thebrowser.dia` — S · real DMG/feed verified ✓ · 2026-08-17
 - [x] [**CodexBar**](com-steipete-codexbar.md) · `com.steipete.codexbar` — S · 真包 v0.56.1 验证 ✓（SUFeedURL 指向 repo 内 appcast.xml；ChangelogCatalog 已有 GitHub 兜底条目）· 2026-08-30
 - [x] [**ClaudeBar**](com-tddworks-claudebar.md) · `com.tddworks.claudebar` — S · 真包 v0.4.85 解包验证 ✓ · 2026-08-30
+- [x] [**VoiceInk**](com-prakashjoshipax-VoiceInk.md) · `com.prakashjoshipax.VoiceInk` — S · 真包 v2.13 挂载验证 ✓ · 2026-08-30
 
 ## Investigated — blocked safely
 

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,6 +118,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
+- [x] [**VoiceInk**](com-prakashjoshipax-VoiceInk.md) · `com.prakashjoshipax.VoiceInk` — S · 真包 v2.13 挂载验证 ✓ · 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 

--- a/docs/app-audits/com-prakashjoshipax-VoiceInk.md
+++ b/docs/app-audits/com-prakashjoshipax-VoiceInk.md
@@ -1,0 +1,66 @@
+# VoiceInk
+
+## 基本信息
+- Bundle ID: `com.prakashjoshipax.VoiceInk`
+- Team ID: `V6J6A3VWY2` (Prakash Joshi)
+- 观测版本: `2.13` (build `213`)
+- 自更新机制: **Sparkle**（`SUFeedURL = https://beingpax.github.io/VoiceInk/appcast.xml`）
+- 分发: GitHub Releases (`Beingpax/VoiceInk`) / Homebrew cask `voiceink`（`auto_updates: true`）
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|            | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|------------|---------|----------|-----|--------|-------------|
+| **stable** | ✓       | — (`auto_updates`) | — | — | — |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **Sparkle**（泛化 `SparkleAppcastSource`，
+零 recipe）。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `com.prakashjoshipax.VoiceInk` | 单一渠道 | — | — | ✓ |
+
+单渠道。appcast 仅 1 条（观测 2026-08-30），无 channel 标记。GitHub 历史上唯一
+prerelease（`v2.0-beta.3`）后跟了正式 `v2.0`——beta 未进 appcast。
+
+## 更新检测
+- 源: 泛化 Sparkle。
+- 版本方案: short `2.13` 与 build `213` 双轨（build = short 去点）；feed 两个
+  字段都有，比较落在 build，显示走 short。tag 有两段号（`v2.1`），不影响——比较
+  走 appcast 不碰 tag。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 无 | 不能 |
+| 证据 | — | feed 条目无 `<sparkle:deltas>`（观测 2026-08-30） | — |
+
+## Changelog
+- 来源: Sparkle inline（feed `<description>`）
+- Recipe 状态: 不需要
+
+## 一键安装
+- 状态: **支持**（Sparkle 原生路径）
+- 格式: feed enclosure 是 `VoiceInk.dmg`（版本号不进文件名；universal，真包核实）
+- **读的是**: 人人可手动下载的 GA（feed 条目与 GitHub release 资产同源）
+- 包验（2026-08-30，v2.13 挂载）: `com.prakashjoshipax.VoiceInk` / short `2.13` /
+  build `213`，`Developer ID Application: Prakash Joshi (V6J6A3VWY2)`，
+  `spctl accepted / Notarized Developer ID`，universal（x86_64+arm64）
+
+## 已知问题
+- 无。
+
+## 如何复验
+```
+# GET https://beingpax.github.io/VoiceInk/appcast.xml → 1 条，head=2.13/213
+# 挂载 VoiceInk.dmg → com.prakashjoshipax.VoiceInk / 2.13 / 213
+# channel-verify --check com.prakashjoshipax.VoiceInk → winning=Sparkle, up to date
+```
+
+## 建议下一步
+无。检测 + 一键 + changelog 均由泛化 Sparkle 源覆盖，零代码，审计文档即交付物。


### PR DESCRIPTION
## What

[VoiceInk](https://tryvoiceink.com/) (Homebrew 90d 2,348 installs, cask `auto_updates`) — its dmg carries `SUFeedURL`, so the **generic Sparkle source already covers detection, one-click and the inline changelog — zero recipe**. Docs-only PR.

## Verification (real artifact)

- Mounted `VoiceInk.dmg` (v2.13): `com.prakashjoshipax.VoiceInk`, short `2.13`, build `213`, Team `V6J6A3VWY2`, notarized, universal.
- Feed: single untagged default-channel item (`2.13/213`); the one historical prerelease (`v2.0-beta.3`) never entered the appcast.
- `channel-verify --check com.prakashjoshipax.VoiceInk` on the real bundle: **Sparkle wins, up to date**.

No code changes.