### PR TITLE
Fix empty WeChat DevTools nightly changelogs

### DIFF
--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -118,13 +118,7 @@ public enum Verify {
         if options.registries.contains(.changelog) {
             // Fall back to the installed copy's version for templated recipes
             // when no version source ran this sweep (`--changelog` on its own).
-            var versions = knownVersions
-            for (key, value) in installed {
-                let bundleID = String(key.dropFirst("vendor:".count).prefix { $0 != ":" })
-                if versions[bundleID] == nil, let marketing = value.marketing {
-                    versions[bundleID] = marketing
-                }
-            }
+            let versions = changelogVersions(known: knownVersions, installed: installed)
             findings += await sweepChangelog(changelog, options: options, versions: versions)
         }
 
@@ -168,6 +162,39 @@ public enum Verify {
                 || ($0.status == .broken && baseline.isReportable($0.recipeID))
                 || ($0.status == .infra && baseline.isInfraReportable($0.recipeID))
         }) ? 1 : 0
+    }
+
+    /// Merge the local-scan fallback into the versions a live source resolved.
+    /// Installed apps are indexed as `vendor:<bundle-id>:<channel>`; keep that
+    /// channel in the changelog key so `--changelog` never templates an RC or
+    /// Nightly URL with the installed Stable version. The bare bundle id remains
+    /// for ordinary single-channel recipes whose `channel` is nil.
+    static func changelogVersions(
+        known: [String: String], installed: [String: InstalledVersion]
+    ) -> [String: String] {
+        var versions = known
+        let prefix = "vendor:"
+        for (key, value) in installed {
+            guard key.hasPrefix(prefix), let marketing = value.marketing else { continue }
+            let channelKey = String(key.dropFirst(prefix.count))
+            if versions[channelKey] == nil { versions[channelKey] = marketing }
+
+            guard let channelSeparator = channelKey.lastIndex(of: ":") else { continue }
+            let bundleID = String(channelKey[..<channelSeparator])
+            if versions[bundleID] == nil { versions[bundleID] = marketing }
+        }
+        return versions
+    }
+
+    /// A channel-scoped recipe may only use that channel's version. Falling back
+    /// to the bare bundle-id value here turns a changelog-only Stable install into
+    /// bogus RC/Nightly requests. Bare keys are exclusively for recipes whose
+    /// channel is nil.
+    static func changelogVersion(
+        for recipe: ChangelogRecipe, versions: [String: String]
+    ) -> String? {
+        guard let channel = recipe.channel else { return versions[recipe.bundleID] }
+        return versions["\(recipe.bundleID):\(channel.rawValue)"]
     }
 
     private static func filtered<T>(
@@ -522,8 +549,7 @@ public enum Verify {
             // Templated recipes need a concrete version to resolve their URL —
             // use the one this run's probe just read, so the sweep checks the
             // page the app would actually open.
-            let version = recipe.channel.flatMap { versions["\(recipe.bundleID):\($0.rawValue)"] }
-                ?? versions[recipe.bundleID]
+            let version = changelogVersion(for: recipe, versions: versions)
             // With no version at all, `resolvedSource` silently falls back to the
             // untemplated `source` — which for these vendors is a generic landing
             // page that has never parsed. Reporting that as breakage would be a

--- a/CLI/Tests/DuoKitTests/ChangelogVersionRoutingTests.swift
+++ b/CLI/Tests/DuoKitTests/ChangelogVersionRoutingTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import DuoUpdaterCore
+
+@testable import DuoKit
+
+@Suite struct ChangelogVersionRoutingTests {
+
+    /// Regression for the issue #191 reproduction command. A changelog-only sweep
+    /// has no freshly probed versions, so its installed fallback must retain the
+    /// release channel instead of trying every templated recipe with one bare version.
+    @Test func installedFallbackKeepsTheReleaseChannel() {
+        let bundleID = "com.tencent.wechatdevtools"
+        let installed = [
+            "vendor:\(bundleID):stable": InstalledVersion(
+                marketing: "2.02.2608060", build: nil, vendorBuild: nil),
+            "vendor:\(bundleID):nightly": InstalledVersion(
+                marketing: "2.02.2609022", build: nil, vendorBuild: nil),
+        ]
+
+        let versions = Verify.changelogVersions(known: [:], installed: installed)
+
+        #expect(versions["\(bundleID):stable"] == "2.02.2608060")
+        #expect(versions["\(bundleID):nightly"] == "2.02.2609022")
+        #expect(Set(versions.values).contains("2.02.2608060"))
+        #expect(Set(versions.values).contains("2.02.2609022"))
+    }
+
+    /// A bare Stable fallback must not be reused for sibling channel recipes.
+    /// This is what made the issue's `--changelog` reproduction command fabricate
+    /// 404s for the RC and Nightly URL templates on a machine with Stable installed.
+    @Test func channelRecipeNeverFallsBackToABareSiblingVersion() throws {
+        let bundleID = "com.tencent.wechatdevtools"
+        let recipes = ChangelogRecipeRegistry.recipes.filter { $0.bundleID == bundleID }
+        let versions = [
+            bundleID: "2.02.2608060",
+            "\(bundleID):stable": "2.02.2608060",
+        ]
+
+        for recipe in recipes {
+            let version = Verify.changelogVersion(for: recipe, versions: versions)
+            if recipe.channel == .stable {
+                #expect(version == "2.02.2608060")
+            } else {
+                #expect(version == nil)
+            }
+        }
+    }
+
+    /// Live probe answers are newer evidence than the local scan and must not be
+    /// overwritten when a full sweep has both.
+    @Test func knownChannelVersionWinsOverInstalledFallback() {
+        let bundleID = "com.tencent.wechatdevtools"
+        let key = "\(bundleID):nightly"
+        let versions = Verify.changelogVersions(
+            known: [key: "2.02.2609032"],
+            installed: [
+                "vendor:\(key)": InstalledVersion(
+                    marketing: "2.02.2609022", build: nil, vendorBuild: nil),
+            ])
+
+        #expect(versions[key] == "2.02.2609032")
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -210,10 +210,12 @@ public enum StructuredChangelogDecoder {
     private struct WeChatDevToolsLog: Decodable {
         let version: String?
         let updateTime: String?
+        let summary: String?
         let categories: [WeChatDevToolsCategory]?
         enum CodingKeys: String, CodingKey {
             case version
             case updateTime = "update_time"
+            case summary = "desc"
             case categories
         }
     }
@@ -244,6 +246,16 @@ public enum StructuredChangelogDecoder {
                 blocks.append(.note(line))
                 items.append(line)
             }
+        }
+        // Nightly builds can be published before Tencent has any categorized change
+        // lines ready (`categories: []`). The same document still carries its channel
+        // description in `desc`; keep that truthful vendor-authored context as the
+        // release's fallback instead of treating a valid per-version document as a
+        // broken recipe. Detailed categories continue to win whenever they exist.
+        if blocks.isEmpty,
+           let summary = log.summary.flatMap({ bulletItems(from: $0).first }) {
+            blocks.append(.note(summary))
+            items.append(summary)
         }
         guard !blocks.isEmpty else { return nil }
         return Changelog(entries: [.init(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatDevToolsTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WeChatDevToolsTests.swift
@@ -112,6 +112,25 @@ private let wechatDevToolsRCLogFixture = """
 }
 """
 
+/// The real `logs/nightly_v2.02.2609022.json`, captured 2026-09-03. Tencent
+/// published the build with no categorized change lines; the per-version document
+/// still carries its version, date, and Nightly description.
+private let wechatDevToolsNightlyEmptyCategoriesFixture = """
+{
+  "version": "2.02.2609022",
+  "update_time": "2026-09-02",
+  "tags": [
+    {
+      "text": "Nightly Electron Build",
+      "text_en": "Nightly Electron Build",
+      "color": "red"
+    }
+  ],
+  "desc": "日常构建版本, 2.02.2603212 开始基于 Electron 36.6(对应 Chromium 136)， 2.01.2602282 且更早之前版本是基于 NW.js 0.54.1（Chromium 93)，用于尽快修复缺陷和敏捷上线小的特性；开发自测验证，稳定性欠佳",
+  "categories": []
+}
+"""
+
 /// The `package.json` each build runs on, as captured from four real bundles on
 /// 2026-08-18 — the installed 2.01.2510290 (NW.js, `Contents/Resources/package.nw/`)
 /// and the 2.02 RC / Stable / Nightly pkg payloads (Electron,
@@ -310,6 +329,29 @@ struct WeChatDevToolsChangelogTests {
             "切换 appid 相关反馈问题",
             "showToast 设置自定义图片时无法显示",
             "修复 第三方 AI 评测 `wx.login`",
+        ])
+    }
+
+    /// A valid Nightly document is not a broken recipe merely because Tencent has
+    /// not attached categorized changes to that build. Derive the decoder settings
+    /// from the registered Nightly recipe and surface the vendor's own description.
+    @Test func fallsBackToDescriptionWhenCategoriesAreEmpty() throws {
+        let recipe = try #require(ChangelogRecipeRegistry.recipe(
+            forBundleID: AppScanner.weChatDevToolsBundleID, channel: .nightly))
+        let format = try #require(recipe.structuredFormat)
+        let changelog = try #require(StructuredChangelogDecoder.decode(
+            wechatDevToolsNightlyEmptyCategoriesFixture,
+            format: format,
+            channel: recipe.channel,
+            maxEntries: recipe.maxEntries))
+        let entry = try #require(changelog.entries.first)
+        #expect(changelog.entries.count == 1)
+        #expect(entry.version == "2.02.2609022")
+        #expect(entry.date == "2026-09-02")
+        #expect(entry.items == [
+            "日常构建版本, 2.02.2603212 开始基于 Electron 36.6(对应 Chromium 136)， "
+                + "2.01.2602282 且更早之前版本是基于 NW.js 0.54.1（Chromium 93)，"
+                + "用于尽快修复缺陷和敏捷上线小的特性；开发自测验证，稳定性欠佳",
         ])
     }
 


### PR DESCRIPTION
## Summary

- treat WeChat DevTools per-version payloads with empty categories as valid by surfacing the vendor-provided description
- preserve release channels when changelog-only verification falls back to installed versions
- prevent Stable versions from being substituted into RC or Nightly changelog URLs
- add captured-response and channel-routing regression coverage

## Verification

- `make test`
- focused WeChat DevTools Core and CLI routing suites
- issue reproduction command: no broken changelogs
- live WeChat sweep: 6/6 checks passed
- full live sweep: all 74 changelogs passed; one unrelated LibreOffice installed-version warning

Closes #191
