### PR TITLE
fix: align computeRestartInfo's lookup key, measure the staged-name premise

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3465,7 +3465,15 @@ final class AppListModel {
             // Match on the resolved bundle path, not bundle id: a row whose exact
             // .app isn't running must not pick up a channel sibling's running
             // version (Android Studio Preview vs Stable share one bundle id).
-            let runKey = result.app.path.resolvingSymlinksInPath().path
+            // `running` (below) is keyed with `UpdatePolicy.runtimeBundlePath`, not
+            // bare `resolvingSymlinksInPath()` — this has to match it exactly, or a
+            // path that legitimately carries a `.duoupdater-staged-`/`-old`/`-new`
+            // component would look up under the wrong key. For every path without
+            // one of those components `runtimeBundlePath` returns the identical
+            // resolved string, so this is a no-op change for the paths `AppScanner`
+            // can currently produce (it skips hidden entries and requires
+            // `pathExtension == "app"`, so those components never reach here today).
+            let runKey = UpdatePolicy.runtimeBundlePath(result.app.path)
             // Remember the marketing version this on-disk build carries, so that
             // AFTER a future self-update — when only the build survives in the running
             // process (via `lsappinfo`) — we can still name the version it launched

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -675,21 +675,55 @@ public enum UpdatePolicy {
     }
 
     /// Normalize app bundle paths reported by running processes back to the live
-    /// installed bundle. macOS can keep a process mapped to DuoUpdater's temporary
-    /// `replaceItemAt` staging name after a hot swap; treating that hidden/deleted
-    /// path as distinct makes running detection and Relaunch miss the exact app.
+    /// installed bundle. The premise: macOS *can* keep a process mapped to
+    /// DuoUpdater's temporary `replaceItemAt` staging name after a hot swap;
+    /// treating that hidden/deleted path as distinct would make running detection
+    /// and Relaunch miss the exact app.
     ///
-    /// Rewrites **every** component, not just the last one. An app nested inside
-    /// another app's bundle — Surge ships `Surge.app/Contents/Applications/Surge
-    /// Dashboard.app`, and it is a full app with its own bundle id, not a helper
-    /// the parent process owns — reports a path whose staged component is in the
-    /// middle:
+    /// ⚠️ That premise is asserted at every one of this function's callers and
+    /// measured at none of them (issue #242). The one existing measurement in this
+    /// repo of a related question points the other way:
+    /// `docs/app-audits/com-eusoft-eudic.md` records that after moving a bundle
+    /// aside by hand, both `NSRunningApplication.bundleURL` and `lsappinfo` kept
+    /// reporting the ORIGINAL path, not the moved-aside one — overturning a prior
+    /// assumption to the contrary.
+    ///
+    /// Measured here specifically, 2026-09-03 on macOS 27.0 (26A5425a, arm64): a
+    /// throwaway `.app` was launched, then put through this file's *actual*
+    /// unprivileged swap — `FileManager.moveItem` to `.duoupdater-staged-<name>`
+    /// followed by `FileManager.replaceItemAt`, the same two calls
+    /// `InPlaceSwap.replace(newApp:over:)` makes for an unelevated target. The
+    /// still-running old process's `NSRunningApplication.bundleURL` and
+    /// `lsappinfo`'s `bundle path` both kept reporting the pre-swap path
+    /// throughout and after the swap — no `.duoupdater-staged-` component ever
+    /// appeared. Repeated for the nested shape below (an inner app, itself
+    /// untouched, running out of an outer bundle that gets swapped from under
+    /// it): same result, original path throughout for the inner app too.
+    ///
+    /// So on the one route measured — unprivileged in-place swap, flat and
+    /// nested — this function's rewrite is a no-op on the input it actually
+    /// receives here: nothing in that route ever hands it a path carrying a
+    /// staged/-old/-new component. UNMEASURED: the privileged (administrator
+    /// prompt) swap route (`privilegedReplace`) and the Contents-rotation route
+    /// input methods use (`rotateContents`) — either could behave differently,
+    /// and the commit that added the nested-path rewrite below (1d08b62,
+    /// 2026-08-26) narrates a real Surge incident as if `bundleURL` had shown
+    /// the staged component for the nested Dashboard process, but the commit
+    /// and its tests only ever construct that path as a string literal — no
+    /// raw captured value from the incident backs the claim.
+    /// Don't delete this rewrite on the strength of one route's measurement;
+    /// see issue #242 for what measuring the other two routes would take.
+    ///
+    /// Rewrites **every** component, not just the last one, in case the staged
+    /// name ever does leak through: an app nested inside another app's bundle —
+    /// Surge ships `Surge.app/Contents/Applications/Surge Dashboard.app`, and it
+    /// is a full app with its own bundle id, not a helper the parent process
+    /// owns — would report a path whose staged component is in the middle:
     ///
     ///     /Applications/.duoupdater-staged-Surge.app/Contents/Applications/Surge Dashboard.app
     ///
-    /// Normalising the leaf alone left that string untouched, so nothing could
-    /// tell that the process belonged to Surge at all, and the nested app went on
-    /// running the pre-swap binary out of a bundle that had been moved aside.
+    /// Normalising the leaf alone would leave that string untouched, so nothing
+    /// could tell that the process belonged to Surge at all.
     public static func runtimeBundlePath(_ url: URL) -> String {
         let resolved = url.resolvingSymlinksInPath()
         let stagedPrefix = ".duoupdater-staged-"


### PR DESCRIPTION
## What

Two independent things, both from #242.

### 1. `computeRestartInfo`'s lookup key vs. the map it queries (App/Sources/AppListModel.swift)

`computeRestartInfo` built `runKey` from bare `result.app.path.resolvingSymlinksInPath().path`. The `running` map it looks that key up in — built in `runningBuildVersions()` from `lsappinfo list` — is keyed with `UpdatePolicy.runtimeBundlePath(...)`, which does `resolvingSymlinksInPath()` **plus** rewriting any `.duoupdater-staged-`/`.duoupdater-old`/`.duoupdater-new` path component. A comment right next to the map-building code already claimed the two "line up... with computeRestartInfo's lookup key" — they didn't, for any path carrying one of those components. Fixed by having `runKey` call `runtimeBundlePath` too.

### 2. The staged-name premise itself, measured (DuoUpdaterCore/.../UpdatePolicy.swift)

`runtimeBundlePath`'s doc comment asserts "macOS can keep a process mapped to DuoUpdater's temporary `replaceItemAt` staging name after a hot swap." Per the issue, that's asserted at all ~15 call sites and measured at none. I ran the actual measurement instead of arguing about it further — see **Verification** below — and recorded the result in the doc comment rather than deleting or keeping the rewrite on priors either way.

## Issue verification

What #242 got right:

- The key mismatch is real and exactly as described: `runKey` uses bare `resolvingSymlinksInPath()`, the `running` map uses `runtimeBundlePath`.
- It's currently unreachable: `AppScanner` skips hidden entries (`.duoupdater-staged-*` never enters) and filters on `pathExtension == "app"` (`<App>.app.duoupdater-old` never enters). Confirmed by reading `AppScanner`'s filters directly.
- The Eudic measurement citation is accurate: `docs/app-audits/com-eusoft-eudic.md:175-177` does record `bundleURL`/`lsappinfo` reporting the original path after a bundle was moved aside, overturning a prior assumption.

What the issue said that needed correcting:

- **"asserted in three places"** undercounts by a lot. `runtimeBundlePath` is called from `AppRestarter.swift` (8x), `UpdatePolicy.swift` (2x, plus the doc comment itself), `InPlaceSwap.swift` (1x), `RunningBundlePathCache.swift` (default resolver), `App/Sources/AppListModel.swift` (1x, the `running`-map builder), and three CLI files (`Backups.swift`, `Install.swift`, `Check.swift`). That's why this PR does **not** delete the rewrite on the strength of one measurement — the blast radius of being wrong either way is real.
- The other two `resolvingSymlinksInPath()` call sites in `AppListModel.swift` that the issue's line numbers pointed near (`runningLaunchDatesByPath` / `reconcilePackageRestarts`) are **not** part of this bug — they build and read their own separate, internally-consistent map and never interact with the `runtimeBundlePath`-keyed one. Left untouched.

## Verification

**Unit tests** (all pre-existing, no regressions):

```
cd DuoUpdaterCore && swift test
# Test run with 1964 tests in 154 suites passed after 37.890 seconds with 1 known issue (pre-existing, unrelated).

cd CLI && swift test
# Test run with 185 tests in 24 suites passed after 0.069 seconds.

python3 scripts/check_staged_version_use.py
# ✓ version comparisons discriminate — 211 files, 2 ledger call(s) keyed on the build, 7 marketing-first pick(s), all display-only

python3 scripts/check_app_audits.py
# ✓ app audits consistent — 91 docs, all indexed, no machine inventory, no pointers into untracked evidence
```

**App target compiles** (xcodegen + xcodebuild, isolated `-derivedDataPath`):

```
DUO_TEAM_ID=RS59HDH7Y3 xcodegen generate --spec App/project.yml --project App
xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug \
  -derivedDataPath /tmp/duo-dd-242 build
# ** BUILD SUCCEEDED **
```

**The staged-name premise, measured directly** (not a unit test — an OS-behavior probe, run manually, results written into the doc comment):

- Built a throwaway `.app` (`LSUIElement`, a shell-script executable that sleeps), launched it with `open`.
- Baseline: `NSRunningApplication.bundleURL` and `lsappinfo list`'s `bundle path`, both reporting the original path.
- Ran it through the **actual production code path** — the exact two `FileManager` calls `InPlaceSwap.replace(newApp:over:)` makes for an unelevated target: stage the new bundle beside the target as `.duoupdater-staged-<name>`, then `replaceItemAt`.
- Re-read the same two sources for the still-running old process. Result on macOS 27.0 (26A5425a, arm64): **both still reported the pre-swap path — no `.duoupdater-staged-` component ever appeared**, matching the Eudic finding.
- Repeated for the nested shape the doc comment specifically calls out (an inner app — Surge Dashboard's structural analog — running out of an outer bundle that gets swapped underneath it). Same result: the inner app's `bundleURL`/`lsappinfo` path stayed the original throughout.

This is one route (unprivileged in-place swap) on one OS build. The privileged (admin-prompt) swap route and the Contents-rotation route input methods use are **unmeasured** — either could behave differently, and I did not touch the rewrite's presence or the ~15 call sites based on a single route's result. All of this — including a discrepancy I found in the commit that originally added the nested-path rewrite (1d08b62: its narrative implies `bundleURL` showed the staged component for a real Surge incident, but neither the commit nor its tests capture a raw value — only a constructed string literal) — is written into `runtimeBundlePath`'s doc comment for the next person.

**Not verified / explicitly unmeasured:**

- The privileged (administrator-prompt) swap route (`InPlaceSwap.privilegedReplace`).
- The Contents-rotation route used by input methods (`InPlaceSwap.rotateContents`).
- Whether the 2026-08-26 Surge incident actually involved a staged path in `bundleURL` (no raw log value exists to check against).
- No automated regression test guards the `runKey`/`running`-map fix itself: `App/project.yml` has no test target (per the top-level CLAUDE.md, nothing in `App/Sources` executes under test), and the divergence is currently unreachable through `AppScanner`'s own filters, so there's no way to drive a real scan through the buggy path either. The existing Core test `runtimeBundlePathNormalizesStagedSuffixes` already pins that `runtimeBundlePath` is a no-op on ordinary paths, which is what makes this fix behavior-preserving today.

closes #242
