### PR TITLE
Converge plist version reads on one trim+empty helper

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4511,12 +4511,8 @@ final class AppListModel {
               let dict = (try? PropertyListSerialization.propertyList(
                 from: data, options: [], format: nil)) as? [String: Any]
         else { return (nil, nil) }
-        func nonEmptyVersion(_ key: String) -> String? {
-            guard let value = dict[key] as? String, !value.isEmpty else { return nil }
-            return value
-        }
-        return (nonEmptyVersion("CFBundleShortVersionString"),
-                nonEmptyVersion("CFBundleVersion"))
+        return (VersionSide.plistVersionField(dict["CFBundleShortVersionString"]),
+                VersionSide.plistVersionField(dict["CFBundleVersion"]))
     }
 
     /// Open System Settings → Privacy & Security → App Management and float the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -382,9 +382,8 @@ public struct AppScanner: Sendable {
         // An app with no marketing version can't be update-checked — these are
         // helper/background bundles (URL handlers, login items) that would only
         // ever show as permanent "unknown" noise. Exclude them.
-        guard let rawShortVersion = (plist["CFBundleShortVersionString"] as? String)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-              !rawShortVersion.isEmpty
+        guard let rawShortVersion = VersionSide.plistVersionField(
+            plist["CFBundleShortVersionString"])
         else { return nil }
         var shortVersion = rawShortVersion
 
@@ -411,7 +410,7 @@ public struct AppScanner: Sendable {
         var bundleID = plist["CFBundleIdentifier"] as? String
         /// Set only for WeChat DevTools, from its `package.json` (see below).
         var weChatDevToolsChannel: ReleaseChannel?
-        let buildVersion = plist["CFBundleVersion"] as? String
+        let buildVersion = VersionSide.plistVersionField(plist["CFBundleVersion"])
         if bundleID == Self.duoUpdaterBundleID { return nil }
 
         // WeChat DevTools (微信开发者工具) keeps its real identity OUT of Info.plist.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -254,7 +254,7 @@ public enum RuntimeVersion {
                   identifier.hasSuffix(electronFrameworkID)
             else { continue }
             if identifier == electronFrameworkID,
-               let version = plist["CFBundleVersion"] as? String, !version.isEmpty {
+               let version = VersionSide.plistVersionField(plist["CFBundleVersion"]) {
                 return version
             }
             resigned = framework
@@ -296,7 +296,7 @@ public enum RuntimeVersion {
         }
         let core = bundleURL.appendingPathComponent("Contents/Frameworks/QtCore.framework")
         guard let plist = frameworkPlist(core),
-              let version = plist["CFBundleShortVersionString"] as? String, !version.isEmpty
+              let version = VersionSide.plistVersionField(plist["CFBundleShortVersionString"])
         else { return nil }
         return version
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
@@ -220,8 +220,8 @@ public enum FeedDiscovery {
 
         let bundleID = plist["CFBundleIdentifier"] as? String
         let installed = VersionSide(
-            marketing: (plist["CFBundleShortVersionString"] as? String)?.nonEmpty,
-            build: (plist["CFBundleVersion"] as? String)?.nonEmpty)
+            marketing: VersionSide.plistVersionField(plist["CFBundleShortVersionString"]),
+            build: VersionSide.plistVersionField(plist["CFBundleVersion"]))
 
         let declared = (plist["SUFeedURL"] as? String)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
@@ -346,10 +346,11 @@ public enum SelfUpdaterStaging {
                   // Must be a staged copy of THIS app. Rejects Sparkle's own
                   // Updater.app and anything else sharing the cache namespace.
                   dict["CFBundleIdentifier"] as? String == bundleID,
-                  let short = dict["CFBundleShortVersionString"] as? String
+                  let short = VersionSide.plistVersionField(dict["CFBundleShortVersionString"])
             else { continue }
             return StagedSelfUpdate(
-                version: short, buildVersion: dict["CFBundleVersion"] as? String,
+                version: short,
+                buildVersion: VersionSide.plistVersionField(dict["CFBundleVersion"]),
                 stagedBundlePath: url)
         }
         return nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Traffic/InstalledBuild.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Traffic/InstalledBuild.swift
@@ -26,8 +26,7 @@ public enum InstalledBuild {
               let object = try? PropertyListSerialization.propertyList(
                   from: data, format: nil),
               let fields = object as? [String: Any],
-              let build = fields["CFBundleVersion"] as? String,
-              !build.isEmpty
+              let build = VersionSide.plistVersionField(fields["CFBundleVersion"])
         else { return nil }
         return build
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/VersionSide.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/VersionSide.swift
@@ -47,4 +47,29 @@ public struct VersionSide: Sendable, Equatable {
         guard withBuild, let build, build != marketing else { return marketing }
         return "\(marketing) (\(build))"
     }
+
+    /// One field out of a bundle's raw `Info.plist` dictionary —
+    /// `CFBundleShortVersionString` or `CFBundleVersion` — with a blank value
+    /// folded into `nil`.
+    ///
+    /// `dict["CFBundleVersion"] as? String` only guards against the key being
+    /// absent or non-string; a *present but blank* value sails straight through,
+    /// and vendors ship it both empty (`""`) and whitespace-only (`"   "`).
+    /// Either is dangerous input to ``VersionComparator``: its tokenizer treats a
+    /// string with no digits at all the same as `"0"` (`compare("", "0") ==
+    /// .orderedSame`), so a bundle that declares no version at all reads as "the
+    /// oldest version there is" instead of "unknown" — and once that value is
+    /// paired against a real "0"-tokenizing string (`"0"`, `"0.0"`, `"v0"`, …)
+    /// two genuinely different builds compare as identical.
+    ///
+    /// Trimmed first, so a whitespace-only value cannot slip past a plain
+    /// `isEmpty` check the way `""` cannot slip past a plain `== nil` check —
+    /// every other reader of these two keys used to skip the trim.
+    public static func plistVersionField(_ rawValue: Any?) -> String? {
+        guard let trimmed = (rawValue as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerFilterTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerFilterTests.swift
@@ -33,6 +33,35 @@ private func makeApp(at dir: URL, name: String, info: [String: Any]) throws -> U
     #expect(apps.map(\.name) == ["Real"])  // helper excluded
 }
 
+/// Issue #287: `buildVersion` used to be read with a bare `as? String`, no
+/// emptiness check at all — the one gap `shortVersion` five lines above it
+/// didn't have. A bundle whose `CFBundleVersion` is `""` or all-whitespace must
+/// come out of the scan as `buildVersion == nil`, not as a "readable" blank
+/// string that then tokenizes the same as `"0"` inside `VersionComparator`.
+@Test func scannerReadsABlankBuildVersionAsNilNotEmptyString() throws {
+    let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("scan-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmp) }
+
+    _ = try makeApp(at: tmp, name: "EmptyBuild", info: [
+        "CFBundleIdentifier": "com.example.emptybuild",
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleVersion": "",
+    ])
+    _ = try makeApp(at: tmp, name: "WhitespaceBuild", info: [
+        "CFBundleIdentifier": "com.example.whitespacebuild",
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleVersion": "   ",
+    ])
+
+    let apps = AppScanner(locations: [tmp]).scan()
+    let byName = Dictionary(uniqueKeysWithValues: apps.map { ($0.name, $0) })
+    #expect(byName["EmptyBuild"]?.buildVersion == nil)
+    #expect(byName["WhitespaceBuild"]?.buildVersion == nil)
+    #expect(byName["EmptyBuild"]?.versionSide.build == nil)
+}
+
 @Test func scannerStripsInvisibleBidiMarksFromDisplayName() throws {
     // WhatsApp ships CFBundleDisplayName "\u{200E}WhatsApp" (a leading LEFT-TO-RIGHT
     // MARK). That invisible mark made the canonical name "\u{200E}WhatsApp", which

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstalledBuildTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstalledBuildTests.swift
@@ -74,6 +74,17 @@ private func scratch() -> URL {
         fromPropertyList: ["CFBundleVersion": ""], format: .xml, options: 0)
     try blankData.write(to: blank.appendingPathComponent("Contents/Info.plist"))
     #expect(InstalledBuild.read(at: blank) == nil)
+
+    // Present but whitespace-only — issue #287: a bare `isEmpty` check (what
+    // this read used before converging onto `VersionSide.plistVersionField`)
+    // lets "   " through as a "real" build number.
+    let whitespace = base.appendingPathComponent("Whitespace.app")
+    try FileManager.default.createDirectory(
+        at: whitespace.appendingPathComponent("Contents"), withIntermediateDirectories: true)
+    let whitespaceData = try PropertyListSerialization.data(
+        fromPropertyList: ["CFBundleVersion": "   "], format: .xml, options: 0)
+    try whitespaceData.write(to: whitespace.appendingPathComponent("Contents/Info.plist"))
+    #expect(InstalledBuild.read(at: whitespace) == nil)
 }
 
 // MARK: - Deciding

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
@@ -150,6 +150,46 @@ struct SparkleStagingTests {
         }
     }
 
+    /// Issue #287: `dict["CFBundleShortVersionString"] as? String` only guarded
+    /// non-nil, not non-blank. A staged bundle whose plist declares `""` for
+    /// its marketing version used to come back as a "readable" empty
+    /// `StagedSelfUpdate.version` — which then tokenizes the same as `"0"`
+    /// inside `VersionComparator` and feeds `RestartStandoff.decide` a fake
+    /// verdict. It must instead be skipped exactly as if the key were absent.
+    @Test func aStagedBundleWithBlankMarketingVersionIsNotReported() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            _ = try stage(in: caches, short: "", build: "769")
+            let installed = root.appendingPathComponent("Sparkly.app")
+            try makeApp(at: installed, identifier: bundleID, short: "1.0", build: "765")
+
+            #expect(SelfUpdaterStaging.sparkleStagedBundle(
+                for: app(at: installed, short: "1.0", build: "765"),
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)]) == nil)
+        }
+    }
+
+    /// Same issue, the other field: a blank `CFBundleVersion` on an otherwise
+    /// valid staged bundle must come back as `buildVersion == nil`, not as an
+    /// empty string standing in for "no build" while looking like a value.
+    @Test func aStagedBundleWithBlankBuildVersionReportsNilNotEmptyString() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            _ = try stage(in: caches, short: "26.9.11", build: "   ")
+            let installed = root.appendingPathComponent("Sparkly.app")
+            try makeApp(at: installed, identifier: bundleID, short: "26.9.9", build: "765")
+
+            let found = SelfUpdaterStaging.sparkleStagedBundle(
+                for: app(at: installed, short: "26.9.9", build: "765"),
+                cachesDirectory: caches,
+                parkedInstallerBundleURLs: [parkedInstaller(in: caches)])
+
+            #expect(found?.version == "26.9.11")
+            #expect(found?.buildVersion == nil)
+        }
+    }
+
     /// Nothing staged at all — no cache tree for this app.
     @Test func noSparkleCacheYieldsNil() throws {
         try withScratch { root in

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
@@ -62,6 +62,25 @@ import Testing
     #expect(VersionComparator.compare("v", "v") == .orderedSame)
 }
 
+/// The tokenizer treats a string with no digits at all — including the empty
+/// string — the same as "0", because a missing trailing component is filled
+/// with `.number("0")` on both sides (see `compare`'s loop). That is correct
+/// for "1.2" vs "1.2.0", and it is exactly why an empty *marketing* or *build*
+/// string must never reach this function: "no version" and "the oldest
+/// version there is" become indistinguishable, and a real "0"-tokenizing
+/// string on the other side ("0", "0.0", "00", "v0") reads as an exact match.
+/// This is the ground fact issue #287's whole helper (`VersionSide
+/// .plistVersionField`) exists to keep out of every plist read.
+@Test func emptyStringTokenizesTheSameAsZero() {
+    #expect(VersionComparator.compare("", "0") == .orderedSame)
+    #expect(VersionComparator.compare("", "0.0") == .orderedSame)
+    #expect(VersionComparator.compare("", "00") == .orderedSame)
+    #expect(VersionComparator.compare("", "v0") == .orderedSame)
+    #expect(VersionComparator.isSame(
+        VersionSide(marketing: "", build: nil),
+        as: VersionSide(marketing: "0", build: nil)))
+}
+
 @Test func evaluatePrefersBuildVersion() {
     let app = InstalledApp(
         name: "X", bundleID: "x", shortVersion: "1.0", buildVersion: "100",

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionSideTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionSideTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import DuoUpdaterCore
+
+/// `VersionSide.plistVersionField` is the one place that decides whether a raw
+/// `Info.plist` value counts as "a version" or as "nothing was declared" — see
+/// issue #287. Every reader of `CFBundleShortVersionString` / `CFBundleVersion`
+/// across the engine is supposed to funnel through it rather than repeating its
+/// own `as? String` + emptiness check, because five independent copies of that
+/// check had drifted into five different rules (one didn't trim, one didn't
+/// check emptiness at all).
+struct VersionSideTests {
+
+    @Test func nilInputStaysNil() {
+        #expect(VersionSide.plistVersionField(nil) == nil)
+    }
+
+    @Test func nonStringInputIsNil() {
+        // A plist can legally hold a number under either key (rare, but the
+        // `as? String` cast already handled this — must keep doing so).
+        #expect(VersionSide.plistVersionField(42) == nil)
+    }
+
+    @Test func emptyStringIsNil() {
+        #expect(VersionSide.plistVersionField("") == nil)
+    }
+
+    @Test func whitespaceOnlyStringIsNil() {
+        // The case that slipped past every reader except AppScanner's
+        // shortVersion guard: "   " is non-empty by a bare `isEmpty` check, and
+        // tokenizes identically to "" once inside `VersionComparator`.
+        #expect(VersionSide.plistVersionField("   ") == nil)
+        #expect(VersionSide.plistVersionField("\n\t ") == nil)
+    }
+
+    @Test func realVersionPassesThroughUnchanged() {
+        #expect(VersionSide.plistVersionField("1.0") == "1.0")
+    }
+
+    @Test func realVersionIsTrimmedOfSurroundingWhitespace() {
+        #expect(VersionSide.plistVersionField(" 1.0 ") == "1.0")
+    }
+}


### PR DESCRIPTION
## What

Adds `VersionSide.plistVersionField(_:)` in Core — the one place that reads a raw `Info.plist` value for `CFBundleShortVersionString` / `CFBundleVersion` and decides whether it counts as "a version" (trim, then nil if empty). Converges seven call sites onto it:

- `AppScanner.swift` — `buildVersion` (had **no** filtering at all; the main-scan-path gap the issue names) and `shortVersion` (already correct, now shares the helper without changing its return-nil-to-exclude-the-bundle behavior).
- `SelfUpdaterStaging.swift` (`sparkleStagedBundle`) — `short`/`buildVersion` (had **no** filtering at all; the restart-standoff-input gap the issue names — this feeds `RestartStandoff.decide` alongside the field #274 already fixed).
- `FeedDiscovery.swift`, `RuntimeVersion.swift`, `InstalledBuild.swift` — three more readers of these two keys off a bundle's own `Info.plist`, each converged with only a trim added (no other behavior change).
- `AppListModel.readBundleVersions` (App/Sources, #274's fix) — now delegates to the Core helper instead of its own `isEmpty`-no-trim check, so the logic lives somewhere `swift test` actually runs it.

`FeedDiscovery`'s other two `.nonEmpty` call sites (a *feed item's* version string, a channel tag) are left untouched — they read a remote appcast, not an installed bundle's own plist, so they're not the same invariant, and the `.nonEmpty` extension itself keeps its existing (non-trimming) semantics for them.

## Why

`VersionComparator`'s tokenizer treats a string with no digits — including `""` — the same as `"0"`. Left unfiltered, an empty or whitespace-only `CFBundleShortVersionString`/`CFBundleVersion` reads as "the oldest version there is" instead of "unknown," and compares as *identical* to a real `"0"`/`"0.0"`/`"v0"` on the other side. #240/#274 closed one of six read sites (`AppListModel.readBundleVersions`, filtering only `isEmpty`, no trim); the other five each had their own slightly different rule, so `"   "` (whitespace-only) could still slip through everywhere except `AppScanner`'s `shortVersion`.

## Issue check (#287)

Went through all six locations named in the issue's table, by symbol rather than by line number (line numbers had drifted since #278/#296 touched the same files):

- **Confirmed as described**: `AppScanner.swift` `buildVersion` (no filter) and `shortVersion` (trim+isEmpty, correct); `SelfUpdaterStaging.swift` `sparkleStagedBundle`'s `short` (no filter — only guards non-nil); `AppListModel.readBundleVersions` (`isEmpty`, no trim); `FeedDiscovery.swift`'s `.nonEmpty` (no trim); `RuntimeVersion.swift`'s bare `!isEmpty` (no trim).
- **Confirmed the reachability note**: `AppScanner`'s `shortVersion` guard does `return nil` on blank, excluding the whole bundle from the scan — so a blank-marketing bundle genuinely can't reach `AppListModel` through the scan path, and the two real gaps are exactly the two the issue calls out (`AppScanner.buildVersion`, `SelfUpdaterStaging.sparkleStagedBundle`).
- **Confirmed the `restart()` call chain**: `staged` (line ~4127, from `sparkleStagedBundle`) and `onDisk` (line ~4131, from `readBundleVersions`) both feed `RestartStandoff.decide` at line ~4132 — issue's structural claim holds, only the line numbers moved.
- **What the issue didn't cover, found while implementing**: it names five formats across six sites but doesn't mention `InstalledBuild.swift`'s `read(at:)` (bare `!isEmpty`, no trim) — a seventh site with the same shape, feeding the traffic-log's recorded build after a swap. Converged it too, since it's clearly the same invariant and converging it is risk-free (adds a trim, existing behavior for non-whitespace values is unchanged).
- **Not independently re-verified**: the issue's claim that #221's tokenizer treats `""` as equal to `"0"`/`"0.0"`/`"00"`/`"v0"` — I did verify this directly (see tests below) rather than taking it on faith, and it holds.

## Verification

```
cd DuoUpdaterCore && swift test
→ Test run with 1947 tests in 154 suites passed after 37.450 seconds with 1 known issue.
```

Targeted red→green, before wiring in the helper (ran against the old per-site code with new tests added first): the new tests failed exactly as expected (e.g. `SparkleStagingTests.aStagedBundleWithBlankMarketingVersionIsNotReported` failed because the old code returned a `StagedSelfUpdate` with an empty `version`). After the fix, full run above is green.

```
cd CLI && swift test
→ Test run with 185 tests in 24 suites passed after 0.070 seconds.
```

```
python3 scripts/check_staged_version_use.py
→ ✓ version comparisons discriminate — 211 files, 2 ledger call(s) keyed on the build, 7 marketing-first pick(s), all display-only
```

App/Sources compile check (own derived-data path, since `App/project.yml` has no test target):
```
xcodegen generate ... && xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug -derivedDataPath /tmp/duo-dd-287 build
→ ** BUILD SUCCEEDED **
```

### Mutation testing (by hand, on `VersionSide.plistVersionField`)

1. **Bare `rawValue as? String`** (no trim, no emptiness check — the pre-#274 shape): 7 tests went red across 4 suites — `VersionSideTests.emptyStringIsNil`, `.whitespaceOnlyStringIsNil`, `.realVersionIsTrimmedOfSurroundingWhitespace`; `AppScannerFilterTests.scannerReadsABlankBuildVersionAsNilNotEmptyString`; `SparkleStagingTests.aStagedBundleWithBlankMarketingVersionIsNotReported` and `.aStagedBundleWithBlankBuildVersionReportsNilNotEmptyString`; `InstalledBuildTests.anUnreadableOrBuildlessBundleReadsAsNil`.
2. **isEmpty check restored, trim removed**: 5 whitespace-specific tests went red (the same set minus the plain-`""` cases, which the bare isEmpty check still catches).

Reverted both mutations after confirming; final committed state is the clean version and the full suite is green (above).

## Not verified / out of scope

- `FeedDiscovery.probe(bundleAt:)` — the function whose `installed` field I converged — has **no existing test coverage of that function itself** (all `FeedDiscoveryTests` build `BundleProbe` by hand, bypassing the plist read). This is a pre-existing gap, not introduced here; I didn't add coverage for it since the issue's required test list doesn't call for it and the change there is a strict, low-risk narrowing (adds a trim).
- Did not run `duo verify` — this change touches no recipe/vendor-parsing code, only local bundle-plist reads, so I judged it out of scope for that verification per the repo's own guidance (recipe-touching changes need it, this isn't one).
- `make gallery` was not run — no row-rendering code was touched.
