### PR TITLE
Move rowRoute into Core as UpdateRoute.resolve(_:)

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -481,23 +481,30 @@ final class AppListModel {
     /// view so both windows agree on whether a row is one-click at all — the
     /// invariant that matters, since one window offering Update while the other
     /// does not is the same row telling two stories.
+    ///
+    /// The decision itself is `UpdateRoute.resolve(_:)` in Core (issue #261) — this
+    /// is only the wiring that fills `RouteInputs`. It stays a method the caller
+    /// invokes lazily (`rowState(for:)` passes `self.rowRoute(for: result)` into an
+    /// `@autoclosure` parameter) rather than a stored value, so building
+    /// `RouteInputs` — which calls `canAutoInstall` / `requiresInstaller` /
+    /// `defersToSelfUpdater` and, for installer rows, stats disk via
+    /// `stagedPackage(for:)` — only happens for a row that actually reaches
+    /// `.updateAvailable`. See `RowActionFacts.route`'s doc comment.
     private func rowRoute(for result: UpdateResult) -> UpdateRoute {
-        // Toolbox and TestFlight own their installs outright; the action is "open
-        // them", never an in-place swap. Checked first for that reason.
-        if result.remote?.sourceName == "Toolbox" || result.app.isToolboxManaged { return .toolbox }
-        if result.remote?.sourceName == "TestFlight" { return .testFlight }
-        if defersToSelfUpdater(result) { return .selfUpdater }
-        if result.isMajorUpgrade && (canAutoInstall(result) || requiresInstaller(result)) {
-            return .majorUpgrade
-        }
-        if canAutoInstall(result) { return .autoInstall }
-        if requiresInstaller(result) {
-            return .installer(stagedFileName: stagedPackage(for: result)?.url.lastPathComponent)
-        }
-        if result.remote?.appStore != nil {
-            return .appStore(managedHere: result.app.isiOSAppOnMac && appStoreStrategyIsFullDownload)
-        }
-        return .detectionOnly
+        // `requiresInstaller` is read twice below (the gate, and the installer
+        // rung itself); computed once here rather than reasked, which also means
+        // `stagedPackage(for:)` — the disk stat — only runs when it can matter.
+        let requiresInstaller = requiresInstaller(result)
+        return UpdateRoute.resolve(RouteInputs(
+            isToolboxManaged: result.remote?.sourceName == "Toolbox" || result.app.isToolboxManaged,
+            isTestFlight: result.remote?.sourceName == "TestFlight",
+            defersToSelfUpdater: defersToSelfUpdater(result),
+            isMajorUpgrade: result.isMajorUpgrade,
+            canAutoInstall: canAutoInstall(result),
+            requiresInstaller: requiresInstaller,
+            stagedFileName: requiresInstaller ? stagedPackage(for: result)?.url.lastPathComponent : nil,
+            hasAppStoreAvailability: result.remote?.appStore != nil,
+            appStoreManagedHere: result.app.isiOSAppOnMac && appStoreStrategyIsFullDownload))
     }
 
     /// A pending update the user hasn't ignored or skipped — what the badge counts

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -487,13 +487,22 @@ final class AppListModel {
     /// invokes lazily (`rowState(for:)` passes `self.rowRoute(for: result)` into an
     /// `@autoclosure` parameter) rather than a stored value, so building
     /// `RouteInputs` — which calls `canAutoInstall` / `requiresInstaller` /
-    /// `defersToSelfUpdater` and, for installer rows, stats disk via
-    /// `stagedPackage(for:)` — only happens for a row that actually reaches
-    /// `.updateAvailable`. See `RowActionFacts.route`'s doc comment.
+    /// `defersToSelfUpdater` unconditionally and, when `requiresInstaller` is
+    /// true, reads `stagedPackage(for:)` too — only happens for a row that
+    /// actually reaches `.updateAvailable`. See `RowActionFacts.route`'s doc
+    /// comment, and the note below on what changed inside that boundary.
     private func rowRoute(for result: UpdateResult) -> UpdateRoute {
         // `requiresInstaller` is read twice below (the gate, and the installer
-        // rung itself); computed once here rather than reasked, which also means
-        // `stagedPackage(for:)` — the disk stat — only runs when it can matter.
+        // rung itself); computed once here rather than reasked. This does NOT
+        // narrow when `stagedPackage(for:)` runs — with the ladder collapsed into
+        // one struct, it runs whenever `requiresInstaller` is true, including rows
+        // that go on to resolve as `.majorUpgrade`, `.selfUpdater`, `.toolbox` or
+        // `.testFlight`, none of which reached it in the old short-circuiting
+        // `if`/`else if` chain. It stays cheap for a different reason:
+        // `stagedPackage(for:)` guards on the `stagedPackages[result.id]`
+        // dictionary lookup FIRST, and that is nil for nearly every row (a staged
+        // package is rare), so the `fileExists` stat behind it is skipped before
+        // it runs, not because this call site is skipped.
         let requiresInstaller = requiresInstaller(result)
         return UpdateRoute.resolve(RouteInputs(
             isToolboxManaged: result.remote?.sourceName == "Toolbox" || result.app.isToolboxManaged,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
@@ -134,6 +134,102 @@ public enum UpdateRoute: Sendable, Equatable {
     }
 }
 
+/// Everything `UpdateRoute.resolve(_:)` reads about one row, gathered by the
+/// caller so the decision itself stays pure and testable.
+///
+/// Moved out of `AppListModel.rowRoute(for:)` (issue #261): `App/project.yml`
+/// carries no test target for `App/Sources`, so this was the one rung of the two
+/// row-state ladders that had genuinely been re-derived rather than moved when
+/// `RowActionState` made that trip, and it was executed by nothing — only
+/// hand-compared against the view it replaced. `RowActionFacts.route` stays the
+/// `@autoclosure` deferral point (`routeIsDeferred` pins that); this struct is
+/// built inside it, on the caller's side, once per row that actually reaches
+/// `.updateAvailable`.
+public struct RouteInputs {
+    /// `remote?.sourceName == "Toolbox" || app.isToolboxManaged` — JetBrains
+    /// Toolbox owns the install outright.
+    public var isToolboxManaged: Bool
+    /// `remote?.sourceName == "TestFlight"`.
+    public var isTestFlight: Bool
+    /// `UpdatePolicy.defersToSelfUpdater(...)` — a running self-updating app under
+    /// the "defer while running" policy.
+    public var defersToSelfUpdater: Bool
+    /// `UpdateResult.isMajorUpgrade`.
+    public var isMajorUpgrade: Bool
+    /// `UpdatePolicy.canAutoInstall(...)`.
+    public var canAutoInstall: Bool
+    /// `UpdatePolicy.requiresInstaller(...)`.
+    public var requiresInstaller: Bool
+    /// The staged package's file name, when one is already on disk for this row.
+    /// Only meaningful — and only worth the caller stat'ing disk for — when
+    /// `requiresInstaller` is true.
+    public var stagedFileName: String?
+    /// `remote?.appStore != nil`.
+    public var hasAppStoreAvailability: Bool
+    /// `app.isiOSAppOnMac && <App Store strategy is "full download">`.
+    public var appStoreManagedHere: Bool
+
+    public init(
+        isToolboxManaged: Bool,
+        isTestFlight: Bool,
+        defersToSelfUpdater: Bool,
+        isMajorUpgrade: Bool,
+        canAutoInstall: Bool,
+        requiresInstaller: Bool,
+        stagedFileName: String?,
+        hasAppStoreAvailability: Bool,
+        appStoreManagedHere: Bool
+    ) {
+        self.isToolboxManaged = isToolboxManaged
+        self.isTestFlight = isTestFlight
+        self.defersToSelfUpdater = defersToSelfUpdater
+        self.isMajorUpgrade = isMajorUpgrade
+        self.canAutoInstall = canAutoInstall
+        self.requiresInstaller = requiresInstaller
+        self.stagedFileName = stagedFileName
+        self.hasAppStoreAvailability = hasAppStoreAvailability
+        self.appStoreManagedHere = appStoreManagedHere
+    }
+}
+
+extension UpdateRoute {
+    /// How an available update would be applied — the ladder that used to live in
+    /// `AppListModel.rowRoute(for:)`, moved verbatim. Order is significant and is
+    /// the whole content of this function, the same way it is for
+    /// `RowAction.state(for:)` above.
+    ///
+    /// Toolbox and TestFlight own their installs outright — the action is "open
+    /// them", never an in-place swap — so they are checked first. The
+    /// `.majorUpgrade` gate stays attached to the rung it guards, not hoisted
+    /// out, and reads exactly `isMajorUpgrade && (canAutoInstall ||
+    /// requiresInstaller)`: a major upgrade with neither an auto-install nor an
+    /// installer path falls through instead, same as before.
+    ///
+    /// `.toolbox` / `.testFlight` / `.selfUpdater` deliberately outrank
+    /// `.majorUpgrade` — a major upgrade on one of those routes still shows the
+    /// redirect, not the licence-boundary warning. That is harmless: the redirect
+    /// installs nothing here, so there is nothing for the warning to gate.
+    /// Believed unreachable today (JetBrains ships calendar versions, and
+    /// `UpdateResult.isMajorUpgrade` excludes those), but nothing stated the
+    /// invariant before this, so it is pinned here regardless.
+    public static func resolve(_ inputs: RouteInputs) -> UpdateRoute {
+        if inputs.isToolboxManaged { return .toolbox }
+        if inputs.isTestFlight { return .testFlight }
+        if inputs.defersToSelfUpdater { return .selfUpdater }
+        if inputs.isMajorUpgrade && (inputs.canAutoInstall || inputs.requiresInstaller) {
+            return .majorUpgrade
+        }
+        if inputs.canAutoInstall { return .autoInstall }
+        if inputs.requiresInstaller {
+            return .installer(stagedFileName: inputs.stagedFileName)
+        }
+        if inputs.hasAppStoreAvailability {
+            return .appStore(managedHere: inputs.appStoreManagedHere)
+        }
+        return .detectionOnly
+    }
+}
+
 /// Everything the ladder reads about one row, gathered by the caller so the
 /// decision itself stays pure and testable.
 public struct RowActionFacts {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateRouteResolutionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateRouteResolutionTests.swift
@@ -1,0 +1,155 @@
+import Testing
+@testable import DuoUpdaterCore
+
+/// `UpdateRoute.resolve(_:)` — the ladder that decides how an available update
+/// would be applied. Moved out of `AppListModel.rowRoute(for:)` (issue #261)
+/// because `App/project.yml` has no test target, so this rung of the ladder had
+/// been re-derived (not moved) when `RowActionState` made that trip and was
+/// executed by nothing — only hand-compared against the view it replaced. Order
+/// is significant and is the whole content of these tests, the same way it is for
+/// `RowActionStateTests`.
+@Suite("UpdateRoute.resolve")
+struct UpdateRouteResolutionTests {
+
+    /// A row that falls all the way through to `.detectionOnly` — every flag
+    /// false, nothing staged. Tests build on this and flip one thing at a time.
+    static func inputs(
+        isToolboxManaged: Bool = false,
+        isTestFlight: Bool = false,
+        defersToSelfUpdater: Bool = false,
+        isMajorUpgrade: Bool = false,
+        canAutoInstall: Bool = false,
+        requiresInstaller: Bool = false,
+        stagedFileName: String? = nil,
+        hasAppStoreAvailability: Bool = false,
+        appStoreManagedHere: Bool = false
+    ) -> RouteInputs {
+        RouteInputs(
+            isToolboxManaged: isToolboxManaged,
+            isTestFlight: isTestFlight,
+            defersToSelfUpdater: defersToSelfUpdater,
+            isMajorUpgrade: isMajorUpgrade,
+            canAutoInstall: canAutoInstall,
+            requiresInstaller: requiresInstaller,
+            stagedFileName: stagedFileName,
+            hasAppStoreAvailability: hasAppStoreAvailability,
+            appStoreManagedHere: appStoreManagedHere)
+    }
+
+    // MARK: - Every rung reachable on its own
+
+    @Test("every rung fires when it is the only thing true")
+    func eachRungAlone() {
+        #expect(UpdateRoute.resolve(Self.inputs(isToolboxManaged: true)) == .toolbox)
+        #expect(UpdateRoute.resolve(Self.inputs(isTestFlight: true)) == .testFlight)
+        #expect(UpdateRoute.resolve(Self.inputs(defersToSelfUpdater: true)) == .selfUpdater)
+        #expect(UpdateRoute.resolve(Self.inputs(isMajorUpgrade: true, canAutoInstall: true)) == .majorUpgrade)
+        #expect(UpdateRoute.resolve(Self.inputs(canAutoInstall: true)) == .autoInstall)
+        #expect(UpdateRoute.resolve(Self.inputs(requiresInstaller: true, stagedFileName: "App.pkg"))
+                == .installer(stagedFileName: "App.pkg"))
+        #expect(UpdateRoute.resolve(Self.inputs(hasAppStoreAvailability: true, appStoreManagedHere: true))
+                == .appStore(managedHere: true))
+        #expect(UpdateRoute.resolve(Self.inputs()) == .detectionOnly)
+    }
+
+    // MARK: - Precedence, pairwise against every rung below — a mutation guard for
+    // rung order, the way `RowActionStateTests.inFlightPrecedence` is for the
+    // sibling ladder. Each `#expect` fails if the winning rung is moved below the
+    // one it is being compared against.
+
+    @Test("toolbox outranks everything below it")
+    func toolboxBeatsEverything() {
+        #expect(UpdateRoute.resolve(Self.inputs(isToolboxManaged: true, isTestFlight: true)) == .toolbox)
+        #expect(UpdateRoute.resolve(Self.inputs(isToolboxManaged: true, defersToSelfUpdater: true)) == .toolbox)
+        #expect(UpdateRoute.resolve(Self.inputs(
+            isToolboxManaged: true, isMajorUpgrade: true, canAutoInstall: true)) == .toolbox)
+        #expect(UpdateRoute.resolve(Self.inputs(isToolboxManaged: true, canAutoInstall: true)) == .toolbox)
+        #expect(UpdateRoute.resolve(Self.inputs(
+            isToolboxManaged: true, requiresInstaller: true, stagedFileName: "x.pkg")) == .toolbox)
+        #expect(UpdateRoute.resolve(Self.inputs(isToolboxManaged: true, hasAppStoreAvailability: true)) == .toolbox)
+    }
+
+    @Test("testFlight outranks everything below it")
+    func testFlightBeatsEverything() {
+        #expect(UpdateRoute.resolve(Self.inputs(isTestFlight: true, defersToSelfUpdater: true)) == .testFlight)
+        #expect(UpdateRoute.resolve(Self.inputs(
+            isTestFlight: true, isMajorUpgrade: true, canAutoInstall: true)) == .testFlight)
+        #expect(UpdateRoute.resolve(Self.inputs(isTestFlight: true, canAutoInstall: true)) == .testFlight)
+        #expect(UpdateRoute.resolve(Self.inputs(isTestFlight: true, hasAppStoreAvailability: true)) == .testFlight)
+    }
+
+    /// The invariant issue #261 asks to pin, together with the two tests above:
+    /// `.toolbox` / `.testFlight` / `.selfUpdater` outrank `.majorUpgrade`, so a
+    /// major upgrade on one of those routes shows the redirect, not the
+    /// licence-boundary warning. Harmless — the redirect installs nothing here, so
+    /// there is nothing for the warning to gate — but nothing stated it before
+    /// this.
+    @Test("selfUpdater outranks majorUpgrade")
+    func selfUpdaterBeatsMajorUpgrade() {
+        #expect(UpdateRoute.resolve(Self.inputs(
+            defersToSelfUpdater: true, isMajorUpgrade: true, canAutoInstall: true)) == .selfUpdater)
+        #expect(UpdateRoute.resolve(Self.inputs(
+            defersToSelfUpdater: true, isMajorUpgrade: true, requiresInstaller: true)) == .selfUpdater)
+    }
+
+    @Test("majorUpgrade outranks autoInstall and installer")
+    func majorUpgradeBeatsInstallRoutes() {
+        #expect(UpdateRoute.resolve(Self.inputs(isMajorUpgrade: true, canAutoInstall: true)) == .majorUpgrade)
+        #expect(UpdateRoute.resolve(Self.inputs(isMajorUpgrade: true, requiresInstaller: true)) == .majorUpgrade)
+        #expect(UpdateRoute.resolve(Self.inputs(
+            isMajorUpgrade: true, canAutoInstall: true, requiresInstaller: true)) == .majorUpgrade)
+    }
+
+    @Test("autoInstall outranks installer and appStore")
+    func autoInstallBeatsBelow() {
+        #expect(UpdateRoute.resolve(Self.inputs(canAutoInstall: true, requiresInstaller: true)) == .autoInstall)
+        #expect(UpdateRoute.resolve(Self.inputs(canAutoInstall: true, hasAppStoreAvailability: true)) == .autoInstall)
+    }
+
+    @Test("installer outranks appStore")
+    func installerBeatsAppStore() {
+        #expect(UpdateRoute.resolve(Self.inputs(requiresInstaller: true, hasAppStoreAvailability: true))
+                == .installer(stagedFileName: nil))
+    }
+
+    @Test("appStore outranks the detectionOnly default")
+    func appStoreBeatsDetectionOnly() {
+        #expect(UpdateRoute.resolve(Self.inputs(hasAppStoreAvailability: true)) == .appStore(managedHere: false))
+    }
+
+    // MARK: - The majorUpgrade gate: `isMajorUpgrade && (canAutoInstall ||
+    // requiresInstaller)`
+
+    @Test("majorUpgrade requires an install path — neither present falls through")
+    func majorUpgradeGateRequiresAnInstallPath() {
+        #expect(UpdateRoute.resolve(Self.inputs(isMajorUpgrade: true)) == .detectionOnly)
+        #expect(UpdateRoute.resolve(Self.inputs(isMajorUpgrade: true, hasAppStoreAvailability: true))
+                == .appStore(managedHere: false))
+    }
+
+    @Test("the gate is an OR: either half alone is enough")
+    func majorUpgradeGateIsOr() {
+        #expect(UpdateRoute.resolve(Self.inputs(
+            isMajorUpgrade: true, canAutoInstall: true, requiresInstaller: false)) == .majorUpgrade)
+        #expect(UpdateRoute.resolve(Self.inputs(
+            isMajorUpgrade: true, canAutoInstall: false, requiresInstaller: true)) == .majorUpgrade)
+    }
+
+    // MARK: - Payload carried through unmodified
+
+    @Test("installer carries the staged file name through")
+    func installerCarriesStagedFileName() {
+        #expect(UpdateRoute.resolve(Self.inputs(requiresInstaller: true, stagedFileName: "Foo-2.0.pkg"))
+                == .installer(stagedFileName: "Foo-2.0.pkg"))
+        #expect(UpdateRoute.resolve(Self.inputs(requiresInstaller: true, stagedFileName: nil))
+                == .installer(stagedFileName: nil))
+    }
+
+    @Test("appStore carries managedHere through")
+    func appStoreCarriesManagedHere() {
+        #expect(UpdateRoute.resolve(Self.inputs(hasAppStoreAvailability: true, appStoreManagedHere: true))
+                == .appStore(managedHere: true))
+        #expect(UpdateRoute.resolve(Self.inputs(hasAppStoreAvailability: true, appStoreManagedHere: false))
+                == .appStore(managedHere: false))
+    }
+}


### PR DESCRIPTION
`rowRoute(for:)` decided how an available update would be applied, and lived in
`AppListModel.swift`. `App/project.yml` carries no test target for `App/Sources`,
so — unlike `RowActionState`'s ladder, which #259 moved into Core verbatim and
`RowActionStateTests` now pins — this one had been *re-derived*, not moved, and
was executed by nothing. Two reviewers hand-compared it against
`git show main:App/Sources/MenuContentView.swift` and found no transcription
error, but that is two people reading, not a check.

## The change

`UpdateRoute.resolve(_:)` (Core, `RowActionState.swift`) is the ladder, moved
verbatim onto a new `RouteInputs` struct — the caller's job is now only to fill
it. Order, the `.majorUpgrade` gate, and every returned value are unchanged.

`AppListModel.rowRoute(for:)` is now wiring: it builds `RouteInputs` from
`canAutoInstall` / `requiresInstaller` / `defersToSelfUpdater` /
`stagedPackage(for:)` and hands it to `UpdateRoute.resolve(_:)`. It stays a
method invoked through the same `@autoclosure` `RowActionFacts.route` already
deferred through (`rowState(for:)` still passes `self.rowRoute(for: result)`),
so `RouteInputs` is only built for a row that actually reaches
`.updateAvailable` — the cost `RowActionFacts.route`'s doc comment and
`routeIsDeferred` exist to keep off every other row on every repaint.

One cost change worth stating plainly, not softening: the old ladder
short-circuited, so a Toolbox row called none of `canAutoInstall` /
`requiresInstaller` / `defersToSelfUpdater`, a TestFlight row called none, and a
selfUpdater row called only `defersToSelfUpdater` before returning. Filling
`RouteInputs` calls all three unconditionally for every row that reaches this
function — "always" where it used to be "never" or "one", not "once instead of
twice" the way I first wrote this up. That is the same shape as the
`ListActivity.canOfferUpdateAll` trap CLAUDE.md warns about, and I want to be
explicit that I checked it rather than assumed it away: all three functions are
pure over the `InstallEnvironment` passed in — I read `UpdatePolicy.canAutoInstall`
/ `requiresInstaller` / `defersToSelfUpdater` to confirm neither logs nor
mutates — and `policyEnvironment`'s only expensive field, `elevationRequiredPaths`,
is a memoized cache keyed off `results`, not rebuilt per call. What is left is a
few `Set`/`Dictionary` copies (copy-on-write, so cheap while unmutated) against
that cached set, once per routed row. The `@autoclosure` still keeps the entire
call off rows that never reach `.updateAvailable` — that boundary is unchanged —
this is only about what runs *inside* it once a row crosses that line.

## Pinning the unstated invariant

`.toolbox` / `.testFlight` / `.selfUpdater` are checked ahead of
`.majorUpgrade`, so a major upgrade on one of those routes shows the redirect,
not the licence-boundary warning. Nothing said this on purpose before now; it is
pinned in `selfUpdaterBeatsMajorUpgrade` (and covered for toolbox/testFlight by
the two precedence tests above it) with a comment on `UpdateRoute.resolve`
itself. Believed unreachable today — JetBrains ships calendar versions and
`UpdateResult.isMajorUpgrade` excludes those — and harmless regardless: the
redirect installs nothing here, so there is nothing for the warning to gate.
Behaviour is unchanged; only the statement is new.

## Tests — `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateRouteResolutionTests.swift`

12 tests: every rung reachable alone, pairwise precedence against everything
below it (same shape as `RowActionStateTests.inFlightPrecedence`), the gate as
an OR that needs an install path, and the two payloads (`stagedFileName`,
`managedHere`) carried through unmodified.

Mutants run by hand against `UpdateRoute.resolve`, confirmed red, then reverted
and confirmed green again:

| mutant | caught by |
|---|---|
| move `.majorUpgrade` ahead of toolbox/testFlight/selfUpdater | `toolbox outranks everything below it`, `testFlight outranks everything below it`, `selfUpdater outranks majorUpgrade` |
| drop the `.majorUpgrade` gate (make it unconditional) | `majorUpgrade requires an install path — neither present falls through` |
| swap `.autoInstall` and `.installer` | `autoInstall outranks installer and appStore` |
| swap `.installer` and `.appStore` | `installer outranks appStore` |
| change the gate from `||` to `&&` | `majorUpgrade outranks autoInstall and installer`, `the gate is an OR: either half alone is enough`, `every rung fires when it is the only thing true` |

The first two are the ones the issue asked for explicitly (moved ahead of
toolbox/testFlight/selfUpdater; gate dropped); the other three came from
walking the rest of the ladder the same way.

`routeIsDeferred` in `RowActionStateTests` (unmodified by this PR) is what
actually guards the deferral property — it exercises `RowActionFacts.route`'s
`@autoclosure` directly and does not go through `AppListModel` at all, so it
still pins the mechanism `rowRoute` now relies on. `App/Sources` has no test
target, so there is nowhere to add an equivalent counting test for
`AppListModel.rowRoute` itself; the gallery build (below) is the only
executable check that touches it.

## Verification

```
cd DuoUpdaterCore && swift test 2>&1 | tail -60
```
1918 tests, 150 suites. Two network tests failed on the first run
(`toolboxManagedCopiesResolveDetectionOnly`: a `-1001` timeout probing Android
Studio; `vendorResolvesInstallPlans`: a resolution that came back empty) —
re-running just those two in isolation passed both, confirming vendor-endpoint
flakiness rather than a regression from this change.

```
swift test --package-path CLI
```
184 tests, 24 suites, all green.

```
python3 scripts/check_localizable_keys.py --derived-data /tmp/duo-loc-check-261
python3 scripts/check_staged_version_use.py
python3 scripts/check_app_audits.py
python3 scripts/test_appcast_edit.py
```
All four green (`xcodegen generate` run first with `DUO_TEAM_ID` exported, per
CLAUDE.md, so the localizable-keys checker had a project to scan).

```
GALLERY_DD=/tmp/duo-gallery-261 bash scripts/row-state-gallery.sh
```
Rendered 68/68, no blank tile, no pixel-identical pair. `git status --short
verify/row-states` is empty — this diff does not touch rendering, confirming
the App target still builds and nothing about the row UI changed.

## Not touched

`RowActionState`'s ladder, `RowActionFacts`'s other fields, and everything
under `App/Sources/*RowAction*`, `WorkbenchWindowView.swift`,
`App/RowStateGallery/`, `Localizable.xcstrings`, and `verify/row-states/` — all
out of scope for issue #260, which is reshaping `UpdateRoute.appStore` in
parallel. `git diff --stat` for this PR touches exactly two files plus the new
test file.

## Corrected after review

Two wording claims below were inaccurate and are fixed as of the latest commit
(`Docs: rowRoute's cost comments said the wrong direction`) — the code itself
was not touched:

- The cost paragraph under "The change" originally said `canAutoInstall` /
  `requiresInstaller` moved from being called "up to twice" to "once". Wrong
  direction: the old ladder short-circuited, so Toolbox/TestFlight rows called
  *none* of the three predicates and selfUpdater rows called only one. Filling
  `RouteInputs` calls all three unconditionally now — reworded below to say so,
  plus why that's acceptable (pure predicates, cached elevation set, the
  `@autoclosure` boundary unchanged).
- The comment above `let requiresInstaller` in `AppListModel.swift` said
  `stagedPackage(for:)`'s disk stat "only runs when it can matter." Also wrong:
  it now runs whenever `requiresInstaller` is true, including rows that resolve
  to `.majorUpgrade`/`.selfUpdater`/`.toolbox`/`.testFlight` and never reached it
  before. Reworded to say what actually keeps it cheap — the
  `stagedPackages[result.id]` dictionary lookup returns `nil` first for nearly
  every row, so the `fileExists` stat behind it rarely runs.

Closes #261
