### PR TITLE
fix: unify detection-only fallback affordance (popover vs workbench)

### DIFF
--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1591,12 +1591,17 @@ private struct AppRow: View {
     /// Fallback for updates we can detect but not install in place (GitHub
     /// releases, self-updating apps like Chrome). Opens the official download /
     /// releases page in the browser so the user can grab it through the app's own
-    /// channel; only reveals in Finder if there's no URL to open.
+    /// channel; only reveals in Finder if there's no URL to open — in which case
+    /// the button title says so too (see `DetectionOnlyAffordance`, #197).
     private var openButton: some View {
-        Button("Open") { openAction() }
+        Button(detectionOnlyAffordance.buttonTitle) { openAction() }
             .controlSize(.small)
             .buttonStyle(.bordered)
             .help(openHelp)
+    }
+
+    private var detectionOnlyAffordance: DetectionOnlyAffordance {
+        DetectionOnlyAffordance.resolve(pageURL: result.remote?.pageURL)
     }
 
     /// Shown for a running self-updating app under the "defer while running"

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1594,10 +1594,20 @@ private struct AppRow: View {
     /// channel; only reveals in Finder if there's no URL to open — in which case
     /// the button title says so too (see `DetectionOnlyAffordance`, #197).
     private var openButton: some View {
-        Button(detectionOnlyAffordance.buttonTitle) { openAction() }
+        Button(openButtonTitle) { openAction() }
             .controlSize(.small)
             .buttonStyle(.bordered)
             .help(openHelp)
+    }
+
+    /// `.openPage`'s title is this host's own call (kept out of
+    /// `DetectionOnlyAffordance` on purpose — see its doc comment): the popover
+    /// says "Open" here, matching its other single-word action buttons.
+    private var openButtonTitle: String {
+        switch detectionOnlyAffordance {
+        case .openPage: return String(localized: "Open")
+        case .revealInFinder: return DetectionOnlyAffordance.revealInFinderTitle
+        }
     }
 
     private var detectionOnlyAffordance: DetectionOnlyAffordance {

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -652,11 +652,20 @@ private struct WorkbenchActionView: View {
             // Detection-only tail: no artifact, no vendorInstallerKind, no App
             // Store route above. Mirror the popover's fallback instead of
             // rendering nothing when there's no page either — see
-            // `DetectionOnlyAffordance` (#197).
+            // `DetectionOnlyAffordance` (#197). The title for `.openPage` is
+            // this host's own call (kept out of the shared type on purpose):
+            // "Open page" here, distinct from the popover's single-word "Open".
             let affordance = DetectionOnlyAffordance.resolve(pageURL: result.remote?.pageURL)
-            Button(affordance.buttonTitle) {
+            let title = affordance == .revealInFinder
+                ? DetectionOnlyAffordance.revealInFinderTitle
+                : String(localized: "Open page")
+            Button(title) {
                 switch affordance {
                 case .openPage(let url):
+                    // Unlike the popover's openAction(), this always does a
+                    // plain open — it does not check for a non-http(s) scheme
+                    // and hand it to the app itself via `withApplicationAt:`.
+                    // Pre-existing gap, out of scope for #197.
                     NSWorkspace.shared.open(url)
                 case .revealInFinder:
                     NSWorkspace.shared.activateFileViewerSelecting([result.app.path])
@@ -664,7 +673,7 @@ private struct WorkbenchActionView: View {
             }
             .buttonStyle(.bordered)
             .help(affordance == .revealInFinder
-                  ? String(localized: "Reveal in Finder")
+                  ? DetectionOnlyAffordance.revealInFinderTitle
                   : String(localized: "Open the official download page"))
         }
     }

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -648,10 +648,24 @@ private struct WorkbenchActionView: View {
             .help(storeManagedHere
                   ? String(localized: "Update \(result.app.name) in the App Store — iPhone/iPad apps can’t be updated from here")
                   : appStoreRedirectHelp)
-        } else if let url = result.remote?.pageURL {
-            Button("Open page") { NSWorkspace.shared.open(url) }
-                .buttonStyle(.bordered)
-                .help("Open the official download page")
+        } else {
+            // Detection-only tail: no artifact, no vendorInstallerKind, no App
+            // Store route above. Mirror the popover's fallback instead of
+            // rendering nothing when there's no page either — see
+            // `DetectionOnlyAffordance` (#197).
+            let affordance = DetectionOnlyAffordance.resolve(pageURL: result.remote?.pageURL)
+            Button(affordance.buttonTitle) {
+                switch affordance {
+                case .openPage(let url):
+                    NSWorkspace.shared.open(url)
+                case .revealInFinder:
+                    NSWorkspace.shared.activateFileViewerSelecting([result.app.path])
+                }
+            }
+            .buttonStyle(.bordered)
+            .help(affordance == .revealInFinder
+                  ? String(localized: "Reveal in Finder")
+                  : String(localized: "Open the official download page"))
         }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/DetectionOnlyAffordance.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/DetectionOnlyAffordance.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// What to offer for a result that's detection-only — we can tell the user an
+/// update exists, but there's no artifact to install and no `vendorInstallerKind`
+/// to route through. Both hosts (menu-bar popover and workbench window) hit this
+/// tail case, and it isn't specific to any one source: any result whose remote
+/// `pageURL` is nil lands here (`ElectronManifestSource` is just the first source
+/// that hits it on every result, since it only ever has a release CDN directory,
+/// not a page meant for people).
+///
+/// Before this type existed the two hosts each wrote their own fallback and they
+/// disagreed — see issue #197: the popover offered a button labeled "Open" that
+/// actually revealed the app in Finder (`NSWorkspace.activateFileViewerSelecting`),
+/// while the workbench rendered nothing at all for the identical data.
+public enum DetectionOnlyAffordance: Sendable, Equatable {
+    /// There's somewhere to send the user — the vendor's page, or (when the URL's
+    /// scheme isn't http/https) an app-internal deep link into its own updater.
+    case openPage(URL)
+    /// No page at all. The only honest offer left is showing the user where the
+    /// app lives, so they can deal with it by hand.
+    case revealInFinder
+
+    public static func resolve(pageURL: URL?) -> Self {
+        pageURL.map(Self.openPage) ?? .revealInFinder
+    }
+
+    /// Button title — matches what the action actually does, unlike the old
+    /// popover behavior where a `pageURL == nil` result still said "Open".
+    public var buttonTitle: String {
+        switch self {
+        case .openPage: return String(localized: "Open")
+        case .revealInFinder: return String(localized: "Reveal in Finder")
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/DetectionOnlyAffordance.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/DetectionOnlyAffordance.swift
@@ -12,24 +12,32 @@ import Foundation
 /// disagreed — see issue #197: the popover offered a button labeled "Open" that
 /// actually revealed the app in Finder (`NSWorkspace.activateFileViewerSelecting`),
 /// while the workbench rendered nothing at all for the identical data.
+///
+/// This type only owns the *decision* (is there a page to send the user to, or
+/// not) and the copy for the case both hosts render identically. It deliberately
+/// does not own a title for `.openPage`, nor how a host actually opens that URL:
+/// the popover's `openAction()` recognizes a non-http(s) scheme and hands it to
+/// the app itself via `NSWorkspace.open(_:withApplicationAt:)` so the app's own
+/// updater can act on it (e.g. Chrome's `chrome://` deep link); the workbench
+/// does a plain `NSWorkspace.shared.open(url)` regardless of scheme. That gap
+/// predates this type and is out of scope for #197 — each host still decides it.
 public enum DetectionOnlyAffordance: Sendable, Equatable {
-    /// There's somewhere to send the user — the vendor's page, or (when the URL's
-    /// scheme isn't http/https) an app-internal deep link into its own updater.
+    /// There's a page URL to send the user to — the vendor's download/release
+    /// page, or an app-internal deep link. What the button says and how the URL
+    /// is opened are both a per-host call; see the type doc above.
     case openPage(URL)
     /// No page at all. The only honest offer left is showing the user where the
-    /// app lives, so they can deal with it by hand.
+    /// app lives, so they can deal with it by hand — every host renders this the
+    /// same way, so its copy lives here.
     case revealInFinder
 
     public static func resolve(pageURL: URL?) -> Self {
         pageURL.map(Self.openPage) ?? .revealInFinder
     }
 
-    /// Button title — matches what the action actually does, unlike the old
-    /// popover behavior where a `pageURL == nil` result still said "Open".
-    public var buttonTitle: String {
-        switch self {
-        case .openPage: return String(localized: "Open")
-        case .revealInFinder: return String(localized: "Reveal in Finder")
-        }
+    /// Localized title for the `.revealInFinder` case only. `.openPage` has no
+    /// shared title on purpose — see the type doc.
+    public static var revealInFinderTitle: String {
+        String(localized: "Reveal in Finder")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DetectionOnlyAffordanceTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DetectionOnlyAffordanceTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+struct DetectionOnlyAffordanceTests {
+
+    /// Regression for #197: a detection-only result with no page at all must
+    /// resolve to the reveal-in-Finder affordance, not "openPage" with some
+    /// placeholder URL and not a title that still says "Open" for an action that
+    /// actually reveals the app in Finder.
+    @Test func noPageURLRevealsInFinder() {
+        let affordance = DetectionOnlyAffordance.resolve(pageURL: nil)
+
+        #expect(affordance == .revealInFinder)
+        #expect(affordance.buttonTitle == "Reveal in Finder")
+    }
+
+    @Test func pageURLOpensThatPage() {
+        let url = URL(string: "https://example.com/download")!
+        let affordance = DetectionOnlyAffordance.resolve(pageURL: url)
+
+        #expect(affordance == .openPage(url))
+        #expect(affordance.buttonTitle == "Open")
+    }
+
+    /// The two cases must never share a title — that's exactly the bug: the
+    /// button said "Open" regardless of which action it actually performed.
+    @Test func titlesDifferBetweenCases() {
+        let withPage = DetectionOnlyAffordance.resolve(pageURL: URL(string: "https://example.com")!)
+        let withoutPage = DetectionOnlyAffordance.resolve(pageURL: nil)
+
+        #expect(withPage.buttonTitle != withoutPage.buttonTitle)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DetectionOnlyAffordanceTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DetectionOnlyAffordanceTests.swift
@@ -5,30 +5,26 @@ import Testing
 struct DetectionOnlyAffordanceTests {
 
     /// Regression for #197: a detection-only result with no page at all must
-    /// resolve to the reveal-in-Finder affordance, not "openPage" with some
-    /// placeholder URL and not a title that still says "Open" for an action that
-    /// actually reveals the app in Finder.
+    /// resolve to the reveal-in-Finder affordance — not "openPage" with some
+    /// placeholder URL, and not silently render nothing the way the workbench
+    /// used to.
     @Test func noPageURLRevealsInFinder() {
         let affordance = DetectionOnlyAffordance.resolve(pageURL: nil)
 
         #expect(affordance == .revealInFinder)
-        #expect(affordance.buttonTitle == "Reveal in Finder")
     }
 
-    @Test func pageURLOpensThatPage() {
+    @Test func pageURLResolvesToThatExactPage() {
         let url = URL(string: "https://example.com/download")!
         let affordance = DetectionOnlyAffordance.resolve(pageURL: url)
 
         #expect(affordance == .openPage(url))
-        #expect(affordance.buttonTitle == "Open")
     }
 
-    /// The two cases must never share a title — that's exactly the bug: the
-    /// button said "Open" regardless of which action it actually performed.
-    @Test func titlesDifferBetweenCases() {
-        let withPage = DetectionOnlyAffordance.resolve(pageURL: URL(string: "https://example.com")!)
-        let withoutPage = DetectionOnlyAffordance.resolve(pageURL: nil)
-
-        #expect(withPage.buttonTitle != withoutPage.buttonTitle)
+    /// `.revealInFinder`'s title is the one piece of copy this type does own
+    /// (every host renders it identically) — pin it so a future edit can't
+    /// silently swap it back to something that claims to "Open" like #197 did.
+    @Test func revealInFinderTitleReadsAsReveal() {
+        #expect(DetectionOnlyAffordance.revealInFinderTitle == "Reveal in Finder")
     }
 }


### PR DESCRIPTION
## What

For a result that **has an update, no installable artifact, and no `pageURL`** (any source that never sets `pageURL` — not Electron-specific, `ElectronManifestSource` is just the first one that hits it on every result), the two hosts disagreed on what to offer:

- **Popover** (`MenuContentView.swift`, final `else` in the trailing-view `if` chain): rendered `openButton`, always labeled **"Open"**. But `openAction()` falls back to `NSWorkspace.shared.activateFileViewerSelecting([result.app.path])` (reveal in Finder) when `pageURL == nil` — so the button said "Open" but actually revealed the app in Finder. The tooltip (`openHelp`) already said "Reveal in Finder" correctly; only the button title was wrong.
- **Workbench** (`WorkbenchWindowView.swift`, `updateAction`): the last branch was `else if let url = result.remote?.pageURL { Button("Open page") ... }` — when `pageURL` was nil, **nothing rendered at all**. Same data, no affordance.

## Fix

Added `DetectionOnlyAffordance` in Core (`DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/DetectionOnlyAffordance.swift`) — a pure function `resolve(pageURL: URL?) -> DetectionOnlyAffordance` returning either `.openPage(URL)` or `.revealInFinder`. The type deliberately owns **only** that decision plus the copy for the one case both hosts render identically (`revealInFinderTitle`, "Reveal in Finder"). It does **not** own a title for `.openPage`, and does not speak for how a host opens that URL — each host decides both for itself (see the type's doc comment for why: an earlier revision of this PR had a shared `buttonTitle` that returned "Open" for `.openPage`, which silently renamed the workbench's existing "Open page" button on every detection-only row that *does* have a page — far more rows than the nil case #197 is about. Caught in review; reverted to per-host titles.).

Both hosts now consult it in their final fallback branch:
- **Popover**: `openButton`'s title (`openButtonTitle`) switches on the resolved affordance and says "Open" for `.openPage` (unchanged from before) or `DetectionOnlyAffordance.revealInFinderTitle` for `.revealInFinder`. `openAction()`/`openHelp` are unchanged — they already did the right thing (deep-link vs http(s) page vs reveal-in-Finder); only the mislabeled button text was the bug.
- **Workbench**: the trailing `else if let url = result.remote?.pageURL` branch became an unconditional `else` that resolves the same affordance. `.openPage` still says "Open page" (unchanged) and still does a plain `NSWorkspace.shared.open(url)` (unchanged — see note below on the deep-link gap). `.revealInFinder` is new: it now calls `NSWorkspace.shared.activateFileViewerSelecting([result.app.path])` and shows `DetectionOnlyAffordance.revealInFinderTitle`, matching the popover instead of rendering nothing.

**Known, pre-existing, out-of-scope gap** (documented, not fixed, per review): the popover's `openAction()` recognizes a non-http(s) URL scheme (e.g. `chrome://settings/help`) and hands it to the app itself via `NSWorkspace.open(_:withApplicationAt:)`, so the app's own updater can act on it. The workbench's `.openPage` branch does not do this — it always does a plain `NSWorkspace.shared.open(url)`, scheme or not. This predates this PR; the workbench branch now carries an inline comment calling it out so the next person doesn't assume parity.

**Undeclared-until-now behavior change worth flagging explicitly** (per review — this widening is intentional and consistent with #197's intent, but wasn't called out before): the workbench's fallback was `else if let url = pageURL { ... }` (renders nothing when the condition is false) and is now an unconditional `else`. This means rows that fall through the `appStore` branch above without matching it — i.e. an App Store result where `info.isRegionMismatch` or `info.isLatestMacIncompatible` is true, and `pageURL` also happens to be nil — now land in the new tail and show a "Reveal in Finder" button, where before they showed **nothing**. I believe this is the right behavior (same rationale as #197: some affordance beats none for identical data), but it's a strictly larger set of rows than "detection-only sources with no pageURL" alone, so it's worth a look alongside the rest of this change.

Per CLAUDE.md ("判断逻辑放 Core, App 只留接线"), no existing Core files were touched — only the new `DetectionOnlyAffordance.swift` + its test file.

## Localization

No new keys. All four reused strings — **"Open"**, **"Open page"**, **"Reveal in Finder"**, **"Open the official download page"** — already exist in `App/Resources/Localizable.xcstrings`, fully translated in all 6 locales (de/es/fr/ja/ru/zh-Hans), because they were already used verbatim elsewhere in the App target. Verified by inspecting the catalog directly (`python3 -c "json.load(...)"`), not by running the build-dependent checker script (asked not to, in this worktree — lock contention with parallel worktrees). Coordinator independently confirmed the same four keys are fully covered.

## Test plan

- [x] `swift test --package-path DuoUpdaterCore --filter DetectionOnlyAffordance` — 3/3 pass (see below)
- [ ] Build the App target and eyeball a detection-only result with `pageURL == nil` in both the popover and the workbench window, plus a region-locked/incompatible App Store row with `pageURL == nil` (the newly-widened case above) — not done here (asked not to build the App target in this worktree; coordinator is doing this verification separately)
- [ ] Run `scripts/check_localizable_keys.py` (or `make test`) to confirm no localization drift — not run here per instructions (fixed `/tmp/duo-loc-check` path collides across worktrees)

```
◇ Suite DetectionOnlyAffordanceTests started.
◇ Test noPageURLRevealsInFinder() started.
◇ Test revealInFinderTitleReadsAsReveal() started.
◇ Test pageURLResolvesToThatExactPage() started.
✔ Test noPageURLRevealsInFinder() passed after 0.001 seconds.
✔ Test pageURLResolvesToThatExactPage() passed after 0.001 seconds.
✔ Test revealInFinderTitleReadsAsReveal() passed after 0.003 seconds.
✔ Suite DetectionOnlyAffordanceTests passed after 0.003 seconds.
✔ Test run with 3 tests in 1 suite passed after 0.003 seconds.
```

Fixes #197
