### PR TITLE
Add the vendorDay tooltip to the string catalog

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -12961,6 +12961,53 @@
         }
       }
     },
+    "Published on %@ — the vendor gave only a date, not a time.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veröffentlicht am %@ – der Anbieter nannte nur ein Datum, keine Uhrzeit."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Published on %@ — the vendor gave only a date, not a time."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publicado el %@: el proveedor solo indicó una fecha, no una hora."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publié le %@ — l’éditeur n’a indiqué qu’une date, pas d’heure."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に公開 — ベンダーは日付のみを示し、時刻は示していません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опубликовано %@ — поставщик указал только дату, без времени."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发布于 %@ —— 厂商只给了日期，没有给时间。"
+          }
+        }
+      }
+    },
     "Queued": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
#273 shipped `String(localized: "Published on %@ — the vendor gave only a
date, not a time.")` in ReleaseLogView without a catalog entry, so
`check_localizable_keys.py` fails on main and the tooltip renders its
English source in all six other languages.

Translated for all seven languages. The specifier sequence is `%@` alone in
every one, audited separately — the key checker compares keys, never values,
so a dropped or reordered specifier would pass it silently.

## Verification

```
python3 scripts/check_localizable_keys.py
✓ localizable keys agree — 432 in the catalog, all reachable
```

Specifier audit across all 432 keys × 7 languages: 0 mismatches.

Diff is 47 insertions, 0 deletions — the entry is inserted after `Published %@` so the rest of the file is byte-identical (a JSON round-trip of the original was confirmed byte-identical first, so nothing else could be silently reformatted).