### PR TITLE
Move the badge's rules and the row-facts assembly into Core

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -488,8 +488,12 @@ final class AppListModel {
 
     /// The per-row tables as Core wants them. Seven copies of a
     /// copy-on-write collection: retains, no allocation.
+    ///
+    /// `.live` rather than the plain initialiser, which defaults every table:
+    /// this is the one place completeness matters, so an eighth table has to
+    /// break here rather than go quiet. Same rule as `RowActions.live`.
     private var rowStateTables: RowStateTables {
-        RowStateTables(
+        RowStateTables.live(
             installing: installing,
             needsRestart: needsRestart,
             pendingBatchRestart: pendingBatchRestart,

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -473,29 +473,30 @@ final class AppListModel {
     /// warning that makes that safe lives in the popover. What it may not do is
     /// render a state as nothing.
     func rowState(for result: UpdateResult) -> RowActionState {
-        RowAction.state(for: RowActionFacts(
-            status: result.status,
-            awaitingQuitConfirm: awaitingQuitConfirm[result.id],
-            isRelaunching: relaunching.contains(result.id),
-            hasPendingBatchRestart: pendingBatchRestart[result.id] != nil,
-            justUpdated: justUpdated.contains(result.id),
-            installStage: installing[result.id],
+        // The assembly is `RowActionFacts.assemble` in Core, where it can be
+        // tested; this is the wiring that hands it the tables. `self.` on the
+        // route because it is an `@autoclosure` the facts hold rather than a
+        // value they copy — see `RowActionFacts.route`.
+        RowAction.state(for: RowActionFacts.assemble(
+            for: result,
+            tables: rowStateTables,
             isIgnored: prefs.isIgnored(result.app),
-            isVersionSkipped: prefs.isVersionSkipped(result.app, version: result.remote?.versionSide),
-            stagedRelaunchTarget: actionableStaged(result).map { result.stagedRelaunchLine($0).to },
-            needsRestart: needsRestart.contains(result.id),
-            // Feeds the `.unknown` / `.upToDate` rungs' source-hint and channel
-            // priority — moved here from the popover's own `isMASApp` /
-            // `isTestFlightApp` / `sparkleFeedURL` reads (issue #260), so the
-            // priority between them lives in `RowAction.state` rather than a view.
-            isMASApp: result.app.isMASApp,
-            isTestFlightApp: result.app.isTestFlightApp,
-            hasSparkleFeed: result.app.sparkleFeedURL != nil,
-            // `self.` because the route is an `@autoclosure` the facts hold rather
-            // than a value they copy — see `RowActionFacts.route`. The capture is
-            // safe: the struct is built and consumed in this one expression, and
-            // the closure is called (at most once) before it returns.
+            isVersionSkipped: prefs.isVersionSkipped(
+                result.app, version: result.remote?.versionSide),
             route: self.rowRoute(for: result)))
+    }
+
+    /// The per-row tables as Core wants them. Seven copies of a
+    /// copy-on-write collection: retains, no allocation.
+    private var rowStateTables: RowStateTables {
+        RowStateTables(
+            installing: installing,
+            needsRestart: needsRestart,
+            pendingBatchRestart: pendingBatchRestart,
+            pendingSelfUpdate: pendingSelfUpdate,
+            relaunching: relaunching,
+            awaitingQuitConfirm: awaitingQuitConfirm,
+            justUpdated: justUpdated)
     }
 
     /// How an available update would be applied. Resolved here rather than in each
@@ -541,10 +542,10 @@ final class AppListModel {
     /// A pending update the user hasn't ignored or skipped — what the badge counts
     /// and what "Update All" acts on.
     func isActionableUpdate(_ result: UpdateResult) -> Bool {
-        guard result.hasUpdate else { return false }
-        if prefs.isIgnored(result.app) { return false }
-        if prefs.isVersionSkipped(result.app, version: result.remote?.versionSide) { return false }
-        return true
+        UpdatePolicy.isActionableUpdate(
+            result,
+            isIgnored: prefs.isIgnored(result.app),
+            isVersionSkipped: { prefs.isVersionSkipped(result.app, version: $0) })
     }
 
     var updateCount: Int { results.filter(isActionableUpdate).count }
@@ -578,14 +579,13 @@ final class AppListModel {
     /// blind pass indefinitely: the count filters `results`, and a deleted app has
     /// no row there.
     func needsAction(_ result: UpdateResult) -> Bool {
-        if isActionableUpdate(result) { return true }
-        guard !prefs.isIgnored(result.app) else { return false }
-        return needsRestart.contains(result.id)
-            || pendingBatchRestart[result.id] != nil
-            // Short-circuited on the raw map first: this runs per row on the render
-            // path, and `nudgeableStaged` builds sanitised preference keys out of the
-            // full bundle path before it can answer "nothing is staged".
-            || (pendingSelfUpdate[result.id] != nil && nudgeableStaged(result) != nil)
+        UpdatePolicy.needsAction(
+            result,
+            isIgnored: prefs.isIgnored(result.app),
+            isVersionSkipped: { prefs.isVersionSkipped(result.app, version: $0) },
+            needsRestart: needsRestart.contains(result.id),
+            hasPendingBatchRestart: pendingBatchRestart[result.id] != nil,
+            staged: pendingSelfUpdate[result.id])
     }
 
     /// How many rows `needsAction` marks — the badge's number, and the popover's
@@ -617,7 +617,11 @@ final class AppListModel {
     /// it — which made the badge flicker to the "no updates" icon and back. While a
     /// scan/check is in flight we hold the last settled count instead; otherwise we
     /// track `actionCount` live (so ignoring/skipping an app updates it at once).
-    var badgeCount: Int { (isScanning || isChecking) ? heldBadgeCount : actionCount }
+    var badgeCount: Int {
+        BadgeReadout.count(
+            live: actionCount, held: heldBadgeCount,
+            isScanning: isScanning, isChecking: isChecking)
+    }
     @ObservationIgnored private var heldBadgeCount = 0
 
     // MARK: - Homebrew formulae (CLI tools)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,8 +233,16 @@ skip 一次把 app **永久静音**、真实更新后 Rollback 行被藏起来�
 
 顺带一条会决定你把代码放哪:**`App/Sources` 有两万行,其中只有被 `DuoUpdaterAppTests`
 点名的那几个文件在跑**(见下节),其余的判断没人执行。14 处里 9 处长在那儿,不是巧合。
-**判断逻辑放 Core**(`RelaunchProgress`、`PackageRestartState`、`VisibilityRules` 都是这么落的),
+**判断逻辑放 Core**(`RelaunchProgress`、`PackageRestartState`、`VisibilityRules`、
+`UpdatePolicy.needsAction`、`BadgeReadout`、`RowActionFacts.assemble` 都是这么落的),
 App 只留接线;接线本身要可测,就放进 `ScanRowAssembly` 这类无 UI 依赖的文件。
+
+⚠️ **"接线"不等于"必须留在 App"。** 2026-09-04 搬 `needsAction` / `badgeCount` /
+`rowState` 时先量了一遍依赖:那三处引用的 `InstallStage`、`RowActionFacts`、`UpdateRoute`、
+`stagedRelaunchLine` **全都已经在 Core**,`AppListModel` 的七张表也全是
+`[String: X]` / `Set<String>` 这种 Core 看得见的类型。所以它们整块搬进 Core 就行,
+根本不需要用 App 那个窄 target。**动手前先量依赖,别默认"它在 App 里所以只能在 App 测"**
+——`App/Sources` 里剩下的东西有多少是这种情况,没量过。
 
 ## App 层的测试 target
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/ListActivity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/ListActivity.swift
@@ -108,3 +108,21 @@ public struct ListActivity: Sendable, Equatable {
         canInstallAll && targetCount() > 1
     }
 }
+
+/// What the menu-bar badge should read.
+///
+/// A full refresh blanks every row to `.unknown` before the check repopulates
+/// it, so the live count dips to 0 mid-pass — which made the badge flicker to
+/// the "no updates" icon and back. While a scan or check is in flight the badge
+/// holds the last settled count; otherwise it tracks the live one, so ignoring
+/// or skipping an app updates it at once.
+///
+/// The held value is snapshotted by the caller immediately BEFORE it blanks the
+/// rows. That ordering is the caller's to get right and cannot be checked here;
+/// what is checked here is that a pass in flight reads the held value and a
+/// settled list reads the live one.
+public enum BadgeReadout {
+    public static func count(live: Int, held: Int, isScanning: Bool, isChecking: Bool) -> Int {
+        (isScanning || isChecking) ? held : live
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
@@ -311,6 +311,42 @@ extension UpdateRoute {
 
 /// Everything the ladder reads about one row, gathered by the caller so the
 /// decision itself stays pure and testable.
+/// The per-row state a UI layer keeps outside `UpdateResult`, keyed by row id.
+///
+/// Exists so that filling `RowActionFacts` — deciding which table answers which
+/// fact, and under which key — is testable. That wiring used to sit in
+/// `AppListModel`, where nothing executes it, and it is the kind of code that
+/// fails by looking right: a fact fed from the neighbouring table, or looked up
+/// under `bundleID` where the tables are keyed by install path, compiles and
+/// renders a plausible row.
+public struct RowStateTables: Sendable {
+    public var installing: [String: InstallStage]
+    public var needsRestart: Set<String>
+    public var pendingBatchRestart: [String: String]
+    public var pendingSelfUpdate: [String: StagedSelfUpdate]
+    public var relaunching: Set<String>
+    public var awaitingQuitConfirm: [String: String]
+    public var justUpdated: Set<String>
+
+    public init(
+        installing: [String: InstallStage] = [:],
+        needsRestart: Set<String> = [],
+        pendingBatchRestart: [String: String] = [:],
+        pendingSelfUpdate: [String: StagedSelfUpdate] = [:],
+        relaunching: Set<String> = [],
+        awaitingQuitConfirm: [String: String] = [:],
+        justUpdated: Set<String> = []
+    ) {
+        self.installing = installing
+        self.needsRestart = needsRestart
+        self.pendingBatchRestart = pendingBatchRestart
+        self.pendingSelfUpdate = pendingSelfUpdate
+        self.relaunching = relaunching
+        self.awaitingQuitConfirm = awaitingQuitConfirm
+        self.justUpdated = justUpdated
+    }
+}
+
 public struct RowActionFacts {
     public var status: UpdateStatus
     public var awaitingQuitConfirm: String?
@@ -417,5 +453,44 @@ public enum RowAction {
             if facts.isTestFlightApp { return .upToDate(channel: .testFlight) }
             return .upToDate(channel: .none)
         }
+    }
+}
+
+extension RowActionFacts {
+    /// Fill the facts for one row from the tables a UI layer holds.
+    ///
+    /// Every table is looked up under `result.id`, which is the install PATH —
+    /// two copies of one app share a bundle id and must not share a row's
+    /// install stage or relaunch flag.
+    ///
+    /// `route` stays an `@autoclosure` all the way through: only the
+    /// `.updateAvailable` rung reads it, and computing it is the expensive part
+    /// of assembling facts (it rebuilds an `InstallEnvironment`, and stats the
+    /// disk for pkg rows). This function must not call it — `routeIsDeferred`
+    /// counts the calls.
+    public static func assemble(
+        for result: UpdateResult,
+        tables: RowStateTables,
+        isIgnored: Bool,
+        isVersionSkipped: Bool,
+        route: @escaping @autoclosure () -> UpdateRoute
+    ) -> RowActionFacts {
+        let staged = UpdatePolicy.actionableStaged(
+            result, staged: tables.pendingSelfUpdate[result.id])
+        return RowActionFacts(
+            status: result.status,
+            awaitingQuitConfirm: tables.awaitingQuitConfirm[result.id],
+            isRelaunching: tables.relaunching.contains(result.id),
+            hasPendingBatchRestart: tables.pendingBatchRestart[result.id] != nil,
+            justUpdated: tables.justUpdated.contains(result.id),
+            installStage: tables.installing[result.id],
+            isIgnored: isIgnored,
+            isVersionSkipped: isVersionSkipped,
+            stagedRelaunchTarget: staged.map { result.stagedRelaunchLine($0).to },
+            needsRestart: tables.needsRestart.contains(result.id),
+            isMASApp: result.app.isMASApp,
+            isTestFlightApp: result.app.isTestFlightApp,
+            hasSparkleFeed: result.app.sparkleFeedURL != nil,
+            route: route())
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowActionState.swift
@@ -345,6 +345,35 @@ public struct RowStateTables: Sendable {
         self.awaitingQuitConfirm = awaitingQuitConfirm
         self.justUpdated = justUpdated
     }
+
+    /// The same tables with **no defaults** — what a UI layer must use.
+    ///
+    /// Every parameter above has a default because the tests populate one table
+    /// at a time on purpose, which is exactly the shape CLAUDE.md records for
+    /// `RowActions`: nine closures with empty defaults meant a forgotten one
+    /// compiled and shipped a dead button. Here there is one production caller,
+    /// so adding an eighth table and forgetting to wire it would compile, render
+    /// a plausible row, and be caught by nothing — not the gallery (which never
+    /// goes through `assemble`), not `RowActionStateTests` (which builds facts
+    /// directly), not the assembly suite (which populates partially by design).
+    ///
+    /// Calling this from the UI makes that omission a compile error at the one
+    /// place it matters, the way `RowActions.live` does.
+    public static func live(
+        installing: [String: InstallStage],
+        needsRestart: Set<String>,
+        pendingBatchRestart: [String: String],
+        pendingSelfUpdate: [String: StagedSelfUpdate],
+        relaunching: Set<String>,
+        awaitingQuitConfirm: [String: String],
+        justUpdated: Set<String>
+    ) -> RowStateTables {
+        RowStateTables(
+            installing: installing, needsRestart: needsRestart,
+            pendingBatchRestart: pendingBatchRestart,
+            pendingSelfUpdate: pendingSelfUpdate, relaunching: relaunching,
+            awaitingQuitConfirm: awaitingQuitConfirm, justUpdated: justUpdated)
+    }
 }
 
 public struct RowActionFacts {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -663,6 +663,73 @@ public enum UpdatePolicy {
     /// the Ignored tag: hidden in the app, still nagging in Notification Center.
     /// Ignore and skip both mean "stop telling me about this", so both are gates
     /// here, not just on the updates-available path.
+    /// A pending update the user hasn't ignored or skipped — what the badge counts
+    /// and what "Update All" acts on.
+    public static func isActionableUpdate(
+        _ result: UpdateResult,
+        isIgnored: Bool,
+        isVersionSkipped: (VersionSide?) -> Bool
+    ) -> Bool {
+        guard result.hasUpdate else { return false }
+        if isIgnored { return false }
+        if isVersionSkipped(result.remote?.versionSide) { return false }
+        return true
+    }
+
+    /// A row that still has something for the user to do: a pending update, or a
+    /// relaunch that finishes one already on disk.
+    ///
+    /// The badge counts these, not the actionable updates alone. The
+    /// version-comparison half of `needsRestart` is only reached when the row has
+    /// nothing newer to install (a row with an update shows Update instead), so
+    /// counting updates alone put the menu bar at "no updates" while the list
+    /// underneath showed apps running old code with a Relaunch button each.
+    ///
+    /// **The ignored check is deliberately NOT first.** An actionable update wins
+    /// over it — `isActionableUpdate` has already applied ignore and skip itself,
+    /// so reaching the guard means the row has no offerable update, and only then
+    /// does hiding the app suppress its relaunch and staged-nudge terms. Hoisting
+    /// the guard above the first line changes nothing today for the same reason,
+    /// which is exactly why it is worth pinning: the two orders are only equivalent
+    /// while `isActionableUpdate` keeps applying both preferences.
+    ///
+    /// `staged` is the RAW per-row entry and is checked for nil before
+    /// `nudgeableStaged` is consulted. ⚠️ **That check is behaviour-neutral here,
+    /// and no test pins it** — `nudgeableStaged(_:staged:isIgnored:…)` reaches
+    /// `actionableStaged`, which returns nil for a nil entry without touching a
+    /// preference. It is kept as a cheap call-avoidance on a path that runs per
+    /// row on every render, nothing more.
+    ///
+    /// It is written down because the version this replaced needed it for a
+    /// stronger reason that no longer applies: in `AppListModel` the call was
+    /// `nudgeableStaged(result)`, which computed `prefs.isIgnored(result.app)`
+    /// itself — building a sanitised preference key out of the full bundle path
+    /// before it could answer "nothing is staged". Here the caller has already
+    /// resolved `isIgnored` to a `Bool`, so that cost is gone. Do not restore the
+    /// old justification if you touch this.
+    ///
+    /// An uninstalled app cannot strand the badge even though a package-restart
+    /// entry can be carried across a blind pass indefinitely: the caller filters
+    /// its own rows, and a deleted app has none.
+    public static func needsAction(
+        _ result: UpdateResult,
+        isIgnored: Bool,
+        isVersionSkipped: (VersionSide?) -> Bool,
+        needsRestart: Bool,
+        hasPendingBatchRestart: Bool,
+        staged: StagedSelfUpdate?
+    ) -> Bool {
+        if isActionableUpdate(result, isIgnored: isIgnored, isVersionSkipped: isVersionSkipped) {
+            return true
+        }
+        guard !isIgnored else { return false }
+        return needsRestart
+            || hasPendingBatchRestart
+            || (staged != nil && nudgeableStaged(
+                result, staged: staged, isIgnored: isIgnored,
+                isVersionSkipped: { isVersionSkipped($0) }) != nil)
+    }
+
     public static func nudgeableStaged(
         _ result: UpdateResult,
         staged: StagedSelfUpdate?,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BadgeAndNeedsActionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BadgeAndNeedsActionTests.swift
@@ -117,6 +117,38 @@ struct NeedsActionTests {
         #expect(!needsAction(row(installed: "2.0", latest: nil), staged: stagedBuild("1.0")))
     }
 
+    /// Skipping the version silences a staged build too. This is the ONLY reason
+    /// the term goes through `nudgeableStaged` rather than the cheaper
+    /// `actionableStaged`, which applies the newer-than-installed gate but not
+    /// the user's skip — so without this case, swapping one for the other leaves
+    /// every other case green while a hidden version keeps lighting the badge.
+    ///
+    /// Mutation: `nudgeableStaged(…)` replaced by
+    /// `actionableStaged(result, staged: staged)`.
+    @Test func askippedVersionSilencesAStagedBuildToo() {
+        #expect(!needsAction(row(latest: nil), skipped: true, staged: stagedBuild("2.0")))
+        // The same row without the skip does count — otherwise the assertion
+        // above would hold for the wrong reason.
+        #expect(needsAction(row(latest: nil), skipped: false, staged: stagedBuild("2.0")))
+    }
+
+    /// Which version is offered to the skip check: the REMOTE side, not the
+    /// installed one. Reading the installed side would silence the app
+    /// permanently after a single skip — the failure `VersionSide` exists to
+    /// prevent.
+    ///
+    /// Mutation: `isVersionSkipped(result.app.versionSide)` in
+    /// `isActionableUpdate`.
+    @Test func theSkipCheckIsAskedAboutTheRemoteVersion() {
+        var seen: [VersionSide?] = []
+        _ = UpdatePolicy.isActionableUpdate(
+            row(installed: "1.0", latest: "2.0"), isIgnored: false,
+            isVersionSkipped: { seen.append($0); return false })
+
+        #expect(seen.count == 1)
+        #expect(seen.first??.marketing == "2.0")
+    }
+
     /// Nothing staged means nothing to count. Deliberately NOT a test of the
     /// `staged != nil` short-circuit that precedes the `nudgeableStaged` call:
     /// that check is behaviour-neutral (see the note on `needsAction`), so no
@@ -237,6 +269,59 @@ struct RowFactsAssemblyTests {
         #expect(!f.needsRestart && !f.isRelaunching && !f.justUpdated)
     }
 
+    /// The five facts that come from somewhere other than a table. The fixture
+    /// used by every other case here is all-false and all-nil, so a transposition
+    /// among them is invisible: `isIgnored: isVersionSkipped` renders a skipped
+    /// row as Ignored (`RowAction.state` ranks ignored first), and the three
+    /// source hints feed the `.unknown`/`.upToDate` rungs' badges.
+    ///
+    /// Same fixture-distribution trap CLAUDE.md records twice for the gallery —
+    /// a fixture that is constant across a set of branches measures one branch
+    /// and reports on all of them.
+    ///
+    /// Mutations: transpose `isIgnored` with `isVersionSkipped`; feed any one of
+    /// the three hints from either of the other two.
+    @Test func theNonTableFactsEachComeFromTheirOwnSource() {
+        let ignored = RowActionFacts.assemble(
+            for: row, tables: RowStateTables(), isIgnored: true,
+            isVersionSkipped: false, route: .autoInstall)
+        #expect(ignored.isIgnored && !ignored.isVersionSkipped)
+
+        let skipped = RowActionFacts.assemble(
+            for: row, tables: RowStateTables(), isIgnored: false,
+            isVersionSkipped: true, route: .autoInstall)
+        #expect(skipped.isVersionSkipped && !skipped.isIgnored)
+
+        for (label, app) in [
+            ("mas", hinted(isMASApp: true)),
+            ("testflight", hinted(isTestFlightApp: true)),
+            ("sparkle", hinted(sparkle: URL(string: "https://example.com/appcast.xml"))),
+        ] {
+            let f = RowActionFacts.assemble(
+                for: UpdateResult(app: app, remote: nil, status: .upToDate),
+                tables: RowStateTables(), isIgnored: false, isVersionSkipped: false,
+                route: .autoInstall)
+            let hits = [f.isMASApp, f.isTestFlightApp, f.hasSparkleFeed].filter { $0 }.count
+            #expect(hits == 1, "\(label) set \(hits) hints")
+            switch label {
+            case "mas": #expect(f.isMASApp)
+            case "testflight": #expect(f.isTestFlightApp)
+            default: #expect(f.hasSparkleFeed)
+            }
+        }
+    }
+
+    private func hinted(
+        isMASApp: Bool = false, isTestFlightApp: Bool = false, sparkle: URL? = nil
+    ) -> InstalledApp {
+        InstalledApp(
+            name: "Example", bundleID: "com.example.app",
+            shortVersion: "1.0", buildVersion: nil,
+            path: URL(fileURLWithPath: Self.path),
+            isMASApp: isMASApp, isToolboxManaged: false,
+            isTestFlightApp: isTestFlightApp, sparkleFeedURL: sparkle)
+    }
+
     /// A staged build not ahead of what is installed is not a relaunch target —
     /// the target goes through `UpdatePolicy.actionableStaged`, not straight off
     /// the table.
@@ -268,11 +353,20 @@ struct RowFactsAssemblyTests {
         final class Counter: @unchecked Sendable { var calls = 0 }
         let counter = Counter()
 
-        _ = RowActionFacts.assemble(
+        let facts = RowActionFacts.assemble(
             for: row, tables: RowStateTables(), isIgnored: false,
             isVersionSkipped: false,
-            route: { counter.calls += 1; return UpdateRoute.autoInstall }())
+            route: { counter.calls += 1; return UpdateRoute.majorUpgrade }())
 
         #expect(counter.calls == 0)
+
+        // Deferred is only half of it: `RowActionFacts.route` has a DEFAULT, so
+        // dropping the argument from `assemble` altogether compiles and leaves a
+        // deferral-only assertion green — while every `.updateAvailable` row in
+        // production renders whatever that default happens to be. Read it once
+        // and check the value arrived. (`routeIsDeferred` in RowActionStateTests
+        // carries the same positive pole for the same reason.)
+        #expect(facts.route() == .majorUpgrade)
+        #expect(counter.calls == 1)
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BadgeAndNeedsActionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BadgeAndNeedsActionTests.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// The badge's two rules, which lived in `AppListModel` where nothing executed
+/// them. Two tests in this very suite already referred to
+/// `AppListModel.needsAction` in prose — Core documenting a rule it could not
+/// run — which is what prompted moving them here rather than testing them
+/// through the App target.
+///
+/// Each case names the single-line mutation it must fail under.
+struct NeedsActionTests {
+
+    private func app(_ short: String, ignoredMarker: String = "app") -> InstalledApp {
+        InstalledApp(
+            name: ignoredMarker, bundleID: "com.example.\(ignoredMarker)",
+            shortVersion: short, buildVersion: nil,
+            path: URL(fileURLWithPath: "/Applications/\(ignoredMarker).app"),
+            isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
+    }
+
+    private func row(
+        installed: String = "1.0", latest: String? = "2.0"
+    ) -> UpdateResult {
+        guard let latest else {
+            return UpdateResult(app: app(installed), remote: nil, status: .upToDate)
+        }
+        return UpdateResult(
+            app: app(installed),
+            remote: RemoteVersion(
+                shortVersion: latest, version: nil, downloadURL: nil, sourceName: "GitHub"),
+            status: .updateAvailable(latest: latest))
+    }
+
+    private func stagedBuild(_ version: String) -> StagedSelfUpdate {
+        StagedSelfUpdate(
+            version: version, buildVersion: nil,
+            stagedBundlePath: URL(fileURLWithPath: "/tmp/staged.app"))
+    }
+
+    private func needsAction(
+        _ result: UpdateResult,
+        ignored: Bool = false,
+        skipped: Bool = false,
+        needsRestart: Bool = false,
+        batchRestart: Bool = false,
+        staged: StagedSelfUpdate? = nil
+    ) -> Bool {
+        UpdatePolicy.needsAction(
+            result, isIgnored: ignored, isVersionSkipped: { _ in skipped },
+            needsRestart: needsRestart, hasPendingBatchRestart: batchRestart,
+            staged: staged)
+    }
+
+    // MARK: what counts
+
+    /// Mutation: `guard result.hasUpdate else { return false }` deleted from
+    /// `isActionableUpdate`.
+    @Test func anOfferableUpdateCounts() {
+        #expect(needsAction(row()))
+        #expect(!needsAction(row(latest: nil)))
+    }
+
+    /// Ignoring an app takes it off the badge even though the update is real.
+    ///
+    /// Mutation: drop `if isIgnored { return false }` from `isActionableUpdate`
+    /// — the outer `guard !isIgnored` does NOT cover this, because the update
+    /// returns true on the line above it.
+    @Test func anIgnoredAppWithAnUpdateDoesNotCount() {
+        #expect(!needsAction(row(), ignored: true))
+    }
+
+    /// Mutation: drop the `isVersionSkipped` check from `isActionableUpdate`.
+    @Test func askippedVersionDoesNotCount() {
+        #expect(!needsAction(row(), skipped: true))
+    }
+
+    /// The reason the badge counts more than updates: a row whose update is
+    /// already on disk and only needs a relaunch. Counting updates alone put the
+    /// menu bar at "no updates" above a list of Relaunch buttons.
+    ///
+    /// Mutation: drop the `needsRestart` term.
+    @Test func aRowWaitingOnlyForARelaunchCounts() {
+        #expect(needsAction(row(latest: nil), needsRestart: true))
+    }
+
+    /// Mutation: drop the `hasPendingBatchRestart` term.
+    @Test func aRowHeldForABatchRelaunchCounts() {
+        #expect(needsAction(row(latest: nil), batchRestart: true))
+    }
+
+    /// Both relaunch terms are gated on the app not being hidden — this is what
+    /// the outer `guard !isIgnored` actually protects, and it is reachable only
+    /// for a row with no offerable update.
+    ///
+    /// Mutation: delete `guard !isIgnored else { return false }`.
+    @Test func hidingAnAppAlsoSuppressesItsRelaunchTerms() {
+        #expect(!needsAction(row(latest: nil), ignored: true, needsRestart: true))
+        #expect(!needsAction(row(latest: nil), ignored: true, batchRestart: true))
+    }
+
+    // MARK: the staged self-update term
+
+    /// A staged build newer than what is installed counts, so the badge stays lit
+    /// for an update that is downloaded but not yet live.
+    ///
+    /// Mutation: drop the `staged` term.
+    @Test func aStagedNewerBuildCounts() {
+        #expect(needsAction(row(latest: nil), staged: stagedBuild("2.0")))
+    }
+
+    /// A staged build that is NOT ahead of the installed copy would apply a
+    /// downgrade, so it must not light the badge.
+    ///
+    /// Mutation: `nudgeableStaged(...) != nil` replaced by `staged != nil`.
+    @Test func aStagedBuildThatIsNotAheadDoesNotCount() {
+        #expect(!needsAction(row(installed: "2.0", latest: nil), staged: stagedBuild("1.0")))
+    }
+
+    /// Nothing staged means nothing to count. Deliberately NOT a test of the
+    /// `staged != nil` short-circuit that precedes the `nudgeableStaged` call:
+    /// that check is behaviour-neutral (see the note on `needsAction`), so no
+    /// assertion can distinguish it, and the first version of this case pretended
+    /// otherwise by counting preference reads — of which there are none either
+    /// way. Mutation-checked: removing the short-circuit leaves every case here
+    /// green, and that is correct rather than a gap.
+    @Test func nothingStagedCountsForNothing() {
+        #expect(!needsAction(row(latest: nil), staged: nil))
+    }
+}
+
+/// The badge's hold-during-refresh rule.
+struct BadgeReadoutTests {
+
+    /// A settled list tracks the live count, so ignoring or skipping an app
+    /// changes the badge at once.
+    @Test func aSettledListShowsTheLiveCount() {
+        #expect(BadgeReadout.count(live: 3, held: 99, isScanning: false, isChecking: false) == 3)
+    }
+
+    /// A refresh blanks every row before the check repopulates it, so the live
+    /// count dips to 0 mid-pass — which flickered the badge to the "no updates"
+    /// icon and back.
+    ///
+    /// Mutations: drop `isScanning` from the condition; drop `isChecking`. Both
+    /// halves are separately asserted because a refresh passes through scanning
+    /// and checking as two phases.
+    @Test func aPassInFlightHoldsTheLastSettledCount() {
+        #expect(BadgeReadout.count(live: 0, held: 3, isScanning: true, isChecking: false) == 3)
+        #expect(BadgeReadout.count(live: 0, held: 3, isScanning: false, isChecking: true) == 3)
+    }
+}
+
+/// Filling `RowActionFacts` from the UI layer's tables — the wiring that used to
+/// sit in `AppListModel`.
+///
+/// The decision it feeds (`RowAction.state`) has its own suite. What is pinned
+/// here is which table answers which fact, and under which key, because that is
+/// the half that fails by looking right.
+struct RowFactsAssemblyTests {
+
+    private static let path = "/Applications/Example.app"
+
+    private var row: UpdateResult {
+        UpdateResult(
+            app: InstalledApp(
+                name: "Example", bundleID: "com.example.app",
+                shortVersion: "1.0", buildVersion: nil,
+                path: URL(fileURLWithPath: Self.path),
+                isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil),
+            remote: nil, status: .upToDate)
+    }
+
+    private func facts(
+        _ tables: RowStateTables, route: @escaping @autoclosure () -> UpdateRoute = .autoInstall
+    ) -> RowActionFacts {
+        RowActionFacts.assemble(
+            for: row, tables: tables, isIgnored: false, isVersionSkipped: false,
+            route: route())
+    }
+
+    /// Each table populated ALONE, asserting the one fact it owns is set and its
+    /// neighbours are not. This is the shape that catches a fact fed from the
+    /// table next to it — the failure this extraction exists for — which an
+    /// assertion per fact over a fully-populated fixture would not.
+    ///
+    /// Mutation: swap any two table reads in `assemble`, e.g.
+    /// `justUpdated: tables.needsRestart.contains(result.id)`.
+    @Test func eachTableAnswersOnlyItsOwnFact() {
+        let id = Self.path
+
+        let relaunching = facts(RowStateTables(relaunching: [id]))
+        #expect(relaunching.isRelaunching)
+        #expect(!relaunching.justUpdated && !relaunching.needsRestart)
+        #expect(relaunching.awaitingQuitConfirm == nil && relaunching.installStage == nil)
+
+        let restart = facts(RowStateTables(needsRestart: [id]))
+        #expect(restart.needsRestart)
+        #expect(!restart.isRelaunching && !restart.justUpdated)
+
+        let updated = facts(RowStateTables(justUpdated: [id]))
+        #expect(updated.justUpdated)
+        #expect(!updated.needsRestart && !updated.isRelaunching)
+
+        let batch = facts(RowStateTables(pendingBatchRestart: [id: "2.0"]))
+        #expect(batch.hasPendingBatchRestart)
+        #expect(batch.awaitingQuitConfirm == nil)
+
+        let quit = facts(RowStateTables(awaitingQuitConfirm: [id: "Example"]))
+        #expect(quit.awaitingQuitConfirm == "Example")
+        #expect(!quit.hasPendingBatchRestart)
+
+        let installing = facts(RowStateTables(installing: [id: .queued]))
+        #expect(installing.installStage == .queued)
+        #expect(!installing.isRelaunching)
+    }
+
+    /// The tables are keyed by install PATH, not bundle id: two copies of one app
+    /// share a bundle id, and must not share a row's install stage or relaunch
+    /// flag. A lookup-key mix-up is a defect shape this repo has already shipped
+    /// once (`computeRestartInfo`'s key, #242).
+    ///
+    /// Mutation: `tables.installing[result.app.bundleID ?? ""]`, or
+    /// `.contains(result.app.bundleID ?? "")`. The `?? ""` is needed to make the
+    /// mutation compile at all — `bundleID` is `String?`, so the naive form is a
+    /// type error, and the type system is already half of this guard. The half it
+    /// does not cover is someone reaching for `?? ""` to silence it.
+    @Test func theTablesAreKeyedByInstallPathNotBundleID() {
+        let byBundleID = RowStateTables(
+            installing: ["com.example.app": .queued],
+            needsRestart: ["com.example.app"],
+            relaunching: ["com.example.app"],
+            justUpdated: ["com.example.app"])
+        let f = facts(byBundleID)
+
+        #expect(f.installStage == nil)
+        #expect(!f.needsRestart && !f.isRelaunching && !f.justUpdated)
+    }
+
+    /// A staged build not ahead of what is installed is not a relaunch target —
+    /// the target goes through `UpdatePolicy.actionableStaged`, not straight off
+    /// the table.
+    ///
+    /// Mutation: `stagedRelaunchTarget` taken from
+    /// `tables.pendingSelfUpdate[result.id]` directly.
+    @Test func theRelaunchTargetGoesThroughTheStagedPolicy() {
+        let behind = StagedSelfUpdate(
+            version: "0.9", buildVersion: nil,
+            stagedBundlePath: URL(fileURLWithPath: "/tmp/staged.app"))
+        #expect(facts(RowStateTables(pendingSelfUpdate: [Self.path: behind]))
+            .stagedRelaunchTarget == nil)
+
+        let ahead = StagedSelfUpdate(
+            version: "2.0", buildVersion: nil,
+            stagedBundlePath: URL(fileURLWithPath: "/tmp/staged.app"))
+        #expect(facts(RowStateTables(pendingSelfUpdate: [Self.path: ahead]))
+            .stagedRelaunchTarget != nil)
+    }
+
+    /// `assemble` must not evaluate the route. Computing it rebuilds an
+    /// `InstallEnvironment` and stats the disk for pkg rows, and only the
+    /// `.updateAvailable` rung ever reads it — the cost this `@autoclosure`
+    /// exists to avoid for every installing, ignored or quit-confirming row.
+    ///
+    /// Mutation: change `route` to a plain (non-autoclosure) parameter, or store
+    /// `route()` into a local inside `assemble`.
+    @Test func assemblingFactsDoesNotComputeTheRoute() {
+        final class Counter: @unchecked Sendable { var calls = 0 }
+        let counter = Counter()
+
+        _ = RowActionFacts.assemble(
+            for: row, tables: RowStateTables(), isIgnored: false,
+            isVersionSkipped: false,
+            route: { counter.calls += 1; return UpdateRoute.autoInstall }())
+
+        #expect(counter.calls == 0)
+    }
+}


### PR DESCRIPTION
Three decisions lived in `AppListModel`, where nothing executes them: what the
badge counts, what it shows while a refresh is in flight, and which of the
model's per-row tables answers which fact in `RowActionFacts`. Two tests in
Core's own suite already referred to `AppListModel.needsAction` **in prose** —
Core documenting rules it could not run.

## Measured before moving anything

| Named target | What the measurement said | Action |
| --- | --- | --- |
| `visible` / filtering | **already in Core** — `VisibilityRules`, `ListActivity`, with 18 cases between `ListActivityTests` and `SkippedVersionTests` | nothing to do |
| `needsAction` / `badgeCount` | absent from Core; only *mentioned* in two Core test comments | moved to Core |
| `rowState(for:)` | decision already in Core (`RowAction.state`); the assembly was in App — but every type it touches (`InstallStage`, `RowActionFacts`, `UpdateRoute`, `stagedRelaunchLine`) is already public in Core, and the seven tables are plain `[String: X]` / `Set<String>` | moved to Core |

So **none of this needed the App test target from #315.** `RowStateTables` carries
the tables so the lookup itself is testable — that is the half that fails by
looking right: a fact fed from the neighbouring table, or read under `bundleID`
where the tables are keyed by install path (a key mix-up this repo has shipped
before, #242).

The `route` stays an `@autoclosure` the whole way through: only the
`.updateAvailable` rung reads it, and computing it rebuilds an
`InstallEnvironment` and stats the disk for pkg rows.

## Verification

**18 new cases. 22 of 23 mutations red, each on the case it should be.**

| Mutation | Case it kills |
| --- | --- |
| `isActionableUpdate` drops `hasUpdate` / `isIgnored` / `isVersionSkipped` | the three matching cases |
| `needsAction` drops the `needsRestart` / `hasPendingBatchRestart` term | the two relaunch cases |
| `needsAction`'s outer `guard !isIgnored` deleted | `hidingAnAppAlsoSuppressesItsRelaunchTerms` |
| staged term dropped / stops checking nudgeability | the two staged cases |
| badge drops `isScanning`; badge drops `isChecking` | `aPassInFlightHoldsTheLastSettledCount` |
| any two table reads swapped in `assemble` (3 tried) | `eachTableAnswersOnlyItsOwnFact` |
| a table read under `bundleID ?? ""` (2 tried) | `theTablesAreKeyedByInstallPathNotBundleID` |
| relaunch target taken straight off the table | `theRelaunchTargetGoesThroughTheStagedPolicy` |
| `route()` evaluated inside `assemble` | `assemblingFactsDoesNotComputeTheRoute` |

- `make test` — exit 0. **Core 2058 → 2076 (+18 cases, +3 suites)**, CLI 188,
  App 9 of 9, four python gates green.
- `xcodebuild -scheme DuoUpdater` — `** BUILD SUCCEEDED **`.
- `make gallery` — exit 0, all five gates.

## The eighteenth mutation is documented, not covered — and measuring it changed what the code means

`needsAction` checks the raw staged entry for nil before consulting
`nudgeableStaged`. The comment inherited from `AppListModel` said that avoids
building sanitised preference keys out of the full bundle path.

**That was true there and is not true here.** In `AppListModel` the call was
`nudgeableStaged(result)`, which computed `prefs.isIgnored(result.app)` itself.
Here the caller has already resolved `isIgnored` to a `Bool`, so
`nudgeableStaged` reaches `actionableStaged` and returns nil for a nil entry
without touching a preference. Removing the short-circuit leaves every case
green, and that is correct rather than a gap.

Kept as a cheap call-avoidance on a per-row render path, with the old
justification explicitly retired in the doc comment so it is not restored. The
first version of that test counted preference reads — of which there are none
either way — and so claimed to pin something unpinnable.

## Two of my own mutations were invalid before they were useful

- `tables.installing[result.app.bundleID]` **does not compile**: `bundleID` is
  `String?`. The type system is already half of that guard; the test covers the
  half that remains, which is someone reaching for `?? ""` to silence it.
- "route computed eagerly" written as `{ let r = route(); return r }()` is still
  lazy — it is inside the autoclosure. It only goes red once `assemble` really
  evaluates `route()` into a local.

No CHANGELOG entry and no version bump: nothing here is visible to users.


---

**Review round 1** found five holes, all on the test side, and **all five were
confirmed by mutation before fixing** — each was green against the fifteen cases
as first committed:

| Mutation that used to pass | Now caught by |
| --- | --- |
| staged term drops the skip verdict (`actionableStaged` for `nudgeableStaged`) | `askippedVersionSilencesAStagedBuildToo` |
| `route: route())` deleted from `assemble` (its default takes over) | `assemblingFactsDoesNotComputeTheRoute` |
| `isIgnored` transposed with `isVersionSkipped` | `theNonTableFactsEachComeFromTheirOwnSource` |
| a source hint fed from another | same |
| skip check asked about the INSTALLED version side | `theSkipCheckIsAskedAboutTheRemoteVersion` |

Plus `RowStateTables.live` — a defaultless factory for the one production call
site, because defaulting all seven tables is the `RowActions` hazard verbatim.

The review found **no behavioural divergence** between the old and new paths, and
independently recomputed the short-circuit conclusion above. It also corrected a
premise of mine: `@escaping` on the route is not new — `RowActionFacts.init`
already declared `@autoclosure @escaping` on main, so the "built and consumed in
one expression" argument is unchanged.
