### PR TITLE
Derive build-cache paths per checkout, and reclaim the dead ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,20 @@ popover 和工作台是同一份数据的两个视图(工作台 = 放大版 popo
 
 - **合并前独立复算。** 凡是正确性落在一条**规则**上的(正则、版本比较、条目选择),把规则移植到 Python 打真实响应体,而不是重读 Swift。#76 靠这个确认了 feed 是发布时间序、以及新加的"winner 条目只能含一次匹配"不会误伤 671 条里的任何一条。两个独立证人胜过一个。
 
-顺带:`make test` 会跑 `scripts/check_localizable_keys.py`,它用固定路径 `/tmp/duo-loc-check` 做构建缓存,**两个 worktree 同时跑会锁冲突**。看到 `database is locked` 先查是不是自己撞自己(`ps` 要 grep `xcodebuild`,不只是 `swift-test`),别当成真失败。
+顺带:**构建缓存路径一律经 `scripts/derived_data_path.py` 取,别写死。** 它按 checkout 派生
+(`/tmp/duo-<用途>-<hash8>`)并顺手回收已经不存在的 checkout 留下的那些。
+`check_localizable_keys.py`(在 `make test` 里)、`row-state-gallery.sh`、`app-tests.sh` 都走它。
+
+以前 loc-check 用死路径 `/tmp/duo-loc-check`,**两个 worktree 同时 `make test` 会撞
+xcodebuild 的 SQLite 锁**,症状是 `database is locked` 或者干脆卡住——而这两种都长得像真失败。
+现在这个前提没了(实测 28 个 worktree 算出 28 个不同路径)。如果**还是**看到
+`database is locked`,先查是不是自己撞自己(`ps` 要 grep `xcodebuild`,不只是 `swift-test`),
+再看是不是同一个 checkout 里跑了两遍——**同 checkout 并发是唯一剩下的碰撞面**,没修。
+
+⚠️ **回收是刻意 fail-closed 的**:只删同时满足「名字是 `duo-<用途>-<8 位 hex>`」和「带 `origin`
+标记且标记指向的 checkout 已经没了」的目录。手工造的那些(`/tmp/duo-dd-292`、`/tmp/duo-pr240-dd`
+之类)一律不碰——2026-09-04 量的时候 `/tmp` 里有 **19G** 这类缓存、每份约 450M,而磁盘只剩
+38G。**给每个 checkout 发一个独立路径而不回收,等于把一个会误判的失败换成一块满了的盘。**
 
 ## 断言「没有 X」「到处都 Y」之前，先量一遍
 
@@ -255,9 +268,9 @@ App 只留接线;接线本身要可测,就放进 `ScanRowAssembly` 这类无 UI 
 - **只在 `project.yml` 比 `project.pbxproj` 新的时候才重新生成。** 无条件生成会重写
   `project.pbxproj`,让紧随其后的 `check_localizable_keys.py` 的增量构建每次失效,
   `make test` 从此每次全量重编整个 app。
-- **derived data 路径按 checkout 派生**(`/tmp/duo-app-tests-<hash>`),`APP_TESTS_DD` 可覆盖。
-  固定路径会精确复刻 `/tmp/duo-loc-check` 那个多 worktree 撞锁的坑,而这次的症状是
-  **测试随机失败**,比"构建变慢"更容易被误读成真回归。
+- **derived data 路径走 `scripts/derived_data_path.py`**(见上),`APP_TESTS_DD` 可覆盖。
+  写死路径会复刻多 worktree 撞锁的坑,而这里的症状是**测试随机失败**,
+  比"构建变慢"更容易被误读成真回归。
 - **每条用例都要写清它对应哪一行变异**,并且合并前真的跑一遍那个变异确认它变红。
   `ScanRowAssemblyTests` 现在是 9 条用例 / 10 个变异,10 个全部**编译通过**(不是靠编译
   错误变红)且只打中该打中的用例。没有对应变异的用例(`anUnprovenCopyFallsBackToItsBundle`

--- a/scripts/app-tests.sh
+++ b/scripts/app-tests.sh
@@ -7,17 +7,10 @@
 set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Per-checkout derived data. A fixed path would be shared by every worktree open
-# at once, and this repo routinely has a dozen: two concurrent runs then collide
-# the way `make test`'s /tmp/duo-loc-check already does, except here the symptom
-# is tests failing rather than a build stalling, which reads as a real regression.
-# `APP_TESTS_DD` overrides, as GALLERY_DD does for the gallery.
-#
-# Two runs in the SAME checkout still share this directory, and two concurrent
-# xcodebuilds on one derived-data path is the hazard CLAUDE.md records for
-# /tmp/duo-loc-check. Not fixed here — `make gallery` and the loc-check have the
-# same shape — so don't run this alongside itself in one checkout.
-DD="${APP_TESTS_DD:-/tmp/duo-app-tests-$(printf %s "$REPO" | shasum | cut -c1-8)}"
+# Per checkout, and the dead ones reclaimed — see scripts/derived_data_path.py.
+# Two runs in the SAME checkout still share it, which is the one collision left;
+# don't run this alongside itself. `APP_TESTS_DD` overrides.
+DD="${APP_TESTS_DD:-$(python3 "$REPO/scripts/derived_data_path.py" app-tests "$REPO")}"
 
 # Exported before xcodegen for the reason install.sh and row-state-gallery.sh
 # state: the spec reads $DUO_TEAM_ID for DEVELOPMENT_TEAM, and regenerating

--- a/scripts/check_localizable_keys.py
+++ b/scripts/check_localizable_keys.py
@@ -125,11 +125,24 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--derived-data",
-        default="/tmp/duo-loc-check",
-        help="where to build (kept separate from the install build's cache)",
+        default=None,
+        help="where to build (kept separate from the install build's cache); "
+        "defaults to a per-checkout path under /tmp",
     )
     args = parser.parse_args()
-    derived_data = pathlib.Path(args.derived_data)
+    # A per-checkout path, not a fixed one. `make test` runs this in every
+    # worktree, and this repo keeps a couple of dozen open, so a shared cache is
+    # the likeliest of all of them to be built twice at once — CLAUDE.md records
+    # the resulting `database is locked` as something to recognise rather than
+    # something to prevent. See scripts/derived_data_path.py.
+    derived_data = pathlib.Path(
+        args.derived_data
+        or subprocess.run(
+            [sys.executable, str(REPO / "scripts" / "derived_data_path.py"),
+             "loc-check", str(REPO)],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    )
 
     build(derived_data)
     source = keys_from_source(derived_data)

--- a/scripts/derived_data_path.py
+++ b/scripts/derived_data_path.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Print a per-checkout derived-data path, and prune the ones left by checkouts
+that are gone.
+
+Why per checkout: a fixed path is shared by every worktree open at once, and
+this repo routinely has a couple of dozen. Two concurrent xcodebuilds on one
+derived-data path collide on its SQLite lock, and the symptom — `database is
+locked`, or a build that simply stalls — reads as a real failure. CLAUDE.md
+records that trap for `/tmp/duo-loc-check`; this removes it instead of asking
+the next person to recognise it.
+
+Why prune: measured 2026-09-04, `/tmp` held 19 GB of these caches at ~450 MB
+each, on a volume with 38 GiB free. Handing every checkout its own path without
+reclaiming the dead ones trades a confusing failure for a full disk. Each
+directory carries an `origin` marker naming the checkout it belongs to; a
+directory whose checkout no longer exists is deleted.
+
+Pruning is deliberately fail-closed: it only ever removes a directory that
+matches `duo-<name>-<8 hex>` AND carries a readable `origin` marker pointing
+somewhere that is gone. The unmarked caches an operator made by hand
+(`/tmp/duo-dd-292`, `/tmp/duo-pr240-dd`, …) are never touched.
+"""
+import hashlib
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+BASE = pathlib.Path("/tmp")
+MARKER = "origin"
+
+
+def repo_root(argv: list[str]) -> pathlib.Path:
+    if len(argv) > 2:
+        return pathlib.Path(argv[2]).resolve()
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
+    if out.returncode != 0:
+        raise SystemExit("derived_data_path: not inside a git checkout")
+    return pathlib.Path(out.stdout.strip()).resolve()
+
+
+def prune(name: str, keep: pathlib.Path) -> None:
+    pattern = re.compile(rf"^duo-{re.escape(name)}-[0-9a-f]{{8}}$")
+    for path in BASE.glob(f"duo-{name}-*"):
+        if path == keep or not path.is_dir() or not pattern.match(path.name):
+            continue
+        marker = path / MARKER
+        try:
+            origin = marker.read_text(encoding="utf-8").strip()
+        except OSError:
+            # No marker: not ours to reclaim. Leave it.
+            continue
+        if origin and not pathlib.Path(origin).exists():
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def main() -> int:
+    if len(sys.argv) < 2 or not re.fullmatch(r"[a-z0-9-]+", sys.argv[1]):
+        raise SystemExit("usage: derived_data_path.py <name> [repo-root]")
+    name = sys.argv[1]
+    root = repo_root(sys.argv)
+    digest = hashlib.sha256(str(root).encode()).hexdigest()[:8]
+    path = BASE / f"duo-{name}-{digest}"
+    path.mkdir(parents=True, exist_ok=True)
+    (path / MARKER).write_text(f"{root}\n", encoding="utf-8")
+    prune(name, keep=path)
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/row-state-gallery.sh
+++ b/scripts/row-state-gallery.sh
@@ -7,7 +7,9 @@
 # can see — fails the run.
 set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DD="${GALLERY_DD:-/tmp/duo-gallery}"
+# Per checkout, and the dead ones reclaimed — see scripts/derived_data_path.py
+# for why a fixed path is a trap here. `GALLERY_DD` still overrides.
+DD="${GALLERY_DD:-$(python3 "$REPO/scripts/derived_data_path.py" gallery "$REPO")}"
 
 # Must be exported before xcodegen, exactly as install.sh/notarize.sh do it: the
 # spec reads $DUO_TEAM_ID for DEVELOPMENT_TEAM, and regenerating without it writes


### PR DESCRIPTION
`scripts/check_localizable_keys.py` built into a fixed `/tmp/duo-loc-check`, and
`make test` runs it **in every worktree** — of which this repo routinely keeps a
couple of dozen open. Two concurrent runs collide on that derived-data
directory's SQLite lock, and both symptoms — `database is locked`, or a build
that just stalls — read as a real failure. CLAUDE.md carried this as a trap to
*recognise*; this removes the precondition.

Measured: **28 worktrees → 28 distinct paths.**

`row-state-gallery.sh` had the same fixed-path shape, and `app-tests.sh` (from
#315) had a per-checkout path with the reasoning inline. All three now call
`scripts/derived_data_path.py`, which is also where the reasoning lives.

## Why it reclaims, not just derives

Handing every checkout its own path without reclaiming the dead ones trades a
confusing failure for a full disk. Measured today:

```
$ du -sch /tmp/duo-*
 19G   total          # ~450 MB each
$ df -h /tmp
avail: 38Gi  used: 96%
```

The names already in there — `duo-dd-292`, `duo-dd-242`, `duo-pr240-dd`, and
**fourteen** `duo-gallery-*` variants — are past sessions hand-picking paths to
dodge this very collision. That workaround is what this replaces.

So each directory carries an `origin` marker naming its checkout, and one whose
checkout is gone is deleted on the next run.

## Reclamation is fail-closed, and that is tested against the real /tmp

It removes a directory only when **both** hold: the name matches
`duo-<name>-<8 hex>`, **and** an `origin` marker inside names a checkout that no
longer exists. Anything unmarked is not ours to reclaim.

| Fixture | Expected | Result |
| --- | --- | --- |
| marked, checkout missing | deleted | deleted |
| unmarked, hand-made | kept | kept |
| marked, checkout alive | kept | kept |
| the 14 pre-existing `duo-gallery-*` | kept | all kept |

## Verification

- `make test` — exit 0. Core 2058 / CLI 188 / App 9 of 9, four python gates
  green, loc-check building into `/tmp/duo-loc-check-42f71b5e`.
- `make gallery` — exit 0, all five gates.
- Path uniqueness across every worktree `git worktree list` reports: 28/28.
- The helper is idempotent (same checkout → same path, twice) and
  checkout-sensitive (a different root → a different hash).

**Not reproduced:** the original `database is locked` incident. It is recorded in
CLAUDE.md from a past session, and what this change does is delete its
precondition (shared mutable path), not re-observe the symptom.

## Deliberately unchanged

`install.sh` (`/tmp/duo-dd`), `build-cli.sh` (`/tmp/duo-cli-dd`) and
`notarize.sh` / `publish-release.sh` (`/tmp/duo-notary-dd`) still use fixed
paths. Those are single-operator commands where a second concurrent run is
already a mistake for other reasons — and `install.sh`'s cache being shared is
arguably what makes repeated `make install` fast. Left for a separate decision
rather than swept in here.

**One collision remains, and CLAUDE.md now says so:** two runs in the *same*
checkout still share a path.

No CHANGELOG entry and no version bump — nothing here is visible to users.
