### PR TITLE
test(core): restore end-to-end Electron manifest coverage for Canva/ChatWise

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ElectronManifestTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ElectronManifestTests.swift
@@ -245,6 +245,94 @@ struct ElectronManifestSourceTests {
         #expect(entry?.isHealthy == true)
     }
 
+    // MARK: - #291: end-to-end coverage for real vendor shapes, without the
+    // arm64-mac.yml sibling routing #280 removed. These two used to be named
+    // `aRealCanvaShapedManifestIsUnaffectedByItsForbiddenSibling` and
+    // `aNativeArm64FilesEntryIsUnaffectedBySiblingProbeOutcome` — they carried
+    // "sibling" in their names because they were originally written to prove
+    // a real vendor's behavior was UNCHANGED by a sibling probe outcome. #280
+    // deleted the sibling probe itself and took these two down with it on the
+    // theory that "sibling" in the name meant they tested sibling-probing
+    // machinery. They didn't: what they actually exercise is the full
+    // `latestVersion(for:)` pipeline (URL resolution, SHA512 extraction,
+    // RecipeHealth) against a real vendor body — coverage the surviving
+    // `fallsBackToTheUniversalArtifactWhenNoArchIsNamed` and
+    // `picksTheArm64ArtifactOverTheOneTheManifestCallsPrimary` above do NOT
+    // provide, since those two call `ElectronManifest.parse` and
+    // `artifact(forArch:)` directly and never touch `latestVersion(for:)`,
+    // `resolvedDownloadURL`, or `RecipeHealth` at all.
+
+    @Test func aRealCanvaShapedManifestResolvesEndToEnd() async throws {
+        // Canva's ACTUAL shape, end to end (2026-09-01, real body): its default
+        // manifest names a `universal` artifact, which `artifact(forArch:)`
+        // picks before ever considering the top-level `path` fallback branch.
+        let domain = "https://desktop-release.canva.com"
+        FixtureProtocol.requestedURLs = []
+        FixtureProtocol.routes = [
+            "\(domain)/latest-mac.yml": .init(status: 200, body: """
+                version: 1.124.1
+                files:
+                  - url: Canva-1.124.1-universal-mac.zip
+                    sha512: ZIPSHA==
+                    size: 220714081
+                  - url: Canva-1.124.1-universal.dmg
+                    sha512: DMGSHA==
+                    size: 229488791
+                path: Canva-1.124.1-universal-mac.zip
+                sha512: ZIPSHA==
+                """, transportFailure: false),
+        ]
+        let bundleID = "com.duoupdater.test.electron.canvaReal"
+        let source = ElectronManifestSource(session: fixtureSession())
+
+        let remote = try #require(await source.latestVersion(
+            for: electronApp(bundleID: bundleID, domain: domain)))
+        #expect(remote.shortVersion == "1.124.1")
+        #expect(remote.downloadURL == URL(string: "\(domain)/Canva-1.124.1-universal-mac.zip"))
+        #expect(remote.vendorInstallerKind == .zip)
+        #expect(remote.expectedSHA512 == "ZIPSHA==")
+        #expect(FixtureProtocol.requestedURLs == ["\(domain)/latest-mac.yml"])
+
+        let entry = await RecipeHealth.shared.snapshot().first { $0.id == bundleID }
+        #expect(entry?.isHealthy == true)
+    }
+
+    @Test func aNativeArm64FilesEntryResolvesEndToEnd() async throws {
+        // ChatWise 26.8.0's shape (2026-09-01, real body): `files:` already
+        // carries a native arm64 entry, and the top-level `path` names x64.
+        // `artifact(forArch:)` picks the native entry before ever reaching the
+        // `path` fallback branch.
+        let domain = "https://cdn-chatwise.example.test"
+        FixtureProtocol.requestedURLs = []
+        FixtureProtocol.routes = [
+            "\(domain)/latest-mac.yml": .init(status: 200, body: """
+                version: 26.8.0
+                files:
+                  - url: ChatWise-26.8.0-x64.zip
+                    sha512: X64SHA==
+                    size: 100
+                  - url: ChatWise-26.8.0-arm64.zip
+                    sha512: ARM64SHA==
+                    size: 99
+                path: ChatWise-26.8.0-x64.zip
+                sha512: X64SHA==
+                """, transportFailure: false),
+        ]
+        let bundleID = "com.duoupdater.test.electron.nativeArm64Entry"
+        let source = ElectronManifestSource(session: fixtureSession())
+
+        let remote = try #require(await source.latestVersion(
+            for: electronApp(bundleID: bundleID, domain: domain)))
+        #expect(remote.shortVersion == "26.8.0")
+        #expect(remote.downloadURL == URL(string: "\(domain)/ChatWise-26.8.0-arm64.zip"))
+        #expect(remote.vendorInstallerKind == .zip)
+        #expect(remote.expectedSHA512 == "ARM64SHA==")
+        #expect(FixtureProtocol.requestedURLs == ["\(domain)/latest-mac.yml"])
+
+        let entry = await RecipeHealth.shared.snapshot().first { $0.id == bundleID }
+        #expect(entry?.isHealthy == true)
+    }
+
     @Test func aNon200ManifestRecordsAMiss() async throws {
         let domain = "https://cdn-404.example.test"
         FixtureProtocol.requestedURLs = []


### PR DESCRIPTION
Closes #291

## 改了什么

`ElectronManifestTests.swift` 里加回两条测试,分别是原 `aRealCanvaShapedManifestIsUnaffectedByItsForbiddenSibling` 和 `aNativeArm64FilesEntryIsUnaffectedBySiblingProbeOutcome`(#280 连带兄弟探测机制一起删掉的)的不带兄弟探测版本:

- `aRealCanvaShapedManifestResolvesEndToEnd` — Canva 1.124.1 真实 manifest body(universal 命名的 dmg/zip 三次重复列在 `files:` 里),走完整 `ElectronManifestSource.latestVersion(for:)`。
- `aNativeArm64FilesEntryResolvesEndToEnd` — ChatWise 26.8.0 真实 manifest body(`files:` 有原生 arm64 条目,顶层 `path` 却指向 x64),同样走完整 pipeline。

两条都去掉了 `arm64-mac.yml` 路由(生产代码里对应的兄弟探测本身已在 #280 删除),版本号/下载 URL/sha512/`vendorInstallerKind`/`RecipeHealth` 断言照旧搬回来,并新增 `FixtureProtocol.requestedURLs` 断言,钉住新代码只会请求 bundle 自己 channel 对应的那一个 manifest。

只改了测试文件,生产代码未动。

## 为什么

#280 删 `mayProbeArchSibling` 时把这两条测试也删了。它们名字里带 "sibling",但被测的主体不是兄弟探测机制——是拿真实厂商 manifest body 走完整的 `latestVersion(for:)`(URL 拼接、SHA512 提取、RecipeHealth 记录)。现存的 `fallsBackToTheUniversalArtifactWhenNoArchIsNamed` / `picksTheArm64ArtifactOverTheOneTheManifestCallsPrimary` 只调用 `ElectronManifest.parse` + `artifact(forArch:)`,是同步的、不碰网络、不碰 `resolvedDownloadURL` 的 URL 解析、也不碰 `RecipeHealth`。所以 Canva 和 ChatWise 这两个真实厂商形状的端到端回归保护,在 #280 之后就消失了,唯一剩下的端到端测试是 Notion 形状的 `theBundleDeclaredManifestIsTheOnlyTrackRead`。

## issue 核实

issue #291 判断是对的,逐条核对如下:

- (a) 两条被删测试确实用的是真实厂商 manifest body,不是合成的——Canva 那条连域名 `desktop-release.canva.com` 都是真的(2026-09-01 观测),ChatWise 那条 body 内容标注为 "ChatWise 26.8.0's shape (2026-09-01)",域名是占位符但 body 是真实结构(这也是该文件里其他"真实厂商形状"测试的一贯写法,比如 Notion 的高低版本不匹配那两条)。
- (b) 两条确实调用 `source.latestVersion(for: app)`,走完整异步 pipeline,包含 URL fetch(经 fixture)、`ElectronManifest.parse`、`resolvedDownloadURL` 的相对路径解析、`RecipeHealth.shared.recordSuccess`。
- (c) 现存的 `fallsBackToTheUniversalArtifactWhenNoArchIsNamed` 和 `picksTheArm64ArtifactOverTheOneTheManifestCallsPrimary` 确认只覆盖 `ElectronManifest.parse` + `artifact(forArch:)` 这一层——同步函数,没有 `async`,不接触 `ElectronManifestSource`、`URLSession`、`RecipeHealth`。

issue 没有说错或说漏的地方;它建议的"把这两条改写成不带兄弟探测的版本重新加回去"就是这次改动做的事。

## 验证

```
cd DuoUpdaterCore && swift test --filter ElectronManifest
```
→ 19 个测试全部通过(含新加的 2 条)。

变异测试:把 `ElectronManifestSource.swift` 里 `resolvedDownloadURL` 的拼接逻辑从

```swift
URL(string: $0.url, relativeTo: resolvedURL.deletingLastPathComponent())?.absoluteURL
```

改成丢掉 `relativeTo` 的错误版本

```swift
URL(string: $0.url)?.absoluteURL
```

重跑 `swift test --filter ElectronManifestSourceTests`:3 个测试红——新加的 `aRealCanvaShapedManifestResolvesEndToEnd`、`aNativeArm64FilesEntryResolvesEndToEnd`,以及既有的 `theBundleDeclaredManifestIsTheOnlyTrackRead`(它是唯一现存的另一条端到端测试,同样依赖这段逻辑,红属预期)。确认新测试确实钉住了 `resolvedDownloadURL` 这条链路,而不是只把断言誊抄回来。已还原生产代码(`git diff` 对 `ElectronManifestSource.swift` 为空)。

全量:
```
cd DuoUpdaterCore && swift test
```
→ 1936 个测试、153 个 suite 全部通过,1 个 known issue(与 #280 自己的验证记录一致,非本次改动引入)。

未验证:CLI 包未改动,未单独跑 `CLI && swift test`;`duo verify`(#204/#280 修的是网络行为)未重跑,本 issue 范围仅测试回归,判断不涉及网络行为,认为不需要;`App/Sources` 未涉及,未做 `xcodebuild`。
