### PR TITLE
fix(ui): explain relaunch before feed downgrade

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -426,6 +426,17 @@ final class AppListModel {
         UpdatePolicy.laggingRemoteVersion(result)
     }
 
+    /// The one version-line fact the row should explain. The precedence lives in
+    /// Core so a relaunch and a lagging-feed note cannot silently swap places in a
+    /// view with no test target (#210).
+    func versionLineState(for result: UpdateResult) -> RowVersionLineState {
+        RowVersionLine.state(
+            staged: actionableStaged(result),
+            pendingBatchRestartMarketing: pendingBatchRestart[result.id],
+            restartFrom: needsRestart.contains(result.id) ? restartFromSide(result.id) : nil,
+            downgradeVersion: downgradeNote(result))
+    }
+
     /// Bring JetBrains Toolbox forward — the action for every Toolbox-managed row,
     /// in both windows. On the model rather than duplicated per view, for the same
     /// reason `rowState` is: one row, one behaviour.

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1114,30 +1114,25 @@ private struct AppRow: View {
 
     @ViewBuilder
     private var versionLine: some View {
-        if let staged = model.actionableStaged(result) {
+        switch model.versionLineState(for: result) {
+        case .stagedRelaunch(let staged):
             // Relaunch applies this staged build, which `actionableStaged` guarantees
             // is the latest — so the line is a plain installed → staged. (A staged
             // build that trails the latest isn't shown as Relaunch; it goes through
             // the normal updateAvailable line/Update button below.)
             stagedVersionLine(staged)
-        } else if let older = model.downgradeNote(result) {
-            // Vendor's latest is *older* than what's installed — show it muted with a
-            // down-arrow (only reachable under "Show all", since the row is upToDate).
-            downgradeVersionLine(older)
-        } else if let from = model.pendingBatchRestart[result.id] {
+        case .restart(let from):
             // Update All has landed the new bundle but intentionally postpones its
-            // process-version sweep/restarts until every installer is finished.
-            // Keep the row concrete instead of flashing a false completion.
-            restartVersionLine(from: .init(marketing: from))
-        } else if model.needsRestart.contains(result.id),
-                  let from = model.restartFromSide(result.id) {
-            // Self-updated on disk, restart pending. Show the running version → the
-            // installed version so the row reads as a real change, not a static
-            // "v1.6.1". `lsappinfo` only exposes the running *build*; `restartFromVersion`
-            // recovers the marketing version from the rollback backup when it can, so
-            // the from side reads "26.609.71450 (3965)" rather than a bare "3965".
+            // process-version sweep/restarts until every installer is finished; a
+            // normal pending restart reaches the same line with the recovered
+            // running version/build. Either one outranks an action-less downgrade
+            // note because this line explains the Relaunch button (#210).
             restartVersionLine(from: from)
-        } else {
+        case .downgrade(let older):
+            // Vendor's latest is *older* than what's installed — show it muted with a
+            // down-arrow only when no pending relaunch has a more important fact.
+            downgradeVersionLine(older)
+        case .status:
             switch result.status {
             case .updateAvailable(let latest):
             HStack(spacing: 4) {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowVersionLine.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowVersionLine.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The fact a row's version line should explain.
+///
+/// This is separate from `RowActionState` because the action and the version text
+/// do not carry the same payload, but their priorities must tell one story. A row
+/// can be both ahead of its feed and waiting for a relaunch: the relaunch is the
+/// action, so the line must explain the running → on-disk change rather than show
+/// the otherwise-correct, action-less installed ↓ remote note (#210).
+public enum RowVersionLineState: Sendable, Equatable {
+    /// The app's own updater has the current release staged for a relaunch.
+    case stagedRelaunch(StagedSelfUpdate)
+    /// A landed update is waiting for the running process to restart.
+    case restart(from: VersionSide)
+    /// The vendor's advertised release trails what is installed; no action wins.
+    case downgrade(to: String)
+    /// Render the ordinary line derived from `UpdateStatus`.
+    case status
+}
+
+public enum RowVersionLine {
+    /// Resolve the version line in action priority order.
+    ///
+    /// `restartFrom` must be supplied only when the caller's restart detector says
+    /// the process is stale. `pendingBatchRestartMarketing` is separate because a
+    /// batch deliberately defers that detector until all installs finish, while it
+    /// already knows the pre-install marketing version.
+    public static func state(
+        staged: StagedSelfUpdate?,
+        pendingBatchRestartMarketing: String?,
+        restartFrom: VersionSide?,
+        downgradeVersion: String?
+    ) -> RowVersionLineState {
+        if let staged { return .stagedRelaunch(staged) }
+        if let from = pendingBatchRestartMarketing {
+            return .restart(from: VersionSide(marketing: from))
+        }
+        if let restartFrom { return .restart(from: restartFrom) }
+        if let downgradeVersion { return .downgrade(to: downgradeVersion) }
+        return .status
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowVersionLineTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowVersionLineTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+@Suite("Row version-line precedence")
+struct RowVersionLineTests {
+    private let staged = StagedSelfUpdate(
+        version: "26.9.2", buildVersion: "802",
+        stagedBundlePath: URL(fileURLWithPath: "/tmp/Eudic.app"))
+
+    /// Regression for #210: Eudic is ahead of the lagging feed, but the process is
+    /// still on 26.8.3. The Relaunch action has to be explained by 26.8.3 → 26.9.1;
+    /// the action-less 26.9.1 ↓ 26.9.0 note is secondary.
+    @Test("restart outranks a lagging-feed downgrade note")
+    func restartBeatsDowngrade() {
+        let from = VersionSide(marketing: "26.8.3")
+        #expect(RowVersionLine.state(
+            staged: nil,
+            pendingBatchRestartMarketing: nil,
+            restartFrom: from,
+            downgradeVersion: "26.9.0") == .restart(from: from))
+    }
+
+    /// Before the post-batch process sweep, the provisional restart fact carries
+    /// the same user action and therefore has the same priority.
+    @Test("a deferred batch restart also outranks the downgrade note")
+    func batchRestartBeatsDowngrade() {
+        #expect(RowVersionLine.state(
+            staged: nil,
+            pendingBatchRestartMarketing: "26.8.3",
+            restartFrom: nil,
+            downgradeVersion: "26.9.0")
+            == .restart(from: VersionSide(marketing: "26.8.3")))
+    }
+
+    /// The app's already-downloaded latest remains the most concrete next action.
+    @Test("a staged relaunch keeps first priority")
+    func stagedBeatsRestart() {
+        #expect(RowVersionLine.state(
+            staged: staged,
+            pendingBatchRestartMarketing: "26.8.3",
+            restartFrom: VersionSide(marketing: "26.8.3"),
+            downgradeVersion: "26.9.0") == .stagedRelaunch(staged))
+    }
+
+    /// The downgrade note is still useful when no relaunch fact supersedes it.
+    @Test("the downgrade note remains for an action-less row")
+    func downgradeRemainsWithoutAction() {
+        #expect(RowVersionLine.state(
+            staged: nil,
+            pendingBatchRestartMarketing: nil,
+            restartFrom: nil,
+            downgradeVersion: "26.9.0") == .downgrade(to: "26.9.0"))
+        #expect(RowVersionLine.state(
+            staged: nil,
+            pendingBatchRestartMarketing: nil,
+            restartFrom: nil,
+            downgradeVersion: nil) == .status)
+    }
+}


### PR DESCRIPTION
Closes #210

## Summary
- move version-line precedence into a pure, testable `RowVersionLine` resolver in Core
- make staged relaunch, pending batch restart, and normal restart outrank the action-less lagging-feed note
- keep the downgrade line unchanged when no relaunch action is pending

## Regression
A row that has 26.9.1 on disk, 26.8.3 still running, and a lagging feed advertising 26.9.0 now shows `26.8.3 → 26.9.1` beside Relaunch instead of the unrelated `26.9.1 ↓ 26.9.0`.

## Verification
- `swift test --filter RowVersionLineTests` (4 tests)
- `python3 scripts/check_staged_version_use.py`
- `xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`