### PR TITLE
fix(app): ignore empty bundle versions

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4488,8 +4488,12 @@ final class AppListModel {
               let dict = (try? PropertyListSerialization.propertyList(
                 from: data, options: [], format: nil)) as? [String: Any]
         else { return (nil, nil) }
-        return (dict["CFBundleShortVersionString"] as? String,
-                dict["CFBundleVersion"] as? String)
+        func nonEmptyVersion(_ key: String) -> String? {
+            guard let value = dict[key] as? String, !value.isEmpty else { return nil }
+            return value
+        }
+        return (nonEmptyVersion("CFBundleShortVersionString"),
+                nonEmptyVersion("CFBundleVersion"))
     }
 
     /// Open System Settings → Privacy & Security → App Management and float the


### PR DESCRIPTION
## Summary
- treat empty CFBundleShortVersionString values as absent when re-reading an app bundle
- apply the same invariant to CFBundleVersion so an empty build cannot create a readable VersionSide either
- preserve non-empty version strings unchanged

## Tests
- xcodebuild -project DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug -derivedDataPath /tmp/duo-pr240-dd CODE_SIGNING_ALLOWED=NO build

Closes #240