### PR TITLE
fix(app): route workbench version lines through RowVersionLine

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -426,9 +426,12 @@ final class AppListModel {
         UpdatePolicy.laggingRemoteVersion(result)
     }
 
-    /// The one version-line fact the row should explain. The precedence lives in
-    /// Core so a relaunch and a lagging-feed note cannot silently swap places in a
-    /// view with no test target (#210).
+    /// The one version-line fact the row should explain, read by both windows. The
+    /// precedence lives in Core so a relaunch and a lagging-feed note cannot
+    /// silently swap places in a view with no test target (#210) — and so the two
+    /// windows can't each grow their own ladder with different coverage (#289: the
+    /// workbench used to run two, neither with a downgrade or pending-batch-restart
+    /// branch, so a row's version line could disagree with its own action button).
     func versionLineState(for result: UpdateResult) -> RowVersionLineState {
         RowVersionLine.state(
             staged: actionableStaged(result),

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -506,8 +506,7 @@ struct WorkbenchWindowView: View {
                     isChecking: model.installing[result.id] != nil,
                     isSelected: result.id == selection,
                     isRunning: model.isRunning(result),
-                    needsRestart: model.needsRestart.contains(result.id),
-                    runningVersion: model.restartFromSide(result.id),
+                    versionLineState: model.versionLineState(for: result),
                     showsRuntime: model.prefs.showRuntimeTags,
                     isIgnored: model.prefs.isIgnored(result.app),
                     isVersionSkipped: model.prefs.isVersionSkipped(
@@ -538,8 +537,7 @@ struct WorkbenchWindowView: View {
                     isChecking: model.installing[result.id] != nil,
                     isSelected: result.id == selection,
                     isRunning: model.isRunning(result),
-                    needsRestart: model.needsRestart.contains(result.id),
-                    runningVersion: model.restartFromSide(result.id),
+                    versionLineState: model.versionLineState(for: result),
                     showsRuntime: model.prefs.showRuntimeTags,
                     isIgnored: model.prefs.isIgnored(result.app),
                     isVersionSkipped: model.prefs.isVersionSkipped(
@@ -625,14 +623,15 @@ private struct WorkbenchSidebarRow: View {
     let isSelected: Bool
     /// Whether the app currently has a running process — shows the green live dot.
     let isRunning: Bool
-    /// Self-updated on disk, waiting for a relaunch to take effect (the "Relaunch"
-    /// state). When set, the subtitle shows running → installed instead of a bare
-    /// version, so the row says what the restart will land.
-    let needsRestart: Bool
-    /// The running side of a relaunch line, still in parts so it can be formatted
-    /// against the on-disk side rather than in isolation. nil when not lagging an
-    /// on-disk build.
-    let runningVersion: UpdateResult.VersionSide?
+    /// The one version-line fact this row should explain, in the same priority
+    /// order the popover reads (`AppListModel.versionLineState(for:)` /
+    /// `RowVersionLine`): a staged self-update relaunch, a pending restart (either
+    /// confirmed or still awaiting the batch's post-install sweep), a lagging-feed
+    /// downgrade note, or the plain status line. Passed in rather than recomputed
+    /// from `needsRestart`/`pendingBatchRestart` here so this row can't drift into
+    /// its own ladder again (#289) — it stays exactly what the popover and the
+    /// action button already agreed on.
+    let versionLineState: RowVersionLineState
     /// Whether to show the runtime chip (Electron / Tauri / native / …).
     let showsRuntime: Bool
     /// The user's two verdicts, and the ways back out of them. Passed in rather
@@ -730,33 +729,61 @@ private struct WorkbenchSidebarRow: View {
 
     @ViewBuilder
     private var subtitle: some View {
-        if case .updateAvailable(let latest) = result.status {
-            // Same-marketing build bump (JetBrains EAP, Surge): show the builds so it
-            // doesn't read as a no-op "2026.2 → 2026.2".
-            let bump = result.buildBump(latest: latest)
-            let from = bump.map { "\(result.installedDisplay ?? "?") (\($0.installed))" }
-                ?? (result.installedDisplay ?? "?")
-            let to = bump.map { "\(latest) (\($0.remote))" } ?? latest
-            Text("\(from) → \(to)")
+        switch versionLineState {
+        case .stagedRelaunch(let staged):
+            // The app's own updater already has the latest downloaded; Relaunch
+            // just swaps to it. `actionableStaged` (upstream of this state)
+            // guarantees the staged build is current, so there's nothing newer to
+            // note here — mirrors the popover's `stagedVersionLine`.
+            let line = result.stagedRelaunchLine(staged)
+            Text("\(line.from) → \(line.to)")
                 .font(.caption)
-                // White over the blue highlight when selected; blue tint otherwise.
                 .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.tint))
                 .lineLimit(1)
-        } else if needsRestart, let running = runningVersion {
+                .minimumScaleFactor(0.75)
+        case .restart(let from):
             // Self-updated on disk: show running version → the version on disk, so
             // "Relaunch" reads as a real change. Formatted as a pair by
             // `relaunchLine`, which keeps the build numbers only when the marketing
             // versions cannot tell the two apart — the same rule the update subtitle
-            // above gets from `buildBump`.
-            let line = UpdateResult.relaunchLine(from: running, to: result.relaunchTargetSide)
+            // below gets from `buildBump`. `from` covers both a confirmed restart
+            // and a batch install still awaiting the post-install process sweep
+            // (#289) — either way the Restart button below needs this line to
+            // agree with it instead of falling back to a bare "v<version>".
+            let line = UpdateResult.relaunchLine(from: from, to: result.relaunchTargetSide)
             Text("\(line.from) → \(line.to)")
                 .font(.caption)
                 .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.orange))
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
-        } else {
-            Text("v\(result.installedDisplay ?? "?")")
-                .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+        case .downgrade(let older):
+            // Vendor's latest is *older* than what's installed — action-less, so
+            // muted like the popover's `downgradeVersionLine`. No pending relaunch
+            // outranks it here, or `versionLineState` would have returned one of
+            // the cases above instead.
+            let installed = result.app.shortVersion ?? "?"
+            Text("\(installed) ↓ \(older)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        case .status:
+            if case .updateAvailable(let latest) = result.status {
+                // Same-marketing build bump (JetBrains EAP, Surge): show the builds so it
+                // doesn't read as a no-op "2026.2 → 2026.2".
+                let bump = result.buildBump(latest: latest)
+                let from = bump.map { "\(result.installedDisplay ?? "?") (\($0.installed))" }
+                    ?? (result.installedDisplay ?? "?")
+                let to = bump.map { "\(latest) (\($0.remote))" } ?? latest
+                Text("\(from) → \(to)")
+                    .font(.caption)
+                    // White over the blue highlight when selected; blue tint otherwise.
+                    .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.tint))
+                    .lineLimit(1)
+            } else {
+                Text("v\(result.installedDisplay ?? "?")")
+                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
         }
     }
 }
@@ -1067,16 +1094,39 @@ private struct DetailHeader: View {
 
     @ViewBuilder
     private var versionLine: some View {
-        if case .updateAvailable(let latest) = result.status {
-            let bump = result.buildBump(latest: latest)
-            let from = bump.map { "\(result.installedDisplay ?? "?") (\($0.installed))" }
-                ?? (result.installedDisplay ?? "?")
-            let to = bump.map { "\(latest) (\($0.remote))" } ?? latest
-            Text("\(from)  →  \(to)")
+        // Same fact, same priority order as the popover and the sidebar row
+        // (`AppListModel.versionLineState(for:)` / `RowVersionLine`) — this pane
+        // used to run its own two-branch ladder with no downgrade note and no
+        // pending-batch-restart branch, so it could show "up to date" on a row the
+        // action button beside it already offered Restart for (#289).
+        switch model.versionLineState(for: result) {
+        case .stagedRelaunch(let staged):
+            let line = result.stagedRelaunchLine(staged)
+            Text("\(line.from)  →  \(line.to)")
                 .font(.callout).foregroundStyle(.tint)
-        } else {
-            Text("v\(result.installedDisplay ?? "?") · up to date")
+                .lineLimit(1).minimumScaleFactor(0.75)
+        case .restart(let from):
+            let line = UpdateResult.relaunchLine(from: from, to: result.relaunchTargetSide)
+            Text("\(line.from)  →  \(line.to)")
+                .font(.callout).foregroundStyle(.orange)
+                .lineLimit(1).minimumScaleFactor(0.75)
+        case .downgrade(let older):
+            let installed = result.app.shortVersion ?? "?"
+            Text("\(installed)  ↓  \(older)")
                 .font(.callout).foregroundStyle(.secondary)
+                .lineLimit(1).minimumScaleFactor(0.75)
+        case .status:
+            if case .updateAvailable(let latest) = result.status {
+                let bump = result.buildBump(latest: latest)
+                let from = bump.map { "\(result.installedDisplay ?? "?") (\($0.installed))" }
+                    ?? (result.installedDisplay ?? "?")
+                let to = bump.map { "\(latest) (\($0.remote))" } ?? latest
+                Text("\(from)  →  \(to)")
+                    .font(.callout).foregroundStyle(.tint)
+            } else {
+                Text("v\(result.installedDisplay ?? "?") · up to date")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #289

## 改了什么

工作台的版本行原来有两条独立于 `RowVersionLine` 的 `if/else` 阶梯：

- `WorkbenchSidebarRow.subtitle`（原 `WorkbenchWindowView.swift:732`）：`updateAvailable → needsRestart+runningVersion → 兜底 "v<version>"`。
- `DetailHeader.versionLine`（原 `WorkbenchWindowView.swift:1069`）：只有 `updateAvailable` 和 `"up to date"` 两支。

两条都没有 downgrade 分支，sidebar 那条也从没收到 `pendingBatchRestart`（两个调用点都只传了 `needsRestart`/`runningVersion`）。现在两个视图都改成对 `model.versionLineState(for:)` 返回的 `RowVersionLineState` 做**穷尽 switch**（`.stagedRelaunch` / `.restart` / `.downgrade` / `.status`），画法各自保留原有字号/选中态反色等工作台特有的呈现，但"现在是什么状态"和 popover、和 `RowActionState` 走的是同一个函数。

`WorkbenchSidebarRow` 的两个字段 `needsRestart: Bool` / `runningVersion: VersionSide?` 合并成一个 `versionLineState: RowVersionLineState`，两个调用点（apps 列表、brew 列表）都改成传 `model.versionLineState(for: result)`。

顺带按 issue 里指出的措辞问题，改了 `AppListModel.versionLineState(for:)` 上那句 #279 留下的注释——它当时只把"两边阶梯"收敛到了 popover 一侧，现在措辞改成两个窗口都读它。

## 为什么

可达的不一致（issue 里描述、这次沿 `AppListModel` 的时序验证过）：Update All 落地一个之前在运行的 app 后，`runInstall` 在 `.awaitingBatchRestart` 分支立刻把 `pendingBatchRestart[id]` 设成旧版本号（`AppListModel.swift` 现 3143-3146 行），但 `needsRestart` 要等整批装完、批次末尾统一跑一次 `performLocalRescan()` 才会被填上（5216 行，随后才 `pendingBatchRestart.removeAll()`）。这段窗口里 `rowState(for:)` 已经读了 `hasPendingBatchRestart` 因而显示 Restart 按钮，而工作台的两条旧阶梯都没读 `pendingBatchRestart`，于是同一行按钮说 Restart、sidebar 说裸版本号、详情面板说 up to date。

## issue 核实

三条都核实过，issue 说的都对，没有需要订正的地方：

- **(a) `downgradeNote` 只有一个调用点**：确认为真。`grep -rn downgradeNote App/Sources` 只命中 `AppListModel.swift:425`（定义）和 `:437`（`versionLineState` 内部调用），而 `versionLineState` 本身在改动前只被 `MenuContentView.swift:1117` 调用一处。
- **(b) 工作台两条阶梯的覆盖面**：确认为真，逐行读过 `WorkbenchSidebarRow.subtitle`（updateAvailable → needsRestart+runningVersion → 兜底）和 `DetailHeader.versionLine`（updateAvailable / else "up to date"），且两个 `WorkbenchSidebarRow(...)` 调用点都没有传 `pendingBatchRestart`。
- **(c) 可达窗口确实存在**：沿 `AppListModel.installAll`/`runInstall` 走了一遍时序，见上文「为什么」——`pendingBatchRestart` 在批内逐个安装时设置，`needsRestart` 在批末统一设置，中间这段窗口对多装几个 app 的批次是真实可达的（不是理论上的竞态）。

没有发现 issue 遗漏的地方。

## 验证

```
cd DuoUpdaterCore && swift test --filter RowVersionLine
```
```
✔ Test run with 4 tests in 1 suite passed after 0.001 seconds.
```
（这几条测试钉的是 `RowVersionLine.state` 本身的优先级，逻辑没有改动，用来确认改动没有间接影响它。）

```
python3 scripts/check_staged_version_use.py
```
```
✓ version comparisons discriminate — 211 files, 2 ledger call(s) keyed on the build, 7 marketing-first pick(s), all display-only
```

App 编译（`export DUO_TEAM_ID=RS59HDH7Y3 && xcodegen generate && xcodebuild ... -derivedDataPath /tmp/duo-dd-289`）：`** BUILD SUCCEEDED **`，改动涉及的两个文件没有新增警告。

**变异测试**：`App/Sources` 没有测试 target，判断逻辑本身在 Core 且未改动，所以这次不是"新加一个判据、变异它"，而是新加了两处**穷尽 switch**（不带 `default:`）作为编译期防线——`RowVersionLineState` 以后再加一个 case，这两处会在 PR 里直接编译失败，而不是安静地漏画。为验证这道防线是真的而不是装饰，临时删掉 sidebar 那处 switch 的 `.downgrade` 分支重新编译：

```
error: switch must be exhaustive
```

复现后已还原（`diff` 确认与改动前一致），再次编译 `** BUILD SUCCEEDED **`。

**未验证 / 我的猜测**：

- 工作台两个视图本身的渲染判断（`App/Sources` 没有测试 target）没有单元测试覆盖，只验证了它能编译、且穷尽 switch 会在漏分支时报错——没有跑起真实 app 去肉眼核对四种状态在 sidebar 和详情面板里画出来的实际像素/文案是否符合预期。
- `make gallery` 按 brief 要求没有跑（会和并行的其他 agent 撞 `verify/row-states`）。已核实 `App/RowStateGallery/main.swift` / `Cases.swift` 只构造 `PopoverRowAction` / `WorkbenchRowAction`（`RowActionState` 驱动的按钮控件），从未引用 `WorkbenchSidebarRow`、`DetailHeader.versionLine` 或 `RowVersionLine`，所以这次改动大概率不在 gallery 的渲染路径上——但这条只是读代码得出的推断，不是跑过 gallery 拿真实截图比对过的结论。
