### PR TITLE
install.sh: per-checkout derived data, and stop discarding the build log

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,17 @@ set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_DIR="$REPO/App"
-DD="${DERIVED_DATA:-/tmp/duo-dd}"
+
+# Per checkout, and the dead ones reclaimed — see scripts/derived_data_path.py,
+# which app-tests.sh and row-state-gallery.sh already go through. This used to be
+# a fixed /tmp/duo-dd shared by every worktree open at once, which is a couple of
+# dozen here: two concurrent builds collide on one derived-data directory, and
+# the failure reads as a broken build rather than as contention. Two runs in the
+# SAME checkout still share it — the one collision left, and not worth a lock.
+# `DERIVED_DATA` overrides, and is exported so the checks this script calls can
+# name the directory they want you to delete.
+DD="${DERIVED_DATA:-$(python3 "$REPO/scripts/derived_data_path.py" install "$REPO")}"
+export DERIVED_DATA="$DD"
 PRODUCT="$DD/Build/Products/Release/DuoUpdater.app"
 DEST="/Applications/DuoUpdater.app"
 # The Developer ID team the build signs with, and the identity every gate in
@@ -37,11 +47,29 @@ say "Generating Xcode project from App/project.yml"
 ( cd "$APP_DIR" && xcodegen generate >/dev/null )
 
 say "Building Release (Developer ID signing)"
+# To a file rather than to /dev/null. xcodebuild prints compile errors on
+# STDOUT, so discarding it left a failed install showing thirteen lines that say
+# only "** BUILD FAILED **" — the reason existed and was thrown away, and the
+# only way to see it was to reconstruct the command by hand. Per process, not
+# just per checkout: a second run in this checkout would otherwise truncate the
+# log the first one is about to quote from.
+mkdir -p "$DD"
+LOG="$DD/install-$$.log"
+set +e
 xcodebuild -project "$APP_DIR/DuoUpdater.xcodeproj" \
            -scheme DuoUpdater -configuration Release \
-           -derivedDataPath "$DD" build >/dev/null
+           -derivedDataPath "$DD" build > "$LOG" 2>&1
+STATUS=$?
+set -e
+if [ $STATUS -ne 0 ]; then
+  # `|| true` because `set -o pipefail` is on and a grep that matches nothing
+  # exits 1 — which under errexit would abort this script before it prints the
+  # log path, turning "here is what broke" back into silence.
+  grep -E "error:|warning: .*(signing|provisioning)|\*\* BUILD FAILED" "$LOG" | head -40 || true
+  die "build failed — full log: $LOG"
+fi
 
-[ -d "$PRODUCT" ] || die "build produced no app at $PRODUCT"
+[ -d "$PRODUCT" ] || die "build produced no app at $PRODUCT (log: $LOG)"
 
 say "Re-signing Sparkle helper tools"
 identity="$(codesign -dvv "$PRODUCT" 2>&1 | sed -n 's/^Authority=//p' | head -n 1)"

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -16,6 +16,11 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_DIR="$REPO/App"
 DD="${DERIVED_DATA:-/tmp/duo-notary-dd}"
+# Exported so verify-localizations.sh can name this directory in the one message
+# whose whole content is "delete the derived-data directory" — the release path
+# uses a different one from `make install`, and a remedy naming the wrong
+# directory is worse than one naming none.
+export DERIVED_DATA="$DD"
 BUILD_APP="$DD/Build/Products/Release/DuoUpdater.app"
 STAGE_DIR="${DIST_DIR:-$REPO/dist/notarize}"
 STAGE_APP="$STAGE_DIR/DuoUpdater.app"

--- a/scripts/verify-localizations.sh
+++ b/scripts/verify-localizations.sh
@@ -42,13 +42,23 @@ for lang in $langs; do
 done
 
 if [ -n "$missing" ]; then
+    # The caller exports DERIVED_DATA, so name the directory rather than printing
+    # a shell expansion the reader has to resolve. It used to print
+    # `${DERIVED_DATA:-/tmp/duo-dd}` literally, which a reader pastes into a shell
+    # where that variable is unset — so the fix deleted a fixed path that the
+    # build being complained about need never have used.
+    if [ -n "${DERIVED_DATA:-}" ]; then
+        remedy="rm -rf \"$DERIVED_DATA\" && make install"
+    else
+        remedy="rm -rf the derived-data directory this build used, then make install"
+    fi
     die "the string catalog did not compile into this build — missing or empty:$missing
 
    Every string would fall back to English, in every language.
    This is what an incremental build does after Localizable.xcstrings changes.
    Delete the derived-data directory and build again:
 
-       rm -rf \"\${DERIVED_DATA:-/tmp/duo-dd}\" && make install"
+       $remedy"
 fi
 
 printf '   %s\n' "$langs"


### PR DESCRIPTION
Two things `make install` was doing that made a failure unreadable, plus the message that was pointing at the wrong directory.

**Per-checkout derived data.** `DD` was a fixed `/tmp/duo-dd`, shared by every worktree open at once — a couple of dozen here. It now goes through `scripts/derived_data_path.py`, the route `app-tests.sh` and `row-state-gallery.sh` already take, which hands each checkout its own path and reclaims the ones left by checkouts that are gone. `DERIVED_DATA` still overrides.

**The build log is kept.** `xcodebuild … build >/dev/null` discarded stdout, which is where xcodebuild prints compile errors. A failed install showed thirteen lines whose entire content was `** BUILD FAILED **`; the reason existed and was thrown away. Output now goes to `$DD/install-$$.log` — per process, so a second run in one checkout cannot truncate the log the first is about to quote — and a failure prints the matching error lines followed by the path.

**A remedy that named the wrong directory.** `verify-localizations.sh` printed the literal text `${DERIVED_DATA:-/tmp/duo-dd}`. A reader pastes that into a shell where the variable is unset, so the "delete the derived data and rebuild" fix deleted a fixed path the build being complained about need never have used. Callers now export their resolved path and the message names it; `notarize.sh` exports too, because the release path uses a different directory and a remedy naming the wrong one is worse than one naming none.

**Verified, both paths.**

A deliberate type error in `App/Sources/RuntimeTag.swift`, then `scripts/install.sh` (reverted after):

```
/…/App/Sources/RuntimeTag.swift:366:39: error: cannot convert value of type 'String' to specified type 'Int'
** BUILD FAILED **
✗ build failed — full log: /tmp/duo-install-b6aef131/install-11110.log
```

Before this change the same failure printed `** BUILD FAILED **` and nothing else.

`make install` — exit 0, deployed, all 7 `.lproj` present so `verify-localizations.sh` passed, built under `/tmp/duo-install-b6aef131`.

Both branches of the remedy message, run with `DERIVED_DATA` set and unset: the first names the directory, the second says to delete the one the build used rather than naming a wrong one.

```
make test   # exit 0 — Core 2240 (1 known issue), CLI 188, App 9/9 executed,
            # loc keys 515, version-lint 231 files, audits 108 docs
```

**Not in scope, same class:** `build-cli.sh` (`/tmp/duo-cli-dd`) and `notarize.sh` / `publish-release.sh` (`/tmp/duo-notary-dd`) still use fixed paths. The old `/tmp/duo-dd` is left on disk on purpose — worktrees that have not taken this commit are still using it.
