### PR TITLE
Chronic check failures: divergence between the banner and the row badge is intentional

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -5835,12 +5835,12 @@ final class AppListModel {
     /// by `UpdateResult.id` (the install path). In memory only — a fresh launch
     /// starts everyone at zero, which is the right bias: after a relaunch we have no
     /// evidence a failure is chronic and should say so once more.
+    ///
+    /// This is the ONLY place a chronic streak is tracked. `RowAction.state(for:)`
+    /// — the ladder both the popover and the workbench draw a row from — has no
+    /// notion of it and is not meant to: see `failedCheckResults` below and
+    /// `CheckFailureRules` for why (issue #264).
     @ObservationIgnored private var consecutiveCheckFailures: [String: Int] = [:]
-
-    /// Rows this many rounds deep stop driving the banner and the header count.
-    /// Three rounds of a check interval (an hour by default) is long past the point
-    /// where "retry" is the useful advice.
-    private static let chronicFailureThreshold = 3
 
     /// Update the streaks from one completed round, and drop rows that are gone.
     /// Called only from `performRefresh` — deliberately NOT from `retryFailedChecks`,
@@ -5854,7 +5854,7 @@ final class AppListModel {
             }
         }
         let newlyChronic = next.filter {
-            $0.value == Self.chronicFailureThreshold
+            $0.value == CheckFailureRules.chronicThreshold
         }.keys.sorted()
         if !newlyChronic.isEmpty {
             Log.app.info(
@@ -5863,16 +5863,30 @@ final class AppListModel {
         consecutiveCheckFailures = next
     }
 
+    /// Rows this many rounds deep stop driving the *aggregate* surfaces below —
+    /// the banner, the header's "N not checked" line, and the bulk-retry target
+    /// list. They do NOT stop being `.checkFailed` rows: `RowAction.state(for:)`
+    /// never reads `consecutiveCheckFailures` (it has no parameter for it), so a
+    /// chronic row keeps its own orange Failed badge — with its own per-row
+    /// Retry, which re-checks only this app rather than every failed row the way
+    /// the banner's Retry does — for as long as it keeps failing.
+    ///
+    /// That split is deliberate, not an oversight (issue #264): the banner is one
+    /// global claim ("your checks are healthy") that becomes false advice once a
+    /// failure is permanent — a vendor that retired its feed fails identically
+    /// forever, and Alfred's appcast did exactly that for weeks. Left counted, it
+    /// pins the banner up with a Retry that just re-runs the same 404, and stops
+    /// the header from ever reading "up to date" again. A row's own badge makes
+    /// no such claim; it states one fact about one app, and that fact stays true.
+    /// Silencing it would blank the row in the workbench, which shows every
+    /// result unconditionally (no "Show all" gate) — and a blank row there reads
+    /// as "up to date", which is the specific failure mode `RowActionState`
+    /// exists to rule out for every non-quiet state. See `CheckFailureRules`.
     var failedCheckResults: [UpdateResult] {
         results.filter {
             guard case .error = $0.status else { return false }
-            // A vendor that retired its feed fails identically forever — Alfred's
-            // appcast 404'd for weeks. Left in, that pins the banner permanently with
-            // a Retry button that re-runs the same 404, and stops the header from
-            // ever reading "up to date" again. Those rows fall back to the old
-            // behaviour: visible under "Show all", reported by `RecipeHealth` and
-            // `duo verify`, and silent here.
-            return (consecutiveCheckFailures[$0.id] ?? 0) < Self.chronicFailureThreshold
+            return !CheckFailureRules.isChronic(
+                consecutiveFailures: consecutiveCheckFailures[$0.id] ?? 0)
         }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/CheckFailureRules.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/CheckFailureRules.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// How many consecutive check failures make a row "chronic" — worth suppressing
+/// from `AppListModel`'s *aggregate* opinions about the whole list, never from a
+/// row's own account of itself.
+///
+/// `AppListModel.failedCheckResults` uses this to drop a row from the failed-check
+/// banner, the header's "N of M apps not checked" line, and the bulk-retry target
+/// list: a vendor that retired its feed fails identically forever (Alfred's
+/// appcast 404'd for weeks), and left counted there it pins a banner permanently
+/// with a Retry that just re-runs the same 404.
+///
+/// `RowActionState`/`RowAction.state(for:)` deliberately does NOT read this. A
+/// chronic streak does not make "this check failed" stop being true of the row,
+/// and the row's own Failed badge — with its own per-row Retry that re-checks
+/// only this app, unlike the banner's Retry which re-runs every failed check —
+/// stays exactly as informative whether the streak is one round old or thirty.
+/// Suppressing it would make a chronically failing app in the workbench (which
+/// shows every row unconditionally, with no "Show all" gate) render as nothing,
+/// which reads as "up to date" in a window that otherwise reserves blank for
+/// exactly that — see issue #264.
+public enum CheckFailureRules {
+    /// Three rounds of a check interval (an hour by default) is long past the
+    /// point where "retry" is the useful advice — for the banner. See the type
+    /// doc for why a row's own state does not use this at all.
+    public static let chronicThreshold = 3
+
+    /// Whether a row this many consecutive rounds deep should stop driving the
+    /// aggregate surfaces built from `AppListModel.failedCheckResults`.
+    public static func isChronic(consecutiveFailures: Int) -> Bool {
+        consecutiveFailures >= chronicThreshold
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
@@ -58,6 +58,18 @@ public enum RowActionState: Sendable, Equatable {
     /// re-derive it from `UpdateStatus` — doing that is how the popover drifted
     /// back into having a second opinion. Retryable, and NOT the same as having
     /// nothing to do, which is how a blank row reads.
+    ///
+    /// Deliberately carries no notion of how many rounds in a row this row has
+    /// failed. `AppListModel` tracks that streak (`consecutiveCheckFailures`) and
+    /// uses it to drop a chronically-failing row from the *aggregate* surfaces —
+    /// the failed-check banner, the header count, the bulk-retry target list —
+    /// once a failure looks permanent (a retired vendor feed fails identically
+    /// forever). That is a call about whether the WHOLE-LIST claim "your checks
+    /// are healthy" still holds; it says nothing about whether THIS row's own
+    /// fact ("this check failed") is still true, which it always is until a
+    /// check actually succeeds. So this state stays exactly as retryable at
+    /// round 30 as at round 1 — see `AppListModel.failedCheckResults` and
+    /// `CheckFailureRules` for the full reasoning (issue #264).
     case checkFailed(message: String, rateLimited: Bool)
     /// No source covers this app. Nothing was tried; nothing to retry. Carries
     /// what to name instead of an action — a view used to re-derive this from

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CheckFailureRulesTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CheckFailureRulesTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import DuoUpdaterCore
+
+/// Pins the one guard `AppListModel.failedCheckResults` leans on to decide
+/// whether a chronically-failing row still drives the aggregate surfaces (the
+/// failed-check banner, the header's "N not checked" line, the bulk-retry
+/// target list). See `CheckFailureRules` and issue #264 for why this predicate
+/// exists and, just as importantly, why `RowActionState` — the per-row ladder
+/// both windows draw from — never reads it. `RowActionStateTests
+/// .checkFailureIsExplained` is the other half of that pin: it fixes
+/// `RowAction.state(for:)` for an `.error` status as a function of the message
+/// and the rate-limit flag ONLY, with no parameter for a streak to arrive
+/// through in the first place.
+@Suite("CheckFailureRules")
+struct CheckFailureRulesTests {
+
+    /// The boundary is the whole content of this guard: one round short of the
+    /// threshold is not chronic yet, exactly at it is. Delete the `>=` in favor
+    /// of `>` and this goes red at the threshold; delete it in favor of `<` (or
+    /// hardcode `true`/`false`) and one side or the other goes red.
+    @Test("chronic starts exactly at the threshold, not one round early or late")
+    func boundary() {
+        #expect(CheckFailureRules.isChronic(consecutiveFailures: 0) == false)
+        #expect(CheckFailureRules.isChronic(
+            consecutiveFailures: CheckFailureRules.chronicThreshold - 1) == false)
+        #expect(CheckFailureRules.isChronic(
+            consecutiveFailures: CheckFailureRules.chronicThreshold) == true)
+        #expect(CheckFailureRules.isChronic(
+            consecutiveFailures: CheckFailureRules.chronicThreshold + 10) == true)
+    }
+}


### PR DESCRIPTION
Issue #264: `AppListModel.failedCheckResults` excludes a row after 3 consecutive
`.error` rounds from the failed-check banner; `RowAction.state(for:)` has no such
notion, so the same row's badge nags forever. The issue asks: carry `chronic`
into `RowActionFacts` and let the ladder answer it, or write down that the split
is intended and why.

## Decision: the divergence is intentional. Documented it, did not change the ladder.

The banner and the per-row badge are not the same claim, and suppressing one is
not the same call as suppressing the other:

- **The banner is one global claim** — "your checks are healthy" — with **one
  Retry that reruns every failed check**, including whichever ones are
  permanently dead. Once a failure looks permanent (a vendor retired its feed —
  Alfred's appcast 404'd for weeks), that claim is false and that Retry is
  wasted work every time the popover opens. Excluding chronic rows from it is
  correct and unrelated to what any individual row says about itself.
- **The badge is a fact about one row**, with its **own per-row Retry that
  re-checks only that app** (`AppListModel.retry(_:)`, wired in both windows —
  see `MenuContentView.swift:969` / `WorkbenchWindowView.swift:1009`), not the
  bulk one the banner uses. "This check has failed" does not stop being true
  because it has been failing for a while; if anything a long streak is *more*
  worth knowing, not less.

**What a chronically-failing row looks like today, in each window — traced,
not assumed:**

- **Popover, default view.** Never shown, chronic or not: `MenuContentView
  .visible` filters on `model.needsAction(_:)`, which only counts actionable
  updates / restarts / staged relaunches — `.error` never qualifies, so an
  `.error` row (chronic or fresh) is invisible here regardless. Chronic-ness
  changes nothing about this window's default view.
- **Popover, "Show all".** Every row renders, including every `.error` row.
  `RowAction.state` maps it to `.checkFailed`, and `PopoverRowAction
  .errorBadge` draws the orange "Failed"/"Rate-limited" text + a `↻` Retry
  button — identically whether the row is one round or thirty rounds deep.
- **Workbench.** `WorkbenchWindowView.apps` is `model.results` filtered only by
  source (`!= "Homebrew"`) — **no `needsAction`/"Show all" gate at all**.
  Every result is a row, always. A chronic `.error` row draws the same
  Failed/Retry badge as popover's Show-all view (`RowActionViews.swift:176`,
  shared with the popover since #259).

`VisibilityRules` (Core) has nothing to do with any of this — it only answers
"is this app ignored" and "is this version skipped"; it has no branch for
check failures at all, chronic or not.

**Why the badge must not go quiet:** the workbench shows every row
unconditionally. If a chronic row's badge were blanked or demoted to
something silent, the row would render the same as an up-to-date row in the
one window that has no other cue — exactly the "空白被读成没事" failure mode
`CLAUDE.md` documents for this workbench (the reason #259 gave it real
branches for `.error`/`.unknown`/managed/ignored/skipped in the first place,
instead of `EmptyView`). A row that silently stops reporting is worse than
one that keeps nagging.

**Is `consecutiveCheckFailures` reachable and cheap at the point facts are
built?** Yes on both counts, which is why I didn't reject the "carry it into
`RowActionFacts`" option on feasibility grounds — `AppListModel.rowState(for:)`
is a method on the same object that owns `consecutiveCheckFailures`, and a
dictionary lookup by `result.id` costs the same as the half-dozen other
lookups (`relaunching.contains`, `installing[result.id]`,
`pendingBatchRestart[result.id]`, …) it already does inline per row per
redraw. Feasibility isn't what settles this — the blank-row risk above does.

**Would a `chronic:` flag on the existing `.checkFailed` payload (no rendering
change) be safer than nothing?** No — it would be worse than nothing: an
unused field is a fabricated fact nobody asked for, and `make gallery`'s
collision gate would immediately (and correctly) flag "chronic" and
"non-chronic" `.checkFailed` tiles as identical pixels — a real collision,
not a fixture problem, since nothing would read the flag to draw them
differently. Better to not carry information the state has nowhere to spend.

## What changed

Not the ladder — the divergence needed a home to be pinned down, and
`AppListModel`'s own threshold was a private `App`-target constant, which
`CLAUDE.md` already flags as the wrong place for anything that needs a test
(`App/project.yml` carries no test target; nothing in `App/Sources` runs).
So:

- **`DuoUpdaterCore/.../Engine/CheckFailureRules.swift`** (new): extracts the
  boundary AppListModel was comparing against inline
  (`consecutiveFailures >= chronicThreshold`, threshold `3`) into a small,
  testable Core type, with the "why doesn't `RowActionState` read this"
  reasoning written down where the next person will find it.
- **`AppListModel.swift`**: `failedCheckResults` and `recordCheckOutcomes` now
  call `CheckFailureRules` instead of a private constant. No behavior change —
  same threshold, same comparison, same log line. Doc comments on
  `consecutiveCheckFailures` and `failedCheckResults` cross-reference
  `RowActionState.checkFailed` and this issue.
- **`RowActionState.swift`**: `.checkFailed`'s doc comment cross-references
  `AppListModel.failedCheckResults` / `CheckFailureRules`, spelling out why the
  case deliberately carries no streak.
- **`CheckFailureRulesTests.swift`** (new): pins the boundary.

No new `RowActionState` case, no `RowActionFacts` field, no view change — so
no gallery tile changes either (confirmed below).

## Mutants (the one new guard: `CheckFailureRules.isChronic`)

| mutant | result |
|---|---|
| `>=` → `>` | `CheckFailureRulesTests.boundary` fails: `isChronic(consecutiveFailures: chronicThreshold)` now reads `false` |
| body hardcoded to `true` | fails: the two "not yet chronic" assertions (`0`, `threshold - 1`) go red |
| body hardcoded to `false` | fails: the two "chronic" assertions (`threshold`, `threshold + 10`) go red |

All three applied to the working tree, run with `swift test --filter
CheckFailureRules`, confirmed red for the expected reason, then reverted
(diffed back to zero against the pre-mutation file) before committing.

## Verification

```
cd DuoUpdaterCore && swift test
  # 1927 tests, 152 suites, 1 known issue, all passing (40.3s)
swift test --package-path CLI
  # 184 tests, 24 suites, passing
python3 scripts/check_localizable_keys.py --derived-data /tmp/duo-loc-check-264
  # 431 keys, all reachable
python3 scripts/check_staged_version_use.py
  # unaffected, still clean
python3 scripts/check_app_audits.py
  # unaffected, still clean
python3 scripts/test_appcast_edit.py
  # 45 tests, passing
GALLERY_DD=/tmp/duo-gallery-264 bash scripts/row-state-gallery.sh
  # rendered 80 states
  # NOT FAITHFUL: popover/18, popover/21, popover/22, popover/37, workbench/37
  #   (pre-existing, unrelated to this change — see #269)
  # no state renders blank
  # no two states draw the same tile
```

Zero PNG diffs against `main`, except one that isn't real: re-running the
gallery twice, byte-for-byte identical code both times, reproducibly
re-encoded `workbench/04-just-updated.png` 5 bytes different
(`compare -metric AE` / RMSE: well under one pixel-equivalent — not a content
change). #270's own PR body hit and documented this exact same tile the same
way during its rebase. Reverted rather than carry unrelated noise; not
something this issue touches or fixes.

Closes #264
