### PR TITLE
fix: log and surface rejected changelog navigations instead of a blank pane

### DIFF
--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1897,6 +1897,17 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
     /// taps) should not be able to point it anywhere it likes.
     private let originHost: String?
 
+    /// Whether this pane has ever finished a navigation successfully. #292: a
+    /// rejection that happens before the very first load ever commits leaves a
+    /// permanently blank pane, indistinguishable from "this app has no notes" —
+    /// that is the case `reject(_:url:reason:isMainFrame:)` shows a message for.
+    /// A rejection that happens later, after the reader has already shown real
+    /// content (a page that redirects itself mid-session), leaves that content
+    /// alone instead: replacing something the user is reading with an error
+    /// panel over one blocked navigation would be a worse outcome than the
+    /// rejection itself.
+    private var hasCommittedFirstLoad = false
+
     init(origin: URL) {
         self.originHost = origin.host
         super.init()
@@ -1923,15 +1934,18 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
         // a structural gate — it cannot see which address an ordinary DNS name
         // resolves to — but the URL the user lands on now gets the same check as
         // the URL we start from.
+        let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
+
         if let url = navigationAction.request.url,
            url.scheme?.lowercased() == "http" {
+            reject(webView, url: url, reason: "cleartext http connection", isMainFrame: isMainFrame)
             decisionHandler(.cancel); return
         }
 
-        let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
         if isMainFrame,
            let url = navigationAction.request.url,
-           !ChangelogURLPolicy.isDisplayable(url) {
+           let reason = ChangelogURLPolicy.rejectionReason(url) {
+            reject(webView, url: url, reason: reason, isMainFrame: isMainFrame)
             decisionHandler(.cancel); return
         }
 
@@ -1953,6 +1967,64 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
     func cancel() {
         watchdog?.cancel()
         watchdog = nil
+    }
+
+    /// #292: `decidePolicyFor` used to cancel a rejected navigation with nothing
+    /// else — no log line, and if the rejection landed on the pane's very first
+    /// (still-uncommitted) navigation, a permanently blank pane that reads exactly
+    /// like "this app has no changelog". Every rejection is now logged with the
+    /// URL and the reason, and — only in that blank-forever case — the pane shows
+    /// the reason instead of staying blank.
+    ///
+    /// `.error`, not `.info`: per `Log`'s own doc comment, `.info` is memory-only
+    /// for a third-party subsystem and would be gone by the time anyone went
+    /// looking for why a changelog pane went dark.
+    private func reject(_ webView: WKWebView, url: URL, reason: String, isMainFrame: Bool) {
+        Log.changelog.error("webview navigation blocked (\(reason, privacy: .public)) mainFrame=\(isMainFrame ? "yes" : "no", privacy: .public) url=\(Redactor.url(url), privacy: .public) origin=\(self.originHost ?? "?", privacy: .public)")
+        guard isMainFrame, !hasCommittedFirstLoad else { return }
+        showBlockedNotice(webView, reason: reason)
+    }
+
+    /// Puts `reason` on screen in place of a blank pane. `WorkbenchWindowView`'s
+    /// SwiftUI layer already has a `ContentUnavailableView` for "nothing to show"
+    /// (`ReleaseNotesPane.emptyNotes`, `FormulaDetail.noNotes`), but this
+    /// `WKWebView` is owned by `WebViewCache` and mounted through a plain
+    /// `NSViewRepresentable` that only ever creates it — there is no channel from
+    /// here back to that SwiftUI state without threading a binding through the
+    /// cache for every call site that can hand out a cached view. Loading a small
+    /// HTML page directly into the same pane keeps the fix self-contained to this
+    /// type, at the cost of a hand-rolled (not SwiftUI) message; `reason` is one
+    /// of `WebGuardian`'s or `ChangelogURLPolicy`'s own fixed strings, never
+    /// interpolated URL content, so the light escaping below is defence in depth
+    /// rather than the only thing standing between this and a vendor page.
+    ///
+    /// The title is a plain English literal, not `String(localized:)` — it lives
+    /// inside an HTML string handed to `WKWebView`, outside whatever the
+    /// `Localizable.xcstrings` extraction step scans, and this fix does not touch
+    /// that pipeline. Known gap, not an oversight.
+    private func showBlockedNotice(_ webView: WKWebView, reason: String) {
+        let escaped = reason
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+        let html = """
+        <!doctype html><html><head><meta charset="utf-8">
+        <style>
+          :root { color-scheme: light dark; }
+          body {
+            display: flex; align-items: center; justify-content: center;
+            height: 100vh; margin: 0; text-align: center;
+            font-family: -apple-system, sans-serif;
+            background: Canvas; color: GrayText;
+          }
+          .box { max-width: 320px; padding: 24px; }
+          .title { color: CanvasText; font-weight: 600; margin-bottom: 6px; }
+        </style></head>
+        <body><div class="box">
+          <div class="title">Can’t show this page safely</div>
+          <div>\(escaped)</div>
+        </div></body></html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
     }
 
     private func armWatchdog(_ webView: WKWebView) {
@@ -1983,6 +2055,7 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         cancel()
         autoReloads = 0   // a clean load earns back the reload budget
+        hasCommittedFirstLoad = true
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
@@ -26,13 +26,34 @@ public enum ChangelogURLPolicy {
     /// name to reason about, and no vendor publishes notes at a bare address),
     /// `localhost`/`.localhost` and mDNS `.local` names, and non-standard ports.
     public static func isDisplayable(_ url: URL) -> Bool {
-        guard url.scheme?.lowercased() == "https" else { return false }
-        guard url.user == nil, url.password == nil else { return false }
-        guard let host = url.host, !host.isEmpty else { return false }
-        guard !isIPLiteral(host) else { return false }
-        guard !isLocalHostname(host) else { return false }
-        if let port = url.port, port != 443 { return false }
-        return true
+        rejectionReason(url) == nil
+    }
+
+    /// Which guard `url` fails, or `nil` when it would pass `isDisplayable`.
+    ///
+    /// Exists so a caller that refuses a navigation — `WorkbenchWindowView`'s
+    /// web-view guardian, in particular — can say *why* instead of just
+    /// cancelling. #292: that guardian re-checks every main-frame navigation, not
+    /// only the recipe's starting URL, so it can now discover a rejection well
+    /// after the pane has already been shown; a plain `Bool` had nothing left to
+    /// hand a log line or a user-facing message at that point. Deliberately
+    /// categorical rather than including the attacker/vendor-controlled host or
+    /// port: those already reach the log line through the caller's own URL
+    /// argument (safe there because it goes through a redactor, not straight to
+    /// on-screen HTML), and keeping this string free of interpolated URL content
+    /// means a caller can put it on screen without having to re-derive an
+    /// escaping rule for it.
+    ///
+    /// Checked in the same order as `isDisplayable`, so the reason reported is
+    /// always the same guard that actually rejected the URL.
+    public static func rejectionReason(_ url: URL) -> String? {
+        guard url.scheme?.lowercased() == "https" else { return "not an https URL" }
+        guard url.user == nil, url.password == nil else { return "URL carries credentials" }
+        guard let host = url.host, !host.isEmpty else { return "URL has no host" }
+        guard !isIPLiteral(host) else { return "host is an IP literal, not a name" }
+        guard !isLocalHostname(host) else { return "host is a reserved local-only name" }
+        if let port = url.port, port != 443 { return "non-standard port" }
+        return nil
     }
 
     /// `url` when it passes, `nil` when it does not — so a caller can fall through
@@ -86,9 +107,16 @@ public enum ChangelogURLPolicy {
     }
 
     /// Names whose local destination follows from the name itself, without a DNS
-    /// lookup: RFC 6761 reserves `localhost` and every name below it for loopback;
-    /// RFC 6762 gives `.local` to link-local multicast DNS. A trailing root label
-    /// and case do not change either name. Ordinary domains merely containing
+    /// lookup: RFC 6761 reserves `localhost` and every name below it for loopback.
+    /// RFC 6762 §3 gives `.local.` to link-local multicast DNS, but its own
+    /// wording is about multi-label names of the form `single-dns-label.local.`
+    /// — it never discusses the bare single-label name `local` on its own, so
+    /// citing it for that half of this check overstates what it says. The bare
+    /// name is refused anyway, on different (and simpler) grounds: no public CA
+    /// issues an https certificate for an unqualified single-label name, so
+    /// nothing legitimate can ever be reached at `https://local/`, and refusing
+    /// it costs no real vendor a changelog page. A trailing root label and case
+    /// do not change any of these names. Ordinary domains merely containing
     /// these words (for example `localhost.example.com`) remain displayable.
     static func isLocalHostname(_ host: String) -> Bool {
         let withoutRootLabel = host.count > 1 && host.hasSuffix(".")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
@@ -47,6 +47,29 @@ struct ChangelogURLPolicyTests {
         }
     }
 
+    /// #292: the bare single-label `local` (no dot, nothing below it) had no
+    /// test of its own — deleting that disjunct out of `isLocalHostname` left
+    /// every other test in this file green. RFC 6762 §3 only ever discusses
+    /// multi-label `single-dns-label.local.` names, so this half of the check
+    /// doesn't rest on that citation; it rests on there being no public CA that
+    /// issues an https certificate for an unqualified single-label name, which
+    /// makes `https://local/` unreachable from anywhere legitimate regardless.
+    @Test func bareLocalIsRejected() {
+        for s in ["https://local/notes", "https://LOCAL./notes"] {
+            #expect(!ChangelogURLPolicy.isDisplayable(url(s)), "\(s) should be refused")
+        }
+    }
+
+    @Test func rejectionReasonNamesTheFailingGuard() {
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://example.com/notes")) == nil)
+        #expect(ChangelogURLPolicy.rejectionReason(url("http://example.com/notes")) != nil)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://user:pw@example.com/notes")) != nil)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://192.168.1.10/notes")) != nil)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://local/notes")) != nil)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://macbook.local/notes")) != nil)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://example.com:8443/notes")) != nil)
+    }
+
     @Test func localWordsInsideOrdinaryDomainsStillPass() {
         for s in [
             "https://localhost.example.com/notes",


### PR DESCRIPTION
## What

Closes #292.

`WebGuardian.decidePolicyFor` (in `App/Sources/WorkbenchWindowView.swift`) has two `decisionHandler(.cancel); return` branches that reject a navigation: a cleartext-http downgrade, and `ChangelogURLPolicy` failing on a URL a server redirected the pane to (per #275, which re-checks the policy on every main-frame navigation, not just the recipe's starting URL). Neither branch logged anything or told the user why, and if the rejection landed on the pane's very first, still-uncommitted navigation, the result was a permanently blank pane — indistinguishable from "this app just has no changelog."

This PR:

1. Adds `ChangelogURLPolicy.rejectionReason(_:)` (Core) — same guards as `isDisplayable`, same order, but names the one that failed instead of returning a bare `Bool`. `isDisplayable` is now defined in terms of it. The reason strings are deliberately categorical (never interpolate the URL's own host/port), so a caller can put one on screen without inventing an escaping rule for attacker/vendor-controlled text.
2. Wires both rejection branches in `WebGuardian` to log at `.error` (with the URL and the reason) and, only when nothing has ever loaded into the pane yet, load a small HTML message into the same `WKWebView` in place of the blank page. A rejection *after* the pane has already shown real content just logs and leaves that content alone — replacing something the user is reading with an error panel over one blocked navigation would be worse than the rejection itself.
3. Adds the missing `bare == "local"` test case, plus a smoke test over `rejectionReason`.
4. Tightens `isLocalHostname`'s doc comment: RFC 6762 §3 only discusses multi-label `single-dns-label.local.` names, never the bare single-label `local` this check also rejects. Confirmed by reading the RFC text directly. The rejection itself is correct and unaffected — no public CA issues an https cert for an unqualified single-label name — the citation was just overstating what the RFC says.

## Why

Same reasoning the issue gives: a security-relevant `.cancel()` that leaves no trace and no visible reason is exactly the silent-failure shape this repo has been burned by before, and a guard with zero test coverage is a guard nobody has verified.

## Issue check

The issue's two claims were both verified, not just accepted:

- **"Deleting `bare == \"local\"` leaves the existing tests green"** — reproduced directly: removed the disjunct, ran the suite, all 16 pre-existing tests passed. Restored, added `bareLocalIsRejected` + `rejectionReasonNamesTheFailingGuard`, re-ran the mutation — both new tests now fail. Restored again, full suite green.
- **"RFC 6762 §3 only covers multi-label names"** — checked against the RFC text (not memory): §3's own wording is about `single-dns-label.local.`, and never discusses a bare `local`. Confirmed the issue's framing; reworded the doc comment accordingly rather than changing behavior.

One thing the issue didn't spell out that I had to decide: **what happens to a rejection that occurs *after* the pane already shows real content** (a mid-session redirect, not the first load). The issue's language ("发生在首个 provisional navigation 尚未 commit 内容时") points at the first-load case specifically. I chose to log-and-leave-alone rather than blank the pane in that case too, since replacing content the user is reading with an error panel over a single blocked in-page navigation seemed like a worse outcome than the (already logged) rejection itself. Flagging this as a judgment call in case the intent was to always show the reason.

Also worth flagging: the on-screen message is a plain English literal loaded as raw HTML into the `WKWebView`, not `String(localized:)` — it's outside whatever the `Localizable.xcstrings` extraction step scans, and this fix doesn't touch that pipeline. Documented inline as a known gap, not silently skipped.

## Verification

```
cd DuoUpdaterCore && swift test --filter ChangelogURLPolicy
# 18 tests, 1 suite, all passed

cd DuoUpdaterCore && swift test
# 1936 tests, 153 suites passed, 1 known issue (pre-existing, GitHubReleaseRuleTests, unrelated)

cd CLI && swift test --filter Changelog
# 21 tests, 3 suites, all passed

python3 scripts/check_staged_version_use.py
# version comparisons discriminate -- 211 files, all display-only

xcodegen generate (with DUO_TEAM_ID set) + xcodebuild -project App/DuoUpdater.xcodeproj \
  -scheme DuoUpdater -configuration Debug -derivedDataPath /tmp/duo-dd-292 build
# BUILD SUCCEEDED, no new warnings from WorkbenchWindowView.swift
```

**Mutation test, Core (`bare == "local"` disjunct):** removed it — `bareLocalIsRejected` and `rejectionReasonNamesTheFailingGuard` both failed as expected; restored — full suite green again.

**Mutation test, App layer:** `App/Sources` has no test target, so this can't run under `swift test`. Instead, verified against a real `WKWebView` with a standalone harness (not committed — `WebGuardian` is `private`, so this reimplements just `reject`/`showBlockedNotice` against the same WebKit APIs):

- With the fix: loading a plain `http://` URL produces both a `log show`-queryable `.error` entry (`webview navigation blocked (cleartext http connection) mainFrame=yes url=http://example.invalid/test`) and on-screen text "Can't show this page safely | cleartext http connection" instead of a blank pane.
- Mutated `reject()` back to a bare cancel (the pre-fix behavior): no log entry, and the load times out with nothing ever rendered — reproducing the exact blank-forever symptom from the issue.

## Not verified

- The App-layer fix has no automated regression coverage (no test target in `App/Sources`, longstanding per `CLAUDE.md`) — the harness above is a one-time manual check, not something that runs again on the next change to this file.
- Did not verify how this interacts with VoiceOver/accessibility on the injected HTML message, or exact rendering across every macOS version — it's a small static page with `color-scheme: light dark` and standard CSS system colors, not exercised beyond the harness above.
