### PR TITLE
Docker reads as Electron: take a wrapper's runtime from the bundle that draws its windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ release and the Sparkle appcast, so this file is the single source of truth for
 
 ## 0.3.79
 
-**Docker's mark now describes Docker's interface instead of its daemon.** The row said "native"; Docker Desktop is an Electron app. The mark is read from the app's bundle, and Docker's bundle is a wrapper: the program it names is a background service written in Go, it carries no framework of its own, and the actual window-drawing app sits one level inside it. Everything was being read correctly out of the wrong file. Duo Updater now looks in the nested app when — and only when — the outer one brings nothing itself and contains exactly one such app that proves what it is built with, so a helper process shipped alongside a real interface still cannot lend its identity to its host. Docker reads as Electron 42.5.0. Of the two hundred and ten apps on the machine this was written on, it is the only row that changes.
+**Docker's mark now describes Docker's interface instead of its daemon.** The row said "native"; Docker Desktop is an Electron app. The mark is read from the app's bundle, and Docker's bundle is a wrapper: the program it names is a background service written in Go, it carries no framework of its own, and the actual window-drawing app sits one level inside it. Everything was being read correctly out of the wrong file. Duo Updater now looks in the nested app when — and only when — the outer one brings nothing itself and contains exactly one such app that proves what it is built with, so a helper process shipped alongside a real interface still cannot lend its identity to its host. Docker reads as Electron 42.5.0, and of the hundred and forty-six apps in the list on the machine this was written on, it is the only row that changes.
 
 ## 0.3.78
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ reads the section matching the version being shipped and embeds it in the GitHub
 release and the Sparkle appcast, so this file is the single source of truth for
 "what's new" — keep each version's prose written for users, not commit-speak.
 
+## 0.3.79
+
+**Docker's mark now describes Docker's interface instead of its daemon.** The row said "native"; Docker Desktop is an Electron app. The mark is read from the app's bundle, and Docker's bundle is a wrapper: the program it names is a background service written in Go, it carries no framework of its own, and the actual window-drawing app sits one level inside it. Everything was being read correctly out of the wrong file. Duo Updater now looks in the nested app when — and only when — the outer one brings nothing itself and contains exactly one such app that proves what it is built with, so a helper process shipped alongside a real interface still cannot lend its identity to its host. Docker reads as Electron 42.5.0. Of the two hundred and ten apps on the machine this was written on, it is the only row that changes.
+
 ## 0.3.78
 
 **An app that leaves its own name blank now gets one anyway.** Eudic (欧路词典) sat in the list with an icon, a version, and nothing at all where the name goes. Its bundle does declare a display name — and leaves it empty, because the real names live in the app's translations — and Duo Updater treated that empty answer as the answer instead of asking the next question. It now falls through to the app's other name, and to the name of the app file after that, so a row is never nameless. One app in a hundred and fifty here was affected; the point is that the information was already there and was being skipped.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/InstalledApp.swift
@@ -184,6 +184,12 @@ public struct InstalledApp: Sendable, Identifiable, Hashable {
     /// Which of Apple's UI frameworks the executable links, and whether Swift is
     /// in there. Empty when the binary could not be read.
     ///
+    /// The executable of whichever bundle `runtime` describes — normally this app's
+    /// own, and for a wrapper the nested bundle's, because a label and the link list
+    /// under it have to be facts about one binary. Docker's are two different ones:
+    /// its launcher is a Go daemon that links AppKit, its Electron stub links only
+    /// the framework. See `AppRuntimeDetector.interfaceBundle(at:)`.
+    ///
     /// Separate from `runtime` because it answers a different question and cannot
     /// be collapsed into one: an app that links both AppKit and SwiftUI — half of
     /// the native apps on a normal machine — has no single true label. See

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -36,6 +36,22 @@ public enum AppRuntime: String, Sendable, Hashable, CaseIterable, Codable {
     case chromium
     /// A native Mac app — AppKit and/or SwiftUI, whatever language it is written in.
     case native
+
+    /// Whether this case was decided by something the packager had to *ship* — a
+    /// framework, a runtime directory, a payload archive, a crate compiled in —
+    /// rather than by which of Apple's frameworks a binary links.
+    ///
+    /// The distinction matters in exactly one place: attributing a nested bundle's
+    /// runtime to the app that wraps it. A bundled runtime is evidence about that
+    /// bundle and nothing else, so it travels; "links AppKit" is true of a helper
+    /// process and of the interface alike, so it does not. `.iOSApp` is decided by
+    /// a wrapper layout that cannot occur one level down inside `Contents/MacOS`.
+    var isBundled: Bool {
+        switch self {
+        case .electron, .tauri, .flutter, .qt, .java, .chromium: true
+        case .native, .catalyst, .iOSApp: false
+        }
+    }
 }
 
 /// Which of Apple's UI frameworks a bundle's executable actually links.
@@ -134,12 +150,18 @@ public enum AppRuntimeDetector {
     /// Both facts from a single pass. The executable's load commands are read at
     /// most once here — the scan calls this for every app on the machine, and the
     /// runtime and the framework set are two questions about the same list.
+    ///
+    /// - Parameter followingNestedBundle: whether a wrapper that ships no runtime
+    ///   of its own may be answered from the single `.app` nested inside it. False
+    ///   only in that recursive call, so the descent is one level deep by
+    ///   construction and cannot loop on a bundle that nests itself.
     public static func read(
         bundleAt bundleURL: URL,
         isiOSAppOnMac: Bool,
         infoPlist: [String: Any],
         linkedLibraries: LibraryReader = { MachOImports.linkedLibraries(at: $0) },
-        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:)
+        carriesTauriCrate: TauriProof = RuntimeVersion.carriesTauriCrate(bundleAt:),
+        followingNestedBundle: Bool = true
     ) -> Reading {
         // A wrapped iOS app has no `Contents/` at all, so every rule below would
         // look in the wrong place, and its own executable sits inside the wrapper
@@ -201,6 +223,44 @@ public enum AppRuntimeDetector {
         // same convention, which is why it is matched by name above first.
         if frameworkNames.contains(where: { $0.hasSuffix(" Framework.framework") }) {
             return reading(.chromium)
+        }
+
+        // A wrapper whose interface lives in a nested bundle. Docker's shape: the
+        // outer `Docker.app` declares `com.docker.backend` — a 218 MB Go daemon
+        // that links AppKit — ships no `Contents/Frameworks` at all, and keeps the
+        // actual GUI at `Contents/MacOS/Docker Desktop.app`, where the Electron
+        // framework and the `app.asar` are. Every rule above is correct about the
+        // file it was pointed at and none of them is looking at the app. See #208.
+        //
+        // `Contents/MacOS/*.app` is also where *subprocesses* live, so recursing
+        // into any nested bundle would start attributing a helper's runtime to its
+        // host. Three conditions keep the two apart, measured over the 214 bundles
+        // in `/Applications`, `~/Applications`, `/System/Applications` and their
+        // Utilities folders — six have a nested `.app` and only Docker passes:
+        //
+        // 1. **The outer bundle ships no framework of its own.** An app with a GUI
+        //    of its own has something in `Contents/Frameworks`; the other five here
+        //    have 3 to 29 entries, Docker has no such directory. A wrapper that
+        //    brings nothing is not the thing drawing the windows.
+        // 2. **Exactly one nested `.app`.** Helpers come in sets — Parallels ships
+        //    three, QQ four, WeChat two. A lone nested bundle is not proof, but a
+        //    crowd of them is proof of the opposite.
+        // 3. **The nested bundle names a runtime it *bundled*.** OrbStack's sole
+        //    nested `scli.app` is a CLI helper and would pass 1 and 2 if OrbStack
+        //    shipped no frameworks; it reads as nothing, so nothing is claimed.
+        //    Only the cases decided by positive, bundled evidence are adopted —
+        //    `.native` and `.catalyst` are read off a binary's load commands, which
+        //    a helper links exactly like an interface, and adopting those would be
+        //    guessing. The outer bundle's own answer stands instead.
+        //
+        // The whole rule therefore fails toward silence: a nested bundle that
+        // cannot prove what it is leaves the label where it was.
+        if followingNestedBundle,
+           frameworkNames.isEmpty,
+           let nested = nestedInterface(
+            in: contents, linkedLibraries: linkedLibraries,
+            carriesTauriCrate: carriesTauriCrate, fm: fm) {
+            return nested.reading
         }
 
         // Everything left is decided by what the binary links, so an unreadable one
@@ -271,6 +331,56 @@ public enum AppRuntimeDetector {
         }
 
         return reading(nil)
+    }
+
+    /// The bundle whose contents describe the app's interface: the bundle itself
+    /// for everything ordinary, and the single nested `.app` for a wrapper that
+    /// ships no runtime of its own — see the rule in `read`.
+    ///
+    /// Exists so that the runtime's *version* is read from the same place as the
+    /// runtime's *name*. `RuntimeVersion` looks for an Electron framework under
+    /// `Contents/Frameworks`, which for Docker is a directory that does not exist;
+    /// without this the row would say Electron and the popover would have no
+    /// version to show, from a bundle that plainly carries one.
+    public static func interfaceBundle(at bundleURL: URL) -> URL {
+        let contents = bundleURL.appendingPathComponent("Contents")
+        let fm = FileManager.default
+        let frameworksDirectory = contents.appendingPathComponent("Frameworks")
+        guard ((try? fm.contentsOfDirectory(atPath: frameworksDirectory.path)) ?? []).isEmpty,
+              let nested = nestedInterface(
+                in: contents,
+                linkedLibraries: { MachOImports.linkedLibraries(at: $0) },
+                carriesTauriCrate: RuntimeVersion.carriesTauriCrate(bundleAt:),
+                fm: fm)
+        else { return bundleURL }
+        return nested.bundle
+    }
+
+    /// The sole nested `.app` under `Contents/MacOS`, read one level deep, when it
+    /// names a runtime it had to bundle. Nil for every other shape — no nested
+    /// bundle, more than one, or one that proves nothing about itself.
+    ///
+    /// The caller has already established that the outer bundle ships no frameworks;
+    /// this is the part both callers must agree on, so it lives in one place.
+    private static func nestedInterface(
+        in contents: URL,
+        linkedLibraries: LibraryReader,
+        carriesTauriCrate: TauriProof,
+        fm: FileManager
+    ) -> (bundle: URL, reading: Reading)? {
+        let macOS = contents.appendingPathComponent("MacOS")
+        let nestedNames = ((try? fm.contentsOfDirectory(atPath: macOS.path)) ?? [])
+            .filter { $0.hasSuffix(".app") }
+        guard nestedNames.count == 1 else { return nil }
+        let nested = macOS.appendingPathComponent(nestedNames[0])
+        let plist = NSDictionary(
+            contentsOf: nested.appendingPathComponent("Contents/Info.plist")) as? [String: Any]
+        let reading = read(
+            bundleAt: nested, isiOSAppOnMac: false, infoPlist: plist ?? [:],
+            linkedLibraries: linkedLibraries, carriesTauriCrate: carriesTauriCrate,
+            followingNestedBundle: false)
+        guard let runtime = reading.runtime, runtime.isBundled else { return nil }
+        return (nested, reading)
     }
 
     /// Which of Apple's UI frameworks appear in a load-command list.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -46,10 +46,16 @@ public enum AppRuntime: String, Sendable, Hashable, CaseIterable, Codable {
     /// bundle and nothing else, so it travels; "links AppKit" is true of a helper
     /// process and of the interface alike, so it does not. `.iOSApp` is decided by
     /// a wrapper layout that cannot occur one level down inside `Contents/MacOS`.
+    ///
+    /// `.tauri` is the case that looks like it belongs here and does not. It is not
+    /// shipped beside the binary, it is *compiled into* it, which is why
+    /// `RuntimeVersion` refuses to follow the redirect for it — see the note there.
+    /// A nested bundle that may not lend its version must not lend its name either,
+    /// or the row would be labelled from a binary the popover is forbidden to read.
     var isBundled: Bool {
         switch self {
-        case .electron, .tauri, .flutter, .qt, .java, .chromium: true
-        case .native, .catalyst, .iOSApp: false
+        case .electron, .flutter, .qt, .java, .chromium: true
+        case .tauri, .native, .catalyst, .iOSApp: false
         }
     }
 }
@@ -153,8 +159,10 @@ public enum AppRuntimeDetector {
     ///
     /// - Parameter followingNestedBundle: whether a wrapper that ships no runtime
     ///   of its own may be answered from the single `.app` nested inside it. False
-    ///   only in that recursive call, so the descent is one level deep by
-    ///   construction and cannot loop on a bundle that nests itself.
+    ///   only in that recursive call, so the descent this function makes is one
+    ///   level deep. It is not the whole story about termination — the proof this
+    ///   passes down re-enters through `RuntimeVersion`, which is why that side
+    ///   declines the redirect for `.tauri`.
     public static func read(
         bundleAt bundleURL: URL,
         isiOSAppOnMac: Bool,
@@ -234,16 +242,24 @@ public enum AppRuntimeDetector {
         //
         // `Contents/MacOS/*.app` is also where *subprocesses* live, so recursing
         // into any nested bundle would start attributing a helper's runtime to its
-        // host. Three conditions keep the two apart, measured over the 214 bundles
-        // in `/Applications`, `~/Applications`, `/System/Applications` and their
-        // Utilities folders — six have a nested `.app` and only Docker passes:
+        // host. Three conditions keep the two apart. Measured over the 146 bundles
+        // `AppScanner.defaultLocations` actually reads — /Applications, its
+        // Utilities, ~/Applications and the two Input Methods folders, minus
+        // anything resolving under /System — seven nest an `.app` and only Docker
+        // passes:
         //
-        // 1. **The outer bundle ships no framework of its own.** An app with a GUI
-        //    of its own has something in `Contents/Frameworks`; the other five here
-        //    have 3 to 29 entries, Docker has no such directory. A wrapper that
-        //    brings nothing is not the thing drawing the windows.
+        // 1. **The outer bundle ships no framework of its own.** The weakest of the
+        //    three and worth saying so: 35 of those 146 ship none, and they are
+        //    ordinary apps drawing their own windows — MarkEdit, Keka, Figma,
+        //    IntelliJ. This condition does not identify a wrapper. What it does is
+        //    hold the one near-miss on this machine: `/Applications/WeChat.app`
+        //    nests exactly one `.app`, and that one ships
+        //    `WeChatAppEx Framework.framework`, which satisfies the Chromium rule
+        //    above — so WeChat passes conditions 2 and 3, and its own 28 frameworks
+        //    are the only thing between it and a label read off its web-view
+        //    subprocess. Do not weaken this one.
         // 2. **Exactly one nested `.app`.** Helpers come in sets — Parallels ships
-        //    three, QQ four, WeChat two. A lone nested bundle is not proof, but a
+        //    three, QQ four, WeType two. A lone nested bundle is not proof, but a
         //    crowd of them is proof of the opposite.
         // 3. **The nested bundle names a runtime it *bundled*.** OrbStack's sole
         //    nested `scli.app` is a CLI helper and would pass 1 and 2 if OrbStack
@@ -251,12 +267,16 @@ public enum AppRuntimeDetector {
         //    Only the cases decided by positive, bundled evidence are adopted —
         //    `.native` and `.catalyst` are read off a binary's load commands, which
         //    a helper links exactly like an interface, and adopting those would be
-        //    guessing. The outer bundle's own answer stands instead.
+        //    guessing. See `AppRuntime.isBundled` for why `.tauri` is excluded too.
+        //    The outer bundle's own answer stands in all of those cases.
         //
-        // The whole rule therefore fails toward silence: a nested bundle that
-        // cannot prove what it is leaves the label where it was.
+        // Placed after the layout rules and before the ones that read a binary, so
+        // a nested runtime never overrides a runtime the outer bundle proved it
+        // ships — but it does take precedence over the outer's Tauri/Catalyst/native
+        // verdicts, which are read from a launcher's load commands. That is the
+        // intent: when the wrapper brings nothing and the bundle inside it brings a
+        // whole runtime, the load commands describe the launcher, not the app.
         if followingNestedBundle,
-           frameworkNames.isEmpty,
            let nested = nestedInterface(
             in: contents, linkedLibraries: linkedLibraries,
             carriesTauriCrate: carriesTauriCrate, fm: fm) {
@@ -343,15 +363,11 @@ public enum AppRuntimeDetector {
     /// without this the row would say Electron and the popover would have no
     /// version to show, from a bundle that plainly carries one.
     public static func interfaceBundle(at bundleURL: URL) -> URL {
-        let contents = bundleURL.appendingPathComponent("Contents")
-        let fm = FileManager.default
-        let frameworksDirectory = contents.appendingPathComponent("Frameworks")
-        guard ((try? fm.contentsOfDirectory(atPath: frameworksDirectory.path)) ?? []).isEmpty,
-              let nested = nestedInterface(
-                in: contents,
-                linkedLibraries: { MachOImports.linkedLibraries(at: $0) },
-                carriesTauriCrate: RuntimeVersion.carriesTauriCrate(bundleAt:),
-                fm: fm)
+        guard let nested = nestedInterface(
+            in: bundleURL.appendingPathComponent("Contents"),
+            linkedLibraries: { MachOImports.linkedLibraries(at: $0) },
+            carriesTauriCrate: RuntimeVersion.carriesTauriCrate(bundleAt:),
+            fm: FileManager.default)
         else { return bundleURL }
         return nested.bundle
     }
@@ -360,19 +376,42 @@ public enum AppRuntimeDetector {
     /// names a runtime it had to bundle. Nil for every other shape — no nested
     /// bundle, more than one, or one that proves nothing about itself.
     ///
-    /// The caller has already established that the outer bundle ships no frameworks;
-    /// this is the part both callers must agree on, so it lives in one place.
+    /// All three conditions live here, in one copy, because `read` and
+    /// `interfaceBundle` have to reach the same verdict for the runtime's name and
+    /// its version to describe the same bundle.
     private static func nestedInterface(
         in contents: URL,
         linkedLibraries: LibraryReader,
         carriesTauriCrate: TauriProof,
         fm: FileManager
     ) -> (bundle: URL, reading: Reading)? {
+        // Condition 1, and the one place in this file where "no frameworks" has to
+        // mean more than an empty list. Every rule above reads `Contents/Frameworks`
+        // as `(try? …) ?? []`, where a directory that cannot be *listed* is
+        // indistinguishable from one that is not there — harmless for those, since
+        // an unreadable directory simply fails to match a framework name. Here it
+        // would flip the answer the other way and hand the label to a subprocess, so
+        // the absence has to be established rather than assumed: an empty listing
+        // counts, a failed listing counts only if the directory really is gone.
+        let frameworks = contents.appendingPathComponent("Frameworks")
+        let listing = try? fm.contentsOfDirectory(atPath: frameworks.path)
+        guard listing?.isEmpty ?? !fm.fileExists(atPath: frameworks.path) else { return nil }
+
+        // A bundle is a directory, and the tally has to say so: `Contents/MacOS` is
+        // mostly executables, and a plain file named `uninstall.app` counting as a
+        // second bundle would take the count to two and turn the rule off with
+        // nothing anywhere saying why. `isDirectory` follows symlinks, so a nested
+        // bundle reached through one still counts and a broken link does not.
         let macOS = contents.appendingPathComponent("MacOS")
-        let nestedNames = ((try? fm.contentsOfDirectory(atPath: macOS.path)) ?? [])
-            .filter { $0.hasSuffix(".app") }
-        guard nestedNames.count == 1 else { return nil }
-        let nested = macOS.appendingPathComponent(nestedNames[0])
+        let nested = ((try? fm.contentsOfDirectory(atPath: macOS.path)) ?? [])
+            .filter { name in
+                guard name.hasSuffix(".app") else { return false }
+                var isDirectory: ObjCBool = false
+                return fm.fileExists(atPath: macOS.appendingPathComponent(name).path,
+                                     isDirectory: &isDirectory) && isDirectory.boolValue
+            }
+            .map(macOS.appendingPathComponent)
+        guard nested.count == 1, let nested = nested.first else { return nil }
         let plist = NSDictionary(
             contentsOf: nested.appendingPathComponent("Contents/Info.plist")) as? [String: Any]
         let reading = read(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -37,9 +37,20 @@ public enum RuntimeVersion {
     ///   fifty. See `carriesTauriCrate(bundleAt:)`.
     public static func read(
         _ runtime: AppRuntime,
-        bundleAt bundleURL: URL,
+        bundleAt inputBundleURL: URL,
         scanningBinaries: Bool
     ) -> String? {
+        // Read from wherever the runtime actually is. For a wrapper whose interface
+        // is a nested bundle — Docker's `Contents/MacOS/Docker Desktop.app` — every
+        // reader below would look in a `Contents/Frameworks` that does not exist and
+        // report no version for a bundle that carries one. The same function decides
+        // this as decided the runtime's name, so the two cannot disagree; for the
+        // ordinary bundle it returns the bundle and nothing changes. See #208.
+        //
+        // The cache key follows, because it is derived from `bundleURL` below: the
+        // entry is keyed on the nested executable, which is the one whose bytes the
+        // answer was read from and the one an update rewrites.
+        let bundleURL = AppRuntimeDetector.interfaceBundle(at: inputBundleURL)
         // Some of these readers walk a whole binary, so the answer is remembered —
         // against the *executable's own identity*, its size and modification date,
         // rather than against a version string.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -43,14 +43,34 @@ public enum RuntimeVersion {
         // Read from wherever the runtime actually is. For a wrapper whose interface
         // is a nested bundle — Docker's `Contents/MacOS/Docker Desktop.app` — every
         // reader below would look in a `Contents/Frameworks` that does not exist and
-        // report no version for a bundle that carries one. The same function decides
-        // this as decided the runtime's name, so the two cannot disagree; for the
-        // ordinary bundle it returns the bundle and nothing changes. See #208.
+        // report no version for a bundle that carries one. For the ordinary bundle it
+        // returns the bundle it was given and nothing changes. See #208.
         //
         // The cache key follows, because it is derived from `bundleURL` below: the
         // entry is keyed on the nested executable, which is the one whose bytes the
         // answer was read from and the one an update rewrites.
-        let bundleURL = AppRuntimeDetector.interfaceBundle(at: inputBundleURL)
+        //
+        // `.tauri` is deliberately exempt, for two reasons that happen to want the
+        // same thing. It is the one runtime that is *compiled into the executable*
+        // rather than shipped beside it, so a crate path found in a nested binary
+        // is a fact about that binary and about nothing else — following the
+        // redirect would let a nested bundle lend its identity to its wrapper,
+        // which is the error this whole rule exists to prevent.
+        //
+        // And it is the edge that would close a cycle. `carriesTauriCrate` is this
+        // function; `AppRuntimeDetector` calls it, `interfaceBundle` calls the
+        // detector, so a redirect here would run detector → proof → detector. The
+        // detector's own `followingNestedBundle` guard does not cover that, because
+        // the path leaves the detector and comes back in. On a bundle whose
+        // `Contents/MacOS` holds a symlink to itself the descent then terminates
+        // only when the path outgrows PATH_MAX, having walked the executable once
+        // per level: measured at 1.83s against 0.071s for the same bundle without
+        // the symlink, ~26 walks of a 60 MB binary where one was intended. Nothing
+        // ships that layout; the guard is here so the invariant is stated in code
+        // rather than left to the shape of what happens to be installed.
+        let bundleURL = runtime == .tauri
+            ? inputBundleURL
+            : AppRuntimeDetector.interfaceBundle(at: inputBundleURL)
         // Some of these readers walk a whole binary, so the answer is remembered —
         // against the *executable's own identity*, its size and modification date,
         // rather than against a version string.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -64,10 +64,12 @@ public enum RuntimeVersion {
         // the path leaves the detector and comes back in. On a bundle whose
         // `Contents/MacOS` holds a symlink to itself the descent then terminates
         // only when the path outgrows PATH_MAX, having walked the executable once
-        // per level: measured at 1.83s against 0.071s for the same bundle without
-        // the symlink, ~26 walks of a 60 MB binary where one was intended. Nothing
-        // ships that layout; the guard is here so the invariant is stated in code
-        // rather than left to the shape of what happens to be installed.
+        // per level: 0.38s of CPU against 0.02s for the same bundle without the
+        // symlink, ~26 walks of a 60 MB binary where one was intended. (Measured
+        // after #216 made `probe` use `Data.range(of:)`; against the byte loop it
+        // replaced the same pair read 1.48s against 0.05s.) Nothing ships that
+        // layout; the guard is here so the invariant is stated in code rather than
+        // left to the shape of what happens to be installed.
         let bundleURL = runtime == .tauri
             ? inputBundleURL
             : AppRuntimeDetector.interfaceBundle(at: inputBundleURL)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
@@ -569,8 +569,8 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
     // whose `Contents/MacOS` links to itself — the re-entrant call goes through the
     // production proof, so a counter cannot see it, and the only signal left is a
     // clock. The exemption below is the thing that has to hold; the loop follows
-    // from it. Measured while it did not hold: 1.83s against 0.071s, ~26 walks of a
-    // 60 MB binary, terminating only when the path outgrew PATH_MAX.
+    // from it. Measured while it did not hold: 0.38s of CPU against 0.02s, ~26
+    // walks of a 60 MB binary, terminating only when the path outgrew PATH_MAX.
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let wrapper = try builder.app("Wrapper")
     let inner = try builder.app(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
@@ -400,6 +400,10 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
     // rule is correct about the launcher and none of them is looking at the app.
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let wrapper = try builder.app("Docker", executable: "com.docker.backend")
+    // Docker's outer bundle has no `Contents/Frameworks` at all, which is not the
+    // same thing as an empty one — the rule has to accept both, and only this test
+    // constructs the shape that actually ships.
+    try FileManager.default.removeItem(at: wrapper.appendingPathComponent("Contents/Frameworks"))
     let gui = try builder.app("Docker Desktop", frameworks: ["Electron Framework.framework"])
     try builder.nest(gui, in: wrapper)
     #expect(detect(wrapper, plist: ["CFBundleExecutable": "com.docker.backend"],
@@ -407,14 +411,22 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
 }
 
 @Test func aWrapperThatShipsFrameworksOfItsOwnIsNotReadFromANestedBundle() throws {
-    // OrbStack, WeChat and QQ all keep a nested `.app` under `Contents/MacOS` and
-    // all ship 3 to 29 frameworks of their own. An app carrying its own runtime is
-    // the app; recursing there would hand a helper's identity to its host.
+    // WeChat's shape, and the live near-miss: `/Applications/WeChat.app` nests
+    // exactly one `.app`, and that one ships `WeChatAppEx Framework.framework`,
+    // which satisfies the Chromium rule. Conditions 2 and 3 both pass. Its own 28
+    // frameworks are the only thing keeping the row from being labelled off a
+    // web-view subprocess.
+    //
+    // The host ships `Sparkle.framework` deliberately: it has to fall through every
+    // rule above the nested one, or `read` returns before reaching the condition
+    // under test and the test proves nothing. With `frameworkNames.isEmpty` deleted
+    // from the rule, this is what fails.
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
-    let host = try builder.app("Suite", frameworks: ["QtCore.framework"])
-    let helper = try builder.app("Renderer", frameworks: ["Electron Framework.framework"])
-    try builder.nest(helper, in: host)
-    #expect(detect(host, libraries: reader(appKit)) == .qt)
+    let host = try builder.app("WeChatish", frameworks: ["Sparkle.framework"])
+    let subprocess = try builder.app("AppEx", frameworks: ["AppEx Framework.framework"])
+    try builder.nest(subprocess, in: host)
+    #expect(detect(host, libraries: reader(appKit)) == .native)
+    #expect(AppRuntimeDetector.interfaceBundle(at: host) == host)
 }
 
 @Test func severalNestedBundlesReadAsHelpersRatherThanAsAnInterface() throws {
@@ -434,10 +446,27 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
     // conditions and has nothing to say about itself. `.native` and `.catalyst` are
     // read off load commands, which a helper carries exactly like an interface, so
     // neither is adopted — only a runtime the nested bundle had to *ship*.
+    //
+    // The two bundles have to link *different* things or this cannot fail: with one
+    // reader answering the same list for both, adopting the nested reading and
+    // declining it produce the same verdict, and the guard could be deleted for
+    // free. Here the outer is Catalyst and the nested is plain native, so an
+    // adopted reading changes the answer and the assertion sees it.
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let wrapper = try builder.app("Tool")
     try builder.nest(try builder.app("scli"), in: wrapper)
-    #expect(detect(wrapper, libraries: reader(appKit)) == .native)
+    #expect(detect(wrapper, libraries: reader(byPath: [
+        "scli.app": [appKit],
+        "Tool.app": [catalystUIKit, appKit],
+    ])) == .catalyst)
+
+    // And the other way round, so neither verdict is adopted in either direction.
+    let ported = try builder.app("Ported")
+    try builder.nest(try builder.app("agent"), in: ported)
+    #expect(detect(ported, libraries: reader(byPath: [
+        "agent.app": [catalystUIKit, appKit],
+        "Ported.app": [appKit],
+    ])) == .native)
 
     let silent = try builder.app("Mystery")
     try builder.nest(try builder.app("mystery-cli"), in: silent)
@@ -445,10 +474,13 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
 }
 
 @Test func theNestedReadingIsAdoptedWholeIncludingWhatItLinks() throws {
-    // Both halves of the reading have to come from the same bundle or the popover
-    // contradicts itself. Docker's launcher links AppKit and its Electron stub links
-    // only the framework, so the line under the label is empty — which is the fact
-    // about the interface, where "AppKit" was the fact about a background daemon.
+    // Both halves of the reading have to come from the same bundle, because
+    // `InstalledApp.linkedFrameworks` is documented as the link list of whichever
+    // executable `runtime` describes. Docker's are two different binaries: its
+    // launcher is a Go daemon linking AppKit, its Electron stub links only the
+    // framework. `RuntimeTag.linkedLine` draws this only for `.native` and
+    // `.catalyst`, so nothing renders it for Docker either way — the contract is
+    // what is being kept here, ahead of the first consumer that relies on it.
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let wrapper = try builder.app("Docker", executable: "com.docker.backend")
     try builder.nest(try builder.app("Docker Desktop", frameworks: ["Electron Framework.framework"]),
@@ -510,6 +542,64 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
     try builder.nest(try builder.app("Helper", frameworks: ["Electron Framework.framework"]),
                      in: host)
     #expect(AppRuntimeDetector.interfaceBundle(at: host) == host)
+}
+
+@Test func aPlainFileNamedLikeABundleDoesNotCountAsOne() throws {
+    // `Contents/MacOS` is mostly executables. A file called `uninstall.app` beside
+    // the real interface would take the tally to two and turn the rule off, and
+    // nothing anywhere would say why — the app would simply keep the wrong label.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let wrapper = try builder.app("Docker", executable: "com.docker.backend")
+    try builder.nest(try builder.app("Docker Desktop", frameworks: ["Electron Framework.framework"]),
+                     in: wrapper)
+    try Data().write(to: wrapper.appendingPathComponent("Contents/MacOS/uninstall.app"))
+    #expect(detect(wrapper, plist: ["CFBundleExecutable": "com.docker.backend"],
+                   libraries: reader(appKit)) == .electron)
+}
+
+@Test func aTauriVersionIsNeverReadFromANestedBundle() throws {
+    // Tauri is compiled into the executable rather than shipped beside it, so a
+    // crate path found one level down is a fact about that binary and nothing else.
+    // Following the redirect would let a nested bundle lend its identity to its
+    // wrapper — the error the rest of this rule exists to prevent.
+    //
+    // It is also the edge that would close a cycle: `carriesTauriCrate` is
+    // `RuntimeVersion.read`, the detector calls it, and `interfaceBundle` calls the
+    // detector. That consequence is deliberately not tested by timing a bundle
+    // whose `Contents/MacOS` links to itself — the re-entrant call goes through the
+    // production proof, so a counter cannot see it, and the only signal left is a
+    // clock. The exemption below is the thing that has to hold; the loop follows
+    // from it. Measured while it did not hold: 1.83s against 0.071s, ~26 walks of a
+    // 60 MB binary, terminating only when the path outgrew PATH_MAX.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let wrapper = try builder.app("Wrapper")
+    let inner = try builder.app(
+        "Inner", executableContents: "registry/src/index/tauri-2.11.5/src/lib.rs",
+        frameworks: ["Electron Framework.framework"])
+    try builder.nest(inner, in: wrapper)
+    #expect(AppRuntimeDetector.interfaceBundle(at: wrapper).lastPathComponent == "Inner.app")
+    #expect(RuntimeVersion.read(.tauri, bundleAt: wrapper, scanningBinaries: true) == nil)
+}
+
+@Test(.enabled(if: geteuid() != 0, "chmod 000 does not stop root, and this turns on a read failing"))
+func aFrameworksDirectoryThatCannotBeListedIsNotReadAsAnAbsentOne() throws {
+    // Everywhere else in this file `Contents/Frameworks` is read as
+    // `(try? …) ?? []`, and a directory that cannot be listed simply fails to match
+    // a framework name — harmless. For this rule the same collapse would flip the
+    // answer the other way and hand the label to a subprocess, so the absence has
+    // to be established rather than assumed.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let host = try builder.app("Guarded")
+    try builder.nest(try builder.app("Inner", frameworks: ["Electron Framework.framework"]),
+                     in: host)
+    let frameworks = host.appendingPathComponent("Contents/Frameworks")
+    try FileManager.default.setAttributes([.posixPermissions: 0o000],
+                                          ofItemAtPath: frameworks.path)
+    defer {
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                               ofItemAtPath: frameworks.path)
+    }
+    #expect(detect(host, libraries: reader(appKit)) == .native)
 }
 
 // MARK: - Failing closed

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
@@ -62,11 +62,30 @@ private struct BundleBuilder {
         }
         return bundle
     }
+
+    /// Move a built bundle into another's `Contents/MacOS`, where a wrapper keeps
+    /// its interface and where helper processes live too.
+    @discardableResult
+    func nest(_ inner: URL, in outer: URL) throws -> URL {
+        let destination = outer
+            .appendingPathComponent("Contents/MacOS")
+            .appendingPathComponent(inner.lastPathComponent)
+        try FileManager.default.moveItem(at: inner, to: destination)
+        return destination
+    }
 }
 
 /// A library reader that answers the same list for any executable.
 private func reader(_ libraries: String...) -> AppRuntimeDetector.LibraryReader {
     { _ in Set(libraries) }
+}
+
+/// A library reader whose answer depends on which executable it is handed, for
+/// the cases where a bundle and the bundle nested inside it link different things.
+private func reader(
+    byPath answers: [String: Set<String>], default fallback: Set<String> = []
+) -> AppRuntimeDetector.LibraryReader {
+    { url in answers.first { url.path.contains($0.key) }?.value ?? fallback }
 }
 
 private let appKit = "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit"
@@ -371,6 +390,126 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
     let reading = AppRuntimeDetector.read(bundleAt: bundle, isiOSAppOnMac: true, infoPlist: [:])
     #expect(reading.runtime == .iOSApp)
     #expect(reading.frameworks.isEmpty)
+}
+
+// MARK: - A wrapper whose interface is a nested bundle
+
+@Test func aWrapperThatShipsNothingIsReadFromTheOneBundleNestedInIt() throws {
+    // Docker's shape (#208): the outer bundle declares a daemon that links AppKit,
+    // ships no `Contents/Frameworks` at all, and keeps the GUI one level down. Every
+    // rule is correct about the launcher and none of them is looking at the app.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let wrapper = try builder.app("Docker", executable: "com.docker.backend")
+    let gui = try builder.app("Docker Desktop", frameworks: ["Electron Framework.framework"])
+    try builder.nest(gui, in: wrapper)
+    #expect(detect(wrapper, plist: ["CFBundleExecutable": "com.docker.backend"],
+                   libraries: reader(appKit)) == .electron)
+}
+
+@Test func aWrapperThatShipsFrameworksOfItsOwnIsNotReadFromANestedBundle() throws {
+    // OrbStack, WeChat and QQ all keep a nested `.app` under `Contents/MacOS` and
+    // all ship 3 to 29 frameworks of their own. An app carrying its own runtime is
+    // the app; recursing there would hand a helper's identity to its host.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let host = try builder.app("Suite", frameworks: ["QtCore.framework"])
+    let helper = try builder.app("Renderer", frameworks: ["Electron Framework.framework"])
+    try builder.nest(helper, in: host)
+    #expect(detect(host, libraries: reader(appKit)) == .qt)
+}
+
+@Test func severalNestedBundlesReadAsHelpersRatherThanAsAnInterface() throws {
+    // Parallels ships three, QQ four, WeChat two. One nested bundle is not proof of
+    // an interface, but a crowd of them is proof of the opposite.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let wrapper = try builder.app("Wrapper")
+    for name in ["Helper One", "Helper Two"] {
+        try builder.nest(try builder.app(name, frameworks: ["Electron Framework.framework"]),
+                         in: wrapper)
+    }
+    #expect(detect(wrapper, libraries: reader(appKit)) == .native)
+}
+
+@Test func aNestedBundleThatProvesNothingLeavesTheLabelWhereItWas() throws {
+    // OrbStack's `scli.app` is a command-line helper: it would pass the other two
+    // conditions and has nothing to say about itself. `.native` and `.catalyst` are
+    // read off load commands, which a helper carries exactly like an interface, so
+    // neither is adopted — only a runtime the nested bundle had to *ship*.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let wrapper = try builder.app("Tool")
+    try builder.nest(try builder.app("scli"), in: wrapper)
+    #expect(detect(wrapper, libraries: reader(appKit)) == .native)
+
+    let silent = try builder.app("Mystery")
+    try builder.nest(try builder.app("mystery-cli"), in: silent)
+    #expect(detect(silent, libraries: reader("/usr/lib/libSystem.B.dylib")) == nil)
+}
+
+@Test func theNestedReadingIsAdoptedWholeIncludingWhatItLinks() throws {
+    // Both halves of the reading have to come from the same bundle or the popover
+    // contradicts itself. Docker's launcher links AppKit and its Electron stub links
+    // only the framework, so the line under the label is empty — which is the fact
+    // about the interface, where "AppKit" was the fact about a background daemon.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let wrapper = try builder.app("Docker", executable: "com.docker.backend")
+    try builder.nest(try builder.app("Docker Desktop", frameworks: ["Electron Framework.framework"]),
+                     in: wrapper)
+    let reading = AppRuntimeDetector.read(
+        bundleAt: wrapper, isiOSAppOnMac: false,
+        infoPlist: ["CFBundleExecutable": "com.docker.backend"],
+        linkedLibraries: reader(byPath: [
+            "com.docker.backend": [appKit, swiftUI],
+            "Docker Desktop.app": [],
+        ]))
+    #expect(reading.runtime == .electron)
+    #expect(reading.frameworks.names == [])
+}
+
+@Test func theDescentStopsAfterOneLevel() throws {
+    // A wrapper inside a wrapper is not a shape anything ships, and the guard that
+    // keeps it out is the same one that makes a bundle nesting a link to itself
+    // terminate. Nothing about the verdicts of real apps would change if it were
+    // lost, so only this notices.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let inner = try builder.app("Inner")
+    try builder.nest(try builder.app("Deep", frameworks: ["Electron Framework.framework"]),
+                     in: inner)
+    let outer = try builder.app("Outer")
+    try builder.nest(inner, in: outer)
+    #expect(detect(outer, libraries: reader(appKit)) == .native)
+}
+
+@Test func theRuntimeVersionIsReadFromTheSameBundleAsTheRuntimeName() throws {
+    // Otherwise the row says Electron and the popover has no version to show, out of
+    // a bundle that plainly carries one — `RuntimeVersion` would be reading a
+    // `Contents/Frameworks` that does not exist. Docker's real answer is 42.5.0.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let wrapper = try builder.app("Docker", executable: "com.docker.backend")
+    let gui = try builder.app("Docker Desktop", frameworks: ["Electron Framework.framework"])
+    let framework = gui.appendingPathComponent("Contents/Frameworks/Electron Framework.framework")
+    try FileManager.default.createDirectory(
+        at: framework.appendingPathComponent("Resources"), withIntermediateDirectories: true)
+    try PropertyListSerialization
+        .data(fromPropertyList: ["CFBundleIdentifier": "com.github.Electron.framework",
+                                 "CFBundleVersion": "42.5.0"],
+              format: .xml, options: 0)
+        .write(to: framework.appendingPathComponent("Resources/Info.plist"))
+    try builder.nest(gui, in: wrapper)
+
+    #expect(AppRuntimeDetector.interfaceBundle(at: wrapper).lastPathComponent
+            == "Docker Desktop.app")
+    #expect(RuntimeVersion.read(.electron, bundleAt: wrapper, scanningBinaries: true) == "42.5.0")
+}
+
+@Test func anOrdinaryBundleIsItsOwnInterface() throws {
+    // The redirection has to be invisible to the 209 bundles in 210 that are not
+    // wrappers — including the ones that do nest a helper.
+    let builder = try BundleBuilder(); defer { builder.cleanUp() }
+    let plain = try builder.app("Plain", frameworks: ["Electron Framework.framework"])
+    #expect(AppRuntimeDetector.interfaceBundle(at: plain) == plain)
+    let host = try builder.app("Suite", frameworks: ["QtCore.framework"])
+    try builder.nest(try builder.app("Helper", frameworks: ["Electron Framework.framework"]),
+                     in: host)
+    #expect(AppRuntimeDetector.interfaceBundle(at: host) == host)
 }
 
 // MARK: - Failing closed


### PR DESCRIPTION
Docker's row carried the **native** mark for an app whose interface is Electron.

## What was wrong

Nothing `AppRuntimeDetector` read was wrong about the file it read. `/Applications/Docker.app` declares `com.docker.backend` — 218 MB of Go that links AppKit — ships no `Contents/Frameworks` at all, and keeps the GUI one level down:

```
/Applications/Docker.app/Contents/
    Info.plist                          CFBundleExecutable = com.docker.backend, LSUIElement = true
    MacOS/com.docker.backend            Go daemon, links AppKit
    MacOS/Docker Desktop.app/Contents/
        Frameworks/Electron Framework.framework    ← the app
        Resources/app.asar
```

The detector was looking one level too high.

## The rule

`Contents/MacOS/*.app` is also where subprocesses live, so the descent is gated on three conditions rather than on "there is a nested app":

1. **The outer bundle ships no framework of its own.** An app drawing its own windows has something in `Contents/Frameworks`.
2. **Exactly one `.app` directly in `Contents/MacOS`.** Helpers come in sets — Parallels ships three, QQ four, WeChat two.
3. **The nested bundle names a runtime it had to *ship*** (Electron/Qt/Flutter/Java/Chromium/Tauri). `.native` and `.catalyst` are read off load commands, which a helper links exactly like an interface — adopting those would be guessing. The outer bundle's own answer stands instead.

The rule therefore fails toward silence, which is the standard the rest of the file holds to.

## Measured

Surveyed the population `AppScanner.defaultLocations` actually reads — `/Applications`, its Utilities, `~/Applications`, and the two Input Methods folders, minus anything resolving under `/System/`, which `scan` drops. **146 bundles. 35 ship no framework of their own and so reach the new rule on every scan. 7 nest an `.app`. 1 passes.**

| app | own frameworks | nested |
|---|---|---|
| **Docker** | **0** | **`Docker Desktop.app`** |
| WeChat | 28 | `WeChatAppEx.app` |
| OrbStack | 3 | `scli.app` |
| WeType (`/Library/Input Methods`) | 5 | 2 |
| QQ | 5 | 4 |
| Parallels Desktop | 28 | 3 |
| WeChat-vendor | 29 | 2 |

**Condition 1 is the weak one and the comment now says so.** 35 of 146 pass it, and they are ordinary apps drawing their own windows — MarkEdit, Keka, Figma, IntelliJ. What it actually does is hold the one near-miss: WeChat nests exactly one `.app`, and that one ships `WeChatAppEx Framework.framework`, which satisfies the Chromium rule — so WeChat passes conditions 2 and 3, and its own 28 frameworks are the only thing between it and a label read off a web-view subprocess.

A/B of the detector at `main` and at this branch over 210 bundles (the wider sweep, so the survey is not marking its own homework) differs on exactly one row:

```
- Docker.app  runtime=native    fw=["AppKit"]  ver=-       iface=self
+ Docker.app  runtime=electron  fw=[]          ver=42.5.0  iface=Docker Desktop.app
```

`fw=[]` is the honest reading: Docker's Electron stub links `Electron Framework` and `libSystem` and nothing else. `AppKit` was a fact about a background daemon.

## RuntimeVersion follows the same decision

Both go through `AppRuntimeDetector.interfaceBundle(at:)`, so the version is read from the same bundle as the name. Without it the row would say Electron and the popover would show no version, out of a bundle that plainly carries one. 42.5.0 confirmed two ways independently of the Swift path:

```
Electron Framework.framework/Resources/Info.plist  CFBundleVersion = 42.5.0
strings Electron\ Framework | grep Electron/       Electron/42.5.0
```

## Review pass

An adversarial review of this branch found two real bugs and two tests that pinned nothing; all are fixed in `e8c8160`, and the sweep above is unchanged by those fixes.

- **A recursion cycle the depth guard did not cover.** `carriesTauriCrate` *is* `RuntimeVersion.read`, the detector calls it, and `interfaceBundle` calls the detector — so the descent left the detector and re-entered where `followingNestedBundle` could not see it. On a bundle whose `Contents/MacOS` links to itself it terminated only at PATH_MAX, walking the executable once per level: **0.38s of CPU against 0.02s** for the same bundle without the link, ~26 walks of a 60 MB binary. (Re-measured on top of #216, which made that search faster; against the byte loop it replaced the pair read 1.48s against 0.05s.) `.tauri` is now exempt from the redirect, which closes the only edge and is independently right — Tauri is compiled *into* the binary, so a crate path one level down is a fact about that binary, not its wrapper. `.tauri` leaves `isBundled` for the same reason.
- **An unreadable `Contents/Frameworks` read as an absent one**, flipping the rule *toward* recursing. Now established rather than assumed.
- **Two conditions were not pinned by any test.** Found by mutation: deleting `runtime.isBundled` left the suite green (one reader answered the same list for both bundles, so adopting and declining gave the same verdict), and deleting `frameworkNames.isEmpty` left it green too (the host shipped `QtCore.framework`, so `read` returned at the Qt rule and never reached the condition under test). Both mutations now fail, as does collapsing condition 1 back to `(try? …) ?? []`.

Also corrected: the survey population (I had counted 65 `/System` bundles that never get a row and missed the Input Methods roots, where WeType is a seventh nested-`.app` case), the claim that WeChat nests two (it nests one — the two were `WeChat-vendor.app`), and a test comment that justified itself by the "Links …" line, which `RuntimeTag` draws only for `.native`/`.catalyst` and has never drawn for Docker.

## Known, deliberately not in this PR

`hasSelfUpdater`, `hasSparkleUpdater`, the Sparkle feed read and `ElectronUpdateConfig.read` all read the **outer** bundle for the same reason the runtime label did. Docker's `Squirrel.framework` sits in the nested bundle, so its `hasSelfUpdater` is `false` today. Unlike `runtime`, that flag decides whether we install over a running app or defer to its own updater, so widening it is a product call and not a label fix — filing separately rather than smuggling it in here.

## Tests

```
swift test --filter AppRuntimeDetection   43 tests passed
make test                                 1807 + 184 tests passed (453s), 1 known issue
```

Closes #208
