### PR TITLE
Wire Electron into install policy/routing, and fix duo install's misleading refusal text

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4514,7 +4514,26 @@ final class AppListModel {
         guard !requiresInstaller(result) else { return false }
         guard appManagementStatus == .granted else { return false }
         switch result.remote?.sourceName {
-        case "Sparkle", "Vendor", "GitHub":
+        // Electron (electron-builder manifests) belongs here, not in the
+        // default/serial case (#192's sixth decision point, found during that
+        // fix's review and deliberately handled in this follow-up). It goes
+        // through the exact same pipeline as Vendor/GitHub — `VendorInstaller`
+        // downloads the archive and `InPlaceSwap` swaps it in — with no shared
+        // system UI/tooling, which is this function's own stated criterion for
+        // "stays serial".
+        //
+        // The one real question was whether parallelizing could race an
+        // electron-builder app's own self-updater (electron-updater/Squirrel
+        // .Mac). It can't, and not because of anything in THIS function: every
+        // target here already passed `installAllTargets()`'s `defersToSelfUpdater`
+        // filter (so a currently-running self-updating app never reaches this
+        // switch at all), and the staged-build check
+        // (`UpdatePolicy.stagedBlocksInstall`) is enforced inside `runInstall`
+        // itself — the function both `installInParallel` and the serial loop
+        // call — so it applies identically to a parallel target and a serial
+        // one. This switch decides scheduling throughput only; it was never
+        // the layer guarding against a ShipIt-style collision.
+        case "Sparkle", "Vendor", "GitHub", "Electron":
             return true
         default:
             return false

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4508,31 +4508,37 @@ final class AppListModel {
     }
 
     /// Only independent archive/appcast installs run in parallel, and only once
-    /// App Management is known granted. Package installers, Homebrew, and App Store
-    /// all involve shared system UI/tools, so they stay serial.
+    /// App Management is known granted.
+    ///
+    /// The switch below is reached ONLY by results `installAllTargets()` already
+    /// passed through `canAutoInstall(result) || requiresInstaller(result)` — so
+    /// a source `UpdatePolicy` has no case for at all (Xcode Releases, Toolbox,
+    /// TestFlight: always `default: false` on both) never reaches `targets` to
+    /// begin with, let alone this function. It isn't mis-scheduled here; it's
+    /// simply not a candidate. `requiresInstaller` results are peeled off first
+    /// by the guard above (a Vendor/GitHub/Electron `.pkg`, a signed Sparkle
+    /// `.pkg`, a Homebrew cask needing the manual installer) — those go through
+    /// the system installer, the batch's phase 3, never this switch.
+    ///
+    /// What can still reach `default: false` here, given the above, is exactly
+    /// two sources: Homebrew (shells out to the `brew` CLI, one shared process
+    /// per invocation) and App Store (drives `mas` or App Store.app's own UI
+    /// automation) — both share a system-level resource a second simultaneous
+    /// install would contend with, so they stay serial. Sparkle/Vendor/GitHub/
+    /// Electron are independent in-place archive swaps (`InPlaceSwap`) with no
+    /// such shared resource, so they run in the bounded parallel window —
+    /// Electron joined this list in #192's follow-up: it goes through the exact
+    /// same `VendorInstaller`+`InPlaceSwap` pipeline as Vendor/GitHub, so by
+    /// this function's own criterion it belongs here, not in `default`. (Whether
+    /// parallelizing could race an electron-builder app's own self-updater is a
+    /// question this switch was never answering: `defersToSelfUpdater` already
+    /// excluded a running one from `targets`, and `UpdatePolicy
+    /// .stagedBlocksInstall` is enforced inside `runInstall` itself, which the
+    /// parallel and serial paths both call — identically either way.)
     private func canBatchInstallInParallel(_ result: UpdateResult) -> Bool {
         guard !requiresInstaller(result) else { return false }
         guard appManagementStatus == .granted else { return false }
         switch result.remote?.sourceName {
-        // Electron (electron-builder manifests) belongs here, not in the
-        // default/serial case (#192's sixth decision point, found during that
-        // fix's review and deliberately handled in this follow-up). It goes
-        // through the exact same pipeline as Vendor/GitHub — `VendorInstaller`
-        // downloads the archive and `InPlaceSwap` swaps it in — with no shared
-        // system UI/tooling, which is this function's own stated criterion for
-        // "stays serial".
-        //
-        // The one real question was whether parallelizing could race an
-        // electron-builder app's own self-updater (electron-updater/Squirrel
-        // .Mac). It can't, and not because of anything in THIS function: every
-        // target here already passed `installAllTargets()`'s `defersToSelfUpdater`
-        // filter (so a currently-running self-updating app never reaches this
-        // switch at all), and the staged-build check
-        // (`UpdatePolicy.stagedBlocksInstall`) is enforced inside `runInstall`
-        // itself — the function both `installInParallel` and the serial loop
-        // call — so it applies identically to a parallel target and a serial
-        // one. This switch decides scheduling throughput only; it was never
-        // the layer guarding against a ShipIt-style collision.
         case "Sparkle", "Vendor", "GitHub", "Electron":
             return true
         default:

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -217,7 +217,22 @@ public enum Install {
                 return .refuse("App Store updates need the menu-bar app (the store's "
                     + "install path is not reachable from a CLI)")
             }
-            return .refuse("detection only — this app has no installable artefact we vet")
+            // Two different reasons read identically as "neither flag is true",
+            // and #193 was this text conflating them: a source `UpdatePolicy`
+            // has never heard of (Xcode Releases, Toolbox — no case in
+            // `canAutoInstall`/`requiresInstaller`, so always `default: false`)
+            // is not the same situation as a recognised source (Vendor, GitHub,
+            // Electron, Homebrew) that simply resolved to no artifact THIS
+            // time (no asset pattern matched, no known archive extension, a
+            // manual-installer cask). The first has no install path even in
+            // principle; the second is one manifest edit away from working.
+            // Before #192 wired Electron into the switches, every Electron app
+            // fell into the first bucket while this text described the second —
+            // sending anyone who read it to the wrong layer entirely.
+            if UpdatePolicy.isRecognizedInstallSource(result.remote?.sourceName) {
+                return .refuse("detection only — this app has no installable artefact we vet")
+            }
+            return .refuse("detection only — no install route is wired up for this source yet")
         }
         if UpdatePolicy.defersToSelfUpdater(
             result, settings: settings.updateSettings, environment: environment) {

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -217,22 +217,22 @@ public enum Install {
                 return .refuse("App Store updates need the menu-bar app (the store's "
                     + "install path is not reachable from a CLI)")
             }
-            // Two different reasons read identically as "neither flag is true",
-            // and #193 was this text conflating them: a source `UpdatePolicy`
-            // has never heard of (Xcode Releases, Toolbox — no case in
-            // `canAutoInstall`/`requiresInstaller`, so always `default: false`)
-            // is not the same situation as a recognised source (Vendor, GitHub,
-            // Electron, Homebrew) that simply resolved to no artifact THIS
-            // time (no asset pattern matched, no known archive extension, a
-            // manual-installer cask). The first has no install path even in
-            // principle; the second is one manifest edit away from working.
-            // Before #192 wired Electron into the switches, every Electron app
-            // fell into the first bucket while this text described the second —
-            // sending anyone who read it to the wrong layer entirely.
-            if UpdatePolicy.isRecognizedInstallSource(result.remote?.sourceName) {
-                return .refuse("detection only — this app has no installable artefact we vet")
-            }
-            return .refuse("detection only — no install route is wired up for this source yet")
+            // #193 originally split this into two messages — "no artefact this
+            // time" for a recognised source vs. "no route wired up yet" for one
+            // `UpdatePolicy` has no case for — reasoning that the two situations
+            // shouldn't share text. Reverted (see #192's follow-up review):
+            // measured against what `UpdatePolicy.isRecognizedInstallSource`
+            // actually excludes in production — Xcode Releases, Toolbox,
+            // TestFlight — every one of them is PERMANENTLY, DELIBERATELY
+            // artefact-less by design (Xcode's download 302s to an Apple-ID
+            // login page; Toolbox/TestFlight hand the install to their own
+            // app), not a policy gap waiting to be closed. "No route wired up
+            // yet" was therefore never true for any source that could actually
+            // reach this branch — it just relocated #193's original complaint
+            // (a message asserting something false) to the other bucket. One
+            // message, worded to be accurate for both "never has one" and
+            // "doesn't have one this time" is available.
+            return .refuse("detection only — this source publishes no installable artefact")
         }
         if UpdatePolicy.defersToSelfUpdater(
             result, settings: settings.updateSettings, environment: environment) {

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -61,6 +61,20 @@ import DuoUpdaterCore
         #expect(route == .vendor)
     }
 
+    /// #192: `VendorInstaller.download()` already vetted "Electron" (electron-
+    /// builder manifests) — the policy switches and `route(for:)` just hadn't
+    /// caught up, so this one-clicked to nothing. Same shape as
+    /// `aVendorArchiveInstalls`, proving the wiring now agrees end to end.
+    @Test func anElectronArchiveInstalls() {
+        let decision = Install.classify(
+            result(source: "Electron"), settings: settings(), environment: environment())
+        guard case .install(let route) = decision else {
+            Issue.record("expected an install, got \(decision)")
+            return
+        }
+        #expect(route == .vendor)
+    }
+
     /// The store route is refused up front rather than attempted and failed
     /// halfway: it needs the privileged helper or the Accessibility API, and a
     /// standalone binary has neither.
@@ -90,6 +104,41 @@ import DuoUpdaterCore
         #expect(why.contains("detection only"))
     }
 
+    /// Same as `detectionOnlyIsRefused`, for Electron: it is a *recognized*
+    /// source (has its own case in `canAutoInstall`/`requiresInstaller`) that
+    /// simply resolved to no artifact this time, so it gets the same "no
+    /// installable artefact we vet" wording — not the "no route wired up"
+    /// wording reserved for sources the policy has never heard of (#193).
+    @Test func electronDetectionOnlyIsRefusedWithTheArtefactWording() {
+        let decision = Install.classify(
+            result(source: "Electron", vendorKind: nil),
+            settings: settings(), environment: environment())
+        guard case .refuse(let why) = decision else {
+            Issue.record("expected a refusal, got \(decision)")
+            return
+        }
+        #expect(why.contains("no installable artefact we vet"))
+    }
+
+    /// #193: the two ways `!canAuto && !needsInstaller` can happen must not
+    /// share a message. A source `UpdatePolicy` has never heard of (no case in
+    /// `canAutoInstall`/`requiresInstaller`, so always `default: false`) has no
+    /// install path even in principle — unlike Electron above, which has a case
+    /// and just didn't resolve an artifact this time. Before #192 this exact
+    /// wording ("no installable artefact we vet") is what Electron got too,
+    /// which is why the bug report is titled "the reason is fake".
+    @Test func aSourceThePolicyHasNoCaseForGetsTheNoRouteWording() {
+        let decision = Install.classify(
+            result(source: "Xcode Releases", vendorKind: nil),
+            settings: settings(), environment: environment())
+        guard case .refuse(let why) = decision else {
+            Issue.record("expected a refusal, got \(decision)")
+            return
+        }
+        #expect(why.contains("no install route is wired up"))
+        #expect(!why.contains("no installable artefact we vet"))
+    }
+
     /// The same rule the app applies: don't swap a bundle under a running app
     /// that updates itself, unless the user asked for exactly that.
     @Test func aRunningSelfUpdaterIsDeferredUnlessOverridden() {
@@ -102,6 +151,26 @@ import DuoUpdaterCore
         }
         guard case .install = Install.classify(
             result(source: "Vendor"),
+            settings: settings(vendorPolicy: .alwaysOverwrite), environment: running)
+        else {
+            Issue.record("alwaysOverwrite should install anyway")
+            return
+        }
+    }
+
+    /// Same rule for Electron (#192): electron-builder apps embed their own
+    /// updater (electron-updater / Squirrel.Mac), so a running one must defer
+    /// exactly like a running Vendor app does above.
+    @Test func aRunningElectronSelfUpdaterIsDeferredUnlessOverridden() {
+        let running = environment(running: true)
+        guard case .refuse = Install.classify(
+            result(source: "Electron"), settings: settings(), environment: running)
+        else {
+            Issue.record("a running electron app should defer under deferWhenRunning")
+            return
+        }
+        guard case .install = Install.classify(
+            result(source: "Electron"),
             settings: settings(vendorPolicy: .alwaysOverwrite), environment: running)
         else {
             Issue.record("alwaysOverwrite should install anyway")
@@ -126,6 +195,25 @@ import DuoUpdaterCore
                 sourceName: "Alcove", requiresManualInstaller: false),
             status: .updateAvailable(latest: "2.0"))
         #expect(InstallCoordinator.route(for: unknown, requiresInstaller: false) == .sparkle)
+    }
+
+    /// #192: Electron is no longer an unknown source — `route(for:)` must send
+    /// it to `.vendor`, same as Vendor/GitHub, not fall through to `.sparkle`
+    /// (which would hand an electron-builder zip to `SparkleInstaller`, which
+    /// throws `.notSparkleUpdate` for any non-Sparkle source).
+    @Test func anElectronSourceRoutesToVendor() {
+        let electron = UpdateResult(
+            app: InstalledApp(
+                name: "Fixture", bundleID: "com.example.fixture", shortVersion: "1.0",
+                buildVersion: "1", path: URL(fileURLWithPath: "/Applications/Fixture.app"),
+                isMASApp: false, sparkleFeedURL: nil),
+            remote: RemoteVersion(
+                shortVersion: "2.0", version: nil,
+                downloadURL: URL(string: "https://example.com/fixture.zip"),
+                sourceName: "Electron", requiresManualInstaller: false,
+                vendorInstallerKind: .zip),
+            status: .updateAvailable(latest: "2.0"))
+        #expect(InstallCoordinator.route(for: electron, requiresInstaller: false) == .vendor)
     }
 
     @Test func requiringAnInstallerBeatsTheSourceName() {

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -104,11 +104,9 @@ import DuoUpdaterCore
         #expect(why.contains("detection only"))
     }
 
-    /// Same as `detectionOnlyIsRefused`, for Electron: it is a *recognized*
-    /// source (has its own case in `canAutoInstall`/`requiresInstaller`) that
-    /// simply resolved to no artifact this time, so it gets the same "no
-    /// installable artefact we vet" wording — not the "no route wired up"
-    /// wording reserved for sources the policy has never heard of (#193).
+    /// Same as `detectionOnlyIsRefused`, for Electron: recognized source
+    /// (has its own case in `canAutoInstall`/`requiresInstaller`), just no
+    /// artifact resolved this time.
     @Test func electronDetectionOnlyIsRefusedWithTheArtefactWording() {
         let decision = Install.classify(
             result(source: "Electron", vendorKind: nil),
@@ -117,17 +115,23 @@ import DuoUpdaterCore
             Issue.record("expected a refusal, got \(decision)")
             return
         }
-        #expect(why.contains("no installable artefact we vet"))
+        #expect(why.contains("no installable artefact"))
     }
 
-    /// #193: the two ways `!canAuto && !needsInstaller` can happen must not
-    /// share a message. A source `UpdatePolicy` has never heard of (no case in
-    /// `canAutoInstall`/`requiresInstaller`, so always `default: false`) has no
-    /// install path even in principle — unlike Electron above, which has a case
-    /// and just didn't resolve an artifact this time. Before #192 this exact
-    /// wording ("no installable artefact we vet") is what Electron got too,
-    /// which is why the bug report is titled "the reason is fake".
-    @Test func aSourceThePolicyHasNoCaseForGetsTheNoRouteWording() {
+    /// #193 (follow-up): a source `UpdatePolicy` has no case for at all — Xcode
+    /// Releases never resolves an artifact, by design (`downloadURL: nil`, its
+    /// download 302s to an Apple-ID login page) — must get the SAME wording as
+    /// Electron above, not a distinct "no install route wired up yet" message.
+    ///
+    /// #193 originally introduced exactly that distinct message, reasoning it
+    /// should read differently from "no artifact this time". It was reverted
+    /// (see `Install.swift`'s comment) once measured against production: every
+    /// source that reaches this branch — Xcode Releases, Toolbox, TestFlight —
+    /// is permanently artefact-less by design, so "not wired up yet" was false
+    /// for all of them; it just relocated #193's original complaint (a message
+    /// asserting something untrue) to the other bucket. This test pins the
+    /// collapse so the split doesn't quietly come back.
+    @Test func aSourceThePolicyHasNoCaseForGetsTheSameGenericWording() {
         let decision = Install.classify(
             result(source: "Xcode Releases", vendorKind: nil),
             settings: settings(), environment: environment())
@@ -135,8 +139,8 @@ import DuoUpdaterCore
             Issue.record("expected a refusal, got \(decision)")
             return
         }
-        #expect(why.contains("no install route is wired up"))
-        #expect(!why.contains("no installable artefact we vet"))
+        #expect(why.contains("no installable artefact"))
+        #expect(!why.contains("wired up"))
     }
 
     /// The same rule the app applies: don't swap a bundle under a running app

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -146,14 +146,8 @@ public enum UpdatePolicy {
             // .kind(of:)` returns nil), stay detection-only (vendorInstallerKind
             // nil), so they fall through here.
             //
-            // Electron is deliberately NOT added to `UpdateResult
-            // .licenseNeutralSources` (Models/UpdateResult.swift): unlike Vendor
-            // (our own hand-curated, vetted registry) and GitHub (open-source
-            // feeds), an electron-builder manifest can belong to a commercial app
-            // we've done no license review of, so a major-version jump arriving
-            // through this source still raises the "may need a new license"
-            // warning. Same conservative treatment as Homebrew — a decision, not
-            // an oversight (see #192).
+            // Electron is deliberately NOT in `UpdateResult.licenseNeutralSources`
+            // (Models/UpdateResult.swift) — see that property's comment for why.
             return result.remote?.vendorInstallerKind != nil
                 && result.remote?.requiresManualInstaller == false
         case "App Store":
@@ -319,20 +313,21 @@ public enum UpdatePolicy {
     /// in `canAutoInstall` / `requiresInstaller` — i.e. whether the policy has an
     /// opinion about it at all.
     ///
-    /// Exists only to let a caller tell apart two situations that otherwise both
-    /// read as `!canAutoInstall && !requiresInstaller`:
-    ///   - a recognised source that resolved to no artifact THIS time (a GitHub
-    ///     rule with no asset pattern, an Electron manifest whose file has no
-    ///     known extension, a Homebrew cask needing a manual installer) — the
-    ///     update is real, we just have nothing to hand an installer;
-    ///   - a source the policy has never heard of (Xcode Releases, Toolbox) —
-    ///     there is no install path here even in principle.
-    /// `duo install`'s refusal text (`CLI/Sources/DuoKit/Install.swift`) uses
-    /// this to stop conflating the two (#193): the former said "no installable
-    /// artefact we vet", which was actively wrong for the latter — before #192
-    /// wired Electron into the switches above, that message is exactly what an
-    /// Electron app got, and it sent whoever read it looking at the manifest
-    /// instead of at this file.
+    /// NOT used to shape `duo install`'s refusal text. #193 originally used
+    /// this to split that text in two — "no artefact THIS time" for a
+    /// recognised source vs. "no route wired up yet" for one this function
+    /// returns false for — but every source that returns false here in
+    /// production (Xcode Releases, Toolbox, TestFlight) is permanently,
+    /// deliberately artefact-less by design, not a policy gap waiting to be
+    /// closed, so "not wired up yet" was never true for anything that could
+    /// reach it. `Install.swift`'s follow-up review reverted the split; see
+    /// its comment there.
+    ///
+    /// What this DOES back: `isRecognizedInstallSourceCoversEveryProductionSourceOrExplainsWhyNot`
+    /// (`UpdatePolicyTests.swift`), which checks every name `SourceStack.make()`
+    /// can actually produce against this function, so a source that SHOULD
+    /// get install support but doesn't (Electron before #192) fails a test
+    /// instead of silently offering nothing.
     public static func isRecognizedInstallSource(_ sourceName: String?) -> Bool {
         switch sourceName {
         case "Sparkle", "Homebrew", "Vendor", "GitHub", "Electron", "App Store":

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -134,12 +134,26 @@ public enum UpdatePolicy {
         case "Homebrew":
             return result.remote?.sourceIdentifier != nil
                 && result.remote?.requiresManualInstaller == false
-        case "Vendor", "GitHub":
+        case "Vendor", "GitHub", "Electron":
             // A vendor-website or GitHub-release app with a resolved installer
-            // archive (zip/dmg/tar.gz). We download it, verify the code signature
-            // matches the installed app's Team ID, then swap in place — same
-            // channel, no mix. GitHub rules without an asset pattern stay
-            // detection-only (vendorInstallerKind nil), so they fall through here.
+            // archive (zip/dmg/tar.gz), or an electron-builder manifest resolved
+            // the same way — `VendorInstaller.download()` already vets all three
+            // identically (see its own comment: Team-ID + bundle-id gates, same
+            // pipeline). We download it, verify the code signature matches the
+            // installed app's Team ID, then swap in place — same channel, no mix.
+            // GitHub rules without an asset pattern, and Electron manifests whose
+            // chosen artifact has no recognised extension (`ElectronManifestSource
+            // .kind(of:)` returns nil), stay detection-only (vendorInstallerKind
+            // nil), so they fall through here.
+            //
+            // Electron is deliberately NOT added to `UpdateResult
+            // .licenseNeutralSources` (Models/UpdateResult.swift): unlike Vendor
+            // (our own hand-curated, vetted registry) and GitHub (open-source
+            // feeds), an electron-builder manifest can belong to a commercial app
+            // we've done no license review of, so a major-version jump arriving
+            // through this source still raises the "may need a new license"
+            // warning. Same conservative treatment as Homebrew — a decision, not
+            // an oversight (see #192).
             return result.remote?.vendorInstallerKind != nil
                 && result.remote?.requiresManualInstaller == false
         case "App Store":
@@ -226,6 +240,16 @@ public enum UpdatePolicy {
             let ext = result.remote?.downloadURL?.pathExtension.lowercased() ?? ""
             return Self.sparkleArchiveExtensions.contains(ext)
         default:
+            // "Electron" deliberately falls here rather than getting its own
+            // case. An electron-builder input method is a real shape (Squirrel.Mac
+            // apps are ordinary `.app` bundles like any other), but we have no
+            // vetted registry over that source the way Vendor is, and getting the
+            // rotation wrong on a registered input source is the WeType incident
+            // (see `canAutoInstall`'s comment above) — expensive to get wrong and
+            // untested for this source. Closed by default is the safe direction;
+            // `canAutoInstall` reads this as false, so an Electron-packaged input
+            // method simply never offers the one-click. Revisit only with a
+            // specific app on record (see #192).
             return false
         }
     }
@@ -270,7 +294,11 @@ public enum UpdatePolicy {
         switch result.remote?.sourceName {
         case "Homebrew":
             return result.remote?.requiresManualInstaller == true
-        case "Vendor", "GitHub":
+        case "Vendor", "GitHub", "Electron":
+            // electron-builder can publish a `.pkg` alongside (or instead of) the
+            // Squirrel `.zip` — `ElectronManifestSource.kind(of:)` recognises it —
+            // so this needs the same route as Vendor/GitHub: system installer, not
+            // an in-place swap.
             return result.remote?.vendorInstallerKind == .pkg
         case "Sparkle":
             // Sparkle permits signed package enclosures. They must retain Gate 1
@@ -281,6 +309,33 @@ public enum UpdatePolicy {
                   Self.sparklePackageExtensions.contains(ext),
                   result.app.sparkleEdPublicKey?.isEmpty == false,
                   result.remote?.edSignature?.isEmpty == false else { return false }
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether this source appears as its own case (not the `default:` branch)
+    /// in `canAutoInstall` / `requiresInstaller` — i.e. whether the policy has an
+    /// opinion about it at all.
+    ///
+    /// Exists only to let a caller tell apart two situations that otherwise both
+    /// read as `!canAutoInstall && !requiresInstaller`:
+    ///   - a recognised source that resolved to no artifact THIS time (a GitHub
+    ///     rule with no asset pattern, an Electron manifest whose file has no
+    ///     known extension, a Homebrew cask needing a manual installer) — the
+    ///     update is real, we just have nothing to hand an installer;
+    ///   - a source the policy has never heard of (Xcode Releases, Toolbox) —
+    ///     there is no install path here even in principle.
+    /// `duo install`'s refusal text (`CLI/Sources/DuoKit/Install.swift`) uses
+    /// this to stop conflating the two (#193): the former said "no installable
+    /// artefact we vet", which was actively wrong for the latter — before #192
+    /// wired Electron into the switches above, that message is exactly what an
+    /// Electron app got, and it sent whoever read it looking at the manifest
+    /// instead of at this file.
+    public static func isRecognizedInstallSource(_ sourceName: String?) -> Bool {
+        switch sourceName {
+        case "Sparkle", "Homebrew", "Vendor", "GitHub", "Electron", "App Store":
             return true
         default:
             return false
@@ -323,6 +378,15 @@ public enum UpdatePolicy {
             // they fell to `default: false` and had their bundles swapped under
             // them while running even when the user had explicitly asked us not
             // to — the one thing this setting exists to promise.
+            return true
+        case "Electron":
+            // electron-builder apps are self-updating by construction: the
+            // framework embeds electron-updater, which drives Squirrel.Mac on
+            // macOS to fetch and stage its own releases. Same reasoning as the
+            // GitHub case just above — and the same failure mode if this case is
+            // ever removed: the bundle gets swapped out from under a running app
+            // while the user explicitly asked us not to touch self-updating apps
+            // that are open (see #192).
             return true
         default:
             // Homebrew (auto_updates casks are excluded upstream), App Store and
@@ -520,7 +584,13 @@ public enum UpdatePolicy {
         // stale staging directory belonging to a different mechanism must not block
         // them.
         switch result.remote?.sourceName {
-        case "Vendor", "GitHub", "Sparkle": return staged
+        case "Vendor", "GitHub", "Sparkle", "Electron": return staged
+        // Electron belongs on the protected side, not the excluded one: an
+        // electron-builder app's own self-updater (electron-updater / Squirrel
+        // .Mac, see `defersToSelfUpdater`) parks its staged build the same way
+        // Sparkle's ShipIt does, so a stale staging directory here is exactly
+        // the collision this function exists to catch, not a leftover from a
+        // mechanism we don't swap ourselves.
         default:                            return nil
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
@@ -111,10 +111,10 @@ public actor InstallCoordinator {
     public static func route(for result: UpdateResult, requiresInstaller: Bool) -> Route {
         if requiresInstaller { return .installer }
         switch result.remote?.sourceName {
-        case "Homebrew":          return .homebrew
-        case "Vendor", "GitHub":  return .vendor
-        case "App Store":         return .appStore
-        default:                  return .sparkle
+        case "Homebrew":                    return .homebrew
+        case "Vendor", "GitHub", "Electron": return .vendor
+        case "App Store":                   return .appStore
+        default:                            return .sparkle
         }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -492,6 +492,15 @@ public struct UpdateResult: Sendable, Identifiable {
     /// Deliberately excludes "Homebrew" (some casks wrap paid apps) and a Sparkle
     /// feed that merely set no `minimumAutoupdateVersion` (a paid app may simply
     /// omit it), both of which keep the warning — the conservative direction.
+    ///
+    /// Also deliberately excludes "Electron" (#192): an electron-builder manifest
+    /// can belong to a commercial app we've done no license review of, unlike
+    /// Vendor (our own hand-curated, vetted registry) or GitHub (open-source
+    /// feeds) — so a major-version jump arriving through this source still
+    /// raises the "may need a new license" warning. Same conservative treatment
+    /// as Homebrew, not an oversight. `UpdatePolicy.canAutoInstall`'s
+    /// `"Vendor", "GitHub", "Electron"` case (Engine/UpdatePolicy.swift) points
+    /// back here rather than repeating this.
     private static let licenseNeutralSources: Set<String> = ["Vendor", "GitHub", "App Store"]
 
     /// True when the available update is a notable/major upgrade — the signal we

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
@@ -607,13 +607,55 @@ private func storeAvailability(
 /// for, versus one that always falls to `default: false` in
 /// `canAutoInstall`/`requiresInstaller` and so has no install path even in
 /// principle.
-@Test func isRecognizedInstallSourceMatchesThePolicySwitches() {
-    for name in ["Sparkle", "Homebrew", "Vendor", "GitHub", "Electron", "App Store"] {
-        #expect(UpdatePolicy.isRecognizedInstallSource(name), "\(name) should be recognized")
+///
+/// Derived from `SourceStack.make(githubToken:)` — the actual production
+/// registry — rather than a hand-written name list, per the rule against
+/// lists that drift (CLAUDE.md: "用例要从 registry 推导、覆盖全部 channel").
+/// A hand-written list caught nothing when Electron itself was added to the
+/// stack without a matching decision in `UpdatePolicy`, which is exactly the
+/// bug #192/#193 were about; this shape makes the next one fail loudly
+/// instead. Every name the stack can produce must be EITHER recognized by
+/// `isRecognizedInstallSource` OR listed in `deliberatelyUnwired` with a
+/// reason — no third option, no silent gap.
+///
+/// `Toolbox` and `TestFlight` never appear in `SourceStack`: `UpdateChecker`
+/// answers them before the stack runs at all (store/Toolbox management is
+/// detected up front, not through an `UpdateSource`). They're supplied here
+/// by hand for exactly that reason, not discovered — and are as much a part
+/// of "every source `duo install` can see a result from" as anything the
+/// stack assembles.
+@Test func isRecognizedInstallSourceCoversEveryProductionSourceOrExplainsWhyNot() {
+    let sourcesOutsideTheStack = ["Toolbox", "TestFlight"]
+
+    let deliberatelyUnwired: [String: String] = [
+        // XcodeReleasesSource never resolves an installable artifact — Apple
+        // gates every Xcode download behind an Apple ID and its own installer
+        // UI, so this source is always detection-only by construction.
+        "Xcode Releases": "always detection-only — no installable artifact exists to vet",
+        // JetBrains Toolbox owns the install; there is no bundle of ours to swap.
+        "Toolbox": "Toolbox manages the app itself",
+        // Apple's TestFlight app owns the install.
+        "TestFlight": "TestFlight manages the app itself",
+    ]
+
+    let stackNames = Set(SourceStack.make(githubToken: nil).map(\.name))
+    let allProductionNames = stackNames.union(sourcesOutsideTheStack)
+    #expect(!allProductionNames.isEmpty)  // guards against an empty stack passing vacuously
+
+    for name in allProductionNames {
+        if UpdatePolicy.isRecognizedInstallSource(name) {
+            #expect(deliberatelyUnwired[name] == nil,
+                "\(name) is claimed by isRecognizedInstallSource AND listed as deliberately unwired — pick one")
+        } else {
+            #expect(deliberatelyUnwired[name] != nil,
+                "\(name) is a real production source with no UpdatePolicy decision recorded — either give it a case in canAutoInstall/requiresInstaller, or add it to deliberatelyUnwired here with a reason")
+        }
     }
-    for name in ["Toolbox", "TestFlight", "Xcode Releases", "SomeFutureSource", nil] {
-        #expect(!UpdatePolicy.isRecognizedInstallSource(name), "\(name ?? "nil") should not be recognized")
-    }
+
+    // And the converse: nothing claims to be recognized that production can't
+    // actually produce, and nil is never mistaken for a real source.
+    #expect(!UpdatePolicy.isRecognizedInstallSource(nil))
+    #expect(!UpdatePolicy.isRecognizedInstallSource("SomeFutureSource"))
 }
 
 // MARK: - isRunning

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdatePolicyTests.swift
@@ -206,6 +206,27 @@ private func storeAvailability(
             settings: defaultSettings(), environment: environment(),
             expected: true
         ),
+        // Electron: an electron-builder manifest, gated exactly like Vendor/GitHub
+        // (see #192 — `VendorInstaller.download()` already vetted this source,
+        // the policy switches just hadn't caught up).
+        (
+            name: "electron manifest with a resolved installer archive is auto-installable",
+            result: fixtureResult(source: "Electron", vendorInstallerKind: .zip),
+            settings: defaultSettings(), environment: environment(),
+            expected: true
+        ),
+        (
+            name: "electron manifest with no resolved artifact (detection-only) is not auto-installable",
+            result: fixtureResult(source: "Electron", vendorInstallerKind: nil),
+            settings: defaultSettings(), environment: environment(),
+            expected: false
+        ),
+        (
+            name: "electron manifest with requiresManualInstaller is not auto-installable",
+            result: fixtureResult(source: "Electron", requiresManualInstaller: true, vendorInstallerKind: .zip),
+            settings: defaultSettings(), environment: environment(),
+            expected: false
+        ),
         // App Store: needs availability info, and the route gate (full → helper).
         (
             name: "app store with full strategy and helper approved is auto-installable",
@@ -364,6 +385,21 @@ private func storeAvailability(
             expected: true
         ),
         (
+            // electron-builder can publish a `.pkg` alongside its Squirrel `.zip` —
+            // `ElectronManifestSource.kind(of:)` recognises the extension — so this
+            // needs the same system-installer route as Vendor/GitHub (see #192).
+            name: "electron pkg needs the system installer",
+            result: fixtureResult(source: "Electron", vendorInstallerKind: .pkg),
+            settings: defaultSettings(), environment: environment(),
+            expected: true
+        ),
+        (
+            name: "electron zip does not need the system installer",
+            result: fixtureResult(source: "Electron", vendorInstallerKind: .zip),
+            settings: defaultSettings(), environment: environment(),
+            expected: false
+        ),
+        (
             name: "sparkle archive does not route to the system installer",
             result: fixtureResult(
                 source: "Sparkle", downloadURL: URL(string: "https://example.com/fixture.dmg"),
@@ -439,6 +475,24 @@ private func storeAvailability(
         (
             name: "GitHub source still installs under alwaysOverwrite",
             result: fixtureResult(source: "GitHub", vendorInstallerKind: .dmg),
+            settings: defaultSettings(policy: .alwaysOverwrite),
+            environment: environment(running: [fixturePath]),
+            expected: false
+        ),
+        // Electron: apps built with electron-builder embed electron-updater
+        // (Squirrel.Mac on macOS), so they are self-updating the same way GitHub-
+        // sourced apps are treated above — see #192 for the incident that made
+        // omitting a source here a user-visible bug, not a cosmetic gap.
+        (
+            name: "electron source defers while running — electron-updater/Squirrel.Mac self-updates too",
+            result: fixtureResult(source: "Electron", vendorInstallerKind: .zip),
+            settings: defaultSettings(policy: .deferWhenRunning),
+            environment: environment(running: [fixturePath]),
+            expected: true
+        ),
+        (
+            name: "electron source still installs under alwaysOverwrite",
+            result: fixtureResult(source: "Electron", vendorInstallerKind: .zip),
             settings: defaultSettings(policy: .alwaysOverwrite),
             environment: environment(running: [fixturePath]),
             expected: false
@@ -523,6 +577,42 @@ private func storeAvailability(
     for c in cases {
         let actual = UpdatePolicy.defersToSelfUpdater(c.result, settings: c.settings, environment: c.environment)
         #expect(actual == c.expected, "\(c.name): expected \(c.expected), got \(actual)")
+    }
+}
+
+// MARK: - stagedBlocksInstall (Electron)
+
+/// `stagedBlocksInstall`'s own route list lives in `StagedBlocksInstallTests.swift`
+/// (out of scope for #192's lane); this pins the one row that changed there —
+/// Electron moving from the unlisted default (`nil`, unprotected) to the
+/// protected list alongside Vendor/GitHub/Sparkle. electron-updater/Squirrel.Mac
+/// parks its own staged build exactly like Sparkle's ShipIt does, so a stale
+/// staging directory here is the same collision this function exists to catch,
+/// not a leftover from a mechanism we don't swap ourselves.
+@Test func electronStagedBuildBlocksInstall() {
+    let result = fixtureResult(source: "Electron", vendorInstallerKind: .zip)
+    let blocking = UpdatePolicy.stagedBlocksInstall(
+        result, staged: staged("9.9.9"))
+    #expect(blocking != nil)
+}
+
+@Test func electronWithNoStagedBuildIsNotBlocked() {
+    let result = fixtureResult(source: "Electron", vendorInstallerKind: .zip)
+    #expect(UpdatePolicy.stagedBlocksInstall(result, staged: nil) == nil)
+}
+
+// MARK: - isRecognizedInstallSource
+
+/// Backs `duo install`'s refusal text (#193): a source the policy has a case
+/// for, versus one that always falls to `default: false` in
+/// `canAutoInstall`/`requiresInstaller` and so has no install path even in
+/// principle.
+@Test func isRecognizedInstallSourceMatchesThePolicySwitches() {
+    for name in ["Sparkle", "Homebrew", "Vendor", "GitHub", "Electron", "App Store"] {
+        #expect(UpdatePolicy.isRecognizedInstallSource(name), "\(name) should be recognized")
+    }
+    for name in ["Toolbox", "TestFlight", "Xcode Releases", "SomeFutureSource", nil] {
+        #expect(!UpdatePolicy.isRecognizedInstallSource(name), "\(name ?? "nil") should not be recognized")
     }
 }
 
@@ -1059,6 +1149,12 @@ struct LaggingRemoteVersionTests {
         // the input-method rule and not a missing field.
         ("a Homebrew cask", fixtureResult(source: "Homebrew", sourceIdentifier: "fixture", app: app)),
         ("a detection-only vendor recipe", fixtureResult(source: "Vendor", app: app)),
+        // Electron is deliberately NOT in `isContentsRotatable`'s switch (#192):
+        // unlike Vendor, we have no vetted registry over what an arbitrary
+        // electron-builder manifest ships, so an Electron-packaged input method
+        // stays closed even with a well-formed zip archive — the safe default,
+        // not an oversight.
+        ("an electron zip", fixtureResult(source: "Electron", vendorInstallerKind: .zip, app: app)),
     ]
     for (what, result) in refused {
         #expect(!UpdatePolicy.canAutoInstall(


### PR DESCRIPTION
## Summary

`ElectronManifestSource` (2026-08-31) computes a full install spec — `downloadURL`, `vendorInstallerKind`, `expectedSHA512` — and `VendorInstaller.download()` already vets `sourceName == "Electron"` alongside "Vendor"/"GitHub". But nothing downstream consumed it: `UpdatePolicy`'s four decision points and `InstallCoordinator.route(for:)` had no `"Electron"` case, so they all fell to their `default`, and the one-click never appeared (#192). `duo install`'s refusal text then blamed a nonexistent cause — "no installable artefact we vet" — when the real problem was the missing wiring, not a missing artifact (#193).

## Changes

**Engine** (`DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift`, `Install/InstallCoordinator.swift`):
- `canAutoInstall`: `"Electron"` joins the `"Vendor", "GitHub"` case (same artifact-kind gating).
- `requiresInstaller`: same merge, so an Electron `.pkg` (electron-builder can publish one) still routes to the system installer.
- `defersToSelfUpdater`: new `"Electron"` case returning `true` — electron-builder apps embed electron-updater/Squirrel.Mac, so they're self-updating by construction, same reasoning as the existing `"GitHub"` case.
- `stagedBlocksInstall`: `"Electron"` joins the protected list — electron-updater/Squirrel.Mac parks a staged build the same way Sparkle's ShipIt does.
- `InstallCoordinator.route(for:)`: `"Electron"` joins `"Vendor", "GitHub"` → `.vendor`.
- New `UpdatePolicy.isRecognizedInstallSource(_:)` — used by the CLI fix below.

**Two decisions left deliberately unchanged, with inline comments explaining why (not oversights):**
- `UpdateResult.licenseNeutralSources` (out of my lane, not touched) does **not** get `"Electron"` — no vetted registry backs an arbitrary electron-builder manifest, so major-version jumps through this source still raise the license warning. Same conservative treatment as Homebrew.
- `UpdatePolicy.isContentsRotatable` does **not** get `"Electron"` — closed by default, so an Electron-packaged input method stays non-installable (safety direction, mirrors the WeType incident reasoning already in the file).

**CLI** (`CLI/Sources/DuoKit/Install.swift`):
- `classify()`'s refusal text now distinguishes "recognized source, no artifact this time" (`"no installable artefact we vet"`) from "source `UpdatePolicy` has no case for" (`"no install route is wired up for this source yet"`), using the new `isRecognizedInstallSource`.

**Tests:**
- `UpdatePolicyTests.swift`: Electron rows added to `canAutoInstallCoversEveryBranch`, `requiresInstallerCoversEveryBranch`, `defersToSelfUpdaterCoversEveryBranch`, and `inputMethodsRefuseEveryRouteThatReplacesTheWholeBundle` (pins the `isContentsRotatable` decision). New tests for `stagedBlocksInstall` and `isRecognizedInstallSource`.
- `InstallTests.swift`: `anUnknownSourceFallsToSparkle` kept as-is (Electron is no longer an unknown source); added `anElectronSourceRoutesToVendor`, `anElectronArchiveInstalls`, `electronDetectionOnlyIsRefusedWithTheArtefactWording`, `aRunningElectronSelfUpdaterIsDeferredUnlessOverridden`, and `aSourceThePolicyHasNoCaseForGetsTheNoRouteWording` (pins the #193 message split).

## Test plan

```
$ swift test --package-path DuoUpdaterCore --filter UpdatePolicy
...
✔ Test run with 36 tests in 5 suites passed after 0.004 seconds.

$ swift test --package-path CLI --filter Install
...
✔ Test run with 28 tests in 6 suites passed after 0.013 seconds.
```

Both packages also build clean (`swift build --package-path DuoUpdaterCore`, `swift build --package-path CLI`) with no new warnings.

## Follow-up: the sixth decision point

The scope note above flagged `App/Sources/AppListModel.swift`'s `canBatchInstallInParallel` — a sixth `sourceName` switch not in #192's original table, gating whether Update All runs a route in the parallel batch or serially. That lane was opened up and it's now fixed here too:

- **`canBatchInstallInParallel`**: `"Electron"` joins `"Sparkle", "Vendor", "GitHub"`. Checked before adding it: Electron goes through the identical `VendorInstaller` + `InPlaceSwap` pipeline as Vendor/GitHub (no shared system UI/tooling, which is this function's own stated criterion), and the one real risk — parallelizing racing an electron-builder app's own self-updater — turned out not to be this function's job to guard: every target already passed `defersToSelfUpdater` before reaching this switch, and `stagedBlocksInstall` is enforced inside `runInstall` itself, which both the parallel and serial paths call identically. Reasoning is recorded inline.
- **Test hygiene**: `isRecognizedInstallSourceMatchesThePolicySwitches` was a hand-written name list, which is exactly the kind of thing CLAUDE.md warns drifts silently. Replaced with `isRecognizedInstallSourceCoversEveryProductionSourceOrExplainsWhyNot`, derived from `SourceStack.make(githubToken:)` (the real production registry) plus `Toolbox`/`TestFlight` (which short-circuit before the stack runs). Every name production can produce must now be either recognized or listed in an explicit `deliberatelyUnwired` map with a reason — a source added to the stack with no matching `UpdatePolicy` decision now fails the test instead of passing silently.

Re-ran both required suites after these changes:
```
$ swift test --package-path DuoUpdaterCore --filter UpdatePolicy
...
✔ Test run with 36 tests in 5 suites passed after 0.007 seconds.

$ swift test --package-path CLI --filter Install
...
✔ Test run with 28 tests in 6 suites passed after 0.014 seconds.
```

Fixes #192
Fixes #193


## Follow-up 2: adversarial review findings (independent Opus pass)

1. **The new refuse-text split had zero true positives.** Measured which `sourceName`s can actually reach the "no install route is wired up for this source yet" branch in production: only `Xcode Releases`, `Toolbox`, `TestFlight` — and all three are permanently, deliberately artefact-less by design (Xcode's download 302s to an Apple-ID login page; Toolbox/TestFlight hand the install to their own app). "Not wired up yet" was false for every source that could reach it. Reverted to one message, reworded to be accurate for both cases: `"detection only — this source publishes no installable artefact"`. `isRecognizedInstallSource` stays, but now backs only the registry-derived drift test, not the CLI text; its doc comment says so. Test `aSourceThePolicyHasNoCaseForGetsTheNoRouteWording` replaced with `aSourceThePolicyHasNoCaseForGetsTheSameGenericWording`, which pins the collapse.
2. **`licenseNeutralSources`'s Electron decision moved to where the array lives** (`Models/UpdateResult.swift:495`, now in this PR's lane) instead of only in `UpdatePolicy.canAutoInstall`, so the next person editing that array actually sees the annotation. `UpdatePolicy.swift` now carries a one-line pointer.
3. **`canBatchInstallInParallel`'s doc comment made exhaustive.** It named three sources that stay serial without establishing those are the *only* ones that can reach `default: false`. Traced the reachability: the switch is only called on `installAllTargets()`'s output (already filtered to `canAutoInstall || requiresInstaller`), so a source `UpdatePolicy` has no case for never reaches it, and `requiresInstaller` results are peeled off one line above the switch — leaving exactly Homebrew and App Store as the only real members of `default: false`, both sharing a system-level resource. Comment-only change; the case list is unchanged.

```
$ swift test --package-path DuoUpdaterCore --filter UpdatePolicy
✔ Test run with 36 tests in 5 suites passed after 0.012 seconds.

$ swift test --package-path CLI --filter Install
✔ Test run with 28 tests in 6 suites passed after 0.018 seconds.
```
