### PR TITLE
docs(core): pin Docker updater ownership

### DIFF
--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -196,6 +196,13 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
       按 bundle id 限定的 step 0.8。两 channel 均仅检测，未接一键（装机带特权
       helper/LaunchDaemon/XPC，一键是独立范围决策）。
 
+- [ ] **Docker Desktop — nightly** · `com.docker.docker` — UI 的更新设置代码里存在受
+      feature flag 控制的 `useNightlyBuildUpdates`；观测 stable bundle 只给出 `channelID=main`，
+      backend 使用 `desktop.docker.com/mac/main/arm64/appcast.json`。尚未取得真实 nightly
+      构件，也未验证开关落盘后的本地信号和 endpoint，故暂不登记为 detectable。不要从嵌套
+      `Docker Desktop.app` 的 Squirrel 推断渠道：实际更新器是外层
+      `com.docker.backend.updater`（见 `docs/app-audits/com-docker-docker.md`）。
+
 ---
 
 ## §2c 扫描 2026-08-27（CapCut 落地后复扫）

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -468,6 +468,16 @@ public struct AppScanner: Sendable {
         // still inferred from the feed's own items. See the type's doc comment.
         if feedURL == nil { feedURL = SparkleFeedCatalog.feed(forBundleID: bundleID) }
 
+        // Update ownership deliberately stays with the scanned install bundle.
+        // `AppRuntimeDetector.interfaceBundle` may descend into a nested GUI to
+        // describe its runtime, but that GUI cannot lend updater metadata to its
+        // wrapper. Docker is the concrete trap: Docker Desktop.app embeds a dormant
+        // Squirrel framework, while com.docker.backend.updater owns the real update
+        // flow and reads Docker's appcast.json. There is no Docker ShipIt cache.
+        // Borrowing the nested marker would opt the outer com.docker.docker bundle
+        // into generic ShipIt staging/download probes for a state that cannot exist.
+        // Keep electron config, Squirrel, Sparkle and feed facts on `bundleURL`.
+
         // The electron-builder equivalent, read the same way and for the same
         // reason: it is a file the packager wrote, not something inferred.
         let electronUpdate = ElectronUpdateConfig.read(fromBundleAt: bundleURL)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerTests.swift
@@ -58,3 +58,52 @@ import Foundation
     let gone = URL(fileURLWithPath: "/Applications/DuoUpdaterTests-\(UUID().uuidString).app")
     #expect(AppScanner().scan(bundlesAt: [gone]).isEmpty)
 }
+
+/// Runtime attribution and update ownership are different questions. Docker's
+/// outer bundle launches the product, while its one nested GUI supplies the
+/// Electron runtime label. That nested GUI also happens to embed Squirrel, but
+/// Docker updates through `com.docker.backend.updater`, not ShipIt (#217).
+@Test func nestedInterfaceDoesNotLendItsUpdaterToTheWrapper() throws {
+    let fm = FileManager.default
+    let root = fm.temporaryDirectory
+        .appendingPathComponent("scanner-docker-\(UUID().uuidString)")
+    defer { try? fm.removeItem(at: root) }
+
+    let wrapper = root.appendingPathComponent("Docker.app")
+    let nested = wrapper.appendingPathComponent("Contents/MacOS/Docker Desktop.app")
+    let nestedFrameworks = nested.appendingPathComponent("Contents/Frameworks")
+    try fm.createDirectory(
+        at: nestedFrameworks.appendingPathComponent("Electron Framework.framework"),
+        withIntermediateDirectories: true)
+    try fm.createDirectory(
+        at: nestedFrameworks.appendingPathComponent("Squirrel.framework"),
+        withIntermediateDirectories: true)
+
+    let outerPlist: [String: Any] = [
+        "CFBundleDisplayName": "Docker",
+        "CFBundleIdentifier": "com.docker.docker",
+        "CFBundleShortVersionString": "4.89.0",
+        "CFBundleVersion": "238018",
+        "CFBundleExecutable": "com.docker.backend",
+    ]
+    let nestedPlist: [String: Any] = [
+        "CFBundleDisplayName": "Docker Desktop",
+        "CFBundleIdentifier": "com.electron.dockerdesktop",
+        "CFBundleShortVersionString": "4.89.0",
+        "CFBundleVersion": "4.89.0.9",
+    ]
+    for (bundle, plist) in [(wrapper, outerPlist), (nested, nestedPlist)] {
+        let info = bundle.appendingPathComponent("Contents/Info.plist")
+        try fm.createDirectory(at: info.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try PropertyListSerialization
+            .data(fromPropertyList: plist, format: .xml, options: 0)
+            .write(to: info)
+    }
+
+    let app = try #require(AppScanner().scan(bundlesAt: [wrapper]).first)
+    #expect(app.runtime == .electron)
+    #expect(!app.hasSelfUpdater)
+    #expect(!app.hasSparkleUpdater)
+    #expect(app.electronUpdate == nil)
+    #expect(app.sparkleFeedURL == nil)
+}

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -67,7 +67,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] **Postman** · `com.postmanlabs.mac` — P C (one-click) · ✓ src=Vendor
 - [x] **AweSun** · `com.oray.sunlogin.macclient` — P C (one-click, WAF) · ✓ src=Vendor
 - [x] [**VLC**](org-videolan-vlc.md) · `org.videolan.vlc` — P C (one-click, two-stage changelog) · ✓ src=Vendor · nightly 共享 bundle id，未签名 → **一键永久不可**，检测已可行（#93 已解决），尚未接 recipe（issue #95）
-- [ ] **Docker** · `com.docker.docker` — P · ⏭ skipped (cask now needs sudo to install)
+- [x] [**Docker**](com-docker-docker.md) · `com.docker.docker` — P C (one-click dmg) · ✓ src=Vendor · 外层 backend 拥有更新流程；嵌套 GUI 的 Squirrel 是闲置框架，不借给扫描器 · 2026-09-02
 - [x] **Raycast** · `com.raycast.macos` — P · ✓ src=Vendor
 - [x] **Alfred** · `com.runningwithcrayons.Alfred` — P · ✓ src=Vendor
 - [x] **Shottr** · `cc.ffitch.shottr` — P · ✓ src=Vendor

--- a/docs/app-audits/com-docker-docker.md
+++ b/docs/app-audits/com-docker-docker.md
@@ -1,0 +1,108 @@
+# Docker Desktop
+
+## 基本信息
+
+- Bundle ID: `com.docker.docker`
+- Team ID: `9BNSXJN65R`
+- 观测版本: 4.89.0 / build 238018（Apple Silicon）
+- stable 构建信号: `channelID=main`
+- 外层可执行文件: `com.docker.backend`
+- 界面 bundle: `Contents/MacOS/Docker Desktop.app`，Bundle ID
+  `com.electron.dockerdesktop`，观测版本 4.89.0 / build 4.89.0.9
+- 自更新机制: 外层 Go backend 的 `com.docker.backend.updater`；嵌套 Electron GUI
+  虽然带 `Squirrel.framework`，但不拥有 Docker 的更新流程
+
+## 覆盖矩阵
+
+> ✓ = 已接入　○ = 可接入（未实现）　✗ = 已调查不可行　— = 不适用
+
+| channel | Sparkle | Homebrew | MAS | GitHub | VendorProbe | Changelog |
+|---|---:|---:|---:|---:|---:|---:|
+| stable | — | ✗（auto_updates 且版本滞后） | — | — | ✓ | ✓ |
+| nightly | — | — | — | — | ○（缺真实构件/信号） | — |
+
+当前生效源: **VendorProbe**。2026-09-02 用观测 stable bundle 跑完整生产链，检测到
+stable，VendorProbe 返回 4.89.0 和 build 238018，结果为 up to date。
+
+## 更新检测
+
+- DuoUpdater 端点: `https://desktop.docker.com/mac/main/arm64/appcast.xml`
+- 版本字段: enclosure 的 `sparkle:shortVersionString`，与
+  `CFBundleShortVersionString` 同构
+- 下载地址: 同一 enclosure 的完整 `Docker.dmg`；正则刻意排除相邻 delta
+- 选择方式: `.selectHighestVersion`。Docker 的 feed 不是严格 newest-first，不能取第一项
+- Docker 自身的 backend 使用同一发布面的 JSON 版本：
+  `https://desktop.docker.com/mac/main/arm64/appcast.json`
+
+XML 里使用 Sparkle namespace 只是 feed 格式，不代表 Docker.app 嵌入 Sparkle。实际 bundle
+没有 `Sparkle.framework` 或 `SUFeedURL`。
+
+## 更新所有权：为什么不跟随嵌套界面 bundle
+
+`AppRuntimeDetector.interfaceBundle(at:)` 会进入唯一的嵌套 GUI，让产品行正确显示 Electron
+及其版本；这个重定向只描述 UI runtime，不能改变更新所有权。四类更新探针仍读取外层安装
+bundle：`SUFeedURL`、`app-update.yml`、Squirrel 和 Sparkle。
+
+证据链：
+
+1. backend 日志以 `com.docker.backend.updater` 组件执行 background check，读取
+   `mac/main/arm64/appcast.json` 并维护更新状态。
+2. GUI 的设置代码读取 backend 提供的 `stateFromBackend`，安装动作调用
+   `desktopBackendsClient.update.applyUpdate()`，不是 Electron `autoUpdater`。
+3. 嵌套 bundle 没有 `app-update.yml`；也没有 Docker 对应的 ShipIt 进程或
+   `ShipItState.plist` 命名空间。
+
+因此嵌套的 `Squirrel.framework` 是闲置实现细节。若把它借给外层 bundle，
+`hasSelfUpdater` 会错误变成 true，通用探针随后只会寻找不存在的
+`com.docker.docker.ShipIt` 状态。#217 的处理是固定这条边界，而不是重定向探针。
+
+## Changelog
+
+- 已有 `ChangelogRecipe` 从 Docker Desktop release notes 的 Markdown 生成原生条目
+- VendorProbe 的 `changelogURL` 指向 `https://docs.docker.com/desktop/release-notes/`
+- release notes 中包含多平台下载链接；抽取器已有回归测试，避免把这些链接当正文噪声
+
+## 一键安装
+
+- 状态: 支持
+- 格式: Apple Silicon dmg
+- 产物: `Docker.app`
+- 安全闸: bundle ID `com.docker.docker`、Team ID `9BNSXJN65R`、签名/公证及架构检查
+- VendorProbe 与 Docker backend 指向同一 build 238018 的 dmg，版本命名空间一致
+
+## Channels
+
+stable 已验证。GUI 代码里另有 feature-flagged `useNightlyBuildUpdates` 设置，但 stable
+构建只观测到 `channelID=main`。在拿到真实 nightly 构件、落盘信号和 endpoint 前，不把它
+登记为可检测渠道；缺口记录在 `CHANNEL_COVERAGE_TODO.md` §2b。
+
+## 已知边界
+
+- 通用 `SelfUpdaterStaging` 能识别 Sparkle/ShipIt 标准缓存，不能识别 Docker backend 私有的
+  已下载待安装状态。若要覆盖，应以实际 backend 状态布局另做 detector，不能借嵌套 Squirrel。
+- nightly 尚未验证，stable recipe 必须继续由 channel gate 限定，不能猜测跨轨更新。
+
+## 如何复验
+
+```sh
+swift run --package-path application-test channel-verify "<Docker.app>" --expect stable
+
+# 外层和界面 bundle 的身份、版本及 channelID
+plutil -p "<Docker.app>/Contents/Info.plist"
+plutil -p "<Docker.app>/Contents/MacOS/Docker Desktop.app/Contents/Info.plist"
+
+# 嵌套 GUI 有 Squirrel，但没有标准 electron-updater manifest
+find "<Docker.app>/Contents/MacOS/Docker Desktop.app/Contents" \
+  -maxdepth 3 \( -name 'Squirrel.framework' -o -name 'app-update.yml' \) -print
+```
+
+复验更新所有权时，应在 Docker 执行一次后台检查后搜索 host logs 中的
+`com.docker.backend.updater`、`appcast.json` 和 `applyUpdate`；不要用 Squirrel 框架的存在
+替代运行证据。
+
+## 下一步
+
+1. 若能取得真实 nightly 构件，比较其 Info.plist、backend settings 和更新 endpoint，再决定
+   ChannelBinding 或独立 recipe。
+2. 若产品需要展示 Docker 已下载待安装状态，先记录 backend 的稳定状态文件/IPC，再添加专用
+   staging detector；不要复用 ShipIt。


### PR DESCRIPTION
Closes #217

## Summary
- keep update metadata probes on Docker's outer install bundle while still reading the nested GUI for runtime attribution
- add a Docker-shaped scanner regression proving nested Squirrel does not set `hasSelfUpdater`
- persist the full Docker integration audit and track the unverified nightly channel separately

## Why
Docker's update flow is owned by `com.docker.backend.updater`, which reads the main-channel appcast and exposes update state/actions to the Electron UI. The Squirrel framework inside `Docker Desktop.app` is dormant: there is no Docker ShipIt namespace to inspect. Redirecting updater probes to the nested bundle would therefore manufacture ownership and enable generic ShipIt probes that cannot succeed.

## Verification
- `swift test --filter nestedInterfaceDoesNotLendItsUpdaterToTheWrapper`
- `python3 scripts/check_app_audits.py`
- `swift run --package-path application-test channel-verify "<Docker.app>" --expect stable` (observed 4.89.0 / 238018, Vendor, up to date)
- `git diff --check`