### PR TITLE
Add arm64→x86_64 downgrade gate beside Gate 5 (#196)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/DeltaApplier.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/DeltaApplier.swift
@@ -209,7 +209,10 @@ public enum DeltaApplier {
 public func deltaRouteFailureIsWorthRetrying(_ error: Error) -> Bool {
     guard let verify = error as? SignatureVerifier.VerifyError else { return true }
     switch verify {
-    case .unsupportedSystemVersion, .unrunnableArchitecture:
+    case .unsupportedSystemVersion, .unrunnableArchitecture, .architectureDowngrade:
+        // Same shape as gate 5/6: which slices a bundle was built with is a
+        // property of the VERSION, so the full archive carries the identical
+        // set and would be refused for the identical reason (issue #196).
         return false
     case .edSignatureMissing, .edSignatureInvalid, .codeSignatureInvalid,
          .noTeamIdentifier, .teamIdentifierMismatch,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
@@ -14,11 +14,13 @@ import Security
 /// Gate 5b (`verifyNoArchitectureDowngrade`) is a NARROWER liveness check than 5
 /// and 6: not "can this Mac run the download" but "does the download run worse
 /// than what's already installed" (arm64 → x86_64-only, still launchable under
-/// Rosetta, but never natively again). It is defined here beside Gate 5 but, as
-/// of this writing, is not yet called from `SparkleInstaller`/`VendorInstaller`
-/// — wiring it in needs the installed app's URL threaded to the same call site
-/// as Gate 5 (`result.app.path` is already in scope there for Gates 3/4). See
-/// issue #196.
+/// Rosetta, but never natively again). Both installers call it immediately
+/// AFTER gate 5, never before — a package that is both unrunnable and a
+/// downgrade must fail with gate 5's "cannot launch" message (the more severe,
+/// still-true problem), not gate 5b's "this would run translated" (which
+/// implies it launches). Like gate 5, it never sees the pkg route: `newApp`
+/// there is handed straight to Installer.app, so `PackageInstaller` stays
+/// gated on signature + Team ID only, same as gate 5. See issue #196.
 public enum SignatureVerifier {
 
     public enum VerifyError: LocalizedError {
@@ -339,12 +341,17 @@ public enum SignatureVerifier {
         return downloaded.contains(NSBundleExecutableArchitectureX86_64)
     }
 
-    /// Gate 5b, run beside Gate 5 on the downloaded bundle. Only meaningful on
-    /// Apple silicon: an Intel Mac never had an arm64 slice to lose, and this
-    /// product ships arm64-only besides (`App/project.yml`, `ARCHS: arm64`), so
-    /// there is no Intel host for `installedApp` to be read from in practice —
-    /// this still checks `host` explicitly rather than assume it, so the gate
-    /// stays correct if that ever changes.
+    /// Gate 5b, called by both installers immediately AFTER Gate 5 passes on the
+    /// same `newApp`/`installedApp` pair — never before, and never on its own:
+    /// a package that Gate 5 would refuse outright (arm64 host, no Rosetta,
+    /// Intel-only download) must fail with Gate 5's "cannot launch" message,
+    /// not this one's "would run translated", which implies it launches at
+    /// all. Only meaningful on Apple silicon: an Intel Mac never had an arm64
+    /// slice to lose, and this product ships arm64-only besides
+    /// (`App/project.yml`, `ARCHS: arm64`), so there is no Intel host for
+    /// `installedApp` to be read from in practice — this still checks `host`
+    /// explicitly rather than assume it, so the gate stays correct if that
+    /// ever changes.
     public static func verifyNoArchitectureDowngrade(
         installedApp: URL,
         downloadedApp: URL,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
@@ -10,6 +10,15 @@ import Security
 /// Mac at all, by architecture and by the OS version it declares it needs.
 /// Callers pick the gates that apply to their route: the Sparkle installer runs
 /// all of them, the vendor installer runs 2–6 (no feed signature to check).
+///
+/// Gate 5b (`verifyNoArchitectureDowngrade`) is a NARROWER liveness check than 5
+/// and 6: not "can this Mac run the download" but "does the download run worse
+/// than what's already installed" (arm64 → x86_64-only, still launchable under
+/// Rosetta, but never natively again). It is defined here beside Gate 5 but, as
+/// of this writing, is not yet called from `SparkleInstaller`/`VendorInstaller`
+/// — wiring it in needs the installed app's URL threaded to the same call site
+/// as Gate 5 (`result.app.path` is already in scope there for Gates 3/4). See
+/// issue #196.
 public enum SignatureVerifier {
 
     public enum VerifyError: LocalizedError {
@@ -21,6 +30,7 @@ public enum SignatureVerifier {
         case noBundleIdentifier(which: String)
         case bundleIdentifierMismatch(installed: String, downloaded: String)
         case unrunnableArchitecture(built: String, host: String)
+        case architectureDowngrade(installed: String, downloaded: String)
         case unsupportedSystemVersion(required: String, host: String)
 
         public var errorDescription: String? {
@@ -41,6 +51,8 @@ public enum SignatureVerifier {
                 return "Bundle identifier mismatch: installed “\(installed)” vs downloaded “\(downloaded)”. Refusing to install."
             case .unrunnableArchitecture(let built, let host):
                 return "The download is built for \(built) and this Mac runs \(host). Refusing to install a build it cannot launch."
+            case .architectureDowngrade(let installed, let downloaded):
+                return "The installed app runs natively (\(installed)) but this download only has \(downloaded). The download would still launch — under translation, from here on — so this is a downgrade, not an unrunnable build. Refusing to install it."
             case .unsupportedSystemVersion(let required, let host):
                 return "The download requires macOS \(required) and this Mac runs macOS \(host). Refusing to install a build it cannot launch."
             }
@@ -292,6 +304,68 @@ public enum SignatureVerifier {
         // above, so this line is only reached with slices we could read.
         throw VerifyError.unrunnableArchitecture(
             built: names, host: host == .arm64 ? "arm64" : "x86_64")
+    }
+
+    // MARK: Gate 5b — the download must not drop a slice the installed bundle has
+
+    /// Whether swapping `installed`'s architectures for `downloaded`'s would be a
+    /// downgrade: the installed bundle can run natively (it has an arm64 slice)
+    /// and the download cannot (it has none) — while still being a real
+    /// replacement, i.e. it does carry SOME slice (x86_64) rather than reading as
+    /// unparseable.
+    ///
+    /// Gate 5 above asks only "can THIS Mac run the download" — and on Apple
+    /// silicon while Rosetta still covers apps, an Intel-only build answers that
+    /// question ✅. The install then proceeds: it lands, it launches, and from
+    /// that point on the app runs translated, including on the NEXT check, which
+    /// picks the same Intel-only asset again. This predicate catches that one
+    /// case instead: not "can it run", but "does it run WORSE than what's already
+    /// there".
+    ///
+    /// Deliberately narrower than "any slice was dropped": going from universal
+    /// to arm64-only, or from arm64-only to universal, both leave a native arm64
+    /// slice in `downloaded` — normal thinning, not a downgrade, and both must
+    /// return `false` here. Only `downloaded` having x86_64 but no arm64 is
+    /// provably worse than an `installed` that has arm64.
+    ///
+    /// Fails open on an empty set on EITHER side, matching `canRun` above and for
+    /// the same reason: an unreadable Mach-O header (installed OR downloaded)
+    /// must not start refusing swaps that install fine today. This predicate
+    /// proves a downgrade; it is not a proof that no downgrade occurred.
+    static func isArchitectureDowngrade(installed: Set<Int>, downloaded: Set<Int>) -> Bool {
+        guard !installed.isEmpty, !downloaded.isEmpty else { return false }
+        guard installed.contains(NSBundleExecutableArchitectureARM64) else { return false }
+        guard !downloaded.contains(NSBundleExecutableArchitectureARM64) else { return false }
+        return downloaded.contains(NSBundleExecutableArchitectureX86_64)
+    }
+
+    /// Gate 5b, run beside Gate 5 on the downloaded bundle. Only meaningful on
+    /// Apple silicon: an Intel Mac never had an arm64 slice to lose, and this
+    /// product ships arm64-only besides (`App/project.yml`, `ARCHS: arm64`), so
+    /// there is no Intel host for `installedApp` to be read from in practice —
+    /// this still checks `host` explicitly rather than assume it, so the gate
+    /// stays correct if that ever changes.
+    public static func verifyNoArchitectureDowngrade(
+        installedApp: URL,
+        downloadedApp: URL,
+        host: HostArch = .current
+    ) throws {
+        guard host == .arm64 else { return }
+        let installedArchs = executableArchitectures(ofAppAt: installedApp)
+        let downloadedArchs = executableArchitectures(ofAppAt: downloadedApp)
+        guard isArchitectureDowngrade(installed: installedArchs, downloaded: downloadedArchs)
+        else { return }
+        func names(_ archs: Set<Int>) -> String {
+            archs.map { arch -> String in
+                switch arch {
+                case NSBundleExecutableArchitectureARM64:  return "arm64"
+                case NSBundleExecutableArchitectureX86_64: return "x86_64"
+                default: return "arch \(arch)"
+                }
+            }.sorted().joined(separator: " + ")
+        }
+        throw VerifyError.architectureDowngrade(
+            installed: names(installedArchs), downloaded: names(downloadedArchs))
     }
 
     // MARK: Gate 6 — the download declares an OS floor this Mac is below

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
@@ -256,6 +256,21 @@ public actor SparkleInstaller {
         // by filename, which cannot see inside a Mach-O; this reads the real
         // slices, so a mis-named artifact is refused instead of installed.
         try SignatureVerifier.verifyRunnableArchitecture(appAt: newApp)
+        // Gate 5b — and it is not a WORSE build than what's already here. Must run
+        // AFTER gate 5, not before: a package that is both unrunnable and a
+        // downgrade (arm64 host, no Rosetta, Intel-only download) has to fail
+        // with gate 5's "cannot launch" message, the true and more severe
+        // problem — gate 5b's "this would run translated" is only correct once
+        // gate 5 has already confirmed the download CAN launch here. `newApp`
+        // here is either the unpacked archive or `DeltaApplier.reconstruct`'s
+        // output (step 3 above merges both into one URL), and this runs on
+        // both identically — the patch route's doc comment states its output
+        // "goes through exactly the same gates a downloaded archive does", and
+        // nothing here assumes a patch's architecture set matches the baseline's.
+        try SignatureVerifier.verifyNoArchitectureDowngrade(
+            installedApp: result.app.path,
+            downloadedApp: newApp
+        )
         // Gate 6 — and this Mac is not below the OS floor the bundle declares.
         // Same shape of claim as gate 5 and the same blind spot behind it: the
         // download was selected from what a source published, and most sources

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
@@ -18,6 +18,11 @@ import CryptoKit
 ///   - **Gate 5** is not about trust but about liveness: the bundle must have a
 ///     Mach-O slice this Mac can launch (assets are chosen by filename, and
 ///     filenames lie).
+///   - **Gate 5b**, run only once gate 5 has already passed: the download must
+///     not drop the arm64 slice the INSTALLED bundle has. Gate 5 alone answers
+///     "can this Mac run it" — on Apple silicon with Rosetta that is true of an
+///     Intel-only build too, so without this a native install silently becomes
+///     translated, permanently (see `SignatureVerifier.verifyNoArchitectureDowngrade`).
 ///   - **Gate 6**, liveness too: this Mac must not be below the
 ///     `LSMinimumSystemVersion` the bundle declares. Vendor probes and GitHub
 ///     releases mostly publish no OS requirement anywhere we can read before
@@ -257,6 +262,21 @@ public actor VendorInstaller {
         // by filename, which cannot see inside a Mach-O; this reads the real
         // slices, so a mis-named artifact is refused instead of installed.
         try SignatureVerifier.verifyRunnableArchitecture(appAt: newApp)
+        // Gate 5b — and it is not a WORSE build than what's already here. Must run
+        // AFTER gate 5, not before: a package that is both unrunnable and a
+        // downgrade (arm64 host, no Rosetta, Intel-only download) has to fail
+        // with gate 5's "cannot launch" message, the true and more severe
+        // problem — gate 5b's "this would run translated" is only correct once
+        // gate 5 has already confirmed the download CAN launch here. Runs
+        // identically for both routes above (full archive and delta
+        // reconstruction) — `DeltaApplier.reconstruct` states plainly that its
+        // output "goes through exactly the same gates a downloaded archive
+        // does", and this is one of them; the patch is cut by the vendor and
+        // nothing here assumes its architecture set matches the baseline's.
+        try SignatureVerifier.verifyNoArchitectureDowngrade(
+            installedApp: result.app.path,
+            downloadedApp: newApp
+        )
         // Gate 6 — and this Mac is not below the OS floor the bundle declares.
         // Same shape of claim as gate 5 and the same blind spot behind it: the
         // download was selected from what a source published, and most sources

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
@@ -122,3 +122,191 @@ struct ArchitectureGateTests {
         }
     }
 }
+
+/// Gate 5b: a build that DOES launch (Gate 5 passes it) must still be refused
+/// if it drops the arm64 slice the INSTALLED bundle already has — Gate 5 alone
+/// answers "can this Mac run it", not "is this worse than what's there", so an
+/// Intel-only download quietly downgrades a native install to translated on
+/// every future check too. See issue #196.
+struct ArchitectureDowngradeGateTests {
+
+    private let arm = NSBundleExecutableArchitectureARM64
+    private let intel = NSBundleExecutableArchitectureX86_64
+
+    // MARK: `isArchitectureDowngrade` — the six boundaries from #196
+
+    @Test func universalToArmOnlyIsNormalThinningNotADowngrade() {
+        // Installed universal → downloaded arm64-only: the download still runs
+        // natively. Not a downgrade.
+        #expect(!SignatureVerifier.isArchitectureDowngrade(
+            installed: [arm, intel], downloaded: [arm]))
+    }
+
+    @Test func armOnlyToUniversalIsAllowed() {
+        #expect(!SignatureVerifier.isArchitectureDowngrade(
+            installed: [arm], downloaded: [arm, intel]))
+    }
+
+    @Test func armOnlyToIntelOnlyIsTheOneNewRejection() {
+        #expect(SignatureVerifier.isArchitectureDowngrade(
+            installed: [arm], downloaded: [intel]))
+    }
+
+    @Test func universalToIntelOnlyIsAlsoADowngrade() {
+        // Not one of the six enumerated boundaries, but the same rule: a
+        // universal install losing its arm64 slice is exactly as much a
+        // downgrade as an arm64-only one losing it.
+        #expect(SignatureVerifier.isArchitectureDowngrade(
+            installed: [arm, intel], downloaded: [intel]))
+    }
+
+    @Test func unreadableInstalledArchitectureIsAllowedThrough() {
+        // Same shape as Gate 5's own fail-open: an unreadable header must not
+        // start refusing swaps that install fine today, and this predicate
+        // proves a downgrade, not the absence of one.
+        #expect(!SignatureVerifier.isArchitectureDowngrade(installed: [], downloaded: [intel]))
+    }
+
+    @Test func unreadableDownloadedArchitectureIsAllowedThrough() {
+        #expect(!SignatureVerifier.isArchitectureDowngrade(installed: [arm], downloaded: []))
+    }
+
+    @Test func bothSidesUnreadableIsAllowedThrough() {
+        #expect(!SignatureVerifier.isArchitectureDowngrade(installed: [], downloaded: []))
+    }
+
+    @Test func intelOnlyToIntelOnlyIsNotADowngrade() {
+        // Nothing arm64 was ever there to lose.
+        #expect(!SignatureVerifier.isArchitectureDowngrade(installed: [intel], downloaded: [intel]))
+    }
+
+    // MARK: `verifyNoArchitectureDowngrade` — real Mach-O fixtures, through the throwing gate
+
+    /// A bundle whose executable is a real (if minimal) Mach-O built for exactly
+    /// the given cputypes — one slice per type, so a "universal" fixture is one
+    /// call with two types. Mirrors `ArchitectureGateTests.bundle(cputype:subtype:in:)`
+    /// but this gate needs to construct BOTH an installed and a downloaded
+    /// bundle per test, so it takes a set of slices instead of one.
+    private func bundle(cputypes: [Int32], in dir: URL, name: String) throws -> URL {
+        let app = dir.appendingPathComponent("\(name).app")
+        let macOS = app.appendingPathComponent("Contents/MacOS")
+        try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+
+        if cputypes.count <= 1 {
+            var header = Data()
+            func word(_ value: UInt32) {
+                withUnsafeBytes(of: value.littleEndian) { header.append(contentsOf: $0) }
+            }
+            word(0xfeed_facf)                                     // MH_MAGIC_64
+            word(UInt32(bitPattern: cputypes.first ?? 0x0100_000c))
+            word(0)                                                // subtype
+            word(2)                                                // MH_EXECUTE
+            word(0); word(0); word(0x0020_0085); word(0)
+            try header.write(to: macOS.appendingPathComponent(name))
+        } else {
+            // A fat (universal) binary: FAT_MAGIC header followed by one
+            // `fat_arch` entry per slice, each pointing at a trivial Mach-O.
+            var slices: [Data] = []
+            for cputype in cputypes {
+                var header = Data()
+                func word(_ value: UInt32) {
+                    withUnsafeBytes(of: value.littleEndian) { header.append(contentsOf: $0) }
+                }
+                word(0xfeed_facf)
+                word(UInt32(bitPattern: cputype))
+                word(0)
+                word(2)
+                word(0); word(0); word(0x0020_0085); word(0)
+                slices.append(header)
+            }
+            var fat = Data()
+            func bigWord(_ value: UInt32, into data: inout Data) {
+                withUnsafeBytes(of: value.bigEndian) { data.append(contentsOf: $0) }
+            }
+            bigWord(0xcafe_babe, into: &fat)                       // FAT_MAGIC
+            bigWord(UInt32(cputypes.count), into: &fat)
+            var offset = UInt32(fat.count) + UInt32(cputypes.count) * 20
+            for (index, cputype) in cputypes.enumerated() {
+                bigWord(UInt32(bitPattern: cputype), into: &fat)
+                bigWord(0, into: &fat)                             // cpusubtype
+                bigWord(offset, into: &fat)
+                bigWord(UInt32(slices[index].count), into: &fat)
+                bigWord(0, into: &fat)                             // align
+                offset += UInt32(slices[index].count)
+            }
+            for slice in slices { fat.append(slice) }
+            try fat.write(to: macOS.appendingPathComponent(name))
+        }
+
+        let info: [String: String] = [
+            "CFBundleExecutable": name,
+            "CFBundleIdentifier": "test.downgrade.\(name)",
+        ]
+        try PropertyListSerialization
+            .data(fromPropertyList: info, format: .xml, options: 0)
+            .write(to: app.appendingPathComponent("Contents/Info.plist"))
+        return app
+    }
+
+    @Test func throwingGateRefusesArmInstalledIntelOnlyDownload() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arch-downgrade-gate-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let installed = try bundle(cputypes: [0x0100_000c], in: dir, name: "installed")
+        let downloaded = try bundle(cputypes: [0x0100_0007], in: dir, name: "downloaded")
+
+        // The real Mach-O read confirms the fixtures are shaped as intended.
+        #expect(SignatureVerifier.executableArchitectures(ofAppAt: installed) == [arm])
+        #expect(SignatureVerifier.executableArchitectures(ofAppAt: downloaded) == [intel])
+
+        do {
+            try SignatureVerifier.verifyNoArchitectureDowngrade(
+                installedApp: installed, downloadedApp: downloaded, host: .arm64)
+            Issue.record("an arm64 install must not be swapped for an x86_64-only download")
+        } catch let error as SignatureVerifier.VerifyError {
+            let text = error.errorDescription ?? ""
+            // The wording must not read like Gate 5's "cannot launch" — this
+            // build DOES launch, just translated, so a user reading the two
+            // messages side by side must be able to tell them apart.
+            #expect(text.contains("arm64"))
+            #expect(text.contains("x86_64"))
+            #expect(!text.contains("cannot launch"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func throwingGateAllowsUniversalDownloadOverArmInstall() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arch-downgrade-gate-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let installed = try bundle(cputypes: [0x0100_000c], in: dir, name: "installed")
+        let downloaded = try bundle(
+            cputypes: [0x0100_000c, 0x0100_0007], in: dir, name: "downloaded")
+        #expect(SignatureVerifier.executableArchitectures(ofAppAt: downloaded) == [arm, intel])
+
+        #expect(throws: Never.self) {
+            try SignatureVerifier.verifyNoArchitectureDowngrade(
+                installedApp: installed, downloadedApp: downloaded, host: .arm64)
+        }
+    }
+
+    @Test func throwingGateDoesNotApplyOnAnIntelHost() throws {
+        // No Intel host ever ships this product (arm64-only, `App/project.yml`),
+        // but the gate still states the boundary explicitly rather than assume
+        // it — an Intel Mac never had an arm64 slice to lose in the first place.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arch-downgrade-gate-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let installed = try bundle(cputypes: [0x0100_000c], in: dir, name: "installed")
+        let downloaded = try bundle(cputypes: [0x0100_0007], in: dir, name: "downloaded")
+
+        #expect(throws: Never.self) {
+            try SignatureVerifier.verifyNoArchitectureDowngrade(
+                installedApp: installed, downloadedApp: downloaded, host: .x86_64)
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
@@ -310,3 +310,180 @@ struct ArchitectureDowngradeGateTests {
         }
     }
 }
+
+/// PROOF that Gate 5b is actually wired into the two installers' real `apply()`
+/// — not just that the predicate is correct in isolation (that's what the two
+/// suites above already cover). Deleting the `verifyNoArchitectureDowngrade`
+/// call from `VendorInstaller`/`SparkleInstaller` must turn these tests red;
+/// nothing else in this file can, because they never call `isArchitectureDowngrade`
+/// or `verifyNoArchitectureDowngrade` directly — only the installers' public
+/// `apply()`. (A gate no code path calls is worse than no gate at all: the next
+/// reader trusts `SignatureVerifier`'s doc comment listing it. Issue #196.)
+///
+/// The trick is a REAL, already-installed, Developer-ID-signed universal
+/// (`x86_64 arm64`) app found on this machine, copied twice:
+///  - "installed" — copied as-is (still universal), standing in for
+///    `result.app.path`.
+///  - "downloaded" — a second copy, `lipo -thin x86_64`'d, then re-zipped the
+///    same way `ArchiveExtractor` unpacks a real download (`ditto -c/-x -k`).
+///
+/// `lipo -thin` only EXTRACTS an existing slice's bytes; it does not touch
+/// them. Confirmed empirically on a real fixture (`NotchBadge.app`,
+/// 2026-09-01): `codesign --verify --deep --strict` still passes on the
+/// thinned, zip-round-tripped copy, with the SAME Team ID and bundle
+/// identifier as the untouched original. That is what lets this call all the
+/// way into the real `apply()` and past Gates 2–4 without forging a
+/// code-signing identity of our own — a genuine architecture downgrade is the
+/// ONLY thing left for Gate 5b to catch.
+struct ArchitectureDowngradeWiringTests {
+
+    private static let arm = NSBundleExecutableArchitectureARM64
+    private static let intel = NSBundleExecutableArchitectureX86_64
+
+    /// Runs `argv[0]` with the rest as arguments; throws on a non-zero exit.
+    private static func run(_ argv: [String], in directory: URL? = nil) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: argv[0])
+        process.arguments = Array(argv.dropFirst())
+        if let directory { process.currentDirectoryURL = directory }
+        let errPipe = Pipe()
+        process.standardError = errPipe
+        try process.run()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "ArchitectureDowngradeWiringTests", code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: String(decoding: errData, as: UTF8.self)])
+        }
+    }
+
+    /// A real installed universal (`arm64 + x86_64`) app, small enough to copy
+    /// and zip twice per test without slowing the suite — or nil when this
+    /// machine has none, which the caller must treat as "nothing to prove with"
+    /// rather than a failure (this suite runs on whatever `/Applications`
+    /// happens to hold, same as `InstallPipelineSmokeTests.installPipelineDryRun`).
+    private static func findUniversalFixture() -> URL? {
+        guard let apps = try? FileManager.default.contentsOfDirectory(
+            at: URL(fileURLWithPath: "/Applications"), includingPropertiesForKeys: nil
+        ) else { return nil }
+        // Known-small candidates first, so the test doesn't end up copying and
+        // zipping a multi-hundred-MB app just because it sorts first.
+        let preferred = ["NotchBadge.app", "AppCleaner.app", "Klack.app"]
+        let ordered = apps.filter { $0.pathExtension == "app" }.sorted { a, b in
+            (preferred.firstIndex(of: a.lastPathComponent) ?? .max)
+                < (preferred.firstIndex(of: b.lastPathComponent) ?? .max)
+        }
+        for app in ordered {
+            guard SignatureVerifier.executableArchitectures(ofAppAt: app) == [arm, intel],
+                  (try? SignatureVerifier.teamIdentifier(at: app)) != nil
+            else { continue }
+            return app
+        }
+        return nil
+    }
+
+    /// Builds the "installed universal / downloaded x86_64-only" fixture pair
+    /// shared by both installer tests below, or nil when this environment can't
+    /// support the test (see `findUniversalFixture`). `scratch` is the caller's
+    /// scratch dir, removed by the caller.
+    private static func makeDowngradeFixture(in scratch: URL) throws -> (
+        installed: InstalledApp, download: DownloadedUpdate
+    )? {
+        guard let fixture = findUniversalFixture() else { return nil }
+
+        let installedDir = scratch.appendingPathComponent("installed")
+        try FileManager.default.createDirectory(at: installedDir, withIntermediateDirectories: true)
+        let installedApp = installedDir.appendingPathComponent(fixture.lastPathComponent)
+        try run(["/bin/cp", "-R", fixture.path, installedApp.path])
+
+        let thinDir = scratch.appendingPathComponent("thin-src")
+        try FileManager.default.createDirectory(at: thinDir, withIntermediateDirectories: true)
+        let thinApp = thinDir.appendingPathComponent(fixture.lastPathComponent)
+        try run(["/bin/cp", "-R", fixture.path, thinApp.path])
+        guard let exe = Bundle(url: thinApp)?.executableURL else { return nil }
+        try run(["/usr/bin/lipo", "-thin", "x86_64", exe.path, "-output", exe.path + ".thin"])
+        try FileManager.default.removeItem(at: exe)
+        try FileManager.default.moveItem(at: URL(fileURLWithPath: exe.path + ".thin"), to: exe)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: exe.path)
+
+        let zip = scratch.appendingPathComponent("download.zip")
+        try run(
+            ["/usr/bin/ditto", "-c", "-k", "--sequesterRsrc", "--keepParent",
+             fixture.lastPathComponent, zip.path],
+            in: thinDir)
+
+        let installedInfo = InstalledApp(
+            name: fixture.deletingPathExtension().lastPathComponent,
+            bundleID: Bundle(url: installedApp)?.bundleIdentifier,
+            shortVersion: "0.0.0", buildVersion: "0",
+            path: installedApp, isMASApp: false, sparkleFeedURL: nil)
+        let download = DownloadedUpdate(archiveURL: zip, bytesDownloaded: 0, workDir: scratch)
+        return (installedInfo, download)
+    }
+
+    /// Asserts `error` is Gate 5b's refusal, naming the fixture's own message
+    /// wording (distinct from Gate 5's, per #196) — anything else, including a
+    /// silent success, means the gate is no longer reached from `apply()`.
+    private static func expectArchitectureDowngrade(_ error: Error, from label: String) {
+        guard case SignatureVerifier.VerifyError.architectureDowngrade(let installed, let downloaded) = error
+        else {
+            Issue.record("\(label): expected .architectureDowngrade, got \(error) — is Gate 5b still called from apply()?")
+            return
+        }
+        #expect(installed.contains("arm64"), "\(label): installed side should still name arm64")
+        #expect(downloaded == "x86_64", "\(label): downloaded side should be exactly x86_64")
+    }
+
+    @Test func vendorInstallerApplyRefusesTheDowngrade() async throws {
+        guard HostArch.current == .arm64, HostArch.canRunIntelBuilds else {
+            // Without Rosetta, Gate 5 itself would refuse an Intel-only download
+            // here — that would prove Gate 5 works, not Gate 5b specifically.
+            return
+        }
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arch-downgrade-wiring-vendor-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        guard let fixture = try Self.makeDowngradeFixture(in: scratch) else { return }
+
+        let remote = RemoteVersion(
+            shortVersion: "0.0.1", version: "0.0.1", downloadURL: fixture.download.archiveURL,
+            sourceName: "Vendor", vendorInstallerKind: .zip)
+        let result = UpdateResult(
+            app: fixture.installed, remote: remote, status: .updateAvailable(latest: "0.0.1"))
+
+        do {
+            try await VendorInstaller().apply(result, download: fixture.download, onStage: { _ in })
+            Issue.record("VendorInstaller.apply must refuse an arm64→x86_64-only swap")
+        } catch {
+            Self.expectArchitectureDowngrade(error, from: "VendorInstaller")
+        }
+    }
+
+    @Test func sparkleInstallerApplyRefusesTheDowngrade() async throws {
+        guard HostArch.current == .arm64, HostArch.canRunIntelBuilds else { return }
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arch-downgrade-wiring-sparkle-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        guard let fixture = try Self.makeDowngradeFixture(in: scratch) else { return }
+
+        // No `SUPublicEDKey` on the installed app (default nil), so
+        // `SparkleInstaller` takes the unsigned-feed path (code signature +
+        // Team ID + bundle id, same as Vendor/GitHub) rather than needing a
+        // real Ed25519 keypair just to reach Gate 5b.
+        let remote = RemoteVersion(
+            shortVersion: "0.0.1", version: "0.0.1",
+            downloadURL: fixture.download.archiveURL, sourceName: "Sparkle")
+        let result = UpdateResult(
+            app: fixture.installed, remote: remote, status: .updateAvailable(latest: "0.0.1"))
+
+        do {
+            try await SparkleInstaller().apply(result, download: fixture.download, onStage: { _ in })
+            Issue.record("SparkleInstaller.apply must refuse an arm64→x86_64-only swap")
+        } catch {
+            Self.expectArchitectureDowngrade(error, from: "SparkleInstaller")
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds Gate 5b to `SignatureVerifier`, beside Gate 5: a downloaded bundle that
drops the arm64 slice the **installed** bundle already has is refused, even
when Gate 5 (which only asks "can this Mac run it") would let it through via
Rosetta.

- `SignatureVerifier.isArchitectureDowngrade(installed:downloaded:)` — pure predicate.
- `SignatureVerifier.verifyNoArchitectureDowngrade(installedApp:downloadedApp:host:)` — the throwing gate.
- New `VerifyError.architectureDowngrade(installed:downloaded:)`, worded to say
  "this is a downgrade" rather than "this Mac can't run it" (Gate 5's message),
  so the two don't get merged in a user's head.
- `DeltaApplier.deltaRouteFailureIsWorthRetrying` gets the new case added to its
  exhaustive switch, in the "not worth retrying" branch — this is a forced
  compile fix (adding a case to a public enum), not new install-path wiring;
  see "Not wired in" below for why the switch itself needed touching but the
  installers didn't.

## The six boundaries from the issue

| Installed | Downloaded | Result |
|---|---|---|
| universal | arm64-only | **allow** — normal thinning |
| arm64-only | universal | **allow** |
| arm64-only | x86_64-only | **reject** — the one new rejection |
| unreadable (empty set) | x86_64-only | **allow** — fails open, same reasoning as Gate 5's own unreadable-header case |
| arm64-only | unreadable (empty set) | **allow** — same |
| Intel host | — | **not applicable** — gate no-ops when `host != .arm64` |

Also covered (not in the issue's six, but the same rule): **universal →
x86_64-only** rejects too — losing the arm64 slice out of a universal build is
exactly as much a downgrade as losing it out of an arm64-only build. Test:
`universalToIntelOnlyIsAlsoADowngrade`.

## Did I confirm the issue's own claim ("no gate anywhere checks this")?

Yes — grepped for `executableArchitectures`/`NSBundleExecutableArchitecture*`
across `DuoUpdaterCore/Sources`: the only caller was Gate 5 itself, reading the
*downloaded* bundle. Nothing anywhere reads the *installed* bundle's
architecture and compares it to what's being swapped in.

`GitHubReleaseRule.isArchIncompatibleOnly` looked like it might already cover
this — it doesn't. It's a recipe-health classifier (asset exists vs. asset is
arch-incompatible), evaluated with no notion of what's currently installed. It
never blocks a swap.

## Is the new rejection class empty in the real registry today?

**Argument, not proof — grounded in two greps, stated as such:**

1. Scanned `VendorProbeRecipe.swift` (6300+ lines, ~140+ recipes) for any
   install block containing an Intel-shaped token (`x86_64`, `x86-64`,
   `amd64`, standalone `x64`, `intel`) that does **not** also have an
   arm64/aarch64/apple-silicon/universal marker within its own block or the
   15 lines above it (comment context included). Zero hits — the handful of
   real dual-arch feeds in the registry (Brave beta/nightly, HBuilderX,
   HBuilderX Alpha) all anchor their pattern or endpoint to the arm64 asset
   explicitly, even when an x64 asset sits earlier in the same feed.
2. For GitHub-sourced recipes, `GitHubReleaseRule.installableAsset` already
   only falls back to a foreign-arch asset (step 3) when the machine can
   still run it (`canRunIntel`) — its own doc comment states the arch-neutral
   fallback (step 2) is meant for genuinely marker-less **universal** builds.
   A single-match pattern (the overwhelming majority of registry entries, per
   existing `multiCandidateCases` bookkeeping) is unaffected either way.

So: for the registry **as it stands and as intended to behave**, no
currently-passing arm64 install should trip this gate. The one concrete path
that *would* trip it is #194 (`ElectronManifestSource`'s silent fallback to a
manifest's default — x64, for Notion — when the arm64 sibling probe fails) —
that's a live, still-open bug in a different file, and tripping this gate on
it is the intended defense-in-depth catch, not a regression.

## Update: now wired into both installers

The lane was widened (coordinator) after the first push — a gate defined but
never called is worse than no gate at all, since the top-of-file doc comment
already *listed* it, so the next reader would trust it was live. Both
`SparkleInstaller.swift` and `VendorInstaller.swift` now call it, one line
each, right after the existing Gate 5 call:

```swift
try SignatureVerifier.verifyRunnableArchitecture(appAt: newApp)
try SignatureVerifier.verifyNoArchitectureDowngrade(
    installedApp: result.app.path,
    downloadedApp: newApp
)
```

`result.app.path` was already in scope there (used by Gates 3/4 a few lines
above), so this is exactly the one-line drop-in described in the earlier
revision of this PR body.

### 1. Order: Gate 5 THEN Gate 5b, never the reverse

A package that is both unrunnable *and* a downgrade (arm64 host, **no**
Rosetta, Intel-only download) must fail with Gate 5's "cannot launch"
message — the true, more severe problem — not Gate 5b's "this would run
translated", which implies the build launches at all. Since Gate 5b only
runs after Gate 5 returns without throwing, this ordering falls out
naturally from putting the new call directly below the existing one; I did
not need (or want) to restructure the two into a single combined check.

### 2. Delta route: yes, gate 5b runs on it too, confirmed from `reconstruct`'s own contract

`DeltaApplier.reconstruct` (used by both installers when a patch matches the
installed build) does not skip any downstream gate — its doc comment states
plainly: *"What it produces is an app bundle like any other, and it goes
through exactly the same gates a downloaded archive does — code signature,
Team ID, bundle identifier."* Both installers already merge the delta and
full-archive branches back into one `newApp: URL` before Gate 2 runs, and
Gate 5b sits inside that same shared tail alongside Gates 2–6 — so it is
exercised identically regardless of route. I did not assume this — I read
`reconstruct`'s body: it hands `BinaryDelta apply` the *installed* bundle and
a vendor-cut patch, and nothing in that path guarantees the patch's target
architecture set matches the baseline's, so a defense-in-depth check here is
not redundant with anything upstream.

### 3. Pkg route: not applicable, same as Gate 5, now stated in the same doc comment

`PackageInstaller` never unpacks to an `.app` it can read — it hands the
`.pkg` straight to `Installer.app` — so it was already excluded from Gate 5,
and Gate 5b inherits the same exclusion for the same reason. `VendorInstaller`
itself never even reaches `applyVerified` for a `.pkg` (`download()` throws
`.unknownKind` for `kind == .pkg` up front, routing those through
`PackageInstaller` instead), so there's no code path inside the files I
touched that could apply Gate 5b to a pkg by mistake. `SignatureVerifier`'s
top-of-file comment and Gate 5b's own doc comment both say this explicitly
now, matching Gate 5's existing wording.

### Universal-installed + x86_64-only-downloaded (the real Notion shape) — confirmed, not assumed

Checked per the coordinator's ask: `isArchitectureDowngrade` only checks
`installed.contains(arm64)` — never "installed is arm64-ONLY" — so a
**universal** installed bundle losing its arm64 slice trips the same
rejection as an arm64-only one. This was already covered before the wiring
change: `universalToIntelOnlyIsAlsoADowngrade` in `ArchitectureDowngradeGateTests`
pins exactly this case at the predicate level (`installed: [arm, intel],
downloaded: [intel]` → `true`). Confirmed real-world relevance: the
coordinator verified 2026-09-01 that `/Applications/Notion.app` on this
machine is `arm64+x86_64` universal, and `ElectronManifestSource` (#194, not
touched by this PR) can resolve `Notion-7.31.3.zip` — an x64-only artifact
with no architecture token in its filename — as the install candidate. If
that resolution reaches either installer, this gate now refuses the swap.

### New proof-of-wiring test

`ArchitectureDowngradeWiringTests` (in `ArchitectureGateTests.swift`) calls
the REAL `VendorInstaller.apply` / `SparkleInstaller.apply` — not the pure
predicate — so it fails if the two lines above are ever deleted. Mechanism:

1. Find a real, already-installed, Developer-ID-signed **universal**
   (`arm64 + x86_64`) app on the machine (small ones preferred —
   `NotchBadge.app` on the dev machine this was written on).
2. Copy it once unmodified → stands in for `result.app.path` ("installed").
3. Copy it again, `lipo -thin x86_64` the main executable, re-zip it exactly
   the way `ArchiveExtractor` unpacks a real download (`ditto -c/-x -k`) →
   the "downloaded" archive.
4. Hand both to the real `apply()` and assert it throws
   `.architectureDowngrade`.

`lipo -thin` only *extracts* an existing slice's bytes, so the thinned copy's
embedded Mach-O signature, Team ID, and bundle identifier all stay valid and
unchanged — confirmed empirically before writing the Swift test
(`codesign --verify --deep --strict` still passes on the thinned,
zip-round-tripped copy, same Team ID as the untouched original). That's what
lets the test reach all the way through Gates 2–4 into Gate 5b without
forging a code-signing identity.

**Red→green verified by hand**, not just written and trusted: I temporarily
deleted the three-line `verifyNoArchitectureDowngrade` call from
`VendorInstaller.swift`, reran `swift test --filter vendorInstallerApplyRefusesTheDowngrade`,
and it failed exactly as intended:

```
✘ Test vendorInstallerApplyRefusesTheDowngrade() recorded an issue …
  ↳ VendorInstaller.apply must refuse an arm64→x86_64-only swap
```

then restored the file (`diff` against the pre-edit copy showed no
difference) and confirmed green again before pushing.

The test skips (does not fail) when the host isn't Apple silicon, has no
Rosetta, or has no suitable local universal app — same environment-gated
pattern as the existing `InstallPipelineSmokeTests.installPipelineDryRun`,
and for the same underlying reason here: without Rosetta, Gate 5 itself would
refuse an Intel-only download before Gate 5b ever runs, which would prove
Gate 5 works and nothing about Gate 5b specifically.

## Testing

```
swift test --package-path DuoUpdaterCore --filter Architecture
```

29 tests in 7 suites, 0 failures — the pre-existing Gate 5 suite, the 12
`ArchitectureDowngradeGateTests` (predicate boundaries), and the 2 new
`ArchitectureDowngradeWiringTests` (real `apply()` end-to-end, red→green
verified as described above).

Did not run `make test` — it shells out to a localization checker that locks a
fixed `/tmp` path and collides across worktrees (per repo `CLAUDE.md`); this
PR touches no localization surface.

Fixes #196
