### PR TITLE
Share the "has this landed" test, and move the staged-package prune into Core

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3827,42 +3827,28 @@ final class AppListModel {
     /// button that can't do anything.
     private func pruneStagedPackages() {
         guard !stagedPackages.isEmpty else { return }
-        let onDisk = Dictionary(results.map { ($0.id, $0.app) }, uniquingKeysWith: { a, _ in a })
-        let offered = Dictionary(
-            results.compactMap { r -> (String, VersionSide)? in
-                guard let side = r.remote?.versionSide, !side.isEmpty else { return nil }
-                return (r.id, side)
+        // The rules are `StagedPackagePrune` in Core, which shares its "has this
+        // landed" test with `PackageRestartState` rather than keeping a second
+        // copy of the expression here.
+        let keep = StagedPackagePrune.keep(
+            staged: stagedPackages.mapValues {
+                StagedPackageFacts(versionSide: $0.versionSide, stagedAt: $0.stagedAt)
             },
-            uniquingKeysWith: { a, _ in a })
-        let kept = stagedPackages.filter { id, staged in
-            // A landed package that left a stale copy running is no longer "on offer"
-            // (the app is now current) and its download may have been swept, yet its
-            // entry must survive to keep the Restart badge lit until the app is
-            // relaunched. `reconcilePackageRestarts` retires it once it settles.
-            if packageRestartPending.contains(id) { return true }
-            let fileThere = FileManager.default.fileExists(atPath: staged.url.path)
-            guard let app = onDisk[id] else {
-                // Row missing from THIS scan (bundle mid-swap): don't reclaim on a
-                // blind pass — a genuinely deleted app is still bounded by the file
-                // backstop once its download is swept.
-                return fileThere
-            }
-            // Landed (the app now IS the staged version): keep so restart tracking
-            // survives a one-scan flicker of the launch-time signal, even if the
-            // download was swept. Reconcile settles it once the copy is fresh/gone.
-            // `buildIsDerived` matches the guard `reconcilePackageRestarts` passes
-            // to `PackageRestartState.resolve` — same two inputs, same namespace
-            // problem for `AppScanner.buildVersionIsOverridden` apps (#285).
-            if VersionComparator.isSame(app.versionSide, as: staged.versionSide,
-                buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID: app.bundleID)
-            ) { return true }
-            // Otherwise it's only usable while still on offer and re-openable.
-            return offered[id].map {
-                VersionComparator.isSame($0, as: staged.versionSide)
-            } == true && fileThere
-        }
-        guard kept.count != stagedPackages.count else { return }
-        stagedPackages = kept
+            onDisk: Dictionary(results.map { ($0.id, $0.app) }, uniquingKeysWith: { a, _ in a }),
+            offered: Dictionary(
+                results.compactMap { r -> (String, VersionSide)? in
+                    guard let side = r.remote?.versionSide, !side.isEmpty else { return nil }
+                    return (r.id, side)
+                },
+                uniquingKeysWith: { a, _ in a }),
+            pending: packageRestartPending,
+            downloadExists: { [stagedPackages] id in
+                guard let url = stagedPackages[id]?.url else { return false }
+                return FileManager.default.fileExists(atPath: url.path)
+            })
+
+        guard keep.count != stagedPackages.count else { return }
+        stagedPackages = stagedPackages.filter { keep.contains($0.key) }
         persistStagedPackages()
     }
 

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3836,6 +3836,11 @@ final class AppListModel {
             },
             onDisk: Dictionary(results.map { ($0.id, $0.app) }, uniquingKeysWith: { a, _ in a }),
             offered: Dictionary(
+                // `!side.isEmpty` is defensive, not required: `VersionComparator
+                // .isSame` returns false when there is nothing comparable, so an
+                // empty side reaches the same answer either way. Kept because it
+                // says what an empty side means here; do not read it as a
+                // precondition Core relies on.
                 results.compactMap { r -> (String, VersionSide)? in
                     guard let side = r.remote?.versionSide, !side.isEmpty else { return nil }
                     return (r.id, side)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartReconciler.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartReconciler.swift
@@ -144,3 +144,81 @@ public enum RestartLine {
         return VersionSide(marketing: marketing == build ? nil : marketing, build: build)
     }
 }
+
+/// Which staged package entries are still worth keeping.
+///
+/// A staged entry outlives its download: the file can be swept by the system
+/// while the entry still has a job to do (keeping the Restart badge lit until
+/// the user relaunches). So this is not "is the file there" — it is four rules,
+/// and three of them keep an entry whose file is gone.
+///
+/// Split out of `AppListModel.pruneStagedPackages` for the reason its own
+/// comment gave away: it decided "has this landed" with its own copy of the
+/// expression in `PackageRestartState`, kept in step by a comment saying so.
+/// Both now call `PackageRestartState.hasLanded`, and a test asserts the two
+/// agree — including for the derived-build apps where the copies were most
+/// likely to diverge.
+public enum StagedPackagePrune {
+
+    /// - Parameters:
+    ///   - staged: staged packages by row id.
+    ///   - onDisk: the apps THIS scan found. An id missing here is a blind pass.
+    ///   - offered: the version each row's source currently offers, by row id.
+    ///     Absent when the source said nothing, or said nothing usable.
+    ///   - pending: rows whose landed package is waiting on a relaunch.
+    ///   - downloadExists: whether the staged download is still on disk, by row
+    ///     id. A closure rather than a precomputed set so the `pending`
+    ///     short-circuit below keeps costing no syscall — the entries that are
+    ///     certain to be kept never ask.
+    /// - Returns: the ids to keep.
+    public static func keep(
+        staged: [String: StagedPackageFacts],
+        onDisk: [String: InstalledApp],
+        offered: [String: VersionSide],
+        pending: Set<String>,
+        downloadExists: (String) -> Bool
+    ) -> Set<String> {
+        var kept: Set<String> = []
+        for id in staged.keys.sorted() {
+            guard let package = staged[id] else { continue }
+
+            // A landed package that left a stale copy running is no longer "on
+            // offer" (the app is now current) and its download may have been
+            // swept, yet its entry must survive to keep the Restart badge lit
+            // until the app is relaunched. The reconciler retires it once it
+            // settles. Checked first, so this costs no filesystem call.
+            if pending.contains(id) {
+                kept.insert(id)
+                continue
+            }
+
+            guard let app = onDisk[id] else {
+                // Row missing from THIS scan (bundle mid-swap): don't reclaim on
+                // a blind pass — a genuinely deleted app is still bounded by the
+                // file backstop once its download is swept.
+                if downloadExists(id) { kept.insert(id) }
+                continue
+            }
+
+            // Landed: keep, so restart tracking survives a one-scan flicker of
+            // the launch-time signal even if the download was swept.
+            if PackageRestartState.hasLanded(
+                onDiskVersion: app.versionSide, stagedVersion: package.versionSide,
+                buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID: app.bundleID)
+            ) {
+                kept.insert(id)
+                continue
+            }
+
+            // Otherwise it is only usable while still on offer AND re-openable.
+            // Both halves matter: an entry for a version no longer offered would
+            // install something the source has moved past, and one whose download
+            // is gone has nothing to install at all.
+            let stillOffered = offered[id].map {
+                VersionComparator.isSame($0, as: package.versionSide)
+            } == true
+            if stillOffered && downloadExists(id) { kept.insert(id) }
+        }
+        return kept
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartState.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartState.swift
@@ -58,11 +58,37 @@ public enum PackageRestartState: Sendable, Equatable {
         runningLaunchDates: [Date],
         buildIsDerived: Bool = false
     ) -> Self {
-        guard let onDiskVersion else { return .pending }
-        guard VersionComparator.isSame(
-            onDiskVersion, as: stagedVersion, buildIsDerived: buildIsDerived)
+        guard hasLanded(
+            onDiskVersion: onDiskVersion, stagedVersion: stagedVersion,
+            buildIsDerived: buildIsDerived)
         else { return .pending }
         let staleRunning = runningLaunchDates.contains { $0 < stagedAt }
         return staleRunning ? .readyToRestart : .settled
+    }
+
+    /// Whether the app on disk IS the version the staged package installs — as
+    /// opposed to still being the old one (the install has not finished) or
+    /// already carrying a newer one (the staged package was superseded, not
+    /// applied).
+    ///
+    /// Named and shared because **two** places decide it and they must not drift:
+    /// `resolve` above, and `StagedPackagePrune.keep`, which keeps a landed entry
+    /// so restart tracking survives a one-scan flicker even after the download is
+    /// swept. Those were two copies of the same expression in two files, with the
+    /// invariant maintained by a comment in one of them saying it matched the
+    /// other — the shape CLAUDE.md records as having already drifted twice here.
+    ///
+    /// `buildIsDerived` discards the build half: a scanner-substituted build
+    /// (Xcode, 豆包输入法) is not in the package source's namespace, so landing
+    /// falls back to marketing-to-marketing. Getting that wrong on either side
+    /// means a landed package that never lights the badge and never settles.
+    public static func hasLanded(
+        onDiskVersion: VersionSide?,
+        stagedVersion: VersionSide,
+        buildIsDerived: Bool
+    ) -> Bool {
+        guard let onDiskVersion else { return false }
+        return VersionComparator.isSame(
+            onDiskVersion, as: stagedVersion, buildIsDerived: buildIsDerived)
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedPackagePruneTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedPackagePruneTests.swift
@@ -57,7 +57,10 @@ struct StagedPackagePruneTests {
     @Test func aRowWaitingOnARelaunchIsKeptWithNoDownloadAndNoOffer() {
         #expect(keep(
             staged: [Self.path: staged("2.0")],
-            onDisk: [Self.path: app("2.0")],
+            // Reads as the OLD version — the mid-swap case. With `app("2.0")`
+            // here the row also satisfies the landed rule, so deleting the
+            // pending branch left this green: it was measuring the wrong branch.
+            onDisk: [Self.path: app("1.0")],
             pending: [Self.path],
             downloadExists: false) == [Self.path])
     }
@@ -175,13 +178,31 @@ struct StagedPackagePruneTests {
         let blind = "/Applications/Alpha.app"      // kept: blind, download present
         let landed = "/Applications/Beta.app"      // kept: landed
         let waiting = "/Applications/Delta.app"    // kept: pending a relaunch
+        let offeredRow = "/Applications/Zeta.app"  // kept: on offer + downloaded
 
         let out = keep(
-            staged: [blind: staged("2.0"), landed: staged("2.0"), waiting: staged("2.0")],
-            onDisk: [landed: app("2.0", path: landed), waiting: app("2.0", path: waiting)],
+            staged: [blind: staged("2.0"), landed: staged("2.0"),
+                     waiting: staged("2.0"), offeredRow: staged("2.0")],
+            onDisk: [landed: app("2.0", path: landed), waiting: app("2.0", path: waiting),
+                     offeredRow: app("1.0", path: offeredRow)],
+            offered: [offeredRow: VersionSide(marketing: "2.0")],
             pending: [waiting])
 
-        #expect(out == [blind, landed, waiting])
+        #expect(out == [blind, landed, waiting, offeredRow])
+    }
+
+    /// The blind branch sorts FIRST in every other multi-entry case, so an
+    /// assignment there happens to give the right answer — the rows after it put
+    /// themselves back. Here it sorts last, so it has something to displace.
+    ///
+    /// Mutation: `kept = [id]` in the blind branch.
+    @Test func aBlindEntryDoesNotDisplaceAnEarlierKeeper() {
+        let landed = "/Applications/Beta.app"
+        let blind = "/Applications/Zeta.app"
+
+        #expect(keep(
+            staged: [landed: staged("2.0"), blind: staged("2.0")],
+            onDisk: [landed: app("2.0", path: landed)]) == [landed, blind])
     }
 }
 
@@ -202,10 +223,6 @@ struct LandedAgreementTests {
             isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
     }
 
-    /// The inputs where the two copies were most likely to drift: a derived
-    /// build, where landing must fall back to marketing alone. Judged as "not
-    /// landed" by either side, the badge never lights and the entry never
-    /// settles (#285).
     /// No on-disk version at all is NOT landing. `resolve` returns `.pending`
     /// for it, and prune must not keep an entry on the strength of it either —
     /// a row we cannot read a version for has told us nothing.
@@ -222,6 +239,10 @@ struct LandedAgreementTests {
             runningLaunchDates: [Date(timeIntervalSince1970: 500)]) == .pending)
     }
 
+    /// The inputs where the two copies were most likely to drift: a derived
+    /// build, where landing must fall back to marketing alone. Judged "not
+    /// landed" by either side, the badge never lights and the entry never
+    /// settles (#285).
     @Test func bothSidesAgreeOnLandingIncludingDerivedBuilds() {
         let stagedAt = Date(timeIntervalSince1970: 1_000)
         let stale = [Date(timeIntervalSince1970: 500)]
@@ -231,6 +252,13 @@ struct LandedAgreementTests {
              VersionSide(marketing: "2.0", build: "20"), true),
             ("plain, still old",
              app("1.0", build: "10", bundleID: "com.example.app"),
+             VersionSide(marketing: "2.0", build: "20"), false),
+            // Separates the flag's two values in the OTHER direction: an
+            // ordinary app whose marketing matches but whose build moved has not
+            // landed. Hardcoding `buildIsDerived: true` throws the build away,
+            // calls it landed, and passed everything until this case existed.
+            ("plain, marketing matches but the build moved",
+             app("2.0", build: "21", bundleID: "com.example.app"),
              VersionSide(marketing: "2.0", build: "20"), false),
             ("derived build, marketing matches, builds differ",
              app("27.0", build: "27A5237l", bundleID: AppScanner.xcodeBundleID),
@@ -263,7 +291,9 @@ struct LandedAgreementTests {
                     StagedPackageFacts(versionSide: stagedSide, stagedAt: stagedAt)],
                 onDisk: ["/Applications/Example.app": installed],
                 offered: [:], pending: [], downloadExists: { _ in false })
-            #expect(kept.isEmpty != expectedLanded, "prune disagrees for \(label)")
+            #expect(
+                kept == (expectedLanded ? ["/Applications/Example.app"] : []),
+                "prune disagrees for \(label)")
         }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedPackagePruneTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedPackagePruneTests.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// Which staged package entries survive a pass.
+///
+/// A staged entry outlives its download, so this is not "is the file there":
+/// three of the four rules keep an entry whose file is gone. It lived in
+/// `AppListModel` with nothing to execute it, and it decided "has this landed"
+/// with its own copy of the expression in `PackageRestartState`, kept in step by
+/// a comment saying it matched.
+struct StagedPackagePruneTests {
+
+    /// `/Applications`, not a temp dir — see the note in
+    /// `PackageRestartReconcilerTests`; the sibling suite keys launch dates
+    /// through `resolvingSymlinksInPath`, and keeping both fixtures on the same
+    /// footing is what lets the agreement test below compare them.
+    private static let path = "/Applications/Example.app"
+    private static let stagedAt = Date(timeIntervalSince1970: 1_000)
+
+    private func app(
+        _ short: String, build: String? = nil,
+        bundleID: String = "com.example.app", path: String = Self.path
+    ) -> InstalledApp {
+        InstalledApp(
+            name: "Example", bundleID: bundleID,
+            shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: path),
+            isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
+    }
+
+    private func staged(_ short: String, build: String? = nil) -> StagedPackageFacts {
+        StagedPackageFacts(
+            versionSide: VersionSide(marketing: short, build: build), stagedAt: Self.stagedAt)
+    }
+
+    private func keep(
+        staged stagedMap: [String: StagedPackageFacts],
+        onDisk: [String: InstalledApp] = [:],
+        offered: [String: VersionSide] = [:],
+        pending: Set<String> = [],
+        downloadExists: Bool = true
+    ) -> Set<String> {
+        StagedPackagePrune.keep(
+            staged: stagedMap, onDisk: onDisk, offered: offered, pending: pending,
+            downloadExists: { _ in downloadExists })
+    }
+
+    // MARK: the three rules that keep an entry whose download is gone
+
+    /// A landed package waiting on a relaunch keeps its entry even though the app
+    /// is now current (so nothing is "on offer") and the download may have been
+    /// swept. Reclaiming it here would drop the Restart badge the reconciler is
+    /// holding.
+    ///
+    /// Mutation: delete the `pending.contains(id)` branch.
+    @Test func aRowWaitingOnARelaunchIsKeptWithNoDownloadAndNoOffer() {
+        #expect(keep(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            pending: [Self.path],
+            downloadExists: false) == [Self.path])
+    }
+
+    /// …and it costs no filesystem call, which is why that branch is first.
+    ///
+    /// Mutation: move the `pending` check below the `downloadExists` read, or
+    /// hoist `downloadExists(id)` above it.
+    @Test func aPendingRowIsAnsweredWithoutTouchingTheFilesystem() {
+        var asked = 0
+        _ = StagedPackagePrune.keep(
+            staged: [Self.path: staged("2.0")], onDisk: [:], offered: [:],
+            pending: [Self.path],
+            downloadExists: { _ in asked += 1; return true })
+
+        #expect(asked == 0)
+    }
+
+    /// A landed package keeps its entry even with the download swept, so restart
+    /// tracking survives a one-scan flicker of the launch-time signal.
+    ///
+    /// Mutation: delete the `hasLanded` branch.
+    @Test func aLandedPackageIsKeptWithItsDownloadSwept() {
+        #expect(keep(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("2.0")],
+            downloadExists: false) == [Self.path])
+    }
+
+    /// A row missing from THIS scan is a bundle mid-swap, not a deletion — decide
+    /// nothing from it, and let the file backstop bound it instead.
+    ///
+    /// Mutation: `return` nothing (drop the id) in the blind branch.
+    @Test func aBlindPassKeepsAnEntryWhoseDownloadIsStillThere() {
+        #expect(keep(staged: [Self.path: staged("2.0")], onDisk: [:]) == [Self.path])
+    }
+
+    /// The backstop half: blind AND the download is gone, so there is nothing
+    /// left to install and nothing to wait for.
+    ///
+    /// Mutation: `kept.insert(id)` unconditionally in the blind branch.
+    @Test func aBlindPassDropsAnEntryWhoseDownloadIsGone() {
+        #expect(keep(
+            staged: [Self.path: staged("2.0")], onDisk: [:],
+            downloadExists: false).isEmpty)
+    }
+
+    // MARK: the ordinary rule — still offered AND re-openable
+
+    /// Not landed, not pending, still the version on offer and still downloaded:
+    /// keep, it is usable.
+    @Test func anUnlandedEntryStillOnOfferAndDownloadedIsKept() {
+        #expect(keep(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("1.0")],
+            offered: [Self.path: VersionSide(marketing: "2.0")]) == [Self.path])
+    }
+
+    /// The source has moved past it: installing this would hand the user a
+    /// version its own source no longer offers.
+    ///
+    /// Mutation: drop the `stillOffered` half of the final `&&`.
+    @Test func anUnlandedEntryTheSourceNoLongerOffersIsDropped() {
+        #expect(keep(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("1.0")],
+            offered: [Self.path: VersionSide(marketing: "3.0")]).isEmpty)
+    }
+
+    /// Nothing offered at all is not the same as "offered and matching". A source
+    /// that said nothing this pass must not be read as agreement.
+    ///
+    /// Mutation: `offered[id].map { … } != false` — nil then reads as a match.
+    @Test func anUnlandedEntryWithNothingOnOfferIsDropped() {
+        #expect(keep(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("1.0")]).isEmpty)
+    }
+
+    /// …and the download half of that same rule.
+    ///
+    /// Mutation: drop the `downloadExists(id)` half of the final `&&`.
+    @Test func anUnlandedEntryWhoseDownloadIsGoneIsDropped() {
+        #expect(keep(
+            staged: [Self.path: staged("2.0")],
+            onDisk: [Self.path: app("1.0")],
+            offered: [Self.path: VersionSide(marketing: "2.0")],
+            downloadExists: false).isEmpty)
+    }
+
+    // MARK: more than one entry
+
+    /// Every other case has a single entry, which makes `insert` indistinguishable
+    /// from assignment.
+    ///
+    /// Mutation: `kept = [id]` in any branch.
+    @Test func eachEntryIsJudgedOnItsOwn() {
+        let keeper = "/Applications/Alpha.app"
+        let goner = "/Applications/Beta.app"
+
+        let out = keep(
+            staged: [keeper: staged("2.0"), goner: staged("2.0")],
+            onDisk: [keeper: app("2.0", path: keeper), goner: app("1.0", path: goner)])
+
+        #expect(out == [keeper], "the landed one stays, the stale unoffered one goes")
+    }
+
+    /// Two entries kept through DIFFERENT branches, with the later one taking the
+    /// branch under test. The case above cannot see `kept = [id]` in the landed
+    /// branch, because its landed row sorts first and the row after it is dropped
+    /// anyway — so the assignment happens to produce the right answer.
+    ///
+    /// Mutation: `kept = [id]` in place of `kept.insert(id)` in any branch.
+    @Test func entriesKeptThroughDifferentBranchesAllSurvive() {
+        let blind = "/Applications/Alpha.app"      // kept: blind, download present
+        let landed = "/Applications/Beta.app"      // kept: landed
+        let waiting = "/Applications/Delta.app"    // kept: pending a relaunch
+
+        let out = keep(
+            staged: [blind: staged("2.0"), landed: staged("2.0"), waiting: staged("2.0")],
+            onDisk: [landed: app("2.0", path: landed), waiting: app("2.0", path: waiting)],
+            pending: [waiting])
+
+        #expect(out == [blind, landed, waiting])
+    }
+}
+
+/// The one rule both halves of the package-restart machinery depend on.
+///
+/// `StagedPackagePrune.keep` and `PackageRestartState.resolve` each need to know
+/// whether the app on disk IS the staged version. They used to decide it with
+/// two copies of one expression in two files, and the only thing holding them
+/// together was a comment in one saying it matched the other. These cases assert
+/// the agreement directly, so a change to one side that does not reach the other
+/// fails here rather than in the field.
+struct LandedAgreementTests {
+
+    private func app(_ short: String, build: String?, bundleID: String) -> InstalledApp {
+        InstalledApp(
+            name: "Example", bundleID: bundleID, shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/Example.app"),
+            isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
+    }
+
+    /// The inputs where the two copies were most likely to drift: a derived
+    /// build, where landing must fall back to marketing alone. Judged as "not
+    /// landed" by either side, the badge never lights and the entry never
+    /// settles (#285).
+    /// No on-disk version at all is NOT landing. `resolve` returns `.pending`
+    /// for it, and prune must not keep an entry on the strength of it either —
+    /// a row we cannot read a version for has told us nothing.
+    ///
+    /// Mutation: `guard let onDiskVersion else { return true }` in `hasLanded`.
+    @Test func anAbsentOnDiskVersionIsNotLanded() {
+        let stagedSide = VersionSide(marketing: "2.0", build: "20")
+
+        #expect(!PackageRestartState.hasLanded(
+            onDiskVersion: nil, stagedVersion: stagedSide, buildIsDerived: false))
+        #expect(PackageRestartState.resolve(
+            onDiskVersion: nil, stagedVersion: stagedSide,
+            stagedAt: Date(timeIntervalSince1970: 1_000),
+            runningLaunchDates: [Date(timeIntervalSince1970: 500)]) == .pending)
+    }
+
+    @Test func bothSidesAgreeOnLandingIncludingDerivedBuilds() {
+        let stagedAt = Date(timeIntervalSince1970: 1_000)
+        let stale = [Date(timeIntervalSince1970: 500)]
+        let cases: [(String, InstalledApp, VersionSide, Bool)] = [
+            ("plain, same",
+             app("2.0", build: "20", bundleID: "com.example.app"),
+             VersionSide(marketing: "2.0", build: "20"), true),
+            ("plain, still old",
+             app("1.0", build: "10", bundleID: "com.example.app"),
+             VersionSide(marketing: "2.0", build: "20"), false),
+            ("derived build, marketing matches, builds differ",
+             app("27.0", build: "27A5237l", bundleID: AppScanner.xcodeBundleID),
+             VersionSide(marketing: "27.0", build: "27A5300x"), true),
+            ("derived build, marketing differs",
+             app("26.0", build: "26A100", bundleID: AppScanner.doubaoImeBundleID),
+             VersionSide(marketing: "27.0", build: "27A5300x"), false),
+        ]
+
+        for (label, installed, stagedSide, expectedLanded) in cases {
+            let landed = PackageRestartState.hasLanded(
+                onDiskVersion: installed.versionSide, stagedVersion: stagedSide,
+                buildIsDerived: AppScanner.buildVersionIsOverridden(
+                    bundleID: installed.bundleID))
+            #expect(landed == expectedLanded, "hasLanded disagrees for \(label)")
+
+            // resolve() must classify a landed row as anything but `.pending`,
+            // and an unlanded one as exactly `.pending`.
+            let state = PackageRestartState.resolve(
+                onDiskVersion: installed.versionSide, stagedVersion: stagedSide,
+                stagedAt: stagedAt, runningLaunchDates: stale,
+                buildIsDerived: AppScanner.buildVersionIsOverridden(
+                    bundleID: installed.bundleID))
+            #expect((state != .pending) == expectedLanded, "resolve disagrees for \(label)")
+
+            // prune keeps a landed entry with no offer and no download — which it
+            // can only do by agreeing that it landed.
+            let kept = StagedPackagePrune.keep(
+                staged: ["/Applications/Example.app":
+                    StagedPackageFacts(versionSide: stagedSide, stagedAt: stagedAt)],
+                onDisk: ["/Applications/Example.app": installed],
+                offered: [:], pending: [], downloadExists: { _ in false })
+            #expect(kept.isEmpty != expectedLanded, "prune disagrees for \(label)")
+        }
+    }
+}

--- a/scripts/check_staged_version_use.py
+++ b/scripts/check_staged_version_use.py
@@ -119,16 +119,22 @@ PACKAGE_RESTART_RESOLVE = re.compile(r"PackageRestartState\.resolve\s*\(")
 DERIVED_BUILD_ARGUMENT = "buildIsDerived:"
 PACKAGE_RESTART_WINDOW = 10
 
-# The second such wiring site (#285): `pruneStagedPackages` compares the same
-# scanner-derived on-disk `VersionSide` (`app.versionSide`) against a staged
-# package's, for the identical reason `PackageRestartState.resolve` needed the
-# flag above — so it needs it too. Scoped to `app.versionSide` specifically:
-# the many other `VersionComparator.isSame(` calls compare two sides that are
-# NOT one scanner value against one package/feed value (e.g. two scanner reads
-# of the same app, which share whatever namespace they're in) and must not be
-# forced to carry an argument that means nothing for them.
-PRUNE_STAGED_ISSAME = re.compile(r"VersionComparator\.isSame\s*\(\s*app\.versionSide")
+# The second such site (#285). It used to be `pruneStagedPackages` comparing
+# `app.versionSide` against a staged package's with its own copy of the
+# expression; both copies now go through `PackageRestartState.hasLanded`, so the
+# anchor follows them there. `hasLanded` has no default for the flag, so a
+# missing argument is a compile error rather than something a regex must catch —
+# what is left for this rule is the argument being present and WRONG.
+PRUNE_STAGED_ISSAME = re.compile(r"PackageRestartState\.hasLanded\s*\(")
 PRUNE_STAGED_WINDOW = 6
+
+# `buildIsDerived: false` written out in Sources. Legitimate in tests (they say
+# which case they mean), never in shipping code: the flag exists precisely
+# because the answer depends on the app, and hardcoding it is the same defect as
+# omitting it — a landed Xcode/豆包 package that never lights the badge and never
+# settles. This is what the `resolve` rule below could not see: it only checked
+# that the argument was written at all.
+DERIVED_BUILD_HARDCODED = re.compile(r"buildIsDerived:\s*false\b")
 
 
 # A *different* type also binds the name `staged`: `stagedPackage(for:)` returns
@@ -203,12 +209,14 @@ def main() -> int:
             if PACKAGE_RESTART_RESOLVE.search(line):
                 package_restart_seen += 1
                 call = "\n".join(lines[n - 1:n - 1 + PACKAGE_RESTART_WINDOW])
-                if DERIVED_BUILD_ARGUMENT not in call:
+                if (DERIVED_BUILD_ARGUMENT not in call
+                        or DERIVED_BUILD_HARDCODED.search(call)):
                     package_restart_hits.append(f"{rel}:{n}: {line.strip()}")
             if PRUNE_STAGED_ISSAME.search(line):
                 prune_staged_seen += 1
                 call = "\n".join(lines[n - 1:n - 1 + PRUNE_STAGED_WINDOW])
-                if DERIVED_BUILD_ARGUMENT not in call:
+                if (DERIVED_BUILD_ARGUMENT not in call
+                        or DERIVED_BUILD_HARDCODED.search(call)):
                     prune_staged_hits.append(f"{rel}:{n}: {line.strip()}")
 
     # Vacuity guard. A rule that matches nothing passes forever, which is worse
@@ -232,9 +240,9 @@ def main() -> int:
               "Either the app wiring moved or this rule now guards nothing.")
         return 1
     if prune_staged_seen == 0:
-        print("✗ staged-version guard found no VersionComparator.isSame(app.versionSide "
-              "call in pruneStagedPackages. Either that wiring moved or renamed, or "
-              "this rule now guards nothing.")
+        print("✗ staged-version guard found no PackageRestartState.hasLanded call. "
+              "Either that wiring moved or was renamed, or this rule now guards "
+              "nothing.")
         return 1
 
     if display_hits:
@@ -282,8 +290,8 @@ def main() -> int:
         for hit in package_restart_hits:
             print(f"    {hit}")
     if prune_staged_hits:
-        print(f"✗ {len(prune_staged_hits)} pruneStagedPackages comparison(s) omit "
-              "the derived-build namespace flag.")
+        print(f"✗ {len(prune_staged_hits)} PackageRestartState.hasLanded call(s) "
+              "omit or hardcode the derived-build namespace flag.")
         print("  Pass buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID:) "
               "so a scanner-substituted build is not compared with a staged package's.")
         for hit in prune_staged_hits:

--- a/scripts/check_staged_version_use.py
+++ b/scripts/check_staged_version_use.py
@@ -125,16 +125,33 @@ PACKAGE_RESTART_WINDOW = 10
 # anchor follows them there. `hasLanded` has no default for the flag, so a
 # missing argument is a compile error rather than something a regex must catch —
 # what is left for this rule is the argument being present and WRONG.
-PRUNE_STAGED_ISSAME = re.compile(r"PackageRestartState\.hasLanded\s*\(")
+PRUNE_STAGED_ISSAME = re.compile(
+    r"(?:PackageRestartState|RelaunchProgress)\.hasLanded\s*\(")
+
+# Going through `hasLanded` is not optional. Replacing the old anchor with the
+# one above lost something: it guarded the SHAPE — a scanner-side
+# `app.versionSide` handed straight to `isSame` — so a NEW site written that way
+# was caught even though it never mentioned PackageRestartState. Verified by
+# adding one back: the rule as first rewritten passed it.
+#
+# Expected count is zero, so this needs no vacuity guard: there is no such site
+# left in any Sources tree (the eight remaining `VersionComparator.isSame` calls
+# compare two sides that are not one scanner value against one package value).
+BANNED_DIRECT_LANDED = re.compile(r"VersionComparator\.isSame\s*\(\s*app\.versionSide")
 PRUNE_STAGED_WINDOW = 6
 
-# `buildIsDerived: false` written out in Sources. Legitimate in tests (they say
-# which case they mean), never in shipping code: the flag exists precisely
-# because the answer depends on the app, and hardcoding it is the same defect as
-# omitting it — a landed Xcode/豆包 package that never lights the badge and never
-# settles. This is what the `resolve` rule below could not see: it only checked
-# that the argument was written at all.
-DERIVED_BUILD_HARDCODED = re.compile(r"buildIsDerived:\s*false\b")
+# `buildIsDerived:` written out as a literal in Sources. Legitimate in tests
+# (they say which case they mean), never in shipping code: the flag exists
+# precisely because the answer depends on the app, and hardcoding it is the same
+# defect as omitting it — `false` for an Xcode/豆包 package that has landed means
+# a badge that never lights and an entry that never settles; `true` for anything
+# else throws away a build comparison that was the point.
+#
+# BOTH literals, because a first version checked only `false` and a hardcoded
+# `true` walked through the gate and every test. Not a data-flow analysis: a
+# `let derived = false` two lines up still passes, the same blind spot the
+# display rule above documents.
+DERIVED_BUILD_HARDCODED = re.compile(r"buildIsDerived:\s*(?:false|true)\b")
 
 
 # A *different* type also binds the name `staged`: `stagedPackage(for:)` returns
@@ -172,6 +189,7 @@ def main() -> int:
     display_marketing_hits = []
     package_restart_hits = []
     prune_staged_hits = []
+    banned_landed_hits: list[str] = []
     ledger_seen = 0
     marketing_seen = 0
     package_restart_seen = 0
@@ -212,6 +230,8 @@ def main() -> int:
                 if (DERIVED_BUILD_ARGUMENT not in call
                         or DERIVED_BUILD_HARDCODED.search(call)):
                     package_restart_hits.append(f"{rel}:{n}: {line.strip()}")
+            if BANNED_DIRECT_LANDED.search(line):
+                banned_landed_hits.append(f"{rel}:{n}: {line.strip()}")
             if PRUNE_STAGED_ISSAME.search(line):
                 prune_staged_seen += 1
                 call = "\n".join(lines[n - 1:n - 1 + PRUNE_STAGED_WINDOW])
@@ -240,9 +260,9 @@ def main() -> int:
               "Either the app wiring moved or this rule now guards nothing.")
         return 1
     if prune_staged_seen == 0:
-        print("✗ staged-version guard found no PackageRestartState.hasLanded call. "
-              "Either that wiring moved or was renamed, or this rule now guards "
-              "nothing.")
+        print("✗ staged-version guard found no PackageRestartState/RelaunchProgress"
+              ".hasLanded call. Either that wiring moved or was renamed, or this "
+              "rule now guards nothing.")
         return 1
 
     if display_hits:
@@ -289,15 +309,23 @@ def main() -> int:
               "scanner-substituted build is not compared with a feed build.")
         for hit in package_restart_hits:
             print(f"    {hit}")
+    if banned_landed_hits:
+        print(f"✗ {len(banned_landed_hits)} site(s) compare a scanner-side "
+              "`app.versionSide` directly with VersionComparator.isSame.")
+        print("  Go through PackageRestartState.hasLanded instead — that is the "
+              "one place that knows to drop a scanner-substituted build.")
+        for hit in banned_landed_hits:
+            print(f"    {hit}")
     if prune_staged_hits:
-        print(f"✗ {len(prune_staged_hits)} PackageRestartState.hasLanded call(s) "
-              "omit or hardcode the derived-build namespace flag.")
+        print(f"✗ {len(prune_staged_hits)} hasLanded call(s) omit or hardcode "
+              "the derived-build namespace flag.")
         print("  Pass buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID:) "
               "so a scanner-substituted build is not compared with a staged package's.")
         for hit in prune_staged_hits:
             print(f"    {hit}")
     if (display_hits or ledger_hits or compare_hits or display_marketing_hits
-            or read_hits or package_restart_hits or prune_staged_hits):
+            or read_hits or package_restart_hits or prune_staged_hits
+            or banned_landed_hits):
         return 1
 
     print(f"✓ version comparisons discriminate — {len(files)} files, "


### PR DESCRIPTION
`pruneStagedPackages` decided whether an install had landed with **its own copy**
of the expression in `PackageRestartState.resolve`. Its own comment said so —
*"`buildIsDerived` matches the guard `reconcilePackageRestarts` passes … same two
inputs, same namespace problem"* — which is exactly the arrangement CLAUDE.md
records as having drifted twice in this repo: two ladders over one set of facts,
held together by a comment in one of them.

## What changed

**`PackageRestartState.hasLanded`** is now the single test, called by `resolve`
and by the prune. `LandedAgreementTests` asserts the three consumers agree on the
same inputs — including the derived-build apps (Xcode, 豆包输入法) where the two
copies were most likely to diverge, and where the consequence is a landed package
that never lights the badge and never settles (#285).

**`StagedPackagePrune.keep`** carries the four rules. Three of them keep an entry
whose download is already gone, which is why this was never "is the file there":

| Rule | Keeps an entry with no download? |
| --- | --- |
| waiting on a relaunch (`pending`) | yes — dropping it would kill the badge the reconciler is holding |
| landed | yes — restart tracking must survive a one-scan flicker |
| blind pass | only while the download is there (the backstop) |
| ordinary | still on offer **and** still downloaded |

`downloadExists` is a closure rather than a precomputed set, so the `pending`
short-circuit keeps costing no syscall — and a case counts the calls to pin that.

## The gate earned its keep

`check_staged_version_use.py` **failed the moment the wiring moved**: its second
rule was anchored on the literal `VersionComparator.isSame(app.versionSide` inside
`pruneStagedPackages`. That is the rule working, not breaking.

It now anchors on `hasLanded`. Because `hasLanded` has no default for the flag, a
*missing* argument is a compile error — so what is left for a regex to catch is
the argument being present and **wrong**. Adding that check revealed the sibling
`resolve` rule accepted a hardcoded `buildIsDerived: false`, which is the same
defect as omitting it. Both rules reject it now, verified by mutating each call
site in turn:

```
hardcode false at the resolve call   → ✗ 1 PackageRestartState call(s) omit the flag
hardcode false at the hasLanded call → ✗ 1 hasLanded call(s) omit or hardcode the flag
rename hasLanded                     → ✗ found no PackageRestartState.hasLanded call
```

## Verification

**14 cases, 16 mutations, all 16 red on exactly the case they should be** —
covering each of the four rules in both directions, the syscall short-circuit,
the derived-build flag on both sides, and a nil on-disk version.

- `make test` — exit 0. **Core 2093 → 2107 (+14 cases, +2 suites)**, CLI 188,
  App 9 of 9, four python gates green.
- `xcodebuild -scheme DuoUpdater` — `** BUILD SUCCEEDED **`.
- `make gallery` — exit 0, all five gates.

**Two mutations only became useful after being fixed.** `kept = [id]` survived
until a case kept three entries through three *different* branches with the
landed one sorting in the middle — the single-entry and two-entry fixtures both
happened to produce the right answer under assignment. And `hasLanded` returning
true for an absent on-disk version survived until a case actually passed nil.

No CHANGELOG entry and no version bump: nothing here is visible to users.


---

**Review round 1** confirmed the four equivalences I was unsure about — the
`Set` return and the `count` comparison, the `[stagedPackages]` capture, the
syscall going from always-computed to on-demand, and `hasLanded` not changing
`resolve`'s handling of a nil on-disk side — and then found that **my gate edit
had lost coverage**, plus three unpinned rules. All verified green by mutation
before fixing:

| Mutation that used to pass | Now caught by |
| --- | --- |
| a new direct `VersionComparator.isSame(app.versionSide, …)` site | the restored banned-pattern rule |
| `buildIsDerived: true` hardcoded | the widened literal check **and** a new agreement case |
| delete the `pending` branch | `aRowWaitingOnARelaunchIsKeptWithNoDownloadAndNoOffer` (its fixture was also landed) |
| `kept = [id]` in the blind or offered branch | `aBlindEntryDoesNotDisplaceAnEarlierKeeper`, and an offered row in the multi-branch case |

The gate regression is the one worth reading twice: repointing the anchor
guarded the new call but stopped guarding the *shape*, so the defect class this
PR exists to eliminate became unguarded by the act of eliminating it. The two
rules now cover both halves — go through `hasLanded`, and pass the flag
correctly when you do.

`RelaunchProgress.hasLanded` keeps its `= false` default: the widened anchor
covers its call site for both omission and hardcoding, which closes the hole
without churning eight unrelated test call sites.
