### PR TITLE
Move the row order and the check schedule into Core

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -5343,11 +5343,6 @@ final class AppListModel {
         Log.app.info("permissions: accessibility=\(self.accessibilityTrusted, privacy: .public) appManagement=\(String(describing: self.appManagementStatus), privacy: .public)")
     }
 
-    /// Upper bound on how long after launch the first auto-check may wait. Caps the
-    /// persisted-`lastCheck` interval for the first tick only, so a relaunch refreshes
-    /// within minutes instead of sleeping a full (up to 6h) interval — while a flurry
-    /// of dev relaunches inside this window is still throttled to one check.
-    private static let launchCheckFloor: TimeInterval = 5 * 60
 
     /// Drop the App Nap opt-out (if held). Called when switching to manual, where
     /// there's no loop to keep alive.
@@ -5385,24 +5380,12 @@ final class AppListModel {
             var isFirstCheck = true
             while !Task.isCancelled {
                 guard let self else { return }
-                // The FIRST check after launch uses a small floor instead of the
-                // full interval. `lastCheck` is persisted across relaunches (so we
-                // don't re-check on *every* launch), but a fresh process starts with
-                // an empty in-memory list — without this floor a relaunch that
-                // inherited a recent `lastCheck` would sleep a whole interval (up to
-                // 6h) showing nothing. The floor refreshes promptly after launch
-                // while still throttling rapid dev relaunches within a few minutes.
-                let effectiveInterval = isFirstCheck ? min(interval, Self.launchCheckFloor) : interval
-                // Sleep only until the next check is *due* relative to the last one
-                // — zero (run now) when we're already overdue, e.g. a cold launch.
-                let due = (self.lastCheck ?? .distantPast).addingTimeInterval(effectiveInterval)
-                // A cold launch with nothing in memory yet shows the empty zero-badge
-                // icon until something populates `results`. Check immediately in that
-                // case rather than waiting out the floor, so the menu-bar icon
-                // reflects real state right after (re)launch without a click.
-                let wait = (isFirstCheck && self.results.isEmpty)
-                    ? 0
-                    : max(0, due.timeIntervalSinceNow)
+                // The arithmetic — the launch floor, the due time, and the
+                // run-now case for a cold launch with nothing in memory — is
+                // `CheckSchedule.nextWait` in Core, where it is executed.
+                let wait = CheckSchedule.nextWait(
+                    now: .now, lastCheck: self.lastCheck, interval: interval,
+                    isFirstCheck: isFirstCheck, hasResults: !self.results.isEmpty)
                 if wait > 0 {
                     try? await Task.sleep(for: .seconds(wait))
                     guard !Task.isCancelled else { return }
@@ -6196,33 +6179,14 @@ final class AppListModel {
     ///
     /// …except while the order is frozen (see `pinRowOrder`), when every row the
     /// user can already see keeps the slot it had, whatever its rank has become.
+    /// The order is `RowOrder.sorted` in Core, where it is executed. This is the
+    /// wiring that hands it the tables it ranks by.
     private func sorted(_ list: [UpdateResult]) -> [UpdateResult] {
-        func rank(_ r: UpdateResult) -> Int {
-            if needsRestart.contains(r.id) { return 0 }
-            // A staged build that IS the latest is one relaunch from live, just like
-            // needs-restart — top tier. One that trails the latest ranks as a normal
-            // pending update (it'll show Update).
-            if actionableStaged(r) != nil { return 0 }
-            if r.hasUpdate { return 1 }
-            return 2
-        }
-        return list.sorted { a, b in
-            // Frozen: pinned rows hold their recorded slot, and anything that showed
-            // up since the freeze goes after them (inserting into the middle would
-            // push the pinned rows down, which is the thing being prevented).
-            if !pinnedOrder.isEmpty {
-                switch (pinnedOrder[a.id], pinnedOrder[b.id]) {
-                case let (pa?, pb?): return pa < pb
-                case (_?, nil): return true
-                case (nil, _?): return false
-                case (nil, nil): break  // both new — fall through to the normal order
-                }
-            }
-            let ra = rank(a), rb = rank(b)
-            if ra != rb { return ra < rb }
-            return a.app.name.localizedCaseInsensitiveCompare(b.app.name) == .orderedAscending
-        }
+        RowOrder.sorted(
+            list, needsRestart: needsRestart,
+            stagedSelfUpdates: pendingSelfUpdate, pinnedOrder: pinnedOrder)
     }
+
 
     // MARK: - Frozen row order
     //

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -5406,6 +5406,12 @@ final class AppListModel {
                 } else {
                     let why = offline ? "offline" : "busy"
                     Log.app.info("scheduler: tick deferred (\(why, privacy: .public)) — retrying in 60s")
+                    // The only back-off on this path, and the condition that reaches it
+                    // is decided elsewhere: `CheckSchedule.nextWait` returns 0 for a cold
+                    // launch with an empty list, and a deferred tick leaves both
+                    // `isFirstCheck` and `lastCheck` untouched — so the next call answers
+                    // 0 again. Cold launch plus no network lands exactly here. Do not
+                    // remove this sleep on the grounds that the wait above covers it.
                     try? await Task.sleep(for: .seconds(60))
                 }
             }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrder.swift
@@ -82,13 +82,23 @@ public enum CheckSchedule {
         lastCheck: Date?,
         interval: TimeInterval,
         isFirstCheck: Bool,
-        hasResults: Bool,
-        launchFloor: TimeInterval = CheckSchedule.launchFloor
+        hasResults: Bool
     ) -> TimeInterval {
         // A cold launch with nothing in memory yet shows the empty zero-badge
         // icon until something populates the list. Check immediately rather than
         // waiting out the floor, so the menu bar reflects real state right after
         // a launch without a click.
+        //
+        // ⚠️ `isFirstCheck &&` is load-bearing, and the two halves guard
+        // different things. Zero here means "run now", NOT "looping here is
+        // safe": when the caller then DEFERS the tick (offline, or a refresh
+        // already running) it leaves `isFirstCheck` and `lastCheck` untouched,
+        // so the next call answers zero again. Without the `isFirstCheck` half
+        // any later tick that found an empty list — a scan that matched nothing,
+        // everything filtered out — would do the same forever. The only thing
+        // between that and an unthrottled run of network checks is the caller's
+        // own back-off (`AppListModel`'s 60s sleep on the deferred branch), and
+        // it lives in another package with nothing pointing at it from here.
         if isFirstCheck && !hasResults { return 0 }
         let effectiveInterval = isFirstCheck ? min(interval, launchFloor) : interval
         // Sleep only until the next check is DUE relative to the last one — zero

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrder.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// The order rows appear in, and how a frozen order holds.
+///
+/// Split out of `AppListModel` because a sort is the kind of code that cannot
+/// fail loudly: reorder two clauses and everything still compiles, still
+/// renders, and the list is simply wrong in a way no assertion about any single
+/// row can see. The repo already gives `DownloadReadout`'s declaration order its
+/// own gate for exactly this reason.
+public enum RowOrder {
+
+    /// - Parameters:
+    ///   - list: the rows to order.
+    ///   - needsRestart: ids whose update is on disk and waiting on a relaunch.
+    ///   - stagedSelfUpdates: raw staged self-updates by id. Filtered through
+    ///     `UpdatePolicy.actionableStaged` here, once per row rather than once
+    ///     per comparison — the version this replaced called it from inside the
+    ///     comparator, so it ran O(n log n) times per sort.
+    ///   - pinnedOrder: the frozen slot of each row that existed when the order
+    ///     was frozen. Empty when the order is live.
+    public static func sorted(
+        _ list: [UpdateResult],
+        needsRestart: Set<String>,
+        stagedSelfUpdates: [String: StagedSelfUpdate],
+        pinnedOrder: [String: Int]
+    ) -> [UpdateResult] {
+        let relaunchable = Set(list.compactMap { row in
+            UpdatePolicy.actionableStaged(row, staged: stagedSelfUpdates[row.id]) != nil
+                ? row.id : nil
+        })
+
+        func rank(_ r: UpdateResult) -> Int {
+            if needsRestart.contains(r.id) { return 0 }
+            // A staged build that IS the latest is one relaunch from live, just
+            // like needs-restart — top tier. One that trails the latest ranks as
+            // a normal pending update (it will show Update).
+            if relaunchable.contains(r.id) { return 0 }
+            if r.hasUpdate { return 1 }
+            return 2
+        }
+
+        return list.sorted { a, b in
+            // Frozen: pinned rows hold their recorded slot, and anything that
+            // showed up since the freeze goes AFTER them — inserting into the
+            // middle would push the pinned rows down, which is the thing being
+            // prevented.
+            if !pinnedOrder.isEmpty {
+                switch (pinnedOrder[a.id], pinnedOrder[b.id]) {
+                case let (pa?, pb?): return pa < pb
+                case (_?, nil): return true
+                case (nil, _?): return false
+                case (nil, nil): break  // both new — fall through to the normal order
+                }
+            }
+            let ra = rank(a), rb = rank(b)
+            if ra != rb { return ra < rb }
+            return a.app.name.localizedCaseInsensitiveCompare(b.app.name) == .orderedAscending
+        }
+    }
+}
+
+/// When the next background check should run.
+///
+/// Arithmetic rather than a policy object because that is all it is — but it is
+/// arithmetic whose wrong version is silent: too long, and a relaunch sits up to
+/// six hours showing nothing; too short, and rapid dev relaunches hammer every
+/// vendor endpoint.
+public enum CheckSchedule {
+
+    /// The first check after launch uses this instead of the full interval.
+    ///
+    /// `lastCheck` is persisted across relaunches so we don't re-check on every
+    /// launch, but a fresh process starts with an empty in-memory list — without
+    /// a floor, a relaunch that inherited a recent `lastCheck` would sleep a
+    /// whole interval showing nothing. Five minutes refreshes promptly after
+    /// launch while still throttling rapid relaunches.
+    public static let launchFloor: TimeInterval = 5 * 60
+
+    /// - Returns: seconds to wait before the next check. Zero means run now.
+    public static func nextWait(
+        now: Date,
+        lastCheck: Date?,
+        interval: TimeInterval,
+        isFirstCheck: Bool,
+        hasResults: Bool,
+        launchFloor: TimeInterval = CheckSchedule.launchFloor
+    ) -> TimeInterval {
+        // A cold launch with nothing in memory yet shows the empty zero-badge
+        // icon until something populates the list. Check immediately rather than
+        // waiting out the floor, so the menu bar reflects real state right after
+        // a launch without a click.
+        if isFirstCheck && !hasResults { return 0 }
+        let effectiveInterval = isFirstCheck ? min(interval, launchFloor) : interval
+        // Sleep only until the next check is DUE relative to the last one — zero
+        // when already overdue.
+        let due = (lastCheck ?? .distantPast).addingTimeInterval(effectiveInterval)
+        return max(0, due.timeIntervalSince(now))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// The order rows appear in.
+///
+/// A sort cannot fail loudly: reorder two clauses and it still compiles, still
+/// renders, and the list is merely wrong in a way no assertion about a single
+/// row can see. It lived in `AppListModel`, where nothing executed it.
+struct RowOrderTests {
+
+    private func row(
+        _ name: String, latest: String? = nil, path: String? = nil
+    ) -> UpdateResult {
+        let id = path ?? "/Applications/\(name).app"
+        let app = InstalledApp(
+            name: name, bundleID: "com.example.\(name.lowercased())",
+            shortVersion: "1.0", buildVersion: nil,
+            path: URL(fileURLWithPath: id),
+            isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
+        guard let latest else {
+            return UpdateResult(app: app, remote: nil, status: .upToDate)
+        }
+        return UpdateResult(
+            app: app,
+            remote: RemoteVersion(
+                shortVersion: latest, version: nil, downloadURL: nil, sourceName: "GitHub"),
+            status: .updateAvailable(latest: latest))
+    }
+
+    private func sorted(
+        _ list: [UpdateResult],
+        needsRestart: Set<String> = [],
+        staged: [String: StagedSelfUpdate] = [:],
+        pinned: [String: Int] = [:]
+    ) -> [String] {
+        RowOrder.sorted(
+            list, needsRestart: needsRestart, stagedSelfUpdates: staged,
+            pinnedOrder: pinned
+        ).map(\.app.name)
+    }
+
+    private func staged(_ version: String) -> StagedSelfUpdate {
+        StagedSelfUpdate(
+            version: version, buildVersion: nil,
+            stagedBundlePath: URL(fileURLWithPath: "/tmp/staged.app"))
+    }
+
+    // MARK: the three tiers
+
+    /// Rows waiting on a relaunch come first, then rows with an update, then the
+    /// rest — and each tier is alphabetical inside itself.
+    ///
+    /// Mutations: swap any two `return` values in `rank`; drop the
+    /// `localizedCaseInsensitiveCompare` tie-break.
+    @Test func rowsAreRankedRestartThenUpdateThenTheRest() {
+        let rows = [
+            row("Zulu"),                       // tier 2
+            row("Alpha", latest: "2.0"),       // tier 1
+            row("Bravo"),                      // tier 0 via needsRestart
+            row("Yankee", latest: "2.0"),      // tier 1
+            row("Charlie"),                    // tier 2
+        ]
+
+        #expect(sorted(rows, needsRestart: ["/Applications/Bravo.app"])
+            == ["Bravo", "Alpha", "Yankee", "Charlie", "Zulu"])
+    }
+
+    /// A staged build that IS the latest is one relaunch from live, so it ranks
+    /// with needs-restart rather than as a pending update.
+    ///
+    /// Mutation: `if relaunchable.contains(r.id) { return 1 }`.
+    @Test func aStagedLatestBuildRanksWithTheRestartTier() {
+        let rows = [row("Alpha", latest: "2.0"), row("Zulu", latest: "2.0")]
+
+        #expect(sorted(rows, staged: ["/Applications/Zulu.app": staged("2.0")])
+            == ["Zulu", "Alpha"])
+    }
+
+    /// …but a staged build that TRAILS the latest is an ordinary pending update:
+    /// it will show Update, not Relaunch. `actionableStaged` is what draws that
+    /// line, and the sort has to go through it rather than test the raw table.
+    ///
+    /// Mutation: rank on `stagedSelfUpdates[r.id] != nil` instead of
+    /// `UpdatePolicy.actionableStaged(...)`.
+    @Test func aStagedBuildThatTrailsTheLatestDoesNotJumpTheQueue() {
+        let rows = [row("Alpha", latest: "3.0"), row("Zulu", latest: "3.0")]
+
+        #expect(sorted(rows, staged: ["/Applications/Zulu.app": staged("2.0")])
+            == ["Alpha", "Zulu"])
+    }
+
+    /// Names sort case-insensitively, so a lowercase app does not fall to the
+    /// bottom of its tier.
+    ///
+    /// Mutation: `a.app.name < b.app.name`.
+    @Test func namesSortCaseInsensitively() {
+        #expect(sorted([row("beta"), row("Alpha"), row("Charlie")])
+            == ["Alpha", "beta", "Charlie"])
+    }
+
+    // MARK: the frozen order
+
+    /// While frozen, pinned rows hold their recorded slot regardless of rank —
+    /// that is the whole point: the list must not reshuffle under the pointer.
+    ///
+    /// Mutation: delete the `if !pinnedOrder.isEmpty` block.
+    @Test func pinnedRowsHoldTheirSlotAgainstTheirRank() {
+        let rows = [row("Alpha", latest: "2.0"), row("Zulu")]
+        let pinned = ["/Applications/Zulu.app": 0, "/Applications/Alpha.app": 1]
+
+        #expect(sorted(rows, pinned: pinned) == ["Zulu", "Alpha"])
+    }
+
+    /// A row that appeared since the freeze goes AFTER every pinned row.
+    /// Inserting it into the middle would push the pinned rows down, which is
+    /// exactly what freezing prevents — even when its rank says it belongs first.
+    ///
+    /// Mutations: `case (_?, nil): return false`; or `case (nil, _?): return true`.
+    @Test func aRowNewSinceTheFreezeGoesAfterEveryPinnedRow() {
+        let rows = [
+            row("Zulu"),                         // pinned, lowest rank
+            row("Alpha", latest: "2.0"),         // NEW, and would rank first
+        ]
+        let pinned = ["/Applications/Zulu.app": 0]
+
+        #expect(sorted(rows, pinned: pinned) == ["Zulu", "Alpha"])
+    }
+
+    /// Two rows that are both new fall through to the ordinary order rather than
+    /// keeping whatever order they arrived in.
+    ///
+    /// Mutation: `case (nil, nil): return false` in place of the `break`.
+    @Test func twoRowsNewSinceTheFreezeUseTheOrdinaryOrder() {
+        let rows = [row("Zulu"), row("Alpha", latest: "2.0")]
+        let pinned = ["/Applications/Other.app": 0]
+
+        #expect(sorted(rows, pinned: pinned) == ["Alpha", "Zulu"])
+    }
+
+    /// An empty pin table means the order is live, not that everything is new.
+    ///
+    /// Mutation: drop the `!pinnedOrder.isEmpty` guard so the switch always runs
+    /// — with no pins every row is `(nil, nil)`, which today falls through, so
+    /// this pins that the guard's absence would be a behaviour change only in
+    /// combination. Kept as the positive pole for the frozen cases above.
+    @Test func anEmptyPinTableSortsNormally() {
+        #expect(sorted([row("Zulu"), row("Alpha", latest: "2.0")]) == ["Alpha", "Zulu"])
+    }
+}
+
+/// When the next background check runs.
+struct CheckScheduleTests {
+
+    private let now = Date(timeIntervalSince1970: 10_000)
+
+    /// A cold launch with nothing in memory checks immediately, whatever the
+    /// persisted `lastCheck` says — otherwise the menu bar shows the empty
+    /// zero-badge icon until the floor expires.
+    ///
+    /// Mutation: drop the `isFirstCheck && !hasResults` early return.
+    @Test func aColdLaunchWithAnEmptyListChecksImmediately() {
+        #expect(CheckSchedule.nextWait(
+            now: now, lastCheck: now, interval: 6 * 3600,
+            isFirstCheck: true, hasResults: false) == 0)
+    }
+
+    /// The first check after launch is capped at the floor, not the full
+    /// interval. A relaunch that inherited a recent `lastCheck` would otherwise
+    /// sleep up to six hours.
+    ///
+    /// Mutation: `let effectiveInterval = interval`.
+    @Test func theFirstCheckIsCappedAtTheLaunchFloor() {
+        let wait = CheckSchedule.nextWait(
+            now: now, lastCheck: now, interval: 6 * 3600,
+            isFirstCheck: true, hasResults: true)
+
+        #expect(wait == CheckSchedule.launchFloor)
+    }
+
+    /// Later checks use the full interval — the floor is a launch concession, not
+    /// the schedule.
+    ///
+    /// Mutation: `min(interval, launchFloor)` unconditionally.
+    @Test func laterChecksUseTheFullInterval() {
+        #expect(CheckSchedule.nextWait(
+            now: now, lastCheck: now, interval: 6 * 3600,
+            isFirstCheck: false, hasResults: true) == 6 * 3600)
+    }
+
+    /// The wait is measured from the LAST check, not from now, so a check that
+    /// is already overdue runs at once instead of sleeping another interval.
+    ///
+    /// Mutation: `return effectiveInterval` instead of the due-time difference.
+    @Test func anOverdueCheckRunsAtOnce() {
+        #expect(CheckSchedule.nextWait(
+            now: now, lastCheck: now.addingTimeInterval(-7 * 3600),
+            interval: 6 * 3600, isFirstCheck: false, hasResults: true) == 0)
+    }
+
+    /// A partially elapsed interval waits only the remainder.
+    ///
+    /// Mutation: ignore `lastCheck` and return the whole interval.
+    @Test func aPartlyElapsedIntervalWaitsOnlyTheRemainder() {
+        #expect(CheckSchedule.nextWait(
+            now: now, lastCheck: now.addingTimeInterval(-3600),
+            interval: 6 * 3600, isFirstCheck: false, hasResults: true) == 5 * 3600)
+    }
+
+    /// Never checked before: run now rather than treating a missing date as
+    /// "just checked".
+    ///
+    /// Mutation: `(lastCheck ?? now)`.
+    @Test func neverHavingCheckedRunsNow() {
+        #expect(CheckSchedule.nextWait(
+            now: now, lastCheck: nil, interval: 6 * 3600,
+            isFirstCheck: false, hasResults: true) == 0)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderTests.swift
@@ -116,15 +116,21 @@ struct RowOrderTests {
     /// Inserting it into the middle would push the pinned rows down, which is
     /// exactly what freezing prevents — even when its rank says it belongs first.
     ///
+    /// Asserted in BOTH input orders, which is not belt-and-braces: with two
+    /// elements Swift's sort calls the comparator exactly once, as
+    /// `(list[1], list[0])`, so one input order reaches only ONE arm of the
+    /// pinned/new switch. The first line below lands on `(nil, _?)` and the
+    /// second on `(_?, nil)`; with only the first, the other arm could be
+    /// `fatalError()` and every case here would still pass.
+    ///
     /// Mutations: `case (_?, nil): return false`; or `case (nil, _?): return true`.
     @Test func aRowNewSinceTheFreezeGoesAfterEveryPinnedRow() {
-        let rows = [
-            row("Zulu"),                         // pinned, lowest rank
-            row("Alpha", latest: "2.0"),         // NEW, and would rank first
-        ]
         let pinned = ["/Applications/Zulu.app": 0]
+        let zulu = row("Zulu")                    // pinned, lowest rank
+        let alpha = row("Alpha", latest: "2.0")   // NEW, and would rank first
 
-        #expect(sorted(rows, pinned: pinned) == ["Zulu", "Alpha"])
+        #expect(sorted([zulu, alpha], pinned: pinned) == ["Zulu", "Alpha"])
+        #expect(sorted([alpha, zulu], pinned: pinned) == ["Zulu", "Alpha"])
     }
 
     /// Two rows that are both new fall through to the ordinary order rather than
@@ -140,10 +146,10 @@ struct RowOrderTests {
 
     /// An empty pin table means the order is live, not that everything is new.
     ///
-    /// Mutation: drop the `!pinnedOrder.isEmpty` guard so the switch always runs
-    /// — with no pins every row is `(nil, nil)`, which today falls through, so
-    /// this pins that the guard's absence would be a behaviour change only in
-    /// combination. Kept as the positive pole for the frozen cases above.
+    /// No mutation: the `!pinnedOrder.isEmpty` guard is provably a no-op — with
+    /// no pins every lookup is `(nil, nil)`, which falls through anyway — so it
+    /// saves two dictionary reads and nothing else. This case is the positive
+    /// pole for the frozen ones above, not a guard on that line.
     @Test func anEmptyPinTableSortsNormally() {
         #expect(sorted([row("Zulu"), row("Alpha", latest: "2.0")]) == ["Alpha", "Zulu"])
     }
@@ -175,7 +181,12 @@ struct CheckScheduleTests {
             now: now, lastCheck: now, interval: 6 * 3600,
             isFirstCheck: true, hasResults: true)
 
-        #expect(wait == CheckSchedule.launchFloor)
+        // Literals on both sides. Written as `wait == CheckSchedule.launchFloor`
+        // the assertion is self-referential: change the constant to fifty
+        // minutes and it still passes, so the number — a product decision about
+        // how long after a relaunch the user may wait — was pinned by nothing.
+        #expect(wait == 5 * 60)
+        #expect(CheckSchedule.launchFloor == 5 * 60)
     }
 
     /// Later checks use the full interval — the floor is a launch concession, not
@@ -205,6 +216,23 @@ struct CheckScheduleTests {
         #expect(CheckSchedule.nextWait(
             now: now, lastCheck: now.addingTimeInterval(-3600),
             interval: 6 * 3600, isFirstCheck: false, hasResults: true) == 5 * 3600)
+    }
+
+    /// The run-now shortcut is for a COLD launch only. A later tick that happens
+    /// to find the list empty — a scan that matched nothing, everything filtered
+    /// out — must still wait out the interval. Without the `isFirstCheck` half of
+    /// that condition it answers zero forever, and because a deferred tick leaves
+    /// `isFirstCheck` and `lastCheck` untouched, the loop becomes an unthrottled
+    /// run of network checks behind nothing but the caller's 60s back-off.
+    ///
+    /// Every other case here passes `hasResults: true`, so that conjunct was
+    /// constant across the whole suite and dropping it passed all six.
+    ///
+    /// Mutation: `if !hasResults { return 0 }`.
+    @Test func aLaterTickWithAnEmptyListStillWaitsTheInterval() {
+        #expect(CheckSchedule.nextWait(
+            now: now, lastCheck: now, interval: 6 * 3600,
+            isFirstCheck: false, hasResults: false) == 6 * 3600)
     }
 
     /// Never checked before: run now rather than treating a missing date as


### PR DESCRIPTION
Two more decisions out of `AppListModel`, both of the kind that **cannot fail
loudly**.

## The row order

A sort compiles and renders whatever you write. Reorder two clauses and the list
is merely wrong, in a way no assertion about any single row can see — the reason
this repo already gives `DownloadReadout`'s declaration order [its own gate](https://github.com/jizhi0v0/duo-updater/blob/main/CLAUDE.md).

Two non-obvious invariants ride on it:

- **A staged build that IS the latest ranks with needs-restart**, not as a
  pending update — it is one relaunch from live. One that *trails* the latest is
  an ordinary update, and `UpdatePolicy.actionableStaged` is what draws that
  line, so the sort has to go through it rather than test the raw table.
- **While frozen, a row that appeared since the freeze goes AFTER every pinned
  row** — inserting it into the middle would push the pinned rows down, which is
  precisely what freezing prevents.

*Incidental improvement:* `rank` called `actionableStaged` from inside the
comparator, so it ran O(n log n) times per sort. It is computed once per row now
— same answers, since it is a pure function of the row and its staged entry.

## The check schedule

Arithmetic, and its wrong version is silent in both directions: too long and a
relaunch sits up to six hours showing nothing; too short and a flurry of dev
relaunches hammers every vendor endpoint. The launch floor moves with it, because
the number *is* the policy.

## Verification

**15 cases, 18 mutations, all 18 red on exactly the case they should be.**

| Mutation | Case it kills |
| --- | --- |
| any tier in `rank` renumbered (3 tried) | the ranking cases |
| rank on the raw staged table instead of `actionableStaged` | `aStagedBuildThatTrailsTheLatestDoesNotJumpTheQueue` |
| case-sensitive name compare; tie-break dropped | `namesSortCaseInsensitively` |
| frozen block deleted; new rows sorted before pinned; two-new fall-through removed; slots compared backwards | the four frozen cases |
| first check uses the full interval; every check capped at the floor | `theFirstCheckIsCappedAtTheLaunchFloor`, `laterChecksUseTheFullInterval` |
| cold-launch early return dropped | `aColdLaunchWithAnEmptyListChecksImmediately` |
| nil `lastCheck` read as now; `lastCheck` ignored entirely | `neverHavingCheckedRunsNow`, `anOverdueCheckRunsAtOnce` |

- `make test` — exit 0. **Core 2107 → 2122 (+15 cases, +2 suites)**, CLI 188,
  App 9 of 9, four python gates green.
- `xcodebuild -scheme DuoUpdater` — `** BUILD SUCCEEDED **`.
- `make gallery` — exit 0, all five gates.
- `AppListModel` — 48 lines out, 12 back.

No CHANGELOG entry and no version bump: nothing here is visible to users.


---

**Review round 1** found no behavioural regression — it re-derived the
comparator's strict weak ordering, the `Set` precomputation, and the arithmetic
line by line — and then found that **my mutation set was self-selected**. I had
picked fifteen mutations my cases already covered; three shapes I had not tried
were green:

| Mutation that used to pass | Why it was invisible | Now caught by |
| --- | --- | --- |
| `case (_?, nil): return false` | with two elements the comparator is called once, as `(list[1], list[0])`, so each case reached only one arm | `aRowNewSinceTheFreeze…` asserting both input orders |
| `if !hasResults { return 0 }` | every schedule case passed `hasResults: true`, so the conjunct was constant across the suite | `aLaterTickWithAnEmptyListStillWaitsTheInterval` |
| `launchFloor = 50 * 60` | the assertion was `wait == CheckSchedule.launchFloor` — self-referential | literals on both sides |

The second one has teeth. The list can go empty on a later tick, and a deferred
tick leaves `isFirstCheck` and `lastCheck` untouched — so the mutated version
answers zero forever, and the only thing between that and an unthrottled run of
network checks is the caller's 60s back-off in another package. That coupling now
has a comment on both sides of the boundary, which is all `App/Sources` can have.

Also drops the `launchFloor:` parameter: no caller passed it and no case measured
it, so it was an injection seam that existed only to go un-exercised.
