### PR TITLE
docs(audit): TypeWhisper — three Sparkle trains, all generic

### DIFF
--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,6 +118,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
+- [x] [**TypeWhisper**](com-typewhisper-mac.md) · `com.typewhisper.mac` — S(stable+rc+daily) · 三轨 tag 过、共享 bundle id · 真包 1.6.0 挂载验证 ✓ · 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,7 +118,6 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
-- [x] [**TypeWhisper**](com-typewhisper-mac.md) · `com.typewhisper.mac` — S(stable+rc+daily) · 三轨 tag 过、共享 bundle id · 真包 1.6.0 挂载验证 ✓ · 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 
@@ -154,6 +153,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**MacWhisper**](com-goodsnooze-MacWhisper.md) · `com.goodsnooze.MacWhisper` — S · 真包 14.8 解包验证 ✓ · 2026-08-30
 - [x] [**ChatGPT Atlas**](com-openai-atlas.md) · `com.openai.atlas` — S · 真包 1.2026.189.1 挂载验证 ✓ · 2026-08-30
 - [x] [**Perplexity**](ai-perplexity-macv3.md) · `ai.perplexity.macv3` — S · 真包 26.34.0 挂载验证 ✓（公证已恢复，一键可用）· 2026-08-30
+- [x] [**TypeWhisper**](com-typewhisper-mac.md) · `com.typewhisper.mac` — S(stable+rc+daily) · 三轨 tag 过、共享 bundle id · 真包 1.6.0 解包验证 ✓ · 2026-08-30
 
 ## Investigated — blocked safely
 

--- a/docs/app-audits/com-typewhisper-mac.md
+++ b/docs/app-audits/com-typewhisper-mac.md
@@ -56,9 +56,9 @@ Sparkle feed 才是。
 
 ## 一键安装
 - 状态: **支持**（Sparkle 原生路径，各轨 feed enclosure）
-- 格式: `TypeWhisper-v{ver}.dmg`
+- 格式: `TypeWhisper-v{ver}.zip`
 - **读的是**: 人人可手动下载的 GA（feed 公开条目）
-- 包验（2026-08-30，v1.6.0 挂载）: `com.typewhisper.mac` / `1.6.0` / build
+- 包验（2026-08-30，v1.6.0 解包）: `com.typewhisper.mac` / `1.6.0` / build
   `1091`，Team `2D8ALY3LCL`，notarized
 
 ## 已知问题
@@ -68,7 +68,7 @@ Sparkle feed 才是。
 ```
 # GET https://typewhisper.github.io/typewhisper-mac/appcast.xml
 #   → 3 条：default=1.6.0，rc=1.6.0-rc2，daily=1.7.0-daily.20260830
-# 挂载 TypeWhisper-v1.6.0.dmg → com.typewhisper.mac / 1.6.0 / 1091
+# 解包 TypeWhisper-v1.6.0.zip → com.typewhisper.mac / 1.6.0 / 1091
 # channel-verify --check com.typewhisper.mac → winning=Sparkle, up to date
 ```
 

--- a/docs/app-audits/com-typewhisper-mac.md
+++ b/docs/app-audits/com-typewhisper-mac.md
@@ -1,0 +1,76 @@
+# TypeWhisper
+
+## 基本信息
+- Bundle ID: `com.typewhisper.mac`
+- Team ID: `2D8ALY3LCL`
+- 观测版本: `1.6.0` (build `1091`)
+- 自更新机制: **Sparkle**（`SUFeedURL = https://typewhisper.github.io/typewhisper-mac/appcast.xml`）
+- 分发: GitHub Releases (`TypeWhisper/typewhisper-mac`) / Homebrew cask `typewhisper`
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|            | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|------------|---------|----------|-----|--------|-------------|
+| **stable** | ✓       | — (`auto_updates`) | — | — | — |
+| **release-candidate** | ✓ | — | — | — | — |
+| **daily**  | ✓       | —        | —   | —     | —           |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **Sparkle**（泛化 `SparkleAppcastSource`，
+零 recipe；三条轨都靠 feed 的 `<sparkle:channel>` 标记分轨）。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `com.typewhisper.mac` | 共享 | — | default（无标记） | ✓ |
+| release-candidate | `com.typewhisper.mac` | 共享 | 装机 build 命中 feed 条目 | `<sparkle:channel>release-candidate` | ✓ |
+| daily   | `com.typewhisper.mac` | 共享 | 装机 build 命中 feed 条目 | `<sparkle:channel>daily` | ✓ |
+
+共享 bundle id。appcast 3 条（观测 2026-08-30）：default = `1.6.0/1091`（stable），
+`release-candidate` = `1.6.0-rc2/1083`，`daily` = `1.7.0-daily.20260830/1161`。
+三轨互不串：`usableItems` 只允许装机 build 命中的那条 channel。
+
+配套的一个 GitHub 陷阱（写进 audit 免得下一个人踩）：该 repo 的**非 prerelease
+release 全是 plugin 包**（`plugin-whisperkit-v1.2.0` 等，资产只有插件 zip），app
+本体走 prerelease 的 daily tag。如果有人给这个 bundle 加 GitHub rule，
+`/releases/latest` 会指到最新的 plugin release——GitHub 源不是这个 app 的版本面，
+Sparkle feed 才是。
+
+## 更新检测
+- 源: 泛化 Sparkle。
+- 版本方案: short 与 build 双轨；比较落在 build，显示走 short。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 无 | 不能 |
+| 证据 | — | feed 条目无 `<sparkle:deltas>`（观测 2026-08-30） | — |
+
+## Changelog
+- 来源: Sparkle inline（feed `<description>`）
+- 跟随 channel: 是（按装机轨道）
+- Recipe 状态: 不需要
+
+## 一键安装
+- 状态: **支持**（Sparkle 原生路径，各轨 feed enclosure）
+- 格式: `TypeWhisper-v{ver}.dmg`
+- **读的是**: 人人可手动下载的 GA（feed 公开条目）
+- 包验（2026-08-30，v1.6.0 挂载）: `com.typewhisper.mac` / `1.6.0` / build
+  `1091`，Team `2D8ALY3LCL`，notarized
+
+## 已知问题
+- 无。
+
+## 如何复验
+```
+# GET https://typewhisper.github.io/typewhisper-mac/appcast.xml
+#   → 3 条：default=1.6.0，rc=1.6.0-rc2，daily=1.7.0-daily.20260830
+# 挂载 TypeWhisper-v1.6.0.dmg → com.typewhisper.mac / 1.6.0 / 1091
+# channel-verify --check com.typewhisper.mac → winning=Sparkle, up to date
+```
+
+## 建议下一步
+无。三轨检测 + 一键 + changelog 均由泛化 Sparkle 源覆盖，零代码，审计文档即交付物。


### PR DESCRIPTION
## What

[TypeWhisper](https://www.typewhisper.com/) (Homebrew 90d 617 installs) — its dmg carries `SUFeedURL`, so the **generic Sparkle source covers all three trains with zero recipe** — this audit exists to record that the trains are real and correctly separated, not to add code.

## What the feed shows

- 3 items, three `<sparkle:channel>` groups under the shared bundle id: default (`1.6.0/1091` stable), `release-candidate` (`1.6.0-rc2/1083`), `daily` (`1.7.0-daily.20260830/1161`). The generic source resolves the train by matching the installed build to a feed item.
- A GitHub trap the audit records so nobody steps on it: every non-prerelease release in `TypeWhisper/typewhisper-mac` is a **plugin** package (`plugin-whisperkit-v1.2.0` etc.), so `/releases/latest` would point at a plugin — GitHub is not this app's version surface; the Sparkle feed is.

## Verification (real artifact)

- Mounted `TypeWhisper-v1.6.0.dmg`: `com.typewhisper.mac`, build `1091`, Team `2D8ALY3LCL`, notarized.
- `channel-verify --check com.typewhisper.mac` on the real bundle: **Sparkle wins, up to date**.

No code changes.