### PR TITLE
Move the package-restart reconciliation and the restart line into Core

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -392,13 +392,10 @@ final class AppListModel {
     /// or it is the build over again), which is exactly the case where the target's
     /// build has to stay for the two sides to be comparable at all.
     func restartFromSide(_ id: String) -> UpdateResult.VersionSide? {
-        guard let runningBuild = runningVersionByID[id] else { return nil }
-        let build = UpdateResult.strippingBuildPrefix(runningBuild)
-        // Prefer the rollback backup's marketing (authoritative, written when *we*
-        // installed); fall back to the build→marketing history recovered for apps
-        // that self-updated outside us.
-        let marketing = backupVersions[id] ?? recoveredRestartMarketing[id]
-        return .init(marketing: marketing == build ? nil : marketing, build: build)
+        RestartLine.fromSide(
+            runningBuild: runningVersionByID[id],
+            backupMarketing: backupVersions[id],
+            recoveredMarketing: recoveredRestartMarketing[id])
     }
 
     /// The raw staged self-update for a row, if its own updater has downloaded a
@@ -3371,74 +3368,41 @@ final class AppListModel {
     /// Rebuilds `packageRestartPending` from scratch each pass; the caller unions it
     /// into `needsRestart`. Must run before `computeRestartInfo` finalizes that set.
     private func reconcilePackageRestarts() {
-        guard !stagedPackages.isEmpty else {
-            packageRestartPending.removeAll()
-            notifiedPackageRestart.removeAll()
-            return
-        }
-        let launchDates = runningLaunchDatesByPath()
-        let onDiskByID = Dictionary(
-            results.map { ($0.id, $0.app) }, uniquingKeysWith: { a, _ in a })
+        // The decision is `PackageRestartReconciler` in Core, where its
+        // one-line rules — decide nothing from a blind pass, carry a lit badge
+        // through a momentary old read, release the notify-once guard only on a
+        // real resolution — are executed. This is the effects half.
+        let outcome = PackageRestartReconciler.reconcile(
+            staged: stagedPackages.mapValues {
+                StagedPackageFacts(versionSide: $0.versionSide, stagedAt: $0.stagedAt)
+            },
+            onDisk: Dictionary(results.map { ($0.id, $0.app) }, uniquingKeysWith: { a, _ in a }),
+            launchDates: runningLaunchDatesByPath(),
+            previouslyPending: packageRestartPending,
+            previouslyNotified: notifiedPackageRestart)
 
-        var pending: Set<String> = []
-        var settledIDs: [String] = []
-        for (id, staged) in stagedPackages {
-            guard let app = onDiskByID[id] else {
-                // The row is missing from THIS scan — the bundle can be briefly
-                // unreadable while Installer swaps it. Decide nothing from a blind
-                // pass: carry a restart that was already pending forward so one
-                // missed scan can't drop the badge (or let `pruneStagedPackages`
-                // reclaim the entry). A genuinely deleted app is reclaimed later by
-                // the file-existence backstop in prune.
-                if packageRestartPending.contains(id) { pending.insert(id) }
-                continue
+        packageRestartPending = outcome.pending
+        notifiedPackageRestart = outcome.notified
+        for id in outcome.settled { stagedPackages[id] = nil }
+
+        for id in outcome.toNotify {
+            guard let app = results.first(where: { $0.id == id })?.app else { continue }
+            let version = app.shortVersion
+            // Badge always; banner only if the user keeps update notifications on
+            // — the pkg lands out of a rescan, not a click, so this is an
+            // unsolicited background event like the "new update" nudge.
+            if prefs.notifyOnUpdates {
+                UpdateNotifier.readyToRestart(
+                    app: app.name, version: version, appID: app.bundleID)
             }
-            let key = app.path.resolvingSymlinksInPath().path
-            let state = PackageRestartState.resolve(
-                onDiskVersion: app.versionSide,
-                stagedVersion: staged.versionSide,
-                stagedAt: staged.stagedAt,
-                runningLaunchDates: launchDates[key] ?? [],
-                buildIsDerived: AppScanner.buildVersionIsOverridden(
-                    bundleID: app.bundleID))
-            switch state {
-            case .pending:
-                // Not landed. Normally there's no badge yet; but if one was already
-                // lit (landed earlier) and the version momentarily reads old — a
-                // partial `package.json` read mid-swap — carry it rather than
-                // flickering the badge off and re-notifying on the next good pass.
-                if packageRestartPending.contains(id) { pending.insert(id) }
-            case .readyToRestart:
-                pending.insert(id)
-                if notifiedPackageRestart.insert(id).inserted {
-                    let version = app.shortVersion
-                    // Badge always; banner only if the user keeps update notifications
-                    // on — the pkg lands out of a rescan, not a click, so this is an
-                    // unsolicited background event like the "new update" nudge.
-                    if prefs.notifyOnUpdates {
-                        UpdateNotifier.readyToRestart(
-                            app: app.name, version: version, appID: app.bundleID)
-                    }
-                    Log.install.info("package landed, awaiting restart: \(app.name, privacy: .public) \(version ?? "?", privacy: .public)")
-                }
-            case .settled:
-                // Landed with nothing stale running (never open, or already
-                // relaunched). The install is fully done — drop the re-open entry.
-                settledIDs.append(id)
-            }
+            Log.install.info("package landed, awaiting restart: \(app.name, privacy: .public) \(version ?? "?", privacy: .public)")
         }
-        packageRestartPending = pending
-        for id in settledIDs { stagedPackages[id] = nil }
-        // Clear the notify-once guard ONLY when a restart genuinely resolves (settled,
-        // or its staged entry is gone) — never merely because the id fell out of
-        // `pending` for one pass, which would let the same landing re-notify. (A
-        // DuoUpdater relaunch, which doesn't persist this set, can still re-remind
-        // once for a restart that was already pending — acceptable, it's real.)
-        notifiedPackageRestart.formIntersection(Set(stagedPackages.keys))
-        if !settledIDs.isEmpty {
+
+        if !outcome.settled.isEmpty {
             persistStagedPackages()
         }
     }
+
 
     /// The restart happened (or the app was already gone), so a landed pkg has
     /// nothing left to restart: drop its pending state, the one-time-notify guard,

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3372,11 +3372,19 @@ final class AppListModel {
         // one-line rules — decide nothing from a blind pass, carry a lit badge
         // through a momentary old read, release the notify-once guard only on a
         // real resolution — are executed. This is the effects half.
+        // One dictionary, used for the decision AND for the announcements below.
+        // Looking the app up a second way would put "recorded as notified" and
+        // "actually notified" on two different sources: `outcome.notified` is
+        // assigned unconditionally, so a lookup that missed would leave the id in
+        // the notify-once guard with no banner ever posted — silent, and
+        // permanent. The old code could not diverge because both lived in one
+        // branch holding one `app`.
+        let onDisk = Dictionary(results.map { ($0.id, $0.app) }, uniquingKeysWith: { a, _ in a })
         let outcome = PackageRestartReconciler.reconcile(
             staged: stagedPackages.mapValues {
                 StagedPackageFacts(versionSide: $0.versionSide, stagedAt: $0.stagedAt)
             },
-            onDisk: Dictionary(results.map { ($0.id, $0.app) }, uniquingKeysWith: { a, _ in a }),
+            onDisk: onDisk,
             launchDates: runningLaunchDatesByPath(),
             previouslyPending: packageRestartPending,
             previouslyNotified: notifiedPackageRestart)
@@ -3386,7 +3394,14 @@ final class AppListModel {
         for id in outcome.settled { stagedPackages[id] = nil }
 
         for id in outcome.toNotify {
-            guard let app = results.first(where: { $0.id == id })?.app else { continue }
+            // `toNotify` only ever holds ids the reconciler resolved through
+            // `onDisk`, so a miss here is impossible rather than merely unlikely.
+            // Logged instead of skipped silently: the guard is already set, so a
+            // swallowed announcement never comes back.
+            guard let app = onDisk[id] else {
+                Log.install.error("no row for a package restart to announce: \(id, privacy: .public)")
+                continue
+            }
             let version = app.shortVersion
             // Badge always; banner only if the user keeps update notifications on
             // — the pkg lands out of a rescan, not a click, so this is an

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartReconciler.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartReconciler.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// What a staged package needs to say about itself for the reconciler to decide.
+///
+/// Deliberately not the App's `StagedPackage`, which also carries the download
+/// URL and the persistence fields: the decision reads exactly two things, and a
+/// narrow input is what lets a test state a case in one line.
+public struct StagedPackageFacts: Sendable, Equatable {
+    public var versionSide: VersionSide
+    public var stagedAt: Date
+
+    public init(versionSide: VersionSide, stagedAt: Date) {
+        self.versionSide = versionSide
+        self.stagedAt = stagedAt
+    }
+}
+
+/// The outcome of one reconciliation pass. Every field is a decision; the caller
+/// performs the effects (notify, drop the staged entry, persist).
+public struct PackageRestartReconciliation: Sendable, Equatable {
+    /// Rows that should show a Relaunch affordance and keep the badge lit.
+    public var pending: Set<String>
+    /// Staged entries that are fully done and should be dropped.
+    public var settled: [String]
+    /// Rows to announce, once each — already folded into `notified`.
+    public var toNotify: [String]
+    /// The notify-once guard as it should be after this pass.
+    public var notified: Set<String>
+}
+
+/// Decide, for every staged package, whether its install has landed, whether a
+/// stale copy is still running, and whether this is the first pass that can say
+/// so.
+///
+/// Split out of `AppListModel.reconcilePackageRestarts` because the rules here
+/// are one-liners with sharp edges and nothing executed them: a pass that cannot
+/// see a bundle must decide NOTHING, a pending row that was already lit must
+/// stay lit, and the notify-once guard must survive a row falling out of
+/// `pending` for a single pass. Each of those is one line, and each of them is a
+/// user-visible defect when it is the wrong line.
+public enum PackageRestartReconciler {
+
+    /// - Parameters:
+    ///   - staged: staged packages by row id (the install path).
+    ///   - onDisk: the apps THIS scan found, by row id. An id missing here is a
+    ///     blind pass, not a deletion.
+    ///   - launchDates: launch dates of running copies, by resolved bundle path.
+    ///   - previouslyPending: the badge state going in.
+    ///   - previouslyNotified: the notify-once guard going in.
+    public static func reconcile(
+        staged: [String: StagedPackageFacts],
+        onDisk: [String: InstalledApp],
+        launchDates: [String: [Date]],
+        previouslyPending: Set<String>,
+        previouslyNotified: Set<String>
+    ) -> PackageRestartReconciliation {
+        // Nothing staged: no badge, and no guard to keep. Both sets are dropped
+        // rather than intersected, so a cleared queue cannot leave a row lit.
+        guard !staged.isEmpty else {
+            return PackageRestartReconciliation(
+                pending: [], settled: [], toNotify: [], notified: [])
+        }
+
+        var pending: Set<String> = []
+        var settled: [String] = []
+        var toNotify: [String] = []
+        var notified = previouslyNotified
+
+        // Sorted so a pass is reproducible. The ids are independent of each
+        // other — every branch below reads and writes only its own id — so the
+        // order is free to be deterministic, and a test that asserts on
+        // `settled` should not have to sort it first.
+        for id in staged.keys.sorted() {
+            guard let package = staged[id] else { continue }
+            guard let app = onDisk[id] else {
+                // The row is missing from THIS scan — a bundle can be briefly
+                // unreadable while Installer swaps it. Decide nothing from a
+                // blind pass: carry a restart that was already pending so one
+                // missed scan cannot drop the badge or let the staged entry be
+                // reclaimed. A genuinely deleted app is reclaimed later by the
+                // file-existence backstop in the caller's prune.
+                if previouslyPending.contains(id) { pending.insert(id) }
+                continue
+            }
+            let key = app.path.resolvingSymlinksInPath().path
+            switch PackageRestartState.resolve(
+                onDiskVersion: app.versionSide,
+                stagedVersion: package.versionSide,
+                stagedAt: package.stagedAt,
+                runningLaunchDates: launchDates[key] ?? [],
+                buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID: app.bundleID)
+            ) {
+            case .pending:
+                // Not landed. Normally there is no badge yet; but if one was
+                // already lit (it landed on an earlier pass) and the version
+                // momentarily reads old — a partial `package.json` read
+                // mid-swap — carry it rather than flickering the badge off and
+                // re-announcing on the next good pass.
+                if previouslyPending.contains(id) { pending.insert(id) }
+            case .readyToRestart:
+                pending.insert(id)
+                if notified.insert(id).inserted { toNotify.append(id) }
+            case .settled:
+                // Landed with nothing stale running (never opened, or already
+                // relaunched). Done — drop the re-open entry.
+                settled.append(id)
+            }
+        }
+
+        // Release the notify-once guard ONLY when a restart genuinely resolves
+        // (settled, or its staged entry is gone) — never merely because an id
+        // fell out of `pending` for one pass, which would let the same landing
+        // announce itself again.
+        notified.formIntersection(Set(staged.keys).subtracting(settled))
+
+        return PackageRestartReconciliation(
+            pending: pending, settled: settled, toNotify: toNotify, notified: notified)
+    }
+}
+
+/// The "from" side of a restart line, as the user should read it.
+///
+/// `lsappinfo` only exposes the running process's *build* (e.g. "3965"), so a
+/// bare restart line reads as a mystery number with its marketing version lost.
+/// The marketing half is recovered from one of two records, in this order:
+///
+///   1. the rollback backup written right before we swapped (our own installs),
+///   2. the build→marketing history captured when we scanned that build before
+///      it was swapped out (apps that updated through their own updater).
+///
+/// Both survive our relaunches. The marketing half is left nil when it adds
+/// nothing — nothing recovered it, or it is the build over again — which is
+/// exactly the case where the target's build has to stay for the two sides to be
+/// comparable at all.
+public enum RestartLine {
+    public static func fromSide(
+        runningBuild: String?,
+        backupMarketing: String?,
+        recoveredMarketing: String?
+    ) -> VersionSide? {
+        guard let runningBuild else { return nil }
+        let build = UpdateResult.strippingBuildPrefix(runningBuild)
+        let marketing = backupMarketing ?? recoveredMarketing
+        return VersionSide(marketing: marketing == build ? nil : marketing, build: build)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartReconcilerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartReconcilerTests.swift
@@ -11,14 +11,24 @@ import Testing
 /// Each case names the single-line mutation it must fail under.
 struct PackageRestartReconcilerTests {
 
+    /// `/Applications`, deliberately not a temp directory. `reconcile` keys
+    /// `launchDates` by `path.resolvingSymlinksInPath()`, which really does touch
+    /// the filesystem: on macOS `/tmp` and `/var` are symlinks, so a fixture
+    /// under either is rewritten to `/private/…`, stops matching the key this
+    /// suite builds, and every landed case silently reads as `.settled` — which
+    /// still "passes" for the cases that expect settling.
     private static let path = "/Applications/Example.app"
+    private static let otherPath = "/Applications/Other.app"
     private static let stagedAt = Date(timeIntervalSince1970: 1_000)
 
-    private func app(_ short: String, build: String? = nil) -> InstalledApp {
+    private func app(
+        _ short: String, build: String? = nil,
+        bundleID: String = "com.example.app", path: String = Self.path
+    ) -> InstalledApp {
         InstalledApp(
-            name: "Example", bundleID: "com.example.app",
+            name: "Example", bundleID: bundleID,
             shortVersion: short, buildVersion: build,
-            path: URL(fileURLWithPath: Self.path),
+            path: URL(fileURLWithPath: path),
             isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
     }
 
@@ -37,12 +47,13 @@ struct PackageRestartReconcilerTests {
         staged stagedMap: [String: StagedPackageFacts],
         onDisk: [String: InstalledApp],
         launches: [Date] = [],
+        launchesByPath: [String: [Date]]? = nil,
         pending: Set<String> = [],
         notified: Set<String> = []
     ) -> PackageRestartReconciliation {
         PackageRestartReconciler.reconcile(
             staged: stagedMap, onDisk: onDisk,
-            launchDates: launches.isEmpty ? [:] : [Self.path: launches],
+            launchDates: launchesByPath ?? (launches.isEmpty ? [:] : [Self.path: launches]),
             previouslyPending: pending, previouslyNotified: notified)
     }
 
@@ -172,6 +183,93 @@ struct PackageRestartReconcilerTests {
             notified: [Self.path])
         #expect(done.settled == [Self.path])
         #expect(done.notified.isEmpty)
+    }
+
+    /// The guard is released for an app whose staged entry is simply GONE, not
+    /// just for one that settled. `pruneStagedPackages` drops entries in the same
+    /// post-rescan pass without touching this set, so without the intersection an
+    /// app whose entry was swept keeps its guard forever — and the next time it
+    /// stages a package and lands, the badge never announces it again.
+    ///
+    /// Mutation: `notified.subtract(settled)` in place of
+    /// `notified.formIntersection(Set(staged.keys).subtracting(settled))`.
+    @Test func theGuardIsAlsoReleasedWhenTheStagedEntryIsSweptAway() {
+        let out = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            launches: Self.staleLaunch,
+            notified: [Self.path, Self.otherPath])
+
+        #expect(out.notified == [Self.path], "the swept id keeps no guard")
+    }
+
+    /// Apps whose stored build is NOT their `CFBundleVersion` — Xcode, 豆包输入法
+    /// — have to be compared on marketing alone, or a landed package reads as
+    /// still pending: its marketing matches while the two builds are in different
+    /// namespaces and can never be equal. The badge would never light and the
+    /// staged entry would never settle.
+    ///
+    /// The rule itself is pinned by `PackageRestartStateTests`; what is pinned
+    /// here is the PLUMBING, which is what this move touched. Every other case in
+    /// this suite uses a bundle id for which the flag is constantly false, so a
+    /// hardcoded `false` passed all of them.
+    ///
+    /// Mutation: `buildIsDerived: false` instead of
+    /// `AppScanner.buildVersionIsOverridden(bundleID: app.bundleID)`.
+    @Test func anAppWhoseStoredBuildIsDerivedIsJudgedOnMarketingAlone() {
+        let out = reconcile(
+            staged: [Self.path: staged("27.0", build: "27A5237l")],
+            onDisk: [Self.path: app(
+                "27.0", build: "27A5300x", bundleID: AppScanner.xcodeBundleID)],
+            launches: Self.staleLaunch)
+
+        #expect(out.pending == [Self.path], "landed: the builds are not comparable")
+        #expect(out.toNotify == [Self.path])
+    }
+
+    /// A mixed pass: one row blind, two landing with a stale copy running, two
+    /// landing with nothing stale. Every other case here has a single staged
+    /// entry, which makes `insert`/`append` indistinguishable from assignment and
+    /// leaves the one genuinely cross-id statement — the guard intersection —
+    /// with nothing to do.
+    ///
+    /// The ids are chosen so that each accumulating write happens BEFORE a later
+    /// row writes the same collection: iteration is sorted, so Alpha (blind) is
+    /// visited before Beta, and Echo before Gamma. A first version of this case
+    /// had the landing row sort first, and `pending = [id]` survived it — the
+    /// blind row's `insert` afterwards put the wiped id back.
+    ///
+    /// Mutations: `pending = [id]`, `toNotify = [id]`, `settled = [id]` in place
+    /// of the inserts and appends.
+    @Test func aMixedPassKeepsEveryRowsOwnOutcome() {
+        let alpha = "/Applications/Alpha.app"   // blind, already pending
+        let beta = "/Applications/Beta.app"     // lands, stale copy running
+        let delta = "/Applications/Delta.app"   // lands, stale copy running
+        let echo = "/Applications/Echo.app"     // lands, nothing stale
+        let gamma = "/Applications/Gamma.app"   // lands, nothing stale
+
+        let out = reconcile(
+            staged: [
+                alpha: staged("2.0"), beta: staged("2.0"), delta: staged("2.0"),
+                echo: staged("2.0"), gamma: staged("2.0"),
+            ],
+            onDisk: [
+                beta: app("2.0", path: beta), delta: app("2.0", path: delta),
+                echo: app("2.0", path: echo), gamma: app("2.0", path: gamma),
+            ],
+            launchesByPath: [
+                beta: Self.staleLaunch, delta: Self.staleLaunch,
+                echo: Self.freshLaunch, gamma: Self.freshLaunch,
+            ],
+            pending: [alpha],
+            notified: [alpha])
+
+        #expect(out.pending == [alpha, beta, delta])
+        #expect(out.toNotify == [beta, delta])
+        #expect(out.settled == [echo, gamma])
+        // alpha's entry is still staged, so its guard survives; beta and delta
+        // just earned theirs; echo and gamma settled and hold none.
+        #expect(out.notified == [alpha, beta, delta])
     }
 
     /// An empty queue clears both sets outright rather than intersecting, so a

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartReconcilerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartReconcilerTests.swift
@@ -1,0 +1,257 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// The reconciliation pass that decides which landed packages still need a
+/// relaunch. It lived in `AppListModel`, where nothing executed it, and its
+/// rules are one-liners whose wrong version is a user-visible defect: a badge
+/// that drops on a blind pass, a badge that flickers off mid-swap, a landing
+/// that announces itself twice.
+///
+/// Each case names the single-line mutation it must fail under.
+struct PackageRestartReconcilerTests {
+
+    private static let path = "/Applications/Example.app"
+    private static let stagedAt = Date(timeIntervalSince1970: 1_000)
+
+    private func app(_ short: String, build: String? = nil) -> InstalledApp {
+        InstalledApp(
+            name: "Example", bundleID: "com.example.app",
+            shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: Self.path),
+            isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
+    }
+
+    private func staged(_ short: String, build: String? = nil) -> StagedPackageFacts {
+        StagedPackageFacts(
+            versionSide: VersionSide(marketing: short, build: build),
+            stagedAt: Self.stagedAt)
+    }
+
+    /// A copy launched BEFORE the package was staged is the stale one.
+    private static let staleLaunch = [Date(timeIntervalSince1970: 500)]
+    /// A copy launched after it has already picked up the new code.
+    private static let freshLaunch = [Date(timeIntervalSince1970: 2_000)]
+
+    private func reconcile(
+        staged stagedMap: [String: StagedPackageFacts],
+        onDisk: [String: InstalledApp],
+        launches: [Date] = [],
+        pending: Set<String> = [],
+        notified: Set<String> = []
+    ) -> PackageRestartReconciliation {
+        PackageRestartReconciler.reconcile(
+            staged: stagedMap, onDisk: onDisk,
+            launchDates: launches.isEmpty ? [:] : [Self.path: launches],
+            previouslyPending: pending, previouslyNotified: notified)
+    }
+
+    // MARK: the three states
+
+    /// Landed, and a copy that predates the hand-off is still running: light the
+    /// badge and announce it.
+    @Test func aLandedPackageWithAStaleCopyRunningIsReadyToRestart() {
+        let out = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            launches: Self.staleLaunch)
+
+        #expect(out.pending == [Self.path])
+        #expect(out.toNotify == [Self.path])
+        #expect(out.settled.isEmpty)
+    }
+
+    /// Landed with nothing stale running — never opened, or already relaunched.
+    /// The staged entry is dropped and no badge is lit.
+    @Test func aLandedPackageWithNothingStaleRunningSettles() {
+        let out = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            launches: Self.freshLaunch)
+
+        #expect(out.settled == [Self.path])
+        #expect(out.pending.isEmpty)
+        #expect(out.toNotify.isEmpty)
+    }
+
+    /// Not landed yet — the disk still reads the old version — and no badge was
+    /// lit before, so none is lit now.
+    @Test func aPackageThatHasNotLandedLightsNothing() {
+        let out = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("1.0")],
+            launches: Self.staleLaunch)
+
+        #expect(out.pending.isEmpty)
+        #expect(out.settled.isEmpty)
+        #expect(out.toNotify.isEmpty)
+    }
+
+    // MARK: the two carry-forward rules
+
+    /// A pass that cannot see the bundle decides NOTHING. A bundle is briefly
+    /// unreadable while Installer swaps it, and one missed scan must not drop
+    /// the badge or let the staged entry be reclaimed.
+    ///
+    /// Mutation: delete `if previouslyPending.contains(id) { pending.insert(id) }`
+    /// from the `onDisk[id] == nil` branch.
+    @Test func aBlindPassCarriesAnAlreadyLitBadgeAndSettlesNothing() {
+        let out = reconcile(
+            staged: [Self.path: staged("2.0")], onDisk: [:], pending: [Self.path])
+
+        #expect(out.pending == [Self.path])
+        #expect(out.settled.isEmpty, "a pass that cannot see the app must not reclaim it")
+    }
+
+    /// …but a blind pass does not INVENT a badge either.
+    ///
+    /// Mutation: `pending.insert(id)` unconditionally in that branch.
+    @Test func aBlindPassDoesNotLightABadgeThatWasNotLit() {
+        let out = reconcile(staged: [Self.path: staged("2.0")], onDisk: [:])
+
+        #expect(out.pending.isEmpty)
+    }
+
+    /// A momentary old read mid-swap — a partial `package.json` — must not
+    /// flicker a lit badge off, because the next good pass would re-announce it.
+    ///
+    /// Mutation: delete `if previouslyPending.contains(id) { pending.insert(id) }`
+    /// from the `.pending` branch.
+    @Test func anAlreadyLitBadgeSurvivesAMomentaryOldRead() {
+        let out = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("1.0")],
+            launches: Self.staleLaunch,
+            pending: [Self.path])
+
+        #expect(out.pending == [Self.path])
+        #expect(out.toNotify.isEmpty, "carrying a badge is not announcing it again")
+    }
+
+    // MARK: the notify-once guard
+
+    /// Announced once, not once per pass.
+    ///
+    /// Mutation: `toNotify.append(id)` unconditionally instead of behind
+    /// `notified.insert(id).inserted`.
+    @Test func aLandingIsAnnouncedOnlyOnce() {
+        let first = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            launches: Self.staleLaunch)
+        #expect(first.toNotify == [Self.path])
+
+        let second = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            launches: Self.staleLaunch,
+            pending: first.pending, notified: first.notified)
+        #expect(second.toNotify.isEmpty)
+        #expect(second.pending == [Self.path], "still lit, just not re-announced")
+    }
+
+    /// The guard is released only when the restart genuinely resolves — never
+    /// because the id merely fell out of `pending` for one pass. This is what
+    /// stops the same landing announcing itself again.
+    ///
+    /// Mutation: `notified.formIntersection(Set(staged.keys))` without
+    /// `.subtracting(settled)`, or intersecting with `pending` instead.
+    @Test func theGuardIsReleasedOnlyWhenTheRestartResolves() {
+        // Fell out of pending for a pass (a blind pass), staged entry still
+        // there: the guard must be KEPT, or the next good pass re-announces.
+        let blind = reconcile(
+            staged: [Self.path: staged("2.0")], onDisk: [:], notified: [Self.path])
+        #expect(blind.notified == [Self.path])
+
+        // Actually settled: the guard goes, so a future staging of the same app
+        // can announce again.
+        let done = reconcile(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            launches: Self.freshLaunch,
+            notified: [Self.path])
+        #expect(done.settled == [Self.path])
+        #expect(done.notified.isEmpty)
+    }
+
+    /// An empty queue clears both sets outright rather than intersecting, so a
+    /// cleared queue cannot leave a row lit.
+    ///
+    /// Mutation: return `previouslyPending` / `previouslyNotified` instead of
+    /// empty sets from the early return.
+    @Test func anEmptyQueueClearsEverything() {
+        let out = reconcile(
+            staged: [:], onDisk: [Self.path: app("2.0")],
+            pending: [Self.path], notified: [Self.path])
+
+        #expect(out.pending.isEmpty && out.notified.isEmpty)
+    }
+}
+
+/// The "from" side of a restart line.
+struct RestartLineTests {
+
+    /// Nothing running means no line at all.
+    @Test func nothingRunningHasNoFromSide() {
+        #expect(RestartLine.fromSide(
+            runningBuild: nil, backupMarketing: "1.0", recoveredMarketing: "1.0") == nil)
+    }
+
+    /// The backup wins: it was written by us at swap time, so it is
+    /// authoritative over the scanned history.
+    ///
+    /// Mutation: `recoveredMarketing ?? backupMarketing`.
+    @Test func theRollbackBackupOutranksTheScannedHistory() {
+        let side = RestartLine.fromSide(
+            runningBuild: "3965", backupMarketing: "26.609.71450",
+            recoveredMarketing: "26.500.00000")
+
+        #expect(side?.marketing == "26.609.71450")
+        #expect(side?.build == "3965")
+    }
+
+    /// With no backup, the scanned build→marketing history fills in — that is
+    /// the case for apps that updated through their own updater.
+    ///
+    /// Mutation: drop the `?? recoveredMarketing` fallback.
+    @Test func theScannedHistoryFillsInWhenThereIsNoBackup() {
+        #expect(RestartLine.fromSide(
+            runningBuild: "3965", backupMarketing: nil,
+            recoveredMarketing: "26.500.00000")?.marketing == "26.500.00000")
+    }
+
+    /// A marketing string that is just the build again adds nothing, and saying
+    /// it twice would cost the target's build the space it needs for the two
+    /// sides to be comparable at all.
+    ///
+    /// Mutation: `marketing: marketing` without the `== build` test.
+    @Test func aMarketingStringEqualToTheBuildIsDropped() {
+        let side = RestartLine.fromSide(
+            runningBuild: "3965", backupMarketing: "3965", recoveredMarketing: nil)
+
+        #expect(side?.marketing == nil)
+        #expect(side?.build == "3965")
+    }
+
+    /// JetBrains stamps `CFBundleVersion` as "IU-262.6653.22" while the build id
+    /// everything else speaks has no prefix, so the running build is stripped
+    /// into that one namespace — and the "is the marketing string just the build
+    /// again" test has to be made AFTER stripping, or a recovered "262.6653.22"
+    /// stops matching a running "IU-262.6653.22" and gets shown twice.
+    ///
+    /// The fixture needs a build that actually carries a prefix: with a plain
+    /// "3965" the raw and stripped forms are the same string, and comparing
+    /// against either passes. The first version of this case did exactly that
+    /// and let the mutation through.
+    ///
+    /// Mutation: compare against the raw `runningBuild` rather than the stripped
+    /// `build`; or drop `strippingBuildPrefix` entirely.
+    @Test func theBuildIsStrippedBeforeItIsComparedAndShown() {
+        let side = RestartLine.fromSide(
+            runningBuild: "IU-262.6653.22", backupMarketing: "262.6653.22",
+            recoveredMarketing: nil)
+
+        #expect(side?.build == "262.6653.22", "the prefix is not part of the number")
+        #expect(side?.marketing == nil, "and the comparison is made after stripping")
+    }
+}


### PR DESCRIPTION
The second batch out of `AppListModel`, picked because both are made of one-line
rules whose wrong version is user-visible, and nothing executed either.

## `PackageRestartReconciler`

Decides, per staged package, whether the install has landed, whether a stale
copy is still running, and whether this is the first pass that can say so. Three
sharp edges, each one line:

- **A pass that cannot see the bundle decides nothing.** Installer makes a
  bundle briefly unreadable mid-swap. One missed scan dropping the badge would
  also let `pruneStagedPackages` reclaim the entry.
- **A momentarily old read must not flicker a lit badge off** — a partial
  `package.json` read — because the next good pass would re-announce it.
- **The notify-once guard is released only when a restart genuinely resolves**,
  never because an id fell out of `pending` for a single pass.

It takes `StagedPackageFacts` rather than the App's `StagedPackage` (which also
carries the download URL and persistence fields): the decision reads exactly two
of them. The App keeps the effects — notify, drop the settled entry, persist.

Iteration is over sorted keys now. Every branch reads and writes only its own id,
so the order was already free; making it deterministic lets a test assert on
`settled` without sorting first.

## `RestartLine`

Recovers the marketing half of a running build, which `lsappinfo` reports only as
a number. The rollback backup written at swap time outranks the scanned
build→marketing history; a marketing string that is just the build again is
dropped — **after** the JetBrains-style prefix is stripped, so a recovered
`262.6653.22` still matches a running `IU-262.6653.22`.

## Verification

**17 cases, 18 mutations, all 18 red on exactly the case they should be.**

| Mutation | Case it kills |
| --- | --- |
| blind pass drops the carry-forward / lights unconditionally / settles | the two blind-pass cases |
| `.pending` drops the flicker guard | `anAlreadyLitBadgeSurvivesAMomentaryOldRead` |
| notify every pass instead of once | `aLandingIsAnnouncedOnlyOnce` |
| guard intersected with `pending`; guard kept across a settle | `theGuardIsReleasedOnlyWhenTheRestartResolves` |
| empty queue returns the old sets | `anEmptyQueueClearsEverything` |
| `recoveredMarketing ?? backupMarketing`; fallback dropped | the two precedence cases |
| marketing equal to the build kept | `aMarketingStringEqualToTheBuildIsDropped` |
| compare against the unstripped build; `strippingBuildPrefix` dropped | `theBuildIsStrippedBeforeItIsComparedAndShown` |

- `make test` — exit 0. **Core 2076 → 2093 (+17 cases, +2 suites)**, CLI 188,
  App 9 of 9, four python gates green.
- `xcodebuild -scheme DuoUpdater` — `** BUILD SUCCEEDED **`.
- `make gallery` — exit 0, all five gates.
- `AppListModel` — 70 lines out, 34 back.

**Two of the thirteen mutations only became useful after being fixed**, and both
failures were mine: one was malformed and did not compile (a mutation that fails
to build proves nothing), and the strip test used a plain `"3965"`, whose raw and
stripped forms are the same string — so comparing against either passed and the
mutation went straight through. It now uses a build that carries a prefix.

No CHANGELOG entry and no version bump: nothing here is visible to users.


---

**Review round 1** confirmed the four equivalences I was unsure about — the
`formIntersection` rewrite, the two app-lookup sources, the version read moving
to a second loop, and the sort — and found three gaps plus one seam. All three
gaps were **verified green by mutation before fixing**:

| Mutation that used to pass | Now caught by |
| --- | --- |
| `notified.subtract(settled)` (loses the "entry swept away" half) | `theGuardIsAlsoReleasedWhenTheStagedEntryIsSweptAway` |
| `buildIsDerived: false` hardcoded | `anAppWhoseStoredBuildIsDerivedIsJudgedOnMarketingAlone` |
| `pending = [id]` / `toNotify = [id]` / `settled = [id]` | `aMixedPassKeepsEveryRowsOwnOutcome` |

The seam was mine, introduced by this PR: looking the app up a second way for
the announcement loop split "recorded as notified" from "actually notified", so
a miss would have left the id guarded with no banner ever posted. One dictionary
now serves both, and the impossible branch logs instead of skipping silently.

On the sort justification in my own commit message — "every branch reads and
writes only its own id" — the review checked it properly: `notified` **is**
cross-id, but only ever inserted into, and `.inserted` for one id cannot be
changed by another. The conclusion holds; the reasoning I gave for it was
thinner than it should have been.
