### PR TITLE
fix: an app is Tauri when the binary says so, not when the packaging resembles it (#206)

### DIFF
--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -900,7 +900,6 @@ private struct AppRow: View {
             // by its edges rather than its centre. See `RunningIndicator.opticalNudge`.
             if let runtime {
                 RuntimeTag(runtime: runtime, bundle: result.app.path,
-                           appVersion: result.app.shortVersion,
                            frameworks: result.app.linkedFrameworks)
             }
         }

--- a/App/Sources/Preferences.swift
+++ b/App/Sources/Preferences.swift
@@ -212,10 +212,16 @@ final class Preferences {
     /// Show a small chip beside each app's name naming what it is built with —
     /// Electron, Tauri, Qt, native, … See `AppRuntime`.
     ///
-    /// Default ON. The information is free (the scan already reads every bundle
-    /// this comes from) and it explains rows that otherwise look alike: an app the
+    /// Default ON, because it explains rows that otherwise look alike: an app the
     /// App Store manages already says so on the right-hand side, while everything
     /// else was indistinguishable.
+    ///
+    /// This gates the *display* only. The scan works the runtime out either way —
+    /// the workbench's own filters read it — so turning this off hides the mark
+    /// without saving the work behind it. Worth knowing because that work is no
+    /// longer nothing: since #206, proving an app is Tauri means reading its
+    /// executable through. It is confined to the bundles a cheap plist-and-link
+    /// filter admits, six of about a hundred and fifty here.
     var showRuntimeTags: Bool {
         didSet { defaults.set(showRuntimeTags, forKey: Key.showRuntimeTags) }
     }

--- a/App/Sources/RuntimeTag.swift
+++ b/App/Sources/RuntimeTag.swift
@@ -29,9 +29,6 @@ struct RuntimeTag: View {
     /// runtime's own version lives inside it. Nil where there is no real app behind
     /// the mark.
     var bundle: URL?
-    /// The app's own version, used only as the cache key for the runtime-version
-    /// read: an app that has not been updated cannot have changed its runtime.
-    var appVersion: String?
     /// What the app's binary actually links, shown in the click-through detail for
     /// the cases where the runtime label alone is not the whole answer. Empty is
     /// normal — nothing is claimed when nothing was read.
@@ -147,8 +144,7 @@ struct RuntimeTag: View {
             // the same cached entry back out.
             guard !versionLoaded, let bundle else { return }
             version = await Task.detached(priority: .utility) {
-                RuntimeVersion.read(runtime, bundleAt: bundle,
-                                    appVersion: appVersion, scanningBinaries: true)
+                RuntimeVersion.read(runtime, bundleAt: bundle, scanningBinaries: true)
             }.value
             versionLoaded = true
         }

--- a/App/Sources/RuntimeTag.swift
+++ b/App/Sources/RuntimeTag.swift
@@ -55,10 +55,10 @@ struct RuntimeTag: View {
 
     @State private var showingDetail = false
     @State private var version: String?
-    /// Separate from `version` being nil, which is a real answer: a runtime with no
-    /// trustworthy version, or a Tauri fingerprint with no Tauri crate behind it.
-    /// Without this the nil answer is never remembered and every re-open pays for
-    /// the search again — a quarter of a second, each time, on a large binary.
+    /// Separate from `version` being nil, which is a real answer: Chromium,
+    /// Flutter and the Apple-platform runtimes have no version worth printing, and
+    /// a rebranded Electron framework can hide the one it has. Without this the nil
+    /// answer is never remembered and every re-open pays for the search again.
     @State private var versionLoaded = false
 
     var body: some View {
@@ -139,10 +139,12 @@ struct RuntimeTag: View {
         .padding(14)
         .frame(width: 300, alignment: .leading)
         .task {
-            // Off the main thread and only once the detail is actually open: for
-            // Tauri this walks the whole executable, which is a quarter of a second
-            // on a large one. That cost is fine for a single app someone asked
-            // about and would be indefensible during a scan of the whole library.
+            // Off the main thread and only once the detail is actually open: a
+            // rebranded Electron framework is found by walking a binary, which is
+            // fine for a single app someone asked about and would be indefensible
+            // during a scan of the whole library. Tauri's walk is already paid for
+            // — the scan had to do it to reach the verdict at all, and this reads
+            // the same cached entry back out.
             guard !versionLoaded, let bundle else { return }
             version = await Task.detached(priority: .utility) {
                 RuntimeVersion.read(runtime, bundleAt: bundle,

--- a/App/Sources/RuntimeTag.swift
+++ b/App/Sources/RuntimeTag.swift
@@ -52,10 +52,13 @@ struct RuntimeTag: View {
 
     @State private var showingDetail = false
     @State private var version: String?
-    /// Separate from `version` being nil, which is a real answer: Chromium,
-    /// Flutter and the Apple-platform runtimes have no version worth printing, and
-    /// a rebranded Electron framework can hide the one it has. Without this the nil
-    /// answer is never remembered and every re-open pays for the search again.
+    /// Separate from `version` being nil, which is a real answer: Flutter and the
+    /// Apple-platform runtimes have no version worth printing, and a rebranded
+    /// Electron framework can hide the one it has. A Tauri mark can reach it too,
+    /// though it is now rare rather than ordinary — the binary was unreadable at
+    /// this moment, or it changed between the scan that produced the verdict and
+    /// this read. Without this the nil answer is never remembered and every re-open
+    /// pays for the search again.
     @State private var versionLoaded = false
 
     var body: some View {

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1108,7 +1108,6 @@ private struct DetailHeader: View {
                         // so they scale without losing their stroke ratio.
                         if model.prefs.showRuntimeTags, let runtime = result.app.runtime {
                             RuntimeTag(runtime: runtime, bundle: result.app.path,
-                                       appVersion: result.app.shortVersion,
                                        frameworks: result.app.linkedFrameworks, size: 18)
                         }
                     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ reads the section matching the version being shipped and embeds it in the GitHub
 release and the Sparkle appcast, so this file is the single source of truth for
 "what's new" — keep each version's prose written for users, not commit-speak.
 
+## 0.3.78
+
+**The mark that says what an app is built with now needs proof for Tauri, not a resemblance.** Tauri leaves nothing in a bundle to find — no framework, no folder of its own — so that one mark was worked out from how the app was packaged plus the fact that it links Apple's web view. Longbridge matches all of that and is not Tauri: it draws its own windows with the same renderer Zed uses, and embeds a web view for one corner of its interface. Duo Updater now reads Tauri's own fingerprint out of the binary before claiming it, so an app is called Tauri when it is one — and Longbridge reads as the native Mac app it is.
+
 ## 0.3.77
 
 **Every app in the list now says what it is built with.** A row for an App Store app has always carried the store's badge, and every other row looked alike — a Sparkle app, an Electron app and a native one were indistinguishable. Each name now carries the technology's own mark — click it for a word and a sentence, or hover for the tooltip: Electron, Tauri, Flutter, Qt, Java, Chromium, Mac Catalyst, an iPhone app on Apple silicon, or a native Mac app — with the runtime's version where that can be read as a fact (Electron 42.4.1, Qt 6.2, the Chromium an app embeds, the Tauri it was built with). It is read from the bundle itself — the framework a packager had to ship, the runtime a launcher needs, the libraries the binary links — so it is a fact about what is installed rather than a guess from the app's name. Where a long name leaves no room, the symbol steps aside rather than pushing the name onto a second line: the name is the row. Turn the whole thing off in Settings → General.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
@@ -172,9 +172,13 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
     /// binary, … Nil when the bundle carries no evidence either way, which the UI
     /// must render as "no badge" rather than as "native".
     ///
-    /// Purely descriptive: nothing in the update engine reads it. It is a fact
-    /// about the bundle, read at scan time from the same directory listing and
-    /// Info.plist the scan is already paying for. See `AppRuntimeDetector`.
+    /// Purely descriptive: nothing in the update engine reads it. Mostly it is a
+    /// fact read from the directory listing and Info.plist the scan is already
+    /// paying for — with one exception that stopped being free in #206: proving an
+    /// app is Tauri means reading its executable through, which the scan does for
+    /// the handful of bundles the cheap markers admit (six of about a hundred and
+    /// fifty here, half a second between them, remembered per binary afterwards).
+    /// See `AppRuntimeDetector`.
     public let runtime: AppRuntime?
 
     /// Which of Apple's UI frameworks the executable links, and whether Swift is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -10,10 +10,10 @@ import Foundation
 /// the bundle does not say.
 ///
 /// Every case is decided from something the packager *wrote*: a framework it had
-/// to bundle, a directory its launcher needs, or the dylibs its executable links.
-/// Nothing here guesses from an app's name or vendor. See `AppRuntimeDetector` for
-/// the evidence behind each case, and note that `tauri` is the one heuristic in
-/// the set.
+/// to bundle, a directory its launcher needs, the dylibs its executable links, or
+/// a Cargo path baked into it. Nothing here guesses from an app's name or vendor,
+/// and nothing is inferred from the absence of a marker. See `AppRuntimeDetector`
+/// for the evidence behind each case.
 public enum AppRuntime: String, Sendable, Hashable, CaseIterable, Codable {
     /// A wrapped iPhone/iPad app running on Apple Silicon.
     case iOSApp = "ios"
@@ -21,7 +21,9 @@ public enum AppRuntime: String, Sendable, Hashable, CaseIterable, Codable {
     case catalyst
     /// Chromium + Node, bundled by Electron.
     case electron
-    /// A Rust binary drawing into the system WebView (Tauri / wry).
+    /// A Rust app built on the Tauri framework, drawing into the system WebView.
+    /// Requires the `tauri` crate itself: wry — the WebView layer Tauri sits on —
+    /// is embedded by apps that are not Tauri at all.
     case tauri
     /// Flutter's macOS embedder.
     case flutter
@@ -79,7 +81,7 @@ public struct LinkedFrameworks: OptionSet, Sendable, Hashable, Codable {
 
 /// Reads an installed bundle and says which runtime it was built with.
 ///
-/// Two evidence sources, cheapest first:
+/// Three evidence sources, cheapest first:
 ///
 /// 1. **Bundle layout.** A packager cannot hide the runtime it bundles: Electron
 ///    ships `Electron Framework.framework` (or an `app.asar`), Flutter ships
@@ -90,6 +92,10 @@ public struct LinkedFrameworks: OptionSet, Sendable, Hashable, Codable {
 ///    all — nothing on disk says AppKit. The executable's linked dylibs do, and
 ///    they also separate a Catalyst app (links out of `/System/iOSSupport/`) from
 ///    an AppKit one. See `MachOImports`.
+/// 3. **Binary contents.** Tauri writes nothing to either — its only trace is a
+///    Cargo path inside the executable. Reading a whole binary is far too
+///    expensive to do for every app, so it runs only for the bundles the first
+///    two sources have already narrowed to a handful. See the `tauri` rule below.
 ///
 /// Returns nil when neither source recognizes anything, which is the honest answer
 /// for a launcher shell script, a Python app, or a C++ app that links neither
@@ -99,6 +105,12 @@ public enum AppRuntimeDetector {
     /// Injected so the rules can be tested without a real Mach-O binary on disk.
     /// Production always passes `MachOImports.linkedLibraries(at:)`.
     public typealias LibraryReader = (URL) -> Set<String>?
+
+    /// Whether a bundle's executable actually carries the Tauri framework crate —
+    /// the one rule here that needs the *contents* of a binary rather than its
+    /// header. Injected for the same reason as `LibraryReader`; production passes
+    /// `RuntimeVersion.carriesTauriCrate(bundleAt:infoPlist:)`.
+    public typealias TauriProof = (URL, [String: Any]) -> Bool
 
     /// Everything one read of a bundle can say about how it was built.
     public struct Reading: Sendable, Equatable {
@@ -111,10 +123,12 @@ public enum AppRuntimeDetector {
         bundleAt bundleURL: URL,
         isiOSAppOnMac: Bool,
         infoPlist: [String: Any],
-        linkedLibraries: LibraryReader = { MachOImports.linkedLibraries(at: $0) }
+        linkedLibraries: LibraryReader = { MachOImports.linkedLibraries(at: $0) },
+        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:infoPlist:)
     ) -> AppRuntime? {
         read(bundleAt: bundleURL, isiOSAppOnMac: isiOSAppOnMac,
-             infoPlist: infoPlist, linkedLibraries: linkedLibraries).runtime
+             infoPlist: infoPlist, linkedLibraries: linkedLibraries,
+             carriesTauriCrate: carriesTauriCrate).runtime
     }
 
     /// Both facts from a single pass. The executable's load commands are read at
@@ -124,7 +138,8 @@ public enum AppRuntimeDetector {
         bundleAt bundleURL: URL,
         isiOSAppOnMac: Bool,
         infoPlist: [String: Any],
-        linkedLibraries: LibraryReader = { MachOImports.linkedLibraries(at: $0) }
+        linkedLibraries: LibraryReader = { MachOImports.linkedLibraries(at: $0) },
+        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:infoPlist:)
     ) -> Reading {
         // A wrapped iOS app has no `Contents/` at all, so every rule below would
         // look in the wrong place, and its own executable sits inside the wrapper
@@ -192,7 +207,9 @@ public enum AppRuntimeDetector {
         // ends the enquiry.
         guard let libraries else { return reading(nil) }
 
-        // Tauri — the one inference here, and worth stating plainly:
+        // Tauri — the one case decided by reading a binary's *contents*, and the
+        // reason is worth stating because the cheaper rule was tried first and
+        // broke.
         //
         // Tauri bundles nothing distinctive. Its frontend is compiled into the
         // binary and it draws into the system WebView, so there is no framework to
@@ -200,17 +217,35 @@ public enum AppRuntimeDetector {
         // (via cargo-bundle) writes the legacy pair `LSRequiresCarbon` +
         // `CSResourcesFileMapped`, which essentially nothing else still emits.
         //
-        // That pair alone says "cargo-bundle", not "Tauri" — Warp and Zed are
-        // cargo-bundled Rust apps with their own renderers and carry it too. The
-        // WebKit link is what separates them: a Tauri app must link WebKit to have
-        // a window at all, and those two do not. Measured across 140 installed apps
-        // this split every cargo-bundled app correctly, but it remains a heuristic:
-        // a future cargo-bundled app that embeds a WebView for something incidental
-        // would read as Tauri. It fails toward a wrong *label*, never toward a
-        // wrong install decision — nothing routes on this value.
+        // That pair says "cargo-bundle", not "Tauri" — Warp and Zed are cargo-
+        // bundled Rust apps with their own renderers and carry it too. Adding "and
+        // links WebKit" separated those two and looked sufficient, on the reasoning
+        // that a Tauri app must link WebKit to have a window at all. It is not
+        // sufficient, and the counterexample was already installed: Longbridge
+        // draws with GPUI — the same renderer as Zed, pulled from the same repo —
+        // and embeds a renamed wry fork (`lb-wry-0.53.3`) for incidental web
+        // content. Cargo-bundled, links WebKit, contains not one occurrence of the
+        // string "tauri". It read as Tauri for exactly as long as the WebKit rule
+        // stood. See issue #206.
+        //
+        // So the plist pair plus WebKit is kept as a *filter*, not a verdict: it
+        // costs two dictionary lookups, and on a 193-app library it admits three
+        // bundles. Those three pay for the proof — the `tauri-<semver>` Cargo path
+        // Rust bakes into the binary, which is positive evidence and yields the
+        // version besides. Measured warm: 0.006s and 0.039s for the two real Tauri
+        // apps (the needle is found and the walk stops), 0.25s for Longbridge's
+        // 262 MB binary, where the whole file is walked to prove absence. Paid once
+        // per app version — `RuntimeVersion` remembers the answer, nil included,
+        // and the app's detail view reads the version back out of the same entry.
+        //
+        // The residual risk moved rather than vanished, and it moved to the safer
+        // side: a Tauri app whose binary keeps no `tauri-` crate path now reads as
+        // native instead of an unrelated app reading as Tauri. Both are labels —
+        // nothing routes on this value.
         if infoPlist["LSRequiresCarbon"] as? Bool == true,
            infoPlist["CSResourcesFileMapped"] as? Bool == true,
-           MachOImports.links(libraries, framework: "WebKit") {
+           MachOImports.links(libraries, framework: "WebKit"),
+           carriesTauriCrate(bundleURL, infoPlist) {
             return reading(.tauri)
         }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -234,9 +234,10 @@ public enum AppRuntimeDetector {
         // for the proof — the `tauri-<semver>` Cargo path Rust bakes into the
         // binary, which is positive evidence and yields the version besides.
         //
-        // Six candidates is 471 MB of executable, and five of them stop early
-        // because the needle is found (6 ms for a 9 MB binary, 39 ms for a 64 MB
-        // one); only Longbridge's 262 MB is walked end to end, to prove absence.
+        // Six candidates is 471 MiB of executable. Five stop when the needle is
+        // found, which is later in each file than "early" suggests — measured
+        // first-match offsets are 34%, 52%, 63%, 66% and 86% of the way in — and
+        // only Longbridge's 261 MiB is walked end to end, to prove absence.
         // Whole-library sweep in a release build: 0.50s, against 0.05s for a second
         // sweep once everything is remembered. I/O is not the cost — the same
         // machine reads a cold 795 MB binary in 0.169s — the byte search is, which
@@ -244,10 +245,12 @@ public enum AppRuntimeDetector {
         // half a second.
         //
         // The residual risk moved rather than vanished, and it moved to the safer
-        // side: a Tauri app whose binary keeps no `tauri-` crate path now reads as
-        // native instead of an unrelated app reading as Tauri. Both are labels —
-        // nothing routes on this value. `RuntimeVersion.carriesTauriCrate` lists
-        // the two binary shapes that can hide the path.
+        // side: an app now reads as native when its binary keeps no `tauri-` crate
+        // path — or when that binary could not be read at this moment, since the
+        // proof cannot tell a caller "I don't know". Either beats an unrelated app
+        // reading as Tauri, and both are labels: nothing routes on this value.
+        // `RuntimeVersion.carriesTauriCrate` lists the two binary shapes that can
+        // hide the path even when the read succeeds.
         if infoPlist["LSRequiresCarbon"] as? Bool == true,
            infoPlist["CSResourcesFileMapped"] as? Bool == true,
            MachOImports.links(libraries, framework: "WebKit"),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -97,7 +97,7 @@ public struct LinkedFrameworks: OptionSet, Sendable, Hashable, Codable {
 ///    expensive to do for every app, so it runs only for the bundles the first
 ///    two sources have already narrowed to a handful. See the `tauri` rule below.
 ///
-/// Returns nil when neither source recognizes anything, which is the honest answer
+/// Returns nil when none of the three recognizes anything, which is the honest answer
 /// for a launcher shell script, a Python app, or a C++ app that links neither
 /// AppKit nor a bundled toolkit — the UI shows no badge rather than a wrong one.
 public enum AppRuntimeDetector {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -109,8 +109,8 @@ public enum AppRuntimeDetector {
     /// Whether a bundle's executable actually carries the Tauri framework crate —
     /// the one rule here that needs the *contents* of a binary rather than its
     /// header. Injected for the same reason as `LibraryReader`; production passes
-    /// `RuntimeVersion.carriesTauriCrate(bundleAt:infoPlist:)`.
-    public typealias TauriProof = (URL, [String: Any]) -> Bool
+    /// `RuntimeVersion.carriesTauriCrate(bundleAt:)`.
+    public typealias TauriProof = (URL) -> Bool
 
     /// Everything one read of a bundle can say about how it was built.
     public struct Reading: Sendable, Equatable {
@@ -124,7 +124,7 @@ public enum AppRuntimeDetector {
         isiOSAppOnMac: Bool,
         infoPlist: [String: Any],
         linkedLibraries: LibraryReader = { MachOImports.linkedLibraries(at: $0) },
-        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:infoPlist:)
+        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:)
     ) -> AppRuntime? {
         read(bundleAt: bundleURL, isiOSAppOnMac: isiOSAppOnMac,
              infoPlist: infoPlist, linkedLibraries: linkedLibraries,
@@ -139,7 +139,7 @@ public enum AppRuntimeDetector {
         isiOSAppOnMac: Bool,
         infoPlist: [String: Any],
         linkedLibraries: LibraryReader = { MachOImports.linkedLibraries(at: $0) },
-        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:infoPlist:)
+        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:)
     ) -> Reading {
         // A wrapped iOS app has no `Contents/` at all, so every rule below would
         // look in the wrong place, and its own executable sits inside the wrapper
@@ -229,23 +229,29 @@ public enum AppRuntimeDetector {
         // stood. See issue #206.
         //
         // So the plist pair plus WebKit is kept as a *filter*, not a verdict: it
-        // costs two dictionary lookups, and on a 193-app library it admits three
-        // bundles. Those three pay for the proof — the `tauri-<semver>` Cargo path
-        // Rust bakes into the binary, which is positive evidence and yields the
-        // version besides. Measured warm: 0.006s and 0.039s for the two real Tauri
-        // apps (the needle is found and the walk stops), 0.25s for Longbridge's
-        // 262 MB binary, where the whole file is walked to prove absence. Paid once
-        // per app version — `RuntimeVersion` remembers the answer, nil included,
-        // and the app's detail view reads the version back out of the same entry.
+        // costs two dictionary lookups, and across the ~145 bundles in
+        // `/Applications` and `~/Applications` here it admits six. Those six pay
+        // for the proof — the `tauri-<semver>` Cargo path Rust bakes into the
+        // binary, which is positive evidence and yields the version besides.
+        //
+        // Six candidates is 471 MB of executable, and five of them stop early
+        // because the needle is found (6 ms for a 9 MB binary, 39 ms for a 64 MB
+        // one); only Longbridge's 262 MB is walked end to end, to prove absence.
+        // Whole-library sweep in a release build: 0.50s, against 0.05s for a second
+        // sweep once everything is remembered. I/O is not the cost — the same
+        // machine reads a cold 795 MB binary in 0.169s — the byte search is, which
+        // is also why a debug build takes 104s for that sweep and a release build
+        // half a second.
         //
         // The residual risk moved rather than vanished, and it moved to the safer
         // side: a Tauri app whose binary keeps no `tauri-` crate path now reads as
         // native instead of an unrelated app reading as Tauri. Both are labels —
-        // nothing routes on this value.
+        // nothing routes on this value. `RuntimeVersion.carriesTauriCrate` lists
+        // the two binary shapes that can hide the path.
         if infoPlist["LSRequiresCarbon"] as? Bool == true,
            infoPlist["CSResourcesFileMapped"] as? Bool == true,
            MachOImports.links(libraries, framework: "WebKit"),
-           carriesTauriCrate(bundleURL, infoPlist) {
+           carriesTauriCrate(bundleURL) {
             return reading(.tauri)
         }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -2,32 +2,39 @@ import Foundation
 
 /// The version of the runtime an app was built with — "Electron 42.4.1", "Qt 6.2".
 ///
-/// Only for the four runtimes where a version can be read as a *fact*. The others
-/// are left blank on purpose, and the reasons are worth keeping because each looks
-/// like it would work:
+/// Only where a version can be read as a *fact*. The rest are left blank on
+/// purpose, and the reasons are worth keeping because each looks like it would
+/// work:
 ///
-/// - **Chromium** publishes three different things under one roof. Chrome's own
-///   framework reports the Chrome version (152.0.7977.65), Spotify's embedded CEF
-///   reports the CEF version (146.0.10.0), and Helium's fork reports *Helium's app
-///   version* (0.16.2.1). Printing any of them after the word "Chromium" would be
-///   wrong for two apps out of three.
 /// - **Flutter**'s embedder carries the *app's* version, not the framework's:
 ///   LocalSend's `FlutterMacOS.framework` says 1.18.2, which is LocalSend. Two
 ///   other Flutter apps say a placeholder 1.0.
 /// - **Native**, **Catalyst** and **iOS App** are not versioned things.
+///
+/// **Chromium used to be on that list and no longer is**, which is worth spelling
+/// out because the reason it was there is still true of the obvious source. Its
+/// framework *plist* reports three different things depending on the app — Chrome's
+/// own says the Chrome version (152.0.7977.65), Spotify's embedded CEF says the CEF
+/// version (146.0.10.0), and Helium's fork says *Helium's app version* (0.16.2.1),
+/// so printing that after the word "Chromium" would be wrong for two apps in three.
+/// `chromiumVersion` reads no plist: it takes the `Chrome/<version>` token out of
+/// the framework's user-agent string, which is the engine describing itself and
+/// agrees for all three.
 public enum RuntimeVersion {
 
     /// Reads the runtime version, or nil where there is nothing trustworthy to read.
     ///
-    /// - Parameter scanningBinaries: whether to allow the one reader that has to
-    ///   walk the executable (Tauri, and the two rebranded Electron shapes). Off
-    ///   during a scan, where it would be paid for every app on the machine, and on
-    ///   when a single app's detail is being shown.
+    /// - Parameter scanningBinaries: whether to allow the readers that walk a whole
+    ///   binary — the two rebranded Electron shapes, and Chromium's user-agent. Off
+    ///   when the caller would pay it for every app on the machine, on when a single
+    ///   app's detail is being shown.
     ///
-    ///   `.tauri` is the exception: it arrives here with scanning on even during a
-    ///   scan, because for that runtime the walk *is* the detection — but only for
-    ///   the two or three bundles `AppRuntimeDetector` has already narrowed to. See
-    ///   `carriesTauriCrate(bundleAt:infoPlist:)`.
+    ///   It is **not** a promise that a library-wide scan never walks a binary, and
+    ///   it stopped being one in this branch: `.tauri` arrives here with scanning on
+    ///   from inside the scan itself, because for that runtime the walk *is* the
+    ///   detection. What keeps that affordable is not this flag but the filter in
+    ///   `AppRuntimeDetector`, which admits six bundles out of about a hundred and
+    ///   fifty. See `carriesTauriCrate(bundleAt:)`.
     public static func read(
         _ runtime: AppRuntime,
         bundleAt bundleURL: URL,
@@ -45,10 +52,10 @@ public enum RuntimeVersion {
         // may be running. Size-and-mtime changes whenever the bytes this answer was
         // read from change, which is the only thing that can make it stale.
         //
-        // The lookup deliberately sits *above* the `scanningBinaries` guard: a
-        // remembered answer costs nothing, so a caller that forbade scanning still
-        // gets it. That is what lets a version paid for once be available to
-        // everything afterwards.
+        // The lookup deliberately sits *above* the `scanningBinaries` guard, so a
+        // caller that forbade scanning still gets an answer someone else paid for.
+        // It is not free — building the key parses `Contents/Info.plist` and stats
+        // the executable — but that is microseconds against a walk of the file.
         //
         // Nil is cached too: "no Tauri crate in here" is an answer, and the
         // expensive one to reach. An *unreadable* binary is not — see `.tauri`.
@@ -83,7 +90,13 @@ public enum RuntimeVersion {
         case .flutter, .native, .catalyst, .iOSApp:
             version = nil
         }
-        if let key { remember(version, for: key) }
+        // A nil reached only because scanning was forbidden is not an answer about
+        // the app, it is an answer about the caller — and the two callers share a
+        // key. `.tauri` and `.chromium` return above rather than fall through here;
+        // `.electron` cannot, because its cheap path and its scanning path are one
+        // function. Without this line a single `scanning: false` read of a
+        // re-signed Electron framework would pin "no version" for the process.
+        if let key, version != nil || scanningBinaries { remember(version, for: key) }
         return version
     }
 
@@ -97,6 +110,13 @@ public enum RuntimeVersion {
     /// bundled framework and leaves the app's own binary byte-identical would go
     /// unnoticed; no packager produces that, since the executable is re-signed
     /// either way.
+    ///
+    /// Two places where it stands in rather than measures: `attributesOfItem` does
+    /// not follow symlinks while `FileHandle` does, so a bundle whose executable is
+    /// a symlink would be keyed on the link (whose size is the length of its path)
+    /// rather than on the bytes read; and a filesystem with coarse timestamps could
+    /// in principle hold two same-sized binaries under one key. Neither shape
+    /// appears in `/Applications`.
     private static func executableIdentity(of executable: URL) -> String? {
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: executable.path),
               let size = attributes[.size] as? NSNumber,
@@ -314,12 +334,25 @@ public enum RuntimeVersion {
         guard let handle = try? FileHandle(forReadingFrom: binary) else { return .unreadable }
         defer { try? handle.close() }
 
+        // How far to read, so a window can tell "the end of my buffer" from "the
+        // end of the file" — see `firstVersion`. Taken once, up front; a file that
+        // grows underneath the walk simply ends the walk where it was going to end
+        // anyway.
+        let size: UInt64
+        do {
+            size = try handle.seekToEnd()
+            try handle.seek(toOffset: 0)
+        } catch { return .unreadable }
+
         let needle = Array(prefix.utf8)
-        // Read in chunks, overlapping by enough that a version straddling a
-        // boundary is still whole in one of them.
+        // Read in chunks, carrying enough of each into the next that a match cut by
+        // a boundary is whole in one window — and one byte more than that, so the
+        // window also holds the character *before* such a match. Both of
+        // `firstVersion`'s rules need context the chunk alone cannot supply.
         let chunkSize = 4 * 1024 * 1024
-        let overlap = 64
+        let overlap = 128
         var carry = Data()
+        var consumed: UInt64 = 0
         while true {
             // `try?` is not available here, and the reason is the whole point of
             // this type: `read(upToCount:)` returns nil *at end of file*, and
@@ -333,9 +366,21 @@ public enum RuntimeVersion {
             let chunk: Data?
             do { chunk = try handle.read(upToCount: chunkSize) } catch { return .unreadable }
             guard let chunk, !chunk.isEmpty else { break }
+            consumed += UInt64(chunk.count)
+            let continuation = !carry.isEmpty
             var window = carry
             window.append(chunk)
-            if let version = firstVersion(in: Array(window), after: needle, components: components) {
+            if let version = firstVersion(
+                in: Array(window), after: needle, components: components,
+                // In a continuation window the first byte is there only to be the
+                // character before the second: a match starting *on* it has no
+                // predecessor in this window, and was already whole in the previous
+                // one, which had `overlap` bytes of room after it.
+                from: continuation ? 1 : 0,
+                // And only the last window may read "my buffer ended" as "the
+                // version ended".
+                isFinal: consumed >= size
+            ) {
                 return .found(version)
             }
             carry = window.suffix(overlap)
@@ -354,12 +399,38 @@ public enum RuntimeVersion {
 
     /// The first `<needle><major>.<minor>.<patch>` in `bytes`, where the character
     /// before the needle is not part of a longer identifier.
-    private static func firstVersion(in bytes: [UInt8], after needle: [UInt8], components: Int) -> String? {
-        guard bytes.count > needle.count else { return nil }
+    ///
+    /// `bytes` is one window of a larger file, and both of those rules need to know
+    /// it. Reading the edge of the buffer as the edge of the file gets each rule
+    /// wrong in its own direction, and neither is theoretical — both were
+    /// reproduced against this code:
+    ///
+    /// - **The digit run.** `tauri-2.11.50` cut by a boundary returned `2.11.5`:
+    ///   three components, last one a digit, looks finished. `isFinal` says whether
+    ///   a run that reached the end of the buffer may be trusted; when it may not,
+    ///   the candidate is skipped and the carry presents it whole next time.
+    /// - **The identifier guard.** `index > 0` is a claim about the *file*, and in
+    ///   a continuation window index 0 is not the start of anything — its real
+    ///   predecessor is in the previous chunk. `xtauri-2.11.5` positioned there
+    ///   passed a guard that rejects it everywhere else. `start` is 1 for those
+    ///   windows, so every position examined has its predecessor in hand.
+    ///
+    /// This second one is why the fix belongs in this branch rather than after it:
+    /// it hands out a `tauri-` match that is not one, which for a *displayed
+    /// version* was cosmetic and for a *verdict* is the exact false positive the
+    /// rest of this change exists to prevent.
+    private static func firstVersion(
+        in bytes: [UInt8],
+        after needle: [UInt8],
+        components: Int,
+        from start: Int = 0,
+        isFinal: Bool = true
+    ) -> String? {
+        guard bytes.count > needle.count, start <= bytes.count - needle.count - 1 else { return nil }
         let digits = UInt8(ascii: "0")...UInt8(ascii: "9")
         let dot = UInt8(ascii: ".")
         let dash = UInt8(ascii: "-")
-        outer: for index in 0...(bytes.count - needle.count - 1) {
+        outer: for index in start...(bytes.count - needle.count - 1) {
             for offset in 0..<needle.count where bytes[index + offset] != needle[offset] { continue outer }
             if index > 0 {
                 let before = bytes[index - 1]
@@ -382,6 +453,10 @@ public enum RuntimeVersion {
                 }
                 cursor += 1
             }
+            // A run that stopped because the buffer did, in a window that is not the
+            // end of the file, is not a finished version — whatever digits follow
+            // are in the next chunk.
+            if !isFinal, cursor == bytes.count { continue }
             if dots == components - 1, let last = version.last, last.isNumber { return version }
         }
         return nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -326,8 +326,10 @@ public enum RuntimeVersion {
         read(.tauri, bundleAt: bundleURL, scanningBinaries: true) != nil
     }
 
-    /// Walks a binary looking for `<needle><version>`, in chunks so a 261 MB
-    /// executable never lands in memory at once.
+    /// Walks a binary looking for `<needle><version>` in chunks, so that a 261 MiB
+    /// executable never lands in memory at once — see the pool in `probe`, without
+    /// which that sentence was false.
+    ///
     /// Three outcomes, because two of them are not the same thing. A binary that
     /// was read to the end and does not contain the needle is *evidence*; a binary
     /// that could not be opened or could not be read through is the absence of
@@ -355,13 +357,18 @@ public enum RuntimeVersion {
     /// did until round 3 of review noticed.
     static let scanOverlap = 128
 
+    /// How much is read at a time. Internal for the same reason as `scanOverlap`:
+    /// the boundary tests place their payload where these two numbers put the seam,
+    /// and a literal on the test side goes stale silently — the test keeps passing
+    /// while testing nothing.
+    static let scanChunkSize = 4 * 1024 * 1024
+
     private static func probe(_ binary: URL, for prefix: String, components: Int) -> Probe {
         guard let handle = try? FileHandle(forReadingFrom: binary) else { return .unreadable }
         defer { try? handle.close() }
 
         let needle = Array(prefix.utf8)
 
-        let chunkSize = 4 * 1024 * 1024
 
         // `try?` is not available here, and the reason is the whole point of this
         // type: `read(upToCount:)` returns nil *at end of file*, and `try?` flattens
@@ -370,7 +377,7 @@ public enum RuntimeVersion {
         // to end. `do`/`catch` keeps them apart.
         var failed = false
         func read() -> Data? {
-            do { return try handle.read(upToCount: chunkSize) }
+            do { return try handle.read(upToCount: scanChunkSize) }
             catch { failed = true; return nil }
         }
 
@@ -385,35 +392,63 @@ public enum RuntimeVersion {
         // with every later window wrongly calling itself final. A lookahead cannot
         // go stale, and it keeps this working on anything unseekable besides.
         var carry = Data()
+        // Where `window[0]` sits in the file. `carry.isEmpty` looks like the same
+        // question and is not: if a window is no longer than `scanOverlap`, the
+        // carry is the whole of it and the next window still begins at offset 0.
+        // Asking about the offset directly is what keeps `from: 1` from blinding
+        // the first bytes of the file for the rest of the walk.
+        var windowStart = 0
         var pending = read()
         if failed { return .unreadable }
+        var outcome: Probe?
 
         while let chunk = pending, !chunk.isEmpty {
-            let following = read()
-            if failed { return .unreadable }
-            // A short read is legal mid-file; only an empty one is the end. Finality
-            // is therefore decided by the *next* read, not by this one's length —
-            // treating a short read as the end would report a truncated binary as
-            // proof of absence.
-            let isFinal = following?.isEmpty ?? true
-            let continuation = !carry.isEmpty
-            var window = carry
-            window.append(chunk)
-            if let version = firstVersion(
-                in: Array(window), after: needle, components: components,
-                // In a continuation window the first byte is there only to be the
-                // character before the second: a match starting *on* it has no
-                // predecessor in this window, and was already whole in the previous
-                // one, which had `scanOverlap` bytes of room after it.
-                from: continuation ? 1 : 0,
-                // And only the last window may read "my buffer ended" as "the
-                // version ended".
-                isFinal: isFinal
-            ) {
-                return .found(version)
+            // A pool per window, because `read(upToCount:)` hands back a bridged
+            // `NSData` that is autoreleased. Without one nothing drains until the
+            // walk returns, and the "never lands in memory at once" above is false
+            // in the most literal way — the whole file lands, one chunk at a time.
+            // Measured on Longbridge's 261 MiB binary, peak footprint for a single
+            // probe: **+278 MiB without the pool, +30 MiB with it**. That comment
+            // has been shipping since before this branch and was describing an
+            // intent rather than a measurement; the pool is what makes it true, and
+            // this branch is what made it matter, by moving the walk onto the scan.
+            autoreleasepool {
+                let following = read()
+                // A short read is legal mid-file; only an empty one is the end.
+                // Finality is decided by the *next* read rather than by this one's
+                // length — treating a short read as the end would report a
+                // truncated binary as proof of absence. A read that *threw* says
+                // nothing about the end either, so it must not claim finality.
+                let isFinal = failed ? false : (following?.isEmpty ?? true)
+
+                var window = carry
+                window.append(chunk)
+                let version = firstVersion(
+                    in: Array(window), after: needle, components: components,
+                    // In a continuation window the first byte is there only to be
+                    // the character before the second: a match starting *on* it has
+                    // no predecessor in this window, and was already whole in the
+                    // previous one, which had `scanOverlap` bytes of room after it.
+                    from: windowStart == 0 ? 0 : 1,
+                    // And only the last window may read "my buffer ended" as "the
+                    // version ended".
+                    isFinal: isFinal
+                )
+
+                // Deliberately before the `failed` check. A match is positive
+                // evidence and complete in itself; bytes *after* it failing to read
+                // says nothing about it, and discarding it would turn a proven
+                // Tauri app into a native one for that scan. Only the absence of a
+                // match depends on having read the whole file, and that is the case
+                // this hands to `.unreadable`.
+                if let version { outcome = .found(version); return }
+                if failed { outcome = .unreadable; return }
+
+                carry = window.suffix(scanOverlap)
+                windowStart += window.count - carry.count
+                pending = isFinal ? nil : following
             }
-            carry = window.suffix(scanOverlap)
-            pending = isFinal ? nil : following
+            if let outcome { return outcome }
         }
         return .absent
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -20,9 +20,14 @@ public enum RuntimeVersion {
     /// Reads the runtime version, or nil where there is nothing trustworthy to read.
     ///
     /// - Parameter scanningBinaries: whether to allow the one reader that has to
-    ///   walk the executable (Tauri). Off during a scan — it costs about half a
-    ///   second on a large binary, times every app — and on when a single app's
-    ///   detail is being shown.
+    ///   walk the executable (Tauri, and the two rebranded Electron shapes). Off
+    ///   during a scan, where it would be paid for every app on the machine, and on
+    ///   when a single app's detail is being shown.
+    ///
+    ///   `.tauri` is the exception: it arrives here with scanning on even during a
+    ///   scan, because for that runtime the walk *is* the detection — but only for
+    ///   the two or three bundles `AppRuntimeDetector` has already narrowed to. See
+    ///   `carriesTauriCrate(bundleAt:infoPlist:)`.
     public static func read(
         _ runtime: AppRuntime,
         bundleAt bundleURL: URL,
@@ -223,18 +228,35 @@ public enum RuntimeVersion {
     /// Cargo dependency path Rust bakes into panic metadata:
     /// `…/registry/src/…/tauri-2.11.5/src/lib.rs`.
     ///
-    /// This doubles as the only *proof* that an app is Tauri at all. The detector
-    /// reaches that verdict from a packaging fingerprint plus a WebKit link, which
-    /// is a heuristic — and a measurable one: of five apps it matched here, four
-    /// carry a `tauri-` crate and Longbridge carries `wry-0.53.3` and no Tauri at
-    /// all. So a nil from this reader is informative rather than a failure, and the
-    /// caller shows no version rather than a wrong one.
-    ///
     /// `tauri-runtime-wry-2.11.4` deliberately does not match: the character after
     /// the prefix has to be a digit, so only the framework crate itself is read.
     private static func tauriVersion(bundleAt bundleURL: URL) -> String? {
         guard let executable = executableURL(bundleAt: bundleURL) else { return nil }
         return scan(executable, for: "tauri-", components: 3)
+    }
+
+    /// Whether this bundle is Tauri at all — `AppRuntimeDetector`'s proof, not a
+    /// display value.
+    ///
+    /// One read answers both questions, so they share one cache entry: either a
+    /// crate path is there or it is not, and if it is, its version is right beside
+    /// it. The detector asks this during a scan and the app's detail view asks
+    /// `read(_:bundleAt:appVersion:scanningBinaries:)` later; both land on the same
+    /// key, so the walk happens once per app version rather than once per asker.
+    ///
+    /// The key's version comes from the same `CFBundleShortVersionString` the scan
+    /// stores as `InstalledApp.shortVersion` and the detail view passes back. The
+    /// two agree for everything that can reach here — the scan rewrites that string
+    /// only for Xcode and JetBrains bundles, and neither is cargo-bundled — and if
+    /// they ever disagreed the cost would be a second walk, not a wrong answer.
+    ///
+    /// A nil is a real answer and is remembered as one: proving that a 262 MB
+    /// binary contains no `tauri-` crate means reading all of it, which is the
+    /// expensive case and so the one most worth paying for exactly once.
+    public static func carriesTauriCrate(bundleAt bundleURL: URL, infoPlist: [String: Any]) -> Bool {
+        read(.tauri, bundleAt: bundleURL,
+             appVersion: infoPlist["CFBundleShortVersionString"] as? String,
+             scanningBinaries: true) != nil
     }
 
     /// Walks a binary looking for `<needle><version>`, in chunks so a 261 MB

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -90,12 +90,20 @@ public enum RuntimeVersion {
         case .flutter, .native, .catalyst, .iOSApp:
             version = nil
         }
-        // A nil reached only because scanning was forbidden is not an answer about
-        // the app, it is an answer about the caller — and the two callers share a
-        // key. `.tauri` and `.chromium` return above rather than fall through here;
-        // `.electron` cannot, because its cheap path and its scanning path are one
-        // function. Without this line a single `scanning: false` read of a
-        // re-signed Electron framework would pin "no version" for the process.
+        // A nil reached under `scanningBinaries: false` is not an answer about the
+        // app, it is an answer about the caller — and both callers share a key. So
+        // no nil is remembered from such a read, for any runtime: for `.electron`
+        // it would be actively wrong (a single such read of a re-signed framework
+        // would pin "no version" for the life of the process, since its cheap path
+        // and its scanning path are one function), and for `.qt`, `.java` and the
+        // unversioned runtimes it costs nothing, because their nil is reached
+        // without walking anything.
+        //
+        // No production caller passes false today — `RuntimeTag` and
+        // `carriesTauriCrate` both pass true. This closes the trap rather than a
+        // live bug, and the trap is newly unconditional: the caller-supplied
+        // `appVersion` used to be the one thing that could vary between two callers
+        // of the same bundle.
         if let key, version != nil || scanningBinaries { remember(version, for: key) }
         return version
     }
@@ -330,43 +338,64 @@ public enum RuntimeVersion {
         case unreadable
     }
 
+    /// How much of each chunk is carried into the next: enough that a match cut by
+    /// a boundary is whole in one window, and one byte more than that, so the window
+    /// also holds the character *before* such a match. Both of `firstVersion`'s
+    /// rules need context the chunk alone cannot supply.
+    ///
+    /// It is therefore also the longest match that can be seen across a boundary —
+    /// `Chrome/` plus four components is under 30 bytes. A differential fuzz of
+    /// 20,000 random layouts against a whole-file reference found no disagreement,
+    /// and the only way to manufacture one was a "version" of over a hundred digits,
+    /// which fails toward *missing* the match rather than inventing one.
+    ///
+    /// Internal rather than a local, because the test that pins the boundary rules
+    /// has to place its payload on the seam this number defines. Written as a
+    /// literal there, the test passes against the unfixed reader — which is what it
+    /// did until round 3 of review noticed.
+    static let scanOverlap = 128
+
     private static func probe(_ binary: URL, for prefix: String, components: Int) -> Probe {
         guard let handle = try? FileHandle(forReadingFrom: binary) else { return .unreadable }
         defer { try? handle.close() }
 
-        // How far to read, so a window can tell "the end of my buffer" from "the
-        // end of the file" — see `firstVersion`. Taken once, up front; a file that
-        // grows underneath the walk simply ends the walk where it was going to end
-        // anyway.
-        let size: UInt64
-        do {
-            size = try handle.seekToEnd()
-            try handle.seek(toOffset: 0)
-        } catch { return .unreadable }
-
         let needle = Array(prefix.utf8)
-        // Read in chunks, carrying enough of each into the next that a match cut by
-        // a boundary is whole in one window — and one byte more than that, so the
-        // window also holds the character *before* such a match. Both of
-        // `firstVersion`'s rules need context the chunk alone cannot supply.
+
         let chunkSize = 4 * 1024 * 1024
-        let overlap = 128
+
+        // `try?` is not available here, and the reason is the whole point of this
+        // type: `read(upToCount:)` returns nil *at end of file*, and `try?` flattens
+        // a thrown error into that same nil — so a completed walk and a failed one
+        // would be indistinguishable, which is exactly the confusion `Probe` exists
+        // to end. `do`/`catch` keeps them apart.
+        var failed = false
+        func read() -> Data? {
+            do { return try handle.read(upToCount: chunkSize) }
+            catch { failed = true; return nil }
+        }
+
+        // One chunk of lookahead, so a window knows whether it is the last.
+        //
+        // Asking the file for its size up front is the obvious way to know that,
+        // and it is wrong in both directions. A file truncated under the walk never
+        // reaches the recorded size, so *no* window is ever final and a version
+        // ending at the real EOF is discarded — which for `.tauri` is a cached
+        // verdict of "not Tauri", precisely the class `.unreadable` was added to
+        // keep out of the cache. A file appended to keeps being read past that size
+        // with every later window wrongly calling itself final. A lookahead cannot
+        // go stale, and it keeps this working on anything unseekable besides.
         var carry = Data()
-        var consumed: UInt64 = 0
-        while true {
-            // `try?` is not available here, and the reason is the whole point of
-            // this type: `read(upToCount:)` returns nil *at end of file*, and
-            // `try?` flattens a thrown error into that same nil — so a completed
-            // walk and a failed one would be indistinguishable, which is exactly
-            // the confusion `Probe` exists to end. `do`/`catch` keeps them apart.
-            //
-            // The loop also ends on an empty read rather than on a short one: a
-            // short read is legal mid-file, and treating it as the end would report
-            // a truncated binary as proof of absence.
-            let chunk: Data?
-            do { chunk = try handle.read(upToCount: chunkSize) } catch { return .unreadable }
-            guard let chunk, !chunk.isEmpty else { break }
-            consumed += UInt64(chunk.count)
+        var pending = read()
+        if failed { return .unreadable }
+
+        while let chunk = pending, !chunk.isEmpty {
+            let following = read()
+            if failed { return .unreadable }
+            // A short read is legal mid-file; only an empty one is the end. Finality
+            // is therefore decided by the *next* read, not by this one's length —
+            // treating a short read as the end would report a truncated binary as
+            // proof of absence.
+            let isFinal = following?.isEmpty ?? true
             let continuation = !carry.isEmpty
             var window = carry
             window.append(chunk)
@@ -375,15 +404,16 @@ public enum RuntimeVersion {
                 // In a continuation window the first byte is there only to be the
                 // character before the second: a match starting *on* it has no
                 // predecessor in this window, and was already whole in the previous
-                // one, which had `overlap` bytes of room after it.
+                // one, which had `scanOverlap` bytes of room after it.
                 from: continuation ? 1 : 0,
                 // And only the last window may read "my buffer ended" as "the
                 // version ended".
-                isFinal: consumed >= size
+                isFinal: isFinal
             ) {
                 return .found(version)
             }
-            carry = window.suffix(overlap)
+            carry = window.suffix(scanOverlap)
+            pending = isFinal ? nil : following
         }
         return .absent
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -58,7 +58,14 @@ public enum RuntimeVersion {
         // the executable — but that is microseconds against a walk of the file.
         //
         // Nil is cached too: "no Tauri crate in here" is an answer, and the
-        // expensive one to reach. An *unreadable* binary is not — see `.tauri`.
+        // expensive one to reach. An *unreadable* binary is not — but only `.tauri`
+        // gets that distinction, because only there is the nil a verdict. The
+        // Electron and Chromium readers go through `scan`, which flattens
+        // `.unreadable` into the same nil as a real absence, so a framework binary
+        // that is briefly unreadable pins "no version" for the process. The key is
+        // the *main* executable's stat, which can still succeed while the framework
+        // binary does not, so this is reachable — and it costs a missing version
+        // label, not a wrong runtime.
         let executable = executableURL(bundleAt: bundleURL)
         let key = executable.flatMap { executableIdentity(of: $0) }
             .map { "\(bundleURL.path)|\(runtime.rawValue)|\($0)" }
@@ -334,7 +341,7 @@ public enum RuntimeVersion {
     /// was read to the end and does not contain the needle is *evidence*; a binary
     /// that could not be opened or could not be read through is the absence of
     /// evidence, and only the first may be remembered as an answer.
-    private enum Probe {
+    enum Probe: Equatable {
         case found(String)
         case absent
         case unreadable
@@ -349,7 +356,8 @@ public enum RuntimeVersion {
     /// `Chrome/` plus four components is under 30 bytes. A differential fuzz of
     /// 20,000 random layouts against a whole-file reference found no disagreement,
     /// and the only way to manufacture one was a "version" of over a hundred digits,
-    /// which fails toward *missing* the match rather than inventing one.
+    /// which fails toward *missing* the match — or toward returning a later, real
+    /// one — rather than toward inventing a version that is not there.
     ///
     /// Internal rather than a local, because the test that pins the boundary rules
     /// has to place its payload on the seam this number defines. Written as a
@@ -366,7 +374,29 @@ public enum RuntimeVersion {
     private static func probe(_ binary: URL, for prefix: String, components: Int) -> Probe {
         guard let handle = try? FileHandle(forReadingFrom: binary) else { return .unreadable }
         defer { try? handle.close() }
+        return probe(reading: { try handle.read(upToCount: scanChunkSize) },
+                     for: prefix, components: components)
+    }
 
+    /// The walk itself, over a source of chunks rather than over a file.
+    ///
+    /// The seam exists because of what it is like not to have it. Three rounds of
+    /// review found three real defects in this loop — a match discarded when the
+    /// read *after* it failed, a short read read as end-of-file, and the first bytes
+    /// of a file going unexamined for the rest of the walk — and not one of them was
+    /// expressible as a test, because `probe` opened its own `FileHandle` and no
+    /// test can make a real file throw halfway through or hand back a short read.
+    /// Every fix was verified by hand and pinned by nothing: putting the old body
+    /// back left the entire suite green.
+    ///
+    /// A closure that hands back one chunk at a time is enough to say all of it, and
+    /// it is the shape this file's neighbours already use (`LibraryReader`,
+    /// `TauriProof`).
+    static func probe(
+        reading next: () throws -> Data?,
+        for prefix: String,
+        components: Int
+    ) -> Probe {
         let needle = Array(prefix.utf8)
 
 
@@ -377,7 +407,7 @@ public enum RuntimeVersion {
         // to end. `do`/`catch` keeps them apart.
         var failed = false
         func read() -> Data? {
-            do { return try handle.read(upToCount: scanChunkSize) }
+            do { return try next() }
             catch { failed = true; return nil }
         }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -31,21 +31,31 @@ public enum RuntimeVersion {
     public static func read(
         _ runtime: AppRuntime,
         bundleAt bundleURL: URL,
-        appVersion: String?,
         scanningBinaries: Bool
     ) -> String? {
-        // Three of these readers can walk a whole binary — a second on a large one
-        // — so the answer is remembered against the app's own version.
+        // Some of these readers walk a whole binary, so the answer is remembered —
+        // against the *executable's own identity*, its size and modification date,
+        // rather than against a version string.
+        //
+        // A version string was the first key and it was the wrong one twice over.
+        // Plenty of apps ship a new build under an unchanged marketing version
+        // (Amp: ten builds in a day, all `1.0`), so that key cannot see an update
+        // it is supposed to invalidate on; and it cannot see a bundle rewritten
+        // underneath it either, which is exactly what an install does while a scan
+        // may be running. Size-and-mtime changes whenever the bytes this answer was
+        // read from change, which is the only thing that can make it stale.
         //
         // The lookup deliberately sits *above* the `scanningBinaries` guard: a
         // remembered answer costs nothing, so a caller that forbade scanning still
-        // gets it. That is what lets a version paid for once, by opening one app's
-        // detail, be available to everything afterwards. An app that has
-        // not been updated cannot have changed its runtime, and one that has gets a
-        // new key rather than a stale answer. Nil is cached too: "no Tauri crate in
-        // here" is an answer, and it is the expensive one to reach.
-        let key = "\(bundleURL.path)|\(appVersion ?? "?")|\(runtime.rawValue)"
-        if let remembered = cached(key) { return remembered }
+        // gets it. That is what lets a version paid for once be available to
+        // everything afterwards.
+        //
+        // Nil is cached too: "no Tauri crate in here" is an answer, and the
+        // expensive one to reach. An *unreadable* binary is not — see `.tauri`.
+        let executable = executableURL(bundleAt: bundleURL)
+        let key = executable.flatMap { executableIdentity(of: $0) }
+            .map { "\(bundleURL.path)|\(runtime.rawValue)|\($0)" }
+        if let key, let remembered = cached(key) { return remembered }
 
         let version: String?
         switch runtime {
@@ -53,24 +63,57 @@ public enum RuntimeVersion {
             // The re-signed case needs a scan; the ordinary one does not, and
             // `electronVersion` takes the cheap path first either way.
             version = electronVersion(bundleAt: bundleURL, scanning: scanningBinaries)
-        case .qt:       version = qtVersion(bundleAt: bundleURL)
+        case .qt:       version = qtVersion(bundleAt: bundleURL, executable: executable)
         case .java:     version = javaVersion(bundleAt: bundleURL)
         case .tauri:
-            guard scanningBinaries else { return nil }
-            version = tauriVersion(bundleAt: bundleURL)
+            guard scanningBinaries, let executable else { return nil }
+            // The one place the difference between "proved absent" and "could not
+            // read" matters, because a nil here is a *verdict* — `carriesTauriCrate`
+            // turns it into "this app is not Tauri" and the cache would keep that
+            // for the life of the process. A half-read binary must therefore leave
+            // no trace: no answer, nothing remembered, asked again next time.
+            switch probe(executable, for: "tauri-", components: 3) {
+            case .found(let found): version = found
+            case .absent:           version = nil
+            case .unreadable:       return nil
+            }
         case .chromium:
             guard scanningBinaries else { return nil }
             version = chromiumVersion(bundleAt: bundleURL)
         case .flutter, .native, .catalyst, .iOSApp:
             version = nil
         }
-        remember(version, for: key)
+        if let key { remember(version, for: key) }
         return version
     }
 
-    /// Remembered answers, keyed by bundle path, app version and runtime. Only ever
-    /// grows by one entry per app per update, and only for apps whose detail has
-    /// actually been opened.
+    /// What the answer was read from, as far as staleness is concerned: the main
+    /// executable's size and modification date. Nil when it cannot be stat-ed, and
+    /// a nil identity means the answer is simply not cached — better to re-read
+    /// than to remember something under a key that cannot expire.
+    ///
+    /// The main executable stands in for the whole bundle, including for Electron,
+    /// where the bytes actually read live in a framework. An update that changes a
+    /// bundled framework and leaves the app's own binary byte-identical would go
+    /// unnoticed; no packager produces that, since the executable is re-signed
+    /// either way.
+    private static func executableIdentity(of executable: URL) -> String? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: executable.path),
+              let size = attributes[.size] as? NSNumber,
+              let modified = attributes[.modificationDate] as? Date
+        else { return nil }
+        return "\(size.int64Value)-\(modified.timeIntervalSince1970)"
+    }
+
+    /// Remembered answers, keyed by bundle path, runtime, and what the executable
+    /// looked like when the answer was read.
+    ///
+    /// Grows by one entry per app per update, for every app whose detail has been
+    /// opened *and* for every cargo-bundled WebView app on the machine, since the
+    /// scan proves those to classify them — six bundles here. Two scans that
+    /// overlap can both miss and both walk the same binary; they write the same
+    /// value, so the cost is a duplicated read rather than a wrong answer, and
+    /// de-duplicating in flight is not worth a second lock.
     ///
     /// `Synchronization.Mutex` would be the modern way to hold this and needs
     /// macOS 15; the package targets 14. A lock around a dictionary is what the
@@ -176,8 +219,8 @@ public enum RuntimeVersion {
     ///
     /// The plist stays as a fallback for an app that reaches Qt indirectly — if
     /// nothing in the main executable names QtCore, there is no load command to read.
-    private static func qtVersion(bundleAt bundleURL: URL) -> String? {
-        if let executable = executableURL(bundleAt: bundleURL),
+    private static func qtVersion(bundleAt bundleURL: URL, executable: URL?) -> String? {
+        if let executable,
            let dylibs = MachOImports.loadedDylibs(at: executable),
            let entry = dylibs.first(where: { isQtCore($0.key) }),
            entry.value != "0.0.0" {
@@ -224,45 +267,51 @@ public enum RuntimeVersion {
 
     // MARK: - Tauri
 
-    /// Tauri compiles into the executable, so the only record of its version is the
-    /// Cargo dependency path Rust bakes into panic metadata:
-    /// `…/registry/src/…/tauri-2.11.5/src/lib.rs`.
+    /// Whether this bundle is Tauri at all — `AppRuntimeDetector`'s proof, and the
+    /// version it displays, from one read.
+    ///
+    /// Tauri compiles into the executable, so its only trace is the Cargo
+    /// dependency path Rust bakes into panic metadata:
+    /// `…/registry/src/…/tauri-2.11.5/src/lib.rs`. Either that path is there or it
+    /// is not, and if it is, the version is right beside it — so the detector
+    /// asking "is this Tauri" during a scan and the detail view asking "which
+    /// Tauri" later share one cache entry, and the walk happens once per binary
+    /// rather than once per asker.
     ///
     /// `tauri-runtime-wry-2.11.4` deliberately does not match: the character after
     /// the prefix has to be a digit, so only the framework crate itself is read.
-    private static func tauriVersion(bundleAt bundleURL: URL) -> String? {
-        guard let executable = executableURL(bundleAt: bundleURL) else { return nil }
-        return scan(executable, for: "tauri-", components: 3)
-    }
-
-    /// Whether this bundle is Tauri at all — `AppRuntimeDetector`'s proof, not a
-    /// display value.
     ///
-    /// One read answers both questions, so they share one cache entry: either a
-    /// crate path is there or it is not, and if it is, its version is right beside
-    /// it. The detector asks this during a scan and the app's detail view asks
-    /// `read(_:bundleAt:appVersion:scanningBinaries:)` later; both land on the same
-    /// key, so the walk happens once per app version rather than once per asker.
+    /// Two shapes this cannot see, both of which read as *not Tauri*:
     ///
-    /// The key's version comes from the same `CFBundleShortVersionString` the scan
-    /// stores as `InstalledApp.shortVersion` and the detail view passes back. The
-    /// two agree for everything that can reach here — the scan rewrites that string
-    /// only for Xcode and JetBrains bundles, and neither is cargo-bundled — and if
-    /// they ever disagreed the cost would be a second walk, not a wrong answer.
-    ///
-    /// A nil is a real answer and is remembered as one: proving that a 262 MB
-    /// binary contains no `tauri-` crate means reading all of it, which is the
-    /// expensive case and so the one most worth paying for exactly once.
-    public static func carriesTauriCrate(bundleAt bundleURL: URL, infoPlist: [String: Any]) -> Bool {
-        read(.tauri, bundleAt: bundleURL,
-             appVersion: infoPlist["CFBundleShortVersionString"] as? String,
-             scanningBinaries: true) != nil
+    /// - **A `tauri` taken as a git or path dependency.** Cargo lays those out as
+    ///   `git/checkouts/tauri-<hash>/<rev>/…`, with no version to find. Rare for a
+    ///   shipped app, which takes the crates.io release, but not hypothetical — the
+    ///   Longbridge audit in `docs/app-audits/` shows exactly that layout for two
+    ///   of its own dependencies.
+    /// - **A universal binary's other slice.** The gate that admits a bundle here
+    ///   parses the arm64 slice (`MachOImports`); this walks the file end to end,
+    ///   so on a fat binary it also passes over the Intel one. Both slices come out
+    ///   of the same `cargo build` and carry the same crate paths, so the answer
+    ///   agrees — it is the bytes read, not the verdict, that are larger than they
+    ///   need to be. One of the six candidates here (CC Switch) is fat.
+    public static func carriesTauriCrate(bundleAt bundleURL: URL) -> Bool {
+        read(.tauri, bundleAt: bundleURL, scanningBinaries: true) != nil
     }
 
     /// Walks a binary looking for `<needle><version>`, in chunks so a 261 MB
     /// executable never lands in memory at once.
-    private static func scan(_ binary: URL, for prefix: String, components: Int) -> String? {
-        guard let handle = try? FileHandle(forReadingFrom: binary) else { return nil }
+    /// Three outcomes, because two of them are not the same thing. A binary that
+    /// was read to the end and does not contain the needle is *evidence*; a binary
+    /// that could not be opened or could not be read through is the absence of
+    /// evidence, and only the first may be remembered as an answer.
+    private enum Probe {
+        case found(String)
+        case absent
+        case unreadable
+    }
+
+    private static func probe(_ binary: URL, for prefix: String, components: Int) -> Probe {
+        guard let handle = try? FileHandle(forReadingFrom: binary) else { return .unreadable }
         defer { try? handle.close() }
 
         let needle = Array(prefix.utf8)
@@ -271,14 +320,34 @@ public enum RuntimeVersion {
         let chunkSize = 4 * 1024 * 1024
         let overlap = 64
         var carry = Data()
-        while let chunk = try? handle.read(upToCount: chunkSize), !chunk.isEmpty {
+        while true {
+            // `try?` is not available here, and the reason is the whole point of
+            // this type: `read(upToCount:)` returns nil *at end of file*, and
+            // `try?` flattens a thrown error into that same nil — so a completed
+            // walk and a failed one would be indistinguishable, which is exactly
+            // the confusion `Probe` exists to end. `do`/`catch` keeps them apart.
+            //
+            // The loop also ends on an empty read rather than on a short one: a
+            // short read is legal mid-file, and treating it as the end would report
+            // a truncated binary as proof of absence.
+            let chunk: Data?
+            do { chunk = try handle.read(upToCount: chunkSize) } catch { return .unreadable }
+            guard let chunk, !chunk.isEmpty else { break }
             var window = carry
             window.append(chunk)
             if let version = firstVersion(in: Array(window), after: needle, components: components) {
-                return version
+                return .found(version)
             }
             carry = window.suffix(overlap)
-            if chunk.count < chunkSize { break }
+        }
+        return .absent
+    }
+
+    /// The version alone, for the readers where a failure to read and a genuine
+    /// absence lead to the same place — nothing is shown either way.
+    private static func scan(_ binary: URL, for prefix: String, components: Int) -> String? {
+        if case .found(let version) = probe(binary, for: prefix, components: components) {
+            return version
         }
         return nil
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
@@ -79,7 +79,7 @@ private func detect(
     isiOSAppOnMac: Bool = false,
     plist: [String: Any] = ["CFBundleExecutable": "Stub"],
     libraries: @escaping AppRuntimeDetector.LibraryReader = { _ in [] },
-    tauriProof: @escaping AppRuntimeDetector.TauriProof = { _, _ in false }
+    tauriProof: @escaping AppRuntimeDetector.TauriProof = { _ in false }
 ) -> AppRuntime? {
     AppRuntimeDetector.detect(
         bundleAt: bundle, isiOSAppOnMac: isiOSAppOnMac, infoPlist: plist,
@@ -184,7 +184,7 @@ private func cargoBundlePlist() -> [String: Any] {
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Shell")
     #expect(detect(bundle, plist: cargoBundlePlist(), libraries: reader(appKit, webKit),
-                   tauriProof: { _, _ in true }) == .tauri)
+                   tauriProof: { _ in true }) == .tauri)
 }
 
 @Test func cargoBundledAppsWithoutAWebViewAreNativeNotTauri() throws {
@@ -193,7 +193,7 @@ private func cargoBundlePlist() -> [String: Any] {
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Terminal")
     #expect(detect(bundle, plist: cargoBundlePlist(), libraries: reader(appKit),
-                   tauriProof: { _, _ in true }) == .native)
+                   tauriProof: { _ in true }) == .native)
 }
 
 @Test func aWebKitLinkAloneIsNotTauri() throws {
@@ -202,7 +202,7 @@ private func cargoBundlePlist() -> [String: Any] {
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Native")
     #expect(detect(bundle, libraries: reader(appKit, swiftUI, webKit),
-                   tauriProof: { _, _ in true }) == .native)
+                   tauriProof: { _ in true }) == .native)
 }
 
 @Test func aCargoBundledWebViewAppWithoutTheTauriCrateIsNative() throws {
@@ -212,7 +212,7 @@ private func cargoBundlePlist() -> [String: Any] {
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Broker")
     #expect(detect(bundle, plist: cargoBundlePlist(), libraries: reader(appKit, webKit),
-                   tauriProof: { _, _ in false }) == .native)
+                   tauriProof: { _ in false }) == .native)
 }
 
 @Test func theTauriProofIsAskedOnlyAboutCargoBundledWebViewApps() throws {
@@ -223,7 +223,7 @@ private func cargoBundlePlist() -> [String: Any] {
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     final class Counter: @unchecked Sendable { var asked = 0 }
     let counter = Counter()
-    let proof: AppRuntimeDetector.TauriProof = { _, _ in counter.asked += 1; return true }
+    let proof: AppRuntimeDetector.TauriProof = { _ in counter.asked += 1; return true }
 
     // An Electron app, a Qt app, a plain native one, and a cargo-bundled app that
     // links no WebView: four shapes, none of them a candidate.
@@ -253,6 +253,29 @@ private func cargoBundlePlist() -> [String: Any] {
     #expect(AppRuntimeDetector.detect(
         bundleAt: bundle, isiOSAppOnMac: false, infoPlist: cargoBundlePlist(),
         linkedLibraries: reader(appKit, webKit)) == .tauri)
+}
+
+@Test func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
+    // What makes the walk affordable on a scheduled, library-wide scan is that the
+    // second scan does not repeat it. Nothing about the *verdicts* would change if
+    // the memoization were lost — every scan would simply start reading hundreds of
+    // megabytes again — so this is the only thing that would notice.
+    //
+    // Making the binary unreadable between the two calls is how the test tells a
+    // remembered answer from a fresh one: `stat` still succeeds, so the key is
+    // unchanged, while a re-read would fail and the app would come back native.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let bundle = try builder.app(
+        "Shell", executableContents: "registry/src/index/tauri-2.11.1/src/lib.rs")
+    let verdict = { AppRuntimeDetector.detect(
+        bundleAt: bundle, isiOSAppOnMac: false, infoPlist: cargoBundlePlist(),
+        linkedLibraries: reader(appKit, webKit)) }
+    #expect(verdict() == .tauri)
+
+    let executable = bundle.appendingPathComponent("Contents/MacOS/Stub")
+    try FileManager.default.setAttributes([.posixPermissions: 0o000],
+                                          ofItemAtPath: executable.path)
+    #expect(verdict() == .tauri, "the walk is not repeated for a binary that has not changed")
 }
 
 @Test func theRealProofRejectsAWryOnlyBinary() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
@@ -255,7 +255,8 @@ private func cargoBundlePlist() -> [String: Any] {
         linkedLibraries: reader(appKit, webKit)) == .tauri)
 }
 
-@Test func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
+@Test(.enabled(if: geteuid() != 0, "chmod 000 does not stop root, and these turn on a read failing"))
+func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
     // What makes the walk affordable on a scheduled, library-wide scan is that the
     // second scan does not repeat it. Nothing about the *verdicts* would change if
     // the memoization were lost — every scan would simply start reading hundreds of

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
@@ -21,9 +21,12 @@ private struct BundleBuilder {
     ///   - frameworks: names to create under `Contents/Frameworks`.
     ///   - directories: extra directories relative to `Contents` (`jbr`, `Java`, …).
     ///   - files: extra files relative to `Contents` (`Resources/app.asar`).
+    ///   - executableContents: bytes to write into the stub executable, for the one
+    ///     rule that reads a binary's contents rather than its header.
     func app(
         _ name: String,
         executable: String? = "Stub",
+        executableContents: String = "",
         frameworks: [String] = [],
         directories: [String] = [],
         files: [String] = []
@@ -48,7 +51,14 @@ private struct BundleBuilder {
         if let executable {
             let macos = contents.appendingPathComponent("MacOS")
             try fm.createDirectory(at: macos, withIntermediateDirectories: true)
-            try Data().write(to: macos.appendingPathComponent(executable))
+            try Data(executableContents.utf8).write(to: macos.appendingPathComponent(executable))
+            // A real Info.plist as well as the dictionary the caller passes in:
+            // `RuntimeVersion` finds the executable by reading the bundle's own
+            // plist off disk, so a bundle without one has no binary to read.
+            try PropertyListSerialization
+                .data(fromPropertyList: ["CFBundleExecutable": executable],
+                      format: .xml, options: 0)
+                .write(to: contents.appendingPathComponent("Info.plist"))
         }
         return bundle
     }
@@ -68,10 +78,18 @@ private func detect(
     _ bundle: URL,
     isiOSAppOnMac: Bool = false,
     plist: [String: Any] = ["CFBundleExecutable": "Stub"],
-    libraries: @escaping AppRuntimeDetector.LibraryReader = { _ in [] }
+    libraries: @escaping AppRuntimeDetector.LibraryReader = { _ in [] },
+    tauriProof: @escaping AppRuntimeDetector.TauriProof = { _, _ in false }
 ) -> AppRuntime? {
     AppRuntimeDetector.detect(
-        bundleAt: bundle, isiOSAppOnMac: isiOSAppOnMac, infoPlist: plist, linkedLibraries: libraries)
+        bundleAt: bundle, isiOSAppOnMac: isiOSAppOnMac, infoPlist: plist,
+        linkedLibraries: libraries, carriesTauriCrate: tauriProof)
+}
+
+/// The tauri-bundler plist pair — what admits a bundle to the proof, and on its
+/// own says only "cargo-bundle".
+private func cargoBundlePlist() -> [String: Any] {
+    ["CFBundleExecutable": "Stub", "LSRequiresCarbon": true, "CSResourcesFileMapped": true]
 }
 
 // MARK: - Layout rules
@@ -162,13 +180,11 @@ private func detect(
 
 // MARK: - Load-command rules
 
-@Test func detectsTauriFromCargoBundleMarkersPlusWebKit() throws {
+@Test func detectsTauriFromCargoBundleMarkersPlusWebKitPlusTheCrate() throws {
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Shell")
-    let plist: [String: Any] = [
-        "CFBundleExecutable": "Stub", "LSRequiresCarbon": true, "CSResourcesFileMapped": true,
-    ]
-    #expect(detect(bundle, plist: plist, libraries: reader(appKit, webKit)) == .tauri)
+    #expect(detect(bundle, plist: cargoBundlePlist(), libraries: reader(appKit, webKit),
+                   tauriProof: { _, _ in true }) == .tauri)
 }
 
 @Test func cargoBundledAppsWithoutAWebViewAreNativeNotTauri() throws {
@@ -176,18 +192,81 @@ private func detect(
     // windows. Without this split they would both be mislabeled Tauri.
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Terminal")
-    let plist: [String: Any] = [
-        "CFBundleExecutable": "Stub", "LSRequiresCarbon": true, "CSResourcesFileMapped": true,
-    ]
-    #expect(detect(bundle, plist: plist, libraries: reader(appKit)) == .native)
+    #expect(detect(bundle, plist: cargoBundlePlist(), libraries: reader(appKit),
+                   tauriProof: { _, _ in true }) == .native)
 }
 
 @Test func aWebKitLinkAloneIsNotTauri() throws {
-    // Plenty of native apps embed a WKWebView (Raycast does). Only the packager
-    // fingerprint plus WebKit means Tauri.
+    // Plenty of native apps embed a WKWebView (Raycast does). The packager
+    // fingerprint has to be there too.
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Native")
-    #expect(detect(bundle, libraries: reader(appKit, swiftUI, webKit)) == .native)
+    #expect(detect(bundle, libraries: reader(appKit, swiftUI, webKit),
+                   tauriProof: { _, _ in true }) == .native)
+}
+
+@Test func aCargoBundledWebViewAppWithoutTheTauriCrateIsNative() throws {
+    // Longbridge, and the reason the WebKit rule alone was not enough (#206). It
+    // draws with GPUI like Zed and embeds a renamed wry fork for web content, so
+    // every cheap marker says Tauri and the binary says otherwise.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let bundle = try builder.app("Broker")
+    #expect(detect(bundle, plist: cargoBundlePlist(), libraries: reader(appKit, webKit),
+                   tauriProof: { _, _ in false }) == .native)
+}
+
+@Test func theTauriProofIsAskedOnlyAboutCargoBundledWebViewApps() throws {
+    // The proof reads a whole executable, so what keeps it affordable during a scan
+    // of the entire library is that almost nothing reaches it. If a later edit
+    // moved the rule above the cheap filters, every app on the machine would pay —
+    // and nothing about the *verdicts* would change, so only this notices.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    final class Counter: @unchecked Sendable { var asked = 0 }
+    let counter = Counter()
+    let proof: AppRuntimeDetector.TauriProof = { _, _ in counter.asked += 1; return true }
+
+    // An Electron app, a Qt app, a plain native one, and a cargo-bundled app that
+    // links no WebView: four shapes, none of them a candidate.
+    _ = detect(try builder.app("Editor", frameworks: ["Electron Framework.framework"]),
+               libraries: reader(appKit), tauriProof: proof)
+    _ = detect(try builder.app("Viewer", frameworks: ["QtCore.framework"]),
+               libraries: reader(appKit), tauriProof: proof)
+    _ = detect(try builder.app("Plain"), libraries: reader(appKit, swiftUI), tauriProof: proof)
+    _ = detect(try builder.app("Terminal"), plist: cargoBundlePlist(),
+               libraries: reader(appKit), tauriProof: proof)
+    #expect(counter.asked == 0)
+
+    _ = detect(try builder.app("Shell"), plist: cargoBundlePlist(),
+               libraries: reader(appKit, webKit), tauriProof: proof)
+    #expect(counter.asked == 1)
+}
+
+// MARK: - The proof, through the real reader
+
+@Test func theRealProofReadsTheCratePathOutOfTheBinary() throws {
+    // End to end through `RuntimeVersion.carriesTauriCrate`, the closure production
+    // actually passes — the injected proofs above would keep passing if it broke.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let bundle = try builder.app(
+        "Shell",
+        executableContents: "junk/Users/x/.cargo/registry/src/index/tauri-2.11.1/src/lib.rsmore")
+    #expect(AppRuntimeDetector.detect(
+        bundleAt: bundle, isiOSAppOnMac: false, infoPlist: cargoBundlePlist(),
+        linkedLibraries: reader(appKit, webKit)) == .tauri)
+}
+
+@Test func theRealProofRejectsAWryOnlyBinary() throws {
+    // The same shape with Longbridge's contents: wry is there, the framework crate
+    // is not. `tauri-runtime-wry-2.11.4` is included deliberately — it contains the
+    // needle as a substring and must not be read as the crate.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let bundle = try builder.app(
+        "Broker",
+        executableContents: "registry/src/index/lb-wry-0.53.3/src/lib.rs "
+            + "and tauri-runtime-wry-2.11.4/src/lib.rs")
+    #expect(AppRuntimeDetector.detect(
+        bundleAt: bundle, isiOSAppOnMac: false, infoPlist: cargoBundlePlist(),
+        linkedLibraries: reader(appKit, webKit)) == .native)
 }
 
 @Test func detectsCatalyst() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -278,6 +278,83 @@ private func bundleWithPayload(
     #expect(b.version(.tauri) == "2.11.50")
 }
 
+// MARK: - The walk, driven through its own seam
+//
+// Everything below drives `probe` with a scripted chunk source instead of a file,
+// which is the only way to say "this read was short" or "this read threw". Each of
+// these pins a fix that three rounds of review made and that the suite could not
+// see: putting the pre-fix body back left every other test green.
+
+/// A chunk source that hands back the pieces it was given, and throws when it
+/// reaches a scripted failure.
+private struct ScriptedReads {
+    enum Step { case chunk(String); case fail }
+    private var steps: [Step]
+    private var index = 0
+
+    init(_ steps: [Step]) { self.steps = steps }
+
+    struct Failure: Error {}
+
+    mutating func next() throws -> Data? {
+        guard index < steps.count else { return nil }
+        defer { index += 1 }
+        switch steps[index] {
+        case .chunk(let text): return Data(text.utf8)
+        case .fail: throw Failure()
+        }
+    }
+}
+
+private func probe(_ steps: [ScriptedReads.Step],
+                   for prefix: String = "tauri-",
+                   components: Int = 3) -> RuntimeVersion.Probe {
+    var reads = ScriptedReads(steps)
+    return RuntimeVersion.probe(reading: { try reads.next() },
+                                for: prefix, components: components)
+}
+
+@Test func aMatchSurvivesAReadThatFailsAfterIt() throws {
+    // The lookahead is read before the current window is scanned, so the order of
+    // those two steps decides what happens when chunk N holds the crate path and
+    // read N+1 throws. Checking `failed` first threw the proof away and reported a
+    // proven Tauri app as native. A match is complete in itself; bytes after it
+    // failing to read say nothing about it.
+    #expect(probe([.chunk("registry/tauri-2.11.5/src"), .fail]) == .found("2.11.5"))
+}
+
+@Test func aReadThatFailsBeforeAnyMatchIsNotProofOfAbsence() throws {
+    // The other half, and the one that must not become `.absent`: absence is a
+    // claim about the whole file, so it may only be made after reading all of it.
+    #expect(probe([.chunk("nothing to see here"), .fail]) == .unreadable)
+}
+
+@Test func aShortReadInTheMiddleIsNotTheEndOfTheFile() throws {
+    // `read(upToCount:)` may legally return fewer bytes than asked for. Ending the
+    // walk there would report a truncated read as proof of absence — and would miss
+    // everything after it.
+    #expect(probe([.chunk("no crate here"), .chunk("x"), .chunk("registry/tauri-2.9.9/src")])
+            == .found("2.9.9"))
+}
+
+@Test func aWindowNoLongerThanTheCarryDoesNotBlindTheStartOfTheFile() throws {
+    // Continuation windows skip index 0, because its real predecessor is in the
+    // previous chunk. But if a window is no longer than the carry, the carry IS the
+    // whole window — so the next window still begins at file offset 0, and so does
+    // every window after it, and a match at the start of the file is never examined
+    // again. Asking `carry.isEmpty` cannot see that; asking for the window's file
+    // offset can.
+    //
+    // Reproduced at 18 bytes with a short first read, which is why it needs the
+    // scripted source: no real 4 MiB read behaves this way.
+    #expect(probe([.chunk("tauri-9.16.2"), .chunk("a9  ")]) == .found("9.16.2"))
+}
+
+@Test func absenceIsOnlyClaimedAfterReadingToTheEnd() throws {
+    #expect(probe([.chunk("registry/wry-0.53.3/src"), .chunk(" and nothing else")]) == .absent)
+    #expect(probe([]) == .absent, "a zero-byte binary contains no crate path")
+}
+
 private let stamp = Date(timeIntervalSince1970: 1_700_000_000)
 
 @Test func aProvenAbsenceIsRememberedToo() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -38,14 +38,16 @@ private struct VersionBundle {
         try contents.write(to: url, atomically: true, encoding: .utf8)
     }
 
-    /// Writes the executable *and* the Info.plist that names it, the way a bundle
-    /// the reader has to find its way around actually looks.
-    /// The same, for a payload measured in megabytes rather than characters.
+    /// The same as below, for a payload measured in megabytes rather than
+    /// characters.
     func executable(_ name: String, containingBytes bytes: Data) throws {
         try executable(name, containing: "")
         try bytes.write(to: bundle.appendingPathComponent("Contents/MacOS/\(name)"))
     }
 
+    /// Writes the executable *and* the Info.plist that names it, the way a bundle
+    /// the reader has to find its way around actually looks.
+    ///
     /// - Parameters:
     ///   - stampedAt: a fixed modification date, for the one test that needs two
     ///     different payloads to look identical to the cache key.
@@ -251,8 +253,15 @@ private func bundleWithPayload(
     //
     // For a displayed version that was cosmetic. For a verdict it is the false
     // positive this whole change exists to prevent, so it is pinned here.
-    let overlap = 128
-    let b = try bundleWithPayload("Shell", "xtauri-2.11.5 ", at: chunkSize - overlap - 1)
+    //
+    // The offset is taken from `RuntimeVersion.scanOverlap` rather than written as
+    // a number, and that is the point of the test rather than a detail of it: with
+    // 128 hardcoded, this passed against the unfixed reader — whose overlap was 64,
+    // which put the payload in the middle of a window where the guard works fine.
+    // Any future change to the overlap has to keep dragging the payload onto the
+    // seam, or the test quietly stops testing anything.
+    let b = try bundleWithPayload(
+        "Shell", "xtauri-2.11.5 ", at: chunkSize - RuntimeVersion.scanOverlap - 1)
     defer { b.cleanUp() }
     #expect(b.version(.tauri) == nil)
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -228,10 +228,12 @@ func anAnswerIsRememberedAgainstTheBinaryItWasReadFrom() throws {
     #expect(b.version(.tauri) == "2.12.0", "different bytes — read again, do not remember 2.11.5")
 }
 
-/// `RuntimeVersion` walks a binary in 4 MiB chunks. Both tests below place their
-/// payload against that boundary, which is the only place the two window-edge rules
-/// can be observed at all.
-private let chunkSize = 4 * 1024 * 1024
+/// Both tests below place their payload against a chunk boundary, which is the only
+/// place the two window-edge rules can be observed at all — so both numbers that
+/// decide where that boundary falls are read from the reader itself. Written as
+/// literals, the payload drifts off the seam the moment either is tuned, and the
+/// tests keep passing while testing nothing.
+private let chunkSize = RuntimeVersion.scanChunkSize
 
 /// A bundle whose executable is larger than one chunk, with `payload` written at
 /// `offset` so it straddles — or sits just before — the first boundary.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -12,6 +12,12 @@ private struct VersionBundle {
         bundle = root.appendingPathComponent("\(name).app")
         try FileManager.default.createDirectory(
             at: bundle.appendingPathComponent("Contents"), withIntermediateDirectories: true)
+        // Every bundle gets an executable and an Info.plist naming it, even the
+        // ones whose rule never looks at either. The cache keys on that file, so a
+        // fixture without one is a fixture with the cache silently switched off —
+        // which is how seven of these tests came to assert their values against an
+        // uncached reader without anything noticing.
+        try executable(name, containing: "")
     }
 
     func cleanUp() { try? FileManager.default.removeItem(at: root) }
@@ -34,6 +40,13 @@ private struct VersionBundle {
 
     /// Writes the executable *and* the Info.plist that names it, the way a bundle
     /// the reader has to find its way around actually looks.
+    /// The same, for a payload measured in megabytes rather than characters.
+    func executable(_ name: String, containingBytes bytes: Data) throws {
+        try executable(name, containing: "")
+        try bytes.write(to: bundle.appendingPathComponent("Contents/MacOS/\(name)"))
+    }
+
+    /// - Parameters:
     ///   - stampedAt: a fixed modification date, for the one test that needs two
     ///     different payloads to look identical to the cache key.
     func executable(_ name: String, containing text: String, stampedAt stamp: Date? = nil) throws {
@@ -146,7 +159,10 @@ private struct VersionBundle {
 }
 
 @Test func theTauriScanIsSkippedWhenScanningIsNotAllowed() throws {
-    // The scan walks the whole executable, so a full library scan must never do it.
+    // Not a statement that a library-wide scan never walks a binary — since #206 it
+    // does, for the handful of bundles `AppRuntimeDetector` has narrowed to. This
+    // pins the flag itself: a caller that passes false gets no walk and, because
+    // nothing was proved, nothing is remembered either.
     let b = try VersionBundle("Shell"); defer { b.cleanUp() }
     try b.executable("Shell", containing: "tauri-2.11.5/src/lib.rs")
     #expect(b.version(.tauri, scanning: false) == nil)
@@ -181,7 +197,8 @@ private struct VersionBundle {
     #expect(b.version(.chromium, scanning: false) == nil)
 }
 
-@Test func anAnswerIsRememberedAgainstTheBinaryItWasReadFrom() throws {
+@Test(.enabled(if: geteuid() != 0, "chmod 000 does not stop root, and these turn on a read failing"))
+func anAnswerIsRememberedAgainstTheBinaryItWasReadFrom() throws {
     // The expensive readers walk a whole binary; asking twice for a binary that has
     // not changed must not pay twice. Taking away read permission between the two
     // is how the test tells a remembered answer from a fresh one: `stat` still
@@ -207,6 +224,47 @@ private struct VersionBundle {
 
     try b.executable("Shell", containing: "registry/src/index/tauri-2.12.0/src/lib.rs and padding")
     #expect(b.version(.tauri) == "2.12.0", "different bytes — read again, do not remember 2.11.5")
+}
+
+/// `RuntimeVersion` walks a binary in 4 MiB chunks. Both tests below place their
+/// payload against that boundary, which is the only place the two window-edge rules
+/// can be observed at all.
+private let chunkSize = 4 * 1024 * 1024
+
+/// A bundle whose executable is larger than one chunk, with `payload` written at
+/// `offset` so it straddles — or sits just before — the first boundary.
+private func bundleWithPayload(
+    _ name: String, _ payload: String, at offset: Int
+) throws -> VersionBundle {
+    let b = try VersionBundle(name)
+    var bytes = [UInt8](repeating: UInt8(ascii: "."), count: chunkSize + 4096)
+    bytes.replaceSubrange(offset..<(offset + payload.utf8.count), with: Array(payload.utf8))
+    try b.executable(name, containingBytes: Data(bytes))
+    return b
+}
+
+@Test func aCandidateAtAChunkBoundaryIsStillHeldToTheIdentifierRule() throws {
+    // `xtauri-2.11.5` is not a Tauri crate path anywhere — the character before the
+    // needle makes it part of a longer identifier. It was accepted at exactly one
+    // offset per chunk: the first byte of a continuation window, whose real
+    // predecessor lives in the previous chunk and so could not be checked.
+    //
+    // For a displayed version that was cosmetic. For a verdict it is the false
+    // positive this whole change exists to prevent, so it is pinned here.
+    let overlap = 128
+    let b = try bundleWithPayload("Shell", "xtauri-2.11.5 ", at: chunkSize - overlap - 1)
+    defer { b.cleanUp() }
+    #expect(b.version(.tauri) == nil)
+}
+
+@Test func aVersionCutByAChunkBoundaryIsReadWhole() throws {
+    // `tauri-2.11.50` positioned so the boundary falls between the `5` and the `0`.
+    // Three components with a digit last looks like a finished version, so the
+    // truncated `2.11.5` was returned — a real version, for a real app, off by a
+    // factor of ten.
+    let b = try bundleWithPayload("Shell", " tauri-2.11.50 ", at: chunkSize - " tauri-2.11.5".utf8.count)
+    defer { b.cleanUp() }
+    #expect(b.version(.tauri) == "2.11.50")
 }
 
 private let stamp = Date(timeIntervalSince1970: 1_700_000_000)
@@ -238,7 +296,8 @@ private let stamp = Date(timeIntervalSince1970: 1_700_000_000)
     #expect(b.version(.tauri) == nil, "the proven absence is remembered, not walked again")
 }
 
-@Test func aBinaryThatCannotBeReadThroughIsNotRememberedAsProofOfAbsence() throws {
+@Test(.enabled(if: geteuid() != 0, "chmod 000 does not stop root, and these turn on a read failing"))
+func aBinaryThatCannotBeReadThroughIsNotRememberedAsProofOfAbsence() throws {
     // The distinction `Probe` exists for. A nil from the Tauri reader is a verdict —
     // `carriesTauriCrate` turns it into "not Tauri" — so a read that never reached
     // the end must leave nothing behind, or one unlucky moment during an install

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -34,10 +34,17 @@ private struct VersionBundle {
 
     /// Writes the executable *and* the Info.plist that names it, the way a bundle
     /// the reader has to find its way around actually looks.
-    func executable(_ name: String, containing text: String) throws {
+    ///   - stampedAt: a fixed modification date, for the one test that needs two
+    ///     different payloads to look identical to the cache key.
+    func executable(_ name: String, containing text: String, stampedAt stamp: Date? = nil) throws {
         let macos = bundle.appendingPathComponent("Contents/MacOS")
         try FileManager.default.createDirectory(at: macos, withIntermediateDirectories: true)
-        try Data(text.utf8).write(to: macos.appendingPathComponent(name))
+        let executable = macos.appendingPathComponent(name)
+        try Data(text.utf8).write(to: executable)
+        if let stamp {
+            try FileManager.default.setAttributes([.modificationDate: stamp],
+                                                  ofItemAtPath: executable.path)
+        }
         let plist = try PropertyListSerialization.data(
             fromPropertyList: ["CFBundleExecutable": name], format: .xml, options: 0)
         try plist.write(to: bundle.appendingPathComponent("Contents/Info.plist"))
@@ -46,7 +53,7 @@ private struct VersionBundle {
     func version(_ runtime: AppRuntime, scanning: Bool = true) -> String? {
         // A fresh key per bundle — each test builds its own temp directory, so the
         // path already makes the cache entry unique.
-        RuntimeVersion.read(runtime, bundleAt: bundle, appVersion: "1.0", scanningBinaries: scanning)
+        RuntimeVersion.read(runtime, bundleAt: bundle, scanningBinaries: scanning)
     }
 }
 
@@ -174,17 +181,76 @@ private struct VersionBundle {
     #expect(b.version(.chromium, scanning: false) == nil)
 }
 
-@Test func anAnswerIsRememberedAgainstTheAppVersion() throws {
-    // The expensive readers walk a whole binary; asking twice for an app that has
-    // not changed must not pay twice. Deleting the evidence between the two reads
-    // is how the test can tell a cached answer from a fresh one.
+@Test func anAnswerIsRememberedAgainstTheBinaryItWasReadFrom() throws {
+    // The expensive readers walk a whole binary; asking twice for a binary that has
+    // not changed must not pay twice. Taking away read permission between the two
+    // is how the test tells a remembered answer from a fresh one: `stat` still
+    // succeeds so the key is unchanged, while a re-read would fail and return nil.
+    // Deleting the file would not do — that changes the key rather than the answer.
     let b = try VersionBundle("Shell"); defer { b.cleanUp() }
     try b.executable("Shell", containing: "registry/src/index/tauri-2.11.5/src/lib.rs")
-    #expect(RuntimeVersion.read(.tauri, bundleAt: b.bundle, appVersion: "1.0", scanningBinaries: true) == "2.11.5")
+    #expect(b.version(.tauri) == "2.11.5")
 
-    try FileManager.default.removeItem(at: b.bundle.appendingPathComponent("Contents/MacOS/Shell"))
-    #expect(RuntimeVersion.read(.tauri, bundleAt: b.bundle, appVersion: "1.0", scanningBinaries: true) == "2.11.5",
-            "same version — the remembered answer stands")
-    #expect(RuntimeVersion.read(.tauri, bundleAt: b.bundle, appVersion: "1.1", scanningBinaries: true) == nil,
-            "a new app version is a new question, and the binary is gone")
+    let executable = b.bundle.appendingPathComponent("Contents/MacOS/Shell")
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: executable.path)
+    #expect(b.version(.tauri) == "2.11.5", "same binary — the remembered answer stands")
+}
+
+@Test func aRewrittenBinaryIsANewQuestionEvenUnderTheSameAppVersion() throws {
+    // What the old version-string key could not see. An app that ships a new build
+    // under an unchanged marketing version is ordinary — Amp shipped ten in a day,
+    // all called 1.0 — and so is a bundle rewritten under a running scan by an
+    // install. Either one has to invalidate the answer, and only the bytes can say.
+    let b = try VersionBundle("Shell"); defer { b.cleanUp() }
+    try b.executable("Shell", containing: "registry/src/index/tauri-2.11.5/src/lib.rs")
+    #expect(b.version(.tauri) == "2.11.5")
+
+    try b.executable("Shell", containing: "registry/src/index/tauri-2.12.0/src/lib.rs and padding")
+    #expect(b.version(.tauri) == "2.12.0", "different bytes — read again, do not remember 2.11.5")
+}
+
+private let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+
+@Test func aProvenAbsenceIsRememberedToo() throws {
+    // The expensive answer, and the one a scan pays for on every cargo-bundled
+    // WebView app that turns out not to be Tauri: proving the crate is absent means
+    // reading the binary end to end. Longbridge's is 262 MB.
+    //
+    // Nil is indistinguishable from a failed read at the call site, so this cannot
+    // be tested by breaking the file — it swaps the contents for a version that
+    // *would* match while restoring the size and modification date, so the key is
+    // unchanged. A second reader that answers 2.9.9 did not use the cache. (This
+    // caught a real bug: `read(upToCount:)` returns nil at EOF, so an earlier draft
+    // reported every completed walk as unreadable and cached nothing at all.)
+    let b = try VersionBundle("Shell"); defer { b.cleanUp() }
+    try b.executable("Shell", containing: "registry/src/index/wry-0.53.3/src/lib.rs", stampedAt: stamp)
+    #expect(b.version(.tauri) == nil)
+
+    let executable = b.bundle.appendingPathComponent("Contents/MacOS/Shell")
+    let before = try FileManager.default.attributesOfItem(atPath: executable.path)
+    try b.executable("Shell", containing: "registry/src/index/tauri-2.9.9/src/lib.r", stampedAt: stamp)
+    let after = try FileManager.default.attributesOfItem(atPath: executable.path)
+    try #require(after[.size] as? NSNumber == before[.size] as? NSNumber,
+                 "the two payloads must be the same length or the key changes for the wrong reason")
+    try #require(after[.modificationDate] as? Date == stamp,
+                 "and the same modification date — restoring one is lossy, so both are stamped")
+
+    #expect(b.version(.tauri) == nil, "the proven absence is remembered, not walked again")
+}
+
+@Test func aBinaryThatCannotBeReadThroughIsNotRememberedAsProofOfAbsence() throws {
+    // The distinction `Probe` exists for. A nil from the Tauri reader is a verdict —
+    // `carriesTauriCrate` turns it into "not Tauri" — so a read that never reached
+    // the end must leave nothing behind, or one unlucky moment during an install
+    // would mislabel the app for the life of the process.
+    let b = try VersionBundle("Shell"); defer { b.cleanUp() }
+    try b.executable("Shell", containing: "registry/src/index/tauri-2.11.5/src/lib.rs")
+    let executable = b.bundle.appendingPathComponent("Contents/MacOS/Shell")
+
+    // Unreadable at the moment of asking: no answer, and nothing cached.
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: executable.path)
+    #expect(b.version(.tauri) == nil)
+
+    try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: executable.path)
+    #expect(b.version(.tauri) == "2.11.5", "the earlier failure was not remembered as an answer")
 }

--- a/docs/app-audits/com-longbridge-app-desktop.md
+++ b/docs/app-audits/com-longbridge-app-desktop.md
@@ -52,6 +52,30 @@ Store 搜索没有 Longbridge Desktop。公开 stable 分发由厂商自己的 r
 - Intel: manifest 虽提供 `macos-x86_64.dmg`，当前 VendorInstallSpec 不支持按运行架构
   分支选择 URL，因此本次不宣称 Intel 一键安装覆盖。
 
+## 运行时（GPUI，不是 Tauri）
+
+Longbridge 桌面端用 **GPUI** 画界面 —— 和 Zed 同一套渲染框架，直接从 Zed 仓库拉：
+
+```
+~/.cargo/git/checkouts/zed-a70e2ad075855582/6ae5231
+~/.cargo/git/checkouts/gpui-component-95ce574d8a0da8b8/20a1bb4   # github.com/longbridge/gpui-component
+```
+
+`gpui-component`（那套 UI 组件库）是长桥自己维护的开源项目。
+
+**它同时内嵌了一个改名的 wry 分叉**，只用于承载局部网页内容，不是主界面：
+
+```
+~/.cargo/registry/src/rsproxy.cn-…/lb-wry-0.53.3/src/wkwebview/…
+```
+
+`0.19.1` 实包里 `strings` 计数：`gpui` 2140 处、`zed` 1238 处、**`tauri` 0 处**。
+
+这正是 issue #206 的根因。旧的 Tauri 判据是「cargo-bundle 的 plist 指纹 +
+链了 WebKit」，Longbridge 三条全中却不是 Tauri —— Zed 和 Warp 只是碰巧没内嵌
+WebView 才逃过。判据现在改成正面证据（二进制里必须有 `tauri-<semver>` crate 路径），
+Longbridge 归到 `native`。见 `AppRuntimeDetector`。
+
 ## 已知问题
 - preview 渠道已经停止更新；保留为明确的死轨记录，不添加旧 endpoint recipe。
 - 官方 manifest 发布十六进制 SHA-256，而 VendorInstallSpec 的内联 checksum 闸当前只支持


### PR DESCRIPTION
Closes #206.

## What was wrong

Tauri bundles nothing distinctive — its frontend compiles into the binary and it draws into the system WebView — so `AppRuntimeDetector` inferred it from two cheap markers: the tauri-bundler plist pair (`LSRequiresCarbon` + `CSResourcesFileMapped`) and a WebKit link. The plist pair alone only says "cargo-bundle"; the WebKit link was there to separate Warp and Zed, which are cargo-bundled Rust apps with their own renderers.

The counterexample was already installed. **Longbridge draws with GPUI — the same renderer as Zed, pulled from the same repo — and embeds a renamed wry fork for incidental web content:**

```
~/.cargo/git/checkouts/zed-a70e2ad075855582/6ae5231
~/.cargo/git/checkouts/gpui-component-95ce574d8a0da8b8/20a1bb4   # github.com/longbridge/gpui-component
~/.cargo/registry/src/rsproxy.cn-…/lb-wry-0.53.3/src/wkwebview/…
```

`strings` on the 0.19.1 binary: `gpui` 2140, `zed` 1238, **`tauri` 0**. Cargo-bundled, links WebKit, is not Tauri. Zed and Warp escaped only by not happening to embed a web view — which the old comment predicted almost word for word: *"a future cargo-bundled app that embeds a WebView for something incidental would read as Tauri."*

## The fix

Keep the cheap markers as a **filter** and add the proof: the `tauri-<semver>` Cargo path Rust bakes into the binary. Positive evidence, and it yields the version besides.

`RuntimeVersion.carriesTauriCrate` routes through the same cache the detail view reads, so the walk happens once per app version rather than once per asker — which also closes the second half of #206 (the version shown in the popover is now already paid for by the scan).

## Cost

The worry that deferred this was scanning binaries during a library-wide scan. It doesn't apply, because almost nothing reaches the scan — on a 144-app library the filter admits six bundles:

| bundle | binary | crate found | warm |
|---|---|---|---|
| STCM Editor | 10 MB | `tauri-2.10.1` | 0.006s |
| Conductor | 65 MB | `tauri-2.11.1` | 0.039s |
| Longbridge | 262 MB | **none** — full walk to prove absence | 0.25s |
| CC Switch / Clash Verge / Handy | — | found | — |

Whole sweep of 144 bundles, **release build**: `0.50s`, and a repeat sweep `0.05s` (cache). Note that a debug build is ~200× slower on this path (`-Onone` byte loop, 104s for the same sweep) — the new tests use tiny stub executables, so `make test` is unaffected.

## Verification

```
make test
```

Core: `1771 tests in 139 suites passed ... with 1 known issue`. CLI: `184 tests in 24 suites passed`. All three scripts green (`check_localizable_keys`, `check_staged_version_use`, `check_app_audits`).

Real-library sweep, release build, comparing every bundle's verdict before and after:

```
SWEEP total=144
SWEEP changed=["Longbridge.app: tauri -> native"]
counts: electron 36, native 78, qt 10, tauri 5, chromium 3, flutter 3, java 3, catalyst 1, (none) 5
```

Exactly one classification changes, and it is the one that was wrong.

## Residual risk, stated plainly

A Tauri app whose binary keeps no `tauri-` crate path would now read as native. That is the safer direction — an app reading as itself-minus-a-label, rather than an unrelated app claiming to be Tauri — and nothing routes on this value; it is a label in the UI. Both Tauri versions observed here (v2.10, v2.11) carry the path, and the mechanism is Rust's, not Tauri's, so v1 should behave the same; I have no v1 app installed to confirm that, and have not asserted it in the code comments.
