### PR TITLE
Harden nestedInterfaceDoesNotLendItsUpdaterToTheWrapper's fixture

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerTests.swift
@@ -61,8 +61,14 @@ import Foundation
 
 /// Runtime attribution and update ownership are different questions. Docker's
 /// outer bundle launches the product, while its one nested GUI supplies the
-/// Electron runtime label. That nested GUI also happens to embed Squirrel, but
-/// Docker updates through `com.docker.backend.updater`, not ShipIt (#217).
+/// Electron runtime label. That nested GUI also happens to embed Squirrel,
+/// Sparkle and an electron-builder manifest, but Docker updates through
+/// `com.docker.backend.updater`, not ShipIt (#217). The fixture plants all
+/// three files (plus a nested `SUFeedURL`) precisely so each probe has
+/// something to wrongly find if it ever descended into the nested bundle —
+/// see #290: an earlier version of this fixture only planted Squirrel, so a
+/// mutation moving `hasSparkleUpdater` or `ElectronUpdateConfig.read` onto
+/// `AppRuntimeDetector.interfaceBundle(at:)` left this test green.
 @Test func nestedInterfaceDoesNotLendItsUpdaterToTheWrapper() throws {
     let fm = FileManager.default
     let root = fm.temporaryDirectory
@@ -78,6 +84,14 @@ import Foundation
     try fm.createDirectory(
         at: nestedFrameworks.appendingPathComponent("Squirrel.framework"),
         withIntermediateDirectories: true)
+    try fm.createDirectory(
+        at: nestedFrameworks.appendingPathComponent("Sparkle.framework"),
+        withIntermediateDirectories: true)
+    let nestedResources = nested.appendingPathComponent("Contents/Resources")
+    try fm.createDirectory(at: nestedResources, withIntermediateDirectories: true)
+    try "provider: generic\nurl: https://example.com/nested-updates\n".write(
+        to: nestedResources.appendingPathComponent("app-update.yml"),
+        atomically: true, encoding: .utf8)
 
     let outerPlist: [String: Any] = [
         "CFBundleDisplayName": "Docker",
@@ -86,11 +100,25 @@ import Foundation
         "CFBundleVersion": "238018",
         "CFBundleExecutable": "com.docker.backend",
     ]
+    // `SUFeedURL` on the nested plist is a belt-and-suspenders addition, not a
+    // mutation witness: `sparkleFeedURL` reads the SHARED `plist` this test
+    // parses once from `wrapper`'s own Info.plist (see `AppScanner.readApp`,
+    // which loads `infoURL` from `bundleURL` before either bundle's identity
+    // is known), never a plist re-read from `interfaceBundle`. A path-swap
+    // mutation analogous to the other three probes' therefore has nothing to
+    // move — the address would have to come from swapping `bundleID` itself
+    // (SparkleFeedCatalog looks up by bundle id, not by path), which is a
+    // change to a different, shared fact and not a faithful analog of "this
+    // one probe descended a level". Confirmed by hand (#290): rerouting the
+    // `SUFeedURL` read through a plist loaded from `interfaceBundle(at:)`
+    // left this test green, because neither plist here sets `SUFeedURL` and
+    // the `SparkleFeedCatalog` fallback still keys off the outer bundle id.
     let nestedPlist: [String: Any] = [
         "CFBundleDisplayName": "Docker Desktop",
         "CFBundleIdentifier": "com.electron.dockerdesktop",
         "CFBundleShortVersionString": "4.89.0",
         "CFBundleVersion": "4.89.0.9",
+        "SUFeedURL": "https://example.com/nested-appcast.xml",
     ]
     for (bundle, plist) in [(wrapper, outerPlist), (nested, nestedPlist)] {
         let info = bundle.appendingPathComponent("Contents/Info.plist")


### PR DESCRIPTION
## 改了什么

`AppScannerTests.nestedInterfaceDoesNotLendItsUpdaterToTheWrapper` 守护四个探针（Squirrel/`hasSelfUpdater`、Sparkle/`hasSparkleUpdater`、`ElectronUpdateConfig.read`、`sparkleFeedURL`）继续读外层 `bundleURL` 而不是下降进嵌套 GUI（`AppRuntimeDetector.interfaceBundle(at:)`）。fixture 之前只造了嵌套的 `Squirrel.framework`，所以另外两个基于文件存在性的探针即使被误改成走 `interfaceBundle`，测试也照样绿。

补了 fixture：
- `nested/Contents/Frameworks/Sparkle.framework`
- `nested/Contents/Resources/app-update.yml`（`provider: generic` + `url`）
- 额外在嵌套 plist 上加了 `SUFeedURL`（belt-and-suspenders，见下）

生产代码 `AppScanner.swift` **未改动**——这个 issue 只是把测试补硬，不推翻 #217/#277 的结论（Docker 更新由 `com.docker.backend.updater` 拥有，四个探针继续读外层 bundle 是对的）。

## issue 核实

issue 说对的部分：四个探针里只有 Squirrel 那条真正被 fixture 钉住，Sparkle 和 `ElectronUpdateConfig` 两条因为缺文件而空过。这一点我独立变异确认了，见下面「变异测试」。

issue 里`sparkleFeedURL`那行的判断（"按 bundle id 查 catalog，不按路径，结构上也不是「改路径」能移动的"）我做了进一步验证，比 issue 本身说得更具体：

`sparkleFeedURL` 的来源是 `AppScanner.readApp` 一开始（在任何一个 bundle 的身份被判定之前）从 `bundleURL` 读的**同一份共享 `plist`**（`SUFeedURL` 键），落空后才 fallback 到 `SparkleFeedCatalog.feed(forBundleID:)`——按 `bundleID` 查表，不按路径。所以：
- 即便把 `SUFeedURL` 的读取改成从 `AppRuntimeDetector.interfaceBundle(at:)` 重新加载一份 plist 再查（我实际做了这个改动去测），fixture 里嵌套 plist 原本没设 `SUFeedURL`，测试依旧绿——直到我在这次 PR 里往嵌套 plist 加了一条 `SUFeedURL` 作为兜底。
- 但就算嵌套 plist 有 `SUFeedURL`，`bundleID` 变量本身仍然是外层的 `com.docker.docker`（除非走 WeChat DevTools 那条特殊路径），所以 catalog fallback 分支永远查外层 id。要让"改路径"这个动作单独影响 `sparkleFeedURL`，必须同时改 `bundleID` 这个被几十处逻辑共享的事实——这已经不是"这一个探针下降一层"的忠实类比，而是改了一个完全不同、影响面大得多的量。

所以我按 issue 建议的做法：**没有**为 `sparkleFeedURL`硬凑一条会红的变异，而是在测试注释里写清楚它靠的是"共享 plist 在身份判定前就已固定" + "catalog 按 id 不按路径"这两条结构性保证，并把嵌套 plist 上加的那条 `SUFeedURL` 标注为"belt-and-suspenders，不是变异见证"，避免让读者以为四个探针的硬度是一样的。

issue 没有说错的地方，也没有发现它漏了别的探针——`AppScanner.swift` 里那条注释点名的四个名词（Electron config、Squirrel、Sparkle、feed）跟 issue 表格里列的四行完全对应，没有第五个探针共享同一段落逻辑。

## 变异测试

**修复前**（生产代码原样，仅确认 issue 现状）：

| 探针 | 变异（改成读 `interfaceBundle(at: bundleURL)`） | 结果 |
|---|---|---|
| `hasSelfUpdater`（Squirrel） | `squirrel = interfaceBundle(...).appendingPathComponent(...)` | 红（fixture 本来就造了嵌套 Squirrel） |
| `hasSparkleUpdater` | `sparkle = interfaceBundle(...).appendingPathComponent(...)` | 绿（fixture 没造嵌套 Sparkle，issue 说对了） |
| `ElectronUpdateConfig.read` | `ElectronUpdateConfig.read(fromBundleAt: interfaceBundle(...))` | 绿（fixture 没造嵌套 app-update.yml，issue 说对了） |
| `sparkleFeedURL` | 把 `SUFeedURL` 读取改成从 `interfaceBundle` 重新加载的 plist 里查 | 绿（两边 plist 都没设 `SUFeedURL`，catalog fallback 仍查外层 bundle id） |

每次改完都跑 `swift test --filter nestedInterfaceDoesNotLendItsUpdaterToTheWrapper`，跑完立刻还原生产代码（`git diff` 确认改动清零）。

**补完 fixture 之后，四次变异重跑**：

| 探针 | 结果 |
|---|---|
| `hasSelfUpdater`（Squirrel） | 红（不变） |
| `hasSparkleUpdater` | 红（**从绿变红**，fixture 补的 `Sparkle.framework` 生效） |
| `ElectronUpdateConfig.read` | 红（**从绿变红**，fixture 补的 `app-update.yml` 生效） |
| `sparkleFeedURL` | 未再次变异（结构上不适用，见上）——保持用注释说明，而不是硬凑一条会红的变异 |

## 验证

```
cd DuoUpdaterCore && swift test --filter nestedInterfaceDoesNotLendItsUpdaterToTheWrapper
# passed（fixture 补完后，真实生产代码下）

cd DuoUpdaterCore && swift test --filter AppScanner
# 19 tests, 0 failures

cd DuoUpdaterCore && swift test
# Test run with 1934 tests in 153 suites passed after 39.631 seconds with 1 known issue.
# （known issue 是 GitHubReleaseRuleTests.swift:754 一条既有的、与本次改动无关的记录，非本 PR 引入）
```

未验证 / 未做的事：
- 没有跑 CLI 的 `swift test`（本次没有改 CLI，且并行环境约束下没必要跑）。
- 没有跑 `make gallery` / `make test`（分派 brief 明确禁止，避免和并行 worktree 撞锁）。

closes #290
