### PR TITLE
Match discovered feed builds with version semantics

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
@@ -305,8 +305,11 @@ public enum FeedDiscovery {
         // release's `CFBundleShortVersionString`), which is precisely why
         // `SparkleAppcastSource.channel(ofInstalled:in:)` scans the build across
         // every item before it will consider marketing at all.
-        guard let installedBuild = probe.installed.build,
-              let matched = feedItems.first(where: { $0.version == installedBuild })
+        guard let installedBuild = probe.installed.build else {
+            return .review(.installedBuildNotInFeed, candidate.url)
+        }
+        guard let matched = SparkleAppcastSource.item(
+            matchingInstalledBuild: installedBuild, in: feedItems)
         else {
             return .review(.installedBuildNotInFeed, candidate.url)
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -337,6 +337,21 @@ public struct SparkleAppcastSource: UpdateSource {
         return allowed
     }
 
+    /// Find the feed item that describes an installed build. Prefer a byte-for-byte
+    /// match before accepting a comparator-equivalent spelling: normalization must
+    /// not let an earlier `1.0.0` entry steal a later exact `1.0` match.
+    static func item(
+        matchingInstalledBuild build: String,
+        in items: [SparkleAppcastItem]
+    ) -> SparkleAppcastItem? {
+        if let exact = items.first(where: { $0.version == build }) { return exact }
+        let installedBuild = VersionSide(build: build)
+        return items.first(where: {
+            VersionComparator.isSame(
+                VersionSide(build: $0.version), as: installedBuild)
+        })
+    }
+
     /// The Sparkle channel the installed build sits on, found by matching the
     /// installed version to a feed item — build number first (Sparkle's
     /// canonical key), then the marketing string. nil = the default (stable)
@@ -368,7 +383,7 @@ public struct SparkleAppcastSource: UpdateSource {
     /// showed it at all.
     static func channel(ofInstalled app: InstalledApp, in items: [SparkleAppcastItem]) -> String? {
         if let b = app.buildVersion, !b.isEmpty,
-           let match = items.first(where: { $0.version == b }) {
+           let match = item(matchingInstalledBuild: b, in: items) {
             return normalizeChannel(match.channel)
         }
         if let s = app.shortVersion, !s.isEmpty,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
@@ -113,6 +113,33 @@ private func item(
     #expect(verdict == .adopt(URL(string: "https://example.invalid/appcast.xml")!))
 }
 
+@Test func equivalentBuildSpellingsStillIdentifyTheInstalledFeedItem() {
+    let expected = FeedDiscovery.Verdict.adopt(
+        URL(string: "https://example.invalid/appcast.xml")!)
+
+    #expect(FeedDiscovery.decide(
+        probe(marketing: "1.2.3", build: "1.2.3"),
+        feedItems: [item(short: "1.2.3", version: "v1.2.3")]) == expected,
+        "a conventional version prefix does not change build identity")
+
+    #expect(FeedDiscovery.decide(
+        probe(marketing: "1.0", build: "1.0"),
+        feedItems: [item(short: "1.0", version: "1.0.0")]) == expected,
+        "missing trailing zero components do not change build identity")
+}
+
+@Test func anExactBuildSpellingBeatsAnEarlierEquivalentSpelling() {
+    let verdict = FeedDiscovery.decide(
+        probe(marketing: "1.0", build: "1.0"),
+        feedItems: [
+            item(short: "unrelated", version: "1.0.0"),
+            item(short: "1.0", version: "1.0"),
+        ])
+
+    #expect(verdict == .adopt(
+        URL(string: "https://example.invalid/appcast.xml")!))
+}
+
 // MARK: - the channel gate
 
 @Test func aFeedWhereEveryItemIsChannelTaggedWouldStarveAStableInstall() {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleChannelTests.swift
@@ -96,6 +96,32 @@ struct SparkleChannelTests {
         #expect(SparkleAppcastSource.channel(ofInstalled: app(short: "1.5", build: "x"), in: items) == nil)
     }
 
+    @Test func equivalentBuildSpellingStillPreservesTheInstalledChannel() {
+        let collidingMarketing = [
+            SparkleAppcastItem(shortVersionString: "1.0", version: "101"),
+            SparkleAppcastItem(
+                shortVersionString: "1.0", version: "v100", channel: "beta"),
+        ]
+
+        #expect(SparkleAppcastSource.channel(
+            ofInstalled: app(short: "1.0", build: "100"),
+            in: collidingMarketing) == "beta",
+            "the semantically identical build must win before marketing fallback")
+    }
+
+    @Test func exactBuildSpellingBeatsAnEarlierEquivalentBuild() {
+        let duplicateSpellings = [
+            SparkleAppcastItem(
+                shortVersionString: "1.0", version: "1.0.0", channel: "tip"),
+            SparkleAppcastItem(
+                shortVersionString: "1.0", version: "1.0", channel: "beta"),
+        ]
+
+        #expect(SparkleAppcastSource.channel(
+            ofInstalled: app(short: "1.0", build: "1.0"),
+            in: duplicateSpellings) == "beta")
+    }
+
     /// TypeWhisper's real appcast, 2026-08-31: three trains on one bundle id,
     /// and the `release-candidate` build ships the SAME
     /// `CFBundleShortVersionString` (`1.6.0`) as the stable item that sits


### PR DESCRIPTION
Closes #237.

## What changed

- Match an installed build to a Sparkle feed item with `VersionComparator` semantics, so cross-source spellings such as `v1.2.3` / `1.2.3` and `1.0.0` / `1.0` identify the same build.
- Preserve byte-for-byte matches as the first pass, then use semantic equality. This prevents an earlier equivalent spelling from stealing a later exact item.
- Reuse the same matching rule in `SparkleAppcastSource.channel(ofInstalled:in:)`; the issue audit found that sibling feed-vs-plist comparison had the same omission and could otherwise lose a prerelease channel.
- Leave the marketing fallback as strict string equality because loosening that gate can cross vendor namespaces (the Brave/WeChat cases).

## Verification

- Feed adoption regression: both respelling cases returned `installedBuildNotInFeed` before the fix and adopt afterward.
- Channel regression: a respelled prerelease build fell back to stable before the fix and preserves its channel afterward.
- Adversarial tests prove an exact feed spelling wins over an earlier comparator-equivalent item in both callers.
- `make test` — 1,863 Core tests, 184 CLI tests, localization and all repository guards passed (one pre-existing known Core issue).
- Independent four-case build-identity matrix passed.
