### PR TITLE
docs(registry): record Trae and Hermes as known-unfeasible probes

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -948,6 +948,23 @@ public struct VendorProbeRecipe: Sendable {
 /// releases-list JSON (compared on the `build` field via `versionIsBuild`).
 ///
 /// GitHub-released apps are handled by `GitHubReleasesSource`, not here.
+///
+/// Two more unfeasibles, observed 2026-08-30 and recorded to stop rediscovery:
+/// - **Trae / Trae CN** (`com.trae.app`): the update manifest
+///   (`api.trae.ai/icube/api/v1/native/version/trae/latest`) carries NO version
+///   field — only CDN release-train numbers (`…/releases/stable/2.3.73738/…`)
+///   baked into download URLs, while the installed bundle reports a different
+///   namespace (`CFBundleShortVersionString 3.5.91` for train 2.3.73738).
+///   Homebrew's cask livecheck grabs the train number too, but Homebrew never
+///   compares it to the bundle. No public endpoint yields the app version, so
+///   a probe would compare across namespaces — same class as Brave/Feishu.
+/// - **Hermes (Nous Research desktop)**: the distributed artifact
+///   (`Hermes-Setup.dmg`) is a 0.0.1 bootstrap stub
+///   (`com.nousresearch.hermes.setup`) that downloads the real app elsewhere;
+///   the real bundle id/version cannot be observed without running the
+///   installer. The homepage carries the version (0.20.6, Homebrew's livecheck
+///   scrapes it) but there is no registry key to hang it on until a real
+///   install is observed.
 public enum VendorProbeRegistry {
 
     /// Comet's stable download gateway — the endpoint the probe reads AND the one


### PR DESCRIPTION
## What

Two apps from the 2026-08-30 sweep that were investigated and deliberately NOT integrated — recorded in the known-unfeasible block so nobody spends the hours again:

- **Trae** (`com.trae.app`): the update manifest carries no version field, only CDN release-train numbers in URLs (`…/stable/2.3.73738/…`), while the real bundle reports `3.5.91` — Homebrew's cask livecheck grabs the train number too, but Homebrew never compares it to the bundle. No public endpoint yields the app version → a probe would compare across namespaces (same class as the existing Brave/Feishu entry).
- **Hermes (Nous Research)**: the distributed dmg is a `0.0.1` bootstrap stub (`com.nousresearch.hermes.setup`) that installs the real app elsewhere; the homepage carries the real version (0.20.6) but there is no registry key to hang it on until a real install is observed.

Docs-only, no behavior change.