### PR TITLE
Localize the changelog blocked-notice pane (#299)

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -19752,6 +19752,293 @@
           }
         }
       }
+    },
+    "Can’t show this page safely": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Seite kann nicht sicher angezeigt werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede mostrar esta página de forma segura"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d'afficher cette page en toute sécurité"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このページを安全に表示できません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Невозможно безопасно показать эту страницу"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法安全显示此页面"
+          }
+        }
+      }
+    },
+    "This link isn’t secure (it doesn’t use https).": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Link ist nicht sicher (verwendet kein https)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este enlace no es seguro (no usa https)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce lien n'est pas sécurisé (il n'utilise pas https)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このリンクは安全ではありません（httpsを使用していません）。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта ссылка небезопасна (не использует https)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此链接不安全（未使用 https）。"
+          }
+        }
+      }
+    },
+    "This link includes a login that can’t be shown safely.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Link enthält Anmeldedaten, die nicht sicher angezeigt werden können."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este enlace incluye credenciales que no se pueden mostrar de forma segura."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce lien contient des identifiants qui ne peuvent pas être affichés en toute sécurité."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このリンクにはログイン情報が含まれており、安全に表示できません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта ссылка содержит учётные данные, которые нельзя показать безопасно."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此链接包含登录信息，无法安全显示。"
+          }
+        }
+      }
+    },
+    "This link has no address to load.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Link hat keine Adresse zum Laden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este enlace no tiene ninguna dirección que cargar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce lien n'a pas d'adresse à charger."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このリンクには読み込むアドレスがありません。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У этой ссылки нет адреса для загрузки."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此链接没有可加载的地址。"
+          }
+        }
+      }
+    },
+    "This link points at a raw network address instead of a name.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Link verweist auf eine rohe Netzwerkadresse statt auf einen Namen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este enlace apunta a una dirección de red sin procesar en lugar de un nombre."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce lien pointe vers une adresse réseau brute plutôt qu'un nom."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このリンクは、名前ではなく生のネットワークアドレスを指しています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта ссылка указывает на необработанный сетевой адрес, а не на имя."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此链接指向的是原始网络地址，而不是名称。"
+          }
+        }
+      }
+    },
+    "This link points at a local-only name.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Link verweist auf einen lokal reservierten Namen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este enlace apunta a un nombre exclusivamente local."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce lien pointe vers un nom réservé au réseau local."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このリンクはローカル専用の名前を指しています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта ссылка указывает на локальное имя."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此链接指向一个仅限本地使用的名称。"
+          }
+        }
+      }
+    },
+    "This link uses a non-standard port.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Link verwendet einen nicht standardmäßigen Port."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este enlace usa un puerto no estándar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce lien utilise un port non standard."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このリンクは標準以外のポートを使用しています。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта ссылка использует нестандартный порт."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此链接使用了非标准端口。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1988,7 +1988,14 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
 
         if let url = navigationAction.request.url,
            url.scheme?.lowercased() == "http" {
-            reject(webView, url: url, reason: "cleartext http connection", isMainFrame: isMainFrame)
+            // Same category `ChangelogURLPolicy.rejectionReason` would report for
+            // this URL (`.notHTTPS`) — reused rather than given its own case so
+            // there is exactly one place that owns the log/display text for "this
+            // navigation isn't https". This check exists as its own branch
+            // because it is broader than the policy check below: it also catches
+            // a sub-frame loading http (mixed content), where `isMainFrame` would
+            // otherwise let it through.
+            reject(webView, url: url, reason: .notHTTPS, isMainFrame: isMainFrame)
             decisionHandler(.cancel); return
         }
 
@@ -2029,8 +2036,8 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
     /// `.error`, not `.info`: per `Log`'s own doc comment, `.info` is memory-only
     /// for a third-party subsystem and would be gone by the time anyone went
     /// looking for why a changelog pane went dark.
-    private func reject(_ webView: WKWebView, url: URL, reason: String, isMainFrame: Bool) {
-        Log.changelog.error("webview navigation blocked (\(reason, privacy: .public)) mainFrame=\(isMainFrame ? "yes" : "no", privacy: .public) url=\(Redactor.url(url), privacy: .public) origin=\(self.originHost ?? "?", privacy: .public)")
+    private func reject(_ webView: WKWebView, url: URL, reason: ChangelogURLPolicy.RejectionReason, isMainFrame: Bool) {
+        Log.changelog.error("webview navigation blocked (\(reason.logToken, privacy: .public)) mainFrame=\(isMainFrame ? "yes" : "no", privacy: .public) url=\(Redactor.url(url), privacy: .public) origin=\(self.originHost ?? "?", privacy: .public)")
         guard isMainFrame, !hasCommittedFirstLoad else { return }
         showBlockedNotice(webView, reason: reason)
     }
@@ -2043,19 +2050,30 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
     /// here back to that SwiftUI state without threading a binding through the
     /// cache for every call site that can hand out a cached view. Loading a small
     /// HTML page directly into the same pane keeps the fix self-contained to this
-    /// type, at the cost of a hand-rolled (not SwiftUI) message; `reason` is one
-    /// of `WebGuardian`'s or `ChangelogURLPolicy`'s own fixed strings, never
-    /// interpolated URL content, so the light escaping below is defence in depth
-    /// rather than the only thing standing between this and a vendor page.
+    /// type, at the cost of a hand-rolled (not SwiftUI) message.
     ///
-    /// The title is a plain English literal, not `String(localized:)` — it lives
-    /// inside an HTML string handed to `WKWebView`, outside whatever the
-    /// `Localizable.xcstrings` extraction step scans, and this fix does not touch
-    /// that pipeline. Known gap, not an oversight.
-    private func showBlockedNotice(_ webView: WKWebView, reason: String) {
-        let escaped = reason
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
+    /// #299: both strings below now go through `String(localized:)` — the title
+    /// here, and `reason.localizedDescription` in `ChangelogURLPolicy`. Neither
+    /// ever carries interpolated URL content (see `RejectionReason`'s doc
+    /// comment), but a *translation* of a fixed category can still contain `&`,
+    /// `<`, `>`, or a quote mark — French and German punctuation both do — so the
+    /// escaping below now covers all five HTML-significant characters, not just
+    /// the two an English-only literal happened to need.
+    ///
+    /// `check_localizable_keys.py` cannot see either string: it diffs
+    /// `Localizable.xcstrings` against the keys `SWIFT_EMIT_LOC_STRINGS` recorded
+    /// for `String(localized:)` call sites, and both calls here are ordinary call
+    /// sites like any other — so this is not a blind spot in that checker, it
+    /// would have caught the original English literal too had it gone through
+    /// `String(localized:)` in the first place. The actual blind spot was this
+    /// function loading a *hand-built HTML string* instead of calling
+    /// `String(localized:)` at all; nothing short of grepping `WKWebView`-bound
+    /// strings for the absence of `String(localized:)` would catch a *future*
+    /// literal slipped in here the same way, and that is a much noisier check to
+    /// add than the value of catching one call site.
+    private func showBlockedNotice(_ webView: WKWebView, reason: ChangelogURLPolicy.RejectionReason) {
+        let title = ChangelogURLPolicy.htmlEscaped(String(localized: "Can’t show this page safely"))
+        let body = ChangelogURLPolicy.htmlEscaped(reason.localizedDescription)
         let html = """
         <!doctype html><html><head><meta charset="utf-8">
         <style>
@@ -2070,8 +2088,8 @@ private final class WebGuardian: NSObject, WKNavigationDelegate {
           .title { color: CanvasText; font-weight: 600; margin-bottom: 6px; }
         </style></head>
         <body><div class="box">
-          <div class="title">Can’t show this page safely</div>
-          <div>\(escaped)</div>
+          <div class="title">\(title)</div>
+          <div>\(body)</div>
         </div></body></html>
         """
         webView.loadHTMLString(html, baseURL: nil)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogURLPolicy.swift
@@ -40,20 +40,42 @@ public enum ChangelogURLPolicy {
     /// categorical rather than including the attacker/vendor-controlled host or
     /// port: those already reach the log line through the caller's own URL
     /// argument (safe there because it goes through a redactor, not straight to
-    /// on-screen HTML), and keeping this string free of interpolated URL content
-    /// means a caller can put it on screen without having to re-derive an
-    /// escaping rule for it.
+    /// on-screen HTML). #299: an earlier version of this returned that category
+    /// as a bare `String`, and a caller put it straight on screen — inside a
+    /// signed app that otherwise localizes everything, that string was the one
+    /// English literal `check_localizable_keys.py` cannot see, because it never
+    /// goes through `String(localized:)`. Returning an enum instead of a string
+    /// forces every caller to *choose* a representation rather than reuse
+    /// whichever one first came to hand: `RejectionReason.logToken` for a `Log.`
+    /// line (fixed English, so it stays grep-able across reports) and
+    /// `RejectionReason.localizedDescription` for anything shown to the user.
+    /// Neither carries the host or port that triggered the rejection — that
+    /// property now lives in the type instead of a comment asking callers to
+    /// preserve it by hand.
     ///
     /// Checked in the same order as `isDisplayable`, so the reason reported is
     /// always the same guard that actually rejected the URL.
-    public static func rejectionReason(_ url: URL) -> String? {
-        guard url.scheme?.lowercased() == "https" else { return "not an https URL" }
-        guard url.user == nil, url.password == nil else { return "URL carries credentials" }
-        guard let host = url.host, !host.isEmpty else { return "URL has no host" }
-        guard !isIPLiteral(host) else { return "host is an IP literal, not a name" }
-        guard !isLocalHostname(host) else { return "host is a reserved local-only name" }
-        if let port = url.port, port != 443 { return "non-standard port" }
+    public static func rejectionReason(_ url: URL) -> RejectionReason? {
+        guard url.scheme?.lowercased() == "https" else { return .notHTTPS }
+        guard url.user == nil, url.password == nil else { return .hasCredentials }
+        guard let host = url.host, !host.isEmpty else { return .noHost }
+        guard !isIPLiteral(host) else { return .ipLiteral }
+        guard !isLocalHostname(host) else { return .reservedLocalName }
+        if let port = url.port, port != 443 { return .nonStandardPort }
         return nil
+    }
+
+    /// Which structural guard rejected a changelog URL. See `rejectionReason`
+    /// for why this is a closed set of categories rather than a `String`: no
+    /// case here may ever be given an associated value carrying the URL, host,
+    /// or port that triggered it — that is the whole point of the type.
+    public enum RejectionReason: Sendable, Equatable {
+        case notHTTPS
+        case hasCredentials
+        case noHost
+        case ipLiteral
+        case reservedLocalName
+        case nonStandardPort
     }
 
     /// `url` when it passes, `nil` when it does not — so a caller can fall through
@@ -125,5 +147,69 @@ public enum ChangelogURLPolicy {
         let bare = withoutRootLabel.lowercased()
         return bare == "localhost" || bare.hasSuffix(".localhost")
             || bare == "local" || bare.hasSuffix(".local")
+    }
+}
+
+extension ChangelogURLPolicy.RejectionReason {
+
+    /// Fixed English text for a `Log.` line. Never localized — a log line is
+    /// read by whoever has the crash report or the console output open next to
+    /// the source, not by the person running the app, and translating it would
+    /// break grepping and cross-report comparison (see `Log`'s own doc comment,
+    /// and CLAUDE.md). Kept identical to what `rejectionReason` used to return
+    /// directly, so an existing log search for these phrases still matches.
+    public var logToken: String {
+        switch self {
+        case .notHTTPS: return "not an https URL"
+        case .hasCredentials: return "URL carries credentials"
+        case .noHost: return "URL has no host"
+        case .ipLiteral: return "host is an IP literal, not a name"
+        case .reservedLocalName: return "host is a reserved local-only name"
+        case .nonStandardPort: return "non-standard port"
+        }
+    }
+
+    /// Localized text for the on-screen blocked-notice pane
+    /// (`WorkbenchWindowView`'s `WebGuardian.showBlockedNotice`). Translates
+    /// only these six fixed categories, never the URL, host, or port that
+    /// triggered the rejection — the caller still has to HTML-escape whatever
+    /// this returns before handing it to a web view, since a translation can
+    /// legitimately contain `&`, `<`, `>`, or a quote mark.
+    public var localizedDescription: String {
+        switch self {
+        case .notHTTPS:
+            return String(localized: "This link isn’t secure (it doesn’t use https).")
+        case .hasCredentials:
+            return String(localized: "This link includes a login that can’t be shown safely.")
+        case .noHost:
+            return String(localized: "This link has no address to load.")
+        case .ipLiteral:
+            return String(localized: "This link points at a raw network address instead of a name.")
+        case .reservedLocalName:
+            return String(localized: "This link points at a local-only name.")
+        case .nonStandardPort:
+            return String(localized: "This link uses a non-standard port.")
+        }
+    }
+}
+
+extension ChangelogURLPolicy {
+
+    /// Escapes the five characters that are significant inside HTML text
+    /// content, for embedding `RejectionReason.localizedDescription` (or the
+    /// blocked-notice pane's title) into the hand-built HTML string
+    /// `WorkbenchWindowView`'s `WebGuardian` loads in place of a blank
+    /// changelog pane. `&` is replaced first so it does not double-escape the
+    /// entities this function itself just inserted. Needed because these are
+    /// *translated* strings: a fixed English category never contained a quote
+    /// mark, but German and French punctuation routinely do, and this pane is
+    /// the one place in the app that writes a string into raw HTML rather than
+    /// handing it to a `Text` view that escapes on its own.
+    public static func htmlEscaped(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
@@ -70,6 +70,100 @@ struct ChangelogURLPolicyTests {
         #expect(ChangelogURLPolicy.rejectionReason(url("https://example.com:8443/notes")) != nil)
     }
 
+    /// #299: `rejectionReason` used to return a bare `String` that a caller put
+    /// straight on screen — the one user-visible literal
+    /// `check_localizable_keys.py` cannot see, because it never goes through
+    /// `String(localized:)`. This pins the *specific* case each guard now
+    /// reports, not just non-nil, so a change that reorders `RejectionReason`'s
+    /// cases or has two guards collapse onto the same one is caught here.
+    @Test func rejectionReasonReportsTheSpecificCategory() {
+        #expect(ChangelogURLPolicy.rejectionReason(url("http://example.com/notes")) == .notHTTPS)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://user:pw@example.com/notes")) == .hasCredentials)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://192.168.1.10/notes")) == .ipLiteral)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://local/notes")) == .reservedLocalName)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://macbook.local/notes")) == .reservedLocalName)
+        #expect(ChangelogURLPolicy.rejectionReason(url("https://example.com:8443/notes")) == .nonStandardPort)
+    }
+
+    /// `logToken` feeds a `Log.` line (CLAUDE.md: those stay English and stable
+    /// so reports stay grep-able), `localizedDescription` feeds the on-screen
+    /// blocked-notice pane. They must never be the same representation, or one
+    /// audience is getting the wrong one — and every case needs both, worded
+    /// distinctly, with nothing interpolated into either.
+    @Test func everyReasonHasADistinctLogTokenAndLocalizedDescription() {
+        let allCases: [ChangelogURLPolicy.RejectionReason] = [
+            .notHTTPS, .hasCredentials, .noHost, .ipLiteral, .reservedLocalName, .nonStandardPort,
+        ]
+        var seenLogTokens = Set<String>()
+        var seenDescriptions = Set<String>()
+        for reason in allCases {
+            let token = reason.logToken
+            let description = reason.localizedDescription
+            #expect(!token.isEmpty)
+            #expect(!description.isEmpty)
+            #expect(token != description, "\(reason) should word its log line and its on-screen text differently")
+            #expect(seenLogTokens.insert(token).inserted, "duplicate logToken: \(token)")
+            #expect(seenDescriptions.insert(description).inserted, "duplicate localizedDescription: \(description)")
+        }
+    }
+
+    /// `logToken` is read out of shipped log lines and compared against past
+    /// reports — see CLAUDE.md's rule that `Log.` text must stay stable. This
+    /// pins the exact strings `rejectionReason` used to return directly, before
+    /// #299 turned it into an enum, so a future refactor cannot silently reword
+    /// them.
+    @Test func logTokenTextIsUnchangedFromTheOriginalStrings() {
+        #expect(ChangelogURLPolicy.RejectionReason.notHTTPS.logToken == "not an https URL")
+        #expect(ChangelogURLPolicy.RejectionReason.hasCredentials.logToken == "URL carries credentials")
+        #expect(ChangelogURLPolicy.RejectionReason.noHost.logToken == "URL has no host")
+        #expect(ChangelogURLPolicy.RejectionReason.ipLiteral.logToken == "host is an IP literal, not a name")
+        #expect(ChangelogURLPolicy.RejectionReason.reservedLocalName.logToken == "host is a reserved local-only name")
+        #expect(ChangelogURLPolicy.RejectionReason.nonStandardPort.logToken == "non-standard port")
+    }
+
+    /// The whole point of `RejectionReason` being a closed enum instead of the
+    /// `String` it replaced is that no case can carry the attacker/vendor-
+    /// controlled host or port that triggered it. This is the regression test
+    /// for that property: feed hosts and ports designed to show up if anything
+    /// ever leaked into the text, on every reason `rejectionReason` can return
+    /// for a URL that actually carries one.
+    @Test func neitherRepresentationEverInterpolatesTheURL() {
+        let needle = "tell-tale-host-should-never-appear"
+        let cases: [(URL, ChangelogURLPolicy.RejectionReason)] = [
+            (url("http://\(needle).example/notes"), .notHTTPS),
+            (url("https://user:\(needle)@example.com/notes"), .hasCredentials),
+            (url("https://192.168.1.10/notes"), .ipLiteral),
+            (url("https://\(needle).local/notes"), .reservedLocalName),
+            (url("https://example.com:6667/notes"), .nonStandardPort),
+        ]
+        for (u, expected) in cases {
+            let reason = ChangelogURLPolicy.rejectionReason(u)
+            #expect(reason == expected)
+            #expect(reason?.logToken.contains(needle) != true)
+            #expect(reason?.localizedDescription.contains(needle) != true)
+            #expect(reason?.logToken.contains("6667") != true)
+            #expect(reason?.localizedDescription.contains("6667") != true)
+        }
+    }
+
+    /// #299: the blocked-notice pane writes a *translated* string into raw
+    /// HTML — a fixed English category never needed more than `&`/`<` escaped,
+    /// but a translation of it can legitimately contain any of the five
+    /// characters below (French/German quoting conventions, for one). Mutating
+    /// any single replacement out of `htmlEscaped` must turn one of these red.
+    @Test func htmlEscapedCoversAllFiveSignificantCharacters() {
+        #expect(ChangelogURLPolicy.htmlEscaped("&") == "&amp;")
+        #expect(ChangelogURLPolicy.htmlEscaped("<") == "&lt;")
+        #expect(ChangelogURLPolicy.htmlEscaped(">") == "&gt;")
+        #expect(ChangelogURLPolicy.htmlEscaped("\"") == "&quot;")
+        #expect(ChangelogURLPolicy.htmlEscaped("'") == "&#39;")
+        // Ordering matters: escaping `&` first must not double-escape the
+        // entities this function itself just inserted.
+        #expect(ChangelogURLPolicy.htmlEscaped("<a href=\"x\">it's & done</a>")
+                == "&lt;a href=&quot;x&quot;&gt;it&#39;s &amp; done&lt;/a&gt;")
+        #expect(ChangelogURLPolicy.htmlEscaped("plain text") == "plain text")
+    }
+
     @Test func localWordsInsideOrdinaryDomainsStillPass() {
         for s in [
             "https://localhost.example.com/notes",


### PR DESCRIPTION
Closes #299.

## 改了什么

#298 给「changelog 导航被拒」加了一个可见说明页，`ChangelogURLPolicy.rejectionReason(_:) -> String?` 和 `WebGuardian.showBlockedNotice` 里的标题都是英文字面量，直接拼进 `WKWebView.loadHTMLString` 的 HTML 里，绕开了 `String(localized:)`，因此也绕开了 `check_localizable_keys.py`。

- `ChangelogURLPolicy.rejectionReason` 改为返回一个新的 `RejectionReason` 枚举（6 个 case：`.notHTTPS` / `.hasCredentials` / `.noHost` / `.ipLiteral` / `.reservedLocalName` / `.nonStandardPort`），不再返回 `String`。
- 枚举上挂两个representation，各司其职：
  - `logToken`：固定英文，喂 `Log.` 行，文字与原来 `rejectionReason` 直接返回的字符串逐字相同，日志检索不受影响。
  - `localizedDescription`：`String(localized:)`，喂屏幕上的说明面板。
  - 两者都不带插值——不含触发拒绝的 host/port/URL，这条安全性质现在由类型强制，不再只是注释里的口头约定。
- `showBlockedNotice` 的标题也走 `String(localized:)`；HTML 转义从原来只转 `&`/`<` 两个字符，扩到 `&` `<` `>` `"` `'` 五个——原来的英文字面量从不含引号，但翻译文本会（法语/德语标点里很常见）。转义逻辑上移到 `ChangelogURLPolicy.htmlEscaped(_:)`（Core），这样能在 `swift test` 里测到；`App/Sources` 没有测试 target，原来那份私有实现没人执行。
- 顺带处理了 issue 没提到的一个同类问题：`WebGuardian` 自己还有一条独立分支专门拦截 `http://`（不止主 frame，混合内容的子 frame 也拦，这是它为什么要独立于 `ChangelogURLPolicy` 那条 main-frame-only 检查存在），原来传的是另一个硬编码英文字面量 `"cleartext http connection"`，同样会被塞进同一个 `showBlockedNotice`。这条改为复用 `.notHTTPS`（对这个 URL 来说是同一个分类，只是检查时机更早、覆盖面更广），不再单独维护一份未本地化文案。

## issue 核实

issue 描述准确，建议也基本照单全收了。核实到的补充点：

- issue 只点名了「标题 + `rejectionReason` 返回的分类原因」，**没提到** `WebGuardian` 自己的 `"cleartext http connection"` 字面量——这条同样会走到 `showBlockedNotice`、同样绕过检查器。上面已经一并修了（复用 `.notHTTPS`，见上）。这是我在读代码时发现的，不是 issue 本身写漏的大方向问题，但如果只按 issue 字面量去改，这条会被漏掉。
- issue 说"⚠️ `rejectionReason` 现在返回的是分类常量、零插值……本地化时别破坏它"——这条完全属实，而且是这次改动里我认为风险最高的一点，所以专门写了 `neitherRepresentationEverInterpolatesTheURL` 这条测试，拿一个 tell-tale 的 host/port 喂给每个能触发的 case，断言它不会出现在 `logToken` 或 `localizedDescription` 里。
- issue 最后一条问 `check_localizable_keys.py` 能不能覆盖这类"用户可见但不在目录里"的字符串——**我的判断是：结构上不建议改检查器**。它比对的是 `SWIFT_EMIT_LOC_STRINGS` 记录下来的、`String(localized:)` 调用点产生的 key 集合；这次两个字面量能绕开它，根本原因不是检查器有盲区，而是它们从来没有调用 `String(localized:)`——如果一开始就调用了（哪怕拼进 HTML 字符串里），检查器本来就会抓到。真正的盲区是"这个函数在手搓 HTML 字符串，而不是走 `String(localized:)`"这件事本身；要在检查器层面堵住"以后又有人在这里塞一个没走 `String(localized:)` 的字面量"，需要专门去抓"喂给 `WKWebView` 的字符串里有没有不经过 `String(localized:)` 的字面量"，这是一个噪音远大于收益的检查（`showBlockedNotice` 这种手搓 HTML 的地方在代码库里就这一处）。已经在 `showBlockedNotice` 的文档注释里把这条判断写清楚了，没有去改检查器本身。

## 验证

```
cd DuoUpdaterCore && swift test --filter ChangelogURLPolicyTests   # 23 tests passed
cd DuoUpdaterCore && swift test                                     # 1969 tests, 154 suites, 0 failures, 1 known issue
cd CLI && swift build                                                # Build complete
cd CLI && swift test --filter Changelog                             # 21 tests passed
python3 scripts/check_staged_version_use.py                         # ✓ 通过
export DUO_TEAM_ID=RS59HDH7Y3 && cd App && xcodegen generate
xcodebuild -project App/DuoUpdater.xcodeproj -scheme DuoUpdater -configuration Debug \
  -derivedDataPath /tmp/duo-dd-299 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
                                                                      # BUILD SUCCEEDED
python3 scripts/check_localizable_keys.py --derived-data /tmp/duo-loc-check-299
  # 改前: ✗ 7 key(s) the source asks for are not in the catalog（复现红，逐条列出这次要加的 7 个 key）
  # 改后: ✓ localizable keys agree — 439 in the catalog, all reachable
```

`check_localizable_keys.py` 用的是 `/tmp/duo-loc-check-299` 而不是脚本默认的 `/tmp/duo-loc-check`——跑的时候撞见另一个 worktree（`.codex/worktrees/94a1`）正占着默认路径的构建锁（`ps` 确认了是别的 `xcodebuild` 进程，不是我自己撞自己），换独立路径避开冲突。

**说明符审计**（`check_localizable_keys.py` 只比 key 不看 value，单独写的一次性脚本）：7 个新 key × 6 种语言 = 42 条，逐条比对 `%@`/`%lld` 等说明符序列——全部为空列表，跟英文源一致（这几句设计上就不带插值）。脚本随 PR 未附带（一次性工具），核对方法已写进 `l10n` commit message。

**变异测试**（新增测试的红/绿）：
- 把 `rejectionReason` 里 `guard !isIPLiteral(host) else { return .ipLiteral }` 改成 `return .reservedLocalName`：`rejectionReasonReportsTheSpecificCategory` 和 `neitherRepresentationEverInterpolatesTheURL` 两条测试红。
- 把 `htmlEscaped` 里对 `'` 的替换删掉：`htmlEscapedCoversAllFiveSignificantCharacters` 红（两处断言失败，含组合字符串那条）。
- 两处改动验证完都已还原，验证过 `swift test --filter ChangelogURLPolicyTests` 恢复全绿。

## 没能验证的

- **7×6 = 42 条翻译本身的准确性未经母语者复核**——只保证了结构正确（specifier 为空、标点风格跟目录里同语言的既有条目大致对齐：德语无变化、法语用半角撇号跟目录里多数条目一致、日语/中文用全角括号和句号跟目录里同类条目一致），文字本身的地道程度是我的翻译，不是已验证结论。
- **实机点击验证（真的触发一次说明面板、肉眼看六种语言渲染)未做**——`App/project.yml` 没有测试 target，这条判断没有自动化覆盖；只做到了 `xcodebuild` 编译通过 + `check_localizable_keys.py` 确认 key 都能命中。CLAUDE.md 里 gallery 相关的四个闸门（`make gallery`）这次没碰到（没有改行状态渲染），未跑 `make gallery`。
- 未跑 `make test`（brief 明确要求不跑，避免和并行的其他 worktree 撞 `/tmp/duo-loc-check` 锁）。
