### PR TITLE
Move the freeze release condition and the progress coalescing into Core

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2488,18 +2488,12 @@ final class AppListModel {
     /// cuts that churn by ~50× and removes the visible jitter when several apps
     /// download at once.
     private func setStage(_ id: String, _ stage: InstallStage) {
-        // Progress callbacks dispatch un-awaited onto the main actor, so a late tick
-        // can land after the install finished and cleared `installing[id]`. Resurrecting
-        // a stale stage here would re-show a phantom row and wedge the re-entrancy
-        // guard (`installing[id] == nil`). Every real stage is preceded by a direct
-        // `installing[id] = …` assignment, so a nil here means the install is over.
-        guard installing[id] != nil else { return }
-        if case .downloading(let f) = stage,
-           case .downloading(let prev)? = installing[id],
-           Int(f * 100) == Int(prev * 100) {
-            return  // same whole percent — nothing the user can see changed
-        }
-        installing[id] = stage
+        // Both rules — never resurrect a finished install, and skip a tick that
+        // does not move the whole percent — are `InstallProgressCoalescing` in
+        // Core, where they are executed.
+        guard let folded = InstallProgressCoalescing.fold(
+            current: installing[id], incoming: stage) else { return }
+        installing[id] = folded
     }
 
     /// Flash an "Updated ✓" confirmation on a just-completed row, then let it go.
@@ -6238,12 +6232,13 @@ final class AppListModel {
     /// Safe to call from every settle point; it no-ops until the last one.
     private func releaseRowOrder() {
         guard !pinnedOrder.isEmpty else { return }
-        guard installing.isEmpty, !isInstallingAll, relaunching.isEmpty, justUpdated.isEmpty
-        else {
-            let holding = !installing.isEmpty ? "installing (\(installing.count))"
-                : isInstallingAll ? "batch install"
-                : !relaunching.isEmpty ? "relaunching (\(relaunching.count))"
-                : "just-updated confirmation"
+        // The condition — and which reason gets logged — is `RowOrderFreeze` in
+        // Core, where it is executed. A release term missing here produces a
+        // permanently frozen list, which from outside is indistinguishable from
+        // a freeze that never engaged.
+        if let holding = RowOrderFreeze.holdReason(
+            installCount: installing.count, isInstallingAll: isInstallingAll,
+            relaunchCount: relaunching.count, justUpdatedCount: justUpdated.count) {
             Log.app.debug("row order: still frozen — \(holding, privacy: .public)")
             return
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrderFreeze.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrderFreeze.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// When the row order may stop being frozen, and what to write down while it
+/// cannot.
+///
+/// The other half of `RowOrder`: that decides the order, this decides when the
+/// order is allowed to change. Split out for the reason the freeze's own logging
+/// exists — **a freeze that failed to lift looks exactly like a freeze that never
+/// engaged.** From outside, both are "the list stopped re-sorting", so a release
+/// condition with one term missing produces a permanently frozen list and no
+/// symptom that names itself.
+public enum RowOrderFreeze {
+
+    /// Why the order must stay frozen, or nil when it may be released.
+    ///
+    /// The string is the log line, and it is part of the answer rather than a
+    /// side effect: it is the only thing that distinguishes the two
+    /// indistinguishable states above in a live-log session, so which condition
+    /// is reported is worth pinning too.
+    ///
+    /// - Parameters:
+    ///   - installCount: rows with an install in flight.
+    ///   - isInstallingAll: whether a batch install is running.
+    ///   - relaunchCount: rows being relaunched.
+    ///   - justUpdatedCount: rows still showing the just-updated confirmation.
+    public static func holdReason(
+        installCount: Int,
+        isInstallingAll: Bool,
+        relaunchCount: Int,
+        justUpdatedCount: Int
+    ) -> String? {
+        // Order matters only for which reason is reported; any one of them holds
+        // the freeze. Reported most-specific-first, matching what a reader
+        // watching the log would want to see named.
+        if installCount > 0 { return "installing (\(installCount))" }
+        if isInstallingAll { return "batch install" }
+        if relaunchCount > 0 { return "relaunching (\(relaunchCount))" }
+        if justUpdatedCount > 0 { return "just-updated confirmation" }
+        return nil
+    }
+}
+
+/// How an install-progress tick is folded into the stage a row is showing.
+///
+/// Two rules, both of which fail quietly. Resurrecting a stage for a row whose
+/// install is over re-shows a phantom row AND wedges the re-entrancy guard, which
+/// keys on the stage being absent; and a download that reports every fraction
+/// re-renders every row dozens of times a second, because the stage table
+/// invalidates as a whole.
+public enum InstallProgressCoalescing {
+
+    /// - Parameters:
+    ///   - current: the stage the row is showing, or nil when no install is in
+    ///     flight for it.
+    ///   - incoming: the stage the callback is reporting.
+    /// - Returns: the stage to store, or nil to ignore the tick.
+    public static func fold(
+        current: InstallStage?, incoming: InstallStage
+    ) -> InstallStage? {
+        // Progress callbacks dispatch un-awaited onto the main actor, so a late
+        // tick can land after the install finished and cleared the entry. Every
+        // real stage is preceded by a direct assignment, so nil here means the
+        // install is over — and resurrecting it would re-show a phantom row and
+        // wedge the re-entrancy guard, which tests exactly this nil.
+        guard current != nil else { return nil }
+        if case .downloading(let fraction) = incoming,
+           case .downloading(let previous)? = current,
+           Int(fraction * 100) == Int(previous * 100) {
+            // Same whole percent — nothing the user can see changed. A
+            // `URLSession` download fires this dozens of times a second and the
+            // table invalidates as a whole, so writing it re-renders every row.
+            return nil
+        }
+        return incoming
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrderFreeze.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RowOrderFreeze.swift
@@ -13,6 +13,13 @@ public enum RowOrderFreeze {
 
     /// Why the order must stay frozen, or nil when it may be released.
     ///
+    /// Answers *may the freeze lift*, not *is there a freeze*. The caller still
+    /// owns its own `pinnedOrder.isEmpty` early return, and that one is
+    /// load-bearing: without it a settle point would re-sort a list that was
+    /// never frozen — the exact reordering freezing exists to prevent — and log
+    /// a release that never happened. Now that the ladder lives here, that guard
+    /// reads like part of this condition. It is not.
+    ///
     /// The string is the log line, and it is part of the answer rather than a
     /// side effect: it is the only thing that distinguishes the two
     /// indistinguishable states above in a live-log session, so which condition

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderFreezeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderFreezeTests.swift
@@ -62,12 +62,18 @@ struct RowOrderFreezeTests {
         #expect(hold(relaunches: 1, justUpdated: 1) == "relaunching (1)")
     }
 
-    /// A zero count is not a condition. Guards the counted terms against being
-    /// written as `installCount >= 0` or as a plain optional test.
+    /// A zero count must not be mistaken for a condition — and specifically must
+    /// not SHADOW a later term that is true, which is the only thing this can add
+    /// over the idle case above. Written as `hold(installs: 0, relaunches: 0,
+    /// justUpdated: 0)` it was the same call as `hold()` after defaults, so it
+    /// killed nothing the first case had not already killed.
     ///
-    /// Mutation: `installCount >= 0`, or `relaunchCount != 1`.
-    @Test func zeroCountsDoNotHoldTheFreeze() {
-        #expect(hold(installs: 0, relaunches: 0, justUpdated: 0) == nil)
+    /// Mutation: `installCount >= 0` (or any counted term testing for presence
+    /// rather than for a positive count).
+    @Test func aZeroCountDoesNotShadowALaterCondition() {
+        #expect(hold(installs: 0, batch: true) == "batch install")
+        #expect(hold(installs: 0, relaunches: 1) == "relaunching (1)")
+        #expect(hold(relaunches: 0, justUpdated: 1) == "just-updated confirmation")
     }
 }
 
@@ -100,7 +106,12 @@ struct InstallProgressCoalescingTests {
 
     /// …but crossing into the next percent is written.
     ///
-    /// Mutation: compare the raw fractions.
+    /// What this actually kills is the skip swallowing EVERY download tick — the
+    /// raw-fraction mutation it used to name is killed by the two cases around
+    /// it, not by this one, since `0.5 != 0.51` under either rule.
+    ///
+    /// Mutation: `if case .downloading = incoming, case .downloading? = current`
+    /// with no percent test; or returning `current` instead of `incoming`.
     @Test func aDownloadTickThatCrossesAPercentIsWritten() {
         #expect(InstallProgressCoalescing.fold(
             current: .downloading(fraction: 0.5),
@@ -115,6 +126,11 @@ struct InstallProgressCoalescingTests {
     ///
     /// The earlier fixtures could not see this: 0.5 → 0.5049 and 0.5 → 0.51 give
     /// the same answer under either rule.
+    ///
+    /// ⚠️ These two literals are load-bearing. As doubles the products are
+    /// 50.3999999999999985… and 50.6000000000000014…, so they truncate to the
+    /// same 50 and round to 50 and 51. Tidying them to rounder numbers silently
+    /// retires the case.
     ///
     /// Mutation: `(fraction * 100).rounded() == (previous * 100).rounded()`.
     @Test func thePercentIsTruncatedNotRounded() {
@@ -137,12 +153,34 @@ struct InstallProgressCoalescingTests {
             == .downloading(fraction: 0.5))
     }
 
+    /// The coalescing is percent-based AND download-only: an identical
+    /// non-download stage still writes. `.runningCommand` is the only stage
+    /// carrying a payload, and Homebrew repeats output lines verbatim, so it is
+    /// the case a "let us just dedupe identical stages" edit would break.
+    ///
+    /// Writing the same value again is close to unobservable on screen, so this
+    /// is hardening rather than a live defect — but the widened dedupe survived
+    /// every other case here, and this is `.runningCommand`'s only appearance in
+    /// the suite.
+    ///
+    /// Mutation: `if current == incoming { return nil }`.
+    @Test func anIdenticalNonDownloadStageIsStillWritten() {
+        #expect(InstallProgressCoalescing.fold(
+            current: .runningCommand("==> Downloading"),
+            incoming: .runningCommand("==> Downloading"))
+            == .runningCommand("==> Downloading"))
+    }
+
     /// The percent test needs BOTH sides to be downloads. Arriving at a download
     /// from any other stage must write, or the first progress tick of every
     /// install would be swallowed.
     ///
     /// Mutation: drop the `case .downloading(let previous)? = current` pattern
     /// so the incoming fraction is compared against a default.
+    /// ⚠️ `0.0` is load-bearing: it is the only fraction for which "compare the
+    /// incoming percent against a default of zero" — the mutation below — gives
+    /// the same answer as the real rule for the wrong reason. With 0.5 here the
+    /// case stops killing it.
     @Test func theFirstDownloadTickAfterAnotherStageIsWritten() {
         for stage in [InstallStage.queued, .checking, .installing, .extracting] {
             #expect(InstallProgressCoalescing.fold(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderFreezeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RowOrderFreezeTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// When the frozen row order may be released.
+///
+/// The failure this guards is silent by construction: a release term that stops
+/// firing leaves the list permanently frozen, and from outside that is
+/// indistinguishable from a freeze that never engaged — both are "the list
+/// stopped re-sorting". Nothing executed it before.
+struct RowOrderFreezeTests {
+
+    private func hold(
+        installs: Int = 0, batch: Bool = false, relaunches: Int = 0, justUpdated: Int = 0
+    ) -> String? {
+        RowOrderFreeze.holdReason(
+            installCount: installs, isInstallingAll: batch,
+            relaunchCount: relaunches, justUpdatedCount: justUpdated)
+    }
+
+    /// Nothing in flight: release.
+    ///
+    /// Mutation: return a reason unconditionally.
+    @Test func anIdleListMayBeReleased() {
+        #expect(hold() == nil)
+    }
+
+    /// Each of the four conditions holds the freeze ON ITS OWN. Asserted one at a
+    /// time, because a fixture with several set at once measures only whichever
+    /// is reported first — the shape that let a whole branch set go unmeasured
+    /// twice already in this series.
+    ///
+    /// Mutations: delete any one of the four terms.
+    @Test func eachConditionHoldsTheFreezeByItself() {
+        #expect(hold(installs: 1) != nil)
+        #expect(hold(batch: true) != nil)
+        #expect(hold(relaunches: 1) != nil)
+        #expect(hold(justUpdated: 1) != nil)
+    }
+
+    /// The reported reason is part of the answer, not decoration: it is the only
+    /// thing that tells the two indistinguishable states apart in a live log.
+    /// Each condition names itself, and the counted ones carry their count.
+    ///
+    /// Mutations: swap any two reason strings; drop a count from one.
+    @Test func eachConditionNamesItself() {
+        #expect(hold(installs: 3) == "installing (3)")
+        #expect(hold(batch: true) == "batch install")
+        #expect(hold(relaunches: 2) == "relaunching (2)")
+        #expect(hold(justUpdated: 1) == "just-updated confirmation")
+    }
+
+    /// With more than one condition true, the most specific wins — a reader
+    /// watching the log wants the row-level cause, not the batch flag that is
+    /// true for the whole run.
+    ///
+    /// Mutation: reorder the `if`s.
+    @Test func theMostSpecificReasonIsReported() {
+        #expect(hold(installs: 2, batch: true, relaunches: 1, justUpdated: 1)
+            == "installing (2)")
+        #expect(hold(batch: true, relaunches: 1, justUpdated: 1) == "batch install")
+        #expect(hold(relaunches: 1, justUpdated: 1) == "relaunching (1)")
+    }
+
+    /// A zero count is not a condition. Guards the counted terms against being
+    /// written as `installCount >= 0` or as a plain optional test.
+    ///
+    /// Mutation: `installCount >= 0`, or `relaunchCount != 1`.
+    @Test func zeroCountsDoNotHoldTheFreeze() {
+        #expect(hold(installs: 0, relaunches: 0, justUpdated: 0) == nil)
+    }
+}
+
+/// How an install-progress tick is folded into what a row shows.
+struct InstallProgressCoalescingTests {
+
+    /// A tick for a row whose install is over is dropped. Resurrecting it would
+    /// re-show a phantom row and wedge the re-entrancy guard, which keys on this
+    /// very absence.
+    ///
+    /// Mutation: delete the `guard current != nil`.
+    @Test func aTickForAFinishedInstallIsIgnored() {
+        #expect(InstallProgressCoalescing.fold(
+            current: nil, incoming: .downloading(fraction: 0.5)) == nil)
+        // …including a terminal stage: nil means the install is over, whatever
+        // the tick says.
+        #expect(InstallProgressCoalescing.fold(current: nil, incoming: .done) == nil)
+    }
+
+    /// A download tick that does not move the whole percent is dropped. The
+    /// stage table invalidates as a whole, so writing it re-renders every row —
+    /// dozens of times a second during a download.
+    ///
+    /// Mutation: delete the same-percent branch.
+    @Test func aDownloadTickWithinTheSamePercentIsIgnored() {
+        #expect(InstallProgressCoalescing.fold(
+            current: .downloading(fraction: 0.5),
+            incoming: .downloading(fraction: 0.5049)) == nil)
+    }
+
+    /// …but crossing into the next percent is written.
+    ///
+    /// Mutation: compare the raw fractions.
+    @Test func aDownloadTickThatCrossesAPercentIsWritten() {
+        #expect(InstallProgressCoalescing.fold(
+            current: .downloading(fraction: 0.5),
+            incoming: .downloading(fraction: 0.51)) == .downloading(fraction: 0.51))
+    }
+
+    /// The percent is TRUNCATED, not rounded — what the user reads is
+    /// `Int(fraction * 100)`, so two fractions that display the same number are
+    /// the same tick however they round. 0.504 and 0.506 both display as 50%,
+    /// but they round to 50 and 51, so a rounding version writes a tick that
+    /// changes nothing on screen.
+    ///
+    /// The earlier fixtures could not see this: 0.5 → 0.5049 and 0.5 → 0.51 give
+    /// the same answer under either rule.
+    ///
+    /// Mutation: `(fraction * 100).rounded() == (previous * 100).rounded()`.
+    @Test func thePercentIsTruncatedNotRounded() {
+        #expect(InstallProgressCoalescing.fold(
+            current: .downloading(fraction: 0.504),
+            incoming: .downloading(fraction: 0.506)) == nil)
+    }
+
+    /// The coalescing is for downloads only. A different stage always writes,
+    /// even while a download is showing — otherwise an install that moved on to
+    /// verifying would keep rendering a progress bar.
+    ///
+    /// Mutation: widen the same-percent branch to any incoming stage.
+    @Test func aStageChangeIsAlwaysWritten() {
+        #expect(InstallProgressCoalescing.fold(
+            current: .downloading(fraction: 0.5),
+            incoming: .verifyingSignature) == .verifyingSignature)
+        #expect(InstallProgressCoalescing.fold(
+            current: .queued, incoming: .downloading(fraction: 0.5))
+            == .downloading(fraction: 0.5))
+    }
+
+    /// The percent test needs BOTH sides to be downloads. Arriving at a download
+    /// from any other stage must write, or the first progress tick of every
+    /// install would be swallowed.
+    ///
+    /// Mutation: drop the `case .downloading(let previous)? = current` pattern
+    /// so the incoming fraction is compared against a default.
+    @Test func theFirstDownloadTickAfterAnotherStageIsWritten() {
+        for stage in [InstallStage.queued, .checking, .installing, .extracting] {
+            #expect(InstallProgressCoalescing.fold(
+                current: stage, incoming: .downloading(fraction: 0.0))
+                == .downloading(fraction: 0.0), "\(stage) swallowed the first tick")
+        }
+    }
+}


### PR DESCRIPTION
Two more decisions out of `AppListModel`, both of which **fail quietly**.

## `RowOrderFreeze`

The other half of the `RowOrder` move in #321: that decides the order, this
decides when the order is allowed to change.

It is worth executing for exactly the reason its own logging exists — **a freeze
that failed to lift looks identical to a freeze that never engaged**, because
from outside both are "the list stopped re-sorting". A release term that stops
firing leaves the list permanently frozen and produces no symptom that names
itself.

So the reported reason is part of the answer, not a side effect: it is the only
thing that tells those two states apart in a live log. Which condition gets
named, and that the counted ones carry their counts, are pinned too.

## `InstallProgressCoalescing`

The two rules in `setStage`:

- **Never resurrect a stage for a row whose install is over.** A late progress
  tick lands after the entry was cleared; writing it re-shows a phantom row *and*
  wedges the re-entrancy guard, which keys on that very absence.
- **Skip a download tick that does not move the whole percent.** `URLSession`
  fires these dozens of times a second and the stage table invalidates as a
  whole, so each one re-renders every row.

## Verification

**12 cases, 17 mutations, all 17 red on exactly the case they should be.**

| Mutation | Case it kills |
| --- | --- |
| any one of the four release terms deleted | `eachConditionHoldsTheFreezeByItself` |
| `installCount >= 0` | `zeroCountsDoNotHoldTheFreeze` |
| two reasons swapped; a count dropped from a reason | `eachConditionNamesItself` |
| the reported order reversed | `theMostSpecificReasonIsReported` |
| `guard current != nil` deleted | `aTickForAFinishedInstallIsIgnored` |
| same-percent skip deleted; raw fractions compared; **rounded instead of truncated** | the three download cases |
| skip widened to swallow non-download stages | `aStageChangeIsAlwaysWritten` |

- `make test` — exit 0. **Core 2122 → 2134 (+12 cases, +2 suites)**, CLI 188,
  App 9 of 9, four python gates green.
- `xcodebuild -scheme DuoUpdater` — `** BUILD SUCCEEDED **`.
- `make gallery` — exit 0, all five gates.

**Two of the fourteen only became useful after being fixed, and both were my
fault** — the failure mode this series keeps producing:

- The percent cases used `0.5 → 0.5049` and `0.5 → 0.51`, which give the same
  answer whether the percent is truncated or rounded. `0.504 → 0.506` is the pair
  that separates them, and truncation is the one that matters, because it is what
  the user reads.
- A mutation meant to widen the skip to any incoming stage was written with `??`
  on a non-optional, so it compiled to a no-op and proved nothing. The rewritten
  one is caught.

No CHANGELOG entry and no version bump: nothing here is visible to users.


---

**Review round 1** found no behavioural defect — it re-derived `isEmpty` versus
`count > 0`, the branch order, and that `fold` returns `incoming` unchanged, so
`installing[id] = folded` is today exactly `installing[id] = stage`. Three test
holes, all confirmed green by mutation first:

| Mutation that used to pass | Now caught by |
| --- | --- |
| `if current == incoming { return nil }` — dedupe widened past downloads | `anIdenticalNonDownloadStageIsStillWritten` (`.runningCommand`, which Homebrew repeats verbatim) |
| `installCount >= 0` shadowing a later true term | `aZeroCountDoesNotShadowALaterCondition` — the old case was, after defaults, the same call as the idle one |
| — | the crossing-percent case named a mutation it does not catch; its comment now names the one it does |

One finding I did **not** apply: it reported that the type `RowOrder` does not
exist and asked me to reword the doc comment. It does — `RowOrder.swift:10`, used
at `AppListModel.swift:6185`. The grep was against `main` before #321 landed.

Two fixture values are now marked load-bearing, since both are what a later
tidy-up rounds off: `0.504`/`0.506` truncate to the same percent and round to
different ones, and `0.0` is the only fraction for which the
compare-against-a-default mutation is observable.
