### PR TITLE
Row gallery: measure translated strings, verify tooltip-differentiator claims

### DIFF
--- a/App/RowStateGallery/Cases.swift
+++ b/App/RowStateGallery/Cases.swift
@@ -94,9 +94,24 @@ enum RowStateGalleryCases {
                     state: state, result: result,
                     downloadReadout: popoverDownloadReadoutOverrides[name] ?? .barAndPercent,
                     showsStageLabel: popoverShowsStageLabelOverrides[name] ?? { _ in true })
-                .frame(width: 320, height: 44, alignment: .trailing))
+                .frame(width: tileWidth, height: tileHeight, alignment: .trailing))
         }
     }
+
+    /// The box every ordinary row tile is drawn into — named rather than left as
+    /// a bare `320`/`44` so `RowStateWidthCheck` (#263) can measure a state's
+    /// UNCONSTRAINED width against the exact same number instead of inventing its
+    /// own budget. Not a literal SwiftUI hard clip anywhere else in the app:
+    /// `PopoverRowAction`'s real neighbour in `MenuContentView` is a `minWidth`
+    /// reservation that concedes width to a wide button rather than clipping it,
+    /// and `WorkbenchRowAction`'s only home (`WorkbenchWindowView.DetailHeader`)
+    /// sits after a `Spacer()` with roughly 900pt of window behind it. What DOES
+    /// hold at this size: every tile in the committed English sheet was drawn at
+    /// exactly this width, so it is the widest any state's content has ever
+    /// actually been reviewed at — see `RowStateWidthCheck/main.swift`'s doc
+    /// comment for what exceeding it does and doesn't prove.
+    static let tileWidth: CGFloat = 320
+    static let tileHeight: CGFloat = 44
 
     /// The workbench has no equivalent of "open the popover's explanation panel" —
     /// it points at the popover for that (see the file-level doc comment on
@@ -111,7 +126,7 @@ enum RowStateGalleryCases {
         }
         return AnyView(
             WorkbenchRowAction(state: state, result: result)
-                .frame(width: 320, height: 44, alignment: .trailing))
+                .frame(width: tileWidth, height: tileHeight, alignment: .trailing))
     }
 
     /// Each case names the row it is drawn against, because several states only

--- a/App/RowStateGallery/main.swift
+++ b/App/RowStateGallery/main.swift
@@ -153,7 +153,209 @@ func render() {
               + identical.joined(separator: ", "))
         failed = true
     }
+
+    // #263: TWO of `mayLookAlike`'s seven pairs are justified in their own comment
+    // as differentiated BY the tooltip ("the help text says which one" for
+    // 10-vs-11, "the tooltip is what separates them" for 13-vs-19) — a claim
+    // nothing checked, because `.help()` text is invisible in a PNG by
+    // construction. This verifies those two rather than trusting them: collect
+    // every `.help()` string reachable from each side (via `collectHelpTexts`'s
+    // Mirror-reflection walk — see its own doc comment for the technique and its
+    // risk) and require the two sets to differ.
+    //
+    // Deliberately NOT applied to the other five pairs (15-vs-28, 18-vs-22,
+    // 17-vs-23, 27-vs-31, 29-vs-32): their own comments claim the OPPOSITE —
+    // "one button", "a tile cannot show which explanation appears", "the same
+    // marker … never reads like something we could update ourselves" — i.e. those
+    // are deliberately identical end-to-end, tooltip included, not "differentiated
+    // by a tooltip nothing here checks". Running this check against them found
+    // exactly that (identical tooltips) on a first pass — a real discovery, but not
+    // a bug: verified against `RowActionViews.swift`, all three ARE the same
+    // control/wording by design. Folding them into `tooltipDifferentiatedPairs`
+    // would have turned a correct design decision into a build failure.
+    switch tooltipsDifferentiateExemptedPairs() {
+    case .ok(let checked):
+        print("\(checked) mayLookAlike pair(s) claiming a tooltip differentiator"
+              + " checked — every one actually has a different tooltip on each side")
+    case .undifferentiated(let names):
+        print("TOOLTIP DOES NOT DIFFERENTIATE (pixels match AND every collected"
+              + " .help() string matches too — the exemption's own justification is"
+              + " false): " + names.joined(separator: ", "))
+        failed = true
+    case .extractorBroken:
+        // Distinguished from `.undifferentiated` on purpose: if Mirror found NO
+        // `.help()` text anywhere in the whole run, that is far more likely
+        // SwiftUI's private internal shape having changed out from under
+        // `collectHelpTexts` (undocumented by Apple, not guaranteed stable across
+        // an OS/Xcode update) than every single row in the app suddenly losing
+        // its tooltips. Reporting it as its own failure, rather than as N
+        // `.undifferentiated` pairs, keeps a real extractor break from reading
+        // like a wall of unrelated view regressions.
+        print("TOOLTIP EXTRACTOR FOUND NOTHING ANYWHERE: either every `.help()` in"
+              + " the app was removed, or collectHelpTexts's Mirror-reflection"
+              + " technique no longer matches this SwiftUI version's private"
+              + " HelpView<Content> shape — see that function's doc comment.")
+        failed = true
+    case .driftedFromMayLookAlike:
+        print("TOOLTIP CHECK SCOPE DRIFTED: tooltipDifferentiatedPairs names a pair"
+              + " that is no longer in RowStateGalleryCases.mayLookAlike — update"
+              + " (or remove) it to match.")
+        failed = true
+    }
+
     if failed { exit(1) }
+}
+
+/// Result of checking every `mayLookAlike` pair's tooltip text against its pixel
+/// exemption. `.extractorBroken` is kept distinct from `.undifferentiated([...])`
+/// — see the call site for why that distinction matters.
+enum TooltipCheckResult {
+    case ok(checked: Int)
+    case undifferentiated([String])
+    case extractorBroken
+    case driftedFromMayLookAlike
+}
+
+/// `.body` for `PopoverRowAction`/`WorkbenchRowAction` at a state's DEFAULT
+/// `downloadReadout`/`showsStageLabel` — the same defaults `popoverTile`'s
+/// non-explanation branch uses. Deliberately NOT `RowStateGalleryCases`'
+/// `popoverTile`/`workbenchTile`: those wrap the constructed view in `.frame(...)`
+/// and `AnyView` for the PNG pass, and `Mirror` only sees a view's STORED
+/// properties — it cannot see through an unevaluated `body` computed property, so
+/// reflecting the wrapped-but-unevaluated struct finds nothing at all (confirmed:
+/// an earlier version of this function did exactly that and always reported
+/// `.extractorBroken`). Calling `.body` explicitly, on the concrete type, forces
+/// SwiftUI to evaluate the `switch state { … }` into its actual primitive tree
+/// (`Button`, `HelpView`, `_ConditionalContent`, …) BEFORE `Mirror` ever sees it —
+/// which is also why this can't be generalized to walk an arbitrary `AnyView`:
+/// it relies on knowing the concrete type at the call site.
+@MainActor
+private func rowActionHelpTexts(surface: String, state: RowActionState, result: UpdateResult) -> [String] {
+    switch surface {
+    case "popover": return collectHelpTexts(PopoverRowAction(state: state, result: result).body)
+    case "workbench": return collectHelpTexts(WorkbenchRowAction(state: state, result: result).body)
+    default: return []
+    }
+}
+
+/// The subset of `RowStateGalleryCases.mayLookAlike` whose OWN comment claims a
+/// tooltip differentiates the pair — copied out by name rather than computed from
+/// the comment text (comments aren't data). The other five pairs there claim the
+/// opposite (deliberately identical end-to-end — see the doc comment on this
+/// function's call site for why folding them in would be wrong), so this list is
+/// intentionally shorter than `mayLookAlike` itself, not a stand-in for it.
+private let tooltipDifferentiatedPairs: Set<Set<String>> = [
+    // "Both an orange bordered Relaunch; the help text says which one."
+    ["popover/10-relaunch-to-apply-staged", "popover/11-restart-to-apply"],
+    ["workbench/10-relaunch-to-apply-staged", "workbench/11-restart-to-apply"],
+    // "Both a bordered Update: … the tooltip is what separates them."
+    ["popover/13-update-installer", "popover/19-update-app-store"],
+    ["workbench/13-update-installer", "workbench/19-update-app-store"],
+]
+
+@MainActor
+func tooltipsDifferentiateExemptedPairs() -> TooltipCheckResult {
+    // `tooltipDifferentiatedPairs` is a hand-copied subset of `mayLookAlike` — if
+    // a pair is ever dropped or renamed there without this list following, the
+    // loop below would silently skip it (the per-pair `guard` just `continue`s on
+    // a lookup miss) rather than flag the drift. Since a `Set` of `Set<String>`
+    // has no ordering to make "sorted().joined" complain about, catching this
+    // takes an explicit subset check.
+    guard tooltipDifferentiatedPairs.isSubset(of: RowStateGalleryCases.mayLookAlike) else {
+        return .driftedFromMayLookAlike
+    }
+
+    let byName = Dictionary(uniqueKeysWithValues: RowStateGalleryCases.all.map { ($0.0, $0) })
+    var totalHelpStringsFound = 0
+    var undifferentiated: [String] = []
+    var checked = 0
+
+    for pair in tooltipDifferentiatedPairs {
+        let members = pair.sorted()
+        guard members.count == 2,
+              let slashA = members[0].firstIndex(of: "/"),
+              let slashB = members[1].firstIndex(of: "/") else { continue }
+        let surfaceA = String(members[0][..<slashA]), nameA = String(members[0][members[0].index(after: slashA)...])
+        let surfaceB = String(members[1][..<slashB]), nameB = String(members[1][members[1].index(after: slashB)...])
+        // The three explanation-content names (38–40) aren't in `RowStateGalleryCases
+        // .all`'s SURFACE-neutral form the way this lookup wants — they're not part
+        // of any `mayLookAlike` pair today, so this is a defensive guard, not a
+        // known gap.
+        guard surfaceA == surfaceB,
+              let (_, stateA, resultA) = byName[nameA],
+              let (_, stateB, resultB) = byName[nameB] else { continue }
+
+        let helpA = Set(rowActionHelpTexts(surface: surfaceA, state: stateA, result: resultA))
+        let helpB = Set(rowActionHelpTexts(surface: surfaceA, state: stateB, result: resultB))
+        totalHelpStringsFound += helpA.count + helpB.count
+        checked += 1
+        if helpA == helpB {
+            undifferentiated.append("\(surfaceA): \(nameA) vs \(nameB)"
+                                     + " (tooltip set: \(helpA.sorted()))")
+        }
+    }
+
+    guard totalHelpStringsFound > 0 else { return .extractorBroken }
+    guard undifferentiated.isEmpty else { return .undifferentiated(undifferentiated.sorted()) }
+    return .ok(checked: checked)
+}
+
+/// Recursively finds every `.help(...)` payload in a rendered view's tree via
+/// `Mirror` reflection. SwiftUI wraps a `.help()` call in a private `HelpView
+/// <Content>` type carrying the wrapped content plus the help text as a `Text`;
+/// walking for a node whose runtime type name starts with `"HelpView<"` and
+/// pulling every `String` leaf out of its `text` child recovers the tooltip
+/// content with no accessibility tree, no window, and no on-screen anchor —
+/// unlike every other AX-driving technique this repo has needed (see memory
+/// `duo-updater-ax-popover-driving`), because this walks a view VALUE this
+/// process itself constructed, not another process's rendered window.
+///
+/// Verified against SwiftUI's current (2026-09, Xcode 27 beta) internal shape for
+/// both patterns `PopoverRowAction`/`WorkbenchRowAction` actually use: a literal
+/// `.help("...")` (stored as a `LocalizedStringKey`) and `.help(someString)`
+/// (stored as a verbatim `String`) — both landed inside the same `HelpView`
+/// wrapper's `text` child, just with different internal storage underneath, which
+/// is why this walks for ANY `String` leaf rather than one specific storage shape.
+/// Also verified past an unrelated sibling `.help()` in the same `HStack`, and
+/// (separately, in a throwaway probe — not exercised by this file's actual call
+/// site, which never wraps in `AnyView`) confirmed to still work through `AnyView`
+/// erasure.
+///
+/// Fragile BY CONSTRUCTION: `HelpView` and its internal layout are undocumented
+/// SwiftUI implementation details, not a stable public contract, and Apple can
+/// reshape them on any OS/Swift Toolchain update with no compiler error — this
+/// would simply stop finding anything. `tooltipsDifferentiateExemptedPairs()`'s
+/// `.extractorBroken` case is the guard against that turning into silent false
+/// failures (or worse, a silent false pass) if it ever happens.
+@MainActor
+func collectHelpTexts(_ any: Any, depth: Int = 0) -> [String] {
+    // A real view tree from this app is nowhere near this deep; the cutoff exists
+    // so a future SwiftUI internal shape with a reference cycle in its Mirror
+    // children (unlikely, but undocumented territory) fails closed with an empty
+    // result — caught by `.extractorBroken` — rather than hanging.
+    guard depth <= 60 else { return [] }
+    let mirror = Mirror(reflecting: any)
+    var found: [String] = []
+    if String(describing: mirror.subjectType).hasPrefix("HelpView<") {
+        for child in mirror.children where child.label == "text" {
+            found.append(contentsOf: stringLeaves(child.value))
+        }
+    }
+    for child in mirror.children {
+        found.append(contentsOf: collectHelpTexts(child.value, depth: depth + 1))
+    }
+    return found
+}
+
+private func stringLeaves(_ any: Any, depth: Int = 0) -> [String] {
+    guard depth <= 60 else { return [] }
+    if let s = any as? String { return [s] }
+    let mirror = Mirror(reflecting: any)
+    var found: [String] = []
+    for child in mirror.children {
+        found.append(contentsOf: stringLeaves(child.value, depth: depth + 1))
+    }
+    return found
 }
 
 // `ImageRenderer` and AppKit are main-actor bound, and a `tool` target's top level

--- a/App/RowStateWidthCheck/main.swift
+++ b/App/RowStateWidthCheck/main.swift
@@ -42,8 +42,8 @@ import Foundation
 /// harness used for exactly this kind of question. No `AppleLanguages` pinning, no
 /// process relaunch per language, no dependency on `DuoUpdaterCore` or SwiftUI.
 ///
-/// What a pass proves, precisely
-/// ------------------------------
+/// What a pass proves, precisely — and the headroom this admits to
+/// -----------------------------------------------------------------
 /// This measures NATURAL (unconstrained) width — a string's width in its font with
 /// no line limit applied — compared against `tileWidth`, NOT a simulation of
 /// either window's real layout. `PopoverRowAction`'s real neighbour, in
@@ -51,21 +51,34 @@ import Foundation
 /// width to a wide button rather than clipping it; `WorkbenchRowAction`'s only
 /// production home (`WorkbenchWindowView.DetailHeader`) sits after a `Spacer()`
 /// with roughly 900pt of window behind it. Nothing in this codebase hard-clips at
-/// `tileWidth` today. What DOES hold: every tile in the committed English sheet
-/// was drawn at exactly this width, so it is the widest any state's content has
-/// ever actually been reviewed at — a string that needs MORE than that in another
-/// language is asking for room no screenshot in this repo has shown to a human.
-/// A pass is not a promise that nothing can ever look cramped in production; it is
-/// a promise that this string, in this language, is not asking for more room than
-/// the English baseline the sheet already treats as normal — the previously
-/// invisible half of the failure class this exists to surface.
+/// `tileWidth` today, and `tileWidth` was never derived from one — it is the box
+/// every committed tile happens to be drawn into, not a measured production
+/// ceiling.
 ///
-/// The report also prints each string's growth versus its English width, even
-/// when it stays under budget: informational, not a second gate — there is no
-/// non-arbitrary "acceptable growth" number to enforce, but the magnitude is worth
-/// a human's eyes (Russian `Rate-limited` is +103pt over English at `.caption2`
-/// while still clearing a 320pt budget by a wide margin, which is exactly the kind
-/// of number a reviewer should see even though nothing here fails on it).
+/// **Say the number plainly: the widest string measured across en/ru/fr is
+/// `workbench/Not supported on this Mac [label:callout]` at 194.5pt (ru), against
+/// a 320pt budget — 125.5pt of headroom, ~1.65x. A gate with that much slack
+/// cannot fire on anything realistic, and could not have caught the failure that
+/// motivated this issue (the status line left 9pt in Spanish — a different view
+/// this tool structurally can't reach, see above — not 125pt). A PASS from the
+/// OVERFLOW gate below means "not wider than the widest tile this repo has
+/// committed a screenshot of", nothing stronger.**
+///
+/// **The actual signal is the GROWTH RATIO, and it is not a second gate — it is
+/// the primary deliverable.** Every line in `verify/row-state-widths/*.txt` carries
+/// `growth_ratio` (width ÷ its English width, same kind). A translation change
+/// shows up there as a reviewable numeric diff the same way a rendering change
+/// shows up as a PNG diff — read it, don't just check the exit code. To make that
+/// legible without asking a reviewer to scan 150+ rows by hand, any string whose
+/// ratio is 2.0x or more is echoed to the console as `HIGH GROWTH` — informational,
+/// not gating (see `highGrowthRatio`'s own doc comment for why 2.0, chosen before
+/// looking at what it would catch, not tuned to spare any specific string). It
+/// currently catches eight (four per language): ru `Rate-limited`/`Verifying` on
+/// both surfaces (2.7x — `Rate-limited` is the exact string CLAUDE.md already
+/// names as risky) and fr `Verifying`/`Installing` on both surfaces (2.3x). None
+/// of those are false positives to explain away; they are real, already-shipped
+/// translations legitimately larger than anything this sheet has shown a
+/// reviewer, surfaced rather than hidden behind a 320pt pass.
 @MainActor
 func run() -> Bool {
     let languages = Array(CommandLine.arguments.dropFirst())
@@ -99,6 +112,9 @@ func run() -> Bool {
         var lines: [String] = []
         var overflow: [String] = []
         var missing: [String] = []
+        var highGrowth: [String] = []
+        var widestWidth: CGFloat = 0
+        var widestTile = ""
 
         for entry in MeasuredString.all {
             let english = entry.english
@@ -116,20 +132,34 @@ func run() -> Bool {
                 let width = occurrence.kind.width(of: value)
                 let budget = tileWidth
                 let isOver = width > budget
+                let tileLabel = "\(occurrence.surface)/\(entry.key) [\(occurrence.kind.reportKey)]"
                 let baseline = englishWidthByKind[occurrence.kind.reportKey] ?? width
                 let delta = width - baseline
+                // Guards a division by (near-)zero baseline (an empty/near-empty
+                // English string) from reporting a meaningless huge ratio.
+                let ratio = baseline > 0.5 ? width / baseline : 1.0
                 lines.append(
-                    "\(occurrence.surface)/\(entry.key) [\(occurrence.kind.reportKey)]"
+                    tileLabel
                     + "\t\(fmt(width))\t\(fmt(budget))\t\(isOver ? "OVERFLOW" : "ok")"
-                    + "\t\(String(format: "%+.1f", delta))")
+                    + "\t\(String(format: "%+.1f", delta))\t\(String(format: "%.2f", ratio))")
                 if isOver {
-                    overflow.append("\(occurrence.surface)/\(entry.key) [\(occurrence.kind.reportKey)]"
-                                     + " = \"\(value)\" (\(fmt(width))pt > \(fmt(budget))pt)")
+                    overflow.append("\(tileLabel) = \"\(value)\" (\(fmt(width))pt > \(fmt(budget))pt)")
+                }
+                // See the file header ("What a pass proves") for why this is
+                // informational rather than a second gate, and why 2.0 was picked
+                // before looking at what it would catch.
+                if ratio >= highGrowthRatio, lang != "en" {
+                    highGrowth.append("\(tileLabel) = \"\(value)\" (\(String(format: "%.2f", ratio))x"
+                                       + " English's \(fmt(baseline))pt → \(fmt(width))pt)")
+                }
+                if width > widestWidth {
+                    widestWidth = width
+                    widestTile = tileLabel
                 }
             }
         }
 
-        let header = "tile\twidth_pt\tbudget_pt\tstatus\tdelta_vs_en_pt\n"
+        let header = "tile\twidth_pt\tbudget_pt\tstatus\tdelta_vs_en_pt\tgrowth_ratio\n"
         let report = header + lines.sorted().joined(separator: "\n") + "\n"
         let reportURL = outDir.appendingPathComponent("\(lang).txt")
         do {
@@ -146,18 +176,42 @@ func run() -> Bool {
                   + " but this means catalogue coverage regressed): \(missing.joined(separator: ", "))")
             overallFailed = true
         }
+        // Deliberately NOT "overflow is guarded" language — see the file header's
+        // "headroom this admits to". Widest-observed + headroom is stated every
+        // run so this can't be misread as a tight bound in a console scrollback
+        // either, not just in the doc comment.
+        let headroom = tileWidth - widestWidth
         if overflow.isEmpty {
-            print("\(lang): no string exceeds the \(fmt(tileWidth))pt tile width")
+            print("\(lang): no string exceeds the \(fmt(tileWidth))pt tile width"
+                  + " (widest: \(widestTile) at \(fmt(widestWidth))pt —"
+                  + " \(fmt(headroom))pt of headroom left in that budget)")
         } else {
             print("\(lang): OVERFLOW — \(overflow.count) string(s) exceed the tile width:")
             for o in overflow.sorted() { print("  \(o)") }
             overallFailed = true
+        }
+        if !highGrowth.isEmpty {
+            print("\(lang): HIGH GROWTH (≥\(String(format: "%.1f", highGrowthRatio))x English's width —"
+                  + " informational, does not fail the build; see the file header):")
+            for g in highGrowth.sorted() { print("  \(g)") }
         }
     }
     return !overallFailed
 }
 
 private func fmt(_ v: CGFloat) -> String { String(format: "%.1f", v) }
+
+/// A translation drawing at least this many times its English natural width —
+/// picked as a round number BEFORE measuring what it would catch (not tuned to
+/// clear or catch any specific string), so it isn't a threshold reverse-engineered
+/// from the data it grades. Applied per (key, kind), same units `delta_vs_en_pt`
+/// already reports. See the file header ("What a pass proves") for why this is
+/// informational only, not a second gate: doubling in one language is not
+/// inherently a defect (Cyrillic and multi-word German equivalents routinely run
+/// long), so failing the build on it would mean either fixing translations this
+/// tool has no authority over or inventing an exemption list under time pressure
+/// — surfacing it for a human is the honest amount of automation here.
+let highGrowthRatio: CGFloat = 2.0
 
 /// Mirrors `RowStateGalleryCases.tileWidth` (`App/RowStateGallery/Cases.swift`) —
 /// the box every committed `verify/row-states/*.png` tile is drawn into.

--- a/App/RowStateWidthCheck/main.swift
+++ b/App/RowStateWidthCheck/main.swift
@@ -1,0 +1,447 @@
+import AppKit
+import Foundation
+
+/// Measures the natural width of every translatable string the two row-action
+/// views (`PopoverRowAction`, `WorkbenchRowAction`) actually draw, in each of a
+/// small set of languages, against the same 320pt box every committed
+/// `verify/row-states/*.png` tile is drawn into.
+///
+/// Why this exists (#263): `make gallery` pins English on purpose — `ImageRenderer`
+/// follows the host language, so any other locale rewrites all 80 committed PNGs
+/// with a diff that says nothing about the change under review (see that script's
+/// own doc comment). The cost is that the sheet cannot see a translated string
+/// overflowing its slot, which is the one failure this area has actually shipped
+/// (`CLAUDE.md`: the status line left 9pt in Spanish; the workbench's first version
+/// dropped `.lineLimit(1)`/`.minimumScaleFactor(0.7)` and Russian
+/// "Ограничение частоты запросов" would have pushed the app name out).
+///
+/// Why this reads `Localizable.xcstrings` directly instead of rendering the real
+/// views in a pinned locale
+/// ------------------------------------------------------------------------------
+/// The first version of this tool did what `RowStateGallery` does — build
+/// `PopoverRowAction`/`WorkbenchRowAction` from `RowStateGalleryCases.all` and
+/// render them via `ImageRenderer`, switching `AppleLanguages`/`AppleLocale` per
+/// run. It does not work: a `type: tool` product (a bare Mach-O, not an `.app`
+/// bundle) never gets `Localizable.xcstrings` compiled into it — confirmed by
+/// building it with an explicit `Resources` phase and `GENERATE_INFOPLIST_FILE:
+/// YES` and finding no `CompileXCStrings`/`.lproj` step anywhere in the build log,
+/// and separately by a self-check inside the tool (comparing
+/// `Bundle.main.preferredLocalizations.first` against the language it asked for)
+/// that caught its own strings resolving to English regardless of
+/// `AppleLanguages`. So `String(localized:)` in `PopoverRowAction`/
+/// `RowActionViews.swift` always returns the English text in this kind of target,
+/// no matter what locale the process is launched with — the SwiftUI-rendering
+/// approach was measuring English in every language and would never have gone red.
+///
+/// This tool instead reads the actual translated VALUES out of
+/// `App/Resources/Localizable.xcstrings` — the same file that ships to users — and
+/// measures them with the real font/control each call site uses (`NSAttributedString`
+/// for a `Text` tag, a real `NSButton` at the call site's `controlSize` for a
+/// button), the same technique `MenuContentView.swift`'s own `nameColumnDemand`/
+/// `showsStageLabel` already use for layout decisions, and the one PR #267's width
+/// harness used for exactly this kind of question. No `AppleLanguages` pinning, no
+/// process relaunch per language, no dependency on `DuoUpdaterCore` or SwiftUI.
+///
+/// What a pass proves, precisely
+/// ------------------------------
+/// This measures NATURAL (unconstrained) width — a string's width in its font with
+/// no line limit applied — compared against `tileWidth`, NOT a simulation of
+/// either window's real layout. `PopoverRowAction`'s real neighbour, in
+/// `MenuContentView`, is a `minWidth` reservation (`trailingSlot`) that CONCEDES
+/// width to a wide button rather than clipping it; `WorkbenchRowAction`'s only
+/// production home (`WorkbenchWindowView.DetailHeader`) sits after a `Spacer()`
+/// with roughly 900pt of window behind it. Nothing in this codebase hard-clips at
+/// `tileWidth` today. What DOES hold: every tile in the committed English sheet
+/// was drawn at exactly this width, so it is the widest any state's content has
+/// ever actually been reviewed at — a string that needs MORE than that in another
+/// language is asking for room no screenshot in this repo has shown to a human.
+/// A pass is not a promise that nothing can ever look cramped in production; it is
+/// a promise that this string, in this language, is not asking for more room than
+/// the English baseline the sheet already treats as normal — the previously
+/// invisible half of the failure class this exists to surface.
+///
+/// The report also prints each string's growth versus its English width, even
+/// when it stays under budget: informational, not a second gate — there is no
+/// non-arbitrary "acceptable growth" number to enforce, but the magnitude is worth
+/// a human's eyes (Russian `Rate-limited` is +103pt over English at `.caption2`
+/// while still clearing a 320pt budget by a wide margin, which is exactly the kind
+/// of number a reviewer should see even though nothing here fails on it).
+@MainActor
+func run() -> Bool {
+    let languages = Array(CommandLine.arguments.dropFirst())
+    guard !languages.isEmpty else {
+        print("usage: RowStateWidthCheck <language-code> [<language-code> ...]")
+        return false
+    }
+
+    guard let catalog = loadCatalog() else {
+        print("could not read/parse Resources/Localizable.xcstrings from the current"
+              + " directory — run this from the repo root (row-state-width-check.sh does).")
+        return false
+    }
+
+    let outDir = URL(fileURLWithPath: "verify/row-state-widths", isDirectory: true)
+    try? FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+
+    // English widths per (key, kind), computed once so the report's "growth vs
+    // English" column doesn't re-measure English on every language's pass.
+    var englishWidths: [String: [String: CGFloat]] = [:]
+    for entry in MeasuredString.all {
+        var byKind: [String: CGFloat] = [:]
+        for occurrence in entry.occurrences {
+            byKind[occurrence.kind.reportKey] = occurrence.kind.width(of: entry.english)
+        }
+        englishWidths[entry.key] = byKind
+    }
+
+    var overallFailed = false
+    for lang in languages {
+        var lines: [String] = []
+        var overflow: [String] = []
+        var missing: [String] = []
+
+        for entry in MeasuredString.all {
+            let english = entry.english
+            let value: String
+            if lang == "en" {
+                value = english
+            } else if let translated = catalog.value(forKey: entry.key, language: lang) {
+                value = translated
+            } else {
+                missing.append("\(entry.key) [\(lang)]")
+                value = english
+            }
+            let englishWidthByKind = englishWidths[entry.key] ?? [:]
+            for occurrence in entry.occurrences {
+                let width = occurrence.kind.width(of: value)
+                let budget = tileWidth
+                let isOver = width > budget
+                let baseline = englishWidthByKind[occurrence.kind.reportKey] ?? width
+                let delta = width - baseline
+                lines.append(
+                    "\(occurrence.surface)/\(entry.key) [\(occurrence.kind.reportKey)]"
+                    + "\t\(fmt(width))\t\(fmt(budget))\t\(isOver ? "OVERFLOW" : "ok")"
+                    + "\t\(String(format: "%+.1f", delta))")
+                if isOver {
+                    overflow.append("\(occurrence.surface)/\(entry.key) [\(occurrence.kind.reportKey)]"
+                                     + " = \"\(value)\" (\(fmt(width))pt > \(fmt(budget))pt)")
+                }
+            }
+        }
+
+        let header = "tile\twidth_pt\tbudget_pt\tstatus\tdelta_vs_en_pt\n"
+        let report = header + lines.sorted().joined(separator: "\n") + "\n"
+        let reportURL = outDir.appendingPathComponent("\(lang).txt")
+        do {
+            try report.write(to: reportURL, atomically: true, encoding: .utf8)
+        } catch {
+            print("FAILED TO WRITE \(reportURL.path): \(error.localizedDescription)")
+            overallFailed = true
+            continue
+        }
+
+        print("\(lang): measured \(lines.count) strings → \(reportURL.path)")
+        if !missing.isEmpty {
+            print("\(lang): NO TRANSLATION FOUND (measured English as a stand-in,"
+                  + " but this means catalogue coverage regressed): \(missing.joined(separator: ", "))")
+            overallFailed = true
+        }
+        if overflow.isEmpty {
+            print("\(lang): no string exceeds the \(fmt(tileWidth))pt tile width")
+        } else {
+            print("\(lang): OVERFLOW — \(overflow.count) string(s) exceed the tile width:")
+            for o in overflow.sorted() { print("  \(o)") }
+            overallFailed = true
+        }
+    }
+    return !overallFailed
+}
+
+private func fmt(_ v: CGFloat) -> String { String(format: "%.1f", v) }
+
+/// Mirrors `RowStateGalleryCases.tileWidth` (`App/RowStateGallery/Cases.swift`) —
+/// the box every committed `verify/row-states/*.png` tile is drawn into.
+/// Duplicated rather than imported: this tool does not build against
+/// `DuoUpdaterCore`/SwiftUI at all (see the file header for why) — there is no
+/// shared module to pull the constant from. Keep the two numbers in sync if
+/// `tileWidth` there ever changes.
+let tileWidth: CGFloat = 320
+
+// MARK: - What gets measured, and how
+
+/// One way a translated string is actually drawn — which surface, and with what
+/// font/control (the exact modifiers read off `PopoverRowAction.swift`/
+/// `RowActionViews.swift` at the time this was written).
+struct Occurrence {
+    let surface: String
+    let kind: Kind
+}
+
+enum Kind {
+    /// A plain `Text`, no line limit applied for this measurement (this tool
+    /// measures NATURAL width — see the file header for what that does and
+    /// doesn't prove about `.lineLimit(1)`/`.minimumScaleFactor(0.7)`, which both
+    /// views apply to most of these).
+    case tag(NSFont.TextStyle)
+    /// A `Label`'s text portion — the icon and its spacing are fixed-width and
+    /// not translation-dependent, so they are not measured; the doc comment on
+    /// the caller explains why the two workbench-only badges without a popover
+    /// counterpart are still measured this way rather than skipped.
+    case label(NSFont.TextStyle)
+    /// A real `NSButton`, at the same `controlSize` the call site uses — mirrors
+    /// the technique memory `duo-updater-status-line-slot-width` already used and
+    /// validated ("按钮用真 NSButton(.small) 量本地化标题") rather than
+    /// approximating a button's chrome with `NSAttributedString`.
+    case button(NSControl.ControlSize)
+
+    /// A stable string for grouping/reporting — not shown to users, just makes
+    /// the report and the delta-vs-English lookup key deterministic and readable
+    /// (`NSFont.TextStyle.rawValue` is e.g. "UICTFontTextStyleCallout";
+    /// `NSControl.ControlSize.rawValue` is a bare `Int`).
+    var reportKey: String {
+        switch self {
+        case .tag(let style): return "tag:\(Self.shortName(style))"
+        case .label(let style): return "label:\(Self.shortName(style))"
+        case .button(let size): return "button:\(Self.shortName(size))"
+        }
+    }
+
+    private static func shortName(_ style: NSFont.TextStyle) -> String {
+        switch style {
+        case .caption2: return "caption2"
+        case .callout: return "callout"
+        default: return style.rawValue
+        }
+    }
+
+    private static func shortName(_ size: NSControl.ControlSize) -> String {
+        switch size {
+        case .mini: return "mini"
+        case .small: return "small"
+        case .regular: return "regular"
+        case .large: return "large"
+        @unknown default: return "size\(size.rawValue)"
+        }
+    }
+
+    @MainActor
+    func width(of value: String) -> CGFloat {
+        switch self {
+        case .tag(let style), .label(let style):
+            let font = NSFont.preferredFont(forTextStyle: style)
+            return NSAttributedString(string: value, attributes: [.font: font]).size().width
+        case .button(let size):
+            let button = NSButton(title: value, target: nil, action: nil)
+            button.bezelStyle = .rounded
+            button.controlSize = size
+            button.font = NSFont.systemFont(ofSize: NSFont.systemFontSize(for: size))
+            button.sizeToFit()
+            return button.fittingSize.width
+        }
+    }
+}
+
+struct MeasuredString {
+    /// The `Localizable.xcstrings` key.
+    let key: String
+    /// What English actually displays — equal to `key` for a plain
+    /// `Text("...")`/`Button("...")` call site (no `defaultValue:`); different for
+    /// `ignoredRowLabel()`/`skippedRowLabel()`, whose catalogue key
+    /// ("Ignored (row status)"/"Skipped (row status)") is NOT what English shows
+    /// (see `RowActionViews.swift`'s doc comment on those two functions) — and
+    /// `Localizable.xcstrings` has no "en" entry for either (English is supplied
+    /// entirely by the call site's `defaultValue:`, never written to the
+    /// catalogue), so it cannot be read back the way every other key's English
+    /// value can.
+    let english: String
+    let occurrences: [Occurrence]
+}
+
+extension MeasuredString {
+    /// Every STATIC (non-interpolated) translatable string actually drawn inside
+    /// `PopoverRowAction`'s and `WorkbenchRowAction`'s row bodies — read off
+    /// `App/Sources/PopoverRowAction.swift` and `App/Sources/RowActionViews.swift`
+    /// directly, 2026-09-02. Written out by hand rather than derived from the
+    /// source, same as `RowStateGalleryCases.all` (see that file's own doc
+    /// comment): deriving it would auto-cover a new string the moment it's added,
+    /// which is exactly the "nobody drew it" gap that list exists to make
+    /// noticeable. A new `Text`/`Button`/`Label` literal in either file needs a
+    /// line added here.
+    ///
+    /// Excluded on purpose: the three explanation popovers' body text
+    /// (`majorUpgradePopover`/`regionHintPopover`/`macCompatHintPopover`) — each
+    /// wraps inside its own `.frame(width: 290)`/`.frame(width: 300)` with no
+    /// `lineLimit`, so a long translation grows the panel TALLER, not wider; a
+    /// height question, not the one this tool asks. Also excluded: strings built
+    /// from interpolation whose English form isn't a single stable catalogue
+    /// value (`"Update \(version)"`, the two App Store deep-link help strings,
+    /// the restart/relaunch help texts) — `.help()` text is a separate, unmeasured
+    /// gap named in the PR body, not folded in here to avoid conflating "this
+    /// button's visible width" with "this tooltip might also be long".
+    static let all: [MeasuredString] = [
+        // MARK: Tags shared by both surfaces (popover .caption2, workbench .callout)
+        MeasuredString(key: "Ignored (row status)", english: "Ignored", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Skipped (row status)", english: "Skipped", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Failed", english: "Failed", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Rate-limited", english: "Rate-limited", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "App Store", english: "App Store", occurrences: [
+            // `sourceHint(for:)`'s tag, AND the button both surfaces show for an
+            // App Store row that isn't managed here / isn't gated.
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Sparkle", english: "Sparkle", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "TestFlight", english: "TestFlight", occurrences: [
+            // Both the managed-tag (`testFlightManagedLabel`/`testFlightManagedTile`)
+            // and the button (`testFlightButton`/the workbench's TestFlight route).
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Relaunching…", english: "Relaunching…", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Updated", english: "Updated", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        // installStageLabel's static values (the dynamic "N%" case is digits, not
+        // translated text — excluded).
+        MeasuredString(key: "Queued", english: "Queued", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Checking", english: "Checking", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Verifying", english: "Verifying", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Extracting", english: "Extracting", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Installing", english: "Installing", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+        MeasuredString(key: "Installed", english: "Installed", occurrences: [
+            .init(surface: "popover", kind: .tag(.caption2)),
+            .init(surface: "workbench", kind: .tag(.callout)),
+        ]),
+
+        // MARK: Buttons — popover is always .controlSize(.small); workbench never
+        // sets a controlSize, i.e. the default (.regular).
+        MeasuredString(key: "Update", english: "Update", occurrences: [
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Install", english: "Install", occurrences: [
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Relaunch", english: "Relaunch", occurrences: [
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Relaunch now", english: "Relaunch now", occurrences: [
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Toolbox", english: "Toolbox", occurrences: [
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Open", english: "Open", occurrences: [
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        MeasuredString(key: "Reveal in Finder", english: "Reveal in Finder", occurrences: [
+            .init(surface: "popover", kind: .button(.small)),
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+        // Workbench-only: `DetectionOnlyAffordance` gives the popover just "Open"
+        // for `.openPage` (already covered above); the workbench titles that same
+        // case "Open page" instead (`RowActionViews.swift`'s own comment: "this
+        // host's own call, kept out of the shared type on purpose").
+        MeasuredString(key: "Open page", english: "Open page", occurrences: [
+            .init(surface: "workbench", kind: .button(.regular)),
+        ]),
+
+        // MARK: Workbench-only Label badges (major upgrade / App Store gates).
+        // The popover draws the equivalent state as a bare SF Symbol badge with no
+        // text at all (`majorUpgradeBadge`/`appStoreTrailing`'s gate branches) — so
+        // there is no popover occurrence to pair these with, unlike everything
+        // above.
+        MeasuredString(key: "Major update", english: "Major update", occurrences: [
+            .init(surface: "workbench", kind: .label(.callout)),
+        ]),
+        MeasuredString(key: "Not supported on this Mac", english: "Not supported on this Mac", occurrences: [
+            .init(surface: "workbench", kind: .label(.callout)),
+        ]),
+        MeasuredString(key: "Region-locked", english: "Region-locked", occurrences: [
+            .init(surface: "workbench", kind: .label(.callout)),
+        ]),
+    ]
+}
+
+// MARK: - Reading Localizable.xcstrings directly
+
+struct StringCatalog {
+    /// key -> language -> translated value
+    let values: [String: [String: String]]
+
+    func value(forKey key: String, language: String) -> String? {
+        values[key]?[language]
+    }
+}
+
+private func loadCatalog() -> StringCatalog? {
+    let url = URL(fileURLWithPath: "App/Resources/Localizable.xcstrings")
+    guard let data = try? Data(contentsOf: url),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let strings = json["strings"] as? [String: Any] else {
+        return nil
+    }
+    var values: [String: [String: String]] = [:]
+    for (key, entryAny) in strings {
+        guard let entry = entryAny as? [String: Any],
+              let localizations = entry["localizations"] as? [String: Any] else { continue }
+        var byLang: [String: String] = [:]
+        for (lang, locAny) in localizations {
+            guard let loc = locAny as? [String: Any],
+                  let unit = loc["stringUnit"] as? [String: Any],
+                  let value = unit["value"] as? String else { continue }
+            byLang[lang] = value
+        }
+        values[key] = byLang
+    }
+    return StringCatalog(values: values)
+}
+
+// Same reasoning as `RowStateGallery/main.swift`: a `tool` target's top level is
+// not implicitly main-actor bound.
+MainActor.assumeIsolated {
+    if !run() { exit(1) }
+}

--- a/App/project.yml
+++ b/App/project.yml
@@ -51,6 +51,29 @@ targets:
     dependencies:
       - package: DuoUpdaterCore
 
+  # #263: measures (does not render) every translatable string
+  # `PopoverRowAction`/`WorkbenchRowAction` draw, in each of a small set of
+  # languages, against `RowStateGalleryCases.tileWidth` (320pt, mirrored as a
+  # local constant — see this target's own doc comment in main.swift for why it
+  # isn't imported). `make gallery` pins English on purpose (see its target's own
+  # comment above), which means it structurally cannot see a translated string
+  # outgrowing that box; this is the companion check that runs in other languages
+  # instead of widening the committed PNG sheet. Run with `make width-check`
+  # (`scripts/row-state-width-check.sh`).
+  #
+  # Reads `App/Resources/Localizable.xcstrings` directly rather than rendering the
+  # real views through `ImageRenderer` with `AppleLanguages` pinned, which a first
+  # version tried and which does not work: a `type: tool` product never gets the
+  # catalogue compiled into it, so `String(localized:)` inside those views always
+  # resolves English regardless of the process locale — see main.swift's header
+  # comment for how that was confirmed, not assumed. No dependency on
+  # `DuoUpdaterCore` or SwiftUI as a result.
+  RowStateWidthCheck:
+    type: tool
+    platform: macOS
+    sources:
+      - RowStateWidthCheck
+
   DuoUpdater:
     type: application
     platform: macOS

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install cli build test gallery notarize release
+.PHONY: install cli build test gallery width-check notarize release
 
 # Build with a stable Developer ID signature and deploy the canonical copy to
 # /Applications. See scripts/install.sh for why the identity matters (TCC grants).
@@ -26,6 +26,14 @@ test:
 # re-run after a UI change and read the diff. Fails if a state draws nothing.
 gallery:
 	@scripts/row-state-gallery.sh
+
+# Measure (not render) every row-action tile's width in ru/fr against the same
+# 320pt box the gallery's PNGs use — see scripts/row-state-width-check.sh for
+# why those two languages, and App/RowStateWidthCheck/main.swift for what a pass
+# proves. The English pass above cannot see a translated string outgrowing its
+# slot; this is the companion check that catches that class instead.
+width-check:
+	@scripts/row-state-width-check.sh
 
 # The notarytool keychain profile both targets below need. Not a secret — the
 # credentials it names live in the keychain; this is only which of them to use.

--- a/scripts/row-state-width-check.sh
+++ b/scripts/row-state-width-check.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Measure every translatable row-action string's natural width, in each of a
+# small set of languages, against RowStateGalleryCases.tileWidth (320pt) — the
+# box every committed verify/row-states/*.png tile is drawn into.
+#
+# Companion to `make gallery`, not a replacement for it: that script pins English
+# on purpose (`ImageRenderer` follows the host language, so a run in any other
+# locale rewrites all 80 committed PNGs with a diff that says nothing about the
+# change under review — see its own comment). That pin is also why the sheet
+# structurally cannot see the one failure this area has actually shipped: a
+# translated string overflowing its slot (CLAUDE.md: the status line left 9pt in
+# Spanish; the workbench once dropped .lineLimit(1)/.minimumScaleFactor(0.7) and
+# Russian "Ограничение частоты запросов" would have pushed the app name out).
+# Rather than double the committed image count (#263's option 1), this MEASURES —
+# see App/RowStateWidthCheck/main.swift for exactly what a pass proves, and why
+# it reads Localizable.xcstrings directly instead of rendering the real views in
+# a pinned locale (that was tried first; it does not work for a `tool` product) —
+# and commits the measurements, not a second set of pictures.
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DD="${GALLERY_DD:-/tmp/duo-gallery}"
+
+# Same reasoning as row-state-gallery.sh: must be exported before xcodegen, or a
+# bare `xcodegen generate` writes an empty DEVELOPMENT_TEAM that only breaks the
+# next `make install`.
+TEAM="${DUO_TEAM_ID:-RS59HDH7Y3}"
+export DUO_TEAM_ID="$TEAM"
+
+cd "$REPO"
+xcodegen generate --spec App/project.yml --project App >/dev/null
+
+xcodebuild -project App/DuoUpdater.xcodeproj \
+           -scheme RowStateWidthCheck -configuration Debug \
+           -derivedDataPath "$DD" build >/dev/null
+
+BIN="$DD/Build/Products/Debug/RowStateWidthCheck"
+
+# Wipe first, same reasoning as the gallery: a retired language or a string no
+# longer drawn must not leave a stale report behind for something that no longer
+# runs.
+rm -rf "$REPO/verify/row-state-widths"
+
+# Which languages, and why these and not all six the catalogue ships (de, es, fr,
+# ja, ru, zh-Hans): measured on 2026-09-02 against the real Localizable.xcstrings
+# values for every row-action catalogue key (Update/Relaunch/Install/App
+# Store/Toolbox/TestFlight/Ignored/Skipped/Rate-limited/Failed/Major
+# update/Region-locked/Not supported on this Mac/Open page/Reveal in
+# Finder/Queued/Extracting/Installing), at both fonts these views actually use
+# (.caption2 popover, .callout workbench), via NSAttributedString — the same
+# technique #267's width harness used, and the one MenuContentView.swift's own
+# `nameColumnDemand`/`showsStageLabel` measurements use in production. Average
+# width delta vs. English, at .callout:
+#
+#   ru +41.0pt (worst — and the single worst case: Rate-limited +119.3pt, the
+#               exact string CLAUDE.md already names)
+#   fr +25.5pt (second-worst average, narrowly ahead of de; its own
+#               parenthetical already caused a real bug, fixed in #267)
+#   de +24.5pt
+#   es +16.1pt
+#   ja  +6.7pt (net narrower on several keys — CJK glyphs are compact; a few
+#               multi-kana words still run wide, e.g. Install +34.9pt)
+#   zh-Hans -17.8pt (narrower than English on every measured key — no signal)
+#
+# ru and fr are the two that actually threaten this layout; de trails fr by only
+# 1pt on average but neither de nor es tops ru or fr on ANY key measured. ja and
+# zh-Hans would not exercise the failure mode at all — including all six would
+# inflate the report for two languages that have never once been the wide one.
+"$BIN" en ru fr

--- a/verify/row-state-widths/en.txt
+++ b/verify/row-state-widths/en.txt
@@ -1,0 +1,53 @@
+tile	width_pt	budget_pt	status	delta_vs_en_pt
+popover/App Store [button:small]	73.0	320.0	ok	+0.0
+popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0
+popover/Checking [tag:caption2]	46.2	320.0	ok	+0.0
+popover/Extracting [tag:caption2]	50.5	320.0	ok	+0.0
+popover/Failed [tag:caption2]	29.3	320.0	ok	+0.0
+popover/Ignored (row status) [tag:caption2]	37.9	320.0	ok	+0.0
+popover/Install [button:small]	52.0	320.0	ok	+0.0
+popover/Installed [tag:caption2]	42.2	320.0	ok	+0.0
+popover/Installing [tag:caption2]	45.1	320.0	ok	+0.0
+popover/Open [button:small]	49.0	320.0	ok	+0.0
+popover/Queued [tag:caption2]	38.4	320.0	ok	+0.0
+popover/Rate-limited [tag:caption2]	60.8	320.0	ok	+0.0
+popover/Relaunch [button:small]	69.0	320.0	ok	+0.0
+popover/Relaunch now [button:small]	93.0	320.0	ok	+0.0
+popover/Relaunching… [tag:caption2]	69.3	320.0	ok	+0.0
+popover/Reveal in Finder [button:small]	104.0	320.0	ok	+0.0
+popover/Skipped (row status) [tag:caption2]	40.2	320.0	ok	+0.0
+popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0
+popover/TestFlight [button:small]	72.0	320.0	ok	+0.0
+popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0
+popover/Toolbox [button:small]	61.0	320.0	ok	+0.0
+popover/Update [button:small]	59.0	320.0	ok	+0.0
+popover/Updated [tag:caption2]	42.3	320.0	ok	+0.0
+popover/Verifying [tag:caption2]	44.1	320.0	ok	+0.0
+workbench/App Store [button:regular]	85.0	320.0	ok	+0.0
+workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0
+workbench/Checking [tag:callout]	53.0	320.0	ok	+0.0
+workbench/Extracting [tag:callout]	57.5	320.0	ok	+0.0
+workbench/Failed [tag:callout]	33.3	320.0	ok	+0.0
+workbench/Ignored (row status) [tag:callout]	43.2	320.0	ok	+0.0
+workbench/Install [button:regular]	60.0	320.0	ok	+0.0
+workbench/Installed [tag:callout]	47.7	320.0	ok	+0.0
+workbench/Installing [tag:callout]	50.8	320.0	ok	+0.0
+workbench/Major update [label:callout]	74.5	320.0	ok	+0.0
+workbench/Not supported on this Mac [label:callout]	150.6	320.0	ok	+0.0
+workbench/Open [button:regular]	57.0	320.0	ok	+0.0
+workbench/Open page [button:regular]	91.0	320.0	ok	+0.0
+workbench/Queued [tag:callout]	44.3	320.0	ok	+0.0
+workbench/Rate-limited [tag:callout]	69.2	320.0	ok	+0.0
+workbench/Region-locked [label:callout]	81.8	320.0	ok	+0.0
+workbench/Relaunch [button:regular]	80.0	320.0	ok	+0.0
+workbench/Relaunch now [button:regular]	109.0	320.0	ok	+0.0
+workbench/Relaunching… [tag:callout]	78.9	320.0	ok	+0.0
+workbench/Reveal in Finder [button:regular]	120.0	320.0	ok	+0.0
+workbench/Skipped (row status) [tag:callout]	46.0	320.0	ok	+0.0
+workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0
+workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0
+workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0
+workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0
+workbench/Update [button:regular]	69.0	320.0	ok	+0.0
+workbench/Updated [tag:callout]	48.7	320.0	ok	+0.0
+workbench/Verifying [tag:callout]	50.0	320.0	ok	+0.0

--- a/verify/row-state-widths/en.txt
+++ b/verify/row-state-widths/en.txt
@@ -1,53 +1,53 @@
-tile	width_pt	budget_pt	status	delta_vs_en_pt
-popover/App Store [button:small]	73.0	320.0	ok	+0.0
-popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0
-popover/Checking [tag:caption2]	46.2	320.0	ok	+0.0
-popover/Extracting [tag:caption2]	50.5	320.0	ok	+0.0
-popover/Failed [tag:caption2]	29.3	320.0	ok	+0.0
-popover/Ignored (row status) [tag:caption2]	37.9	320.0	ok	+0.0
-popover/Install [button:small]	52.0	320.0	ok	+0.0
-popover/Installed [tag:caption2]	42.2	320.0	ok	+0.0
-popover/Installing [tag:caption2]	45.1	320.0	ok	+0.0
-popover/Open [button:small]	49.0	320.0	ok	+0.0
-popover/Queued [tag:caption2]	38.4	320.0	ok	+0.0
-popover/Rate-limited [tag:caption2]	60.8	320.0	ok	+0.0
-popover/Relaunch [button:small]	69.0	320.0	ok	+0.0
-popover/Relaunch now [button:small]	93.0	320.0	ok	+0.0
-popover/Relaunching… [tag:caption2]	69.3	320.0	ok	+0.0
-popover/Reveal in Finder [button:small]	104.0	320.0	ok	+0.0
-popover/Skipped (row status) [tag:caption2]	40.2	320.0	ok	+0.0
-popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0
-popover/TestFlight [button:small]	72.0	320.0	ok	+0.0
-popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0
-popover/Toolbox [button:small]	61.0	320.0	ok	+0.0
-popover/Update [button:small]	59.0	320.0	ok	+0.0
-popover/Updated [tag:caption2]	42.3	320.0	ok	+0.0
-popover/Verifying [tag:caption2]	44.1	320.0	ok	+0.0
-workbench/App Store [button:regular]	85.0	320.0	ok	+0.0
-workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0
-workbench/Checking [tag:callout]	53.0	320.0	ok	+0.0
-workbench/Extracting [tag:callout]	57.5	320.0	ok	+0.0
-workbench/Failed [tag:callout]	33.3	320.0	ok	+0.0
-workbench/Ignored (row status) [tag:callout]	43.2	320.0	ok	+0.0
-workbench/Install [button:regular]	60.0	320.0	ok	+0.0
-workbench/Installed [tag:callout]	47.7	320.0	ok	+0.0
-workbench/Installing [tag:callout]	50.8	320.0	ok	+0.0
-workbench/Major update [label:callout]	74.5	320.0	ok	+0.0
-workbench/Not supported on this Mac [label:callout]	150.6	320.0	ok	+0.0
-workbench/Open [button:regular]	57.0	320.0	ok	+0.0
-workbench/Open page [button:regular]	91.0	320.0	ok	+0.0
-workbench/Queued [tag:callout]	44.3	320.0	ok	+0.0
-workbench/Rate-limited [tag:callout]	69.2	320.0	ok	+0.0
-workbench/Region-locked [label:callout]	81.8	320.0	ok	+0.0
-workbench/Relaunch [button:regular]	80.0	320.0	ok	+0.0
-workbench/Relaunch now [button:regular]	109.0	320.0	ok	+0.0
-workbench/Relaunching… [tag:callout]	78.9	320.0	ok	+0.0
-workbench/Reveal in Finder [button:regular]	120.0	320.0	ok	+0.0
-workbench/Skipped (row status) [tag:callout]	46.0	320.0	ok	+0.0
-workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0
-workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0
-workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0
-workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0
-workbench/Update [button:regular]	69.0	320.0	ok	+0.0
-workbench/Updated [tag:callout]	48.7	320.0	ok	+0.0
-workbench/Verifying [tag:callout]	50.0	320.0	ok	+0.0
+tile	width_pt	budget_pt	status	delta_vs_en_pt	growth_ratio
+popover/App Store [button:small]	73.0	320.0	ok	+0.0	1.00
+popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0	1.00
+popover/Checking [tag:caption2]	46.2	320.0	ok	+0.0	1.00
+popover/Extracting [tag:caption2]	50.5	320.0	ok	+0.0	1.00
+popover/Failed [tag:caption2]	29.3	320.0	ok	+0.0	1.00
+popover/Ignored (row status) [tag:caption2]	37.9	320.0	ok	+0.0	1.00
+popover/Install [button:small]	52.0	320.0	ok	+0.0	1.00
+popover/Installed [tag:caption2]	42.2	320.0	ok	+0.0	1.00
+popover/Installing [tag:caption2]	45.1	320.0	ok	+0.0	1.00
+popover/Open [button:small]	49.0	320.0	ok	+0.0	1.00
+popover/Queued [tag:caption2]	38.4	320.0	ok	+0.0	1.00
+popover/Rate-limited [tag:caption2]	60.8	320.0	ok	+0.0	1.00
+popover/Relaunch [button:small]	69.0	320.0	ok	+0.0	1.00
+popover/Relaunch now [button:small]	93.0	320.0	ok	+0.0	1.00
+popover/Relaunching… [tag:caption2]	69.3	320.0	ok	+0.0	1.00
+popover/Reveal in Finder [button:small]	104.0	320.0	ok	+0.0	1.00
+popover/Skipped (row status) [tag:caption2]	40.2	320.0	ok	+0.0	1.00
+popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0	1.00
+popover/TestFlight [button:small]	72.0	320.0	ok	+0.0	1.00
+popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0	1.00
+popover/Toolbox [button:small]	61.0	320.0	ok	+0.0	1.00
+popover/Update [button:small]	59.0	320.0	ok	+0.0	1.00
+popover/Updated [tag:caption2]	42.3	320.0	ok	+0.0	1.00
+popover/Verifying [tag:caption2]	44.1	320.0	ok	+0.0	1.00
+workbench/App Store [button:regular]	85.0	320.0	ok	+0.0	1.00
+workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0	1.00
+workbench/Checking [tag:callout]	53.0	320.0	ok	+0.0	1.00
+workbench/Extracting [tag:callout]	57.5	320.0	ok	+0.0	1.00
+workbench/Failed [tag:callout]	33.3	320.0	ok	+0.0	1.00
+workbench/Ignored (row status) [tag:callout]	43.2	320.0	ok	+0.0	1.00
+workbench/Install [button:regular]	60.0	320.0	ok	+0.0	1.00
+workbench/Installed [tag:callout]	47.7	320.0	ok	+0.0	1.00
+workbench/Installing [tag:callout]	50.8	320.0	ok	+0.0	1.00
+workbench/Major update [label:callout]	74.5	320.0	ok	+0.0	1.00
+workbench/Not supported on this Mac [label:callout]	150.6	320.0	ok	+0.0	1.00
+workbench/Open [button:regular]	57.0	320.0	ok	+0.0	1.00
+workbench/Open page [button:regular]	91.0	320.0	ok	+0.0	1.00
+workbench/Queued [tag:callout]	44.3	320.0	ok	+0.0	1.00
+workbench/Rate-limited [tag:callout]	69.2	320.0	ok	+0.0	1.00
+workbench/Region-locked [label:callout]	81.8	320.0	ok	+0.0	1.00
+workbench/Relaunch [button:regular]	80.0	320.0	ok	+0.0	1.00
+workbench/Relaunch now [button:regular]	109.0	320.0	ok	+0.0	1.00
+workbench/Relaunching… [tag:callout]	78.9	320.0	ok	+0.0	1.00
+workbench/Reveal in Finder [button:regular]	120.0	320.0	ok	+0.0	1.00
+workbench/Skipped (row status) [tag:callout]	46.0	320.0	ok	+0.0	1.00
+workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0	1.00
+workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0	1.00
+workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0	1.00
+workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0	1.00
+workbench/Update [button:regular]	69.0	320.0	ok	+0.0	1.00
+workbench/Updated [tag:callout]	48.7	320.0	ok	+0.0	1.00
+workbench/Verifying [tag:callout]	50.0	320.0	ok	+0.0	1.00

--- a/verify/row-state-widths/fr.txt
+++ b/verify/row-state-widths/fr.txt
@@ -1,0 +1,53 @@
+tile	width_pt	budget_pt	status	delta_vs_en_pt
+popover/App Store [button:small]	73.0	320.0	ok	+0.0
+popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0
+popover/Checking [tag:caption2]	56.4	320.0	ok	+10.2
+popover/Extracting [tag:caption2]	95.7	320.0	ok	+45.1
+popover/Failed [tag:caption2]	29.9	320.0	ok	+0.6
+popover/Ignored (row status) [tag:caption2]	31.5	320.0	ok	-6.4
+popover/Install [button:small]	62.0	320.0	ok	+10.0
+popover/Installed [tag:caption2]	35.8	320.0	ok	-6.4
+popover/Installing [tag:caption2]	99.9	320.0	ok	+54.8
+popover/Open [button:small]	53.0	320.0	ok	+4.0
+popover/Queued [tag:caption2]	50.6	320.0	ok	+12.2
+popover/Rate-limited [tag:caption2]	91.6	320.0	ok	+30.8
+popover/Relaunch [button:small]	66.0	320.0	ok	-3.0
+popover/Relaunch now [button:small]	128.0	320.0	ok	+35.0
+popover/Relaunching… [tag:caption2]	93.1	320.0	ok	+23.8
+popover/Reveal in Finder [button:small]	139.0	320.0	ok	+35.0
+popover/Skipped (row status) [tag:caption2]	77.0	320.0	ok	+36.8
+popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0
+popover/TestFlight [button:small]	72.0	320.0	ok	+0.0
+popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0
+popover/Toolbox [button:small]	61.0	320.0	ok	+0.0
+popover/Update [button:small]	88.0	320.0	ok	+29.0
+popover/Updated [tag:caption2]	47.8	320.0	ok	+5.5
+popover/Verifying [tag:caption2]	101.8	320.0	ok	+57.6
+workbench/App Store [button:regular]	85.0	320.0	ok	+0.0
+workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0
+workbench/Checking [tag:callout]	63.9	320.0	ok	+10.9
+workbench/Extracting [tag:callout]	109.4	320.0	ok	+51.9
+workbench/Failed [tag:callout]	34.5	320.0	ok	+1.2
+workbench/Ignored (row status) [tag:callout]	35.9	320.0	ok	-7.4
+workbench/Install [button:regular]	72.0	320.0	ok	+12.0
+workbench/Installed [tag:callout]	40.3	320.0	ok	-7.4
+workbench/Installing [tag:callout]	113.7	320.0	ok	+62.9
+workbench/Major update [label:callout]	110.1	320.0	ok	+35.5
+workbench/Not supported on this Mac [label:callout]	172.5	320.0	ok	+21.8
+workbench/Open [button:regular]	62.0	320.0	ok	+5.0
+workbench/Open page [button:regular]	109.0	320.0	ok	+18.0
+workbench/Queued [tag:callout]	57.8	320.0	ok	+13.4
+workbench/Rate-limited [tag:callout]	104.7	320.0	ok	+35.6
+workbench/Region-locked [label:callout]	114.3	320.0	ok	+32.5
+workbench/Relaunch [button:regular]	77.0	320.0	ok	-3.0
+workbench/Relaunch now [button:regular]	149.0	320.0	ok	+40.0
+workbench/Relaunching… [tag:callout]	106.6	320.0	ok	+27.7
+workbench/Reveal in Finder [button:regular]	161.0	320.0	ok	+41.0
+workbench/Skipped (row status) [tag:callout]	88.0	320.0	ok	+42.0
+workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0
+workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0
+workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0
+workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0
+workbench/Update [button:regular]	102.0	320.0	ok	+33.0
+workbench/Updated [tag:callout]	54.7	320.0	ok	+6.1
+workbench/Verifying [tag:callout]	116.1	320.0	ok	+66.1

--- a/verify/row-state-widths/fr.txt
+++ b/verify/row-state-widths/fr.txt
@@ -1,53 +1,53 @@
-tile	width_pt	budget_pt	status	delta_vs_en_pt
-popover/App Store [button:small]	73.0	320.0	ok	+0.0
-popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0
-popover/Checking [tag:caption2]	56.4	320.0	ok	+10.2
-popover/Extracting [tag:caption2]	95.7	320.0	ok	+45.1
-popover/Failed [tag:caption2]	29.9	320.0	ok	+0.6
-popover/Ignored (row status) [tag:caption2]	31.5	320.0	ok	-6.4
-popover/Install [button:small]	62.0	320.0	ok	+10.0
-popover/Installed [tag:caption2]	35.8	320.0	ok	-6.4
-popover/Installing [tag:caption2]	99.9	320.0	ok	+54.8
-popover/Open [button:small]	53.0	320.0	ok	+4.0
-popover/Queued [tag:caption2]	50.6	320.0	ok	+12.2
-popover/Rate-limited [tag:caption2]	91.6	320.0	ok	+30.8
-popover/Relaunch [button:small]	66.0	320.0	ok	-3.0
-popover/Relaunch now [button:small]	128.0	320.0	ok	+35.0
-popover/Relaunching… [tag:caption2]	93.1	320.0	ok	+23.8
-popover/Reveal in Finder [button:small]	139.0	320.0	ok	+35.0
-popover/Skipped (row status) [tag:caption2]	77.0	320.0	ok	+36.8
-popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0
-popover/TestFlight [button:small]	72.0	320.0	ok	+0.0
-popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0
-popover/Toolbox [button:small]	61.0	320.0	ok	+0.0
-popover/Update [button:small]	88.0	320.0	ok	+29.0
-popover/Updated [tag:caption2]	47.8	320.0	ok	+5.5
-popover/Verifying [tag:caption2]	101.8	320.0	ok	+57.6
-workbench/App Store [button:regular]	85.0	320.0	ok	+0.0
-workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0
-workbench/Checking [tag:callout]	63.9	320.0	ok	+10.9
-workbench/Extracting [tag:callout]	109.4	320.0	ok	+51.9
-workbench/Failed [tag:callout]	34.5	320.0	ok	+1.2
-workbench/Ignored (row status) [tag:callout]	35.9	320.0	ok	-7.4
-workbench/Install [button:regular]	72.0	320.0	ok	+12.0
-workbench/Installed [tag:callout]	40.3	320.0	ok	-7.4
-workbench/Installing [tag:callout]	113.7	320.0	ok	+62.9
-workbench/Major update [label:callout]	110.1	320.0	ok	+35.5
-workbench/Not supported on this Mac [label:callout]	172.5	320.0	ok	+21.8
-workbench/Open [button:regular]	62.0	320.0	ok	+5.0
-workbench/Open page [button:regular]	109.0	320.0	ok	+18.0
-workbench/Queued [tag:callout]	57.8	320.0	ok	+13.4
-workbench/Rate-limited [tag:callout]	104.7	320.0	ok	+35.6
-workbench/Region-locked [label:callout]	114.3	320.0	ok	+32.5
-workbench/Relaunch [button:regular]	77.0	320.0	ok	-3.0
-workbench/Relaunch now [button:regular]	149.0	320.0	ok	+40.0
-workbench/Relaunching… [tag:callout]	106.6	320.0	ok	+27.7
-workbench/Reveal in Finder [button:regular]	161.0	320.0	ok	+41.0
-workbench/Skipped (row status) [tag:callout]	88.0	320.0	ok	+42.0
-workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0
-workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0
-workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0
-workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0
-workbench/Update [button:regular]	102.0	320.0	ok	+33.0
-workbench/Updated [tag:callout]	54.7	320.0	ok	+6.1
-workbench/Verifying [tag:callout]	116.1	320.0	ok	+66.1
+tile	width_pt	budget_pt	status	delta_vs_en_pt	growth_ratio
+popover/App Store [button:small]	73.0	320.0	ok	+0.0	1.00
+popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0	1.00
+popover/Checking [tag:caption2]	56.4	320.0	ok	+10.2	1.22
+popover/Extracting [tag:caption2]	95.7	320.0	ok	+45.1	1.89
+popover/Failed [tag:caption2]	29.9	320.0	ok	+0.6	1.02
+popover/Ignored (row status) [tag:caption2]	31.5	320.0	ok	-6.4	0.83
+popover/Install [button:small]	62.0	320.0	ok	+10.0	1.19
+popover/Installed [tag:caption2]	35.8	320.0	ok	-6.4	0.85
+popover/Installing [tag:caption2]	99.9	320.0	ok	+54.8	2.22
+popover/Open [button:small]	53.0	320.0	ok	+4.0	1.08
+popover/Queued [tag:caption2]	50.6	320.0	ok	+12.2	1.32
+popover/Rate-limited [tag:caption2]	91.6	320.0	ok	+30.8	1.51
+popover/Relaunch [button:small]	66.0	320.0	ok	-3.0	0.96
+popover/Relaunch now [button:small]	128.0	320.0	ok	+35.0	1.38
+popover/Relaunching… [tag:caption2]	93.1	320.0	ok	+23.8	1.34
+popover/Reveal in Finder [button:small]	139.0	320.0	ok	+35.0	1.34
+popover/Skipped (row status) [tag:caption2]	77.0	320.0	ok	+36.8	1.92
+popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0	1.00
+popover/TestFlight [button:small]	72.0	320.0	ok	+0.0	1.00
+popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0	1.00
+popover/Toolbox [button:small]	61.0	320.0	ok	+0.0	1.00
+popover/Update [button:small]	88.0	320.0	ok	+29.0	1.49
+popover/Updated [tag:caption2]	47.8	320.0	ok	+5.5	1.13
+popover/Verifying [tag:caption2]	101.8	320.0	ok	+57.6	2.31
+workbench/App Store [button:regular]	85.0	320.0	ok	+0.0	1.00
+workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0	1.00
+workbench/Checking [tag:callout]	63.9	320.0	ok	+10.9	1.21
+workbench/Extracting [tag:callout]	109.4	320.0	ok	+51.9	1.90
+workbench/Failed [tag:callout]	34.5	320.0	ok	+1.2	1.04
+workbench/Ignored (row status) [tag:callout]	35.9	320.0	ok	-7.4	0.83
+workbench/Install [button:regular]	72.0	320.0	ok	+12.0	1.20
+workbench/Installed [tag:callout]	40.3	320.0	ok	-7.4	0.85
+workbench/Installing [tag:callout]	113.7	320.0	ok	+62.9	2.24
+workbench/Major update [label:callout]	110.1	320.0	ok	+35.5	1.48
+workbench/Not supported on this Mac [label:callout]	172.5	320.0	ok	+21.8	1.14
+workbench/Open [button:regular]	62.0	320.0	ok	+5.0	1.09
+workbench/Open page [button:regular]	109.0	320.0	ok	+18.0	1.20
+workbench/Queued [tag:callout]	57.8	320.0	ok	+13.4	1.30
+workbench/Rate-limited [tag:callout]	104.7	320.0	ok	+35.6	1.51
+workbench/Region-locked [label:callout]	114.3	320.0	ok	+32.5	1.40
+workbench/Relaunch [button:regular]	77.0	320.0	ok	-3.0	0.96
+workbench/Relaunch now [button:regular]	149.0	320.0	ok	+40.0	1.37
+workbench/Relaunching… [tag:callout]	106.6	320.0	ok	+27.7	1.35
+workbench/Reveal in Finder [button:regular]	161.0	320.0	ok	+41.0	1.34
+workbench/Skipped (row status) [tag:callout]	88.0	320.0	ok	+42.0	1.91
+workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0	1.00
+workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0	1.00
+workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0	1.00
+workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0	1.00
+workbench/Update [button:regular]	102.0	320.0	ok	+33.0	1.48
+workbench/Updated [tag:callout]	54.7	320.0	ok	+6.1	1.12
+workbench/Verifying [tag:callout]	116.1	320.0	ok	+66.1	2.32

--- a/verify/row-state-widths/ru.txt
+++ b/verify/row-state-widths/ru.txt
@@ -1,53 +1,53 @@
-tile	width_pt	budget_pt	status	delta_vs_en_pt
-popover/App Store [button:small]	73.0	320.0	ok	+0.0
-popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0
-popover/Checking [tag:caption2]	50.1	320.0	ok	+3.9
-popover/Extracting [tag:caption2]	59.5	320.0	ok	+9.0
-popover/Failed [tag:caption2]	40.6	320.0	ok	+11.4
-popover/Ignored (row status) [tag:caption2]	72.1	320.0	ok	+34.2
-popover/Install [button:small]	82.0	320.0	ok	+30.0
-popover/Installed [tag:caption2]	65.7	320.0	ok	+23.5
-popover/Installing [tag:caption2]	52.7	320.0	ok	+7.6
-popover/Open [button:small]	67.0	320.0	ok	+18.0
-popover/Queued [tag:caption2]	53.2	320.0	ok	+14.8
-popover/Rate-limited [tag:caption2]	163.9	320.0	ok	+103.1
-popover/Relaunch [button:small]	103.0	320.0	ok	+34.0
-popover/Relaunch now [button:small]	144.0	320.0	ok	+51.0
-popover/Relaunching… [tag:caption2]	69.9	320.0	ok	+0.6
-popover/Reveal in Finder [button:small]	116.0	320.0	ok	+12.0
-popover/Skipped (row status) [tag:caption2]	59.8	320.0	ok	+19.6
-popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0
-popover/TestFlight [button:small]	72.0	320.0	ok	+0.0
-popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0
-popover/Toolbox [button:small]	61.0	320.0	ok	+0.0
-popover/Update [button:small]	73.0	320.0	ok	+14.0
-popover/Updated [tag:caption2]	57.1	320.0	ok	+14.8
-popover/Verifying [tag:caption2]	118.3	320.0	ok	+74.2
-workbench/App Store [button:regular]	85.0	320.0	ok	+0.0
-workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0
-workbench/Checking [tag:callout]	57.6	320.0	ok	+4.6
-workbench/Extracting [tag:callout]	68.2	320.0	ok	+10.7
-workbench/Failed [tag:callout]	46.8	320.0	ok	+13.5
-workbench/Ignored (row status) [tag:callout]	82.7	320.0	ok	+39.5
-workbench/Install [button:regular]	96.0	320.0	ok	+36.0
-workbench/Installed [tag:callout]	75.6	320.0	ok	+27.8
-workbench/Installing [tag:callout]	60.4	320.0	ok	+9.6
-workbench/Major update [label:callout]	124.1	320.0	ok	+49.6
-workbench/Not supported on this Mac [label:callout]	194.5	320.0	ok	+43.9
-workbench/Open [button:regular]	79.0	320.0	ok	+22.0
-workbench/Open page [button:regular]	141.0	320.0	ok	+50.0
-workbench/Queued [tag:callout]	61.2	320.0	ok	+16.9
-workbench/Rate-limited [tag:callout]	188.4	320.0	ok	+119.3
-workbench/Region-locked [label:callout]	154.8	320.0	ok	+72.9
-workbench/Relaunch [button:regular]	120.0	320.0	ok	+40.0
-workbench/Relaunch now [button:regular]	168.0	320.0	ok	+59.0
-workbench/Relaunching… [tag:callout]	79.9	320.0	ok	+1.0
-workbench/Reveal in Finder [button:regular]	135.0	320.0	ok	+15.0
-workbench/Skipped (row status) [tag:callout]	68.8	320.0	ok	+22.8
-workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0
-workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0
-workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0
-workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0
-workbench/Update [button:regular]	86.0	320.0	ok	+17.0
-workbench/Updated [tag:callout]	65.8	320.0	ok	+17.2
-workbench/Verifying [tag:callout]	136.1	320.0	ok	+86.1
+tile	width_pt	budget_pt	status	delta_vs_en_pt	growth_ratio
+popover/App Store [button:small]	73.0	320.0	ok	+0.0	1.00
+popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0	1.00
+popover/Checking [tag:caption2]	50.1	320.0	ok	+3.9	1.08
+popover/Extracting [tag:caption2]	59.5	320.0	ok	+9.0	1.18
+popover/Failed [tag:caption2]	40.6	320.0	ok	+11.4	1.39
+popover/Ignored (row status) [tag:caption2]	72.1	320.0	ok	+34.2	1.90
+popover/Install [button:small]	82.0	320.0	ok	+30.0	1.58
+popover/Installed [tag:caption2]	65.7	320.0	ok	+23.5	1.56
+popover/Installing [tag:caption2]	52.7	320.0	ok	+7.6	1.17
+popover/Open [button:small]	67.0	320.0	ok	+18.0	1.37
+popover/Queued [tag:caption2]	53.2	320.0	ok	+14.8	1.38
+popover/Rate-limited [tag:caption2]	163.9	320.0	ok	+103.1	2.70
+popover/Relaunch [button:small]	103.0	320.0	ok	+34.0	1.49
+popover/Relaunch now [button:small]	144.0	320.0	ok	+51.0	1.55
+popover/Relaunching… [tag:caption2]	69.9	320.0	ok	+0.6	1.01
+popover/Reveal in Finder [button:small]	116.0	320.0	ok	+12.0	1.12
+popover/Skipped (row status) [tag:caption2]	59.8	320.0	ok	+19.6	1.49
+popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0	1.00
+popover/TestFlight [button:small]	72.0	320.0	ok	+0.0	1.00
+popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0	1.00
+popover/Toolbox [button:small]	61.0	320.0	ok	+0.0	1.00
+popover/Update [button:small]	73.0	320.0	ok	+14.0	1.24
+popover/Updated [tag:caption2]	57.1	320.0	ok	+14.8	1.35
+popover/Verifying [tag:caption2]	118.3	320.0	ok	+74.2	2.68
+workbench/App Store [button:regular]	85.0	320.0	ok	+0.0	1.00
+workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0	1.00
+workbench/Checking [tag:callout]	57.6	320.0	ok	+4.6	1.09
+workbench/Extracting [tag:callout]	68.2	320.0	ok	+10.7	1.19
+workbench/Failed [tag:callout]	46.8	320.0	ok	+13.5	1.40
+workbench/Ignored (row status) [tag:callout]	82.7	320.0	ok	+39.5	1.91
+workbench/Install [button:regular]	96.0	320.0	ok	+36.0	1.60
+workbench/Installed [tag:callout]	75.6	320.0	ok	+27.8	1.58
+workbench/Installing [tag:callout]	60.4	320.0	ok	+9.6	1.19
+workbench/Major update [label:callout]	124.1	320.0	ok	+49.6	1.67
+workbench/Not supported on this Mac [label:callout]	194.5	320.0	ok	+43.9	1.29
+workbench/Open [button:regular]	79.0	320.0	ok	+22.0	1.39
+workbench/Open page [button:regular]	141.0	320.0	ok	+50.0	1.55
+workbench/Queued [tag:callout]	61.2	320.0	ok	+16.9	1.38
+workbench/Rate-limited [tag:callout]	188.4	320.0	ok	+119.3	2.73
+workbench/Region-locked [label:callout]	154.8	320.0	ok	+72.9	1.89
+workbench/Relaunch [button:regular]	120.0	320.0	ok	+40.0	1.50
+workbench/Relaunch now [button:regular]	168.0	320.0	ok	+59.0	1.54
+workbench/Relaunching… [tag:callout]	79.9	320.0	ok	+1.0	1.01
+workbench/Reveal in Finder [button:regular]	135.0	320.0	ok	+15.0	1.12
+workbench/Skipped (row status) [tag:callout]	68.8	320.0	ok	+22.8	1.50
+workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0	1.00
+workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0	1.00
+workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0	1.00
+workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0	1.00
+workbench/Update [button:regular]	86.0	320.0	ok	+17.0	1.25
+workbench/Updated [tag:callout]	65.8	320.0	ok	+17.2	1.35
+workbench/Verifying [tag:callout]	136.1	320.0	ok	+86.1	2.72

--- a/verify/row-state-widths/ru.txt
+++ b/verify/row-state-widths/ru.txt
@@ -1,0 +1,53 @@
+tile	width_pt	budget_pt	status	delta_vs_en_pt
+popover/App Store [button:small]	73.0	320.0	ok	+0.0
+popover/App Store [tag:caption2]	49.2	320.0	ok	+0.0
+popover/Checking [tag:caption2]	50.1	320.0	ok	+3.9
+popover/Extracting [tag:caption2]	59.5	320.0	ok	+9.0
+popover/Failed [tag:caption2]	40.6	320.0	ok	+11.4
+popover/Ignored (row status) [tag:caption2]	72.1	320.0	ok	+34.2
+popover/Install [button:small]	82.0	320.0	ok	+30.0
+popover/Installed [tag:caption2]	65.7	320.0	ok	+23.5
+popover/Installing [tag:caption2]	52.7	320.0	ok	+7.6
+popover/Open [button:small]	67.0	320.0	ok	+18.0
+popover/Queued [tag:caption2]	53.2	320.0	ok	+14.8
+popover/Rate-limited [tag:caption2]	163.9	320.0	ok	+103.1
+popover/Relaunch [button:small]	103.0	320.0	ok	+34.0
+popover/Relaunch now [button:small]	144.0	320.0	ok	+51.0
+popover/Relaunching… [tag:caption2]	69.9	320.0	ok	+0.6
+popover/Reveal in Finder [button:small]	116.0	320.0	ok	+12.0
+popover/Skipped (row status) [tag:caption2]	59.8	320.0	ok	+19.6
+popover/Sparkle [tag:caption2]	37.4	320.0	ok	+0.0
+popover/TestFlight [button:small]	72.0	320.0	ok	+0.0
+popover/TestFlight [tag:caption2]	48.8	320.0	ok	+0.0
+popover/Toolbox [button:small]	61.0	320.0	ok	+0.0
+popover/Update [button:small]	73.0	320.0	ok	+14.0
+popover/Updated [tag:caption2]	57.1	320.0	ok	+14.8
+popover/Verifying [tag:caption2]	118.3	320.0	ok	+74.2
+workbench/App Store [button:regular]	85.0	320.0	ok	+0.0
+workbench/App Store [tag:callout]	56.4	320.0	ok	+0.0
+workbench/Checking [tag:callout]	57.6	320.0	ok	+4.6
+workbench/Extracting [tag:callout]	68.2	320.0	ok	+10.7
+workbench/Failed [tag:callout]	46.8	320.0	ok	+13.5
+workbench/Ignored (row status) [tag:callout]	82.7	320.0	ok	+39.5
+workbench/Install [button:regular]	96.0	320.0	ok	+36.0
+workbench/Installed [tag:callout]	75.6	320.0	ok	+27.8
+workbench/Installing [tag:callout]	60.4	320.0	ok	+9.6
+workbench/Major update [label:callout]	124.1	320.0	ok	+49.6
+workbench/Not supported on this Mac [label:callout]	194.5	320.0	ok	+43.9
+workbench/Open [button:regular]	79.0	320.0	ok	+22.0
+workbench/Open page [button:regular]	141.0	320.0	ok	+50.0
+workbench/Queued [tag:callout]	61.2	320.0	ok	+16.9
+workbench/Rate-limited [tag:callout]	188.4	320.0	ok	+119.3
+workbench/Region-locked [label:callout]	154.8	320.0	ok	+72.9
+workbench/Relaunch [button:regular]	120.0	320.0	ok	+40.0
+workbench/Relaunch now [button:regular]	168.0	320.0	ok	+59.0
+workbench/Relaunching… [tag:callout]	79.9	320.0	ok	+1.0
+workbench/Reveal in Finder [button:regular]	135.0	320.0	ok	+15.0
+workbench/Skipped (row status) [tag:callout]	68.8	320.0	ok	+22.8
+workbench/Sparkle [tag:callout]	42.6	320.0	ok	+0.0
+workbench/TestFlight [button:regular]	84.0	320.0	ok	+0.0
+workbench/TestFlight [tag:callout]	55.5	320.0	ok	+0.0
+workbench/Toolbox [button:regular]	72.0	320.0	ok	+0.0
+workbench/Update [button:regular]	86.0	320.0	ok	+17.0
+workbench/Updated [tag:callout]	65.8	320.0	ok	+17.2
+workbench/Verifying [tag:callout]	136.1	320.0	ok	+86.1


### PR DESCRIPTION
## Shape chosen: measure, not render (option 2)

`make gallery` pins `AppleLanguages='(en)'` on purpose — `ImageRenderer` follows
the host language, so a run in any other locale rewrites all 80 committed PNGs
with a diff that says nothing about the change under review. That's also why the
sheet structurally can't see the one failure this area has actually shipped: a
translated string overflowing its slot (`CLAUDE.md`: the status line left 9pt in
Spanish; the workbench once drew a bigger font with no
`lineLimit`/`minimumScaleFactor` guard, and Russian's `Rate-limited` would have
pushed the app name out).

I took option 2 over option 1 (a second rendered sheet in ru/de) because a second
picture still needs a human to *notice* overflow — the same weakness that let the
original bug ship — and it doubles the committed diff on every future row change.
A measurement asserts the actual failure mode and fails the build by itself,
which is the whole value of the deliverable.

## What the check actually measures, precisely

`App/RowStateWidthCheck` reads `App/Resources/Localizable.xcstrings` directly and
measures each row-action string's **natural (unconstrained) width**, with the
real font/control each call site uses — `NSAttributedString` for a `Text` tag, a
real `NSButton` at the call site's `controlSize` for a button (same technique
memory `duo-updater-status-line-slot-width` used, and the one PR #267's own width
harness used) — against `RowStateGalleryCases.tileWidth` (320pt, the box every
committed PNG tile is drawn into).

This is **not a simulation of either window's real layout**. `PopoverRowAction`'s
real neighbour in `MenuContentView` is a `minWidth` reservation that concedes
width to a wide button rather than clipping it; `WorkbenchRowAction`'s only
production home (`WorkbenchWindowView.DetailHeader`) sits after a `Spacer()` with
~900pt of window behind it. Nothing in this codebase hard-clips at 320pt today. A
pass proves: this string, in this language, isn't asking for more room than the
English baseline every committed screenshot already treats as normal — which is
exactly the previously-invisible half of the failure class. `App/RowStateWidthCheck/main.swift`'s
header spells this out in full, including why the report also prints growth vs.
English even when nothing fails on it (there's no non-arbitrary "acceptable
growth" number to gate on, but the magnitude is worth a human's eyes).

**Why it reads the string catalogue directly instead of rendering the real views
with `AppleLanguages` pinned** (which I tried first, following `RowStateGallery`'s
own technique): it doesn't work. A `type: tool` product is a bare Mach-O, not an
`.app` bundle, and never gets `Localizable.xcstrings` compiled into it — confirmed
by giving the target an explicit `Resources` build phase + `GENERATE_INFOPLIST_FILE`
and finding no `CompileXCStrings`/`.lproj` step anywhere in the build log, and
separately by a self-check inside that first version (comparing
`Bundle.main.preferredLocalizations.first` against the requested language) that
caught its own strings resolving to English regardless of `AppleLanguages`. Full
story in `main.swift`'s header comment.

## Headroom, disclosed (post-review update)

Coordinator review found the OVERFLOW gate has generous headroom against the
widest real string and asked me to state the number plainly, since the original
PR body didn't. It does — and the number the review cited (136.1pt) wasn't
actually the widest, so I re-measured before responding: the true widest string
across en/ru/fr is `workbench/Not supported on this Mac [label:callout]` at
**194.5pt (ru)**, against the 320pt budget — **125.5pt of headroom, ~1.65x**.
That's the number now stated in `App/RowStateWidthCheck/main.swift`'s header,
and in every run's console output.

A gate with that much slack can't fire on anything realistic. I considered
tightening it (tie the budget to production layout, or fail on a relative growth
threshold) and rejected both — full reasoning and the redone mutation test are in the PR
comments below. Landed instead on: the committed
`verify/row-state-widths/*.txt` files are the actual deliverable (a translation
change is now a reviewable numeric diff, the same role the PNGs play for
`make gallery`), a new `growth_ratio` column makes that diff legible, and
anything growing 2.0x or more over English is echoed to console as
`HIGH GROWTH` — informational, not gating. It currently surfaces 8 real,
already-shipped strings (ru `Rate-limited`/`Verifying`, fr `Verifying`/
`Installing`, each on both surfaces) — not false positives to explain away, just
surfaced instead of hidden behind a 320pt pass. `no string exceeds the 320.0pt
tile width` no longer stands alone as if it meant "overflow is guarded" — every
run now also states the widest string and remaining headroom.


## Languages: ru and fr, not all six

Measured 2026-09-02 against the real `Localizable.xcstrings` values for every
row-action catalogue key, at both fonts these views use (`.caption2`
popover, `.callout` workbench), via `NSAttributedString`. Average width delta vs.
English:

| lang | avg Δ | notes |
|---|---|---|
| **ru** | **+41.0pt** | worst average AND worst single case: `Rate-limited` +119.3pt — the exact string `CLAUDE.md` already names |
| **fr** | **+25.5pt** | second-worst average, narrowly ahead of de; its own parenthetical already caused a real bug (fixed in #267) |
| de | +24.5pt | |
| es | +16.1pt | |
| ja | +6.7pt | net *narrower* on several keys (compact CJK glyphs); a few multi-kana words still run wide |
| zh-Hans | −17.8pt | narrower than English on every measured key — no signal |

ru and fr are the two that actually threaten this layout; de trails fr by 1pt on
average but neither de nor es tops ru or fr on any key measured. Including ja/zh-Hans
would inflate the report for two languages that have never once been the wide one.

## Injected-overflow demonstration (mutation test)

Inflated ru's `Rate-limited` value in `Localizable.xcstrings` to 3× its length,
reran `scripts/row-state-width-check.sh`:

```
ru: OVERFLOW — 2 string(s) exceed the tile width:
  popover/Rate-limited [tag:caption2] = "Ограничение частоты запросов Ограничение частоты запросов Ограничение частоты запросов" (497.4pt > 320.0pt)
  workbench/Rate-limited [tag:callout] = "Ограничение частоты запросов Ограничение частоты запросов Ограничение частоты запросов" (572.1pt > 320.0pt)
```
exit 1. Reverted (`git checkout -- App/Resources/Localizable.xcstrings`), reran:
```
ru: no string exceeds the 320.0pt tile width
```
exit 0.

## Second half of the issue: `.help()` comparison — done, not filed

The issue also flags that seven of `mayLookAlike`'s pairs are justified as "only
the tooltip differs", a claim nothing verifies since `.help()` text doesn't exist
in a PNG. I assessed the cost before building anything, per the issue's own "don't
half-build it": a throwaway probe found `.help(...)` text recoverable via plain
`Mirror` reflection — SwiftUI wraps a `.help()` call in a private
`HelpView<Content>` type carrying the help text as a `Text` — with **no
accessibility tree and no window**, as long as `.body` is called explicitly on the
concrete view type first (`Mirror` only sees stored properties, not a computed
`body` — an early version reflected the unevaluated struct and always found
nothing). That's small enough to just do, so I did: `RowStateGallery/main.swift`
gained `collectHelpTexts` (the reflection walk) and
`tooltipsDifferentiateExemptedPairs`.

**Re-reading the seven pairs' own comments first mattered**: only two actually
claim a tooltip differentiator ("the help text says which one" / "the tooltip is
what separates them" — the 10-vs-11 and 13-vs-19 pairs). The other five claim the
opposite — deliberately identical end-to-end ("one button", "a tile cannot show
which explanation appears", "the same marker … never reads like something we
could update ourselves"). Running the check against all seven first confirmed
exactly that for the five — a real discovery, not a bug, and folding them into the
same gate would have turned a correct design decision into a permanent build
failure. `tooltipDifferentiatedPairs` scopes to just the two real claims, with a
subset check against `mayLookAlike` so it can't silently drift if a pair is ever
renamed there.

Mutation-tested: gave the 10-vs-11 popover pair identical `.help()` text —
```
TOOLTIP DOES NOT DIFFERENTIATE (pixels match AND every collected .help() string matches too — the exemption's own justification is false): popover: 10-relaunch-to-apply-staged vs 11-restart-to-apply (tooltip set: ["MUTATION TEST: identical tooltip"])
```
exit 1. Reverted:
```
4 mayLookAlike pair(s) claiming a tooltip differentiator checked — every one actually has a different tooltip on each side
```
exit 0.

Fragile by construction — `HelpView`'s internal shape is an undocumented SwiftUI
implementation detail Apple can reshape on any OS/Swift update with no compiler
error. `.extractorBroken` distinguishes "nothing has a tooltip anymore" from "the
reflection technique itself broke", so that would fail loudly instead of as a wall
of unrelated-looking false positives.

## What remains invisible

- The five `mayLookAlike` pairs that are deliberately identical (including
  tooltip) still rest on the same "pixels match" pixel gate as before — correctly,
  since they're not claiming a tooltip differentiator to verify.
- `.help()` text on states OUTSIDE `mayLookAlike` (i.e. states that already render
  different pixels) is still unchecked — this PR only closes the gap for pairs
  whose safety claim specifically depends on the tooltip.
- Dynamic/interpolated help strings (`"Update \(version)"`, the App Store
  deep-link help, restart/relaunch help text) are out of scope for the width
  check — no single stable English catalogue value to measure. Named, not silently
  dropped, in `MeasuredString.all`'s doc comment.
- The width check's 320pt budget is honest about not being a literal production
  hard-clip (spelled out in `main.swift`) — a pass means "not wider than any
  already-reviewed tile", not "guaranteed to never look cramped".

## Verification

```
cd DuoUpdaterCore && swift test
  # 1927 tests, 152 suites, 1 known issue, all passing (46.6s)
swift test --package-path CLI
  # 184 tests, 24 suites, passing
python3 scripts/check_localizable_keys.py --derived-data /tmp/duo-loc-check-263
  # ✓ 431 keys, all reachable
python3 scripts/check_staged_version_use.py
  # ✓ clean
python3 scripts/check_app_audits.py
  # ✓ clean
python3 scripts/test_appcast_edit.py
  # 45 tests, passing
GALLERY_DD=/tmp/duo-gallery-263 bash scripts/row-state-gallery.sh
  # rendered 80 states, no blank, no collision,
  # 4 mayLookAlike pair(s) claiming a tooltip differentiator checked — every one differs
GALLERY_DD=/tmp/duo-gallery-263 bash scripts/row-state-width-check.sh
  # en/ru/fr: no string exceeds the 320.0pt tile width
```

`git status --short verify/` is clean except one pre-existing, unrelated
nondeterminism: re-running the (untouched-by-this-PR) render code twice re-encodes
`verify/row-states/workbench/04-just-updated.png` a few bytes different, byte-for-byte
identical source both times — the same tile and cause PR #272's own body documented
and reverted rather than carry. Reverted here too; not something this PR touches or fixes.

Closes #263
