### PR TITLE
Route all five vendor-timestamp sources through publishedFields

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseDate.swift
@@ -19,20 +19,20 @@ import Foundation
 /// dashed (`"2026-08-31"`). `parse` returns nil for that spelling rather than
 /// fabricating a midnight moment the vendor never stated — the release timeline
 /// only plots a `publishedAt` it can trust to the minute (see
-/// `ReleaseTimelineStore`). Use ``parseWithPrecision(_:)`` when the caller has
-/// somewhere honest to put a day-only value (`vendorDay`, not `publishedAt`).
+/// `ReleaseTimelineStore`). Use ``parseWithPrecision(_:)`` (or the even more
+/// convenient ``publishedFields(from:)``) when the caller has somewhere honest
+/// to put a day-only value (`vendorDay`, not `publishedAt`).
 ///
-/// ⚠️ EXCEPTION, not swept up in the above: a bare 8-digit run (`"20260831"`) is
-/// ALSO a calendar day with no time, but `parse` still returns a plain `Date`
-/// for it via the `date(fromDigits:)` branch below — pre-existing behavior from
-/// #222, left unchanged here. Fixing it would touch `parse`'s one return path
-/// shared by every caller (`AlcoveUpdateSource`, `GitHubReleasesSource`,
-/// `ElectronManifestSource`, `VendorProbeSource`, and `SparkleAppcastSource`
-/// before this file's `publishedFields`/`releaseHistory` moved off it), which
-/// needs its own decision per caller, not a change riding along with this one.
-/// `parseWithPrecision` tags this shape `.day` too, for what that is worth: it
-/// changes what a *new* caller of that entry point sees, not what `parse`
-/// itself returns.
+/// #300: every production caller now goes through ``publishedFields(from:)``
+/// (`AlcoveUpdateSource`, `ElectronManifestSource`, `GitHubReleasesSource`,
+/// `SparkleAppcastSource`, `VendorProbeSource`) rather than `parse` directly, so
+/// `parse` itself is `internal`, not `public` — there is no external caller left
+/// to preserve source compatibility for. It stays as the implementation `parse`
+/// always was (unlike `parseWithPrecision`, it still reads a bare 8-digit
+/// `"20260831"` as a plain `Date` rather than tagging it `.day` — pre-existing
+/// #222 behavior), kept because `ReleaseDateTests.swift` uses it to pin the
+/// numeric-window and formatter logic `parseWithPrecision` shares with it, one
+/// layer below the day/minute split.
 public enum ReleaseDate {
 
     /// Convert a raw feed date string to a `Date`, or nil when it's empty or in a
@@ -42,8 +42,10 @@ public enum ReleaseDate {
     /// Returns nil for a *dashed* date-only day (`"2026-08-31"`) — see
     /// ``parseWithPrecision(_:)`` for that case — but NOT for a *bare-digit*
     /// date-only day (`"20260831"`): that one still comes back as a plain `Date`,
-    /// unchanged pre-existing behavior explained on ``ReleaseDate`` above.
-    public static func parse(_ raw: String?) -> Date? {
+    /// unchanged pre-existing behavior explained on ``ReleaseDate`` above. Moot
+    /// for every production caller since #300 (none call `parse` any more), but
+    /// still exercised directly by `ReleaseDateTests.swift`.
+    static func parse(_ raw: String?) -> Date? {
         guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else { return nil }
 
@@ -317,5 +319,27 @@ extension ReleaseDate {
         }
 
         return nil
+    }
+
+    /// Split a raw feed date string into the one field it may honestly fill,
+    /// per ``Precision``: a real time of day becomes `publishedAt` — the only
+    /// tier `ReleaseTimeline.publishedAt`/`ReleaseTimelineStore` may plot to the
+    /// minute — while a bare calendar day becomes `vendorDay` instead of a
+    /// fabricated midnight moment the vendor never stated. Never both.
+    ///
+    /// #300: this is the one place that routing happens, shared by every
+    /// `UpdateSource` that reads a vendor timestamp (`AlcoveUpdateSource`,
+    /// `ElectronManifestSource`, `GitHubReleasesSource`, `SparkleAppcastSource`,
+    /// `VendorProbeSource`) — previously `SparkleAppcastSource` carried its own
+    /// copy of exactly this switch while the other four sources called `parse`
+    /// directly and so had no `vendorDay` tier at all. One routing function
+    /// means the "day precision never reaches `publishedAt`" invariant only
+    /// has to be true in one place for it to be true everywhere.
+    public static func publishedFields(from raw: String?) -> (publishedAt: Date?, vendorDay: Date?) {
+        guard let parsed = parseWithPrecision(raw) else { return (nil, nil) }
+        switch parsed.precision {
+        case .minute: return (parsed.date, nil)
+        case .day: return (nil, parsed.date)
+        }
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AlcoveUpdateSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AlcoveUpdateSource.swift
@@ -89,6 +89,12 @@ public struct AlcoveUpdateSource: UpdateSource {
         guard let latest = try? await fetchLatest(token: token, app: app) else { return nil }
 
         let dmg = latest.assets.first { $0.name == "Alcove.dmg" }?.url
+        // #300: route through the same day/minute split every other source
+        // uses — `latest.publishedAt` is Alcove's own JSON `published_at`,
+        // normally a real ISO8601 timestamp, but nothing about the API
+        // guarantees that, and there is no reason to special-case it if a
+        // bare calendar day ever shows up.
+        let fields = ReleaseDate.publishedFields(from: latest.publishedAt)
         return RemoteVersion(
             // tag_name is the marketing version (== CFBundleShortVersionString).
             shortVersion: latest.tagName,
@@ -102,7 +108,8 @@ public struct AlcoveUpdateSource: UpdateSource {
             // The licensed download needs the same Bearer the probe used.
             downloadHeaders: ["Authorization": "Bearer \(token)"],
             structuredChangelog: Self.changelog(from: latest),
-            publishedAt: ReleaseDate.parse(latest.publishedAt)
+            publishedAt: fields.publishedAt,
+            vendorDay: fields.vendorDay
         )
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifestSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifestSource.swift
@@ -187,6 +187,12 @@ public struct ElectronManifestSource: UpdateSource {
         // read) is broken, so it does not affect the health verdict — same reasoning
         // `GitHubReleasesSource` gives its own `archIncompatible` rows no miss.
         await RecipeHealth.shared.recordSuccess(id: healthID, source: name)
+        // #300: `manifest.releaseDate` is electron-builder's own `releaseDate`
+        // field (normally a full ISO8601 timestamp), routed through the same
+        // day/minute split every other source uses rather than the old
+        // `ReleaseDate.parse`, which had no honest place to put a bare
+        // calendar day and so silently dropped one.
+        let fields = ReleaseDate.publishedFields(from: manifest.releaseDate)
         return RemoteVersion(
             shortVersion: manifest.version,
             version: nil,
@@ -195,7 +201,8 @@ public struct ElectronManifestSource: UpdateSource {
             sourceName: name,
             vendorInstallerKind: Self.kind(of: file?.url),
             expectedSHA512: file?.sha512,
-            publishedAt: ReleaseDate.parse(manifest.releaseDate))
+            publishedAt: fields.publishedAt,
+            vendorDay: fields.vendorDay)
     }
 
     /// The archive kind, from the chosen artifact's own extension.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -540,10 +540,19 @@ public struct GitHubReleasesSource: UpdateSource {
         // visible release history into the timeline at no extra network cost (these
         // are the same releases we already fetched). A single-`latest` fetch yields
         // just one entry; a prerelease-channel list yields the whole page.
+        //
+        // #300: GitHub's `published_at` is normally a full ISO8601 timestamp, so
+        // this almost always resolves to `.minute` in practice — but routing it
+        // through `publishedFields` rather than the old `ReleaseDate.parse` means
+        // a release that only carried a bare calendar day would still get a
+        // history entry (as `vendorDay`) instead of being silently dropped, same
+        // as `SparkleAppcastSource.releaseHistory` already does.
         let history: [ReleaseHistoryEntry] = releases.compactMap { release in
-            guard let v = VendorProbeRecipe.extractVersion(from: release.tag, pattern: rule.versionPattern),
-                  let date = ReleaseDate.parse(release.publishedAt) else { return nil }
-            return ReleaseHistoryEntry(version: v, publishedAt: date)
+            guard let v = VendorProbeRecipe.extractVersion(from: release.tag, pattern: rule.versionPattern)
+            else { return nil }
+            let fields = ReleaseDate.publishedFields(from: release.publishedAt)
+            guard fields.publishedAt != nil || fields.vendorDay != nil else { return nil }
+            return ReleaseHistoryEntry(version: v, publishedAt: fields.publishedAt, vendorDay: fields.vendorDay)
         }
         var skippedForMissingAsset: [String] = []
         var archIncompatible = false
@@ -581,6 +590,11 @@ public struct GitHubReleasesSource: UpdateSource {
                 let structured = body.flatMap {
                     GitHubMarkdownParser.parse(body: $0, version: version, date: release.publishedAt)
                 }
+                // #300: same day/minute split as the history backfill above —
+                // `release.publishedAt` is normally a full ISO8601 timestamp,
+                // but a bare calendar day now lands honestly in `vendorDay`
+                // instead of being dropped by the old `ReleaseDate.parse`.
+                let publishedFields = ReleaseDate.publishedFields(from: release.publishedAt)
 
                 // When the rule names an installable asset and this release ships
                 // a matching one, offer a one-click in-place install (the Team-ID
@@ -608,7 +622,8 @@ public struct GitHubReleasesSource: UpdateSource {
                     releaseNotesHTML: structured == nil ? body : nil,
                     structuredChangelog: structured,
                     changelogURL: page,
-                    publishedAt: ReleaseDate.parse(release.publishedAt),
+                    publishedAt: publishedFields.publishedAt,
+                    vendorDay: publishedFields.vendorDay,
                     releaseHistory: history
                 ), tags: releases.map(\.tag), archIncompatible: false)
             }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -64,7 +64,7 @@ public struct SparkleAppcastSource: UpdateSource {
         // the release timeline in one shot (not just the newest). Keyed on the same
         // version string the timeline dedupes by.
         let history = Self.releaseHistory(from: usable)
-        let bestFields = Self.publishedFields(from: best.pubDate)
+        let bestFields = ReleaseDate.publishedFields(from: best.pubDate)
 
         return RemoteVersion(
             shortVersion: best.shortVersionString,
@@ -85,31 +85,17 @@ public struct SparkleAppcastSource: UpdateSource {
         )
     }
 
-    /// Split a raw `<pubDate>` into the one field it may honestly fill, per
-    /// `ReleaseDate.parseWithPrecision`'s tier: a real time of day becomes
-    /// `publishedAt` — the only tier `ReleaseTimelineStore` may plot to the
-    /// minute — while a bare calendar day (Eudic's appcast ships exactly this:
-    /// `<pubDate>2026-08-31</pubDate>`, #239) becomes `vendorDay` instead of a
-    /// fabricated midnight moment the vendor never stated. Never both, and never
-    /// `publishedAt` for a day-only value — see `ReleaseTimeline`'s three-tier
-    /// doc for why the two must stay separate fields rather than one `Date?`
-    /// with a precision flag beside it.
-    static func publishedFields(from pubDate: String?) -> (publishedAt: Date?, vendorDay: Date?) {
-        guard let parsed = ReleaseDate.parseWithPrecision(pubDate) else { return (nil, nil) }
-        switch parsed.precision {
-        case .minute: return (parsed.date, nil)
-        case .day: return (nil, parsed.date)
-        }
-    }
-
     /// Every in-channel item with a parseable vendor date, turned into a
     /// timeline entry at whatever precision the vendor actually stated (see
-    /// ``publishedFields(from:)``). Pure and separated from `latestVersion` so
-    /// the day/minute routing is unit-testable without a network fetch.
+    /// `ReleaseDate.publishedFields(from:)` — Eudic's appcast is the fixture
+    /// that proves a bare calendar day, `<pubDate>2026-08-31</pubDate>`, routes
+    /// to `vendorDay` rather than a fabricated midnight `publishedAt`, #239).
+    /// Pure and separated from `latestVersion` so the day/minute routing is
+    /// unit-testable without a network fetch.
     static func releaseHistory(from usable: [SparkleAppcastItem]) -> [ReleaseHistoryEntry] {
         usable.compactMap { item in
             guard let v = item.shortVersionString ?? item.version else { return nil }
-            let fields = publishedFields(from: item.pubDate)
+            let fields = ReleaseDate.publishedFields(from: item.pubDate)
             guard fields.publishedAt != nil || fields.vendorDay != nil else { return nil }
             return ReleaseHistoryEntry(version: v, publishedAt: fields.publishedAt, vendorDay: fields.vendorDay)
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -218,19 +218,23 @@ public enum ProbeWarning: Sendable, Equatable {
     /// with no warnings check would call this recipe healthy.
     ///
     /// Deliberately NOT `publishedAtUnreadable`. That one means the pattern DID
-    /// fire and `ReleaseDate` rejected the captured text — there is a value to
-    /// show and a date spelling to add support for. This one means the pattern
-    /// never matched at all, so there is nothing captured to show; the fix is
-    /// to go re-derive the pattern against the vendor's current response, same
-    /// as `displayPatternNoMatch`. A recipe missing `publishedAtPattern`
-    /// entirely stays quiet — that is the normal, supported "no publish time"
-    /// shape and not a degradation of anything the recipe author declared.
+    /// fire and `ReleaseDate` rejected the captured text at both tiers — there
+    /// is a value to show and a date spelling to add support for. This one
+    /// means the pattern never matched at all, so there is nothing captured to
+    /// show; the fix is to go re-derive the pattern against the vendor's
+    /// current response, same as `displayPatternNoMatch`. A recipe missing
+    /// `publishedAtPattern` entirely stays quiet — that is the normal,
+    /// supported "no publish time" shape and not a degradation of anything the
+    /// recipe author declared.
     case publishedAtPatternNoMatch
-    /// `publishedAtPattern` captured a value, but `ReleaseDate` could not parse
-    /// it. The version remains usable, but the release timeline loses its exact
-    /// event and `duo verify`'s age-gated phantom-update check is disabled.
-    /// Carry the captured value so the recipe author can see which date spelling
-    /// needs support without reproducing a response that may already have moved.
+    /// `publishedAtPattern` captured a value, but `ReleaseDate.publishedFields`
+    /// could parse it as neither a `.minute`-precise time nor a bare `.day` —
+    /// so it produced neither `publishedAt` nor `vendorDay`. The version
+    /// remains usable, but the release timeline loses this release's event
+    /// entirely and `duo verify`'s age-gated phantom-update check is disabled.
+    /// Carry the captured value so the recipe author can see which date
+    /// spelling needs support without reproducing a response that may already
+    /// have moved.
     case publishedAtUnreadable(String)
 
     /// The part of a warning that varies, kept OUT of `kind` on purpose.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -3889,12 +3889,13 @@ public enum VendorProbeRegistry {
         // its own .pkg updater; this is the fallback behind the same-Team gate.)
         //
         // No `publishedAtPattern`: the same body also carries `"releaseDate":
-        // "2025-12-17"` (fetched 2026-08-31) — a bare day, which `ReleaseDate.parse`
-        // does not read (it wants a time), so a pattern here would still be
-        // silently inert. #239 gave that shape somewhere honest to go
-        // (`ReleaseDate.parseWithPrecision` → `RemoteVersion.vendorDay`), but
-        // `VendorProbeSource` itself is not wired to that tier yet — left for the
-        // PR that connects it, not this comment update.
+        // "2025-12-17"` (fetched 2026-08-31) — a bare day, no time. #300 wired
+        // `VendorProbeSource` to `ReleaseDate.publishedFields`, so a pattern
+        // here would now land honestly in `RemoteVersion.vendorDay` instead of
+        // being silently inert — the mechanism is ready. Adding the pattern
+        // itself is left for a follow-up: per this repo's fragile-recipe rule,
+        // a recipe change needs the real broken response reproduced and
+        // `duo verify` run against it, not just a mechanism change.
         VendorProbeRecipe(
             bundleID: "cc.ffitch.shottr",
             url: URL(string: "https://shottr.cc/api/version.json")!,
@@ -4525,13 +4526,14 @@ public enum VendorProbeRegistry {
         //
         // The metadata offers a zip where the page offers a dmg; the zip is the
         // same release and unpacks straight into the swap, so it is the better of
-        // the two. `pub_date` is a bare `2026-08-13`, which `ReleaseDate.parse`
-        // still does not read (it wants a time) — that contract is unchanged by
-        // #239. A `publishedAtPattern` here would therefore still be silently
-        // inert today: `VendorProbeSource` feeds it through `parse`, not the new
-        // `ReleaseDate.parseWithPrecision`/`RemoteVersion.vendorDay` day tier, so
-        // wiring one up is left for the PR that connects `VendorProbeSource` to
-        // that tier, not this recipe change.
+        // the two. `pub_date` is a bare `2026-08-13`, no time. #300 wired
+        // `VendorProbeSource` to `ReleaseDate.publishedFields`, so a
+        // `publishedAtPattern` here would now land honestly in
+        // `RemoteVersion.vendorDay` instead of being silently inert — the
+        // mechanism is ready. Adding the pattern itself is left for a
+        // follow-up: per this repo's fragile-recipe rule, a recipe change needs
+        // the real broken response reproduced and `duo verify` run against it,
+        // not just a mechanism change.
         //
         // Verified 2026-08-16 on the downloaded artifact: Kiro.app 1.0.309,
         // dev.kiro.desktop, Developer ID `AMZN Mobile LLC (94KV3E626L)`, notarized

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -628,14 +628,20 @@ public struct VendorProbeSource: UpdateSource {
         // declares no `publishedAtPattern` at all is not a failure — the
         // Release Log falls back to its estimated "≈" window, quietly. A
         // recipe that DOES declare one but gets no match, or a match
-        // `ReleaseDate` can't parse, hits the same fallback but warns: both
-        // silently disable `duo verify`'s age-gated phantom-update check, and
-        // without the warning a declared-but-dead pattern reads identically to
-        // never having declared one at all (issue #288).
+        // `ReleaseDate` can't parse at either tier, hits the same fallback but
+        // warns: both silently disable `duo verify`'s age-gated phantom-update
+        // check, and without the warning a declared-but-dead pattern reads
+        // identically to never having declared one at all (issue #288).
+        //
+        // #300: routed through `publishedFields`, the same day/minute split
+        // every other source uses, so a recipe whose pattern captures a bare
+        // calendar day (Kiro's and Shottr's `publishedAtPattern` candidates,
+        // both `"2025-12-17"`-shaped — see `VendorProbeRecipe`) gets a real
+        // `vendorDay` instead of being warned about as unreadable.
         let publishedAtValue = recipe.publishedAtPattern.flatMap {
             VendorProbeRecipe.extractVersion(from: scope, pattern: $0)
         }
-        let publishedAt = ReleaseDate.parse(publishedAtValue)
+        let publishedFields = ReleaseDate.publishedFields(from: publishedAtValue)
 
         var warnings: [ProbeWarning] = []
         if scoped.fellBack { warnings.append(.entryPatternNoMatch) }
@@ -647,7 +653,8 @@ public struct VendorProbeSource: UpdateSource {
         }
         if recipe.publishedAtPattern != nil, publishedAtValue == nil {
             warnings.append(.publishedAtPatternNoMatch)
-        } else if let publishedAtValue, publishedAt == nil {
+        } else if let publishedAtValue,
+                  publishedFields.publishedAt == nil, publishedFields.vendorDay == nil {
             warnings.append(.publishedAtUnreadable(publishedAtValue))
         }
         var remote: RemoteVersion
@@ -671,7 +678,7 @@ public struct VendorProbeSource: UpdateSource {
                 remote = Self.makeRemoteVersion(
                     recipe: recipe, version: version, install: spec, plan: plan,
                     resolvedDownload: body.resolvedDownload, display: display,
-                    publishedAt: publishedAt,
+                    publishedAt: publishedFields.publishedAt, vendorDay: publishedFields.vendorDay,
                     // Deliberately `body.text`, not `scope`: this parses the WHOLE
                     // response as a Sparkle appcast document (`SparkleAppcastParser`)
                     // rather than reading a pattern out of it, so an entry-scoped
@@ -730,13 +737,13 @@ public struct VendorProbeSource: UpdateSource {
                 remote = Self.makeRemoteVersion(
                     recipe: recipe, version: version, install: nil, plan: nil,
                     resolvedDownload: body.resolvedDownload, display: display,
-                    publishedAt: publishedAt)
+                    publishedAt: publishedFields.publishedAt, vendorDay: publishedFields.vendorDay)
             }
         } else {
             remote = Self.makeRemoteVersion(
                 recipe: recipe, version: version, install: nil, plan: nil,
                 resolvedDownload: body.resolvedDownload, display: display,
-                publishedAt: publishedAt)
+                publishedAt: publishedFields.publishedAt, vendorDay: publishedFields.vendorDay)
         }
 
         return ProbeOutcome(
@@ -1088,6 +1095,7 @@ public struct VendorProbeSource: UpdateSource {
         resolvedDownload: URL?,
         display: String? = nil,
         publishedAt: Date? = nil,
+        vendorDay: Date? = nil,
         deltas: [DeltaPatch] = []
     ) -> RemoteVersion {
         // A build-number recipe routes the value into `version` (compared against
@@ -1127,6 +1135,7 @@ public struct VendorProbeSource: UpdateSource {
                 downloadHeaders: spec.requestHeaders,
                 changelogURL: recipe.changelogURL,
                 publishedAt: publishedAt,
+                vendorDay: vendorDay,
                 // Only on the installable branch: a patch is an alternative route
                 // to an artifact we are going to fetch, so it is meaningless on a
                 // detection-only result that has no artifact to begin with.
@@ -1147,7 +1156,8 @@ public struct VendorProbeSource: UpdateSource {
             // No install spec: detection only — the user downloads by hand.
             requiresManualInstaller: true,
             changelogURL: recipe.changelogURL,
-            publishedAt: publishedAt
+            publishedAt: publishedAt,
+            vendorDay: vendorDay
         )
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseDateParseScopeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseDateParseScopeTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// #300: "day precision never reaches `publishedAt`" used to hold only for
+/// `SparkleAppcastSource` — the other four sources that read a vendor
+/// timestamp (`AlcoveUpdateSource`, `ElectronManifestSource`,
+/// `GitHubReleasesSource`, `VendorProbeSource`) called `ReleaseDate.parse`
+/// directly, which has no `vendorDay` tier at all to protect. That made the
+/// invariant true by convention, not by construction: nothing stopped a sixth
+/// caller from doing the same thing.
+///
+/// After #300 every one of those sources — and any future one — must go
+/// through `ReleaseDate.publishedFields(from:)` (or `parseWithPrecision`
+/// directly), the one place the day/minute split happens. This test pins that
+/// down at the source level rather than trusting it stays true: it scans every
+/// `.swift` file under `DuoUpdaterCore/Sources` for a direct call to
+/// `ReleaseDate.parse(` — `Releases/ReleaseDate.swift` itself, where `parse` is
+/// declared, is the only file allowed to contain that spelling.
+///
+/// **Why a source scan, not just relying on `parse` being `internal`.** Access
+/// control blocks a caller in `CLI`/`App` (separate modules, `parse` isn't
+/// `public`), but `DuoUpdaterCore` is one target — nothing in the language
+/// stops a new file inside it from calling `parse` directly. `ReleaseDateTests.
+/// swift` legitimately calls `parse` dozens of times to pin the formatter
+/// internals `parseWithPrecision` shares with it, so this cannot be "no call to
+/// `parse` anywhere in the module" — it has to be scoped to *production*
+/// sources, which is what the `Sources/` subdirectory (as opposed to `Tests/`)
+/// picks out.
+///
+/// Mutation-tested by hand (see the PR description): temporarily reverting one
+/// of the five converted call sites back to `ReleaseDate.parse(...)` turns this
+/// red, naming the offending file.
+struct ReleaseDateParseScopeTests {
+
+    private static let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()   // DuoUpdaterCoreTests
+        .deletingLastPathComponent()   // Tests
+        .deletingLastPathComponent()   // DuoUpdaterCore
+        .deletingLastPathComponent()   // repo root
+
+    /// The one file allowed to spell `ReleaseDate.parse(` — where it's declared.
+    private static let allowedFile = "Releases/ReleaseDate.swift"
+
+    @Test func noProductionSourceCallsReleaseDateParseDirectly() throws {
+        let sourcesRoot = Self.repoRoot
+            .appendingPathComponent("DuoUpdaterCore/Sources/DuoUpdaterCore")
+        let enumerator = try #require(
+            FileManager.default.enumerator(at: sourcesRoot, includingPropertiesForKeys: nil),
+            Comment(rawValue:
+                "could not enumerate \(sourcesRoot.path) — repoRoot resolution is probably wrong"))
+
+        var offenders: [String] = []
+        var sawAnySwiftFile = false
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "swift" else { continue }
+            sawAnySwiftFile = true
+            let relativePath = url.path.replacingOccurrences(
+                of: sourcesRoot.path + "/", with: "")
+            guard relativePath != Self.allowedFile else { continue }
+
+            let text = try String(contentsOf: url, encoding: .utf8)
+            if text.contains("ReleaseDate.parse(") {
+                offenders.append(relativePath)
+            }
+        }
+
+        // A guard that silently scanned zero files would pass for the wrong
+        // reason — same shape as the empty-fixture traps this repo has hit
+        // before (see CLAUDE.md's fixture-distribution warning).
+        #expect(sawAnySwiftFile,
+            Comment(rawValue: "scanned zero .swift files under \(sourcesRoot.path)"))
+        #expect(offenders.isEmpty,
+            Comment(rawValue:
+                "these production files call ReleaseDate.parse(...) directly instead of "
+                    + "publishedFields(from:)/parseWithPrecision(_:), so a day-only vendor "
+                    + "date they capture would silently reach publishedAt as a fabricated "
+                    + "midnight: \(offenders.sorted().joined(separator: ", "))"))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleReleaseDatePrecisionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleReleaseDatePrecisionTests.swift
@@ -10,25 +10,29 @@ import Foundation
 /// midnight there is a lie about when the vendor shipped, not merely an
 /// approximation of it.
 ///
-/// `SparkleAppcastSource` is the only source this fix touches — it is the one
-/// with a real fixture proving the date-only shape reaches it. The other four
-/// sources (`AlcoveUpdateSource`, `GitHubReleasesSource`, `ElectronManifestSource`,
-/// `VendorProbeSource`) keep calling `ReleaseDate.parse`, whose contract is
-/// unchanged: nil for a bare calendar day, exactly as before this PR.
+/// `SparkleAppcastSource` was the only source #239 touched — it is the one with
+/// a real fixture proving the date-only shape reaches it. #300 moved the
+/// day/minute routing itself into `ReleaseDate.publishedFields(from:)` and
+/// converted the other four sources (`AlcoveUpdateSource`, `GitHubReleasesSource`,
+/// `ElectronManifestSource`, `VendorProbeSource`) to it as well, so this file
+/// now tests the shared routing function directly rather than a copy that used
+/// to live on `SparkleAppcastSource`; `releaseHistorySplitsEntriesByThePrecisionTheFeedActuallyStated`
+/// below still exercises Sparkle's own `releaseHistory(from:)`, which calls the
+/// same shared function against real parsed XML.
 ///
 /// The invariant under test, twice over — once on the pure routing function and
 /// once through the real XML parser end to end: a day-precision date routes to
 /// `vendorDay` and NEVER to `publishedAt`.
 
 @Test func publishedFieldsRoutesAMinutePreciseDateToPublishedAtOnly() {
-    let fields = SparkleAppcastSource.publishedFields(from: "Wed, 24 Jun 2026 17:07:24 +0000")
+    let fields = ReleaseDate.publishedFields(from: "Wed, 24 Jun 2026 17:07:24 +0000")
     #expect(fields.publishedAt == Date(timeIntervalSince1970: 1_782_320_844))
     #expect(fields.vendorDay == nil)
 }
 
 @Test func publishedFieldsRoutesADayOnlyDateToVendorDayNeverPublishedAt() {
     // The exact shape Eudic's appcast ships.
-    let fields = SparkleAppcastSource.publishedFields(from: "2026-08-31")
+    let fields = ReleaseDate.publishedFields(from: "2026-08-31")
     #expect(
         fields.publishedAt == nil,
         "a day-only pubDate must never reach publishedAt — that would fabricate a midnight the vendor never stated")
@@ -36,10 +40,10 @@ import Foundation
 }
 
 @Test func publishedFieldsIsNilForUnparseableOrMissingDates() {
-    let missing = SparkleAppcastSource.publishedFields(from: nil)
+    let missing = ReleaseDate.publishedFields(from: nil)
     #expect(missing.publishedAt == nil)
     #expect(missing.vendorDay == nil)
-    let garbage = SparkleAppcastSource.publishedFields(from: "not a date")
+    let garbage = ReleaseDate.publishedFields(from: "not a date")
     #expect(garbage.publishedAt == nil)
     #expect(garbage.vendorDay == nil)
 }
@@ -104,7 +108,7 @@ private let mixedPrecisionFeed = """
 /// (`fields.publishedAt == nil` fails) while every other test in this file still
 /// compiles — i.e. the assertion is load-bearing, not decorative.
 @Test func dayPrecisionNeverReachesPublishedAtEvenWhenItIsTheOnlyDateOnTheRelease() {
-    let fields = SparkleAppcastSource.publishedFields(from: "2026-01-01")
+    let fields = ReleaseDate.publishedFields(from: "2026-01-01")
     #expect(fields.publishedAt == nil)
     #expect(fields.vendorDay != nil)
 }


### PR DESCRIPTION
Closes #300

## What changed

#239/#273 gave `ReleaseDate` a two-tier precision split (`parseWithPrecision` → `.minute`/`.day`, with `.day` routed to a new `vendorDay` field instead of a fabricated midnight `publishedAt`), but only wired one of five sources — `SparkleAppcastSource` — to it. This PR closes both tails #300 named:

1. **Moved the day/minute routing into `ReleaseDate.publishedFields(from:)`.** It used to live only on `SparkleAppcastSource` as `publishedFields(from:)` (a private-ish static duplicating the exact same switch). Deleted that copy; `SparkleAppcastSource.releaseHistory` and the `best` item now call `ReleaseDate.publishedFields` directly, same as the other four.
2. **Converted `AlcoveUpdateSource`, `ElectronManifestSource`, `GitHubReleasesSource` (both its history-backfill loop and its "best release" resolution), and `VendorProbeSource`** from `ReleaseDate.parse` to `ReleaseDate.publishedFields`, threading the new `vendorDay` field through to `RemoteVersion`/`ReleaseHistoryEntry` at each call site.
3. **`ReleaseDate.parse` is no longer `public`.** After the conversion it has zero production callers (confirmed by grep across `DuoUpdaterCore`, `CLI`, `App`). Kept `internal` rather than deleted, because `ReleaseDateTests.swift` still exercises the numeric-window/RFC822/ISO8601-formatter logic it shares with `parseWithPrecision` — deleting it would have meant rewriting ~30 existing regression assertions for no additional coverage, since both functions share the same private formatters. This resolves the issue's "尾巴一": since `parse` has no caller in production, its bare-`yyyyMMdd`-returns-`Date` exception can no longer reach `publishedAt` anywhere — the exception becomes moot rather than fixed in place.
4. **Added `ReleaseDateParseScopeTests`**, a source scan asserting no `.swift` file under `DuoUpdaterCore/Sources` other than `Releases/ReleaseDate.swift` itself calls `ReleaseDate.parse(` directly. This is what makes "day precision never reaches `publishedAt`" hold unconditionally rather than by convention: `parse` being `internal` blocks a `CLI`/`App` caller by the compiler, but `DuoUpdaterCore` is one target, so nothing in the language stops a *new* file inside it from bypassing `publishedFields`.
5. **Updated the Kiro and Shottr `VendorProbeRecipe` comments** (the two recipes #239 explicitly held back) to say the day-tier mechanism is now wired up in `VendorProbeSource` — adding `publishedAtPattern` to those two recipes is explicitly **out of scope** here, per the repo's fragile-recipe rule (needs the real response reproduced and `duo verify` run against it, not just a mechanism change).

### A judgment call worth flagging: `GitHubReleasesSource`'s history loop

The brief asked me to check whether `.day` is *usable* at `GitHubReleasesSource.swift`'s history-backfill guard (previously `guard ... let date = ReleaseDate.parse(...) else { return nil }`), since its purpose looked different from the other four call sites at first glance. On inspection it isn't different: it only builds `ReleaseHistoryEntry` values for the release timeline backfill, exactly like `SparkleAppcastSource.releaseHistory` already does — and `ReleaseHistoryEntry`'s own doc says "`publishedAt` and `vendorDay` are the same two tiers... exactly one is set for an entry that came from a source that could date the release at all". So I routed `.day` to `vendorDay` here too, same as Sparkle's history. Net effect: a GitHub release with only a bare calendar day now gets a history entry (as `vendorDay`) instead of being silently dropped — previously the guard's `let date = ReleaseDate.parse(...)` requirement meant no date at all → no entry. GitHub's `published_at` is essentially always a full ISO8601 timestamp in practice, so this is unlikely to change real behavior, but it's the same "no honest place for it" defect the rest of the issue is about, and the fix generalizes cleanly.

## Issue check (#300)

**What #300 got right:** both tails it named were real — `parse("20260831")` did still return a `Date` (never fixed, this PR makes it moot instead), and the other four sources really were bypassing `vendorDay` entirely. The suggested two-step plan (decide `parse`'s fate, then convert the four sources) is what this PR does, plus the fifth source's own internal duplicate.

**What it didn't spell out** (found before making changes, as this repo's rules require):
- It undersold `GitHubReleasesSource`: there are **two** `ReleaseDate.parse` call sites in that file, not one — a `guard`-gated history-backfill loop in addition to the "best release" resolution the issue's framing implies. Missing the first one would have left the release-timeline backfill silently dropping day-only GitHub releases even after "fixing" the source.
- It says "#239 复审量过：整个语料里裸 `yyyyMMdd` 出现 0 次" for the general corpus, but that's about fixtures/tests, not live feeds — I did not sweep production feeds for this shape either (see Not verified below); the issue's own "目前不是活的...但话不能说满" caveat still applies.

## Verification

```
cd DuoUpdaterCore && swift build      # clean (pre-existing nonisolated(unsafe) warnings only)
cd DuoUpdaterCore && swift test       # 1965 tests, 155 suites — passed, 1 known issue
                                       # (GitHubReleaseRuleTests.swift:754, pre-existing/network-flaky,
                                       # same one PR #273 called out as unrelated)
cd CLI && swift build                 # clean
cd CLI && swift test                  # 185 tests, 24 suites — all passed
python3 scripts/check_staged_version_use.py   # OK, 211 files
python3 scripts/check_app_audits.py           # OK, 91 docs
python3 scripts/test_appcast_edit.py          # OK, 45 tests
python3 scripts/test_check_staged_version_use.py  # OK, 7 tests
```

**Mutation test** on the new `ReleaseDateParseScopeTests` guard: temporarily changed `AlcoveUpdateSource.swift` to call `ReleaseDate.parse(...)` directly again (simulating exactly the regression this PR fixes for one of the five sources). The guard test went red, correctly naming `Sources/AlcoveUpdateSource.swift` as the offender. Reverted and confirmed green again.

**Not verified / explicitly out of scope:**
- Did not run `duo verify` against any real endpoint — this PR touches parsing/routing logic only, no recipe patterns changed (Kiro/Shottr's `publishedAtPattern` additions, the actual user-visible payoff, are deliberately left for a follow-up per the brief).
- Did not sweep live vendor feeds for a bare-8-digit `yyyyMMdd` date shape actually occurring in production; the "0 occurrences in the test corpus" claim (mine and #300's) is about fixtures, not a live-feed sweep.
- `make gallery` not run — no `App/Sources` changes in this PR.

