### PR TITLE
Track Claude Status Bar — v-tags, versionless dmg

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -801,6 +801,18 @@ public enum GitHubReleaseRegistry {
             installAssetPattern: #"^Pearcleaner\.dmg$"#,
             installerKind: .dmg),
 
+        // Claude Status Bar — menu-bar quota indicator for Claude Code. v-tags,
+        // and the dmg asset name is versionless (ClaudeStatusBar.dmg on every
+        // release), so the asset pattern is the literal filename. Mounted
+        // v0.4.4: com.local.claudestatusbar, short == build == tag, Team
+        // W9JZ4932LA, notarized.
+        GitHubReleaseRule(
+            bundleID: "com.local.claudestatusbar",
+            owner: "m1ckc3s", repo: "claude-status-bar",
+            versionPattern: #"^v([0-9]+(?:\.[0-9]+)+)$"#,
+            installAssetPattern: #"^ClaudeStatusBar\.dmg$"#,
+            installerKind: .dmg),
+
         // RustDesk — tags have no `v` prefix. One-click installs the arm64 dmg
         // asset (`rustdesk-<ver>-aarch64.dmg`): the official GitHub build is a
         // notarized Developer ID app, Team ID HZF9JMC8YN (zhou huabing), matching

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -39,6 +39,16 @@ private func extract(_ tag: String, _ bundleID: String) -> String? {
     #expect(extract("v5.8.1", "io.beekeeperstudio.desktop") == "5.8.1")
 }
 
+@Test func claudeStatusBarRuleReadsVPrefixedTagsAndTheVersionlessDmg() {
+    #expect(extract("v0.4.4", "com.local.claudestatusbar") == "0.4.4")
+    #expect(extract("v0.4.4-beta.1", "com.local.claudestatusbar") == nil)
+    let pattern = try! #require(rule("com.local.claudestatusbar").installAssetPattern)
+    #expect("ClaudeStatusBar.dmg".range(of: pattern, options: .regularExpression) != nil)
+    #expect("ClaudeStatusBar.zip".range(of: pattern, options: .regularExpression) == nil)
+    #expect(rule("com.local.claudestatusbar").slug == "m1ckc3s/claude-status-bar")
+    #expect(rule("com.local.claudestatusbar").installerKind == .dmg)
+}
+
 @Test func insomniaRuleMatchesCoreTagOnly() {
     // Captures the desktop version from a stable core@ tag…
     #expect(extract("core@12.6.0", "com.insomnia.app") == "12.6.0")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -50,6 +50,16 @@ private func extract(_ tag: String, _ bundleID: String) -> String? {
     #expect(rule("net.imput.helium").installerKind == .dmg)
 }
 
+@Test func claudeStatusBarRuleReadsVPrefixedTagsAndTheVersionlessDmg() {
+    #expect(extract("v0.4.4", "com.local.claudestatusbar") == "0.4.4")
+    #expect(extract("v0.4.4-beta.1", "com.local.claudestatusbar") == nil)
+    let pattern = try! #require(rule("com.local.claudestatusbar").installAssetPattern)
+    #expect("ClaudeStatusBar.dmg".range(of: pattern, options: .regularExpression) != nil)
+    #expect("ClaudeStatusBar.zip".range(of: pattern, options: .regularExpression) == nil)
+    #expect(rule("com.local.claudestatusbar").slug == "m1ckc3s/claude-status-bar")
+    #expect(rule("com.local.claudestatusbar").installerKind == .dmg)
+}
+
 @Test func insomniaRuleMatchesCoreTagOnly() {
     // Captures the desktop version from a stable core@ tag…
     #expect(extract("core@12.6.0", "com.insomnia.app") == "12.6.0")

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -119,6 +119,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
 - [x] [**Helium**](net-imput-helium.md) · `net.imput.helium` — G (one-click arm64 dmg) · 真包 0.16.2.1 挂载验证 ✓ · 2026-08-30
+- [x] [**Claude Status Bar**](com-local-claudestatusbar.md) · `com.local.claudestatusbar` — G (one-click dmg) · 真包 v0.4.4 挂载验证 ✓ · 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,6 +118,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
+- [x] [**Claude Status Bar**](com-local-claudestatusbar.md) · `com.local.claudestatusbar` — G (one-click dmg) · 真包 v0.4.4 挂载验证 ✓ · 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 

--- a/docs/app-audits/com-local-claudestatusbar.md
+++ b/docs/app-audits/com-local-claudestatusbar.md
@@ -1,0 +1,64 @@
+# Claude Status Bar
+
+## 基本信息
+- Bundle ID: `com.local.claudestatusbar`
+- Team ID: `W9JZ4932LA` (Elo LLC)
+- 观测版本: `0.4.4`（short == build）
+- 自更新机制: 无（无 `SUFeedURL`）
+- 分发: GitHub Releases (`m1ckc3s/claude-status-bar`) / Homebrew cask `claude-status-bar`
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|            | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|------------|---------|----------|-----|--------|-------------|
+| **stable** | —       | —        | —   | ✓      | —           |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **GitHub**。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `com.local.claudestatusbar` | 单一渠道 | — | tag 锚 `^vX.Y.Z$` | ✓ |
+
+单渠道。全部 release 非 prerelease。
+
+## 更新检测
+- 源: `m1ckc3s/claude-status-bar` GitHub Releases，`/releases/latest`
+- 版本方案: tag `v0.4.4` → `0.4.4` == 包的 short 与 build。同构，无陷阱。
+- 资产文件名**不带版本号**（`ClaudeStatusBar.dmg` 每个 release 同名），版本只来自 tag。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 无 | 不能 |
+| 证据 | — | release 资产只有 dmg，无 delta（观测 2026-08-30） | — |
+
+## Changelog
+- 来源: GitHub Release body（`GitHubReleasesSource` 原生带回）
+- 跟随 channel: 是，仅 stable
+- Recipe 状态: 不需要
+
+## 一键安装
+- 状态: **支持**
+- 格式: dmg — `ClaudeStatusBar.dmg`（无版本号文件名）
+- Pattern: `^ClaudeStatusBar\.dmg$`, kind `.dmg`
+- **读的是**: 人人可手动下载的 GA（官方 repo 公开资产）
+- 包验（2026-08-30，v0.4.4 挂载）: `com.local.claudestatusbar` / `0.4.4`，Team
+  `W9JZ4932LA`，`spctl accepted / Notarized Developer ID`
+
+## 已知问题
+- 无。
+
+## 如何复验
+```
+# GET https://api.github.com/repos/m1ckc3s/claude-status-bar/releases/latest → v0.4.4
+# 挂载 ClaudeStatusBar.dmg → com.local.claudestatusbar / 0.4.4
+# channel-verify --check com.local.claudestatusbar → winning=GitHub, up to date
+```
+
+## 建议下一步
+无。检测 + 一键 + changelog 均已覆盖。


### PR DESCRIPTION
## What

Claude Status Bar (Homebrew 90d 531 installs) — menu-bar quota indicator for Claude Code, no `SUFeedURL` → row was `unknown`. One `GitHubReleaseRule`.

- Repo `m1ckc3s/claude-status-bar`, `/releases/latest`, `vX.Y.Z` tags, no prereleases.
- One-click: literal `^ClaudeStatusBar\.dmg$` — the asset filename is versionless.

## Verification (real artifact)

- Mounted `ClaudeStatusBar.dmg` (v0.4.4): `com.local.claudestatusbar`, short == build == tag, Team `W9JZ4932LA`, notarized.
- `channel-verify --check com.local.claudestatusbar` — **GitHub wins, up to date**.
- `make test` green.

Audit doc: `docs/app-audits/com-local-claudestatusbar.md`.