### PR TITLE
Release 0.3.81

### DIFF
--- a/App/project.yml
+++ b/App/project.yml
@@ -119,8 +119,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.app
-        MARKETING_VERSION: "0.3.80"
-        CURRENT_PROJECT_VERSION: "89"
+        MARKETING_VERSION: "0.3.81"
+        CURRENT_PROJECT_VERSION: "90"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Info.plist
         # Menu-bar-only app: no Dock icon, no main window.
@@ -232,8 +232,8 @@ targets:
         # plist's BundleProgram points at Contents/MacOS/DuoUpdaterHelper. The bundle
         # *identifier* (for signing / XPC pinning) is com.duoupdater.helper.
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.helper
-        MARKETING_VERSION: "0.3.80"
-        CURRENT_PROJECT_VERSION: "89"
+        MARKETING_VERSION: "0.3.81"
+        CURRENT_PROJECT_VERSION: "90"
         SWIFT_VERSION: "6.0"
         # Embed a generated Info.plist into the binary's __TEXT,__info_plist so the
         # helper has a bundle id/version (Bundle.main reads it) without a wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.81
+
+**Word, Excel, PowerPoint, Outlook and OneNote now notice when their update has landed.** These five kept offering to re-open the installer you had already finished with, and never moved on to offering the restart — waiting or re-checking could not have shaken it loose.
+
+**A row waiting to relaunch explains itself again, in both windows.** When an app was both ahead of what its vendor publishes and waiting on a relaunch, the line above the button described something else entirely; the window and the menu also disagreed about rows waiting on an Update All restart.
+
+**Row tags no longer crowd out the app name in Russian.** A few tags were borrowing wording from unrelated strings in every translated language, too.
+
+**Release notes now appear for apps whose vendor dates a release without timing it.** Those releases used to leave no trace anywhere.
+
+**A release-notes page we refuse to open now says why.** It went blank before, which looked exactly like an app that publishes no notes at all.
+
+**WeChat DevTools nightly release notes are no longer empty.**
+
+Under the hood: version and release-date handling were consolidated so a build number can never be read as a marketing version, and the release timeline no longer invents a time of day the vendor never gave.
+
 ## 0.3.80
 
 **Failed checks are visible in the window now.** The window drew nothing for a row whose check had failed — or one you ignored, one you skipped, or one the App Store, Toolbox or TestFlight manages — which looked exactly like "up to date". The two windows now say the same thing about the same app, and the retry button is in both.


### PR DESCRIPTION
Version bump (0.3.80 → 0.3.81, build 89 → 90, both targets) and the 0.3.81 release notes.

`scripts/publish-release.sh` reads the CHANGELOG section for the version being shipped and embeds it in the GitHub release and the Sparkle appcast, so this is the text that goes to every user.

## Claims checked before writing them

- **Office restart** — `versionIsBuild: true` + `install.kind == .pkg` + no `displayVersionPattern` matches exactly five recipes: Word, Excel, PowerPoint, Outlook, OneNote. Those are the recipes that reach `recordStagedPackage`, so they are the ones that were stuck.
- **Date-only release notes** — fetched Eudic's real appcast (`static.eudic.net/pkg/eudic_mac.xml`): its newest entry is `<pubDate>2026-08-31</pubDate>`, date-only. Eudic is a Sparkle feed, which is the path now wired to the day tier, so this is a change a real user with Eudic can see rather than a mechanism with no consumer.