### PR TITLE
docs(core): make Sparkle 1 standoff boundary explicit

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RestartStandoff.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RestartStandoff.swift
@@ -5,8 +5,8 @@ import Foundation
 /// Usually it is, and the quit is ours alone. But an app with its own updater
 /// can have a build already downloaded, unpacked and parked, with an installer
 /// process waiting for precisely one signal: that app terminating. Our restart
-/// is that signal. Sparkle's `Autoupdate` and Squirrel's `ShipIt` both work this
-/// way, and both wait as long as it takes — 22 minutes for ChatGPT on
+/// is that signal. Sparkle 2's installer agent and Squirrel's `ShipIt` both work
+/// this way, and both wait as long as it takes — 22 minutes for ChatGPT on
 /// 2026-08-22, 6 hours 49 minutes for Claude the day before, same PID throughout.
 ///
 /// So a quit we think of as the last step of our install is also the first step
@@ -18,6 +18,17 @@ import Foundation
 ///
 /// Nothing failed. The install was correct, the restart was correct, and the
 /// user saw the update reappear.
+///
+/// **Sparkle 1 is not covered.** Its automatic driver arms an
+/// `NSApplicationWillTerminateNotification` observer in the host process and
+/// launches `Autoupdate.app` only after the quit has begun. Before the decision
+/// this type is asked to make there is therefore no parked helper to enumerate.
+/// Its extracted bundle also lives below a random `NSTemporaryDirectory()` path,
+/// not Sparkle 2's bundle-id-keyed cache. Neither a leftover extraction nor the
+/// mere presence of the Sparkle 1 framework proves that an install is armed.
+/// `disableSuddenTermination` accompanies the hook, but no public cross-process
+/// API and acceptable noise floor have been established for that signal. Do not
+/// turn any of those into a hold-back predicate without first measuring it.
 ///
 /// The decision therefore is not "is another installer armed" — that alone is
 /// harmless — but "is it armed with something OTHER than what we just wrote".

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RestartStandoff.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RestartStandoff.swift
@@ -23,12 +23,21 @@ import Foundation
 /// `NSApplicationWillTerminateNotification` observer in the host process and
 /// launches `Autoupdate.app` only after the quit has begun. Before the decision
 /// this type is asked to make there is therefore no parked helper to enumerate.
-/// Its extracted bundle also lives below a random `NSTemporaryDirectory()` path,
-/// not Sparkle 2's bundle-id-keyed cache. Neither a leftover extraction nor the
-/// mere presence of the Sparkle 1 framework proves that an install is armed.
-/// `disableSuddenTermination` accompanies the hook, but no public cross-process
-/// API and acceptable noise floor have been established for that signal. Do not
-/// turn any of those into a hold-back predicate without first measuring it.
+/// The gap is not that its extraction is unfindable: Sparkle 1 stages downloads
+/// and extraction under `Caches/<bundleID>/org.sparkle-project.Sparkle/
+/// PersistentDownloads/` (confirmed against the 1.16.0 and 1.27.3 sources —
+/// `SPUDownloader.getAndCleanTempDirectory` calls `SPULocalCacheDirectory
+/// .cachePathForBundleIdentifier:`), the same bundle-id-keyed tree
+/// `sparkleStagedBundle` already walks for Sparkle 2's `Installation/`, just a
+/// different subdirectory. What is missing is a signal independent of the host
+/// process that proves an install is armed: `PersistentDownloads/` has the same
+/// stale-leftover problem `Installation/` does — Sparkle only garbage-collects
+/// entries older than ten days, and only on the next staging run — so an
+/// unpacked bundle sitting there is no more evidence than one in `Installation/`
+/// is. `disableSuddenTermination` accompanies the hook, but no public
+/// cross-process API and acceptable noise floor have been established for that
+/// signal. Do not turn any of those into a hold-back predicate without first
+/// measuring it.
 ///
 /// The decision therefore is not "is another installer armed" — that alone is
 /// harmless — but "is it armed with something OTHER than what we just wrote".

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
@@ -361,21 +361,16 @@ public enum SelfUpdaterStaging {
     ///
     /// `…Updater` is Sparkle 2's progress agent — observed live as pid 27939 at
     /// `…/Caches/com.tinyapp.TablePlus/org.sparkle-project.Sparkle/Launcher/<random>/Updater.app`.
-    /// `…Autoupdate` is Sparkle 1's, which ships as `Autoupdate.app` inside the
-    /// host's framework (VLC 1.16.0 on this machine). Sparkle 2 also has an
-    /// `Autoupdate`, but as a bare executable with no bundle — LaunchServices
-    /// cannot enumerate it, so it is not a usable signal and is not one of these.
     ///
-    /// **Sparkle 1 is nonetheless not covered**, and not because of this list:
-    /// `sparkleStagedBundle` walks the `Caches/<id>/org.sparkle-project.Sparkle/`
-    /// layout, which is Sparkle 2's. Sparkle 1 apps have no such directory
-    /// (checked: VLC has a cache directory and no Sparkle subdirectory), so the
-    /// walk finds nothing for them whatever is parked. Listing Sparkle 1's
-    /// identity here costs nothing and errs toward holding back, which is the
-    /// safe direction; it is not a claim that Sparkle 1 staging is detected.
+    /// Sparkle 1's bundled `org.sparkle-project.Sparkle.Autoupdate` is deliberately
+    /// absent. In the automatic-update path the host process arms the quit hook;
+    /// `Autoupdate.app` is launched only after termination begins, too late to be
+    /// evidence for `RestartStandoff`. Sparkle 1 also stages below a random temp
+    /// path instead of the cache tree this detector validates. Querying its bundle
+    /// id here could never make the detector answer non-nil and misleadingly made
+    /// this list look like coverage. See `RestartStandoff`'s known limitation.
     static let sparkleInstallerBundleIDs = [
         "org.sparkle-project.Sparkle.Updater",
-        "org.sparkle-project.Sparkle.Autoupdate",
     ]
 
     /// Bundle locations of every Sparkle installer currently parked, for any app.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
@@ -361,12 +361,16 @@ public enum SelfUpdaterStaging {
     ///
     /// `…Updater` is Sparkle 2's progress agent — observed live as pid 27939 at
     /// `…/Caches/com.tinyapp.TablePlus/org.sparkle-project.Sparkle/Launcher/<random>/Updater.app`.
+    /// Sparkle 2's own `Autoupdate` ships alongside it as a bare executable with
+    /// no bundle (same TablePlus install), so it has no identifier to query.
     ///
-    /// Sparkle 1's bundled `org.sparkle-project.Sparkle.Autoupdate` is deliberately
-    /// absent. In the automatic-update path the host process arms the quit hook;
-    /// `Autoupdate.app` is launched only after termination begins, too late to be
-    /// evidence for `RestartStandoff`. Sparkle 1 also stages below a random temp
-    /// path instead of the cache tree this detector validates. Querying its bundle
+    /// Sparkle 1's `Autoupdate.app` — a real bundle, `CFBundleIdentifier =
+    /// org.sparkle-project.Sparkle.Autoupdate` (VLC 1.16.0, Eudic 1.27.3) — is
+    /// deliberately absent from this list. Not because it is unenumerable: it is
+    /// because in the automatic-update path the host process arms the quit hook
+    /// itself, and `Autoupdate.app` is only launched from `applicationWillTerminate:`
+    /// — after the decision `RestartStandoff` makes has already been acted on, so
+    /// it never exists yet when this list would be queried. Querying its bundle
     /// id here could never make the detector answer non-nil and misleadingly made
     /// this list look like coverage. See `RestartStandoff`'s known limitation.
     static let sparkleInstallerBundleIDs = [

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
@@ -381,14 +381,14 @@ struct SparkleStagingTests {
     /// A tripwire for the machines the test above finds nothing on: changing the
     /// Sparkle 2 identifier fails loudly instead of turning the standoff off in
     /// silence. Sparkle 1's `…Autoupdate` must stay absent: it is launched by the
-    /// host's termination hook only after the decision this detector serves, and
-    /// its random temp staging is not readable through this Sparkle 2 cache walk.
+    /// host's termination hook only after the decision this detector serves, so it
+    /// never exists yet to be queried — not because its staging is unreadable
+    /// through this cache walk (it stages under the same `Caches/<bundleID>/
+    /// org.sparkle-project.Sparkle/` tree Sparkle 2 does, see `RestartStandoff`).
     @Test func theParkedInstallerIdentityCoversSparkle2Only() {
         #expect(SelfUpdaterStaging.sparkleInstallerBundleIDs == [
             "org.sparkle-project.Sparkle.Updater",
         ])
-        #expect(!SelfUpdaterStaging.sparkleInstallerBundleIDs.contains(
-            "org.sparkle-project.Sparkle.Autoupdate"))
     }
 
     // MARK: - The Amp scenario, end to end

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
@@ -378,15 +378,17 @@ struct SparkleStagingTests {
         }
     }
 
-    /// A tripwire for the machines the test above finds nothing on: changing an
-    /// identifier fails loudly instead of turning the standoff off in silence.
-    /// `…Updater` was observed live on 2026-08-22 (pid 27939, parked for
-    /// TablePlus); `…Autoupdate` is Sparkle 1's, as shipped inside VLC 1.16.0.
-    @Test func theInstallerIdentitiesAreTheOnesSparkleShips() {
+    /// A tripwire for the machines the test above finds nothing on: changing the
+    /// Sparkle 2 identifier fails loudly instead of turning the standoff off in
+    /// silence. Sparkle 1's `…Autoupdate` must stay absent: it is launched by the
+    /// host's termination hook only after the decision this detector serves, and
+    /// its random temp staging is not readable through this Sparkle 2 cache walk.
+    @Test func theParkedInstallerIdentityCoversSparkle2Only() {
         #expect(SelfUpdaterStaging.sparkleInstallerBundleIDs == [
             "org.sparkle-project.Sparkle.Updater",
-            "org.sparkle-project.Sparkle.Autoupdate",
         ])
+        #expect(!SelfUpdaterStaging.sparkleInstallerBundleIDs.contains(
+            "org.sparkle-project.Sparkle.Autoupdate"))
     }
 
     // MARK: - The Amp scenario, end to end


### PR DESCRIPTION
Closes #211

## Summary
- document why `RestartStandoff` has an exact Sparkle 2 signal but no equivalent Sparkle 1 signal
- stop querying Sparkle 1's `Autoupdate.app` identity in the live parked-installer detector
- add a tripwire keeping the parked-installer identity set Sparkle-2-only

## Why this does not claim a guard
Sparkle 1 arms its install-on-quit hook in the host process and launches `Autoupdate.app` only after termination has begun. Its extraction lives at a random temporary path rather than Sparkle 2's bundle-id-keyed cache. Consequently the old bundle-ID query could never make `sparkleStagedBundle` return a staged update; it only made the code look like it covered Sparkle 1.

The documented `disableSuddenTermination` lead remains intentionally unimplemented until a public cross-process read and its false-positive rate are measured. Current observed Sparkle 1 exposure remains zero.

## Verification
- `swift test --filter SparkleStagingTests` (16 tests)
- `swift test --filter RestartStandoffTests` (8 tests)
- `git diff --check`