### PR TITLE
fix(scripts): preserve Claude lag state on partial fetches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 
 test:
 	python3 scripts/test_appcast_edit.py
+	python3 scripts/test_claude_lag_probe.py
 	cd DuoUpdaterCore && swift test
 	swift test --package-path CLI
 	python3 scripts/check_localizable_keys.py

--- a/scripts/claude-lag-probe.sh
+++ b/scripts/claude-lag-probe.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Run once; launchd schedules this every 300 seconds.
+#
+# Records when Claude's GA redirect and rollout endpoint begin advertising a
+# release. Keeping this independent of Duo Updater's own decision path lets the
+# resulting timeline distinguish an upstream ramp from a late local observation.
+#
+# A proxy is required on the machine this probe was written for:
+# api.anthropic.com returns a regional 403 when reached directly. launchd does
+# not inherit shell environment, so the LaunchAgent supplies HTTP_PROXY and
+# HTTPS_PROXY. A 403 is recorded as `blocked` and never mutates version state.
+set -u
+
+PROBE_DIR="${CLAUDE_LAG_PROBE_DIR:-$HOME/Library/Application Support/claude-lag-probe}"
+OUT="$PROBE_DIR/claude-lag.jsonl"
+STATE="$PROBE_DIR/.last"
+BEAT="$PROBE_DIR/.lastbeat"
+DIDFILE="${CLAUDE_LAG_DID_FILE:-$HOME/Library/Application Support/Claude/ant-did}"
+CURL="${CLAUDE_LAG_CURL:-/usr/bin/curl}"
+
+mkdir -p "$PROBE_DIR"
+append_json() { printf '%s\n' "$1" >> "$OUT"; }
+
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+[ -r "$DIDFILE" ] || {
+  append_json "{\"at\":\"$now\",\"event\":\"error\",\"why\":\"ant-did unreadable\"}"
+  exit 0
+}
+DID=$(base64 -d < "$DIDFILE" 2>/dev/null)
+[ -n "$DID" ] || {
+  append_json "{\"at\":\"$now\",\"event\":\"error\",\"why\":\"ant-did empty\"}"
+  exit 0
+}
+
+hdr=$("$CURL" -sS --max-time 25 -o /dev/null -D - -w '\nCODE=%{http_code} IP=%{remote_ip}\n' \
+      "https://api.anthropic.com/api/desktop/darwin/universal/zip/latest/redirect" 2>/dev/null)
+code=$(printf '%s' "$hdr" | sed -n 's/.*CODE=\([0-9]*\).*/\1/p' | tail -1)
+ip=$(printf '%s' "$hdr" | sed -n 's/.*IP=\([0-9a-f.:]*\).*/\1/p' | tail -1)
+ga=$(printf '%s' "$hdr" | sed -n 's|.*/universal/\([0-9.]*\)/.*|\1|p' | head -1)
+
+body=$("$CURL" -sS --max-time 25 \
+      "https://api.anthropic.com/api/desktop/darwin/universal/squirrel/update?device_id=$DID" 2>/dev/null)
+ro=$(printf '%s' "$body" | sed -n 's/.*"currentRelease":"\([^"]*\)".*/\1/p')
+pd=$(printf '%s' "$body" | sed -n 's/.*"pub_date":"\([^"]*\)".*/\1/p')
+
+# 403 means the request escaped the proxy and hit the regional block. It is
+# evidence about the network path, but never evidence that a version changed.
+if [ "${code:-0}" = "403" ]; then
+  append_json "{\"at\":\"$now\",\"event\":\"blocked\",\"code\":\"$code\",\"ip\":\"$ip\"}"
+  exit 0
+fi
+
+# Neither endpoint answered: preserve the established `unreachable` event.
+if [ -z "$ga" ] && [ -z "$ro" ]; then
+  append_json "{\"at\":\"$now\",\"event\":\"unreachable\",\"code\":\"${code:-?}\",\"ip\":\"${ip:-?}\"}"
+  exit 0
+fi
+
+# One endpoint answered and one did not. This used to enter the state machine,
+# write a half-empty value to .last, and manufacture another change when the
+# failed endpoint recovered. Record the partial observation, but keep the last
+# complete pair intact so a later real transition retains truthful provenance.
+if [ -z "$ga" ] || [ -z "$ro" ]; then
+  append_json "{\"at\":\"$now\",\"event\":\"partial\",\"ga\":\"$ga\",\"rollout\":\"$ro\",\"code\":\"${code:-?}\",\"ip\":\"${ip:-?}\"}"
+  exit 0
+fi
+
+cur="$ga|$ro"
+last=$(cat "$STATE" 2>/dev/null || printf '')
+if [ "$cur" != "$last" ]; then
+  append_json "{\"at\":\"$now\",\"event\":\"change\",\"ga\":\"$ga\",\"rollout\":\"$ro\",\"pub_date\":\"$pd\",\"prev\":\"$last\",\"ip\":\"$ip\"}"
+  printf '%s' "$cur" > "$STATE"
+else
+  lb=$(cat "$BEAT" 2>/dev/null || printf '0')
+  if [ $(( $(date +%s) - lb )) -ge 3600 ]; then
+    append_json "{\"at\":\"$now\",\"event\":\"beat\",\"ga\":\"$ga\",\"rollout\":\"$ro\",\"ip\":\"$ip\"}"
+    date +%s > "$BEAT"
+  fi
+fi

--- a/scripts/test_claude_lag_probe.py
+++ b/scripts/test_claude_lag_probe.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/claude-lag-probe.sh."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("claude-lag-probe.sh")
+
+
+class ClaudeLagProbeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        self.probe_dir = self.root / "probe state"
+        self.probe_dir.mkdir()
+        self.did_file = self.root / "ant-did"
+        self.did_file.write_bytes(base64.b64encode(b"fixture-device"))
+
+        self.fake_curl = self.root / "fake-curl"
+        self.fake_curl.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import os
+                import sys
+
+                args = " ".join(sys.argv[1:])
+                if "latest/redirect" in args:
+                    ga = os.environ.get("FIXTURE_GA", "")
+                    if ga:
+                        print(f"Location: https://downloads.example/universal/{ga}/Claude.zip")
+                    print(f"CODE={os.environ.get('FIXTURE_CODE', '200')} "
+                          f"IP={os.environ.get('FIXTURE_IP', '203.0.113.8')}")
+                elif "squirrel/update" in args:
+                    rollout = os.environ.get("FIXTURE_ROLLOUT", "")
+                    body = {}
+                    if rollout:
+                        body["currentRelease"] = rollout
+                        body["pub_date"] = "2026-09-02"
+                    print(json.dumps(body, separators=(",", ":")))
+                else:
+                    raise SystemExit(f"unexpected curl invocation: {args}")
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.fake_curl.chmod(self.fake_curl.stat().st_mode | stat.S_IXUSR)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    @property
+    def state(self) -> pathlib.Path:
+        return self.probe_dir / ".last"
+
+    def run_probe(self, ga: str, rollout: str, code: str = "200") -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "CLAUDE_LAG_PROBE_DIR": str(self.probe_dir),
+                "CLAUDE_LAG_DID_FILE": str(self.did_file),
+                "CLAUDE_LAG_CURL": str(self.fake_curl),
+                "FIXTURE_GA": ga,
+                "FIXTURE_ROLLOUT": rollout,
+                "FIXTURE_CODE": code,
+            }
+        )
+        subprocess.run(["/bin/bash", str(SCRIPT)], env=env, check=True)
+        lines = (self.probe_dir / "claude-lag.jsonl").read_text(encoding="utf-8").splitlines()
+        return json.loads(lines[-1])
+
+    def test_missing_ga_is_partial_and_does_not_replace_state(self) -> None:
+        self.state.write_text("1.0|1.0", encoding="utf-8")
+        event = self.run_probe(ga="", rollout="2.0")
+
+        self.assertEqual(event["event"], "partial")
+        self.assertEqual(event["ga"], "")
+        self.assertEqual(event["rollout"], "2.0")
+        self.assertEqual(self.state.read_text(encoding="utf-8"), "1.0|1.0")
+
+    def test_missing_rollout_is_partial_and_does_not_replace_state(self) -> None:
+        self.state.write_text("1.0|1.0", encoding="utf-8")
+        event = self.run_probe(ga="2.0", rollout="")
+
+        self.assertEqual(event["event"], "partial")
+        self.assertEqual(event["ga"], "2.0")
+        self.assertEqual(event["rollout"], "")
+        self.assertEqual(self.state.read_text(encoding="utf-8"), "1.0|1.0")
+
+    def test_two_missing_values_remain_unreachable(self) -> None:
+        self.state.write_text("1.0|1.0", encoding="utf-8")
+        event = self.run_probe(ga="", rollout="")
+
+        self.assertEqual(event["event"], "unreachable")
+        self.assertEqual(self.state.read_text(encoding="utf-8"), "1.0|1.0")
+
+    def test_complete_pair_records_a_real_change_from_last_complete_pair(self) -> None:
+        self.state.write_text("1.0|1.0", encoding="utf-8")
+        self.run_probe(ga="", rollout="2.0")
+        event = self.run_probe(ga="2.0", rollout="2.0")
+
+        self.assertEqual(event["event"], "change")
+        self.assertEqual(event["prev"], "1.0|1.0")
+        self.assertEqual(self.state.read_text(encoding="utf-8"), "2.0|2.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move claude-lag-probe into the repository under scripts/
- record one-sided endpoint failures as partial observations without mutating .last
- preserve the existing unreachable event when neither endpoint answers
- add deterministic regression coverage for both partial directions and recovery provenance

## Tests
- python3 scripts/test_claude_lag_probe.py
- bash -n scripts/claude-lag-probe.sh
- shellcheck scripts/claude-lag-probe.sh

After merge, the local LaunchAgent can be repointed from Application Support to the tracked script.

Closes #229