### PR TITLE
fix: share pruneStagedPackages' derived-build guard with PackageRestartState (#285)

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3855,7 +3855,12 @@ final class AppListModel {
             // Landed (the app now IS the staged version): keep so restart tracking
             // survives a one-scan flicker of the launch-time signal, even if the
             // download was swept. Reconcile settles it once the copy is fresh/gone.
-            if VersionComparator.isSame(app.versionSide, as: staged.versionSide) { return true }
+            // `buildIsDerived` matches the guard `reconcilePackageRestarts` passes
+            // to `PackageRestartState.resolve` — same two inputs, same namespace
+            // problem for `AppScanner.buildVersionIsOverridden` apps (#285).
+            if VersionComparator.isSame(app.versionSide, as: staged.versionSide,
+                buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID: app.bundleID)
+            ) { return true }
             // Otherwise it's only usable while still on offer and re-openable.
             return offered[id].map {
                 VersionComparator.isSame($0, as: staged.versionSide)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartState.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartState.swift
@@ -58,11 +58,9 @@ public enum PackageRestartState: Sendable, Equatable {
         runningLaunchDates: [Date],
         buildIsDerived: Bool = false
     ) -> Self {
-        guard var onDiskVersion else { return .pending }
-        if buildIsDerived {
-            onDiskVersion = VersionSide(marketing: onDiskVersion.marketing)
-        }
-        guard VersionComparator.isSame(onDiskVersion, as: stagedVersion)
+        guard let onDiskVersion else { return .pending }
+        guard VersionComparator.isSame(
+            onDiskVersion, as: stagedVersion, buildIsDerived: buildIsDerived)
         else { return .pending }
         let staleRunning = runningLaunchDates.contains { $0 < stagedAt }
         return staleRunning ? .readyToRestart : .settled

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/VersionComparator.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/VersionComparator.swift
@@ -92,6 +92,27 @@ public enum VersionComparator {
         return comparable.allSatisfy { compare($0.0, $0.1) == .orderedSame }
     }
 
+    /// Same as `isSame(_:as:)`, but for a `lhs` whose `build` may not describe
+    /// `rhs`'s namespace at all — `AppScanner.buildVersionIsOverridden`'s apps
+    /// (Xcode, 豆包输入法) store a vendor build id in that field, not
+    /// `CFBundleVersion`, so comparing it against a package/feed build is
+    /// comparing two unrelated counters. When `buildIsDerived` is true, `lhs`'s
+    /// build is discarded before the comparison, so agreement falls back to
+    /// marketing alone — the only namespace both sides are known to share.
+    ///
+    /// Every caller that reads a scanner-derived build and compares it against
+    /// an offer's `VersionSide` needs this, not just `PackageRestartState`: a
+    /// plain `isSame` call requires ALL fields both sides carry to agree, so a
+    /// landed derived-build app (matching marketing, incomparable build) reads
+    /// as "not landed" — the same false negative `PackageRestartState` used to
+    /// produce before it gained this guard (see #236 / #251).
+    public static func isSame(
+        _ lhs: VersionSide, as rhs: VersionSide, buildIsDerived: Bool
+    ) -> Bool {
+        guard buildIsDerived else { return isSame(lhs, as: rhs) }
+        return isSame(VersionSide(marketing: lhs.marketing), as: rhs)
+    }
+
     /// True when `disk` has reached `target` — the landing test for a swap we are
     /// waiting on. Same build, or a newer one (an app may have moved past the
     /// build we were expecting while we waited).

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
@@ -169,6 +169,31 @@ import Testing
                 "nothing comparable is not sameness")
     }
 
+    /// `isSame(_:as:buildIsDerived:)` is the shared primitive behind both
+    /// `PackageRestartState.resolve` and `AppListModel.pruneStagedPackages` (#285):
+    /// a scanner-substituted build (`AppScanner.buildVersionIsOverridden`'s Xcode,
+    /// 豆包输入法) does not share the other side's namespace, so when
+    /// `buildIsDerived` is true the `lhs` build must be dropped before comparing —
+    /// falling back to marketing alone — rather than let the plain `isSame` rule
+    /// ("every comparable field must agree") veto a real match on an incomparable
+    /// build pair.
+    @Test func isSameWithDerivedBuildFallsBackToMarketing() {
+        // Marketing matches, build is a foreign namespace: derived must call it
+        // the same; the plain rule (every comparable field agrees) must not.
+        #expect(VersionComparator.isSame(
+            s("1.0", "90602"), as: s("1.0", "1"), buildIsDerived: true))
+        #expect(!VersionComparator.isSame(s("1.0", "90602"), as: s("1.0", "1")),
+                "precondition: without the flag the mismatched builds veto it")
+        // Marketing itself differs: dropping the build must not manufacture a
+        // false match out of an unrelated build pair.
+        #expect(!VersionComparator.isSame(
+            s("1.0", "90602"), as: s("1.1", "1"), buildIsDerived: true))
+        // False (the default) must behave exactly like the un-flagged overload.
+        #expect(VersionComparator.isSame(
+            s("1.0", "130"), as: s("1.0", "130"), buildIsDerived: false)
+            == VersionComparator.isSame(s("1.0", "130"), as: s("1.0", "130")))
+    }
+
     /// `hasReached` is the landing test: the exact build, or one past it.
     @Test func hasReachedAcceptsTheTargetOrAnythingPastIt() {
         let target = s("1.0", "130")

--- a/scripts/check_staged_version_use.py
+++ b/scripts/check_staged_version_use.py
@@ -119,6 +119,17 @@ PACKAGE_RESTART_RESOLVE = re.compile(r"PackageRestartState\.resolve\s*\(")
 DERIVED_BUILD_ARGUMENT = "buildIsDerived:"
 PACKAGE_RESTART_WINDOW = 10
 
+# The second such wiring site (#285): `pruneStagedPackages` compares the same
+# scanner-derived on-disk `VersionSide` (`app.versionSide`) against a staged
+# package's, for the identical reason `PackageRestartState.resolve` needed the
+# flag above — so it needs it too. Scoped to `app.versionSide` specifically:
+# the many other `VersionComparator.isSame(` calls compare two sides that are
+# NOT one scanner value against one package/feed value (e.g. two scanner reads
+# of the same app, which share whatever namespace they're in) and must not be
+# forced to carry an argument that means nothing for them.
+PRUNE_STAGED_ISSAME = re.compile(r"VersionComparator\.isSame\s*\(\s*app\.versionSide")
+PRUNE_STAGED_WINDOW = 6
+
 
 # A *different* type also binds the name `staged`: `stagedPackage(for:)` returns
 # a `StagedPackage` — a downloaded `.pkg` installer, not a self-update staged by
@@ -154,9 +165,11 @@ def main() -> int:
     display_hits, ledger_hits, compare_hits, read_hits = [], [], [], []
     display_marketing_hits = []
     package_restart_hits = []
+    prune_staged_hits = []
     ledger_seen = 0
     marketing_seen = 0
     package_restart_seen = 0
+    prune_staged_seen = 0
     files = list(swift_files())
 
     for path in files:
@@ -192,6 +205,11 @@ def main() -> int:
                 call = "\n".join(lines[n - 1:n - 1 + PACKAGE_RESTART_WINDOW])
                 if DERIVED_BUILD_ARGUMENT not in call:
                     package_restart_hits.append(f"{rel}:{n}: {line.strip()}")
+            if PRUNE_STAGED_ISSAME.search(line):
+                prune_staged_seen += 1
+                call = "\n".join(lines[n - 1:n - 1 + PRUNE_STAGED_WINDOW])
+                if DERIVED_BUILD_ARGUMENT not in call:
+                    prune_staged_hits.append(f"{rel}:{n}: {line.strip()}")
 
     # Vacuity guard. A rule that matches nothing passes forever, which is worse
     # than no rule: it reports success while the thing it was written for has
@@ -212,6 +230,11 @@ def main() -> int:
     if package_restart_seen == 0:
         print("✗ staged-version guard found no PackageRestartState.resolve call. "
               "Either the app wiring moved or this rule now guards nothing.")
+        return 1
+    if prune_staged_seen == 0:
+        print("✗ staged-version guard found no VersionComparator.isSame(app.versionSide "
+              "call in pruneStagedPackages. Either that wiring moved or renamed, or "
+              "this rule now guards nothing.")
         return 1
 
     if display_hits:
@@ -258,8 +281,15 @@ def main() -> int:
               "scanner-substituted build is not compared with a feed build.")
         for hit in package_restart_hits:
             print(f"    {hit}")
+    if prune_staged_hits:
+        print(f"✗ {len(prune_staged_hits)} pruneStagedPackages comparison(s) omit "
+              "the derived-build namespace flag.")
+        print("  Pass buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID:) "
+              "so a scanner-substituted build is not compared with a staged package's.")
+        for hit in prune_staged_hits:
+            print(f"    {hit}")
     if (display_hits or ledger_hits or compare_hits or display_marketing_hits
-            or read_hits or package_restart_hits):
+            or read_hits or package_restart_hits or prune_staged_hits):
         return 1
 
     print(f"✓ version comparisons discriminate — {len(files)} files, "


### PR DESCRIPTION
Closes #285

## What

`pruneStagedPackages`'s landing check now shares the same derived-build guard `PackageRestartState.resolve` got in #251:

- `VersionComparator` gains `isSame(_:as:buildIsDerived:)`. When `buildIsDerived` is true it discards `lhs.build` before comparing, falling back to marketing alone — the exact strip-then-compare `PackageRestartState.resolve` used to inline. `resolve` now delegates to it instead of duplicating the logic (Core, judgment logic lives here per this repo's convention).
- `AppListModel.pruneStagedPackages` now passes `buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID:)` into its own `isSame` call, the same input `reconcilePackageRestarts` already passes to `PackageRestartState.resolve`.
- `scripts/check_staged_version_use.py` gets a second narrow wiring guard (mirroring the existing `PackageRestartState.resolve` one) that pins `VersionComparator.isSame(app.versionSide` in `App/Sources` to always carry `buildIsDerived:`. Purely additive — no existing rule touched (`DISPLAY_VERSION_AS_MARKETING` was already mid-edit for #286 upstream; rebased on top of it, not around it).
- `VersionComparatorTests` gets a direct test of the new overload.

## Why

Chose option (b) from the issue (sink to Core) over (a) (pass the flag and stop there): the "drop a scanner-substituted build before comparing" rule now exists in exactly one place, tested once, and used by both call sites. The App-side diff is one line either way; sinking it removes a second copy of the strip-then-compare logic that would otherwise have to stay in sync with Core's by hand.

## Issue verification

Core claim holds up under independent grep/read, with one small correction:

- **Confirmed by reading, not just trusting the issue**: `pruneStagedPackages`'s `VersionComparator.isSame(app.versionSide, as: staged.versionSide)` (no `buildIsDerived`) is exactly the shape #251 fixed in `PackageRestartState.resolve`, and `isSame` requires every field **both** sides carry to agree — so a namespace mismatch on `build` alone (matching marketing) reads as "not landed" even though it landed.
- **Confirmed the "why it hasn't misfired" mechanism independently**, by working through `VersionComparator.isSame`'s actual semantics rather than taking the issue's word for it: for a derived-build app, if marketing doesn't match, both the buggy and fixed comparisons agree it's "not same" (marketing dominates `isSame`'s `allSatisfy`), so the missing flag is inert. Only when marketing DOES match could the two diverge — but in that case `reconcilePackageRestarts` (which runs first and does have the flag) already classified the entry as `.settled` (removed from `stagedPackages` before `pruneStagedPackages` runs) or `.readyToRestart` (caught by the `packageRestartPending` early-return at the top of `pruneStagedPackages`, before the buggy line is ever reached). So the bug really was inert, exactly as claimed — but for a slightly more precise reason than "the ordering avoids it": it's specifically that reconcile disposes of every case where the flag would matter before prune's own check runs.
- **Correction**: the issue says "6 个调用点" all call `computeRestartInfo()` before `computeSelfUpdateStaging()`. Actual count is **5**, not 6 — grep finds 5 call sites of `computeSelfUpdateStaging()` (`AppListModel.swift:2003,2199,2218,3097,4895`), each immediately preceded by `computeRestartInfo()` with no early return in between (checked all 5 individually). `computeRestartInfo()` is additionally called alone at 3 more sites (2721, 5720, 5974) that never reach `computeSelfUpdateStaging()`/`pruneStagedPackages()`, so they don't matter here. Minor overcount, doesn't change the conclusion.
- `pruneStagedPackages`'s doc comment indeed says nothing about needing `reconcilePackageRestarts` to run first — confirmed, as the issue says.

Since this PR fixes the comparison directly rather than choosing "rely on the call order," the ordering dependency is now moot for this specific bug — `pruneStagedPackages` no longer needs `reconcilePackageRestarts` to have run first to get the right answer. (The two functions still have other reasons to run in that order — e.g. `packageRestartPending` bookkeeping — untouched here.)

## Verification

```
$ cd DuoUpdaterCore && swift test --filter "VersionComparatorTests|PackageRestartStateTests"
✔ Test run with 30 tests in 2 suites passed after 0.001 seconds.

$ cd DuoUpdaterCore && swift test   # full suite
━ Test run with 1935 tests in 153 suites passed after 39.549 seconds with 1 known issue.  # pre-existing, unrelated

$ cd CLI && swift test
✔ Test run with 185 tests in 24 suites passed after 0.082 seconds.

$ python3 scripts/check_staged_version_use.py
✓ version comparisons discriminate — 211 files, 2 ledger call(s) keyed on the build, 7 marketing-first pick(s), all display-only

$ xcodegen generate --spec App/project.yml   # DUO_TEAM_ID exported first
$ xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug -derivedDataPath /tmp/duo-dd-285 build
** BUILD SUCCEEDED **
```

**Mutation tests** (required both new guards to go red, then restored):

1. `VersionComparator.isSame(_:as:buildIsDerived:)` body reduced to always call the plain 2-arg `isSame` (i.e. `buildIsDerived` ignored) → `isSameWithDerivedBuildFallsBackToMarketing()` failed as expected (`✘ ... buildIsDerived: true) → false`). Restored, reran green.
2. Dropped the `buildIsDerived:` argument from `pruneStagedPackages`'s call → `check_staged_version_use.py` failed as expected (`✗ 1 pruneStagedPackages comparison(s) omit the derived-build namespace flag.`, pointing at the exact line). Restored, reran green (`✓ ...`).

## Not verified / my guess

- No manual/integration repro against a real Xcode or 豆包输入法 install with an actual staged `.pkg` — this is a pure logic fix, verified via unit tests + mutation tests + reading `VersionComparator`'s real semantics, not an end-to-end run of `pruneStagedPackages` itself (impossible without a test target for `App/Sources`, per this repo's existing constraint).
- Did not chase whether any other call site of `VersionComparator.isSame`/`isNewer` compares a scanner-derived `versionSide` against a non-scanner side; found one candidate (`clearSettledExternalUpdates`, `AppListModel.swift:5582`) but ruled it out because *both* sides there come from `AppScanner` (two scans of the same app), so they share whatever namespace they're in — not the "scanner build vs. package/feed build" mismatch this issue is about. Did not do an exhaustive sweep beyond that.
