### PR TITLE
fix(core): parse dashed release dates

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1341,23 +1341,25 @@ final class AppListModel {
     }
 
     /// Log every release in `checked` that arrived with a trustworthy vendor
-    /// timestamp into the release timeline, then refresh the UI snapshot. The
-    /// store dedupes by (app, version), so re-checks are cheap; only a genuinely
-    /// new release or changed display metadata writes the timeline file. Results
-    /// without a `publishedAt` (vendor probes, MAS, Homebrew) use the observation
-    /// path below rather than this exact-timestamp path.
+    /// date into the release timeline, then refresh the UI snapshot. The store
+    /// dedupes by (app, version), so re-checks are cheap; only a genuinely new
+    /// release or changed display metadata writes the timeline file. Results
+    /// with neither a `publishedAt` nor a `vendorDay` (vendor probes, MAS,
+    /// Homebrew) use the observation path below rather than this path.
     private func recordReleaseTimeline(for checked: [UpdateResult]) async {
         for result in checked {
             guard let remote = result.remote else { continue }
-            // The latest release (when it carries a date)…
-            if remote.publishedAt != nil {
+            // The latest release (when it carries a date, at either the minute
+            // or the day tier — see `ReleaseTimeline`'s three-tier doc)…
+            if remote.publishedAt != nil || remote.vendorDay != nil {
                 await releaseTimelineStore.record(
                     appID: result.app.id,
                     appName: result.app.name,
                     bundleID: result.app.bundleID,
                     version: remote.displayVersion,
                     sourceName: remote.sourceName,
-                    publishedAt: remote.publishedAt
+                    publishedAt: remote.publishedAt,
+                    vendorDay: remote.vendorDay
                 )
             }
             // …plus any prior releases the source surfaced (Sparkle appcast items,
@@ -1370,22 +1372,23 @@ final class AppListModel {
                     bundleID: result.app.bundleID,
                     version: entry.version,
                     sourceName: remote.sourceName,
-                    publishedAt: entry.publishedAt
+                    publishedAt: entry.publishedAt,
+                    vendorDay: entry.vendorDay
                 )
             }
             // Detection-only sources (a vendor probe, a Homebrew cask, the App
-            // Store) report a version but no date. We can't know when they shipped,
-            // only that a version *change* happened between two checks — so track
-            // the reported version and, on a change, log an estimated window.
-            // Build-aware, so a vendor that ships many builds under one marketing
-            // name records one event per RELEASE rather than one for the whole
-            // name. Amp published ten builds as "1.0" in a day; keyed on the
+            // Store) report a version but no date at all. We can't know when they
+            // shipped, only that a version *change* happened between two checks —
+            // so track the reported version and, on a change, log an estimated
+            // window. Build-aware, so a vendor that ships many builds under one
+            // marketing name records one event per RELEASE rather than one for the
+            // whole name. Amp published ten builds as "1.0" in a day; keyed on the
             // marketing string the timeline logged exactly one of them.
             //
             // Events written by earlier builds keep their marketing-only key and
             // are deliberately not rewritten: the history they under-counted
             // cannot be recovered, and re-deriving it would invent dates.
-            if remote.publishedAt == nil, remote.releaseHistory.isEmpty,
+            if remote.publishedAt == nil, remote.vendorDay == nil, remote.releaseHistory.isEmpty,
                case let side = remote.versionSide, !side.isEmpty,
                case let v = side.text(withBuild: true), !v.isEmpty {
                 await releaseTimelineStore.observeForChange(

--- a/App/Sources/ReleaseLogView.swift
+++ b/App/Sources/ReleaseLogView.swift
@@ -199,6 +199,10 @@ private struct ReleaseRow: View {
             Text(published.formatted(date: .omitted, time: .shortened))
                 .font(.caption).foregroundStyle(.secondary).monospacedDigit()
                 .help("Published \(published.formatted(date: .abbreviated, time: .standard))")
+        } else if let day = event.event.vendorDay {
+            Text(day.formatted(ReleaseTiming.vendorDayStyle))
+                .font(.caption).foregroundStyle(.secondary).monospacedDigit()
+                .help(ReleaseTiming.vendorDayHelp(day))
         } else if let range = event.event.estimatedRange {
             Text(ReleaseTiming.approxLabel(range))
                 .font(.caption).foregroundStyle(.tertiary).monospacedDigit()
@@ -210,6 +214,18 @@ private struct ReleaseRow: View {
 /// Compact formatting for an estimated release window, shared by the feed and the
 /// per-app version list.
 enum ReleaseTiming {
+    /// A `vendorDay` names a calendar day the vendor stated, not a moment in our
+    /// own clock — `Date.FormatStyle`'s default `timeZone` is
+    /// `.autoupdatingCurrent`, which would let a UTC-negative reader see the
+    /// UTC-midnight `Date` this holds land on the PREVIOUS calendar day. Always
+    /// render it in the zone it was recorded in, GMT, with no time component (we
+    /// don't have one to show).
+    static let vendorDayStyle = Date.FormatStyle(date: .abbreviated, time: .omitted, timeZone: .gmt)
+
+    static func vendorDayHelp(_ day: Date) -> String {
+        String(localized: "Published on \(day.formatted(vendorDayStyle)) — the vendor gave only a date, not a time.")
+    }
+
     /// "≈ 2:00–6:00 PM" for a tight (≤36h) window, else "≈ within 3d".
     static func approxLabel(_ range: DateInterval) -> String {
         if range.duration <= 36 * 3600 {
@@ -378,6 +394,10 @@ private struct ReleasePatternsView: View {
                     if let published = row.event.publishedAt {
                         Text(published.formatted(date: .abbreviated, time: .shortened))
                             .font(.caption).foregroundStyle(.secondary).monospacedDigit()
+                    } else if let day = row.event.vendorDay {
+                        Text(day.formatted(ReleaseTiming.vendorDayStyle))
+                            .font(.caption).foregroundStyle(.secondary).monospacedDigit()
+                            .help(ReleaseTiming.vendorDayHelp(day))
                     } else if let range = row.event.estimatedRange {
                         Text(range.end.formatted(date: .abbreviated, time: .omitted) + " " + ReleaseTiming.approxLabel(range))
                             .font(.caption).foregroundStyle(.tertiary).monospacedDigit()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -46,12 +46,25 @@ public struct AppStoreAvailability: Sendable, Hashable {
 /// it was published. Sources that hand back a multi-entry feed (a Sparkle appcast,
 /// a GitHub releases list) carry these so the release timeline can backfill an
 /// app's history in one shot, instead of only ever learning the latest.
+///
+/// `publishedAt` and `vendorDay` are the same two tiers `RemoteVersion` and
+/// `ReleaseEvent` carry (see `ReleaseTimelineStore`'s three-tier design):
+/// exactly one is set for an entry that came from a source that could date the
+/// release at all, and both are nil for none of the entries a compliant source
+/// produces (an unparseable date simply isn't turned into an entry).
 public struct ReleaseHistoryEntry: Sendable, Hashable {
     public let version: String
-    public let publishedAt: Date
-    public init(version: String, publishedAt: Date) {
+    /// The vendor's release moment, to the minute. nil when the source could
+    /// only supply a day (see ``vendorDay``).
+    public let publishedAt: Date?
+    /// The vendor's calendar day (UTC start-of-day) for this release, when the
+    /// source stated a day but no time of day. nil when ``publishedAt`` is set.
+    public let vendorDay: Date?
+
+    public init(version: String, publishedAt: Date? = nil, vendorDay: Date? = nil) {
         self.version = version
         self.publishedAt = publishedAt
+        self.vendorDay = vendorDay
     }
 }
 
@@ -188,12 +201,25 @@ public struct RemoteVersion: Sendable, Hashable {
     public let changelogURL: URL?
 
     /// When the vendor *published* this release, parsed from the feed's own
-    /// timestamp (Sparkle `<pubDate>`, GitHub/Alcove `published_at`). This is the
-    /// authoritative release moment — to the minute — that the release timeline
-    /// records. Nil for sources that publish no trustworthy date (most vendor
-    /// probes, MAS, Homebrew); those are never plotted as "when it was released",
-    /// only ever as "when we noticed". See `ReleaseTimelineStore`.
+    /// timestamp (Sparkle `<pubDate>`, GitHub/Alcove `published_at`), when that
+    /// timestamp names a real time of day. This is the authoritative release
+    /// moment — to the minute — that the release timeline records. Nil for
+    /// sources that publish no trustworthy time (most vendor probes, MAS,
+    /// Homebrew, and any feed that names only a day — see ``vendorDay``); those
+    /// are never plotted as "when it was released", only ever as "when we
+    /// noticed" (or, for `vendorDay`, "what day it was"). See `ReleaseTimelineStore`.
     public let publishedAt: Date?
+
+    /// When the vendor published this release, to the DAY only — set when the
+    /// feed's own timestamp names a calendar day but no time (e.g. a bare
+    /// `"2026-08-31"` `<pubDate>`). A real vendor-stated fact, but never eligible
+    /// to stand in for ``publishedAt``: we don't know the hour, and often not
+    /// even the vendor's time zone, so inventing either would be a fabrication.
+    /// The release timeline records this at its own tier — shown as a date only,
+    /// never plotted on the release-habits heatmap. Mutually exclusive with
+    /// ``publishedAt``: a source sets at most one of the two per release. See
+    /// `ReleaseDate.parseWithPrecision` and `ReleaseTimelineStore`.
+    public let vendorDay: Date?
 
     /// Past releases the source surfaced alongside the latest — every dated entry
     /// in a Sparkle appcast / GitHub releases list, so the timeline can backfill
@@ -230,6 +256,7 @@ public struct RemoteVersion: Sendable, Hashable {
         structuredChangelog: Changelog? = nil,
         changelogURL: URL? = nil,
         publishedAt: Date? = nil,
+        vendorDay: Date? = nil,
         releaseHistory: [ReleaseHistoryEntry] = [],
         deltas: [DeltaPatch] = []
     ) {
@@ -255,6 +282,7 @@ public struct RemoteVersion: Sendable, Hashable {
         self.structuredChangelog = structuredChangelog
         self.changelogURL = changelogURL
         self.publishedAt = publishedAt
+        self.vendorDay = vendorDay
         self.releaseHistory = releaseHistory
         self.deltas = deltas
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
@@ -5,22 +5,29 @@ import Foundation
 ///
 /// This is deliberately separate from `AppcastMarkdownParser.displayDate`, which
 /// only produces a *display string* and passes most inputs through verbatim. The
-/// release timeline needs an actual `Date` so it can sort and dedupe. Timestamps
-/// preserve their time of day; date-only feeds resolve to midnight UTC. Four wire
+/// release timeline needs an actual `Date` so it can sort and dedupe. Three wire
 /// formats cover the sources we feed from here (Sparkle `<pubDate>`,
 /// GitHub/Alcove `published_at`):
 ///   - RFC822, e.g. "Wed, 24 Jun 2026 17:07:24 +0000" (RSS standard)
 ///   - ISO8601, e.g. "2026-06-24T17:07:24Z" (GitHub, Alcove), with or without
 ///     fractional seconds
-///   - a dashed calendar date, e.g. "2026-06-24"
 ///   - a bare digit run: a Unix epoch in seconds, e.g. "1750785600" (Surge's
 ///     appcast does this), in milliseconds, or a `yyyyMMdd` calendar date — told
 ///     apart by `date(fromDigits:)`, whose rules are documented there
+///
+/// Some feeds only ever publish a bare calendar day (`"2026-08-31"`, no time).
+/// `parse` returns nil for those rather than fabricating a midnight moment the
+/// vendor never stated — the release timeline only plots a `publishedAt` it can
+/// trust to the minute (see `ReleaseTimelineStore`). Use ``parseWithPrecision(_:)``
+/// when the caller has somewhere honest to put a day-only value (`vendorDay`,
+/// not `publishedAt`).
 public enum ReleaseDate {
 
-    /// Convert a raw feed date string to a `Date`, or nil when it's empty or in a
-    /// format we don't recognize. Never throws — an unparseable date just means
-    /// "no authoritative release time", which the timeline records as absent.
+    /// Convert a raw feed date string to a `Date`, or nil when it's empty, in a
+    /// format we don't recognize, or states only a calendar day with no time of
+    /// day (see ``parseWithPrecision(_:)`` for that case). Never throws — an
+    /// unparseable date just means "no authoritative release time", which the
+    /// timeline records as absent.
     public static func parse(_ raw: String?) -> Date? {
         guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else { return nil }
@@ -31,11 +38,6 @@ public enum ReleaseDate {
         // which also accepts "nan", "infinity", "1e9", "0x1p60" and a sign, and
         // read every one of them as epoch seconds.
         if isNumericRun(trimmed) { return date(fromDigits: trimmed) }
-
-        // Some RSS and JSON feeds publish only a calendar day. Keep this branch
-        // shape-gated: DateFormatter otherwise accepts prefixes and non-ASCII
-        // digits that are not the yyyy-MM-dd wire format we mean to support.
-        if let date = date(fromDashedCalendarDay: trimmed) { return date }
 
         // ISO8601 with fractional seconds (e.g. "...:24.123Z"), then without.
         if let date = isoWithFraction.date(from: trimmed) { return date }
@@ -153,6 +155,17 @@ public enum ReleaseDate {
         return f
     }()
 
+    /// A dashed calendar day, `yyyy-MM-dd` — the shape a Sparkle `<pubDate>` or a
+    /// JSON `pub_date`/`releaseDate` field uses when the vendor names only a day
+    /// (Eudic's appcast, Kiro's and Shottr's own version endpoints all do this).
+    /// Only ``parseWithPrecision(_:)`` calls this — `parse` never does, because
+    /// the `Date` this returns is midnight UTC, and handing that back from `parse`
+    /// would let every existing caller mistake a day for a to-the-minute moment.
+    ///
+    /// Shape-gated deliberately: `DateFormatter` otherwise accepts prefixes and
+    /// non-ASCII digits that are not the wire format we mean to support here
+    /// ("2026-8-31", "26-08-31", full-width digits — verified against a real
+    /// `NSDateFormatter` with `isLenient = false`, which accepts all three).
     private static func date(fromDashedCalendarDay value: String) -> Date? {
         let parts = value.split(separator: "-", omittingEmptySubsequences: false)
         guard parts.count == 3,
@@ -209,4 +222,85 @@ public enum ReleaseDate {
             return f
         }
     }()
+}
+
+// MARK: - Precision-aware parsing
+
+extension ReleaseDate {
+    /// What a parsed vendor timestamp actually pins down. `parse(_:)` collapses
+    /// this distinction away (it only ever hands back a to-the-minute moment, or
+    /// nil); ``parseWithPrecision(_:)`` is for callers with somewhere honest to
+    /// put the coarser tier instead of discarding it.
+    public enum Precision: Sendable, Equatable {
+        /// The vendor stated a real time of day — ISO8601 or RFC822, with hours
+        /// and minutes. This is the only precision `ReleaseTimeline.publishedAt`
+        /// may hold; it is what lets the release-habit heatmap trust the hour.
+        case minute
+        /// The vendor stated only a calendar day (`"2026-08-31"`). Real
+        /// information, but any hour we assigned it would be invented — we don't
+        /// even know what time zone the vendor meant. Must flow only as
+        /// `ReleaseTimeline.vendorDay`, never as `publishedAt`.
+        case day
+    }
+
+    /// A feed date parsed alongside the precision it was actually stated at.
+    public struct Parsed: Sendable, Equatable {
+        /// The instant this string names. For `.day` precision this is the start
+        /// of that calendar day in UTC — a real value (useful for display and for
+        /// sorting release history), but not a claim about the time of day.
+        public let date: Date
+        public let precision: Precision
+
+        public init(date: Date, precision: Precision) {
+            self.date = date
+            self.precision = precision
+        }
+    }
+
+    /// Like `parse(_:)`, but keeps the day-only shapes `parse` discards instead of
+    /// collapsing every result to "trustworthy to the minute". Shares every
+    /// formatter and gate `parse` uses — same acceptance, same rejections — so the
+    /// two can never answer "is this parseable?" differently; only what happens to
+    /// a bare calendar day changes.
+    ///
+    /// Nil under the exact conditions `parse` returns nil: empty, unparseable, or
+    /// (unlike `parse`) never for a *bare-digit* `yyyyMMdd` — that shape still
+    /// goes through `date(fromDigits:)` at `.day` precision here too, since it is
+    /// exactly as day-only as the dashed spelling; `parse` keeps returning that one
+    /// as a plain `Date` (pre-existing behavior, unchanged by this type).
+    public static func parseWithPrecision(_ raw: String?) -> Parsed? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+
+        if isNumericRun(trimmed) {
+            guard let value = date(fromDigits: trimmed) else { return nil }
+            let isBareCalendarDay = trimmed.utf8.count == 8 && isDigitRun(trimmed)
+            return Parsed(date: value, precision: isBareCalendarDay ? .day : .minute)
+        }
+
+        if let value = date(fromDashedCalendarDay: trimmed) {
+            return Parsed(date: value, precision: .day)
+        }
+
+        if let value = isoWithFraction.date(from: trimmed) {
+            return Parsed(date: value, precision: .minute)
+        }
+        if let value = isoPlain.date(from: trimmed) {
+            return Parsed(date: value, precision: .minute)
+        }
+
+        for formatter in zonelessISOFormatters {
+            if let value = formatter.date(from: trimmed) {
+                return Parsed(date: value, precision: .minute)
+            }
+        }
+
+        for formatter in rfc822Formatters {
+            if let value = formatter.date(from: trimmed) {
+                return Parsed(date: value, precision: .minute)
+            }
+        }
+
+        return nil
+    }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
@@ -5,13 +5,14 @@ import Foundation
 ///
 /// This is deliberately separate from `AppcastMarkdownParser.displayDate`, which
 /// only produces a *display string* and passes most inputs through verbatim. The
-/// release timeline needs an actual `Date` so it can sort, dedupe, and (later)
-/// answer "what time of day does this vendor ship?" — a question that dies the
-/// moment we round to a bare day. Three wire formats cover every source we feed
-/// from here (Sparkle `<pubDate>`, GitHub/Alcove `published_at`):
+/// release timeline needs an actual `Date` so it can sort and dedupe. Timestamps
+/// preserve their time of day; date-only feeds resolve to midnight UTC. Four wire
+/// formats cover the sources we feed from here (Sparkle `<pubDate>`,
+/// GitHub/Alcove `published_at`):
 ///   - RFC822, e.g. "Wed, 24 Jun 2026 17:07:24 +0000" (RSS standard)
 ///   - ISO8601, e.g. "2026-06-24T17:07:24Z" (GitHub, Alcove), with or without
 ///     fractional seconds
+///   - a dashed calendar date, e.g. "2026-06-24"
 ///   - a bare digit run: a Unix epoch in seconds, e.g. "1750785600" (Surge's
 ///     appcast does this), in milliseconds, or a `yyyyMMdd` calendar date — told
 ///     apart by `date(fromDigits:)`, whose rules are documented there
@@ -30,6 +31,11 @@ public enum ReleaseDate {
         // which also accepts "nan", "infinity", "1e9", "0x1p60" and a sign, and
         // read every one of them as epoch seconds.
         if isNumericRun(trimmed) { return date(fromDigits: trimmed) }
+
+        // Some RSS and JSON feeds publish only a calendar day. Keep this branch
+        // shape-gated: DateFormatter otherwise accepts prefixes and non-ASCII
+        // digits that are not the yyyy-MM-dd wire format we mean to support.
+        if let date = date(fromDashedCalendarDay: trimmed) { return date }
 
         // ISO8601 with fractional seconds (e.g. "...:24.123Z"), then without.
         if let date = isoWithFraction.date(from: trimmed) { return date }
@@ -136,6 +142,27 @@ public enum ReleaseDate {
         f.dateFormat = "yyyyMMdd"
         return f
     }()
+
+    private static let yyyyDashMMdd: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        f.isLenient = false
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    private static func date(fromDashedCalendarDay value: String) -> Date? {
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              parts[0].utf8.count == 4,
+              parts[1].utf8.count == 2,
+              parts[2].utf8.count == 2,
+              parts.allSatisfy({ isDigitRun(String($0)) })
+        else { return nil }
+        return yyyyDashMMdd.date(from: value)
+    }
 
     // MARK: - Formatters
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
@@ -15,19 +15,34 @@ import Foundation
 ///     appcast does this), in milliseconds, or a `yyyyMMdd` calendar date — told
 ///     apart by `date(fromDigits:)`, whose rules are documented there
 ///
-/// Some feeds only ever publish a bare calendar day (`"2026-08-31"`, no time).
-/// `parse` returns nil for those rather than fabricating a midnight moment the
-/// vendor never stated — the release timeline only plots a `publishedAt` it can
-/// trust to the minute (see `ReleaseTimelineStore`). Use ``parseWithPrecision(_:)``
-/// when the caller has somewhere honest to put a day-only value (`vendorDay`,
-/// not `publishedAt`).
+/// Some feeds only ever publish a bare calendar day, no time — most commonly
+/// dashed (`"2026-08-31"`). `parse` returns nil for that spelling rather than
+/// fabricating a midnight moment the vendor never stated — the release timeline
+/// only plots a `publishedAt` it can trust to the minute (see
+/// `ReleaseTimelineStore`). Use ``parseWithPrecision(_:)`` when the caller has
+/// somewhere honest to put a day-only value (`vendorDay`, not `publishedAt`).
+///
+/// ⚠️ EXCEPTION, not swept up in the above: a bare 8-digit run (`"20260831"`) is
+/// ALSO a calendar day with no time, but `parse` still returns a plain `Date`
+/// for it via the `date(fromDigits:)` branch below — pre-existing behavior from
+/// #222, left unchanged here. Fixing it would touch `parse`'s one return path
+/// shared by every caller (`AlcoveUpdateSource`, `GitHubReleasesSource`,
+/// `ElectronManifestSource`, `VendorProbeSource`, and `SparkleAppcastSource`
+/// before this file's `publishedFields`/`releaseHistory` moved off it), which
+/// needs its own decision per caller, not a change riding along with this one.
+/// `parseWithPrecision` tags this shape `.day` too, for what that is worth: it
+/// changes what a *new* caller of that entry point sees, not what `parse`
+/// itself returns.
 public enum ReleaseDate {
 
-    /// Convert a raw feed date string to a `Date`, or nil when it's empty, in a
-    /// format we don't recognize, or states only a calendar day with no time of
-    /// day (see ``parseWithPrecision(_:)`` for that case). Never throws — an
-    /// unparseable date just means "no authoritative release time", which the
-    /// timeline records as absent.
+    /// Convert a raw feed date string to a `Date`, or nil when it's empty or in a
+    /// format we don't recognize. Never throws — an unparseable date just means
+    /// "no authoritative release time", which the timeline records as absent.
+    ///
+    /// Returns nil for a *dashed* date-only day (`"2026-08-31"`) — see
+    /// ``parseWithPrecision(_:)`` for that case — but NOT for a *bare-digit*
+    /// date-only day (`"20260831"`): that one still comes back as a plain `Date`,
+    /// unchanged pre-existing behavior explained on ``ReleaseDate`` above.
     public static func parse(_ raw: String?) -> Date? {
         guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else { return nil }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseStats.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseStats.swift
@@ -22,9 +22,12 @@ public struct ReleaseStats: Sendable, Equatable {
     /// Build the histogram from release events, bucketing each by its publish
     /// instant in `calendar` (whose `timeZone` decides the wall-clock reading).
     ///
-    /// Only the trustworthy tier counts: events with no real `publishedAt`
-    /// (detection-only estimates) are skipped entirely, so a heatmap built from
-    /// this never reflects our polling clock — only when vendors actually shipped.
+    /// Only the to-the-minute tier counts: events with no real `publishedAt` are
+    /// skipped entirely — both `vendorDay` events (a real vendor date, but no
+    /// time of day, so any hour/weekday bucket would be invented) and
+    /// detection-only `estimatedRange` events (our own polling clock, not the
+    /// vendor's). A heatmap built from this only ever reflects when vendors
+    /// stated they actually shipped.
     public init(events: [ReleaseEvent], calendar: Calendar = .current) {
         var hour = Array(repeating: 0, count: 24)
         var weekday = Array(repeating: 0, count: 7)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimeline.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimeline.swift
@@ -1,17 +1,29 @@
 import Foundation
 
-/// One observed release of an app, in one of two confidence tiers that must never
-/// be conflated:
+/// One observed release of an app, in one of three confidence tiers that must
+/// never be conflated:
 ///
 ///  - **Published** (`publishedAt` set): the vendor's own release moment, to the
-///    minute, from a feed that timestamps its releases (Sparkle/GitHub/Alcove).
-///    The only tier the release-habits heatmap is allowed to use.
-///  - **Estimated** (`estimatedRange` set, `publishedAt` nil): for sources that
-///    report a version but no date (a vendor probe, a Homebrew cask, the App
-///    Store). We can't know *when* they shipped, only that it happened between the
-///    last check that still saw the old version and the first that saw the new one
-///    — so we record that window. Honest about its imprecision (a wide window =
-///    low confidence) and kept out of the heatmap entirely.
+///    minute, from a feed that timestamps its releases with a real time of day
+///    (Sparkle/GitHub/Alcove). The only tier the release-habits heatmap is
+///    allowed to use — see `ReleaseStats`.
+///  - **Vendor day** (`vendorDay` set): the vendor stated a release date but no
+///    time of day (a Sparkle `<pubDate>` or JSON field holding a bare
+///    `"2026-08-31"`). Real, vendor-sourced information — unlike `estimatedRange`
+///    below, this is not something *we* measured — but any hour or weekday we
+///    assigned it would be invented (we don't even know the vendor's time zone),
+///    so it is kept out of the heatmap exactly like the estimated tier and shown
+///    as a date only, never a time. See `ReleaseDate.parseWithPrecision`.
+///  - **Estimated** (`estimatedRange` set): for sources that report a version but
+///    no date at all (a vendor probe, a Homebrew cask, the App Store). We can't
+///    know *when* they shipped, only that it happened between the last check
+///    that still saw the old version and the first that saw the new one — so we
+///    record that window. Honest about its imprecision (a wide window = low
+///    confidence) and kept out of the heatmap entirely.
+///
+/// At most one of `publishedAt` / `vendorDay` / `estimatedRange` is set on any
+/// one event — the three are alternatives, not layers, and a caller that finds
+/// more than one set should not trust either.
 ///
 /// `detectedAt` — when our check first recorded this version — is always set, but
 /// reflects our polling cadence and the user's machine being awake, so it's never
@@ -21,10 +33,13 @@ public struct ReleaseEvent: Codable, Sendable, Hashable {
     /// dedupe key within an app — we record each version exactly once.
     public let version: String
     /// The vendor's published timestamp, to the minute — set only for the
-    /// trustworthy tier. nil for estimated (detection-only) events.
+    /// trustworthy tier. nil for vendor-day and estimated (detection-only) events.
     public let publishedAt: Date?
+    /// The vendor's calendar day (UTC start-of-day) for this release, when the
+    /// source stated a day but no time — set only for that tier. nil otherwise.
+    public let vendorDay: Date?
     /// For the estimated tier: the window the release must have happened in
-    /// (last-saw-old → first-saw-new). nil for published events.
+    /// (last-saw-old → first-saw-new). nil for published and vendor-day events.
     public let estimatedRange: DateInterval?
     /// When our check first recorded this version (our observation, not the
     /// vendor's release moment).
@@ -35,23 +50,28 @@ public struct ReleaseEvent: Codable, Sendable, Hashable {
     public init(
         version: String,
         publishedAt: Date? = nil,
+        vendorDay: Date? = nil,
         estimatedRange: DateInterval? = nil,
         detectedAt: Date,
         sourceName: String
     ) {
         self.version = version
         self.publishedAt = publishedAt
+        self.vendorDay = vendorDay
         self.estimatedRange = estimatedRange
         self.detectedAt = detectedAt
         self.sourceName = sourceName
     }
 
-    /// True when this is a detection-window estimate, not a vendor-published date.
-    public var isApproximate: Bool { publishedAt == nil }
+    /// True when this is a detection-window estimate — not a date the vendor
+    /// actually stated. A vendor-day event is real vendor information (just
+    /// coarser than `publishedAt`), so it does NOT count as approximate here.
+    public var isApproximate: Bool { estimatedRange != nil }
 
-    /// The single instant to sort and place this event by: the real publish date
-    /// when known, else the end of the estimated window (when we first saw it).
-    public var timestamp: Date { publishedAt ?? estimatedRange?.end ?? detectedAt }
+    /// The single instant to sort and place this event by: the real publish
+    /// moment when known, else the vendor's day, else the end of the estimated
+    /// window (when we first saw it).
+    public var timestamp: Date { publishedAt ?? vendorDay ?? estimatedRange?.end ?? detectedAt }
 }
 
 /// The release history we've accumulated for a single app, newest-published last.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
@@ -5,12 +5,16 @@ import Foundation
 /// this records what the vendors published — a release history that survives
 /// restarts and, over time, reveals each app's release cadence and habits.
 ///
-/// Only releases that arrive with a trustworthy vendor timestamp are recorded
-/// (Sparkle `<pubDate>`, GitHub/Alcove `published_at`). Sources that can't supply
-/// an honest release date (vendor probes reading a redirect URL, the App Store,
-/// Homebrew) pass `publishedAt == nil` and are silently skipped — far better an
-/// empty timeline than one polluted with our own polling timestamps masquerading
-/// as release moments.
+/// Only releases that arrive with a trustworthy vendor date are recorded, at
+/// whichever of two tiers the vendor actually stated: a real time of day
+/// (`publishedAt` — Sparkle `<pubDate>`, GitHub/Alcove `published_at`) or a bare
+/// calendar day (`vendorDay` — a Sparkle `<pubDate>` or JSON field that names only
+/// a date, no time; see `ReleaseDate.parseWithPrecision`). Sources that can't
+/// supply an honest release date at all (vendor probes reading a redirect URL,
+/// the App Store, Homebrew) pass both as nil and are silently skipped — far
+/// better an empty timeline than one polluted with our own polling timestamps, or
+/// with an hour/weekday `vendorDay` never actually stated, masquerading as
+/// release moments.
 ///
 /// An `actor` so concurrent checks (many apps at once) can record without racing
 /// on the in-memory map or the file write.
@@ -55,11 +59,18 @@ public actor ReleaseTimelineStore {
         self.observations = Self.loadObservations(from: observationsURL)
     }
 
-    /// Record one observed release. No-op when `publishedAt` is nil (the source
-    /// gave no trustworthy date) or when we've already recorded this version for
-    /// this app — each version is logged exactly once, at first sighting, so
-    /// re-checks don't pile up duplicates or drift the recorded `detectedAt`.
-    /// Duplicate sightings may still refresh the timeline's display metadata.
+    /// Record one observed release. No-op when both `publishedAt` and `vendorDay`
+    /// are nil (the source gave no trustworthy date at all) or when we've already
+    /// recorded this version for this app — each version is logged exactly once,
+    /// at first sighting, so re-checks don't pile up duplicates or drift the
+    /// recorded `detectedAt`. Duplicate sightings may still refresh the
+    /// timeline's display metadata.
+    ///
+    /// `publishedAt` and `vendorDay` are alternatives, never both real for the
+    /// same call: a source names one precision for a given release, and passing
+    /// both would leave the stored event claiming two things about the same
+    /// moment. See `ReleaseEvent`'s three-tier doc for why they can't collapse
+    /// into one field.
     ///
     /// - Returns: true if this call added a new event (a release we hadn't seen).
     @discardableResult
@@ -70,9 +81,10 @@ public actor ReleaseTimelineStore {
         version: String?,
         sourceName: String,
         publishedAt: Date?,
+        vendorDay: Date? = nil,
         detectedAt: Date = Date()
     ) -> Bool {
-        guard let publishedAt else { return false }
+        guard publishedAt != nil || vendorDay != nil else { return false }
         guard let version = version?.trimmingCharacters(in: .whitespacesAndNewlines),
               !version.isEmpty else { return false }
 
@@ -96,6 +108,7 @@ public actor ReleaseTimelineStore {
         let event = ReleaseEvent(
             version: version,
             publishedAt: publishedAt,
+            vendorDay: vendorDay,
             detectedAt: detectedAt,
             sourceName: sourceName
         )
@@ -104,7 +117,11 @@ public actor ReleaseTimelineStore {
         timelines[appID] = timeline
 
         timelinesDirty = true
-        Log.app.info("release-log: \(appName, privacy: .public) \(version, privacy: .public) published \(publishedAt, privacy: .public) via \(sourceName, privacy: .public)")
+        if let publishedAt {
+            Log.app.info("release-log: \(appName, privacy: .public) \(version, privacy: .public) published \(publishedAt, privacy: .public) via \(sourceName, privacy: .public)")
+        } else if let vendorDay {
+            Log.app.info("release-log: \(appName, privacy: .public) \(version, privacy: .public) published on \(vendorDay, privacy: .public) (day precision, no time-of-day) via \(sourceName, privacy: .public)")
+        }
         return true
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -63,11 +63,8 @@ public struct SparkleAppcastSource: UpdateSource {
         // last N releases, so this backfills the app's whole visible history into
         // the release timeline in one shot (not just the newest). Keyed on the same
         // version string the timeline dedupes by.
-        let history: [ReleaseHistoryEntry] = usable.compactMap { item in
-            guard let v = item.shortVersionString ?? item.version,
-                  let date = ReleaseDate.parse(item.pubDate) else { return nil }
-            return ReleaseHistoryEntry(version: v, publishedAt: date)
-        }
+        let history = Self.releaseHistory(from: usable)
+        let bestFields = Self.publishedFields(from: best.pubDate)
 
         return RemoteVersion(
             shortVersion: best.shortVersionString,
@@ -81,10 +78,41 @@ public struct SparkleAppcastSource: UpdateSource {
             releaseNotesHTML: best.descriptionHTML,
             structuredChangelog: structured,
             changelogURL: best.releaseNotesLink,
-            publishedAt: ReleaseDate.parse(best.pubDate),
+            publishedAt: bestFields.publishedAt,
+            vendorDay: bestFields.vendorDay,
             releaseHistory: history,
             deltas: best.deltas
         )
+    }
+
+    /// Split a raw `<pubDate>` into the one field it may honestly fill, per
+    /// `ReleaseDate.parseWithPrecision`'s tier: a real time of day becomes
+    /// `publishedAt` — the only tier `ReleaseTimelineStore` may plot to the
+    /// minute — while a bare calendar day (Eudic's appcast ships exactly this:
+    /// `<pubDate>2026-08-31</pubDate>`, #239) becomes `vendorDay` instead of a
+    /// fabricated midnight moment the vendor never stated. Never both, and never
+    /// `publishedAt` for a day-only value — see `ReleaseTimeline`'s three-tier
+    /// doc for why the two must stay separate fields rather than one `Date?`
+    /// with a precision flag beside it.
+    static func publishedFields(from pubDate: String?) -> (publishedAt: Date?, vendorDay: Date?) {
+        guard let parsed = ReleaseDate.parseWithPrecision(pubDate) else { return (nil, nil) }
+        switch parsed.precision {
+        case .minute: return (parsed.date, nil)
+        case .day: return (nil, parsed.date)
+        }
+    }
+
+    /// Every in-channel item with a parseable vendor date, turned into a
+    /// timeline entry at whatever precision the vendor actually stated (see
+    /// ``publishedFields(from:)``). Pure and separated from `latestVersion` so
+    /// the day/minute routing is unit-testable without a network fetch.
+    static func releaseHistory(from usable: [SparkleAppcastItem]) -> [ReleaseHistoryEntry] {
+        usable.compactMap { item in
+            guard let v = item.shortVersionString ?? item.version else { return nil }
+            let fields = publishedFields(from: item.pubDate)
+            guard fields.publishedAt != nil || fields.vendorDay != nil else { return nil }
+            return ReleaseHistoryEntry(version: v, publishedAt: fields.publishedAt, vendorDay: fields.vendorDay)
+        }
     }
 
     /// Build a native changelog from the in-channel items that ship inline notes

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -3887,6 +3887,14 @@ public enum VendorProbeRegistry {
         // Anchor to `"package"` (leading quote) so it never matches `"betaPackage"`
         // — a stable install is never handed the EAP pkg. (Shottr self-updates via
         // its own .pkg updater; this is the fallback behind the same-Team gate.)
+        //
+        // No `publishedAtPattern`: the same body also carries `"releaseDate":
+        // "2025-12-17"` (fetched 2026-08-31) — a bare day, which `ReleaseDate.parse`
+        // does not read (it wants a time), so a pattern here would still be
+        // silently inert. #239 gave that shape somewhere honest to go
+        // (`ReleaseDate.parseWithPrecision` → `RemoteVersion.vendorDay`), but
+        // `VendorProbeSource` itself is not wired to that tier yet — left for the
+        // PR that connects it, not this comment update.
         VendorProbeRecipe(
             bundleID: "cc.ffitch.shottr",
             url: URL(string: "https://shottr.cc/api/version.json")!,
@@ -4517,8 +4525,13 @@ public enum VendorProbeRegistry {
         //
         // The metadata offers a zip where the page offers a dmg; the zip is the
         // same release and unpacks straight into the swap, so it is the better of
-        // the two. `pub_date` is a bare `2026-08-13`, which `ReleaseDate` does not
-        // parse (it wants a time), so no `publishedAtPattern` here.
+        // the two. `pub_date` is a bare `2026-08-13`, which `ReleaseDate.parse`
+        // still does not read (it wants a time) — that contract is unchanged by
+        // #239. A `publishedAtPattern` here would therefore still be silently
+        // inert today: `VendorProbeSource` feeds it through `parse`, not the new
+        // `ReleaseDate.parseWithPrecision`/`RemoteVersion.vendorDay` day tier, so
+        // wiring one up is left for the PR that connects `VendorProbeSource` to
+        // that tier, not this recipe change.
         //
         // Verified 2026-08-16 on the downloaded artifact: Kiro.app 1.0.309,
         // dev.kiro.desktop, Developer ID `AMZN Mobile LLC (94KV3E626L)`, notarized

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseDateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseDateTests.swift
@@ -43,18 +43,64 @@ import Foundation
     #expect(date == Date(timeIntervalSince1970: 1_782_320_844))
 }
 
-@Test func parsesDashedCalendarDateAtMidnightUTC() {
-    #expect(ReleaseDate.parse("2026-08-31")
-        == Date(timeIntervalSince1970: 1_788_134_400))
-    #expect(ReleaseDate.parse("  2026-08-31\n")
+@Test func parseReturnsNilForADashedCalendarDayNeverAFabricatedMidnight() {
+    // #239: "2026-08-31" IS a real, parseable date (Eudic's <pubDate> uses this
+    // shape) — but `parse` must not hand it back as a plain `Date`, because every
+    // existing caller (SparkleAppcastSource et al.) treats a non-nil `parse`
+    // result as trustworthy to the minute. Day-only values only ever reach a
+    // caller through `parseWithPrecision`, tagged `.day`.
+    #expect(ReleaseDate.parse("2026-08-31") == nil)
+    #expect(ReleaseDate.parse("  2026-08-31\n") == nil)
+}
+
+// MARK: - parseWithPrecision
+
+@Test func parseWithPrecisionReadsADashedCalendarDayAsDayPrecision() {
+    let parsed = ReleaseDate.parseWithPrecision("2026-08-31")
+    #expect(parsed?.date == Date(timeIntervalSince1970: 1_788_134_400))
+    #expect(parsed?.precision == .day)
+    // Whitespace-trimming matches `parse`.
+    #expect(ReleaseDate.parseWithPrecision("  2026-08-31\n")?.date
         == Date(timeIntervalSince1970: 1_788_134_400))
 }
 
-@Test func dashedCalendarDateIsExactAndNonLenient() {
-    for raw in ["2026-02-29", "2026-13-01", "2026-8-31", "26-08-31",
-                "2026-08-31junk", "２０２６-０８-３１"] {
-        #expect(ReleaseDate.parse(raw) == nil, "\(raw) is not a yyyy-MM-dd calendar day")
+@Test func parseWithPrecisionAgreesWithParseOnEveryMinutePreciseShape() {
+    // ISO8601 (with/without fraction), zone-less ISO, RFC822: `parseWithPrecision`
+    // must read the same instant as `parse`, tagged `.minute` — the two can never
+    // be allowed to answer "is this parseable?" differently.
+    for raw in [
+        "2026-06-24T17:07:24Z", "2026-06-24T17:07:24.512Z",
+        "2026-08-14T22:50:24.042387", "2026-08-14T22:50:24",
+        "Wed, 24 Jun 2026 17:07:24 +0000", "Wed, 24 Jun 2026 17:07:24 GMT",
+        "1782320844",
+    ] {
+        let viaParse = ReleaseDate.parse(raw)
+        let viaPrecision = ReleaseDate.parseWithPrecision(raw)
+        #expect(viaParse != nil, "\(raw)")
+        #expect(viaPrecision?.date == viaParse, "\(raw)")
+        #expect(viaPrecision?.precision == .minute, "\(raw)")
     }
+}
+
+@Test func parseWithPrecisionReadsABareEightDigitCalendarDateAsDayPrecision() {
+    // `parse("20260614")` already returns a plain `Date` (pre-existing, #222) —
+    // unchanged here. But it is exactly as day-only as the dashed spelling, so
+    // `parseWithPrecision` tags it `.day` too, for any future caller that reaches
+    // this shape through the precision-aware entry point.
+    let parsed = ReleaseDate.parseWithPrecision("20260614")
+    #expect(parsed?.date == Date(timeIntervalSince1970: 1_781_395_200))
+    #expect(parsed?.precision == .day)
+    // A 13-digit millisecond epoch is a real instant, not a bare day.
+    #expect(ReleaseDate.parseWithPrecision("1750785600000")?.precision == .minute)
+}
+
+@Test func parseWithPrecisionRejectsExactlyWhatParseRejects() {
+    for raw in ["2026-02-29", "2026-13-01", "2026-8-31", "26-08-31",
+                "2026-08-31junk", "２０２６-０８-３１", "not a date", "", "   "] {
+        #expect(ReleaseDate.parseWithPrecision(raw) == nil, "\(raw)")
+        #expect(ReleaseDate.parse(raw) == nil, "\(raw)")
+    }
+    #expect(ReleaseDate.parseWithPrecision(nil) == nil)
 }
 
 // MARK: - Bare digit runs

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseDateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseDateTests.swift
@@ -43,6 +43,20 @@ import Foundation
     #expect(date == Date(timeIntervalSince1970: 1_782_320_844))
 }
 
+@Test func parsesDashedCalendarDateAtMidnightUTC() {
+    #expect(ReleaseDate.parse("2026-08-31")
+        == Date(timeIntervalSince1970: 1_788_134_400))
+    #expect(ReleaseDate.parse("  2026-08-31\n")
+        == Date(timeIntervalSince1970: 1_788_134_400))
+}
+
+@Test func dashedCalendarDateIsExactAndNonLenient() {
+    for raw in ["2026-02-29", "2026-13-01", "2026-8-31", "26-08-31",
+                "2026-08-31junk", "２０２６-０８-３１"] {
+        #expect(ReleaseDate.parse(raw) == nil, "\(raw) is not a yyyy-MM-dd calendar day")
+    }
+}
+
 // MARK: - Bare digit runs
 
 /// A bare number used to be handed to `TimeInterval(String)` and read as epoch

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseStatsTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseStatsTests.swift
@@ -84,6 +84,24 @@ private func event(_ day: Int, _ hour: Int, version: String) -> ReleaseEvent {
     #expect(stats.byHour[9] == 0)        // the estimate's hour is not plotted
 }
 
+/// #239: a `vendorDay` event is real vendor information (unlike the
+/// detection-only estimate above), but still carries no time of day — plotting
+/// it would mean inventing an hour, and possibly a weekday, the vendor never
+/// stated. Must be excluded exactly like the estimated tier.
+@Test func vendorDayEventsAreExcludedEvenThoughTheyAreNotDetectionOnly() {
+    let published = event(24, 17, version: "1")
+    let dayOnly = ReleaseEvent(
+        version: "2",
+        vendorDay: utc.date(from: DateComponents(year: 2026, month: 6, day: 24, hour: 9))!,
+        detectedAt: utc.date(from: DateComponents(year: 2026, month: 6, day: 24, hour: 9))!,
+        sourceName: "Sparkle")
+    #expect(dayOnly.isApproximate == false, "a vendor-stated day is not a detection guess")
+    let stats = ReleaseStats(events: [published, dayOnly], calendar: utc)
+    #expect(stats.total == 1)            // only the minute-precise one counts
+    #expect(stats.byHour[17] == 1)       // Wed 17:00 (published)
+    #expect(stats.byHour[9] == 0)        // the vendor day's arbitrary hour is not plotted
+}
+
 @Test func timeZoneShiftsTheBucket() {
     // 23:00 UTC on Wed the 24th is 08:00 the next day (Thu) in UTC+9.
     var jst = Calendar(identifier: .gregorian)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
@@ -218,6 +218,44 @@ private let d3 = Date(timeIntervalSince1970: 1_720_000_000)
     #expect(await store.totalEvents() == 0)
 }
 
+// MARK: - Vendor-day tier (day precision, no time of day)
+
+@Test func recordsAReleaseWithOnlyAVendorDay() async {
+    // Eudic's shape (#239): the feed states a calendar day, not a time.
+    let store = ReleaseTimelineStore(fileURL: tempFileURL())
+    let added = await store.record(
+        appID: "/Applications/Eudic.app", appName: "Eudic", bundleID: "com.eusoft.eudic",
+        version: "26.9.0", sourceName: "Sparkle", publishedAt: nil, vendorDay: d1)
+    #expect(added)
+    let e = await store.timeline(forAppID: "/Applications/Eudic.app")?.events.first
+    #expect(e?.version == "26.9.0")
+    #expect(e?.publishedAt == nil)
+    #expect(e?.vendorDay == d1)
+    // A vendor-stated day is real vendor information, not a detection guess.
+    #expect(e?.isApproximate == false)
+    #expect(e?.timestamp == d1)
+}
+
+@Test func vendorDayAloneIsEnoughToRecordAndPublishedAtAloneStillIs() async {
+    let store = ReleaseTimelineStore(fileURL: tempFileURL())
+    // Neither date at all → still skipped, exactly as before this tier existed.
+    let skipped = await store.record(appID: "/n.app", appName: "N", bundleID: nil,
+        version: "1", sourceName: "Vendor", publishedAt: nil, vendorDay: nil)
+    #expect(!skipped)
+    #expect(await store.totalEvents() == 0)
+}
+
+/// `publishedAt`, when present, is still what `timestamp` sorts and plots by —
+/// a real time of day outranks a same-release day-only stamp from a different
+/// field on the same call (this shouldn't happen in practice; the sources that
+/// populate `vendorDay` only do so when `publishedAt` is nil, but the store's
+/// own ordering rule should not depend on callers upholding that).
+@Test func publishedAtOutranksVendorDayInTimestampWhenBothAreSomehowSet() {
+    let event = ReleaseEvent(
+        version: "1", publishedAt: d2, vendorDay: d1, detectedAt: d3, sourceName: "Sparkle")
+    #expect(event.timestamp == d2)
+}
+
 @Test func estimatedBaselinePersistsAcrossReload() async {
     let url = tempFileURL()
     let store = ReleaseTimelineStore(fileURL: url)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleReleaseDatePrecisionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleReleaseDatePrecisionTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// #239: date-only vendor timestamps ("2026-08-31", no time of day) are real
+/// feed data — Eudic's real appcast ships exactly this shape
+/// (`<pubDate>2026-08-31</pubDate>`, fixture in `ChangelogExtractorTests.swift`)
+/// — but must never be read as a to-the-minute `publishedAt`: that field is what
+/// `ReleaseTimelineStore` plots on the release-habits heatmap, and a fabricated
+/// midnight there is a lie about when the vendor shipped, not merely an
+/// approximation of it.
+///
+/// `SparkleAppcastSource` is the only source this fix touches — it is the one
+/// with a real fixture proving the date-only shape reaches it. The other four
+/// sources (`AlcoveUpdateSource`, `GitHubReleasesSource`, `ElectronManifestSource`,
+/// `VendorProbeSource`) keep calling `ReleaseDate.parse`, whose contract is
+/// unchanged: nil for a bare calendar day, exactly as before this PR.
+///
+/// The invariant under test, twice over — once on the pure routing function and
+/// once through the real XML parser end to end: a day-precision date routes to
+/// `vendorDay` and NEVER to `publishedAt`.
+
+@Test func publishedFieldsRoutesAMinutePreciseDateToPublishedAtOnly() {
+    let fields = SparkleAppcastSource.publishedFields(from: "Wed, 24 Jun 2026 17:07:24 +0000")
+    #expect(fields.publishedAt == Date(timeIntervalSince1970: 1_782_320_844))
+    #expect(fields.vendorDay == nil)
+}
+
+@Test func publishedFieldsRoutesADayOnlyDateToVendorDayNeverPublishedAt() {
+    // The exact shape Eudic's appcast ships.
+    let fields = SparkleAppcastSource.publishedFields(from: "2026-08-31")
+    #expect(
+        fields.publishedAt == nil,
+        "a day-only pubDate must never reach publishedAt — that would fabricate a midnight the vendor never stated")
+    #expect(fields.vendorDay == Date(timeIntervalSince1970: 1_788_134_400))
+}
+
+@Test func publishedFieldsIsNilForUnparseableOrMissingDates() {
+    let missing = SparkleAppcastSource.publishedFields(from: nil)
+    #expect(missing.publishedAt == nil)
+    #expect(missing.vendorDay == nil)
+    let garbage = SparkleAppcastSource.publishedFields(from: "not a date")
+    #expect(garbage.publishedAt == nil)
+    #expect(garbage.vendorDay == nil)
+}
+
+/// A small appcast with three items — the eudic-shaped date-only release, a
+/// normal RFC822-dated one, and one with no `<pubDate>` at all — parsed through
+/// the real `SparkleAppcastParser`, not hand-built `SparkleAppcastItem` values.
+/// This is what proves the routing survives the XML round trip, not just the
+/// pure string-in/tier-out function above.
+private let mixedPrecisionFeed = """
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <title>26.9.0</title>
+      <sparkle:version>26.9.0</sparkle:version>
+      <sparkle:shortVersionString>26.9.0</sparkle:shortVersionString>
+      <enclosure url="https://example.com/App-26.9.0.zip" length="1000"
+                 type="application/octet-stream"/>
+      <pubDate>2026-08-31</pubDate>
+    </item>
+    <item>
+      <title>4.9.0</title>
+      <sparkle:version>4.9.0</sparkle:version>
+      <sparkle:shortVersionString>4.9.0</sparkle:shortVersionString>
+      <enclosure url="https://example.com/App-4.9.0.zip" length="1000"
+                 type="application/octet-stream"/>
+      <pubDate>Wed, 24 Jun 2026 17:07:24 +0000</pubDate>
+    </item>
+    <item>
+      <title>1.7.0</title>
+      <sparkle:version>1.7.0</sparkle:version>
+      <sparkle:shortVersionString>1.7.0</sparkle:shortVersionString>
+      <enclosure url="https://example.com/App-1.7.0.zip" length="1000"
+                 type="application/octet-stream"/>
+    </item>
+  </channel>
+</rss>
+"""
+
+@Test func releaseHistorySplitsEntriesByThePrecisionTheFeedActuallyStated() throws {
+    let items = SparkleAppcastParser.parse(Data(mixedPrecisionFeed.utf8))
+    #expect(items.count == 3)
+
+    let history = SparkleAppcastSource.releaseHistory(from: items)
+    // The undated item produces no entry at all — never a fabricated one.
+    #expect(history.map(\.version) == ["26.9.0", "4.9.0"])
+
+    let dayOnly = try #require(history.first { $0.version == "26.9.0" })
+    #expect(dayOnly.publishedAt == nil)
+    #expect(dayOnly.vendorDay == Date(timeIntervalSince1970: 1_788_134_400))
+
+    let minutePrecise = try #require(history.first { $0.version == "4.9.0" })
+    #expect(minutePrecise.publishedAt == Date(timeIntervalSince1970: 1_782_320_844))
+    #expect(minutePrecise.vendorDay == nil)
+}
+
+/// Mutation guard: if the day/minute split in `publishedFields` were ever
+/// collapsed back to "always publishedAt" (the exact regression this PR fixes),
+/// this must fail. Verified by hand during review: temporarily changing
+/// `publishedFields`'s `.day` case to `return (parsed.date, nil)` turns this red
+/// (`fields.publishedAt == nil` fails) while every other test in this file still
+/// compiles — i.e. the assertion is load-bearing, not decorative.
+@Test func dayPrecisionNeverReachesPublishedAtEvenWhenItIsTheOnlyDateOnTheRelease() {
+    let fields = SparkleAppcastSource.publishedFields(from: "2026-01-01")
+    #expect(fields.publishedAt == nil)
+    #expect(fields.vendorDay != nil)
+}


### PR DESCRIPTION
## Summary
- parse strict yyyy-MM-dd release dates at midnight UTC
- keep malformed and non-ASCII date-only spellings rejected
- document the newly supported feed shape

## Tests
- swift test --filter ReleaseDate

Closes #239