### PR TITLE
Row status tags: stop borrowing plural/parenthetical translations

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -9341,6 +9341,47 @@
         }
       }
     },
+    "Ignored (row status)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignoriert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignoré"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無視中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорируется"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已忽略"
+          }
+        }
+      }
+    },
     "Ignored apps": {
       "extractionState": "manual",
       "localizations": {
@@ -15609,7 +15650,7 @@
         }
       }
     },
-    "Skipped": {
+    "Skipped (row status)": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -15627,7 +15668,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignoré (version)"
+            "value": "Version ignorée"
           }
         },
         "ja": {

--- a/App/Sources/PopoverRowAction.swift
+++ b/App/Sources/PopoverRowAction.swift
@@ -240,14 +240,17 @@ struct PopoverRowAction: View {
     }
 
     /// Muted tag for an app the user has chosen to ignore — right-click to manage.
+    /// `ignoredRowLabel()` (in `RowActionViews.swift`) is a catalog key distinct
+    /// from the Settings page heading of the same English word — see its doc
+    /// comment for why sharing that key here was wrong.
     private var ignoredTag: some View {
-        Text("Ignored").font(.caption2).foregroundStyle(.tertiary).lineLimit(1).minimumScaleFactor(0.7)
+        Text(ignoredRowLabel()).font(.caption2).foregroundStyle(.tertiary).lineLimit(1).minimumScaleFactor(0.7)
             .help("Hidden from update checks — right-click to stop ignoring")
     }
 
     /// Muted tag for an update whose offered version the user skipped.
     private var skippedTag: some View {
-        Text("Skipped").font(.caption2).foregroundStyle(.tertiary).lineLimit(1).minimumScaleFactor(0.7)
+        Text(skippedRowLabel()).font(.caption2).foregroundStyle(.tertiary).lineLimit(1).minimumScaleFactor(0.7)
             .help("You skipped this version — right-click to un-skip")
     }
 

--- a/App/Sources/RowActionViews.swift
+++ b/App/Sources/RowActionViews.swift
@@ -30,6 +30,26 @@ func installStageLabel(_ stage: InstallStage) -> String {
     }
 }
 
+/// Muted tag for a row hidden from update checks. A distinct catalog key from
+/// `SettingsSection.label` (case `.ignored`) on purpose: that one is a **plural**
+/// page heading ("Ignored" apps), and several languages translated it as such
+/// (es "Ignoradas", fr "Ignorées", ru "Игнорируемые" — all plural). Sharing that
+/// key here read as a plural describing the single app on this row. Shared
+/// between this file and `PopoverRowAction`, same reasoning as `sourceHint`.
+func ignoredRowLabel() -> String {
+    String(localized: "Ignored (row status)", defaultValue: "Ignored",
+           comment: "Muted tag on a single row for an app hidden from update checks. Keep this singular — it is not the plural Settings page heading of the same English word.")
+}
+
+/// Muted tag for a row whose offered version the user skipped. A distinct key
+/// from the popover's original value, which carried a disambiguating
+/// parenthetical sized for a tiny `.caption2` tag (fr: "Ignoré (version)") that
+/// reads oddly once also drawn at the workbench's larger `.callout`.
+func skippedRowLabel() -> String {
+    String(localized: "Skipped (row status)", defaultValue: "Skipped",
+           comment: "Muted tag on a single row for a version the user skipped — short, standalone, no parenthetical qualifier.")
+}
+
 /// The row actions both windows can trigger, as plain closures.
 ///
 /// The views below take these rather than an `AppListModel`, which is what makes
@@ -126,12 +146,12 @@ struct WorkbenchRowAction: View {
             installProgress(stage)
 
         case .ignored:
-            Text("Ignored").font(.callout).foregroundStyle(.tertiary)
+            Text(ignoredRowLabel()).font(.callout).foregroundStyle(.tertiary)
                 .lineLimit(1).minimumScaleFactor(0.7)
                 .help("Hidden from update checks — right-click to stop ignoring")
 
         case .versionSkipped:
-            Text("Skipped").font(.callout).foregroundStyle(.tertiary)
+            Text(skippedRowLabel()).font(.callout).foregroundStyle(.tertiary)
                 .lineLimit(1).minimumScaleFactor(0.7)
                 .help("You skipped this version — right-click to un-skip")
 


### PR DESCRIPTION
## What #259 got wrong

PR #259 pointed both row-status tags at existing catalogue keys instead of
adding near-duplicates. That was right for most reused keys, but two of them
were written for a different context:

- `Ignored` is `SettingsSection.label` for `.ignored` — a **section heading**
  over a *list* of ignored apps. es/fr/ru translated it as a plural.
- `Skipped` was written for the popover's tiny `.caption2` tag only. fr added
  a disambiguating `(version)` parenthetical to keep it apart from `Ignored`
  in that cramped context. #259 also drew it at the workbench's larger
  `.callout`, which is what made the parenthetical read oddly.

Both are now singular, per-row tags at two sizes (`.caption2` in the popover,
`.callout` in the workbench). This PR gives them their own catalogue keys.

## Before / after

| key | lang | before | after | why |
|---|---|---|---|---|
| Ignored | de | Ignoriert | Ignoriert | unchanged — already singular |
| Ignored | es | Ignoradas *(fem. plural)* | **Ignorado** | singular, masculine to match the sibling `Skipped` tag's existing `Omitido` |
| Ignored | fr | Ignorées *(fem. plural)* | **Ignoré** | singular, masculine to match the sibling `Skipped` tag's (old) `Ignoré (version)` |
| Ignored | ja | 無視中 | 無視中 | unchanged — no plural marking in Japanese |
| Ignored | ru | Игнорируемые *(plural adjective)* | **Игнорируется** | 3rd-person singular verb ("is being ignored"), same impersonal-status pattern the sibling `Skipped` tag already uses (`Пропущено`) |
| Ignored | zh-Hans | 已忽略 | 已忽略 | unchanged — no plural marking in Chinese |
| Skipped | de | Übersprungen | Übersprungen | unchanged |
| Skipped | es | Omitido | Omitido | unchanged |
| Skipped | fr | Ignoré (version) | **Version ignorée** | drops the compact-tag parenthetical (reads oddly at `.callout`); explicit noun avoids colliding with the new `Ignoré` above |
| Skipped | ja | スキップ済み | スキップ済み | unchanged |
| Skipped | ru | Пропущено | Пропущено | unchanged |
| Skipped | zh-Hans | 已跳过 | 已跳过 | unchanged |

de/ja/zh-Hans needed no change for either key — flagged correct in the issue
and confirmed unchanged here.

**`Ignorado`/`Ignoré` match a measured convention, not a guess.** Grepped the
whole catalogue for es/fr participle-shaped values: bare status tags are
invariant masculine singular throughout — `Installed`→`Instalado`/`Installé`,
`Updated`→`Actualizado`/`Mis à jour`, `Enabled`→`Activado`/`Activé`,
`Connected`, `Granted`, `Saved`, `Unknown`, `v%@ · up to date`→`· actualizado`/
`· à jour`. Gender/number agreement shows up **only** where the noun is
spelled out: `Ignored apps`→`Apps ignoradas`/`Applications ignorées`,
`Skipped versions`→`Versiones omitidas`/`Versions ignorées`. `Ignored (row
status)` and `Skipped (row status)` are bare tags with no noun in them, so
the invariant-masculine form is what the rest of the catalogue already does
in that shape.

## The fix

Two new catalogue keys, `Ignored (row status)` / `Skipped (row status)`,
following the `String(localized: key, defaultValue:, comment:)` pattern
Apple's Foundation exposes for exactly this — a distinct catalogue key with
the same displayed English text (`Ignored` / `Skipped`, unchanged, so the
gallery's 68 committed PNGs are untouched). Two shared top-level functions in
`RowActionViews.swift` (`ignoredRowLabel()` / `skippedRowLabel()`), same
pattern as the existing `sourceHint(for:)` / `installStageLabel(_:)`, called
from both `RowActionViews.swift` and `PopoverRowAction.swift`.

The old `Ignored` catalogue key is untouched — `SettingsSection.swift` still
uses it, and its plural translations are correct there. The old `Skipped` key
had no other call site, so it's renamed in place rather than left orphaned.

## Swept the other direction

Grepped every `Text("…")` / `String(localized: "…")` / `Label("…")` /
`Picker("…")` literal in `App/Sources` for a key used at more than one call
site, then read each one's context and its six translated values.

**Fixed:** `Ignored`, `Skipped` (above).

**Checked and left alone** — same value, consistent role everywhere it's
used, no plural/heading vs. singular-item mismatch: `Failed`, `Rate-limited`,
`Updated`, `Granted`, `Grant…` (all invariant/singular in every language),
`Saved`, `Restarting…`, `Restart Helper…`, `Turn On Helper…` (same status
word reused across the popover, workbench and Diagnostics settings — one
concept, not two), `Ignore \(name)` / `Skip \(name)` (same context-menu verb
in both windows), `Update` / `Install` / `Open` (infinitive verbs, invariant
by part of speech in every language here).

**Found, not fixed — flagged for a native check:** `SettingsSection.Group`'s
`"App"` heading (groups General/Folders/Updates in the sidebar) shares its
key with `ReleaseLogView`'s app-filter `Picker("App", …)`. ru translates it
as `Приложения` — plural ("Applications"). Structurally similar to the bug
above, but lower confidence: a filter labeled with a plural category name
("Applications:") is a legitimate convention in several languages (English
does the same — "Category: Apps" — even though you pick one), so I don't
have solid grounds to call it wrong in either context, only that the two
contexts happen to share one value. Left unchanged; noting it rather than
guessing at Russian grammar.

**Checked and cleared:** `Removed` (es `Eliminadas`, fr `Supprimées` — both
feminine plural, no noun spelled out, superficially the same shape as this
bug). It is the heading of a collapsible group of entries in
`TrafficWindowView.swift:313`, i.e. genuinely a heading over a list, so the
plural is correct there. Noting it so it isn't re-flagged.

## Verification

- `python3 scripts/check_localizable_keys.py --derived-data /tmp/duo-loc-check-262` (private
  path — a sibling agent is using the default `/tmp/duo-loc-check`):
  `✓ localizable keys agree — 431 in the catalog, all reachable`
- `make install` (Developer ID build + deploy) → `scripts/verify-localizations.sh` passed:
  `de en es fr ja ru zh-Hans` all compiled in.
- **Read the compiled product**, not the source JSON — `plutil -extract` against
  `/Applications/DuoUpdater.app/Contents/Resources/<lang>.lproj/Localizable.strings`
  for both new keys, all six languages: every value matches the table above
  exactly. Also confirmed the *old* `Ignored` key still resolves to the
  original plural `Ignorées` (fr) in the compiled product — the Settings page
  is untouched — and the old `Skipped` key no longer exists in the compiled
  catalog (nothing references it any more).
- **Format-specifier audit**: neither key takes an argument (`Ignored` /
  `Skipped`, no `%@`/`%lld`), so there is nothing for a specifier mismatch to
  hide in any of the twelve values.
- **Width, measured, not eyeballed.** A standalone SwiftUI+AppKit harness
  (not part of this diff) rendered the exact modifiers used at both call
  sites — `.font(.callout)` / `.font(.caption2)`, `.lineLimit(1)`,
  `.minimumScaleFactor(0.7)` — through `ImageRenderer` at 2x scale, and
  measured the unconstrained natural width of every old value against its
  replacement, in the real system font. Every changed string is **narrower or
  equal** to the value it replaces, at both sizes — largest reduction fr
  Ignored, −6.8pt at `.callout`; no value grew. Since the old (wrong) values
  already shipped in this exact slot without a known overflow report, "not
  wider than what already fit" is the concrete claim this proves; I did not
  additionally reproduce the popover's exact remaining-width computation
  (`trailingSlot`/name-column math in `MenuContentView.swift`) because it is
  a `minWidth`, not a hard cap, and the workbench header has ~900pt of
  window width with a `Spacer()` before this tag, so neither call site has a
  fixed budget these strings could exceed.
- **`DuoUpdaterCore`'s test suite structurally cannot see this change.** Core
  compiles neither `App/Sources/` nor `App/Resources/Localizable.xcstrings`
  — it has no dependency on either. The gates above (the key-agreement
  check, the App target building and deploying, the compiled-product
  extraction, `verify/row-states` being empty, and the width measurements)
  are what's actually load-bearing for this diff; `swift test` in
  `DuoUpdaterCore` is not.
- **I did not get a green full `DuoUpdaterCore` run and am not claiming one.**
  Three worktrees ran the full suite against the same local proxy at once;
  this run hung (0% CPU, log flat, one idle proxy connection with nothing
  downloading) and was killed before completing. The one failure it *did*
  record before hanging was `vendorResolvesInstallPlans()` (59.8s, 6 issues
  — `remote?.downloadURL != nil`, `vendorInstallerKind != nil`, the
  `requiresManualInstaller` pairing), a live-network vendor-resolution test.
  Re-run alone, uncontended: `swift test --filter vendorResolvesInstallPlans`
  → `✔ passed after 110.488 seconds`. Passes in isolation, fails under
  three-way proxy congestion — environmental, and this is a test a string
  catalogue change cannot reach. I have not re-run the full suite clean; the
  reviewer is doing one clean run before merge.
- `swift test --package-path CLI`: 184 tests passed.
- `python3 scripts/check_staged_version_use.py`: clean.
- `python3 scripts/check_app_audits.py`: clean.
- `git status --short verify/row-states`: empty — English source text is
  unchanged, so none of the 68 committed gallery PNGs move.

Closes #262
