### PR TITLE
Let a closed vendor track be closed, not a failed check

### DIFF
--- a/App/Sources/AppUpdater.swift
+++ b/App/Sources/AppUpdater.swift
@@ -117,6 +117,11 @@ private final class SelfUpdateInstaller: NSObject, SPUUpdaterDelegate {
         let event = RequestEvent(
             purpose: .selfUpdate, method: "GET", scheme: item.fileURL?.scheme,
             host: host, port: item.fileURL?.port, path: item.fileURL?.path ?? "",
+            // Ours. The self-update is the one fetch that is unambiguously for a
+            // single app, and leaving it blank put our own downloads in the same
+            // column as the Homebrew catalog — which is blank because it is
+            // shared by every app, the opposite reason.
+            appID: Bundle.main.bundlePath,
             // A synthetic task with a single hop: Sparkle's own redirects are as
             // invisible to us as its byte counts, and inventing hops we did not
             // observe would be worse than recording the one we can attest to.

--- a/App/Sources/SelfChangelogView.swift
+++ b/App/Sources/SelfChangelogView.swift
@@ -142,8 +142,10 @@ struct SelfChangelogView: View {
         request.cachePolicy = force ? .reloadIgnoringLocalCacheData : URLRequest.versionFeedCachePolicy
         request.timeoutInterval = 15
         do {
-            let (data, response) = try await URLSession.updates.countedData(
-                for: request, purpose: .selfUpdate)
+            let (data, response) = try await RequestAttribution.withApp(Bundle.main.bundlePath) {
+                try await URLSession.updates.countedData(
+                    for: request, purpose: .selfUpdate)
+            }
             if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
                 state = .failed(String(localized: "GitHub answered HTTP \(http.statusCode)."))
                 return
@@ -177,8 +179,10 @@ struct SelfChangelogView: View {
         var request = URLRequest(url: url)
         request.cachePolicy = force ? .reloadIgnoringLocalCacheData : URLRequest.versionFeedCachePolicy
         request.timeoutInterval = 15
-        guard let (data, response) = try? await URLSession.updates.countedData(
-            for: request, purpose: .selfUpdate),
+        guard let (data, response) = try? await RequestAttribution.withApp(Bundle.main.bundlePath, operation: {
+            try await URLSession.updates.countedData(
+                for: request, purpose: .selfUpdate)
+        }),
               let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode)
         else { return nil }
@@ -207,8 +211,10 @@ struct SelfChangelogView: View {
             request.timeoutInterval = 10
             request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
 
-            guard let (data, response) = try? await URLSession.updates.countedData(
-                    for: request, purpose: .selfUpdate),
+            guard let (data, response) = try? await RequestAttribution.withApp(Bundle.main.bundlePath, operation: {
+                    try await URLSession.updates.countedData(
+                        for: request, purpose: .selfUpdate)
+                }),
                   let http = response as? HTTPURLResponse,
                   (200..<300).contains(http.statusCode),
                   let releases = try? JSONDecoder().decode([PublishedRelease].self, from: data),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -472,6 +472,23 @@ public struct VendorProbeRecipe: Sendable {
     ///    `CapCutProbeRecipeTests` pins both directions against captured bodies.
     public let transientBodyPattern: String?
 
+    /// The body says, in the vendor's own words, that this track has no current
+    /// build.
+    ///
+    /// Distinct from the pattern simply not matching, and the distinction is the
+    /// whole point: a miss is "the recipe stopped working, a human should look",
+    /// while this is "the vendor is between releases on this track, nobody has
+    /// anything to fix". They arrive identically — no version — and only the
+    /// vendor can tell them apart, so this asks the vendor rather than inferring.
+    ///
+    /// Reported as ``ProbeFailure/notApplicable(_:)``, which returns nil instead
+    /// of throwing: no red row, no entry in the failed-check banner, no Retry
+    /// button that could never have worked.
+    ///
+    /// Consulted **only** when the version pattern already failed to match. A
+    /// track that is publishing cannot be talked into looking closed.
+    public let trackClosedPattern: String?
+
     /// Where to send the user to download the update by hand. Defaults to `url`.
     /// Probed updates are always manual (no trusted in-place install path), so
     /// this is the link surfaced to the user.
@@ -666,6 +683,7 @@ public struct VendorProbeRecipe: Sendable {
         mode: Mode,
         versionPattern: String,
         transientBodyPattern: String? = nil,
+        trackClosedPattern: String? = nil,
         downloadURL: URL? = nil,
         changelogURL: URL? = nil,
         selectHighest: Bool = false,
@@ -696,6 +714,7 @@ public struct VendorProbeRecipe: Sendable {
         self.mode = mode
         self.versionPattern = versionPattern
         self.transientBodyPattern = transientBodyPattern
+        self.trackClosedPattern = trackClosedPattern
         self.downloadURL = downloadURL
         self.changelogURL = changelogURL
         self.selectHighest = selectHighest
@@ -760,6 +779,15 @@ public struct VendorProbeRecipe: Sendable {
     /// typo before it ships.
     func matchesTransientBody(_ body: String) -> Bool {
         guard let pattern = transientBodyPattern,
+              let regex = try? NSRegularExpression(pattern: pattern)
+        else { return false }
+        return regex.firstMatch(
+            in: body, options: [], range: NSRange(body.startIndex..., in: body)) != nil
+    }
+
+    /// Whether the vendor states this track has no current build.
+    func matchesTrackClosed(_ body: String) -> Bool {
+        guard let pattern = trackClosedPattern,
               let regex = try? NSRegularExpression(pattern: pattern)
         else { return false }
         return regex.firstMatch(
@@ -5593,12 +5621,19 @@ public enum VendorProbeRegistry {
         // are always three-segment, so a two-segment `version_code` can never
         // collide with an answer.
         //
-        // TRAP, `channel`: `capcutpc_beta` is a REAL CapCut channel token and is
-        // the wrong thing to send here — the endpoint returns no `update_reminder`
-        // at all for it (measured). `capcutpc_0` is what a stable install sends and
-        // what returns BOTH tracks, so both recipes send it. The channel a recipe
-        // serves is decided by which `lastest_*` key it reads, not by this
+        // TRAP, `channel`: `capcutpc_beta` is a REAL CapCut channel token, and
+        // both recipes deliberately send `capcutpc_0` instead. The channel a
+        // recipe serves is decided by which `lastest_*` key it reads, not by this
         // parameter.
+        //
+        // The reason recorded here on 2026-08-27 — "the endpoint returns no
+        // `update_reminder` at all for `capcutpc_beta`" — **is no longer true**,
+        // re-measured 2026-09-04: both tokens now return a 26-field
+        // `update_reminder`, and the two bodies agree field for field. So the
+        // token is now inert rather than harmful. Left as `capcutpc_0` because it
+        // is the value with the longer measured history, not because the old
+        // hazard still exists; anyone changing it should re-measure rather than
+        // trust either version of this paragraph.
         //
         // Version scheme: the `lastest_*_version` integers are nibble-packed
         // (590592 = 0x090300 = 9.3.0), which no regex can decode, so the version is
@@ -5713,10 +5748,25 @@ public enum VendorProbeRegistry {
             channel: .stable, urlKey: "lastest_stable_url",
             packageToken: "capcutpc_0", patchSegment: #"[0-9]+"#,
             versionIsBuild: false),
+        // The beta track is not always open. When a beta graduates and no new one
+        // has started, `lastest_url` carries the STABLE artifact — the pattern
+        // pins `capcutpc_beta` inside the filename, so it correctly refuses to
+        // read a stable build as a beta one, and the probe finds nothing.
+        //
+        // `lastest_beta_number` is the vendor saying so in their own data: "4"
+        // while beta4 was current (2026-08-27), empty once 9.4.0 shipped and no
+        // beta replaced it (2026-09-04, with `lastest_url` == `lastest_stable_url`
+        // == the 9.4.0 stable dmg). Without this the row went red with "no match
+        // in 436155-byte body" and a Retry that could not work until ByteDance
+        // opened the next beta.
+        //
+        // Anchored to the key so it cannot be satisfied by an empty string
+        // anywhere else in a ~436 KB body.
         capCutRecipe(
             channel: .beta, urlKey: "lastest_url",
             packageToken: "capcutpc_beta", patchSegment: #"[0-9]+(?:-beta[0-9]+)?"#,
-            versionIsBuild: true),
+            versionIsBuild: true,
+            trackClosedPattern: ##""lastest_beta_number"\s*:\s*"""##),
 
         // 百度网盘 (Baidu Netdisk) — reads the endpoint the vendor's own download
         // page is built from: `pan.baidu.com/disk/cmsdata?do=client` answers a small
@@ -6466,7 +6516,8 @@ public enum VendorProbeRegistry {
         urlKey: String,
         packageToken: String,
         patchSegment: String,
-        versionIsBuild: Bool
+        versionIsBuild: Bool,
+        trackClosedPattern: String? = nil
     ) -> VendorProbeRecipe {
         let host = #"https://sf16-web-tos-buz\.capcutstatic\.com"#
         return VendorProbeRecipe(
@@ -6483,6 +6534,7 @@ public enum VendorProbeRegistry {
             // settings were returned"; the message text is an internal stack trace
             // and is not matched on. See `transientBodyPattern`.
             transientBodyPattern: #"^\s*\{\s*"data"\s*:\s*\{\s*\}"#,
+            trackClosedPattern: trackClosedPattern,
             downloadURL: URL(string: "https://www.capcut.com/tools/desktop-video-editor"),
             versionIsBuild: versionIsBuild,
             install: VendorInstallSpec(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -593,6 +593,24 @@ public struct VendorProbeSource: UpdateSource {
                     .vendorErrorEnvelope(sampleBytes: body.text.utf8.count),
                     status: body.status, sample: sample)
             }
+            // Ask the vendor before blaming the recipe. A track between releases
+            // and a recipe that stopped working both arrive here with no version,
+            // and only the vendor can tell them apart — CapCut states it by
+            // emptying `lastest_beta_number` when no beta is open. Reported as
+            // `.notApplicable`, which returns nil rather than throwing: no red
+            // row and no Retry button, because there is nothing to retry until
+            // the vendor opens the track again.
+            //
+            // Checked here, after the pattern already failed, so a publishing
+            // track can never be talked into looking closed.
+            if recipe.matchesTrackClosed(body.text) {
+                Log.source.notice(
+                    "vendor probe \(recipe.bundleID, privacy: .public) [\(recipe.channel.rawValue, privacy: .public)]: vendor publishes no current build on this track")
+                return fail(
+                    .notApplicable(
+                        "no current build on the \(recipe.channel.rawValue) track"),
+                    status: body.status, sample: sample)
+            }
             // Symmetric with `GitHubReleasesSource`, which has logged its
             // pattern misses since day one. A probe that fetched fine and matched
             // nothing is the exact shape of a vendor rewriting their page, and

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DormantTrackTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DormantTrackTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A vendor track that is between releases, which is not a broken recipe.
+@Suite
+struct DormantTrackTests {
+
+    private static var beta: VendorProbeRecipe {
+        VendorProbeRegistry.recipes.first {
+            $0.bundleID == CapCutChannel.bundleID && $0.channel == .beta
+        }!
+    }
+
+    @Test("The vendor's own empty beta number is what marks the track closed")
+    func closedTrackIsRecognisedFromTheVendorsOwnField() {
+        // Measured 2026-09-04: 9.4.0 shipped to stable, no beta replaced it, and
+        // `lastest_beta_number` went from "4" to "". `lastest_url` then carries
+        // the stable artifact, the beta pattern correctly refuses it, and without
+        // this the row went red with a Retry that could not work.
+        #expect(Self.beta.matchesTrackClosed(##"…,"lastest_beta_number":"","lastest_url":"…"##))
+        // While a beta is open the same body says so, and nothing is suppressed.
+        #expect(!Self.beta.matchesTrackClosed(##"…,"lastest_beta_number":"4","lastest_url":"…"##))
+    }
+
+    @Test("An empty string elsewhere in 436 KB does not close the track")
+    func theSignalIsAnchoredToItsKey() {
+        // The body is ~436 KB of unrelated settings; an unanchored `""` would
+        // match in a thousand places and silence a genuinely broken recipe.
+        #expect(!Self.beta.matchesTrackClosed(##"{"some_other_key":"","beta_number":"4"}"##))
+    }
+
+    @Test("Only the beta track declares this, and stable never does")
+    func stableCarriesNoDormancySignal() {
+        // Stable has no closed state to declare: `lastest_stable_url` is always
+        // populated. Declaring one there would let a real stable outage pass as
+        // "nothing published", which is the failure this whole mechanism is
+        // shaped to avoid on the other side.
+        let stable = VendorProbeRegistry.recipes.first {
+            $0.bundleID == CapCutChannel.bundleID && $0.channel == .stable
+        }!
+        #expect(stable.trackClosedPattern == nil)
+        #expect(Self.beta.trackClosedPattern != nil)
+    }
+
+    @Test("A closed track is not applicable, not a failure")
+    func closedTrackClassifiesAsNotApplicable() {
+        // `.notApplicable` makes the source return nil rather than throw, so the
+        // row does not go red and the failed-check banner does not count it.
+        // Every other failure stays a failure.
+        #expect(ProbeFailure.notApplicable("x").classification == .notApplicable)
+        #expect(ProbeFailure.versionPatternNoMatch(sampleBytes: 1).classification == .recipe)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -121,9 +121,15 @@ import CryptoKit
 
     for key in targets {
         let remote = results[key] ?? nil
-        if dormantTracks.contains(key) {
-            #expect(remote?.downloadURL == nil,
-                    "\(key) resolves again — the vendor reopened this track, so drop its trackClosedPattern")
+        // Only when it actually resolved nothing. `trackClosedPattern` is a
+        // permanent property of the recipe — it says how this vendor SIGNALS
+        // dormancy, not that the track is closed today — so keying the exemption
+        // on the declaration alone breaks twice over: the sweep fails the day the
+        // vendor reopens the track (and advises deleting the very declaration
+        // that keeps the row calm next time it closes), and while the track IS
+        // open the assertions below are skipped, so a working channel quietly
+        // stops being covered.
+        if remote?.downloadURL == nil, dormantTracks.contains(key) {
             log("• \(key): dormant — vendor publishes no current build on this track")
             continue
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -103,30 +103,27 @@ import CryptoKit
     if !retried.isEmpty {
         log("↻ retried after a first-pass miss: \(retried.map(\.description).joined(separator: ", "))")
     }
-    // Tracks the vendor is currently between releases on.
+    // Tracks the vendor is currently between releases on — derived from the
+    // registry, never hand-listed.
     //
     // A channel recipe that resolves nothing is normally rot, which is what this
-    // sweep exists to catch. It is not rot when the vendor has simply closed a
-    // track: CapCut's beta graduated to stable 9.4.0 and no new beta has opened,
-    // so `lastest_url` now carries `…_capcutpc_0_…` — a stable artifact — and the
-    // recipe's pattern refuses it rather than offering a stable build to beta
-    // users. Refusing is the recipe working. (Measured 2026-09-04: the endpoint
-    // answers 200 with 436 KB, `lastest_beta_number` is empty, and the only
-    // `capcutpc_beta` artifact left is an OLDER 9.3.5-beta1 that the recipe is
-    // pinned away from because taking it would silently downgrade the track.)
+    // sweep exists to catch. It is not rot when the vendor has closed a track,
+    // and the recipe says which tracks can be closed by carrying a
+    // `trackClosedPattern` — the vendor's own statement that nothing is
+    // published there (CapCut empties `lastest_beta_number` between betas).
     //
-    // Each entry is checked below for still being dormant, so this cannot become
-    // a permanent exemption: the day the vendor opens the next beta, the entry
-    // stops matching and the build fails until somebody removes it.
-    let dormantTracks: Set<ChannelProofKey> = [
-        ChannelProofKey("com.lemon.lvoverseas", .beta),
-    ]
+    // Reading it off the registry rather than repeating the key here is the
+    // difference between one source of truth and two that drift: a hand-written
+    // list goes on exempting a recipe whose declaration was removed.
+    let dormantTracks = Set(
+        byKey.values.filter { $0.trackClosedPattern != nil }
+            .map { ChannelProofKey($0.bundleID, $0.channel) })
 
     for key in targets {
         let remote = results[key] ?? nil
         if dormantTracks.contains(key) {
             #expect(remote?.downloadURL == nil,
-                    "\(key) resolves again — the vendor reopened this track, so drop it from dormantTracks")
+                    "\(key) resolves again — the vendor reopened this track, so drop its trackClosedPattern")
             log("• \(key): dormant — vendor publishes no current build on this track")
             continue
         }
@@ -207,6 +204,14 @@ import CryptoKit
 @Test func channelAnchorSurfaceCoversEveryRecipeField() {
     let recipe = VendorProbeRegistry.recipes[0]
     let labels = Mirror(reflecting: recipe).children.compactMap(\.label)
+    // 24 since `trackClosedPattern` (2026-09-04). It stays IN, and unlike its
+    // sibling `transientBodyPattern` it is not channel-neutral: only the beta
+    // recipe carries one, and the string it holds names a beta-specific key
+    // (`lastest_beta_number`). That makes it a field a proof could legitimately
+    // name — it is part of what the recipe reads — without being tautological
+    // the way `channel` is. Useful or not as an anchor, the rule for
+    // `nonAnchorFields` is tautology, and this is not one.
+    //
     // 23 since `transientBodyPattern` (2026-09-01), which stays IN for the same
     // reason `buildNamespace` did (22, 2026-08-30): `nonAnchorFields` is for
     // fields that would make a channel anchor tautological — a `.beta` recipe
@@ -217,7 +222,7 @@ import CryptoKit
     // is a bad proof, not a tautological one, and a proof must name the fields it
     // relies on anyway (#110). Useless as an anchor, harmless in the surface,
     // same as every other Bool here.
-    #expect(labels.count == 23,
+    #expect(labels.count == 24,
             "VendorProbeRecipe gained or lost a field (now \(labels.count): \(labels.sorted())) — decide whether it belongs in the .recipeAnchor surface or in nonAnchorFields, then update this count")
     // A renamed field would turn its exclusion into a silent no-op, quietly
     // widening the surface instead of narrowing it. Same class of bug, other

--- a/docs/app-audits/com-lemon-lvoverseas.md
+++ b/docs/app-audits/com-lemon-lvoverseas.md
@@ -451,6 +451,84 @@ stable 轨没走这条 harness（本机 channel 解析成 beta），但同一 Te
 不是从文件名习惯推的：`capcutpc_beta` 是挂载 beta dmg 后从它自己的
 `Contents/Resources/PackageConfig.plist` → `Channel Name` 读出来的厂商 token。
 
+## 2026-09-04 复测：beta 轨进入空窗期
+
+厂商侧变了四处，其中一处**推翻了 8-27 记录里的一条实测**。同一条 URL、同样的
+`version_code=9.99`，只换 `channel`：
+
+| 字段 | 2026-08-27 | 2026-09-04 |
+|---|---|---|
+| `lastest_url` | `…9_4_0-beta4_4531_capcutpc_**beta**…` | `…9_4_0_4556_capcutpc_**0**…` |
+| `lastest_stable_url` | `…9_3_0_4490…` | `…9_4_0_4556…` |
+| `lastest_sync_url` | `…9_3_5-beta1_4468_capcutpc_beta…` | 不变 |
+| `update_version` | 590848 (9.4.0) | 590848 (9.4.0) |
+| **`lastest_beta_number`** | `"4"` | **`""`** |
+| `channel=capcutpc_beta` 的应答 | 「没有 `update_reminder`」 | **有，26 个字段，与 `capcutpc_0` 逐字段相同** |
+
+读法：**9.4.0 转正了，新一轮 beta 还没开。** `lastest_url` 的语义是「跨轨最新」，
+不是「beta 的」—— 这个假设只在 beta 比 stable 新时成立，8-27 恰好成立，今天不成立。
+
+### 关轨前配方是好的 —— 有「之前」的证据
+
+不是事后推理：**2026-09-02/03 的界面截图里，beta 行是
+`9.4.0-beta7 → 9.4.0-beta8`，带 BETA 徽标，Update 按钮可用。** 也就是说 beta 轨还开着
+的时候，同一条配方、同一个 pattern 正常解析出了 beta8。
+
+这排除了「配方腐坏」这个解释，只剩「厂商关了轨」：beta8 之后 9.4.0 转正（build 4556），
+新一轮 beta 未开，`lastest_url` 于是落回 stable 包。
+
+### 配方是对的，红的是错误分类
+
+beta pattern 把 `capcutpc_beta` 钉在文件名**里面**，所以 `lastest_url` 变成 stable 包时
+它匹配不到、拒绝把 stable 当 beta 给 beta 用户；它也不去读 `lastest_sync_url` 上那个
+更旧的 beta（4468 < 装机 4548），因为那是静默降级。两件都是设计意图。
+
+问题在于「匹配不到」当时只有一种归宿：`versionPatternNoMatch` → 行变红 → 计入
+「N 个 app 检查失败」横幅 → 给一个永远不会成功的 Retry。而这不是失败，是**厂商这条轨
+现在没有东西可发**。
+
+**修法（2026-09-04）**：新增 `VendorProbeRecipe.trackClosedPattern`，只在版本 pattern
+已经匹配失败之后咨询，命中则报 `ProbeFailure.notApplicable` —— 该分类让 source 返回 nil
+而不是抛错，所以不红行、不进横幅、不给 Retry。beta 配方声明的是**厂商自己的字段**：
+
+```
+trackClosedPattern: "lastest_beta_number"\s*:\s*""
+```
+
+锚在 key 上，否则一个空串能在 436 KB 里匹配到上千处，会把真正坏掉的配方一起吞掉。
+stable 配方**不声明**：`lastest_stable_url` 恒有值，给它一个空窗状态等于把真实故障
+说成「厂商没发」。
+
+`vendorResolvesInstallPlans` 的豁免名单**从 registry 推导**（`trackClosedPattern != nil`），
+不手写；并且反过来断言这条轨确实仍解析不出东西 —— 厂商开新 beta 那天豁免失效、构建变红，
+逼人回来删掉它。
+
+### 厂商自己怎么处理这个空窗
+
+CapCut 的更新窗口对 beta7 装机显示 `Current 9.4.0-beta7 → New 9.4.0`，**它跨轨推了
+stable**。所以「beta 轨空了就回退 stable」有厂商先例。跨轨版本比较也验过：
+
+| 比较 | 结果 |
+|---|---|
+| `9.4.0` newer than `9.4.0-beta7` | true（该提就提）|
+| `9.4.0-beta7` newer than `9.4.0` | false（不会降级）|
+| `9.5.0-beta1` newer than `9.4.0` | true（新 beta 一开自动切回）|
+
+**没有实现这条**，理由是它要动 `ChannelProofRegistry`：beta 行的证明当前要求产物名含
+`_capcutpc_beta_`，回退 stable 会产出 `capcutpc_0` 的包并被证明拒绝 —— 那个闸正是为
+「别把另一条轨的包装给这条轨的用户」存在的，为一个 app 的空窗期削弱它需要单独立项。
+现状是：空窗期该 app 静默不更新，用户可自行在 CapCut 里取消 beta 勾选切回 stable。
+
+### 顺带记下的两条厂商侧缺陷（与我们无关，但会被误当成我们的问题）
+
+- CapCut 更新窗口的 "What's new" 面板报 `Couldn't load resources`：那是 Lynx/H5 视图，
+  内容由 ByteDance 的 Gecko 资源分发投递，而 `channel=capcutpc_beta` 的 Gecko 应答是
+  `status 2000 / "[already the latest] or [no hit pkg]" / packages: []`。
+- 同一窗口显示 `Released on 1970-01-01`：`update_reminder` 里**没有任何日期字段**
+  （26 个键全部核对过），客户端把缺失的时间戳渲染成 epoch 0。
+
+两条都不影响我们：我们不读那个面板，`publishedAtPattern` 本来就没配。
+
 ## 已知问题 / 取舍
 
 - **我们会比 CapCut 自己的灰度更早给 beta —— 这是 registry 里唯一一个这样的配方。**


### PR DESCRIPTION
CapCut's beta track closed between releases and the row went red for it.
It should not have.

## What happened

9.4.0 graduated to stable and no new beta has opened, so `lastest_url` —
the field the beta recipe reads — now carries the **stable** artifact. The
recipe pins the beta token inside the filename, so it correctly refuses to
read a stable build as a beta one, and the probe finds no version.

That arrived as a check failure: a red row, a line in the "could not be
checked" banner, and a Retry that cannot work until ByteDance opens the
next beta.

**The recipe was not broken.** Days earlier the same recipe resolved
`9.4.0-beta7 → 9.4.0-beta8` with the Update button live — the "before"
picture rules out rot and leaves only "the vendor closed the track".

## The fix

A recipe can declare `trackClosedPattern`: the vendor saying, in their own
data, that this track has nothing published. CapCut empties
`lastest_beta_number` between betas — `"4"` while beta4 was current, `""`
once 9.4.0 shipped. A match reports `notApplicable`, which returns nil
instead of throwing, so the source simply has no answer.

Three constraints the mechanism is wrong without:

- **consulted only after the version pattern already missed** — a track
  that is publishing can never be talked into looking closed;
- **anchored to its key** — a bare `""` matches in a thousand places in a
  436 KB body and would swallow a genuinely broken recipe;
- **beta only** — stable's field is always populated, and giving it a
  closed state would let a real outage pass as "nothing published".

The vendor sweep's exemption is derived from the registry rather than
hand-listed, and asserts the track is *still* closed, so the day the
vendor reopens it the build fails until the declaration is removed.

## Also

- Corrects a measurement recorded on 2026-08-27 and stale since:
  `capcutpc_beta` does now return an `update_reminder`, field-for-field
  identical to `capcutpc_0`. The comment says so rather than being quietly
  edited, because the next reader should re-measure rather than trust
  either version of it.
- The updater's own release check, changelog fetch and Sparkle download
  showed a blank app column, filed beside the Homebrew catalog — which is
  blank for the opposite reason. The catalog belongs to no app; a
  self-update belongs to exactly one.
- The audit doc carries the re-measurement, the vendor-side defects found
  along the way (their What's new panel and their `1970-01-01` release
  date, neither of which touches us), and why falling back to the stable
  track — which CapCut's own updater does — was **not** implemented: it
  needs `ChannelProofRegistry` to accept a `capcutpc_0` artifact for a
  beta row, and that gate exists to stop exactly that.

## Verification

`make test` — 2222 + 188, green. The new mechanism is covered at the
recipe level and by the live vendor sweep; the `VendorProbeSource` branch
itself has no unit test, which would need a probe harness that can serve a
canned body.
