### PR TITLE
Warn when captured vendor publish dates cannot be parsed

### DIFF
--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -492,4 +492,17 @@ import DuoUpdaterCore
         #expect(onlyTransient.signature == "unknown")
     }
 
+    @Test func aChangingUnreadablePublishDateDoesNotMoveTheSignature() {
+        func finding(_ captured: String) -> Finding {
+            Finding(
+                recipeID: "vendor:com.example.app:stable", registry: .vendor,
+                bundleID: "com.example.app", channel: "stable", status: .warn,
+                warnings: [ProbeWarning.publishedAtUnreadable(captured).display],
+                endpointHost: "example.invalid")
+        }
+
+        #expect(finding("yesterday").signature == finding("last Tuesday").signature,
+                "the captured value is evidence, not a new warning kind")
+    }
+
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -134,9 +134,10 @@ public enum ProbeFailure: Error, Sendable, Equatable {
 
 /// A recipe that still reads a version but has quietly lost part of its job.
 ///
-/// Both of these are invisible today: the probe returns a perfectly good version
-/// and silently drops back to detection-only, or installs without the checksum
-/// the recipe author wrote down. A half-broken recipe reads as healthy.
+/// These are invisible without an explicit warning: the probe returns a perfectly
+/// good version and silently drops back to detection-only, loses release metadata,
+/// or installs without the checksum the recipe author wrote down. A half-broken
+/// recipe reads as healthy.
 public enum ProbeWarning: Sendable, Equatable {
     /// The recipe carries an install spec but the installer URL didn't resolve —
     /// one-click is dead even though detection still works.
@@ -206,6 +207,12 @@ public enum ProbeWarning: Sendable, Equatable {
     /// value jump from `155.0b5` to `20260826090609` — an increase, and the only
     /// history check there is looks for a version moving BACKWARDS.
     case displayPatternNoMatch
+    /// `publishedAtPattern` captured a value, but `ReleaseDate` could not parse
+    /// it. The version remains usable, but the release timeline loses its exact
+    /// event and `duo verify`'s age-gated phantom-update check is disabled.
+    /// Carry the captured value so the recipe author can see which date spelling
+    /// needs support without reproducing a response that may already have moved.
+    case publishedAtUnreadable(String)
 
     /// The part of a warning that varies, kept OUT of `kind` on purpose.
     ///
@@ -228,6 +235,15 @@ public enum ProbeWarning: Sendable, Equatable {
             return host.map { "\(code) from \($0)" } ?? code
         case .installURLTransient(let status):
             return status.map { "HTTP \($0)" }
+        case .publishedAtUnreadable(let value):
+            // Keep a stable prefix longer than Finding.signature's 40-character
+            // window; the captured value can change every release without making
+            // one persistent parser problem look like a new failure each sweep.
+            let oneLine = value.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+            let captured = oneLine.count > 160
+                ? String(oneLine.prefix(160)) + "…"
+                : oneLine
+            return "captured value did not parse: \(captured)"
         default:
             return nil
         }
@@ -246,6 +262,7 @@ public enum ProbeWarning: Sendable, Equatable {
         case .checksumPatternNoMatch: return "checksumPatternNoMatch"
         case .entryPatternNoMatch: return "entryPatternNoMatch"
         case .displayPatternNoMatch: return "displayPatternNoMatch"
+        case .publishedAtUnreadable: return "publishedAtUnreadable"
         }
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -624,13 +624,14 @@ public struct VendorProbeSource: UpdateSource {
             VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
         }
         // Optional authoritative publish time, from the same scope (first match,
-        // so it belongs to the entry `versionPattern` matched). An unparseable or
-        // missing date is not a failure — it just means the Release Log falls back
-        // to its estimated "≈" window, exactly as for recipes with no pattern.
-        let publishedAt = ReleaseDate.parse(
-            recipe.publishedAtPattern.flatMap {
-                VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
-            })
+        // so it belongs to the entry `versionPattern` matched). A missing date is
+        // not a failure — the Release Log falls back to its estimated "≈" window.
+        // A captured but unreadable date takes the same fallback, but warns: it
+        // also silently disables `duo verify`'s age-gated phantom-update check.
+        let publishedAtValue = recipe.publishedAtPattern.flatMap {
+            VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
+        }
+        let publishedAt = ReleaseDate.parse(publishedAtValue)
 
         var warnings: [ProbeWarning] = []
         if scoped.fellBack { warnings.append(.entryPatternNoMatch) }
@@ -639,6 +640,9 @@ public struct VendorProbeSource: UpdateSource {
         // string, a 404 where the release notes were. See `.displayPatternNoMatch`.
         if recipe.displayVersionPattern != nil, display == nil {
             warnings.append(.displayPatternNoMatch)
+        }
+        if let publishedAtValue, publishedAt == nil {
+            warnings.append(.publishedAtUnreadable(publishedAtValue))
         }
         var remote: RemoteVersion
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -839,6 +839,44 @@ private func verdict(
     #expect(remote.publishedAt == parsed)
 }
 
+@Test func anUnreadableCapturedPublishDateIsWarnedAbout() async throws {
+    let body = #"{"version":"3.1.0","published":"sometime yesterday"}"#
+    let server = try RecipeVerificationTests.StubServer(body: body)
+    defer { server.stop() }
+    let recipe = VendorProbeRecipe(
+        bundleID: "com.example.unreadable-date", url: server.url,
+        mode: .responseBody,
+        versionPattern: #""version":"([^"]+)""#,
+        publishedAtPattern: #""published":"([^"]+)""#)
+
+    let outcome = await VendorProbeSource().probeDiagnostic(recipe)
+
+    #expect(outcome.remote?.shortVersion == "3.1.0",
+            "an optional date must not turn a good version into a probe failure")
+    #expect(outcome.remote?.publishedAt == nil)
+    #expect(outcome.failure == nil)
+    #expect(outcome.warnings == [.publishedAtUnreadable("sometime yesterday")])
+    #expect(outcome.warnings.first?.kind == "publishedAtUnreadable")
+    #expect(outcome.warnings.first?.display
+        == "publishedAtUnreadable: captured value did not parse: sometime yesterday")
+}
+
+@Test func aReadableCapturedPublishDateStaysQuiet() async throws {
+    let body = #"{"version":"3.1.0","published":"2026-09-02T06:00:00Z"}"#
+    let server = try RecipeVerificationTests.StubServer(body: body)
+    defer { server.stop() }
+    let recipe = VendorProbeRecipe(
+        bundleID: "com.example.readable-date", url: server.url,
+        mode: .responseBody,
+        versionPattern: #""version":"([^"]+)""#,
+        publishedAtPattern: #""published":"([^"]+)""#)
+
+    let outcome = await VendorProbeSource().probeDiagnostic(recipe)
+
+    #expect(outcome.remote?.publishedAt != nil)
+    #expect(outcome.warnings.isEmpty)
+}
+
 // Recipes without a publishedAtPattern must stay absent rather than inventing a
 // time — the timeline then shows its estimated "≈" window instead.
 @Test func probeWithoutPublishedAtPatternLeavesReleaseTimeUnset() {


### PR DESCRIPTION
Closes #238.

## What changed

- Add `ProbeWarning.publishedAtUnreadable` carrying the value captured by a recipe's `publishedAtPattern`.
- Keep a successfully resolved version usable while surfacing the lost publish timestamp through `ProbeOutcome.warnings`, so `duo verify` no longer reports the recipe as healthy while its release timeline and phantom-update age gate are disabled.
- Render the captured evidence as a single-line, bounded detail while keeping a stable warning prefix across releases.
- Leave valid captured dates quiet and preserve the existing no-pattern fallback.

## Issue audit

Every vendor recipe's `publishedAtPattern` reaches the same extraction site in `VendorProbeSource`, so the warning covers the full registry. The warning flows through the existing generic Core-to-CLI mapping; no consumer-specific wiring is required.

## Verification

- Regression test failed to compile before the new warning case and passes after the implementation.
- End-to-end probe tests cover both an unreadable captured date and a valid captured date.
- CLI coverage proves changing captured evidence does not change the reconcile signature.
- `make test` — 1,874 Core tests, 185 CLI tests, localization and all repository guards passed (one pre-existing known Core issue).
- Independent four-case publish-date warning matrix passed.
