### PR TITLE
Find the Tauri crate path with Data.range(of:) rather than a byte loop

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -397,7 +397,7 @@ public enum RuntimeVersion {
         for prefix: String,
         components: Int
     ) -> Probe {
-        let needle = Array(prefix.utf8)
+        let needle = Data(prefix.utf8)
 
 
         // `try?` is not available here, and the reason is the whole point of this
@@ -454,7 +454,7 @@ public enum RuntimeVersion {
                 var window = carry
                 window.append(chunk)
                 let version = firstVersion(
-                    in: Array(window), after: needle, components: components,
+                    in: window, after: needle, components: components,
                     // In a continuation window the first byte is there only to be
                     // the character before the second: a match starting *on* it has
                     // no predecessor in this window, and was already whole in the
@@ -514,9 +514,28 @@ public enum RuntimeVersion {
     /// it hands out a `tauri-` match that is not one, which for a *displayed
     /// version* was cosmetic and for a *verdict* is the exact false positive the
     /// rest of this change exists to prevent.
+    ///
+    /// Finding the needle is `Data.range(of:)`'s job rather than a byte loop's, and
+    /// that is a measurement rather than a preference. The loop this replaced was
+    /// **200× slower in a debug build than in a release one** — `-Onone` optimises
+    /// none of it, and every one of those hundreds of millions of iterations pays
+    /// full bounds-checking and retain/release. Measured over Longbridge's 261 MiB
+    /// executable, chunked exactly as `probe` chunks it: **75.2 s for the loop,
+    /// 0.151 s for `Data.range(of:)`**, same match positions on every binary tried.
+    /// `range(of:)` lives in a Foundation that is already compiled with
+    /// optimisations, so it does not care how *this* module was built.
+    ///
+    /// That gap was not academic: three scan tests walk the real `/Applications`,
+    /// and #206 put this walk on that path — `scanFindsRealApps` went from 0.24 s to
+    /// 107 s, which is issue #214. The shipped app, being a release build, never saw
+    /// it. Keep the search out of Swift here; the parse below runs a few bytes per
+    /// match and can stay.
+    ///
+    /// Only the *search* moved. Both window-edge rules and the identifier guard are
+    /// unchanged, and so is the order they run in.
     private static func firstVersion(
-        in bytes: [UInt8],
-        after needle: [UInt8],
+        in bytes: Data,
+        after needle: Data,
         components: Int,
         from start: Int = 0,
         isFinal: Bool = true
@@ -525,18 +544,29 @@ public enum RuntimeVersion {
         let digits = UInt8(ascii: "0")...UInt8(ascii: "9")
         let dot = UInt8(ascii: ".")
         let dash = UInt8(ascii: "-")
-        outer: for index in start...(bytes.count - needle.count - 1) {
-            for offset in 0..<needle.count where bytes[index + offset] != needle[offset] { continue outer }
-            if index > 0 {
+        // Offsets are relative to `startIndex`, not to zero. `carry` is a *slice* of
+        // the previous window, and a `Data` slice keeps the indices it was cut from
+        // — `window.startIndex` is 128, not 0, from the second window on. The
+        // `Array(window)` this replaced re-based to zero as a side effect of
+        // copying; nothing does that now, so `bytes[0]` would be a crash and
+        // `index > 0` would be the identifier guard silently skipped.
+        var searchFrom = bytes.startIndex + start
+        while searchFrom < bytes.endIndex,
+              let match = bytes.range(of: needle, in: searchFrom..<bytes.endIndex) {
+            let index = match.lowerBound
+            // Every position is a candidate, exactly as in the loop: a rejected
+            // match must not hide a real one that overlaps it.
+            searchFrom = index + 1
+            if index > bytes.startIndex {
                 let before = bytes[index - 1]
                 let isIdentifier = digits.contains(before) || before == dash
                     || (before | 0x20) >= UInt8(ascii: "a") && (before | 0x20) <= UInt8(ascii: "z")
                 if isIdentifier { continue }
             }
-            var cursor = index + needle.count
+            var cursor = match.upperBound
             var version = ""
             var dots = 0
-            while cursor < bytes.count {
+            while cursor < bytes.endIndex {
                 let byte = bytes[cursor]
                 if digits.contains(byte) {
                     version.append(Character(UnicodeScalar(byte)))
@@ -551,7 +581,7 @@ public enum RuntimeVersion {
             // A run that stopped because the buffer did, in a window that is not the
             // end of the file, is not a finished version — whatever digits follow
             // are in the next chunk.
-            if !isFinal, cursor == bytes.count { continue }
+            if !isFinal, cursor == bytes.endIndex { continue }
             if dots == components - 1, let last = version.last, last.isNumber { return version }
         }
         return nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -516,14 +516,22 @@ public enum RuntimeVersion {
     /// rest of this change exists to prevent.
     ///
     /// Finding the needle is `Data.range(of:)`'s job rather than a byte loop's, and
-    /// that is a measurement rather than a preference. The loop this replaced was
-    /// **200× slower in a debug build than in a release one** — `-Onone` optimises
-    /// none of it, and every one of those hundreds of millions of iterations pays
-    /// full bounds-checking and retain/release. Measured over Longbridge's 261 MiB
-    /// executable, chunked exactly as `probe` chunks it: **75.2 s for the loop,
-    /// 0.151 s for `Data.range(of:)`**, same match positions on every binary tried.
-    /// `range(of:)` lives in a Foundation that is already compiled with
-    /// optimisations, so it does not care how *this* module was built.
+    /// that is a measurement rather than a preference. Two separate comparisons, and
+    /// they are worth keeping apart because each answers a different question:
+    ///
+    /// - **The same loop, debug against release: ~200×** (#214 measured 104 s and
+    ///   0.50 s for one library-wide sweep). `-Onone` optimises none of it, and
+    ///   every one of those hundreds of millions of iterations pays full
+    ///   bounds-checking and retain/release. This is why a release build never
+    ///   showed the problem.
+    /// - **Loop against `Data.range(of:)`, both in a debug build: ~500×.** Measured
+    ///   over Longbridge's 261 MiB executable, chunked exactly as `probe` chunks it:
+    ///   **75.2 s and 0.151 s**, same match positions on every binary tried.
+    ///
+    /// The second is the one this code turns on: `range(of:)` lives in a Foundation
+    /// that is already compiled with optimisations, so it does not care how *this*
+    /// module was built. (That attribution is measured rather than looked up — the
+    /// numbers are solid, the explanation for them is not from Apple's documentation.)
     ///
     /// That gap was not academic: three scan tests walk the real `/Applications`,
     /// and #206 put this walk on that path — `scanFindsRealApps` went from 0.24 s to

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -355,6 +355,45 @@ private func probe(_ steps: [ScriptedReads.Step],
     #expect(probe([]) == .absent, "a zero-byte binary contains no crate path")
 }
 
+/// The one test in this file whose input is the size of a real executable, and the
+/// only kind that can see the defect it exists for.
+///
+/// Every other fixture here is a few hundred bytes, where an implementation 200×
+/// slower than it needs to be is invisible. #206 put this walk on the library scan
+/// while the search was a hand-rolled byte loop — which `-Onone` does not optimise
+/// at all — so a debug build paid what a release build did not: `scanFindsRealApps`
+/// went from 0.24 s to 107 s and the whole suite from seconds to minutes (#214).
+/// The suite stayed green throughout.
+///
+/// 60 MiB is enough to separate the two by far more than machine noise. Measured in
+/// a debug build over Longbridge's 261 MiB binary, chunked as `probe` chunks it:
+/// **75 s for the byte loop, 0.15 s for `Data.range(of:)`**. The threshold below is
+/// two orders of magnitude above the fix and several times under the regression, so
+/// this is not a stopwatch on the machine — it answers one question, which is
+/// whether the search has gone back into unoptimised Swift.
+///
+/// The crate path is in the **last** chunk and the version is asserted, which is
+/// the point rather than a detail: a version that came back from the final chunk is
+/// proof all 60 MiB were walked. Move the payload earlier — or let it stop matching
+/// — and the test becomes fast, green, and empty.
+@Test func theSearchDoesNotDegradeIntoAByteLoop() {
+    let filler = Data(repeating: UInt8(ascii: "."), count: RuntimeVersion.scanChunkSize)
+    let tail = Data("registry/src/index/tauri-2.11.5/src/lib.rs".utf8)
+    var remaining = 16
+    let started = Date()
+    let outcome = RuntimeVersion.probe(
+        reading: {
+            guard remaining > 0 else { return nil }
+            remaining -= 1
+            return remaining == 0 ? tail : filler
+        },
+        for: "tauri-", components: 3)
+    let elapsed = -started.timeIntervalSinceNow
+
+    #expect(outcome == .found("2.11.5"), "the payload is in the last chunk — this is what says it was reached")
+    #expect(elapsed < 5, "60 MiB took \(String(format: "%.2f", elapsed))s; the search is walking bytes in Swift again")
+}
+
 private let stamp = Date(timeIntervalSince1970: 1_700_000_000)
 
 @Test func aProvenAbsenceIsRememberedToo() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -365,12 +365,21 @@ private func probe(_ steps: [ScriptedReads.Step],
 /// went from 0.24 s to 107 s and the whole suite from seconds to minutes (#214).
 /// The suite stayed green throughout.
 ///
-/// 60 MiB is enough to separate the two by far more than machine noise. Measured in
-/// a debug build over Longbridge's 261 MiB binary, chunked as `probe` chunks it:
-/// **75 s for the byte loop, 0.15 s for `Data.range(of:)`**. The threshold below is
-/// two orders of magnitude above the fix and several times under the regression, so
-/// this is not a stopwatch on the machine — it answers one question, which is
-/// whether the search has gone back into unoptimised Swift.
+/// 60 MiB is enough to separate the two by far more than machine noise, and the
+/// four numbers that matter were all measured on this input rather than reasoned
+/// about. **Alone: 0.011 s fixed, 16.7 s with the byte loop put back.** But this
+/// test does not run alone — inside the full suite, with the network tests and the
+/// three real-`/Applications` scans running beside it, the fixed version takes
+/// **0.536 s**, fifty times its solo number, purely from CPU contention.
+///
+/// That inflation is the reason the threshold is where it is. Ten seconds leaves
+/// roughly 18× over the contended green number — enough for a busier or smaller
+/// machine than this one — while still sitting well under a regression, which is
+/// 16.7 s *at its fastest* and would be minutes under the same contention (#214's
+/// scan tests went from 107 s alone to 410 s in the suite). It is not a stopwatch
+/// on the machine; it answers one question, which is whether the search has gone
+/// back into unoptimised Swift. Tighten it toward the green number and this becomes
+/// a test that fails on a loaded laptop, which is a test that gets deleted.
 ///
 /// The crate path is in the **last** chunk and the version is asserted, which is
 /// the point rather than a detail: a version that came back from the final chunk is
@@ -391,7 +400,7 @@ private func probe(_ steps: [ScriptedReads.Step],
     let elapsed = -started.timeIntervalSinceNow
 
     #expect(outcome == .found("2.11.5"), "the payload is in the last chunk — this is what says it was reached")
-    #expect(elapsed < 5, "60 MiB took \(String(format: "%.2f", elapsed))s; the search is walking bytes in Swift again")
+    #expect(elapsed < 10, "60 MiB took \(String(format: "%.2f", elapsed))s; the search is walking bytes in Swift again")
 }
 
 private let stamp = Date(timeIntervalSince1970: 1_700_000_000)


### PR DESCRIPTION
Closes #214.

The Tauri proof #206 added put a whole-binary walk on the library scan, and the walk found its needle with a hand-rolled `[UInt8]` loop. `-Onone` optimises none of that, so a debug build paid what the shipped release build does not.

**Only the search moved.** The version parse still runs the same byte loop at each match position, where it costs a few bytes. The three things the issue asks any fix to preserve are untouched: the identifier guard, the two window-edge rules, and `Probe`'s three-way distinction between a proven absence and a failed read.

## The gap, measured

`probe`'s own chunking lifted out and compiled `-Onone`, over Longbridge's 261 MiB executable:

```
loop  bytes=273854272 hits=0 elapsed=75.219s     # hand-rolled [UInt8] loop
data  bytes=273854272 hits=0 elapsed=0.151s      # Data.range(of:)
array bytes=273854272        elapsed=0.064s      # Array(window) itself — not the cost
```

Two ratios, kept apart because they answer different questions: **~200×** is the same loop debug against release (#214's 104 s / 0.50 s sweep), which is why the shipped app never showed this; **~500×** is the loop against `Data.range(of:)` with both in a debug build, which is what this diff turns on. Foundation is already compiled with optimisations, so it does not care how this module was built — that attribution is measured, not looked up; I could not find it stated in Apple's documentation.

## Before / after

Same machine, debug, whole suite running concurrently:

| | issue #214 | this branch |
|---|---|---|
| `scanFindsRealApps` | 410.1 s (107.2 s alone) | **0.575 s** (0.443 s alone) |
| `extraLocationsAreScannedOnTopOfBuiltInRoots` | 410.2 s | **0.737 s** |
| `listUnknownApps` | 423.1 s | **9.753 s** |
| Core suite total | ~475 s | **54.4 s** |

`make test` end to end is now 2:30, including both packages' builds and the three Python checks. What bounds the suite now is `vendorDownloadPassesSignatureGate` at 54.4 s, which downloads a real vendor package — network time, not CPU.

## The trap that came with it

`carry` is a suffix *slice* of the previous window, and a `Data` slice keeps the indices it was cut from — `window.startIndex` is 128, not 0, from the second window on (verified). The `Array(window)` this replaced re-based to zero as a side effect of copying; nothing does that now, so every offset in `firstVersion` is relative to `startIndex`. Left as it was, `bytes[0]` would crash and `index > 0` would be the identifier guard silently skipped.

## Equivalence, computed independently

Not by re-reading the Swift. Both implementations were built side by side with the walk around them and run against real input:

```
real binaries: 196 files, 588 probes, 7 found, 0 mismatches
fuzz: 20000 layouts, 0 mismatches
```

The first is every executable under `/Applications`, probed for `tauri-`, `Electron/` and `Chrome/`. The second is randomised layouts with randomised chunk (1–40) and overlap (1–20) sizes, so every window boundary rule is exercised at every offset — planted payloads include `xtauri-`, `-tauri-`, `tauri-2.11.5` and `tauri-2.11.50`, which are the shapes the two edge rules exist for.

## The new test

`theSearchDoesNotDegradeIntoAByteLoop` pushes 60 MiB through `probe`'s scripted seam and asserts under ten seconds. Verified both ways against this tree: **16.672 s and failing** with the byte loop restored, **0.011 s** with `Data.range(of:)`.

The threshold is ten rather than five because of something the review pass caught: this test never runs alone. Inside the full suite — beside the network tests and the three real-`/Applications` scans — the fixed version takes **0.536 s**, fifty times its solo number, purely from CPU contention on an idle ten-core machine. Five seconds would have been ~9× of margin, not the two orders of magnitude the comment claimed, and a busier host would eventually have failed a build in which nothing was wrong. Ten leaves ~18× over the contended green number and still sits far under a regression, which is 16.7 s at its fastest and would be minutes under the same contention (#214's scan tests went from 107 s alone to 410 s in the suite).

The crate path sits in the **last** chunk and the version is asserted, which is the vacuity guard rather than a detail: a version returned from the final chunk proves all 60 MiB were walked. Move the payload earlier, or let it stop matching, and the test becomes fast, green and empty.

## Verification

```
make test        # exit 0 — 1797 Core tests in 54.4 s, CLI 184, all three Python checks green
```

The one "known issue" in that run is the pre-existing `withKnownIssue` in `ankiZeroPaddedTagComparesEqualToInstalled`, unrelated to this change.

No CHANGELOG entry: the shipped app is a release build and never paid this. Test-suite and debug-build cost only.
