### PR TITLE
fix(app): recheck changelog navigation URLs

### DIFF
--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1908,26 +1908,35 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
         // Only a link the *user* clicked in the *main* frame is redirected. Everything
-        // else is left alone on purpose:
+        // else is left alone by the outbound-link rule:
         //   • sub-frames — `decidePolicyFor` fires for iframes too, and a changelog
         //     page that embeds a video or a third-party widget would otherwise have
         //     every frame cancelled and thrown at the browser, one window each;
         //   • server-side redirects and SPA routing — a vendor moving
-        //     docs.x.com → x.com/docs is normal, and cancelling it just blanks the
-        //     pane. The URL we start from comes from our own recipe registry, not
-        //     from the page, so this is a usability boundary, not a trust boundary.
-        // One thing here IS a trust boundary: the scheme. `ChangelogURLPolicy` only
-        // vets the URL we start from, and a vendor page that redirects itself to
-        // `http://` would land cleartext content in this in-process web view
-        // anyway — which is the whole thing that policy exists to stop. Cross-host
-        // https redirects stay allowed; only the downgrade is refused.
+        //     docs.x.com → x.com/docs is normal, so cross-host HTTPS redirects stay
+        //     allowed when the destination passes `ChangelogURLPolicy`.
+        //
+        // The policy IS reapplied to every main-frame navigation, including a
+        // server redirect. Vetting only the recipe's starting URL let an accepted
+        // vendor URL redirect to an IP literal or a reserved local hostname and
+        // load an origin the policy would have refused at the door. This remains
+        // a structural gate — it cannot see which address an ordinary DNS name
+        // resolves to — but the URL the user lands on now gets the same check as
+        // the URL we start from.
         if let url = navigationAction.request.url,
            url.scheme?.lowercased() == "http" {
             decisionHandler(.cancel); return
         }
 
+        let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
+        if isMainFrame,
+           let url = navigationAction.request.url,
+           !ChangelogURLPolicy.isDisplayable(url) {
+            decisionHandler(.cancel); return
+        }
+
         guard navigationAction.navigationType == .linkActivated,
-              navigationAction.targetFrame?.isMainFrame ?? true,
+              isMainFrame,
               let url = navigationAction.request.url,
               url.host != originHost,
               url.scheme == "https" || url.scheme == "http"

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
@@ -12,7 +12,10 @@ import Foundation
 /// The rules are deliberately structural, not an allowlist of hosts: a per-recipe
 /// host binding only becomes meaningful once recipes stop being compiled in, and
 /// guessing at vendor domains now would break legitimate documentation sites that
-/// live on a different domain than the download endpoint.
+/// live on a different domain than the download endpoint. Consequently this gate
+/// cannot tell that an otherwise ordinary DNS name resolves to a private address;
+/// callers must not describe it as DNS-rebinding protection. It does reject the
+/// local names whose destination is defined by their spelling.
 public enum ChangelogURLPolicy {
 
     /// Whether `url` may be handed to a web view.
@@ -21,12 +24,13 @@ public enum ChangelogURLPolicy {
     /// transit), URLs carrying credentials (`https://user:pass@host/` renders a
     /// convincing origin and leaks the pair), IP-literal hosts (no certificate
     /// name to reason about, and no vendor publishes notes at a bare address),
-    /// and non-standard ports.
+    /// `localhost`/`.localhost` and mDNS `.local` names, and non-standard ports.
     public static func isDisplayable(_ url: URL) -> Bool {
         guard url.scheme?.lowercased() == "https" else { return false }
         guard url.user == nil, url.password == nil else { return false }
         guard let host = url.host, !host.isEmpty else { return false }
         guard !isIPLiteral(host) else { return false }
+        guard !isLocalHostname(host) else { return false }
         if let port = url.port, port != 443 { return false }
         return true
     }
@@ -79,5 +83,19 @@ public enum ChangelogURLPolicy {
         let bare = host.count > 1 && host.hasSuffix(".") ? String(host.dropLast()) : host
         var address = in_addr()
         return inet_aton(bare, &address) != 0
+    }
+
+    /// Names whose local destination follows from the name itself, without a DNS
+    /// lookup: RFC 6761 reserves `localhost` and every name below it for loopback;
+    /// RFC 6762 gives `.local` to link-local multicast DNS. A trailing root label
+    /// and case do not change either name. Ordinary domains merely containing
+    /// these words (for example `localhost.example.com`) remain displayable.
+    static func isLocalHostname(_ host: String) -> Bool {
+        let withoutRootLabel = host.count > 1 && host.hasSuffix(".")
+            ? String(host.dropLast())
+            : host
+        let bare = withoutRootLabel.lowercased()
+        return bare == "localhost" || bare.hasSuffix(".localhost")
+            || bare == "local" || bare.hasSuffix(".local")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
@@ -34,6 +34,30 @@ struct ChangelogURLPolicyTests {
         #expect(!ChangelogURLPolicy.isDisplayable(url("https://[::1]/notes")))
     }
 
+    @Test func reservedLocalHostnamesAreRejected() {
+        for s in [
+            "https://localhost/notes",
+            "https://LOCALHOST./notes",
+            "https://release-notes.localhost/notes",
+            "https://release-notes.localhost./notes",
+            "https://macbook.local/notes",
+            "https://MACBOOK.LOCAL./notes",
+        ] {
+            #expect(!ChangelogURLPolicy.isDisplayable(url(s)), "\(s) should be refused")
+        }
+    }
+
+    @Test func localWordsInsideOrdinaryDomainsStillPass() {
+        for s in [
+            "https://localhost.example.com/notes",
+            "https://local.example.com/notes",
+            "https://notlocal.example/notes",
+            "https://example.localhost.example/notes",
+        ] {
+            #expect(ChangelogURLPolicy.isDisplayable(url(s)), "\(s) should pass")
+        }
+    }
+
     @Test func aHostThatMerelyLooksNumericIsNotAnIPLiteral() {
         // Four dot-separated labels, but not a dotted quad — must still load.
         #expect(ChangelogURLPolicy.isDisplayable(url("https://1.2.3.example.com/notes")))


### PR DESCRIPTION
## Summary
- reject localhost, .localhost, and mDNS .local changelog hosts, including case and trailing-root-label variants
- reapply ChangelogURLPolicy to every main-frame navigation so redirects cannot land on an origin the starting URL gate would reject
- document that the structural policy cannot identify an ordinary DNS name that resolves to a private address

## Tests
- swift test --filter ChangelogURLPolicy
- xcodebuild -project DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug -derivedDataPath /tmp/duo-pr240-dd CODE_SIGNING_ALLOWED=NO build

Closes #241