### PR TITLE
Add ProbeWarning.publishedAtPatternNoMatch for a dead publishedAtPattern

### DIFF
--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -492,6 +492,19 @@ import DuoUpdaterCore
         #expect(onlyTransient.signature == "unknown")
     }
 
+    // NOTE this is NOT a test of `ProbeWarning.publishedAtUnreadable`'s own
+    // `oneLine`/160-character truncation (added alongside the case itself):
+    // both captured values below are short, whitespace-free, and well under
+    // that 160-character window, so that logic never engages here — deleting
+    // it entirely leaves this test green. What actually keeps the two
+    // signatures equal is `Finding.signature`'s OWN, older `prefix(40)`
+    // window (`Baseline.swift`), which is shorter than the fixed
+    // `"publishedAtUnreadable: captured value did not parse: "` preamble
+    // (53 characters) and so cuts every `publishedAtUnreadable` warning
+    // before any captured text — however that text was formatted — ever
+    // enters the signature. This test demonstrates the CLI's stability
+    // survives even without `.display`'s own truncation, not that the
+    // truncation is what does the work.
     @Test func aChangingUnreadablePublishDateDoesNotMoveTheSignature() {
         func finding(_ captured: String) -> Finding {
             Finding(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -207,6 +207,25 @@ public enum ProbeWarning: Sendable, Equatable {
     /// value jump from `155.0b5` to `20260826090609` — an increase, and the only
     /// history check there is looks for a version moving BACKWARDS.
     case displayPatternNoMatch
+    /// `publishedAtPattern` is set but matched nothing, so the release timeline
+    /// loses its exact event and falls back to its estimated "≈" window, and
+    /// `duo verify`'s age-gated phantom-update check is disabled — the same
+    /// consequence as `publishedAtUnreadable`, reached a different way.
+    ///
+    /// The same shape as `checksumPatternNoMatch` / `entryPatternNoMatch` /
+    /// `displayPatternNoMatch`: a pattern the recipe author wrote down, found
+    /// nothing, and nothing failed — the version keeps resolving, so a sweep
+    /// with no warnings check would call this recipe healthy.
+    ///
+    /// Deliberately NOT `publishedAtUnreadable`. That one means the pattern DID
+    /// fire and `ReleaseDate` rejected the captured text — there is a value to
+    /// show and a date spelling to add support for. This one means the pattern
+    /// never matched at all, so there is nothing captured to show; the fix is
+    /// to go re-derive the pattern against the vendor's current response, same
+    /// as `displayPatternNoMatch`. A recipe missing `publishedAtPattern`
+    /// entirely stays quiet — that is the normal, supported "no publish time"
+    /// shape and not a degradation of anything the recipe author declared.
+    case publishedAtPatternNoMatch
     /// `publishedAtPattern` captured a value, but `ReleaseDate` could not parse
     /// it. The version remains usable, but the release timeline loses its exact
     /// event and `duo verify`'s age-gated phantom-update check is disabled.
@@ -262,6 +281,7 @@ public enum ProbeWarning: Sendable, Equatable {
         case .checksumPatternNoMatch: return "checksumPatternNoMatch"
         case .entryPatternNoMatch: return "entryPatternNoMatch"
         case .displayPatternNoMatch: return "displayPatternNoMatch"
+        case .publishedAtPatternNoMatch: return "publishedAtPatternNoMatch"
         case .publishedAtUnreadable: return "publishedAtUnreadable"
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -624,10 +624,14 @@ public struct VendorProbeSource: UpdateSource {
             VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
         }
         // Optional authoritative publish time, from the same scope (first match,
-        // so it belongs to the entry `versionPattern` matched). A missing date is
-        // not a failure — the Release Log falls back to its estimated "≈" window.
-        // A captured but unreadable date takes the same fallback, but warns: it
-        // also silently disables `duo verify`'s age-gated phantom-update check.
+        // so it belongs to the entry `versionPattern` matched). A recipe that
+        // declares no `publishedAtPattern` at all is not a failure — the
+        // Release Log falls back to its estimated "≈" window, quietly. A
+        // recipe that DOES declare one but gets no match, or a match
+        // `ReleaseDate` can't parse, hits the same fallback but warns: both
+        // silently disable `duo verify`'s age-gated phantom-update check, and
+        // without the warning a declared-but-dead pattern reads identically to
+        // never having declared one at all (issue #288).
         let publishedAtValue = recipe.publishedAtPattern.flatMap {
             VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
         }
@@ -641,7 +645,9 @@ public struct VendorProbeSource: UpdateSource {
         if recipe.displayVersionPattern != nil, display == nil {
             warnings.append(.displayPatternNoMatch)
         }
-        if let publishedAtValue, publishedAt == nil {
+        if recipe.publishedAtPattern != nil, publishedAtValue == nil {
+            warnings.append(.publishedAtPatternNoMatch)
+        } else if let publishedAtValue, publishedAt == nil {
             warnings.append(.publishedAtUnreadable(publishedAtValue))
         }
         var remote: RemoteVersion

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -877,6 +877,32 @@ private func verdict(
     #expect(outcome.warnings.isEmpty)
 }
 
+// A `publishedAtPattern` that matches nothing at all must not be silently
+// indistinguishable from a recipe that never declared one — issue #288.
+// Before this warning existed, both produced the same `nil` `publishedAt`
+// and an empty `outcome.warnings`, so `duo verify` had nothing to say about a
+// recipe that lost its date field entirely.
+@Test func aPublishedAtPatternThatMatchesNothingIsWarnedAbout() async throws {
+    let body = #"{"version":"3.1.0","published_wrong_key":"2026-09-02T06:00:00Z"}"#
+    let server = try RecipeVerificationTests.StubServer(body: body)
+    defer { server.stop() }
+    let recipe = VendorProbeRecipe(
+        bundleID: "com.example.no-publish-match", url: server.url,
+        mode: .responseBody,
+        versionPattern: #""version":"([^"]+)""#,
+        publishedAtPattern: #""published":"([^"]+)""#)
+
+    let outcome = await VendorProbeSource().probeDiagnostic(recipe)
+
+    #expect(outcome.remote?.shortVersion == "3.1.0",
+            "a publishedAtPattern miss must not turn a good version into a probe failure")
+    #expect(outcome.remote?.publishedAt == nil)
+    #expect(outcome.failure == nil)
+    #expect(outcome.warnings == [.publishedAtPatternNoMatch])
+    #expect(outcome.warnings.first?.kind == "publishedAtPatternNoMatch")
+    #expect(outcome.warnings.first?.display == "publishedAtPatternNoMatch")
+}
+
 // Recipes without a publishedAtPattern must stay absent rather than inventing a
 // time — the timeline then shows its estimated "≈" window instead.
 @Test func probeWithoutPublishedAtPatternLeavesReleaseTimeUnset() {


### PR DESCRIPTION
## What

`publishedAtPattern` had two ways to end up `nil`, and only one had a warning:

- pattern matched, `ReleaseDate.parse` rejected it → `ProbeWarning.publishedAtUnreadable` (#256)
- pattern declared but matched **nothing at all** in the response body → silent `nil`, indistinguishable downstream from a recipe that never declared the pattern

Adds `ProbeWarning.publishedAtPatternNoMatch`, the missing sibling to `checksumPatternNoMatch` / `entryPatternNoMatch` / `displayPatternNoMatch`, using the same idiom as `displayPatternNoMatch`:

```swift
if recipe.publishedAtPattern != nil, publishedAtValue == nil {
    warnings.append(.publishedAtPatternNoMatch)
} else if let publishedAtValue, publishedAt == nil {
    warnings.append(.publishedAtUnreadable(publishedAtValue))
}
```

Traced it end to end: `Verify.classify` maps `outcome.warnings` generically via `.display` and only special-cases `installURLTransient` by `hasPrefix`; `Baseline.reconcile`/`Finding.signature` only key on `installURLTransient`'s `kind` specifically. Neither has an exhaustive switch over `ProbeWarning`, so the new case flows through both without any extra registration — verified by grep, no other file in the repo switches over `ProbeWarning` outside `VendorProbeDiagnostics.swift` itself.

Also fixes a decorative test flagged in the issue: `CLI/Tests/DuoKitTests/BaselineTests.swift`'s `aChangingUnreadablePublishDateDoesNotMoveTheSignature`.

## Issue check (#288)

The issue is accurate on both points:

- **The gap is real and reproduces exactly as described.** Changed the response body's key to `published_wrong_key` in a new test mirroring the issue's repro; before the fix, `outcome.warnings == []` and `remote.publishedAt == nil` — a broken recipe reads as healthy.
- **The CLI test claim checks out, with one nuance worth stating precisely.** I measured the fixed prefix `"publishedAtUnreadable: captured value did not parse: "` at 53 characters against `Finding.signature`'s `prefix(40)` window (`Baseline.swift`) — 53 > 40, so the captured value can never enter the signature regardless of formatting. That means the test isn't merely "decorative" in the sense of testing nothing: it does react to changing `Baseline.swift`'s `prefix(40)` to `prefix(200)` (verified — the test goes red). What's wrong is narrower than "decorative": the docstring credited the *wrong* mechanism. It read as guarding `publishedAtUnreadable`'s own `oneLine`/160-char truncation (added in #256), but that logic never engages here (both test values are short and whitespace-free) — deleting it entirely leaves the test green (verified). I corrected the comment to say what the test actually demonstrates (`Finding.signature`'s own, older `prefix(40)`) rather than rewriting the assertions, since the two-option menu in the issue explicitly allowed a comment fix as an alternative to rewriting the test.

I found nothing the issue got wrong or missed.

## Verification

Core, filtered (red → green):
```
$ cd DuoUpdaterCore && swift test --filter aPublishedAtPatternThatMatchesNothingIsWarnedAbout
# before the fix: outcome.warnings == [] (3 failed expectations) — matches the issue's repro exactly
# after the fix:  Test run with 1 test in 0 suites passed after 0.031 seconds.
```

Core, full VendorProbe filter: `Test run with 104 tests in 1 suite passed`

Core, full suite: `Test run with 1937 tests in 153 suites passed after 37.592 seconds with 1 known issue.` (the "known issue" is a pre-existing marker unrelated to this change; some tests here hit real vendor endpoints per this repo's existing test design)

CLI, full suite: `Test run with 185 tests in 24 suites passed after 0.067 seconds.`

`python3 scripts/check_staged_version_use.py`: `✓ version comparisons discriminate`

### Mutation tests

1. New `ProbeWarning.publishedAtPatternNoMatch` production condition: removed the `if recipe.publishedAtPattern != nil, publishedAtValue == nil` branch (left only the old `publishedAtUnreadable` check) → `aPublishedAtPatternThatMatchesNothingIsWarnedAbout` failed with the same 3 issues as the pre-fix run. Restored, re-ran green.
2. `Baseline.swift`'s `prefix(40)` → `prefix(200)`: `aChangingUnreadablePublishDateDoesNotMoveTheSignature` failed (`"...yesterday"` vs `"...last Tuesday"` no longer collapse to the same signature once the window is wide enough to include the captured text) — confirms the corrected comment's claim and that the test is not decorative. Restored via `git checkout`, re-ran green.

### Not verified

- Did not run `duo verify` against real vendor endpoints — this change only adds a new diagnostic case reachable through the existing extraction path already covered by unit tests with stubbed servers; no recipe registry entry or regex was touched, so there is no vendor-specific regression to catch this way. Flagging this explicitly per repo convention rather than asserting it's unnecessary.
- Did not run `make gallery` or touch `App/Sources` — this change is entirely in `DuoUpdaterCore`/`CLI`, no row-rendering or UI surface involved.

closes #288