### PR TITLE
Stop counting a stall against a percentage the App Store has parked

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4782,9 +4782,9 @@ final class AppListModel {
     /// popping back up. It's still there, just not in front.
     ///
     /// An app that is *still running* when this fires never got the quit it was
-    /// asked for: its own save prompt outlasted the installer's ~12s terminate wait
-    /// and then the ~90s post-Continue cap, so we're here on the timeout path with
-    /// the app still up. Reopening a running app is a no-op, and consuming the entry
+    /// asked for: it outlasted the installer's ~12s terminate wait and then the whole
+    /// post-Continue poll budget, so we're here on the failure path with the app still
+    /// up — as `AXError.appStillOpen`, which asks the user for that quit by name. Reopening a running app is a no-op, and consuming the entry
     /// here is what made the late answer an orphan: the user dismisses the prompt
     /// minutes later, the app finally quits, App Store swaps — and by then nothing
     /// remembers that this app is only closed because we asked it to be. So hand it

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -157,7 +157,7 @@ public actor AppStoreAXInstaller {
         let note: String
     }
 
-    public enum AXError: LocalizedError {
+    public enum AXError: LocalizedError, Equatable {
         case notTrusted
         case appStoreUnavailable
         case offerButtonNotFound
@@ -165,6 +165,13 @@ public actor AppStoreAXInstaller {
         case cancelled
         case needsManualConfirmation
         case timedOut
+        /// We gave up waiting because the app never quit — payload is its name.
+        /// Distinct from `timedOut` because the two ask the user for opposite things:
+        /// a timeout says "something went wrong, try again", while this one says the
+        /// one remaining step is theirs. It deliberately does not claim the download
+        /// has finished: the percentage we watch is the same reading for a download and
+        /// for a swap (`progressFraction` matches either), so we do not know which.
+        case appStillOpen(String)
 
         public var errorDescription: String? {
             switch self {
@@ -187,6 +194,8 @@ public actor AppStoreAXInstaller {
                 return "This app needs confirmation in the App Store (e.g. a subscription or purchase). Open the App Store and update it there."
             case .timedOut:
                 return "Timed out waiting for the App Store."
+            case .appStillOpen(let appName):
+                return "Quit \(appName) to finish this update. The App Store won’t replace an app while it is open, and it is still open."
             }
         }
     }
@@ -642,9 +651,10 @@ public actor AppStoreAXInstaller {
             // liveness signal at all the count is not measuring a stall, it is a blind
             // stopwatch — and a blind stopwatch set to 90s is the very bug above. So the
             // cap is picked per poll from whether a percentage is readable at that
-            // moment: ~90s of a number that stopped moving really is a dead swap, while
-            // no number to read at all buys the generous one. Both stay under the 6-min
-            // poll cap below, which remains the backstop.
+            // moment: 225 polls of a number that stopped moving really is a dead swap,
+            // while no number to read at all buys the generous one. Both stay under the
+            // 900-poll cap below, which remains the backstop. (Polls, not seconds — see
+            // `swapHasStalled` for what one actually costs.)
             if continued {
                 postContinueTicks += 1
                 // This poll's reading, kept in a local: whether a percentage is readable
@@ -654,12 +664,17 @@ public actor AppStoreAXInstaller {
                 // on those would put a large region-locked app back under the 90s cap for
                 // the rest of a swap it can no longer report on.
                 let reading = installProgress(in: axApp, names: names, viaUpdatesList: viaUpdatesList)
+                // The app being open is why the number is allowed to stand still, so
+                // the watchdog is told rather than left to read a frozen wait as a
+                // dead swap (see `swapWatchdog`).
+                let stillOpen = bundleID.map { isRunning($0) } ?? false
                 let watch = Self.swapWatchdog(
-                    progress: reading, last: lastInstallProgress, stalledPolls: stalledTicks)
+                    progress: reading, last: lastInstallProgress, stalledPolls: stalledTicks,
+                    appRunning: stillOpen)
                 lastInstallProgress = watch.last
                 stalledTicks = watch.stalledPolls
                 if Self.swapHasStalled(stalledPolls: stalledTicks, progressReadable: reading != nil) {
-                    Log.install.error("appstore-ax: \(appName, privacy: .public) timed out — swap \(reading != nil ? "stalled ~90s on a frozen percentage" : "unreadable and silent ~5min", privacy: .public) (last progress=\(lastInstallProgress.map { "\(Int($0 * 100))%" } ?? "none", privacy: .public); app still running=\(bundleID.map { isRunning($0) } ?? false))")
+                    Log.install.error("appstore-ax: \(appName, privacy: .public) timed out — swap \(reading != nil ? "stalled 225 polls on a frozen percentage" : "unreadable and silent 750 polls", privacy: .public) (last progress=\(lastInstallProgress.map { "\(Int($0 * 100))%" } ?? "none", privacy: .public); app still running=\(stillOpen))")
                     throw AXError.timedOut
                 }
             }
@@ -896,8 +911,11 @@ public actor AppStoreAXInstaller {
             // inside human reaction time for noticing an answer given in App Store.
             try await Task.sleep(for: .milliseconds(askedToQuit ? 1_500 : 400))
         }
-        Log.install.error("appstore-ax: \(appName, privacy: .public) timed out — 6-min poll cap reached (continued=\(continued) sawProgress=\(sawProgress))")
-        throw AXError.timedOut
+        // What a spent budget means depends on what is still true — see
+        // `exhaustedBudgetError`.
+        let stillOpen = bundleID.map { isRunning($0) } ?? false
+        Log.install.error("appstore-ax: \(appName, privacy: .public) timed out — 6-min poll cap reached (continued=\(continued) sawProgress=\(sawProgress) appStillOpen=\(stillOpen))")
+        throw Self.exhaustedBudgetError(appName: appName, continued: continued, appRunning: stillOpen)
     }
 
     /// Bring App Store to the front. Used only at the final swap step (after the user
@@ -948,9 +966,25 @@ public actor AppStoreAXInstaller {
     /// then wait up to ~12s for it to actually exit. Called after the user confirms the
     /// "Close this app to update" sheet: a backgrounded App Store presses Continue but
     /// doesn't reliably bring the app down to complete the swap, so we deliver the quit
-    /// it's waiting for. Graceful only — if the app puts up a save prompt and won't
-    /// exit, we leave it (the install then times out) rather than force-killing unsaved
-    /// work. App Store, seeing the app gone, swaps the new build in on its own.
+    /// it's waiting for. Graceful only — if the app won't exit we leave it rather than
+    /// force-killing unsaved work. App Store, seeing the app gone, swaps the new build
+    /// in on its own. An app that ignores our quit is not a failed install, just one
+    /// whose last step is the user's, so the caller keeps watching (`swapWatchdog`
+    /// stops counting a parked percentage while the app is open) and, if the poll cap
+    /// arrives with it still up, ends by asking for the quit by name
+    /// (`AXError.appStillOpen`) instead of reporting a timeout.
+    ///
+    /// It does **not** follow that the store waits indefinitely. The Spark measurement
+    /// above is the counter-example — a backgrounded App Store parked the sheet and
+    /// never swapped even once the app was gone — and on 2026-09-04 23:37 this same
+    /// WhatsApp update reverted its button to "Update" with the app still up. What we
+    /// can say is that the store did not act while the app was open in either run; the
+    /// watchdog is built so that a store which drops the swap says so by having no
+    /// percentage left to read, and that reading still counts.
+    ///
+    /// Measured 2026-09-05: WhatsApp ignored `terminate()` for the full 12s with no
+    /// save prompt behind it (System Events reported one ordinary window), stayed up
+    /// two more minutes, and the swap completed 14s after the user quit it by hand.
     private func terminateAndWait(bundleID: String, appName: String) async {
         for app in NSRunningApplication.runningApplications(withBundleIdentifier: bundleID) {
             app.terminate()
@@ -962,7 +996,7 @@ public actor AppStoreAXInstaller {
             }
             try? await Task.sleep(for: .milliseconds(200))
         }
-        Log.install.error("appstore-ax: \(appName, privacy: .public) won't quit within 12s (likely a save prompt) — leaving it; install may time out")
+        Log.install.error("appstore-ax: \(appName, privacy: .public) won't quit within 12s — leaving it; the swap waits on the user now")
     }
 
     /// Parse a fraction (0…1) out of an offer-button title like "80% loaded" or
@@ -994,17 +1028,67 @@ public actor AppStoreAXInstaller {
         return (onScreen && !stillIgnoring, stillIgnoring)
     }
 
-    /// One poll of the swap watchdog, as a pure step so the rule that matters is
-    /// assertable: **movement resets the count**. A swap that keeps reporting new
-    /// percentages can run as long as it needs; only one that goes quiet accumulates.
+    /// One poll of the swap watchdog, as a pure step so the rules that matter are
+    /// assertable: **movement resets the count**, and **a percentage parked while the
+    /// app is still open doesn't advance it**. A swap that keeps reporting new
+    /// percentages can run as long as it needs; only one that goes quiet with nothing
+    /// left to wait for accumulates.
+    ///
+    /// The second rule is what the count was missing. App Store parks the swap at a
+    /// fixed percentage until the app closes — that number is frozen *because we are
+    /// waiting*, not because the swap died, so counting it measures the user's
+    /// decision instead of the store's liveness. Measured end to end 2026-09-05
+    /// (WhatsApp 26.34.72 → 26.34.74): Continue at 01:35:22; the app ignored our
+    /// graceful quit and was still up at 01:35:40; the button sat at 80%; at 01:37:43
+    /// the counter — which had been running the whole time the app was open — hit its
+    /// cap and we threw `.timedOut`, our own line reporting the app already gone. App
+    /// Store then finished on its own: installing phase from 01:37:50, the new build
+    /// on disk at 01:37:54, eleven seconds after we called it a failure.
+    ///
+    /// How much headroom the freeze buys is the interval between the quit and the
+    /// throw, and **that is the one number the logs do not hold**: appstoreagent saw
+    /// the process go `none-NotVisible` at 01:37:40.197, but nothing records when the
+    /// user pressed ⌘Q. What can be said is that the 225 counted polls all fell inside
+    /// the window the app was open, and that the swap needed 14 s from 01:37:40 to
+    /// land — comfortably inside a count that starts from zero at the quit.
+    ///
+    /// The freeze is deliberately narrow: it needs a percentage that is **parked**, not
+    /// merely an app that is open. No reading at all keeps counting exactly as before,
+    /// which matters in two places. The Updates-list route reads nil on every poll once
+    /// the row leaves the list, so freezing there would rest on no measurement — and it
+    /// is not a hidden-preference route: a region-locked app takes it whatever the
+    /// user's update strategy. And a store that *drops* a pending swap says so by
+    /// reverting the button to "Update" (observed 2026-09-04 23:37, WhatsApp, app still
+    /// running) — a reading that parses as no percentage. Freezing on nil would have
+    /// reclassified the one signal that says "nothing is coming" as "still waiting".
     ///
     /// - Parameters:
     ///   - progress: this poll's reading, or nil when the button shows no percentage.
     ///   - last: the previous reading, so an unchanged number counts as no movement.
-    static func swapWatchdog(progress: Double?, last: Double?, stalledPolls: Int)
+    ///   - appRunning: whether the app being updated is still open. A percentage parked
+    ///     on the same number while it is counts as nothing at all; the poll cap in
+    ///     `driveToCompletion` stays the backstop for an app that never quits.
+    static func swapWatchdog(progress: Double?, last: Double?, stalledPolls: Int, appRunning: Bool)
     -> (last: Double?, stalledPolls: Int) {
-        guard let progress, progress != last else { return (last, stalledPolls + 1) }
-        return (progress, 0)
+        guard let progress else { return (last, stalledPolls + 1) }
+        guard progress == last else { return (progress, 0) }
+        return (progress, appRunning ? stalledPolls : stalledPolls + 1)
+    }
+
+    /// Which failure a spent poll budget is, read off what is true when it runs out.
+    ///
+    /// Kept pure and separate for the same reason as the watchdog rules beside it: the
+    /// choice is a *statement to the user*, and it is made in a loop nothing can call.
+    ///
+    /// Once the stall counter stops running while the app is open, the only way to
+    /// spend the full 6 minutes after Continue is an app that never quit — App Store
+    /// holds the swap for exactly as long as that takes. That is not a timeout, it is
+    /// a finished download waiting on one keystroke, so it gets a message that names
+    /// the app and says so. Before Continue the budget can run out for the ordinary
+    /// reasons (a download that never finished, a press that never took) and those
+    /// keep the plain timeout, whether or not the app happens to be open.
+    static func exhaustedBudgetError(appName: String, continued: Bool, appRunning: Bool) -> AXError {
+        continued && appRunning ? .appStillOpen(appName) : .timedOut
     }
 
     /// Whether the post-Continue swap should be abandoned, expressed over *stalled*
@@ -1015,14 +1099,22 @@ public actor AppStoreAXInstaller {
     ///
     ///   * `progressReadable` — App Store is showing a percentage right now, so the count
     ///     really is measuring a stall: the number is there and it has stopped moving.
-    ///     ~90s of that (225 polls at 400ms) is a dead swap.
+    ///     225 polls of that is a dead swap.
     ///   * otherwise — there is no liveness signal at all and the count is a blind
     ///     stopwatch, not a stall. That is the Updates-list path's normal state: the row
     ///     leaves the list as it installs, so there is no button left to read a
     ///     percentage off (see `installProgress`). A blind 90s is exactly the flat cap
-    ///     that failed Word (2.73 GB, still installing at 66s), so give it ~5min (750
-    ///     polls) instead — still inside `driveToCompletion`'s 6-min poll cap, which
-    ///     stays the backstop.
+    ///     that failed Word (2.73 GB, still installing at 66s), so give it 750 polls
+    ///     instead — still inside `driveToCompletion`'s 900-poll cap, which stays the
+    ///     backstop.
+    ///
+    /// ⚠️ **These are polls, not seconds, and the two are not the 400 ms apart the sleep
+    /// suggests.** Each poll walks the AX tree two or three times. Measured on the run
+    /// of 2026-09-05: 225 polls took 129 s (01:35:34.304 → 01:37:43.441), i.e. ~575 ms
+    /// each, so the three caps are ~130 s, ~7 min and ~8.5 min rather than the ~90 s,
+    /// ~5 min and ~6 min the comments here used to claim. The cadence varies with how
+    /// much of the tree is there to walk, so treat any second-figure as measured on one
+    /// run, not as a setting.
     ///
     /// The caller passes THIS poll's reading, not "did we ever see one". Latching would
     /// hand a swap the strict cap on the strength of one percentage read seconds before
@@ -1030,6 +1122,14 @@ public actor AppStoreAXInstaller {
     ///
     /// Generous on purpose in both directions: the cost of waiting too long is a slow
     /// row, the cost of giving up too early is calling a finished update a failure.
+    ///
+    /// Neither cap sees a poll where a *readable* percentage stood still with the app
+    /// still open — `swapWatchdog` does not advance the count there, because a store
+    /// waiting for the app to close is not a store that has stopped. What bounds that
+    /// wait is the 900-poll cap in `driveToCompletion`, which ends it by naming the app
+    /// rather than by timing out. The cost of the change is that wait: an app the user
+    /// never quits now holds the single App Store install gate for ~8.5 min instead of
+    /// ~2, against the previous cost of failing an update that was about to succeed.
     static func swapHasStalled(stalledPolls: Int, progressReadable: Bool) -> Bool {
         stalledPolls >= (progressReadable ? 225 : 750)
     }
@@ -1044,21 +1144,43 @@ public actor AppStoreAXInstaller {
         return Self.progressFraction(text)
     }
 
-    /// One offer-button reading with its digits blanked, so two readings that differ
-    /// only by how far the download has got compare equal.
+    /// One offer-button reading with its numbers rounded down to tens, so two readings
+    /// a fraction of a percent apart compare equal while two that are a tenth of the
+    /// download apart do not.
     ///
-    /// This is what keeps the probe's `.notice` lines to the transitions that carry
-    /// information. Numbers are the only thing dropped — a title going from "Loading"
-    /// to "3% loaded" still differs (the word changed), and so does a button appearing
-    /// or vanishing, which is the reading that mattered most in the bug this probe was
-    /// written for.
+    /// This is what keeps the probe's `.notice` lines to the readings that carry
+    /// information. It used to blank digits entirely, and that threw away the one thing
+    /// the swap watchdog reasons about: **movement**. The WhatsApp download of
+    /// 2026-09-05 01:33 left exactly one percentage reading on disk ("0.3% loaded"),
+    /// because every later reading had the shape of the first. The 80% the timeout line
+    /// reported that night appears nowhere else, and neither does the fact that it never
+    /// moved — precisely the evidence that tells a dead swap from a waiting one. (The
+    /// two runs of 2026-09-04, 21 and 26 readings, are **not** the other side of this
+    /// comparison: `readingShape` did not exist yet, so they measure having no dedupe
+    /// at all. Nothing was ever measured against the blanking version but the one line.)
     ///
-    /// Known cost: a child progress ring whose `AXValue` is the numeric fraction also
-    /// collapses, so the dump says a ring exists without ever saying it moved. The
-    /// movement signal we actually act on is the button's own title, which is logged
-    /// with its digits intact on every change of kind.
+    /// Tens rather than every reading: a download ticks the percentage ~2×/s, so the
+    /// digits-intact version put thousands of lines on disk for one large app. Eleven
+    /// buckets per download is the whole shape of the curve at a hundredth of the cost.
+    /// Anything at or above 100 shares the top bucket, which keeps a count or an id
+    /// that wanders into a reading from turning the key into a unique string per poll —
+    /// the same collapse in the other direction.
     static func readingShape(_ dump: String) -> String {
-        dump.replacingOccurrences(of: #"[0-9]+(\.[0-9]+)?"#, with: "N", options: .regularExpression)
+        guard let re = try? NSRegularExpression(pattern: #"[0-9]+(?:\.[0-9]+)?"#) else { return dump }
+        let ns = dump as NSString
+        var out = ""
+        var cursor = 0
+        for m in re.matches(in: dump, range: NSRange(location: 0, length: ns.length)) {
+            out += ns.substring(with: NSRange(location: cursor, length: m.range.location - cursor))
+            // Clamp before converting, not after: `Int(_: Double)` traps on a value
+            // past `Int64.max`, and a long enough digit run reaches it (a 20-digit id
+            // wandering into a title would crash the installer's actor). Clamping the
+            // Double first makes the conversion total.
+            let value = Double(ns.substring(with: m.range)) ?? 0
+            out += "N\(Int(min(max(value / 10, 0), 10)))"
+            cursor = m.range.location + m.range.length
+        }
+        return out + ns.substring(from: cursor)
     }
 
     /// A transient pre-progress state ("Loading", "Opening…") shown right after the

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
@@ -206,8 +206,9 @@ struct AppStoreOfferButtonTests {
     /// lines. Percentages collapse; everything else still counts as a transition.
     @Test func onlyAChangeOfKindIsWorthALogLine() {
         let a = #"role=AXButton AXTitle="3% loaded" AXDescription="3% loaded""#
-        let b = #"role=AXButton AXTitle="76.6% loaded" AXDescription="76.6% loaded""#
-        #expect(AppStoreAXInstaller.readingShape(a) == AppStoreAXInstaller.readingShape(b))
+        let nearby = #"role=AXButton AXTitle="3.4% loaded" AXDescription="3.4% loaded""#
+        #expect(AppStoreAXInstaller.readingShape(a) == AppStoreAXInstaller.readingShape(nearby),
+                "a download ticks ~2×/s; a fraction of a percent is not news")
 
         let loading = #"role=AXButton AXTitle="Loading" AXDescription="Loading""#
         let settled = #"role=AXButton AXTitle="Update" AXDescription="Update""#
@@ -215,6 +216,30 @@ struct AppStoreOfferButtonTests {
         #expect(AppStoreAXInstaller.readingShape(settled) != AppStoreAXInstaller.readingShape(a))
         // The reading that broke DingTalk: the button going missing entirely.
         #expect(AppStoreAXInstaller.readingShape("button=nil") != AppStoreAXInstaller.readingShape(a))
+    }
+
+    /// The regression this replaced. Blanking digits outright made every percentage one
+    /// shape, so a whole download logged its first reading and nothing else: measured on
+    /// the same app either side of the change, WhatsApp left 47 readings on disk on
+    /// 2026-09-04 and one ("0.3% loaded") on 2026-09-05. Movement is the single thing
+    /// the swap watchdog reasons about, so the probe has to be able to show it.
+    ///
+    /// Mutation: replace the bucket with a bare `"N"` — red here, green everywhere else.
+    @Test func aDownloadThatMovedLeavesMoreThanOneLine() {
+        let shapes = ["0.3% loaded", "12% loaded", "40% loaded", "80% loaded", "99.5% loaded"]
+            .map { AppStoreAXInstaller.readingShape(#"AXTitle="\#($0)""#) }
+        #expect(Set(shapes).count == shapes.count,
+                "each tenth of a download must be its own line: \(shapes)")
+    }
+
+    /// Bucketing must not turn the key into a unique string per poll, which is the same
+    /// collapse in the other direction — a probe that logs every reading is one nobody
+    /// reads. Numbers that are counts, not percentages, share the top bucket.
+    ///
+    /// Mutation: drop the `min(…, 10)` cap — red here alone.
+    @Test func numbersPastAHundredShareTheTopBucket() {
+        #expect(AppStoreAXInstaller.readingShape("buttons=100 ours=1")
+                == AppStoreAXInstaller.readingShape("buttons=4096 ours=1"))
     }
 
     // MARK: - Finishing the swap
@@ -301,7 +326,7 @@ struct AppStoreOfferButtonTests {
         for poll in 0..<400 {
             let reading = Double(poll) / 400          // still climbing
             (last, stalled) = AppStoreAXInstaller.swapWatchdog(
-                progress: reading, last: last, stalledPolls: stalled)
+                progress: reading, last: last, stalledPolls: stalled, appRunning: false)
             #expect(stalled == 0, "movement at poll \(poll) must reset the count")
             #expect(!AppStoreAXInstaller.swapHasStalled(stalledPolls: stalled, progressReadable: true))
         }
@@ -314,10 +339,78 @@ struct AppStoreOfferButtonTests {
         var stalled = 0
         for _ in 0..<225 {
             (last, stalled) = AppStoreAXInstaller.swapWatchdog(
-                progress: nil, last: last, stalledPolls: stalled)
+                progress: nil, last: last, stalledPolls: stalled, appRunning: false)
         }
         #expect(stalled == 225)
         #expect(AppStoreAXInstaller.swapHasStalled(stalledPolls: stalled, progressReadable: true))
+    }
+
+    /// The WhatsApp run of 2026-09-05, replayed. App Store parks the swap at a fixed
+    /// percentage until the app closes, so while the app is open a frozen number is the
+    /// store waiting for *us*, not a dead swap. Counting it measured the user's decision
+    /// instead of the store's liveness: the button sat at 80% for the two minutes the
+    /// app stayed up, the user quit it by hand at 01:37:40, and 3.4s later the counter —
+    /// which had run that whole time — hit its cap and threw. App Store then finished on
+    /// its own, the new build on disk 11s after we called the update a failure.
+    ///
+    /// Mutation: drop `appRunning ? stalledPolls :` from `swapWatchdog` — red here on
+    /// three expectations, and the second half still holds it honest the other way
+    /// (freezing unconditionally is `aFrozenPercentageCountsAsStalled`'s mutation).
+    @Test func aFrozenPercentageIsNotAStallWhileTheAppIsStillOpen() {
+        var last: Double? = 0.8
+        var stalled = 0
+        for _ in 0..<400 {  // ~2.5 min of the app refusing to quit
+            (last, stalled) = AppStoreAXInstaller.swapWatchdog(
+                progress: 0.8, last: last, stalledPolls: stalled, appRunning: true)
+        }
+        #expect(stalled == 0, "a store waiting for the app to close has not stalled")
+        #expect(!AppStoreAXInstaller.swapHasStalled(stalledPolls: stalled, progressReadable: true))
+
+        // The app quits: now the number really is the store's to move, and the swap gets
+        // its full ~90s from that moment — not from a countdown already spent.
+        for _ in 0..<224 {
+            (last, stalled) = AppStoreAXInstaller.swapWatchdog(
+                progress: 0.8, last: last, stalledPolls: stalled, appRunning: false)
+        }
+        #expect(!AppStoreAXInstaller.swapHasStalled(stalledPolls: stalled, progressReadable: true))
+        (last, stalled) = AppStoreAXInstaller.swapWatchdog(
+            progress: 0.8, last: last, stalledPolls: stalled, appRunning: false)
+        #expect(AppStoreAXInstaller.swapHasStalled(stalledPolls: stalled, progressReadable: true),
+                "a swap that is genuinely quiet with nothing left to wait for still bails")
+    }
+
+    /// Movement still resets the count while the app is open — the freeze must not
+    /// quietly become "never count anything", which would leave the 6-min cap as the
+    /// only bound on a swap that died with the app up.
+    ///
+    /// Mutation: add `!appRunning` to the guard, so a running app skips the reset — red
+    /// here alone.
+    @Test func movementIsStillMovementWhileTheAppIsOpen() {
+        let (last, stalled) = AppStoreAXInstaller.swapWatchdog(
+            progress: 0.5, last: 0.4, stalledPolls: 17, appRunning: true)
+        #expect(stalled == 0)
+        #expect(last == 0.5)
+    }
+
+    /// What a spent budget means. After Continue the stall counter no longer runs while
+    /// the app is open, so the only way to reach the cap there is an app that never
+    /// quit — a finished download waiting on one keystroke, which the generic timeout
+    /// tells nobody. Before Continue the budget runs out for ordinary reasons and keeps
+    /// the plain timeout, whether or not the app happens to be open.
+    ///
+    /// Mutations: return `.timedOut` unconditionally, and drop the `continued &&` term
+    /// — the first is red on the opening three expectations, the second on the last.
+    @Test func aSpentBudgetWithTheAppStillOpenAsksForTheQuitByName() {
+        let stillOpen = AppStoreAXInstaller.exhaustedBudgetError(
+            appName: "WhatsApp", continued: true, appRunning: true)
+        #expect(stillOpen == .appStillOpen("WhatsApp"))
+        #expect(stillOpen.errorDescription?.contains("WhatsApp") == true)
+        #expect(stillOpen.errorDescription != AppStoreAXInstaller.AXError.timedOut.errorDescription)
+
+        #expect(AppStoreAXInstaller.exhaustedBudgetError(
+            appName: "WhatsApp", continued: true, appRunning: false) == .timedOut)
+        #expect(AppStoreAXInstaller.exhaustedBudgetError(
+            appName: "WhatsApp", continued: false, appRunning: true) == .timedOut)
     }
 
     /// A percentage frozen on the same number is not movement — a wedged install must
@@ -327,7 +420,7 @@ struct AppStoreOfferButtonTests {
         var stalled = 0
         for _ in 0..<10 {
             (last, stalled) = AppStoreAXInstaller.swapWatchdog(
-                progress: 0.4, last: last, stalledPolls: stalled)
+                progress: 0.4, last: last, stalledPolls: stalled, appRunning: false)
         }
         #expect(stalled == 10)
         #expect(last == 0.4)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
@@ -332,6 +332,28 @@ struct AppStoreOfferButtonTests {
         }
     }
 
+    /// The freeze needs a *parked percentage*, not merely an open app. With no reading
+    /// at all there is nothing parked to reason about: the Updates-list route reads nil
+    /// on every poll once the row leaves the list (and a region-locked app takes that
+    /// route whatever the update strategy), and a store that drops a pending swap says
+    /// so by reverting the button to "Update", which also parses as nil. Freezing there
+    /// would reclassify the one signal that says "nothing is coming" as "still waiting"
+    /// and leave only the 900-poll cap.
+    ///
+    /// Mutation: widen the freeze back to `guard let progress, progress != last else {
+    /// return (last, appRunning ? stalledPolls : stalledPolls + 1) }` — red here.
+    @Test func anAppLeftOpenDoesNotFreezeACountWithNoReadingBehindIt() {
+        var last: Double?
+        var stalled = 0
+        for _ in 0..<750 {
+            (last, stalled) = AppStoreAXInstaller.swapWatchdog(
+                progress: nil, last: last, stalledPolls: stalled, appRunning: true)
+        }
+        #expect(stalled == 750)
+        #expect(AppStoreAXInstaller.swapHasStalled(stalledPolls: stalled, progressReadable: false))
+        #expect(last == nil)
+    }
+
     /// No reading at all — normal right after Continue, before the install starts
     /// reporting — counts as no movement, so a swap that never starts still bails.
     @Test func pollsWithNoReadingCountAsStalled() {
@@ -353,9 +375,10 @@ struct AppStoreOfferButtonTests {
     /// which had run that whole time — hit its cap and threw. App Store then finished on
     /// its own, the new build on disk 11s after we called the update a failure.
     ///
-    /// Mutation: drop `appRunning ? stalledPolls :` from `swapWatchdog` — red here on
-    /// three expectations, and the second half still holds it honest the other way
-    /// (freezing unconditionally is `aFrozenPercentageCountsAsStalled`'s mutation).
+    /// Mutations: drop `appRunning ? stalledPolls :` from `swapWatchdog`, and replace it
+    /// with `appRunning ? 0 :` — the first is red on four expectations here, the second
+    /// only on the "frozen, not reset" one, which is why that one exists. Freezing
+    /// unconditionally is `aFrozenPercentageCountsAsStalled`'s mutation.
     @Test func aFrozenPercentageIsNotAStallWhileTheAppIsStillOpen() {
         var last: Double? = 0.8
         var stalled = 0
@@ -364,6 +387,12 @@ struct AppStoreOfferButtonTests {
                 progress: 0.8, last: last, stalledPolls: stalled, appRunning: true)
         }
         #expect(stalled == 0, "a store waiting for the app to close has not stalled")
+        // Frozen, not reset. A count already earned with the app closed must survive the
+        // app coming back for a poll — otherwise a swap that really is dead is handed a
+        // fresh 225 every time a login item or the user reopens the app. Nothing else
+        // here separates the two: every other case starts the freeze from zero.
+        #expect(AppStoreAXInstaller.swapWatchdog(
+            progress: 0.8, last: 0.8, stalledPolls: 200, appRunning: true).stalledPolls == 200)
         #expect(!AppStoreAXInstaller.swapHasStalled(stalledPolls: stalled, progressReadable: true))
 
         // The app quits: now the number really is the store's to move, and the swap gets
@@ -383,8 +412,10 @@ struct AppStoreOfferButtonTests {
     /// quietly become "never count anything", which would leave the 6-min cap as the
     /// only bound on a swap that died with the app up.
     ///
-    /// Mutation: add `!appRunning` to the guard, so a running app skips the reset — red
-    /// here alone.
+    /// Mutation: `guard progress == last || appRunning else { return (progress, 0) }`,
+    /// so a running app skips the reset — red here alone. (`guard progress == last,
+    /// !appRunning` is a different mutation: it is red on the replay case instead,
+    /// because it makes a frozen-and-closed poll reset rather than count.)
     @Test func movementIsStillMovementWhileTheAppIsOpen() {
         let (last, stalled) = AppStoreAXInstaller.swapWatchdog(
             progress: 0.5, last: 0.4, stalledPolls: 17, appRunning: true)


### PR DESCRIPTION
Closes #332.

## What was wrong

App Store parks the swap at a fixed percentage until the app closes. The swap
watchdog read that frozen number as a dead swap, so the countdown was measuring
how long the user took to quit their app rather than whether the store was still
working.

Measured end to end, WhatsApp 26.34.72 → 26.34.74, 2026-09-05:

| time | what happened |
|---|---|
| 01:35:22 | user tapped Relaunch → `terminate()` + foreground App Store |
| 01:35:34 | the app ignored the quit |
| 01:35:40 | still up, sheet still on screen |
| 01:37:40 | the process goes `none-NotVisible` (appstoreagent) |
| **01:37:43** | **we give up — "stalled on a frozen percentage" (80 %)** |
| 01:37:50 | App Store's installing phase starts anyway |
| 01:37:54 | 26.34.74 on disk — 11 s after we called it a failure |

All 225 counted polls fell inside the window the app was open. The issue put the
user's ⌘Q at 01:37:55; **nothing in the log records it at all** — the only
bracket is `none-NotVisible` at 01:37:40.197. So the headroom the freeze buys is
bounded by the logs, not pinned by them.

## What changed

**The stall counter no longer advances against a percentage the store has
parked.** `swapWatchdog` takes `appRunning`.

**The freeze is narrow on purpose — a *parked percentage*, not merely an open
app.** A poll with no reading counts exactly as before. That matters twice: the
Updates-list route reads nil once the row leaves the list, and a store that
*drops* a pending swap says so by reverting the button to "Update" (observed
2026-09-04 23:37, same app, still running), which also parses as nil. Freezing on
nil would have reclassified the one signal meaning "nothing is coming" as "still
waiting".

**The cap now says which failure it is.** Reaching it after Continue can only
mean the app never quit, so the row says *"Quit WhatsApp to finish this update.
The App Store won't replace an app while it is open, and it is still open."* It
deliberately does not claim the download has finished — the percentage we watch
is the same reading for a download and for a swap.

**Cost, stated plainly:** an app the user never quits now holds the single App
Store install gate for the whole poll budget (~8.5 min measured) instead of ~2,
against the previous cost of failing an update that was about to succeed.

**Probe fix, same file:** the dedupe key blanked digits, so a whole download
logged its first reading and nothing else — one line for the run above, which is
why the 80 % appears nowhere but the timeout line. Numbers now round down to
tens, clamped before the `Int` conversion so a long digit run cannot trap.

## What the review changed

An adversarial pass (forbidden from building/testing) found five things; all are
fixed above or below, and I re-verified the two that changed the design.

1. **The freeze was too broad** — it covered `progress == nil`, which is the
   Updates-list route's normal state *and* the signal that the store dropped the
   swap. Narrowed. This also shrinks the blast radius: that route is **not**
   behind the hidden preference — `AppListModel.swift:3052` runs the AX installer
   for every region-locked app regardless of the update strategy. Verified.
2. **"47 readings either side of the change" was false.** 47 was two runs summed
   (21 + 26), and `readingShape` did not exist during either — `git log -S` puts
   it at 491caa0, 2026-09-05 00:25. Those runs measure *no dedupe at all*, not the
   blanking version. Verified and corrected in the comment.
3. **The caps are polls, not seconds, and the seconds were 40 % off.** 225 polls
   took 129 s on the measured run (~575 ms each, not the 400 ms sleep), so
   "~90 s"/"~5 min"/"6-min" were all wrong. Now stated as poll counts, with the
   one measured cadence recorded once.
4. **`Int(value / 10)` could trap** on a digit run past `Int64.max` — inside the
   installer's actor. Clamped before conversion.
5. **Test gap:** every case started the count at zero, so `appRunning ? 0 :`
   passed all of them — freeze and reset-to-zero were indistinguishable. Two new
   assertions.

Also corrected: `terminateAndWait`'s replacement line was an absolute drawn from
one run that the file's own Spark measurement contradicts, and
`reopenIfQuitForUpdate` still described a "~90 s post-Continue cap" and a timeout
path that no longer exist.

## Not in this change

- **A mid-flight row nudge** when `terminateAndWait`'s 12 s window expires. The
  only channel is re-raising the quit prompt, and the poll budget is deliberately
  frozen while that prompt is up — an app that never quits would then hold an
  install permit forever. Needs the budget rule reworked first.
- **Recognising the late landing** (#332's third bullet). Separate change,
  outside the installer.

## Verification

- `make test` — 2255 CLI + 188 Core, App 9 of 9, four Python gates. Green.
- Nine mutations run against the six new/changed cases; each red only on the case
  that claims it, written next to each test.
- `make install`; the new string is in the deployed binary.
