### PR TITLE
lint: widen staged-version marketing-as-display regex to catch optional chains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test:
 	swift test --package-path CLI
 	python3 scripts/check_localizable_keys.py
 	python3 scripts/check_staged_version_use.py
+	python3 scripts/test_check_staged_version_use.py
 	python3 scripts/check_app_audits.py
 
 # Render every row state to verify/row-states/*.png. The images are committed:

--- a/scripts/check_staged_version_use.py
+++ b/scripts/check_staged_version_use.py
@@ -56,8 +56,17 @@ MARKETING_FIRST = re.compile(
 # `RemoteVersion.displayVersion` already hides that fallback one level down, so
 # passing it into `VersionSide(marketing:)` is the same bug without a literal
 # `??` for the rule above to see.
+# `[\w.?]*` (not `[\w.]*`) because `result.remote?.displayVersion` is the
+# standard way this file reaches a `RemoteVersion?` — the `?` of optional
+# chaining is the natural spelling of the very site this rule exists to catch,
+# and a class that excludes it lets that spelling straight through (#286).
+# Known blind spot, not fixable with more character-class: `marketing:
+# version` where `version` was assigned from `displayVersion` on an earlier
+# line (the #235 bug's exact shape on main before it was fixed) is invisible
+# to a single-line/single-statement regex — it needs cross-statement data
+# flow, which is a job for a real dataflow check, not this lint.
 DISPLAY_VERSION_AS_MARKETING = re.compile(
-    r"VersionSide\s*\([^)]*marketing:\s*[\w.]*displayVersion", re.DOTALL)
+    r"VersionSide\s*\([^)]*marketing:\s*[\w.?]*displayVersion", re.DOTALL)
 # A site where marketing-first IS correct because BOTH sides are marketing by
 # construction opts out by name, on the line or anywhere in the comment block
 # directly above it. A marker beats

--- a/scripts/test_check_staged_version_use.py
+++ b/scripts/test_check_staged_version_use.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Regression tests for `check_staged_version_use.py`'s `DISPLAY_VERSION_AS_MARKETING` rule.
+
+#286: the rule PR #250 added used `[\\w.]*` between `marketing:` and
+`displayVersion`, which excludes `?` — so it missed the standard way this
+codebase reaches a `RemoteVersion?` (`result.remote?.displayVersion`), single-
+or multi-line, and also missed the #235 bug's exact original shape
+(`displayVersion` assigned to a local, then `marketing: <that local>`). The
+four cases below are the ones from the issue, pinned to what the fixed rule
+actually does with each — including the one that stays a documented miss.
+
+    python3 scripts/test_check_staged_version_use.py
+"""
+
+import pathlib
+import re
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_staged_version_use as csvu  # noqa: E402
+
+
+def hits(text):
+    return bool(csvu.DISPLAY_VERSION_AS_MARKETING.search(text))
+
+
+class DisplayVersionAsMarketingOptionalChain(unittest.TestCase):
+    """`result.remote?.displayVersion` is the standard way this file reaches a
+    `RemoteVersion?` — the natural spelling of the exact site this rule exists
+    to catch. A character class that excludes `?` lets it straight through."""
+
+    def test_optional_chain_single_line_is_caught(self):
+        self.assertTrue(hits(
+            "VersionSide(marketing: result.remote?.displayVersion, build: nil)"))
+
+    def test_optional_chain_multiline_is_caught(self):
+        self.assertTrue(hits(
+            "VersionSide(\n"
+            "    marketing: result.remote?.displayVersion,\n"
+            "    build: nil)"))
+
+    def test_plain_unwrapped_access_is_still_caught(self):
+        """Not a regression case — pins the shape #250 already caught."""
+        self.assertTrue(hits(
+            "VersionSide(marketing: remote.displayVersion, build: nil)"))
+
+    def test_via_variable_indirection_remains_an_undetected_blind_spot(self):
+        """The #235 bug's exact original shape on main before it was fixed:
+        `displayVersion` assigned to a local first, then `marketing: <local>`.
+        No feasible character class sees this — it is cross-statement data
+        flow, not a spelling variant — so this pins the documented miss rather
+        than pretending the rule covers it. See the comment above
+        `DISPLAY_VERSION_AS_MARKETING` in check_staged_version_use.py."""
+        self.assertFalse(hits(
+            "VersionSide(marketing: version, build: buildVersion)"))
+
+
+class MutationGuard(unittest.TestCase):
+    """Proves the tests above actually depend on the widened character class,
+    not just on `VersionSide`/`marketing:`/`displayVersion` appearing somewhere
+    in the line. Re-runs the two optional-chain cases against the pre-#286
+    pattern and requires them to miss — i.e. this test class itself must fail
+    if the fix in `check_staged_version_use.py` is reverted to the pattern
+    below (the case this whole file exists to prevent from going undetected)."""
+
+    PRE_286_PATTERN = re.compile(
+        r"VersionSide\s*\([^)]*marketing:\s*[\w.]*displayVersion", re.DOTALL)
+
+    def test_pre_fix_pattern_missed_the_optional_chain_single_line(self):
+        self.assertFalse(bool(self.PRE_286_PATTERN.search(
+            "VersionSide(marketing: result.remote?.displayVersion, build: nil)")))
+
+    def test_pre_fix_pattern_missed_the_optional_chain_multiline(self):
+        self.assertFalse(bool(self.PRE_286_PATTERN.search(
+            "VersionSide(\n"
+            "    marketing: result.remote?.displayVersion,\n"
+            "    build: nil)")))
+
+    def test_current_pattern_differs_from_the_pre_fix_pattern(self):
+        """If someone "fixes" the regex back to the narrow character class,
+        this fails loudly instead of the two tests above silently no longer
+        exercising the fix."""
+        self.assertNotEqual(
+            csvu.DISPLAY_VERSION_AS_MARKETING.pattern, self.PRE_286_PATTERN.pattern)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What / why

`DISPLAY_VERSION_AS_MARKETING` (added in #250) used `[\w.]*` between
`marketing:` and `displayVersion`. That character class excludes `?`, so it
missed `result.remote?.displayVersion` — the standard way this codebase
reaches a `RemoteVersion?` — both single-line and multi-line. Widened to
`[\w.?]*`.

Also documented, rather than silently leaving undetected, the one shape no
character class can catch: `marketing: version` where `version` was assigned
from `displayVersion` on an earlier line (the #235 bug's exact original shape
on main before it was fixed). That's cross-statement data flow; a
single-line/single-statement regex has no way to see it. The comment above
`DISPLAY_VERSION_AS_MARKETING` says so explicitly so the next reader doesn't
assume the rule covers more than it does.

## Issue check (#286)

Reproduced independently before touching anything (`/tmp/repro_286.py`, not
committed) — ran the exact pre-fix regex against the four inputs quoted in
the issue:

```
MISS  VersionSide(marketing: result.remote?.displayVersion, build: nil)
HIT   VersionSide(marketing: remote.displayVersion, build: nil)
MISS  VersionSide(\n    marketing: result.remote?.displayVersion,\n    build: nil)
MISS  VersionSide(marketing: version, build: buildVersion)
```

Matches the issue exactly. The issue is correct on both counts it claims:
optional chaining is unmatched, and the via-variable indirection case (which
is literally the #235 bug's pre-fix shape) is unmatched and cannot be fixed
by widening the character class — it needs cross-statement analysis, which is
out of scope for a regex-based lint. I did not find anything the issue got
wrong or left out.

On the suggestion to fix PR #250's description: leaving it as-is. Its
"Direct lint probe confirms a multiline `VersionSide(marketing:
remote.displayVersion, ...)` is rejected" claim was already literally true
(unwrapped `remote.displayVersion`, no `?`) and stays true after this PR —
it was just a narrower case than the one that mattered. Not touching a merged
PR's description for that. Note for anyone re-reading it though: this PR's
multiline test case (`result.remote?.displayVersion` split across lines) is
the one that actually exercises the optional-chain gap; #250's own probe
didn't.

## What was added

- `scripts/test_check_staged_version_use.py`: no test previously exercised
  `DISPLAY_VERSION_AS_MARKETING` directly. Follows the existing
  `test_appcast_edit.py` / `test_claude_lag_probe.py` pattern (import the
  checker module, exercise its regex). Pins all four inputs from the issue:
  the two optional-chain cases (now caught), the plain-access case (already
  worked), and the via-variable case (still a documented miss, asserted as
  such rather than ignored). A `MutationGuard` class re-runs the two
  newly-caught cases against the literal pre-#286 pattern and requires them
  to miss there — so if someone reverts the character class back to `[\w.]*`,
  these tests go red instead of quietly not exercising anything.
- Wired the new test into `make test`, next to the checker it covers.

## Verification

Reproduced red before changing anything:

```
$ python3 /tmp/repro_286.py
MISS  optional chain single-line: 'VersionSide(marketing: result.remote?.displayVersion, build: nil)'
HIT  plain single-line: 'VersionSide(marketing: remote.displayVersion, build: nil)'
MISS  optional chain multiline: 'VersionSide(\n    marketing: result.remote?.displayVersion,\n    build: nil)'
MISS  via-variable (the #235 bug shape): 'VersionSide(marketing: version, build: buildVersion)'
```

After the fix, full lint run on the real tree is still clean (no false
positives on any of the 7 legitimate marketing-first display-only sites):

```
$ python3 scripts/check_staged_version_use.py
✓ version comparisons discriminate — 211 files, 2 ledger call(s) keyed on the build, 7 marketing-first pick(s), all display-only
```

New regression test, green:

```
$ python3 scripts/test_check_staged_version_use.py -v
...
Ran 7 tests in 0.000s
OK
```

Mutation test (per CLAUDE.md — a test that can't go red is decoration):
reverted `DISPLAY_VERSION_AS_MARKETING` in-place to the exact pre-#286
pattern (`[\w.]*`, no `?`) and reran the new test file:

```
FAIL: test_optional_chain_multiline_is_caught ... AssertionError: False is not true
FAIL: test_optional_chain_single_line_is_caught ... AssertionError: False is not true
FAIL: test_current_pattern_differs_from_the_pre_fix_pattern ... AssertionError: <pattern> == <pattern>
FAILED (failures=3)
```

Restored the fix; all 7 tests green again, `check_staged_version_use.py`
still exits 0 on the tree.

Did not run `make test` / `swift test` — this change touches only
`scripts/*.py` and `Makefile`, no Swift, and I'm in a worktree shared with
other parallel agents where `check_localizable_keys.py`'s fixed build-cache
path (`/tmp/duo-loc-check`) lock-collides across worktrees. Ran the Python
pieces directly instead, per this session's operating constraints.

Closes #286.