### PR TITLE
docs(audit): Perplexity — Sparkle covers it, verified on the real build

### DIFF
--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,6 +118,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
+- [x] [**Perplexity**](ai-perplexity-macv3.md) · `ai.perplexity.macv3` — S · 真包 26.34.0 挂载验证 ✓（公证已恢复，一键可用）· 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 
@@ -145,7 +146,6 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**Typeless**](now-typeless-desktop.md) · `now.typeless.desktop` — P+C · electron-builder feed (VendorProbe) · 一键 dmg + sha512 · 结构化 changelog（gzip __NEXT_DATA__，含图）· channel-verify ✓ · 2026-06-19
 - [x] [**OpenClaw**](ai-openclaw-mac.md) · `ai.openclaw.mac` — S · real DMG/feed verified ✓ · 2026-08-17
 - [x] [**Superwhisper**](com-superduper-superwhisper.md) · `com.superduper.superwhisper` — S · real zip/feed verified ✓ · 2026-08-17
-- [x] [**Perplexity Mac**](ai-perplexity-macv3.md) · `ai.perplexity.macv3` — S detection; current dmg unnotarized, no one-click · 2026-08-17
 - [x] [**Dia Browser**](company-thebrowser-dia.md) · `company.thebrowser.dia` — S · real DMG/feed verified ✓ · 2026-08-17
 
 ## Investigated — blocked safely

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,7 +118,6 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
-- [x] [**Perplexity**](ai-perplexity-macv3.md) · `ai.perplexity.macv3` — S · 真包 26.34.0 挂载验证 ✓（公证已恢复，一键可用）· 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 
@@ -153,6 +152,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**GitHub Copilot for Xcode**](com-github-CopilotForXcode.md) · `com.github.CopilotForXcode` — S(stable+prerelease) · 两轨 tag 过、共享 bundle id · 真包 0.51.0 挂载验证 ✓ · 2026-08-30
 - [x] [**MacWhisper**](com-goodsnooze-MacWhisper.md) · `com.goodsnooze.MacWhisper` — S · 真包 14.8 解包验证 ✓ · 2026-08-30
 - [x] [**ChatGPT Atlas**](com-openai-atlas.md) · `com.openai.atlas` — S · 真包 1.2026.189.1 挂载验证 ✓ · 2026-08-30
+- [x] [**Perplexity**](ai-perplexity-macv3.md) · `ai.perplexity.macv3` — S · 真包 26.34.0 挂载验证 ✓（公证已恢复，一键可用）· 2026-08-30
 
 ## Investigated — blocked safely
 

--- a/docs/app-audits/ai-perplexity-macv3.md
+++ b/docs/app-audits/ai-perplexity-macv3.md
@@ -1,39 +1,67 @@
-# Perplexity Mac
+# Perplexity (Personal Computer)
 
 ## 基本信息
 - Bundle ID: `ai.perplexity.macv3`
 - Team ID: `7S8W4W365S`
-- 已验证版本: short `26.31.1`, build `69`
-- 自更新机制: Sparkle
+- 观测版本: `26.34.0` (build `87`)
+- 自更新机制: **Sparkle**（`SUFeedURL = https://macos-download.perplexity.ai/appcast.xml`）
+- 分发: 官方 CDN `macos-download.perplexity.ai` + Homebrew cask `perplexity`
+  （`auto_updates: true`）
 
 ## 覆盖矩阵
 
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
 |            | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
 |------------|---------|----------|-----|--------|-------------|
-| **stable** | ✓       | ✗        | —   | —      | —           |
+| **stable** | ✓       | — (`auto_updates`) | — | — | — |
 
-当前生效源: **Sparkle**。
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **Sparkle**（泛化 `SparkleAppcastSource`，
+零 recipe）。注意与 registry 里既有 Perplexity 系条目区分：`ai.perplexity.comet`（Comet
+浏览器）是另一个 bundle id。
 
 ## Channel 详情
 
-| Channel | Bundle ID | 检测信号 | 状态 |
-|---------|-----------|----------|------|
-| stable | `ai.perplexity.macv3` | `SUFeedURL` | ✓ |
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `ai.perplexity.macv3` | 单一渠道 | — | — | ✓ |
+
+单渠道。appcast 单条（观测 2026-08-30），无 channel 标记。
 
 ## 更新检测
-- Appcast: `https://macos-download.perplexity.ai/appcast.xml`。
-- feed short/build 与真实包完全同构。
+- 源: 泛化 Sparkle。
+- 版本方案: short `26.34.0` 与 build `87` 双轨；feed 两个字段都有，比较落在
+  build，显示走 short。`sparkle:minimumSystemVersion` = 15.0，由下载后检查兜住。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 无 | 不能 |
+| 证据 | — | feed 条目无 `<sparkle:deltas>`（观测 2026-08-30） | — |
 
 ## Changelog
-- 由 Sparkle item description 提供；无专用 recipe。
+- 来源: Sparkle inline（feed `<description>`）
+- Recipe 状态: 不需要
 
 ## 一键安装
-- 状态: 仅检测。
-- 阻塞: 2026-08-17 下载的 DMG 为同 Team Developer ID，但 `spctl` 报 `Unnotarized Developer ID`。
+- 状态: **支持**（Sparkle 原生路径）
+- 格式: feed enclosure 是版本无关的 `Perplexity.dmg`（官方 CDN）
+- **读的是**: 人人可手动下载的 GA（feed 公开条目）
+- 包验（2026-08-30，26.34.0 挂载）: `ai.perplexity.macv3` / `26.34.0` / build
+  `87`，Team `7S8W4W365S`，notarized
 
 ## 已知问题
-- 在上游恢复公证前，安装安全闸会拒绝替换。
+- 历史（2026-08-17 审计）：当时的 dmg 是 `Unnotarized Developer ID`，签名闸挡一键，
+  故早期结论是 detection-only。**2026-08-30 复核：vendor 已恢复公证**（`spctl
+  accepted / Notarized Developer ID`），一键现在可用——本审计据此升级为支持一键。
+
+## 如何复验
+```
+# GET https://macos-download.perplexity.ai/appcast.xml → 1 条，head=26.34.0/87
+# 挂载 Perplexity.dmg → ai.perplexity.macv3 / 26.34.0 / 87
+# channel-verify --check ai.perplexity.macv3 → winning=Sparkle, up to date
+```
 
 ## 建议下一步
-1. 新版本发布后复查公证状态。
-
+无。检测 + 一键 + changelog 均由泛化 Sparkle 源覆盖，零代码，审计文档即交付物。


### PR DESCRIPTION
## What

Perplexity desktop (`ai.perplexity.macv3`) was already audited 2026-08-17 as **detection-only** — the then-current dmg was `Unnotarized Developer ID`, so the signature gate blocked one-click. This PR re-verifies against the real artifact today:

- Mounted `Perplexity.dmg` (26.34.0, build 87): **`spctl accepted / Notarized Developer ID`** (Perplexity AI Inc., Team `7S8W4W365S`) — the vendor restored notarization, so **one-click is now unblocked**.
- `channel-verify --check ai.perplexity.macv3` on the real bundle: **Sparkle wins, up to date** (generic source, zero recipe; feed is a single untagged item).
- The audit doc now records the 8-17 → 8-30 history instead of silently dropping it, and the duplicate stale index line ("current dmg unnotarized") is removed.
- Distinct from the existing `ai.perplexity.comet` (Comet browser) row.

No code changes.