### PR TITLE
Track claude-devtools — Claude Code session visualiser

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -801,6 +801,19 @@ public enum GitHubReleaseRegistry {
             installAssetPattern: #"^Pearcleaner\.dmg$"#,
             installerKind: .dmg),
 
+        // claude-devtools — visualiser/analyser for Claude Code sessions.
+        // v-tags, and each release ships both an arm64 dmg and an x64 dmg plus
+        // zip/blockmap siblings (the cask itself is x86_64-gated, but the repo
+        // has shipped arm64 dmgs all along). Mounted v0.5.0:
+        // com.claudecode.context, short == build == tag, Team 55PSHY2MW6,
+        // notarized.
+        GitHubReleaseRule(
+            bundleID: "com.claudecode.context",
+            owner: "matt1398", repo: "claude-devtools",
+            versionPattern: #"^v([0-9]+(?:\.[0-9]+)+)$"#,
+            installAssetPattern: #"^claude-devtools-[0-9.]+-arm64\.dmg$"#,
+            installerKind: .dmg),
+
         // RustDesk — tags have no `v` prefix. One-click installs the arm64 dmg
         // asset (`rustdesk-<ver>-aarch64.dmg`): the official GitHub build is a
         // notarized Developer ID app, Team ID HZF9JMC8YN (zhou huabing), matching

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -39,6 +39,17 @@ private func extract(_ tag: String, _ bundleID: String) -> String? {
     #expect(extract("v5.8.1", "io.beekeeperstudio.desktop") == "5.8.1")
 }
 
+@Test func claudeDevtoolsRulePinsTheArm64Dmg() {
+    #expect(extract("v0.5.0", "com.claudecode.context") == "0.5.0")
+    #expect(extract("v0.5.0-rc.1", "com.claudecode.context") == nil)
+    let pattern = try! #require(rule("com.claudecode.context").installAssetPattern)
+    #expect("claude-devtools-0.5.0-arm64.dmg".range(of: pattern, options: .regularExpression) != nil)
+    #expect("claude-devtools-0.5.0-x64.dmg".range(of: pattern, options: .regularExpression) == nil)
+    #expect("claude-devtools-0.5.0-arm64.zip".range(of: pattern, options: .regularExpression) == nil)
+    #expect(rule("com.claudecode.context").slug == "matt1398/claude-devtools")
+    #expect(rule("com.claudecode.context").installerKind == .dmg)
+}
+
 @Test func insomniaRuleMatchesCoreTagOnly() {
     // Captures the desktop version from a stable core@ tag…
     #expect(extract("core@12.6.0", "com.insomnia.app") == "12.6.0")

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -118,6 +118,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenCode Desktop**](ai-opencode-desktop.md) · `ai.opencode.desktop` — G C (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**OpenChamber**](dev-openchamber-desktop.md) · `dev.openchamber.desktop` — G (one-click, native arch dmg) · real DMG verified ✓ · 2026-08-17
 - [x] [**Jan**](jan-ai-app.md) · `jan.ai.app` — G (one-click universal zip) · real app verified ✓ · 2026-08-17
+- [x] [**claude-devtools**](com-claudecode-context.md) · `com.claudecode.context` — G (one-click arm64 dmg) · 真包 v0.5.0 挂载验证 ✓ · 2026-08-30
 
 ## Changelog-only (detection via Sparkle or Homebrew)
 

--- a/docs/app-audits/com-claudecode-context.md
+++ b/docs/app-audits/com-claudecode-context.md
@@ -1,0 +1,64 @@
+# claude-devtools
+
+## 基本信息
+- Bundle ID: `com.claudecode.context`
+- Team ID: `55PSHY2MW6` (NALY)
+- 观测版本: `0.5.0`（short == build）
+- 自更新机制: 无（无 `SUFeedURL`）
+- 分发: GitHub Releases (`matt1398/claude-devtools`) / Homebrew cask `claude-devtools`
+  （cask 有 `depends_on arch: :x86_64`，但 repo 一直发 arm64 dmg）
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|            | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|------------|---------|----------|-----|--------|-------------|
+| **stable** | —       | —        | —   | ✓      | —           |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **GitHub**。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `com.claudecode.context` | 单一渠道 | — | tag 锚 `^vX.Y.Z$` | ✓ |
+
+单渠道。全部 release 非 prerelease。
+
+## 更新检测
+- 源: `matt1398/claude-devtools` GitHub Releases，`/releases/latest`
+- 版本方案: tag `v0.5.0` → `0.5.0` == 包的 short 与 build。同构，无陷阱。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 无 | 不能 |
+| 证据 | — | 资产只有 dmg/zip/deb/blockmap，无 delta（观测 2026-08-30） | — |
+
+## Changelog
+- 来源: GitHub Release body（`GitHubReleasesSource` 原生带回）
+- 跟随 channel: 是，仅 stable
+- Recipe 状态: 不需要
+
+## 一键安装
+- 状态: **支持**
+- 格式: dmg — `claude-devtools-{v}-arm64.dmg`（`-x64.dmg` 与 zip/blockmap 是同场兄弟）
+- Pattern: `^claude-devtools-[0-9.]+-arm64\.dmg$`, kind `.dmg`
+- **读的是**: 人人可手动下载的 GA（官方 repo 公开资产）
+- 包验（2026-08-30，v0.5.0 挂载）: `com.claudecode.context` / `0.5.0`，Team
+  `55PSHY2MW6`，`spctl accepted / Notarized Developer ID`
+
+## 已知问题
+- 无。
+
+## 如何复验
+```
+# GET https://api.github.com/repos/matt1398/claude-devtools/releases/latest → v0.5.0
+# 挂载 claude-devtools-0.5.0-arm64.dmg → com.claudecode.context / 0.5.0
+# channel-verify --check com.claudecode.context → winning=GitHub, up to date
+```
+
+## 建议下一步
+无。检测 + 一键 + changelog 均已覆盖。


### PR DESCRIPTION
## What

[claude-devtools](https://github.com/matt1398/claude-devtools) (Homebrew 90d 935 installs) — no `SUFeedURL` → row was `unknown`. One `GitHubReleaseRule`.

- Repo `matt1398/claude-devtools`, `/releases/latest`, `vX.Y.Z` tags, no prereleases.
- One-click: `^claude-devtools-[0-9.]+-arm64\.dmg$`. The cask is x86_64-gated, but the repo has shipped arm64 dmgs all along — verified on the real arm64 artifact.

## Verification (real artifact)

- Mounted `claude-devtools-0.5.0-arm64.dmg`: `com.claudecode.context`, short == build == tag, Team `55PSHY2MW6`, notarized.
- `channel-verify --check com.claudecode.context` — **GitHub wins, up to date**.
- `make test` green.

Audit doc: `docs/app-audits/com-claudecode-context.md`.