### PR TITLE
Gallery: audit the gallery's own exemptions

### DIFF
--- a/App/RowStateGallery/Cases.swift
+++ b/App/RowStateGallery/Cases.swift
@@ -356,6 +356,46 @@ enum RowStateGalleryCases {
         return true
     }
 
+    /// Counts pixels matching `ImageRenderer`'s "unavailable" placeholder — the
+    /// signature yellow it substitutes for content it cannot draw (see
+    /// `notFaithful`'s doc comment for the two things that triggers it): red
+    /// channel over 230, green between 170 and 225, blue under 70, all in 0...255
+    /// (this compares against `NSColor`'s 0...1 components instead).
+    ///
+    /// Threshold and window are #269's, re-measured directly against the
+    /// committed sheet rather than trusted from the issue: scanning all 80
+    /// committed tiles found an exact bimodal split with nothing in between — 65
+    /// tiles at 0 matching pixels, 15 at 638 or more, no tile anywhere from 1 to
+    /// 637. The 0-pixel group includes every tile this app legitimately paints
+    /// orange (the `.tint(.orange)` Relaunch/Update buttons, the amber
+    /// `exclamationmark.triangle.fill`/`globe.badge.chevron.backward` warning
+    /// `Label`s, the rate-limited badge) — none of them land in the window
+    /// because system orange's green channel (~141–153 across the samples
+    /// checked) sits below it; the placeholder's is ~204. So the separation is
+    /// structural, not a threshold picked to happen to clear this sheet: a
+    /// `pixelsMatching > 40` cutoff has roughly 16× headroom on both sides of the
+    /// actual gap (638 down to 40, 40 up from the observed max-non-match of 0).
+    static func placeholderPixelCount(_ rep: NSBitmapImageRep) -> Int {
+        var count = 0
+        for x in 0..<rep.pixelsWide {
+            for y in 0..<rep.pixelsHigh {
+                guard let c = rep.colorAt(x: x, y: y) else { continue }
+                if c.redComponent > 230.0 / 255.0,
+                   c.greenComponent >= 170.0 / 255.0, c.greenComponent <= 225.0 / 255.0,
+                   c.blueComponent < 70.0 / 255.0 {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+
+    /// A tile with more matching pixels than this is presumed to be carrying the
+    /// placeholder, not a few incidental orange pixels — see
+    /// `placeholderPixelCount`'s doc comment for the measurement behind the
+    /// number.
+    static let placeholderPixelThreshold = 40
+
     /// `DownloadReadout`'s declaration order IS the algorithm `AppRow.downloadReadout`
     /// runs — widest first, first fit wins (see that property's doc comment). The
     /// gallery tiles added for #265 make the three cases look different, but a diff

--- a/App/RowStateGallery/Cases.swift
+++ b/App/RowStateGallery/Cases.swift
@@ -386,30 +386,43 @@ enum RowStateGalleryCases {
 
     /// Counts pixels matching `ImageRenderer`'s "unavailable" placeholder — the
     /// signature yellow it substitutes for content it cannot draw (see
-    /// `notFaithful`'s doc comment for the two things that triggers it): red
-    /// channel over 230, green between 170 and 225, blue under 70, all in 0...255
+    /// `notFaithful`'s doc comment for the two things that trigger it): red
+    /// channel over 230, green between 185 and 225, blue under 70, all in 0...255
     /// (this compares against `NSColor`'s 0...1 components instead).
     ///
-    /// Threshold and window are #269's, re-measured directly against the
-    /// committed sheet rather than trusted from the issue: scanning all 80
-    /// committed tiles found an exact bimodal split with nothing in between — 65
-    /// tiles at 0 matching pixels, 15 at 638 or more, no tile anywhere from 1 to
-    /// 637. The 0-pixel group includes every tile this app legitimately paints
-    /// orange (the `.tint(.orange)` Relaunch/Update buttons, the amber
-    /// `exclamationmark.triangle.fill`/`globe.badge.chevron.backward` warning
-    /// `Label`s, the rate-limited badge) — none of them land in the window
-    /// because system orange's green channel (~141–153 across the samples
-    /// checked) sits below it; the placeholder's is ~204. So the separation is
-    /// structural, not a threshold picked to happen to clear this sheet: a
-    /// `pixelsMatching > 40` cutoff has roughly 16× headroom on both sides of the
-    /// actual gap (638 down to 40, 40 up from the observed max-non-match of 0).
+    /// There are TWO margins here, not one, and the window's green floor exists
+    /// to protect the thinner of them:
+    ///
+    /// - **Pixel-count margin**: scanning all 80 committed tiles at this window
+    ///   found an exact bimodal split with nothing in between — 65 tiles at 0
+    ///   matching pixels, 15 at 630 or more (the smallest, `21-…-region-locked`,
+    ///   drops from 638 to 630 once the green floor below is raised — still true
+    ///   for every tile). A `pixelsMatching > 40` cutoff has roughly 15–16×
+    ///   headroom on both sides of that gap.
+    /// - **Colour margin**: real orange this app legitimately paints — the
+    ///   `.tint(.orange)` Relaunch/Update buttons, the amber
+    ///   `exclamationmark.triangle.fill`/`globe.badge.chevron.backward` warning
+    ///   `Label`s, the rate-limited badge — tops out at green ≈167–169 across
+    ///   every sampled pixel in the sheet; the placeholder's is ≈204, with the
+    ///   bulk of it (a strong majority of matching pixels) sitting at exactly
+    ///   204 and the rest (anti-aliased edges) spread down to ≈174. A floor of
+    ///   170 put only 1–3 units between real orange's ceiling and the window —
+    ///   thin enough that a future system-orange nudge could push those hundreds
+    ///   of legitimate pixels straight into the window and fail unrelated tiles
+    ///   by the hundreds, which the pixel-count margin above does nothing to
+    ///   stop (a false positive of that kind arrives WAY over 40). 185 sits
+    ///   roughly halfway between the two clusters — ~18 units above real
+    ///   orange's ceiling, ~19 below the placeholder's centre — trading 1.5% of
+    ///   the placeholder's own matching pixels (still nowhere near the 40-pixel
+    ///   cutoff on the smallest affected tile) for a margin that isn't the one
+    ///   thing standing between this gate and a false-positive storm.
     static func placeholderPixelCount(_ rep: NSBitmapImageRep) -> Int {
         var count = 0
         for x in 0..<rep.pixelsWide {
             for y in 0..<rep.pixelsHigh {
                 guard let c = rep.colorAt(x: x, y: y) else { continue }
                 if c.redComponent > 230.0 / 255.0,
-                   c.greenComponent >= 170.0 / 255.0, c.greenComponent <= 225.0 / 255.0,
+                   c.greenComponent >= 185.0 / 255.0, c.greenComponent <= 225.0 / 255.0,
                    c.blueComponent < 70.0 / 255.0 {
                     count += 1
                 }

--- a/App/RowStateGallery/Cases.swift
+++ b/App/RowStateGallery/Cases.swift
@@ -395,10 +395,12 @@ enum RowStateGalleryCases {
     ///
     /// - **Pixel-count margin**: scanning all 80 committed tiles at this window
     ///   found an exact bimodal split with nothing in between — 65 tiles at 0
-    ///   matching pixels, 15 at 630 or more (the smallest, `21-…-region-locked`,
-    ///   drops from 638 to 630 once the green floor below is raised — still true
-    ///   for every tile). A `pixelsMatching > 40` cutoff has roughly 15–16×
-    ///   headroom on both sides of that gap.
+    ///   matching pixels, 15 at 616 or more. Raising the green floor from 170 to
+    ///   185 costs each affected tile a little of its anti-aliased fringe and
+    ///   nothing else: the smallest, `21-…-region-locked`, goes 658 → 616, and
+    ///   `18-…-major-upgrade`/`22-…-mac-incompatible` go 638 → 630. A
+    ///   `pixelsMatching > 40` cutoff still has ~15× headroom above the gap and
+    ///   the full width of it below.
     /// - **Colour margin**: real orange this app legitimately paints — the
     ///   `.tint(.orange)` Relaunch/Update buttons, the amber
     ///   `exclamationmark.triangle.fill`/`globe.badge.chevron.backward` warning

--- a/App/RowStateGallery/Cases.swift
+++ b/App/RowStateGallery/Cases.swift
@@ -301,34 +301,62 @@ enum RowStateGalleryCases {
     ]
 
     /// Tiles whose PICTURE is a harness artifact and must not be read as the real
-    /// UI. `ImageRenderer` draws an SF Symbol inside a `.buttonStyle(.borderless)`
-    /// button as a yellow "unavailable" placeholder instead of the glyph — verified
-    /// with a three-way probe: a bare `Image(systemName:)` renders correctly, the
-    /// same image wrapped in a borderless Button does not, and `.popover` has no
-    /// bearing on it. These three are the popover's amber/globe badges, and the
-    /// workbench draws the same states correctly (it uses `Label`, not a borderless
-    /// button), so the pair is still worth comparing for CONTENT — just not for how
-    /// the badge itself looks.
+    /// UI. Membership is enforced, not just documented: `main.swift` scans every
+    /// rendered tile for `ImageRenderer`'s placeholder signature
+    /// (`placeholderPixelCount`) and fails the build if a tile carries it and is
+    /// missing from this set (#269) — so an unlisted placeholder tile is caught
+    /// the same run it appears, not discovered by someone reading pixels by hand.
     ///
-    /// They are still checked for blank and for collisions: the state coverage is
-    /// real even when the glyph is not.
+    /// Three separate causes, each its own reason because they differ in whether
+    /// the OTHER surface has a faithful picture to read instead:
     static let notFaithful: Set<String> = [
+        // Cause 1: an SF Symbol inside a `.buttonStyle(.borderless)` button —
+        // verified with a three-way probe: a bare `Image(systemName:)` renders
+        // correctly, the same image wrapped in a borderless Button does not, and
+        // `.popover` has no bearing on it. These three are the popover's
+        // amber/globe badges; the workbench draws the same STATES correctly (it
+        // uses `Label`, not a borderless button) — so for this cause, the other
+        // surface IS a faithful twin. Read that tile instead.
         "popover/18-update-major-upgrade",
         "popover/21-update-app-store-region-locked",
         "popover/22-update-app-store-mac-incompatible",
-        // A DIFFERENT `ImageRenderer` gap, found while adding this case for #265:
-        // it also cannot draw a plain native `ProgressView()` — the yellow/red
-        // "unavailable" placeholder stands in for the spinner on BOTH surfaces (no
-        // `Label`/borderless-button escape hatch here, unlike the three above).
-        // The state coverage is still real (no stage label is drawn, which is the
-        // branch this case exists to exercise) — only the spinner glyph itself is
-        // the harness artifact. This same substitution is visible on several
-        // already-committed tiles that predate #265 (e.g. 02/05/06/07's spinners
-        // and progress bar); widening this list to cover those is a separate,
-        // larger cleanup and out of scope here — flagged instead of silently
-        // left off this one new case.
+
+        // Cause 2: a plain native `ProgressView()` (indeterminate spinner) or
+        // `ProgressView(value:)` (determinate bar) — `ImageRenderer` draws the
+        // same yellow/red "unavailable" placeholder in its place. Unlike cause 1,
+        // NEITHER surface has an escape hatch here: both `PopoverRowAction` and
+        // `WorkbenchRowAction` reach for a real `ProgressView` for every install
+        // stage that isn't the ring readout (`stageProgress`/`installProgress` in
+        // `RowActionViews.swift`/`PopoverRowAction.swift`), so relaunching and the
+        // three non-ring install stages are placeholder-only on both windows —
+        // there is no faithful picture of an installing row anywhere in the
+        // committed sheet. First found on `37-stage-label-hidden` while adding it
+        // for #265; #269 measured the rest of this group (02/05/06/07), which
+        // predate #265 and had been silently wrong the whole time.
+        "popover/02-relaunching",
+        "popover/05-installing-queued",
+        "popover/06-installing-downloading",
+        "popover/07-installing-extracting",
         "popover/37-stage-label-hidden",
+        "workbench/02-relaunching",
+        "workbench/05-installing-queued",
+        "workbench/06-installing-downloading",
+        "workbench/07-installing-extracting",
         "workbench/37-stage-label-hidden",
+
+        // Cause 3: also a plain `ProgressView(value:)`, but WORKBENCH-only — found
+        // by the same #269 scan. `PopoverRowAction.downloadProgress` draws
+        // `ringAndPercent`/`ringOnly` with `ProgressRing`, a shape this file draws
+        // itself rather than borrowing from `ProgressView` (see that type's own
+        // doc comment), so the popover half of these two states renders correctly
+        // — it just looks different from `barAndPercent`, which is the whole
+        // point of the ring readout. `WorkbenchRowAction` has no such alternative:
+        // it always calls `installProgress`, which is `ProgressView(value:)`
+        // regardless of which readout the popover would have picked. So unlike
+        // cause 2, THIS pair has an escape hatch — read the popover tile — it's
+        // just the opposite surface from cause 1's.
+        "workbench/35-download-ring-and-percent",
+        "workbench/36-download-ring-only",
     ]
 
     /// "Nothing was drawn" — every pixel matches the window background painted

--- a/App/RowStateGallery/main.swift
+++ b/App/RowStateGallery/main.swift
@@ -26,6 +26,10 @@ func render() {
     // or not — the audit below needs the full set, not just the violations `blank`
     // collects, to tell a live exemption from a dead one (#271).
     var actuallyBlank: Set<String> = []
+    // Tiles that contain ImageRenderer's placeholder signature (#269) but are not
+    // in `notFaithful` — a silent lie the sheet was previously making no assertion
+    // about at all.
+    var unregisteredPlaceholder: [String] = []
     /// surface → rendered bytes → EVERY state that drew them. All of them, not
     /// just the first: comparing a new tile against a single predecessor makes the
     /// outcome depend on the order the cases happen to be listed in, and this list
@@ -67,6 +71,13 @@ func render() {
             if !RowStateGalleryCases.mayBeBlank.contains("\(surface)/\(name)") {
                 blank.append("\(surface)/\(name)")
             }
+        }
+        // A tile carrying ImageRenderer's placeholder is drawn, so the blank gate
+        // above has nothing to say about it — this is the check that does (#269).
+        let placeholderCount = RowStateGalleryCases.placeholderPixelCount(rep)
+        if placeholderCount > RowStateGalleryCases.placeholderPixelThreshold,
+           !RowStateGalleryCases.notFaithful.contains("\(surface)/\(name)") {
+            unregisteredPlaceholder.append("\(surface)/\(name) (\(placeholderCount)px)")
         }
         // Two states that draw the SAME pixels on one surface means the view is not
         // reading something the state carries. That is how the popover kept its own
@@ -162,6 +173,19 @@ func render() {
         print("no state renders blank")
     } else {
         print("BLANK (a state drawing nothing): \(blank.joined(separator: ", "))")
+        failed = true
+    }
+    // #269: a placeholder-bearing tile used to be indistinguishable from a
+    // genuine one — nothing scanned pixels, so `notFaithful` only grew when a
+    // human happened to notice. This makes an unregistered placeholder a build
+    // failure instead of a silent lie in the committed sheet.
+    if unregisteredPlaceholder.isEmpty {
+        print("no unregistered ImageRenderer placeholder pixels")
+    } else {
+        print("UNFAITHFUL TILE NOT REGISTERED (contains ImageRenderer's placeholder"
+              + " signature — see RowStateGalleryCases.placeholderPixelCount — but is"
+              + " missing from notFaithful; register it there with a reason, don't"
+              + " just silence this): " + unregisteredPlaceholder.joined(separator: ", "))
         failed = true
     }
     if identical.isEmpty {

--- a/App/RowStateGallery/main.swift
+++ b/App/RowStateGallery/main.swift
@@ -22,6 +22,10 @@ func render() {
     var written: [String] = []
     var unrendered: [String] = []
     var blank: [String] = []
+    // Every surface-qualified name that actually rendered blank this run, exempted
+    // or not — the audit below needs the full set, not just the violations `blank`
+    // collects, to tell a live exemption from a dead one (#271).
+    var actuallyBlank: Set<String> = []
     /// surface → rendered bytes → EVERY state that drew them. All of them, not
     /// just the first: comparing a new tile against a single predecessor makes the
     /// outcome depend on the order the cases happen to be listed in, and this list
@@ -58,8 +62,11 @@ func render() {
         // A state that draws nothing is the bug this whole gallery is for, so it is
         // reported rather than silently written as an empty tile.
         let isBlank = RowStateGalleryCases.isBlank(rep)
-        if isBlank, !RowStateGalleryCases.mayBeBlank.contains("\(surface)/\(name)") {
-            blank.append("\(surface)/\(name)")
+        if isBlank {
+            actuallyBlank.insert("\(surface)/\(name)")
+            if !RowStateGalleryCases.mayBeBlank.contains("\(surface)/\(name)") {
+                blank.append("\(surface)/\(name)")
+            }
         }
         // Two states that draw the SAME pixels on one surface means the view is not
         // reading something the state carries. That is how the popover kept its own
@@ -137,6 +144,18 @@ func render() {
               + " mayLookAlike): "
               + deadExemptions.map { $0.sorted().joined(separator: " == ") }
                   .sorted().joined(separator: ", "))
+        failed = true
+    }
+    // Same reasoning, same shape, applied to the OTHER hand-maintained exemption
+    // list: `mayBeBlank` used to be consulted but never audited, so an entry that
+    // stopped drawing blank stayed exempt forever instead of the detector picking
+    // it back up (#271 — #260 walked into exactly this with `workbench/31`/`/32`
+    // and only caught it because someone happened to remove the entries by hand).
+    let deadBlankExemptions = RowStateGalleryCases.mayBeBlank.subtracting(actuallyBlank)
+    if !deadBlankExemptions.isEmpty {
+        print("DEAD EXEMPTION (these no longer render blank — drop them from"
+              + " mayBeBlank): "
+              + deadBlankExemptions.sorted().joined(separator: ", "))
         failed = true
     }
     if blank.isEmpty {


### PR DESCRIPTION
Same bug in two places: `App/RowStateGallery/` keeps three hand-maintained exemption lists, and only `mayLookAlike` was ever audited for a dead entry. `mayBeBlank` (#271) and `notFaithful` (#269) were only ever *consulted* — a stale or missing entry in either one stayed silently in effect. `CLAUDE.md`'s justification for the `mayLookAlike` audit — a hand-maintained exemption nobody checks is a free pass for future drift, and whoever tightened the view is the one who should retire it — transfers to both word for word.

**Edit:** the last commit (`Gallery: widen the placeholder scan's green floor from 170 to 185`) fixes a margin an independent review found the first version of this PR didn't measure — see "Threshold" below. Everything else described here is unchanged by it.

## #271 — `mayBeBlank` dead-exemption gate

Mirrors the existing `mayLookAlike` audit exactly: collect every surface-qualified name that actually rendered blank this run (exempted or not), subtract `mayBeBlank` from that set, fail on the remainder with the same message shape.

One entry can never go dead by construction: `workbench/38`/`39`/`40` are blank because `workbenchTile` deliberately returns `EmptyView()` for the three explanation-content names — no view change can make those draw something. `workbench/30-up-to-date` is the one entry whose blankness depends on how `WorkbenchRowAction` draws `.upToDate(channel: .none)`, which is exactly the case #270 changed for `/31` and `/32` (removed by hand, correctly — but nothing would have failed the build if they'd been left in).

## #269 — `notFaithful` under-reporting

Implemented the issue's own first proposal: scan every rendered tile for `ImageRenderer`'s placeholder signature and fail the build when a tile carries it and isn't registered.

Re-measured rather than trusting either number in play: the issue's table (11 of 3) predates #268's two `ProgressView` registrations and #265's ring-readout cases. Scanning the current 80-tile committed sheet found **15** tiles carrying the placeholder, only **5** registered — 10 unregistered, none of which showed up in the issue's original table (`02/05/06/07` on both surfaces predate #265 entirely; `workbench/35`/`36` didn't exist yet when the issue was filed).

Registered each with a reason, split into three groups rather than one comment, because two different things distinguish them — not just the two known causes, but whether the *other* surface has a faithful twin to read instead:

1. **SF Symbol in `.buttonStyle(.borderless)`** (`popover/18`, `/21`, `/22`, already registered) — workbench draws the same states correctly via `Label`. Escape hatch: read the workbench tile.
2. **Plain `ProgressView()`/`ProgressView(value:)`, no escape hatch anywhere** — `popover` and `workbench` `02/05/06/07` plus the already-registered `37`. Both windows reach for a real `ProgressView` for every non-ring install stage, so there is no faithful picture of an installing row on either surface.
3. **`ProgressView(value:)`, workbench-only** — `workbench/35`/`36`. `PopoverRowAction.downloadProgress` draws the ring readouts with a custom `ProgressRing`, not a `ProgressView`, so the popover half of these two states is genuinely correct. Escape hatch exists, just on the opposite surface from group 1.

### Threshold: two margins, both measured

There are two independent margins here, and an earlier revision of this PR only measured one of them.

**Pixel-count margin.** Scanned all 80 committed tiles for R>230, G∈[window], B<70 pixels. At the shipped window (green floor 185) the result is an exact bimodal split, nothing in between:

| | count |
|---|---|
| tiles at exactly 0 matching pixels | 65 |
| tiles at ≥630 matching pixels | 15 |
| tiles anywhere from 1–629 | **0** |

`pixelsMatching > 40` has ~15–16× headroom on both sides of that gap.

**Colour margin — the one the first pass missed.** Review caught this and I reproduced it independently before changing anything: with the original green floor of 170, the pixel-count margin above was real but the *colour* margin protecting it was not. Every tile this app legitimately paints orange (`.tint(.orange)` Relaunch/Update buttons, amber `exclamationmark.triangle.fill`/`globe.badge.chevron.backward` warning `Label`s, the rate-limited badge) scored 0 in the window, but only because system orange's green channel tops out at ≈167–169 — 1–3 units below a floor of 170, on a colour Apple controls, not this codebase. A future system-orange nudge above that floor would flip hundreds of legitimate pixels into the window at once (single tiles already carry 465–1761 orange-ish pixels), failing unrelated tiles by the hundreds — the pixel-count headroom does nothing to stop a false positive that lands that far over 40, not near it.

Fix: moved the floor from 170 to **185**, roughly halfway between real orange's ceiling (≈167–169) and the placeholder's own centre (≈204, where the bulk of matching pixels sit exactly — the rest are anti-aliased edges spread down to ≈174). That's ~18 units of margin on each side instead of 3 and ~34. Cost: 1.5% of the placeholder's own matching pixels — the smallest affected tile drops from 638 to 630, still nowhere near the 40-pixel cutoff.

## Mutants (red → green, pasted)

**#271** — made `WorkbenchRowAction`'s `.upToDate(channel: .none)` draw `Text("MUTATION-TEST")` instead of `EmptyView()`, leaving `workbench/30-up-to-date` in `mayBeBlank` but no longer blank:

```
RED:
DEAD EXEMPTION (these no longer render blank — drop them from mayBeBlank): workbench/30-up-to-date
(exit 1)

GREEN (reverted):
no state renders blank
(exit 0)
```

**#269** — commented out `"popover/18-update-major-upgrade"` from `notFaithful`, re-run against the shipped 185 floor:

```
RED:
UNFAITHFUL TILE NOT REGISTERED (contains ImageRenderer's placeholder signature — see
RowStateGalleryCases.placeholderPixelCount — but is missing from notFaithful; register
it there with a reason, don't just silence this): popover/18-update-major-upgrade (630px)
(exit 1)

GREEN (reverted):
no unregistered ImageRenderer placeholder pixels
(exit 0)
```

That red run is also the negative-control: all 79 other tiles — including every orange-badge/button tile — passed the scan in the same run, so the same evidence covers both "the gate catches a removed entry" and "the gate doesn't fire on ordinary orange UI." (630px matches the independent re-count at the new floor exactly.)

## Verdict on the `ProgressView()` stand-in

No — leave it as a documented placeholder, don't build a renderable stand-in.

The two causes are not symmetric. The borderless-button SF Symbol has a real escape hatch: the workbench draws the *identical* state correctly via `Label`, so reading that tile costs nothing. A hand-drawn arc for `ProgressView()` would have no such backing — it would be a shape this harness invented, existing nowhere in the shipped app, standing in for a control that *is* real but that `ImageRenderer` specifically cannot draw. That picture would look more trustworthy than the yellow placeholder while being strictly less connected to what ships: the placeholder at least announces "something is wrong here," a drawn stand-in announces nothing. The sheet's whole value, per its own file header, is "a change ... shows up as an image diff instead of being noticed in use — or not"; a fabricated spinner optimizes for the sheet looking complete over the sheet staying honest about what it can and can't show. `notFaithful` plus the new gate already gets the actually-useful outcome — the state coverage is verifiably real (no relevant branch renders blank, nothing collides) and the one thing that isn't real is named, tracked, and enforced.

## Verified

```
cd DuoUpdaterCore && swift test
━ Test run with 1927 tests in 152 suites passed after 43.287 seconds with 1 known issue.

swift test --package-path CLI
✔ Test run with 184 tests in 24 suites passed after 0.075 seconds.

python3 scripts/check_localizable_keys.py --derived-data /tmp/duo-loc-269
✓ localizable keys agree — 431 in the catalog, all reachable

python3 scripts/check_staged_version_use.py
✓ version comparisons discriminate — 210 files, 2 ledger call(s) keyed on the build, 7 marketing-first pick(s), all display-only

python3 scripts/check_app_audits.py
✓ app audits consistent — 90 docs, all indexed, no machine inventory, no pointers into untracked evidence

python3 scripts/test_appcast_edit.py
Ran 45 tests in 0.005s — OK

GALLERY_DD=/tmp/duo-gallery-269 bash scripts/row-state-gallery.sh
rendered 80 states
no state renders blank
no unregistered ImageRenderer placeholder pixels
no two states draw the same tile
(exit 0)
```

`git status --short verify/` is empty — no view changed, so no committed PNG moves. (One flake surfaced repeatedly across every run in this branch, on both the mutated and unmutated code: `workbench/04-just-updated.png` differing by 4 pixels at a 1/255 channel delta, inside the "Updated" checkmark glyph — reproduced identically on plain `main` with none of this PR's code, so it's `ImageRenderer` anti-aliasing jitter, not a regression, and was reverted each time rather than committed.)

Closes #269
Closes #271
