### PR TITLE
Keep scanner-derived builds out of package landing comparisons

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3238,7 +3238,9 @@ final class AppListModel {
                 onDiskVersion: app.versionSide,
                 stagedVersion: staged.versionSide,
                 stagedAt: staged.stagedAt,
-                runningLaunchDates: launchDates[key] ?? [])
+                runningLaunchDates: launchDates[key] ?? [],
+                buildIsDerived: AppScanner.buildVersionIsOverridden(
+                    bundleID: app.bundleID))
             switch state {
             case .pending:
                 // Not landed. Normally there's no badge yet; but if one was already

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartState.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartState.swift
@@ -37,22 +37,32 @@ public enum PackageRestartState: Sendable, Equatable {
     ///   - stagedAt: when the package was handed to macOS's installer.
     ///   - runningLaunchDates: `launchDate` of every currently-running copy of this
     ///     app's bundle (by resolved path — a channel sibling must not stand in).
+    ///   - buildIsDerived: whether `onDiskVersion.build` was substituted by
+    ///     `AppScanner` rather than read from `CFBundleVersion`. A package source's
+    ///     build is not known to share that namespace, so the derived half is
+    ///     discarded and landing falls back to marketing-to-marketing.
     ///
-    /// "Landed" is `onDiskVersion == stagedVersion`: the app now IS the version the
-    /// package installs, as opposed to still being the old one (install not done) or
-    /// already carrying a newer one (the staged package was superseded, not applied).
-    /// Compared as PAIRS. `onDiskVersion` and `stagedVersion` used to be bare
-    /// marketing strings, so for a vendor that keeps one marketing version across
-    /// builds they were equal before the installer had run — `.pending` was never
-    /// returned and a genuinely-unfinished install was classified as landed.
+    /// "Landed" means the two sides agree in every shared version namespace: the app
+    /// now IS the version the package installs, as opposed to still being the old one
+    /// (install not done) or already carrying a newer one (the staged package was
+    /// superseded, not applied). Normally both marketing and build participate. A
+    /// scanner-derived build is removed first because it does not describe the same
+    /// namespace as the package build. These used to be bare marketing strings, so
+    /// for a vendor that keeps one marketing version across builds they were equal
+    /// before the installer had run — `.pending` was never returned and a genuinely-
+    /// unfinished install was classified as landed.
     public static func resolve(
         onDiskVersion: VersionSide?,
         stagedVersion: VersionSide,
         stagedAt: Date,
-        runningLaunchDates: [Date]
+        runningLaunchDates: [Date],
+        buildIsDerived: Bool = false
     ) -> Self {
-        guard let onDiskVersion,
-              VersionComparator.isSame(onDiskVersion, as: stagedVersion)
+        guard var onDiskVersion else { return .pending }
+        if buildIsDerived {
+            onDiskVersion = VersionSide(marketing: onDiskVersion.marketing)
+        }
+        guard VersionComparator.isSame(onDiskVersion, as: stagedVersion)
         else { return .pending }
         let staleRunning = runningLaunchDates.contains { $0 < stagedAt }
         return staleRunning ? .readyToRestart : .settled

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartStateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartStateTests.swift
@@ -104,4 +104,25 @@ struct PackageRestartStateTests {
             runningLaunchDates: [handOff.addingTimeInterval(-3600)]) == .readyToRestart,
             "the build arrived, and a copy from before the hand-off is still up")
     }
+
+    /// `AppScanner` substitutes a vendor-facing build for a small set of apps.
+    /// A package feed's build is not thereby in that namespace, so disagreement
+    /// between those strings cannot veto marketing evidence that the target landed.
+    @Test func aDerivedOnDiskBuildFallsBackToMarketing() {
+        let staged = VersionSide(marketing: "1.1", build: "bundle-build-11")
+
+        #expect(PackageRestartState.resolve(
+            onDiskVersion: VersionSide(marketing: "1.1", build: "vendor-code-1100"),
+            stagedVersion: staged, stagedAt: handOff,
+            runningLaunchDates: [handOff.addingTimeInterval(-60)],
+            buildIsDerived: true) == .readyToRestart,
+            "matching marketing is the only shared namespace")
+
+        #expect(PackageRestartState.resolve(
+            onDiskVersion: VersionSide(marketing: "1.0", build: "vendor-code-1000"),
+            stagedVersion: staged, stagedAt: handOff,
+            runningLaunchDates: [handOff.addingTimeInterval(-60)],
+            buildIsDerived: true) == .pending,
+            "dropping an incomparable build must not make every package landed")
+    }
 }

--- a/scripts/check_staged_version_use.py
+++ b/scripts/check_staged_version_use.py
@@ -99,6 +99,12 @@ def compares_near(lines, index):
 # four landing checks answer "nothing moved".
 SHORT_READ = re.compile(r"readShortVersion(?:OffMain)?\s*\(")
 
+# App/Sources has no test target, so pin the one wiring site that must tell Core
+# when the scanner's build does not share the package source's namespace.
+PACKAGE_RESTART_RESOLVE = re.compile(r"PackageRestartState\.resolve\s*\(")
+DERIVED_BUILD_ARGUMENT = "buildIsDerived:"
+PACKAGE_RESTART_WINDOW = 10
+
 
 # A *different* type also binds the name `staged`: `stagedPackage(for:)` returns
 # a `StagedPackage` — a downloaded `.pkg` installer, not a self-update staged by
@@ -132,8 +138,10 @@ def in_package_scope(lines, index):
 
 def main() -> int:
     display_hits, ledger_hits, compare_hits, read_hits = [], [], [], []
+    package_restart_hits = []
     ledger_seen = 0
     marketing_seen = 0
+    package_restart_seen = 0
     files = list(swift_files())
 
     for path in files:
@@ -159,6 +167,11 @@ def main() -> int:
                     compare_hits.append(f"{rel}:{n}: {line.strip()}")
             if SHORT_READ.search(line) and compares_near(lines, n - 1):
                 read_hits.append(f"{rel}:{n}: {line.strip()}")
+            if PACKAGE_RESTART_RESOLVE.search(line):
+                package_restart_seen += 1
+                call = "\n".join(lines[n - 1:n - 1 + PACKAGE_RESTART_WINDOW])
+                if DERIVED_BUILD_ARGUMENT not in call:
+                    package_restart_hits.append(f"{rel}:{n}: {line.strip()}")
 
     # Vacuity guard. A rule that matches nothing passes forever, which is worse
     # than no rule: it reports success while the thing it was written for has
@@ -175,6 +188,10 @@ def main() -> int:
         print("✗ staged-version guard found no `ledger.isNew/record(version:)` "
               "call at all. Either the nudge ledger was removed (delete rule 2) "
               "or it was renamed and this rule now guards nothing.")
+        return 1
+    if package_restart_seen == 0:
+        print("✗ staged-version guard found no PackageRestartState.resolve call. "
+              "Either the app wiring moved or this rule now guards nothing.")
         return 1
 
     if display_hits:
@@ -207,7 +224,15 @@ def main() -> int:
               "`readVersionSide` so the build can break the tie.")
         for hit in read_hits:
             print(f"    {hit}")
-    if display_hits or ledger_hits or compare_hits or read_hits:
+    if package_restart_hits:
+        print(f"✗ {len(package_restart_hits)} PackageRestartState call(s) omit "
+              "the derived-build namespace flag.")
+        print("  Pass AppScanner.buildVersionIsOverridden(bundleID:) so a "
+              "scanner-substituted build is not compared with a feed build.")
+        for hit in package_restart_hits:
+            print(f"    {hit}")
+    if (display_hits or ledger_hits or compare_hits or read_hits
+            or package_restart_hits):
         return 1
 
     print(f"✓ version comparisons discriminate — {len(files)} files, "


### PR DESCRIPTION
Closes #236.

## What changed

- Tell `PackageRestartState` when `AppScanner` substituted an app-specific build value.
- Remove that derived build before comparing a landed package, so the decision falls back to the shared marketing namespace instead of comparing unrelated scanner/feed build strings.
- Keep differing marketing versions pending, and add Core coverage for both the landed and not-yet-landed cases.
- Add a static App wiring guard because `App/Sources` has no test target.

## Issue audit

The current mismatch is fail-closed: `VersionComparator.isSame` returns false and leaves the package pending. The scanner overrides currently belong to Xcode (detection-only) and Doubao (ZIP install), so neither reaches the staged system-package path today. This fixes the latent namespace bug before a scanner-overridden app gains package support; an accidental cross-namespace string equality can no longer be treated as evidence either.

## Verification

- Regression test failed to compile before the new API/wiring and passes after the change.
- `make test` — 1,860 Core tests, 184 CLI tests, localization and all repository guards passed (one pre-existing known Core issue).
- Unsigned Debug app build passed with `xcodebuild`.
- Independent three-case namespace matrix passed.
- The static guard was mutation-probed: it rejects an omitted `buildIsDerived` argument and accepts the production wiring.
