### PR TITLE
Stop the release path depending on which checkout it runs in, and run tests on GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+# Build and test on a GitHub-hosted Mac.
+#
+# The last workflow this repository had was deleted the day it went public
+# (4ff9a90, 2026-08-14) because it pointed at a self-hosted runner running as the
+# desktop user, and a public repo eventually gets a pull_request trigger pointed at
+# it. That reasoning still stands, so this one is built the other way round:
+#
+#   • GitHub-hosted runner only. Nothing here can reach a machine of ours.
+#   • No secrets. `make test` needs none — both xcodebuild invocations already pass
+#     CODE_SIGNING_ALLOWED=NO, and DUO_TEAM_ID has a default — so a fork's pull
+#     request has nothing to exfiltrate even if it rewrites this file.
+#   • `pull_request`, never `pull_request_target`. The latter runs the BASE
+#     workflow with the repository's secrets available to a fork's code, which is
+#     the standard way this goes wrong.
+#   • Actions pinned by commit SHA, not by tag. A tag can be moved.
+#
+# Standard GitHub-hosted runners are free and unlimited on public repositories, and
+# macos-latest is an arm64 M1 — which matters here because DuoUpdater is arm64-only
+# by product decision (App/project.yml, ARCHS: arm64), so this builds and tests
+# natively rather than under emulation.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Read-only. The release path deliberately does not live in this workflow.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-latest
+    # `make test` reaches vendor endpoints (the install gates download real
+    # packages and verify sha512 + Team ID), so it is slower and less predictable
+    # than a pure unit run. Generous, but far under the 6h job ceiling.
+    timeout-minutes: 60
+    steps:
+      - name: Check out
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      # App/DuoUpdater.xcodeproj is gitignored — the spec in App/project.yml is the
+      # source of truth and scripts/app-tests.sh regenerates it when missing.
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          echo "arch: $(uname -m)"
+
+      - name: make test
+        run: make test

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,132 @@
+# Build, sign, notarize and attest the release artifact on a GitHub-hosted Mac.
+#
+# What this workflow deliberately does NOT do: create a release, push an appcast,
+# or touch anything already published. It has no `contents: write`. The artifact
+# comes out as a workflow artifact and the publishing half stays on the author's
+# Mac, because that half needs the Sparkle EdDSA key — and a leaked Developer ID
+# certificate can be revoked by Apple, while a leaked Sparkle key lets anyone push
+# an update to every installed copy and Sparkle documents no rotation or
+# revocation path for it. The two keys are not the same kind of secret, so they do
+# not live in the same place.
+#
+# The attestation still covers what ships: `dist/DuoUpdater-notarized.zip` and the
+# published `DuoUpdater-<version>-macos.zip` are byte-identical (publish-release.sh
+# copies it), and provenance binds to the digest, so it verifies wherever the file
+# is uploaded from.
+#
+# Manual trigger only. No `push`, no `pull_request`, and never
+# `pull_request_target`: this is the workflow that has secrets, so nothing a fork
+# can influence may start it.
+name: Release build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read       # no release is created here
+  id-token: write      # Sigstore OIDC, for the provenance signature
+  attestations: write  # write the attestation to the repository
+
+jobs:
+  build:
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - name: Check out
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      # A throwaway keychain, made the default so `notarytool --keychain-profile`
+      # and `codesign` both find what they need without either being told about
+      # it. Deleted in the always-run step at the end; the runner is torn down
+      # regardless, but leaving it to that would be relying on someone else's
+      # cleanup for a private key.
+      - name: Load the signing certificate
+        env:
+          CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          [ -n "${CERT_P12:-}" ] || { echo "::error::APPLE_CERT_P12 is not set"; exit 1; }
+          kc="$RUNNER_TEMP/duo-build.keychain-db"
+          kcpass="$(uuidgen)"
+          security create-keychain -p "$kcpass" "$kc"
+          # -lut 21600: do NOT let the keychain auto-lock partway through a build
+          # that can run for tens of minutes. A mid-build lock shows up as a
+          # codesign failure with nothing pointing at the cause.
+          security set-keychain-settings -lut 21600 "$kc"
+          security unlock-keychain -p "$kcpass" "$kc"
+          printf '%s' "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$kc" \
+            -P "${CERT_PASSWORD:-}" -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/cert.p12"
+          # Without this, codesign blocks on a UI prompt that no one can answer
+          # and the job hangs until its timeout rather than failing.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$kcpass" "$kc" >/dev/null
+          security list-keychains -d user -s "$kc" $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s "$kc"
+          echo "DUO_CI_KEYCHAIN=$kc" >> "$GITHUB_ENV"
+          # Names only, never the identity's private material.
+          security find-identity -v -p codesigning "$kc" | sed 's/) .*(/) …(/'
+
+      # Written into the same throwaway keychain, so scripts/notarize.sh runs
+      # unmodified: it takes a profile name and nothing else, which is what keeps
+      # the CI path and the local path from drifting into two procedures.
+      - name: Store notarization credentials
+        env:
+          API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          xcrun notarytool store-credentials duo-ci \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
+            --key-id "$API_KEY_ID" \
+            --issuer "$API_ISSUER_ID" \
+            --keychain "$DUO_CI_KEYCHAIN"
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
+
+      # The same script the author runs locally. Its own gates refuse an ad-hoc
+      # signature, a wrong team, a missing hardened runtime and a get-task-allow
+      # entitlement, so a CI build that is signed wrongly fails here rather than
+      # becoming an artifact nobody checked.
+      - name: Build and notarize
+        env:
+          NOTARYTOOL_PROFILE: duo-ci
+        run: make notarize
+
+      - name: Record what was built
+        run: |
+          set -euo pipefail
+          zip=dist/DuoUpdater-notarized.zip
+          [ -f "$zip" ] || { echo "::error::$zip was not produced"; exit 1; }
+          shasum -a 256 "$zip"
+          ls -l "$zip"
+
+      # Binds this exact file, by digest, to this commit and this workflow, signed
+      # with a short-lived Sigstore certificate. Anyone can check it afterwards:
+      #   gh attestation verify DuoUpdater-<version>-macos.zip --repo jizhi0v0/duo-updater
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: dist/DuoUpdater-notarized.zip
+
+      - name: Upload the artifact
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v4
+        with:
+          name: DuoUpdater-notarized
+          path: dist/DuoUpdater-notarized.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Remove the signing keychain
+        if: always()
+        run: |
+          security default-keychain -s login.keychain-db 2>/dev/null || true
+          [ -n "${DUO_CI_KEYCHAIN:-}" ] && security delete-keychain "$DUO_CI_KEYCHAIN" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/AuthKey.p8" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -82,7 +82,26 @@ jobs:
           API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: |
           set -euo pipefail
-          printf '%s' "$API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          key="$RUNNER_TEMP/AuthKey.p8"
+          # Accept the secret either way round. `base64 -i key.p8 | pbcopy` is the
+          # documented path, but the .p8 is already a text PEM, so pasting it
+          # directly is the obvious mistake to make and notarytool's answer to it is
+          # `invalidPrivateKeyContents` — which names neither the secret nor which
+          # of the two shapes it got. Detect, say so, and fail here with a sentence
+          # somebody can act on.
+          if printf '%s' "$API_KEY_P8" | grep -qa -- "-----BEGIN"; then
+            echo "APPLE_API_KEY_P8 is a PEM; using it as-is"
+            printf '%s\n' "$API_KEY_P8" > "$key"
+          else
+            echo "APPLE_API_KEY_P8 is base64; decoding"
+            # Whitespace stripped first: `base64 -i` wraps its output, and a value
+            # that went through a copy-paste can pick up stray newlines either way.
+            printf '%s' "$API_KEY_P8" | tr -d '[:space:]' | base64 --decode > "$key"
+          fi
+          grep -qa -- "-----BEGIN PRIVATE KEY-----" "$key" || {
+            echo "::error::APPLE_API_KEY_P8 did not yield a PEM private key. It must be either the contents of AuthKey_<KEYID>.p8, or that file base64-encoded (base64 -i AuthKey_<KEYID>.p8 | pbcopy)."
+            exit 1
+          }
           xcrun notarytool store-credentials duo-ci \
             --key "$RUNNER_TEMP/AuthKey.p8" \
             --key-id "$API_KEY_ID" \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -116,7 +116,7 @@ jobs:
           subject-path: dist/DuoUpdater-notarized.zip
 
       - name: Upload the artifact
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: DuoUpdater-notarized
           path: dist/DuoUpdater-notarized.zip

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -53,12 +53,24 @@ jobs:
           kc="$RUNNER_TEMP/duo-build.keychain-db"
           kcpass="$(uuidgen)"
           security create-keychain -p "$kcpass" "$kc"
+          # Recorded IMMEDIATELY, not at the end of this step. Everything below
+          # can fail — a wrong -P password, a `security` quirk — and by then the
+          # private key is already imported. Writing this last meant the
+          # always-run cleanup found DUO_CI_KEYCHAIN unset and never deleted the
+          # keychain, which is the "someone else's cleanup" this step refuses to
+          # rely on.
+          echo "DUO_CI_KEYCHAIN=$kc" >> "$GITHUB_ENV"
           # -lut 21600: do NOT let the keychain auto-lock partway through a build
           # that can run for tens of minutes. A mid-build lock shows up as a
           # codesign failure with nothing pointing at the cause.
           security set-keychain-settings -lut 21600 "$kc"
           security unlock-keychain -p "$kcpass" "$kc"
           printf '%s' "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          # `-P` puts the password in the process's argv, where anything else in
+          # the job can read it out of `ps` for the duration of the call. There is
+          # no stdin form, so the exposure is inherent to `security import`; it is
+          # noted rather than hidden, and the window is one command long on a
+          # single-tenant runner.
           security import "$RUNNER_TEMP/cert.p12" -k "$kc" \
             -P "${CERT_PASSWORD:-}" -T /usr/bin/codesign -T /usr/bin/security
           rm -f "$RUNNER_TEMP/cert.p12"
@@ -66,9 +78,12 @@ jobs:
           # and the job hangs until its timeout rather than failing.
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$kcpass" "$kc" >/dev/null
+          # Unquoted on purpose — the existing list must word-split into separate
+          # arguments. Safe while runner keychain paths contain no spaces, which
+          # is the only reason it is written this way.
+          # shellcheck disable=SC2046
           security list-keychains -d user -s "$kc" $(security list-keychains -d user | tr -d '"')
           security default-keychain -s "$kc"
-          echo "DUO_CI_KEYCHAIN=$kc" >> "$GITHUB_ENV"
           # Names only, never the identity's private material.
           security find-identity -v -p codesigning "$kc" | sed 's/) .*(/) …(/'
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,6 +30,15 @@ permissions:
 jobs:
   build:
     runs-on: macos-latest
+    # The Apple secrets live in this environment, NOT at repository level, and the
+    # environment admits only `main` and `v*`. That distinction is the whole
+    # protection: `workflow_dispatch` runs the workflow file as it exists on the
+    # dispatched ref, so with repository-level secrets anyone able to push a branch
+    # could push a rewritten copy of THIS file, dispatch it there, and be handed the
+    # Developer ID key. With the secrets held here instead, that branch has two
+    # options and neither works — keep this line and fail the branch rule, or delete
+    # it and inherit nothing.
+    environment: release
     timeout-minutes: 90
     steps:
       - name: Check out

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -249,21 +249,47 @@ public enum ChannelBinding {
     /// lower-cased domain), so a case-sensitive `switch` silently failed to bind
     /// — same convention `ChangelogRecipe.recipe(forBundleID:)` already uses.
     public static func resolve(bundleID: String?) -> ResolvedChannel? {
-        guard let id = bundleID?.lowercased() else { return nil }
+        guard let id = bundleID?.lowercased(), let resolver = resolver(for: id) else { return nil }
+        return resolver()
+    }
+
+    /// Whether this id has a case in the switch at all — asked without running the
+    /// resolver, so the answer does not depend on the machine asking.
+    ///
+    /// The distinction is not academic. `resolve` returns nil for two unrelated
+    /// reasons: no case exists, or a case exists and this Mac's preferences resolve
+    /// to nothing. `everyBoundIDHasAResolverBehindIt` only ever meant the first, and
+    /// asked it by calling `resolve` — so on CI it failed for CleanShot, whose
+    /// resolver keys a personalized feed off a licence this repository's author has
+    /// and a runner does not, and reported "`resolve` has no case for it" about a
+    /// line that is right there. A guard that is permanently green on one Mac and red
+    /// everywhere else, with a message stating something false.
+    ///
+    /// `allResolutions` already learned this lesson for CleanShot (see the note
+    /// under it, and `CleanShotChannel.resolve(activationKey:)`); this is the same
+    /// fix for the other half. Sharing ONE switch rather than adding a second list
+    /// is the point — a copy drifts, a call cannot.
+    static func hasResolver(bundleID: String) -> Bool {
+        resolver(for: bundleID.lowercased()) != nil
+    }
+
+    /// The one switch both of the above go through. Returns the resolver itself,
+    /// unevaluated, so asking "is there one" costs no preference read.
+    private static func resolver(for id: String) -> (() -> ResolvedChannel?)? {
         switch id {
-        case DuoPasteChannel.bundleID.lowercased(): return DuoPasteChannel.resolveCurrent()
-        case ForkChannel.bundleID.lowercased():     return ForkChannel.resolveCurrent()
-        case SurgeChannel.bundleID.lowercased():    return SurgeChannel.resolveCurrent()
-        case OrbStackChannel.bundleID.lowercased(): return OrbStackChannel.resolveCurrent()
-        case TablePlusChannel.bundleID.lowercased(): return TablePlusChannel.resolveCurrent()
-        case CleanShotChannel.bundleID.lowercased(): return CleanShotChannel.resolveCurrent()
-        case TailscaleChannel.bundleID.lowercased(): return TailscaleChannel.resolveCurrent()
-        case IINAChannel.bundleID.lowercased():    return IINAChannel.resolveCurrent()
-        case AlfredChannel.bundleID.lowercased():  return AlfredChannel.resolveCurrent()
-        case GhosttyChannel.bundleID.lowercased(): return GhosttyChannel.resolveCurrent()
+        case DuoPasteChannel.bundleID.lowercased(): return DuoPasteChannel.resolveCurrent
+        case ForkChannel.bundleID.lowercased():     return ForkChannel.resolveCurrent
+        case SurgeChannel.bundleID.lowercased():    return SurgeChannel.resolveCurrent
+        case OrbStackChannel.bundleID.lowercased(): return OrbStackChannel.resolveCurrent
+        case TablePlusChannel.bundleID.lowercased(): return TablePlusChannel.resolveCurrent
+        case CleanShotChannel.bundleID.lowercased(): return CleanShotChannel.resolveCurrent
+        case TailscaleChannel.bundleID.lowercased(): return TailscaleChannel.resolveCurrent
+        case IINAChannel.bundleID.lowercased():    return IINAChannel.resolveCurrent
+        case AlfredChannel.bundleID.lowercased():  return AlfredChannel.resolveCurrent
+        case GhosttyChannel.bundleID.lowercased(): return GhosttyChannel.resolveCurrent
         case BetterDisplayChannel.bundleID.lowercased():
-            return BetterDisplayChannel.resolveCurrent()
-        case CapCutChannel.bundleID.lowercased():  return CapCutChannel.resolveCurrent()
+            return BetterDisplayChannel.resolveCurrent
+        case CapCutChannel.bundleID.lowercased():  return CapCutChannel.resolveCurrent
         default:                       return nil
         }
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRestarterTests.swift
@@ -88,13 +88,25 @@ import Foundation
     /// operation. If this regressed, the call would take the operation's 30s
     /// rather than the timeout's 50ms — which is exactly the wedged-launch
     /// behaviour the timeout was added to prevent.
+    ///
+    /// The bound is 15s, not the 50ms the call should actually take, because this
+    /// measures WALL CLOCK and therefore also measures however long this task
+    /// spent unscheduled. It failed at 5.926s on a 3-core CI runner with the whole
+    /// suite running in parallel — with the property intact, since the regression
+    /// takes 30s and nothing near 5.9s can be it. A bound that a loaded machine
+    /// trips is not measuring the property; it is measuring the machine.
+    ///
+    /// 15s keeps a 2× margin to the failure mode, which is the only distinction
+    /// this test can make. Tightening it back toward the real 50ms would look
+    /// stricter and buy nothing: there is no regression between 50ms and 30s to
+    /// catch, because the abandoned operation's sleep is the only other outcome.
     @Test func givingUpDoesNotWaitForTheAbandonedOperation() async {
         let started = ContinuousClock.now
         _ = await AppRestarter.firstToFinish(timeout: .milliseconds(50), fallback: false) {
             try? await Task.sleep(for: .seconds(30))
             return true
         }
-        #expect(ContinuousClock.now - started < .seconds(5))
+        #expect(ContinuousClock.now - started < .seconds(15))
     }
 
     /// `onTimeout` is the log line, so it must fire only when the budget really

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
@@ -375,7 +375,19 @@ struct ArchitectureDowngradeWiringTests {
         // seconds of a 60-minute budget copying it, twice. A hand-kept list of
         // one machine's apps is exactly the kind of fixture choice this repository
         // keeps getting wrong; the size is the actual requirement, so measure it.
-        for app in apps where app.pathExtension == "app" {
+        for candidate in apps where candidate.pathExtension == "app" {
+            // Resolved first, because /Applications can hold SYMLINKS to apps and
+            // every step below behaves differently on one. Measured on a GitHub
+            // runner 2026-09-05: `/Applications/Xcode_26.2.0.app` is a link to
+            // `/Applications/Xcode_26.2.app`, and that single fact produced every
+            // symptom in #336 — `enumerator` does not descend a link, so a 20 GB
+            // Xcode passed a 200 MB cap with a measured size of zero; `cp -R` copies
+            // the link rather than the tree, so the "scratch copy" pointed back at
+            // the original and `lipo`/`removeItem`/`moveItem` were aimed at a real
+            // installed app; and `ditto -c -k` followed it, which is where 593
+            // seconds went. Resolving here fixes all three at the source, and the
+            // scratch guard in `makeDowngradeFixture` stays as the backstop.
+            let app = candidate.resolvingSymlinksInPath()
             guard bundleIsUnder(sizeCap, at: app),
                   SignatureVerifier.executableArchitectures(ofAppAt: app) == [arm, intel],
                   (try? SignatureVerifier.teamIdentifier(at: app)) != nil

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
@@ -358,61 +358,173 @@ struct ArchitectureDowngradeWiringTests {
         }
     }
 
-    /// A real installed universal (`arm64 + x86_64`) app, small enough to copy
-    /// and zip twice per test without slowing the suite — or nil when this
-    /// machine has none, which the caller must treat as "nothing to prove with"
-    /// rather than a failure (this suite runs on whatever `/Applications`
-    /// happens to hold, same as `InstallPipelineSmokeTests.installPipelineDryRun`).
+    /// A real installed universal (`arm64 + x86_64`) app, signed by a team and
+    /// small enough to copy and zip twice per test — or nil, which is a failure.
+    ///
+    /// Searched in TWO passes, because a top-level `/Applications` entry is not the
+    /// only shape a complete signed bundle comes in, and on a hosted runner it is
+    /// not a shape that exists at all. Measured on `macos-latest` 2026-09-04 (run
+    /// 33930802607): zero candidates, so both tests below passed having executed
+    /// none of the code they exist for — #339. The image is not short of universal
+    /// apps; Chrome, Edge and Firefox all ship one. They are simply hundreds of
+    /// megabytes, and the size cap — added the day before to stop a 593-second
+    /// Xcode copy — rejected every one of them.
+    ///
+    /// A vendor's nested helper is the same thing an order of magnitude smaller: a
+    /// separately signed, complete bundle carrying its parent's Team ID. Measured
+    /// here 2026-09-05, `Google Chrome Helper.app` is 184 KB, `[x86_64 arm64]`,
+    /// team `EQHXZ8M8AV`, and drives both tests to Gate 5b's refusal in 0.657 s.
+    /// So pass 1 takes a small top-level app when one exists (the author's Mac),
+    /// and pass 2 descends into exactly the apps the cap rejected (the runner).
     private static func findUniversalFixture() -> URL? {
-        guard let apps = try? FileManager.default.contentsOfDirectory(
+        guard let entries = try? FileManager.default.contentsOfDirectory(
             at: URL(fileURLWithPath: "/Applications"), includingPropertiesForKeys: nil
-        ) else { return nil }
-        // Small enough MEASURED, not by name. The list here used to be
-        // ["NotchBadge.app", "AppCleaner.app", "Klack.app"] — the author's small
-        // apps — with everything else in whatever order the directory came back.
-        // A machine without those three takes the fallback, and on the first CI
-        // run that was Xcode: `vendorInstallerApplyRefusesTheDowngrade` spent 593
-        // seconds of a 60-minute budget copying it, twice. A hand-kept list of
-        // one machine's apps is exactly the kind of fixture choice this repository
-        // keeps getting wrong; the size is the actual requirement, so measure it.
-        for candidate in apps where candidate.pathExtension == "app" {
-            // Resolved first, because /Applications can hold SYMLINKS to apps and
-            // every step below behaves differently on one. Measured on a GitHub
-            // runner 2026-09-05: `/Applications/Xcode_26.2.0.app` is a link to
-            // `/Applications/Xcode_26.2.app`, and that single fact produced every
-            // symptom in #336 — `enumerator` does not descend a link, so a 20 GB
-            // Xcode passed a 200 MB cap with a measured size of zero; `cp -R` copies
-            // the link rather than the tree, so the "scratch copy" pointed back at
-            // the original and `lipo`/`removeItem`/`moveItem` were aimed at a real
-            // installed app; and `ditto -c -k` followed it, which is where 593
-            // seconds went. Resolving here fixes all three at the source, and the
-            // scratch guard in `makeDowngradeFixture` stays as the backstop.
-            let app = candidate.resolvingSymlinksInPath()
-            guard bundleIsUnder(sizeCap, at: app),
-                  SignatureVerifier.executableArchitectures(ofAppAt: app) == [arm, intel],
-                  (try? SignatureVerifier.teamIdentifier(at: app)) != nil
-            else { continue }
+        ) else {
+            Issue.record("ARCH DOWNGRADE FIXTURE: /Applications could not be listed.")
+            return nil
+        }
+        // Resolved before anything else, because /Applications can hold SYMLINKS to
+        // apps and every step below behaves differently on one. Measured on a
+        // GitHub runner 2026-09-05: `/Applications/Xcode_26.2.0.app` is a link to
+        // `/Applications/Xcode_26.2.app`, and that single fact produced every
+        // symptom in #336 — `enumerator` does not descend a link, so a 20 GB Xcode
+        // passed a 200 MB cap with a measured size of zero; `cp -R` copies the link
+        // rather than the tree, so the "scratch copy" pointed back at the original;
+        // and `ditto -c -k` followed it, which is where 593 seconds went.
+        //
+        // Sorted so two runs on one machine choose the SAME fixture. Directory
+        // order is not defined, and a suite that silently swaps its fixture between
+        // runs turns any fixture-shaped failure into a flake.
+        let candidates = entries
+            .filter { $0.pathExtension == "app" }
+            .map { $0.resolvingSymlinksInPath() }
+            .sorted { $0.path < $1.path }
+
+        // Pass 1 — a top-level app already under the copy budget.
+        var rejected: [URL] = []
+        for app in candidates {
+            guard bundleIsUnder(sizeCap, at: app), isUsableFixture(app) else {
+                rejected.append(app)
+                continue
+            }
             print("ARCH DOWNGRADE FIXTURE: \(app.lastPathComponent)")
             return app
         }
-        // Both callers treat nil as "nothing to prove with" and return, so this
-        // branch is the tests passing while executing none of the code they exist
-        // for. That is defensible — not every machine has a universal signed app —
-        // but it must not be SILENT, which it was: the size cap added above makes
-        // the empty case more reachable, and a fixture-shaped hole reads exactly
-        // like a green run. Say so where anyone reading a CI log will see it.
-        print("""
-            ARCH DOWNGRADE FIXTURE: none found under \(sizeCap / 1024 / 1024) MB in \
-            /Applications — the two downgrade-wiring tests PROVED NOTHING on this run.
+
+        // Pass 2 — descend into EVERYTHING pass 1 turned down, not only what the
+        // cap turned down. The narrower version was written first, on the reasoning
+        // that a small app rejected for its architecture or its signature has
+        // nothing usable inside it either, since a helper inherits its parent's
+        // team and architecture set. That reasoning is unmeasured, and it is the
+        // same shape of "throughout" claim this repository keeps getting wrong:
+        // nothing stops an arm64-only app from bundling a universal Sparkle
+        // updater, and one wrong guess here brings back the silent-hole this whole
+        // change exists to close. The small ones are under the cap by definition,
+        // so walking them costs almost nothing, and the budget bounds the rest.
+        var budget = nestedSearchBudget
+        for host in rejected {
+            guard let nested = firstUsableNestedFixture(in: host, budget: &budget)
+            else { continue }
+            print("""
+                ARCH DOWNGRADE FIXTURE: \(nested.lastPathComponent) \
+                (nested in \(host.lastPathComponent))
+                """)
+            return nested
+        }
+
+        // FAILS, where it used to print and return nil. Both callers treat nil as
+        // "nothing to prove with" and return, so that branch was the two tests
+        // passing while executing none of the code they exist for — and a green
+        // run is exactly what a fixture-shaped hole looks like from outside. The
+        // printed warning was not enough: it went by on 2026-09-04 and #339 was
+        // filed off a log nobody would have read otherwise.
+        //
+        // The honest cost: the fixture now comes from someone else's disk image,
+        // and `macos-latest` will eventually move to a newer one. If that image
+        // ships no universal team-signed bundle at any depth, this turns red for a
+        // reason unrelated to the code under test. That is the trade — a red that
+        // names its own cause, over a green that means nothing. The message says
+        // which pass came up empty so the next person does not have to rediscover
+        // this comment.
+        Issue.record("""
+            ARCH DOWNGRADE FIXTURE: none found. No universal, team-signed bundle \
+            under \(sizeCap / 1024 / 1024) MB among \(candidates.count) apps in \
+            /Applications, and none nested inside any of the \(rejected.count) \
+            turned down (\(nestedSearchBudget - budget) entries walked\
+            \(budget <= 0 ? ", BUDGET EXHAUSTED — raise nestedSearchBudget" : "")). \
+            The two downgrade-wiring tests can prove nothing without one, so this \
+            fails rather than passing silently — see #339.
             """)
         return nil
     }
+
+    /// Universal AND signed by a real team — both halves are requirements of the
+    /// gate under test, not conveniences.
+    ///
+    /// Team ID matters because Gate 3 runs BEFORE the gate these tests aim at, so a
+    /// teamless fixture is refused upstream and the tests fail naming the wrong
+    /// reason (measured 2026-09-05: `noTeamIdentifier(which: "installed")` from
+    /// both installers, on the hermetic ad-hoc fixture #339 proposed). It is also
+    /// the only thing keeping Safari out: `/Applications/Safari.app` is a symlink
+    /// into `/System/Volumes/Preboot/Cryptexes/App/…`, and the real bundle behind
+    /// it reads as `[x86_64, arm64]` and sits under the cap — it clears every other
+    /// filter here and is excluded solely by answering nil for a team.
+    private static func isUsableFixture(_ app: URL) -> Bool {
+        SignatureVerifier.executableArchitectures(ofAppAt: app) == [arm, intel]
+            && (try? SignatureVerifier.teamIdentifier(at: app)) != nil
+    }
+
+    /// The first nested `.app` inside `host` that would serve as a fixture,
+    /// charging what it walks against a shared `budget`.
+    ///
+    /// FIRST, not smallest: picking the smallest means evaluating every candidate,
+    /// which is a full walk of an app the cap already called too big — most of what
+    /// the cap exists to avoid. The cap is re-applied to each nested bundle, so
+    /// "first" is still bounded by the same copy budget.
+    private static func firstUsableNestedFixture(in host: URL, budget: inout Int) -> URL? {
+        guard let walk = FileManager.default.enumerator(
+            at: host, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+        else { return nil }
+        for case let entry as URL in walk {
+            guard budget > 0 else { return nil }
+            budget -= 1
+            guard entry.pathExtension == "app" else { continue }
+            // Do not descend into a bundle already being considered. This prune is
+            // most of why the walk is cheap: with it, Chrome costs 1,122 entries
+            // instead of its whole tree.
+            walk.skipDescendants()
+            let nested = entry.resolvingSymlinksInPath()
+            guard bundleIsUnder(sizeCap, at: nested), isUsableFixture(nested) else { continue }
+            return nested
+        }
+        return nil
+    }
+
+    /// Directory entries pass 2 may visit in total, across every oversized app.
+    ///
+    /// A bound rather than a target: pass 2 stops at the first usable bundle, so
+    /// this only decides how long a fruitless search may run. Measured here
+    /// 2026-09-05 with nested `.app` descendants pruned — Google Chrome 1,122
+    /// entries / 0.03 s, CapCut 6,148, Microsoft Word 50,582, and the worst case on
+    /// the machine, Xcode-beta, 164,777 / 3.56 s. 400,000 lets even that finish and
+    /// still holds the whole pass near ten seconds however many such apps are
+    /// installed. Exhausting it is reported in the failure message, because
+    /// "searched everywhere and found nothing" and "ran out of budget" are
+    /// different problems with different fixes.
+    private static let nestedSearchBudget = 400_000
 
     /// The copy budget for a fixture: it is copied twice and zipped once per test,
     /// by two tests. 200 MB of that is already generous; Xcode is a hundred times
     /// it. Measured on the author's Mac 2026-09-05: 55 universal signed candidates
     /// in /Applications, 17 of them under 50 MB, the largest 2.8 GB — so the cap
     /// removes the tail without emptying the population.
+    ///
+    /// On a hosted runner it DID empty the population, which is #339 — every
+    /// universal app on the image is over it. That does not make the cap wrong,
+    /// and raising it is the wrong repair: 593 seconds of a copy is what it was
+    /// added to prevent. Its job simply grew a second half — it now also decides
+    /// which apps pass 2 descends into — so an app being over the cap is no longer
+    /// the end of the search for a fixture inside it.
     private static let sizeCap: Int64 = 200 * 1024 * 1024
 
     /// Whether `url`'s regular files total less than `cap`, **giving up as soon as
@@ -434,9 +546,11 @@ struct ArchitectureDowngradeWiringTests {
     }
 
     /// Builds the "installed universal / downloaded x86_64-only" fixture pair
-    /// shared by both installer tests below, or nil when this environment can't
-    /// support the test (see `findUniversalFixture`). `scratch` is the caller's
-    /// scratch dir, removed by the caller.
+    /// shared by both installer tests below. `scratch` is the caller's scratch dir,
+    /// removed by the caller.
+    ///
+    /// nil means the fixture could not be built, and an issue has already been
+    /// recorded by then — callers return rather than reporting it a second time.
     private static func makeDowngradeFixture(in scratch: URL) throws -> (
         installed: InstalledApp, download: DownloadedUpdate
     )? {
@@ -451,16 +565,33 @@ struct ArchitectureDowngradeWiringTests {
         try FileManager.default.createDirectory(at: thinDir, withIntermediateDirectories: true)
         let thinApp = thinDir.appendingPathComponent(fixture.lastPathComponent)
         try run(["/bin/cp", "-R", fixture.path, thinApp.path])
-        guard let exe = Bundle(url: thinApp)?.executableURL else { return nil }
-        // Everything below rewrites `exe` in place. It must be the copy.
+        // Read off the COPY's own Info.plist and joined onto the COPY's URL, so the
+        // path is structurally incapable of naming anything outside `thinDir`.
         //
-        // On the first CI run (2026-09-05) it was not: the error carried
+        // Everything below rewrites `exe` in place, and on the first CI run
+        // (2026-09-05) it was not the copy: the error carried
         // `NSSourceFilePathErrorKey=/Applications/Xcode_26.2.app/Contents/MacOS/Xcode.thin`,
         // so `lipo`, `removeItem` and `moveItem` had been aimed at a real installed
-        // application rather than at `thinDir`. The mechanism is still unexplained —
-        // probed locally on 2026-09-05, `Bundle(url:)` does return the copy's own
-        // executable even when a `Bundle` for the original already exists — so this
-        // refuses on the fact rather than trusting an explanation nobody has.
+        // application. That line asked `Bundle(url: thinApp)?.executableURL` — a
+        // lookup that answers with whatever the frameworks resolve to, which is a
+        // question this code has no reason to ask. The symlink that run tripped
+        // over is handled at the source now (see `findUniversalFixture`), and the
+        // mechanism was never confirmed; this construction does not need it to be.
+        let infoURL = thinApp.appendingPathComponent("Contents/Info.plist")
+        guard let infoData = try? Data(contentsOf: infoURL),
+              let info = try? PropertyListSerialization.propertyList(
+                from: infoData, options: [], format: nil) as? [String: Any],
+              let exeName = info["CFBundleExecutable"] as? String, !exeName.isEmpty
+        else {
+            Issue.record("fixture \(thinApp.lastPathComponent) declares no CFBundleExecutable")
+            return nil
+        }
+        let exe = thinApp
+            .appendingPathComponent("Contents/MacOS")
+            .appendingPathComponent(exeName)
+        // Kept as the backstop, not as the guard: the construction above already
+        // rules this out, and a precondition that can no longer fire is the cheapest
+        // insurance there is against the next person reintroducing a lookup.
         let scratchRoot = scratch.resolvingSymlinksInPath().path
         guard exe.resolvingSymlinksInPath().path.hasPrefix(scratchRoot + "/") else {
             Issue.record("""

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
@@ -367,20 +367,58 @@ struct ArchitectureDowngradeWiringTests {
         guard let apps = try? FileManager.default.contentsOfDirectory(
             at: URL(fileURLWithPath: "/Applications"), includingPropertiesForKeys: nil
         ) else { return nil }
-        // Known-small candidates first, so the test doesn't end up copying and
-        // zipping a multi-hundred-MB app just because it sorts first.
-        let preferred = ["NotchBadge.app", "AppCleaner.app", "Klack.app"]
-        let ordered = apps.filter { $0.pathExtension == "app" }.sorted { a, b in
-            (preferred.firstIndex(of: a.lastPathComponent) ?? .max)
-                < (preferred.firstIndex(of: b.lastPathComponent) ?? .max)
-        }
-        for app in ordered {
-            guard SignatureVerifier.executableArchitectures(ofAppAt: app) == [arm, intel],
+        // Small enough MEASURED, not by name. The list here used to be
+        // ["NotchBadge.app", "AppCleaner.app", "Klack.app"] — the author's small
+        // apps — with everything else in whatever order the directory came back.
+        // A machine without those three takes the fallback, and on the first CI
+        // run that was Xcode: `vendorInstallerApplyRefusesTheDowngrade` spent 593
+        // seconds of a 60-minute budget copying it, twice. A hand-kept list of
+        // one machine's apps is exactly the kind of fixture choice this repository
+        // keeps getting wrong; the size is the actual requirement, so measure it.
+        for app in apps where app.pathExtension == "app" {
+            guard bundleIsUnder(sizeCap, at: app),
+                  SignatureVerifier.executableArchitectures(ofAppAt: app) == [arm, intel],
                   (try? SignatureVerifier.teamIdentifier(at: app)) != nil
             else { continue }
+            print("ARCH DOWNGRADE FIXTURE: \(app.lastPathComponent)")
             return app
         }
+        // Both callers treat nil as "nothing to prove with" and return, so this
+        // branch is the tests passing while executing none of the code they exist
+        // for. That is defensible — not every machine has a universal signed app —
+        // but it must not be SILENT, which it was: the size cap added above makes
+        // the empty case more reachable, and a fixture-shaped hole reads exactly
+        // like a green run. Say so where anyone reading a CI log will see it.
+        print("""
+            ARCH DOWNGRADE FIXTURE: none found under \(sizeCap / 1024 / 1024) MB in \
+            /Applications — the two downgrade-wiring tests PROVED NOTHING on this run.
+            """)
         return nil
+    }
+
+    /// The copy budget for a fixture: it is copied twice and zipped once per test,
+    /// by two tests. 200 MB of that is already generous; Xcode is a hundred times
+    /// it. Measured on the author's Mac 2026-09-05: 55 universal signed candidates
+    /// in /Applications, 17 of them under 50 MB, the largest 2.8 GB — so the cap
+    /// removes the tail without emptying the population.
+    private static let sizeCap: Int64 = 200 * 1024 * 1024
+
+    /// Whether `url`'s regular files total less than `cap`, **giving up as soon as
+    /// they don't**. The early exit is the point: without it, deciding to reject a
+    /// 20 GB app costs a full recursive walk of 20 GB, which is most of what the
+    /// cap was added to avoid.
+    private static func bundleIsUnder(_ cap: Int64, at url: URL) -> Bool {
+        guard let walk = FileManager.default.enumerator(
+            at: url, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]) else { return false }
+        var total: Int64 = 0
+        for case let file as URL in walk {
+            guard let v = try? file.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+                  v.isRegularFile == true else { continue }
+            total += Int64(v.fileSize ?? 0)
+            if total >= cap { return false }
+        }
+        return true
     }
 
     /// Builds the "installed universal / downloaded x86_64-only" fixture pair
@@ -402,6 +440,23 @@ struct ArchitectureDowngradeWiringTests {
         let thinApp = thinDir.appendingPathComponent(fixture.lastPathComponent)
         try run(["/bin/cp", "-R", fixture.path, thinApp.path])
         guard let exe = Bundle(url: thinApp)?.executableURL else { return nil }
+        // Everything below rewrites `exe` in place. It must be the copy.
+        //
+        // On the first CI run (2026-09-05) it was not: the error carried
+        // `NSSourceFilePathErrorKey=/Applications/Xcode_26.2.app/Contents/MacOS/Xcode.thin`,
+        // so `lipo`, `removeItem` and `moveItem` had been aimed at a real installed
+        // application rather than at `thinDir`. The mechanism is still unexplained —
+        // probed locally on 2026-09-05, `Bundle(url:)` does return the copy's own
+        // executable even when a `Bundle` for the original already exists — so this
+        // refuses on the fact rather than trusting an explanation nobody has.
+        let scratchRoot = scratch.resolvingSymlinksInPath().path
+        guard exe.resolvingSymlinksInPath().path.hasPrefix(scratchRoot + "/") else {
+            Issue.record("""
+                fixture executable resolved outside the scratch copy — refusing to \
+                rewrite it. exe=\(exe.path) scratch=\(scratchRoot)
+                """)
+            return nil
+        }
         try run(["/usr/bin/lipo", "-thin", "x86_64", exe.path, "-output", exe.path + ".thin"])
         try FileManager.default.removeItem(at: exe)
         try FileManager.default.moveItem(at: URL(fileURLWithPath: exe.path + ".thin"), to: exe)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
@@ -171,8 +171,13 @@ import Foundation
         #expect(enumerated == expected,
                 "allResolutions drifted from the resolvers: missing \(expected.subtracting(enumerated).sorted()), extra \(enumerated.subtracting(expected).sorted())")
 
+        // `hasResolver`, not `resolve(...) != nil`: the second asks this Mac's
+        // preferences, and CleanShot's resolver answers nil without a licence — so
+        // this loop passed for the author and failed everywhere else, with a message
+        // blaming a missing case. Same trap `allResolutions` above already avoids by
+        // enumerating CleanShot through its pure resolver.
         for id in enumerated {
-            #expect(ChannelBinding.resolve(bundleID: id) != nil,
+            #expect(ChannelBinding.hasResolver(bundleID: id),
                     "\(id) is enumerated but `resolve` has no case for it")
         }
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
@@ -291,9 +291,17 @@ import Foundation
 /// `boundBundleIDs` but forgotten in `resolve` would make the menu-bar app
 /// recheck that app on every launch, quit and preference write, and resolve
 /// nothing each time — a binding that reads as present and does nothing.
+///
+/// ⚠️ Asked through `hasResolver`, never by calling `resolve` and checking for nil.
+/// `resolve` returns nil for two unrelated reasons — no case, or a case whose
+/// resolver found nothing in THIS Mac's preferences — and this test only ever meant
+/// the first. Calling `resolve` made it pass for anyone with a licensed CleanShot
+/// and fail for everyone else, while reporting "resolve has no case for it" about a
+/// case that exists. It went unseen until the repository first ran its tests on a
+/// machine that was not the author's (2026-09-05).
 @Test func everyBoundIDHasAResolverBehindIt() {
     for id in ChannelBinding.boundBundleIDs {
-        #expect(ChannelBinding.resolve(bundleID: id) != nil,
+        #expect(ChannelBinding.hasResolver(bundleID: id),
                 "\(id) is in boundBundleIDs but ChannelBinding.resolve has no case for it")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -146,16 +146,28 @@ import CryptoKit
     // The file being absent is NOT on its own the production rule. Production asks
     // `identity.resolve(endpoint)`, which stands a declared `fallback` in for an
     // unreadable value — so an identity with a fallback is fully addressable on a
-    // machine that has no such file, and exempting it here would hand a genuine
-    // vendor breakage a free pass. Neither identity-bearing recipe declares a
-    // fallback today, which is precisely why the predicate has to say so rather
-    // than encode today's registry.
+    // machine that has no such file, and exempting it for that would hand a
+    // genuine vendor breakage a free pass.
+    //
+    // ANY unaddressable read, not all of them. `resolveEndpoint` substitutes the
+    // reads in order and returns `.notApplicable` at the FIRST one that resolves
+    // to nil, so one such read decides the whole probe and the rest are never
+    // consulted. `allSatisfy` was the first version of this line and it was wrong
+    // in the direction that costs a green build: codex declares two reads, and the
+    // second one — the plan_type claim — carries `fallback: "unknown"` by design,
+    // so "every read is unaddressable" is false on a machine that has neither
+    // file. CI failed on exactly that (2026-09-05, run 33946637714:
+    // `com.openai.codex [stable] resolved no installer URL`) while the author's
+    // Mac, which has both files, stayed green — the same everyone-but-me shape
+    // this exemption exists to remove. Measured on both sides:
+    //
+    //   author's Mac : bootstrap.json value=SET fallback=nil |
+    //                  ~/.codex/auth.json value=SET fallback=unknown  → probed
+    //   hosted runner: both value=nil                                 → exempt
     let unaddressableKeys = Set(
         byKey.values
             .filter { recipe in
-                let reads = recipe.localReads
-                return !reads.isEmpty
-                    && reads.allSatisfy { $0.value() == nil && $0.fallback == nil }
+                recipe.localReads.contains { $0.value() == nil && $0.fallback == nil }
             }
             .map { ChannelProofKey($0.bundleID, $0.channel) })
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -137,11 +137,25 @@ import CryptoKit
     // when its identity is actually absent here. A machine that has the app must
     // go on being covered, or the exemption quietly deletes the coverage it was
     // meant to preserve.
+    // `localReads`, not `identities`. That property exists precisely so guards
+    // derive from ONE list — its own doc records that splitting the rollout track
+    // out of `identities` broke two guards the day it happened, and enumerating
+    // `identities` here would have made this the third. A track selector with no
+    // fallback answers `.notApplicable("no rollout track at …")` the same way.
+    //
+    // The file being absent is NOT on its own the production rule. Production asks
+    // `identity.resolve(endpoint)`, which stands a declared `fallback` in for an
+    // unreadable value — so an identity with a fallback is fully addressable on a
+    // machine that has no such file, and exempting it here would hand a genuine
+    // vendor breakage a free pass. Neither identity-bearing recipe declares a
+    // fallback today, which is precisely why the predicate has to say so rather
+    // than encode today's registry.
     let unaddressableKeys = Set(
         byKey.values
             .filter { recipe in
-                !recipe.identities.isEmpty
-                    && recipe.identities.allSatisfy { $0.value() == nil }
+                let reads = recipe.localReads
+                return !reads.isEmpty
+                    && reads.allSatisfy { $0.value() == nil && $0.fallback == nil }
             }
             .map { ChannelProofKey($0.bundleID, $0.channel) })
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -119,6 +119,32 @@ import CryptoKit
         byKey.values.filter { $0.trackClosedPattern != nil }
             .map { ChannelProofKey($0.bundleID, $0.channel) })
 
+    // Recipes whose probe cannot even be addressed from this machine, because the
+    // endpoint is keyed by an identifier the vendor's own app writes locally —
+    // Codex reads an `installationId` out of Application Support, and without it
+    // `VendorProbeSource` answers `.notApplicable("no device identity at …")`
+    // rather than failing. That is the recipe working as designed, and on a
+    // machine where the app is not installed it is the ONLY possible answer.
+    //
+    // The first CI run failed here for exactly that reason and it read like a
+    // vendor outage: `com.openai.codex [stable]: v?  [nil] — NO URL`. It is the
+    // same shape as CleanShot's resolver — a test that passes for whoever has the
+    // app installed and fails for everyone else — and the same shape as running
+    // this suite anywhere but the author's Mac.
+    //
+    // Derived from the registry, and — following what 0113017 fixed for track
+    // closure — exempt by RESULT, not by declaration: a recipe is skipped only
+    // when its identity is actually absent here. A machine that has the app must
+    // go on being covered, or the exemption quietly deletes the coverage it was
+    // meant to preserve.
+    let unaddressableKeys = Set(
+        byKey.values
+            .filter { recipe in
+                !recipe.identities.isEmpty
+                    && recipe.identities.allSatisfy { $0.value() == nil }
+            }
+            .map { ChannelProofKey($0.bundleID, $0.channel) })
+
     for key in targets {
         let remote = results[key] ?? nil
         // Only when it actually resolved nothing. `trackClosedPattern` is a
@@ -131,6 +157,10 @@ import CryptoKit
         // stops being covered.
         if remote?.downloadURL == nil, dormantTracks.contains(key) {
             log("• \(key): dormant — vendor publishes no current build on this track")
+            continue
+        }
+        if remote?.downloadURL == nil, unaddressableKeys.contains(key) {
+            log("• \(key): no device identity on this machine — the vendor's app is not installed here, so this probe has nothing to address and proved nothing")
             continue
         }
         let kind = remote?.vendorInstallerKind.map { "\($0)" } ?? "nil"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -11,6 +11,18 @@
 #   NOTARYTOOL_PROFILE=duoupdater-notary make release
 #   TAG=v0.1.1 TITLE="DuoUpdater 0.1.1" NOTARYTOOL_PROFILE=duoupdater-notary scripts/publish-release.sh
 #
+# Or, with the artifact built on a hosted Mac so anyone can tie it to this source:
+#
+#   1. Run .github/workflows/release-build.yml on the commit being released
+#      (Actions → Release build → Run workflow, or `gh workflow run`).
+#   2. CI_RUN_ID=<that run's id> make release
+#
+# That skips the local build entirely and takes the workflow's artifact, but only
+# after checking its SLSA provenance came from THAT workflow in THIS repository,
+# on a hosted runner — and then re-applying notarize.sh's signing gates by hand,
+# since notarize.sh did not run. No notary profile is needed on this path; the
+# Sparkle EdDSA key still is, which is the whole reason publishing stays here.
+#
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -509,7 +521,67 @@ else
     ( cd "$REPO_ROOT" && make test ) || die "tests failed — refusing to publish."
 fi
 
-if [ "$SKIP_NOTARIZE" = "1" ]; then
+if [ -n "${CI_RUN_ID:-}" ]; then
+    # Take the artifact built by .github/workflows/release-build.yml instead of
+    # building here. The point is not convenience: a locally built binary is one
+    # that nobody outside this Mac can tie to the published source, while this one
+    # carries SLSA build provenance that anyone can check with
+    # `gh attestation verify`. The publishing half stays local because the Sparkle
+    # EdDSA key does — see that workflow's header for why the two keys differ.
+    #
+    # Everything below runs BEFORE the artifact is used for anything, because this
+    # is the one path where the bytes were produced somewhere we do not control.
+    say "CI_RUN_ID=$CI_RUN_ID — using that run's artifact instead of building"
+    ci_dir="$(mktemp -d "${TMPDIR:-/tmp}/duo-ci-artifact.XXXXXX")"
+    gh run download "$CI_RUN_ID" --repo "$RELEASE_REPO" \
+        --name DuoUpdater-notarized --dir "$ci_dir" \
+        || die "could not download the artifact from run $CI_RUN_ID"
+    ci_zip="$ci_dir/DuoUpdater-notarized.zip"
+    [ -f "$ci_zip" ] || die "run $CI_RUN_ID had no DuoUpdater-notarized.zip"
+
+    # Provenance first. `--signer-workflow` is the part that carries the weight:
+    # without it any attestation from any workflow in this repository would pass,
+    # which is most of the guarantee gone. `--deny-self-hosted-runners` matters
+    # here specifically — a self-hosted runner running as the desktop user is why
+    # this repository deleted its previous workflow when it went public.
+    say "Verifying the artifact's build provenance"
+    gh attestation verify "$ci_zip" --repo "$RELEASE_REPO" \
+        --signer-workflow "$RELEASE_REPO/.github/workflows/release-build.yml" \
+        --deny-self-hosted-runners \
+        || die "the artifact from run $CI_RUN_ID has no valid provenance from
+  $RELEASE_REPO/.github/workflows/release-build.yml — refusing to publish it."
+
+    # `notarize.sh` did not run here, so its gates have not run either. They are
+    # not optional just because a green workflow produced the file: this script is
+    # the last place that can refuse, and an unsigned, unstapled or wrongly-teamed
+    # build reaches users as "damaged" with no way back.
+    say "Checking the artifact is signed, hardened and stapled"
+    ci_team="${DUO_TEAM_ID:-RS59HDH7Y3}"
+    ci_unpack="$ci_dir/unpacked"
+    mkdir -p "$ci_unpack"
+    ditto -x -k "$ci_zip" "$ci_unpack" || die "could not unpack $ci_zip"
+    ci_app="$(find "$ci_unpack" -maxdepth 1 -name '*.app' -type d | head -n 1)"
+    [ -n "$ci_app" ] || die "no .app inside the artifact from run $CI_RUN_ID"
+    ci_sig="$(codesign -dvv "$ci_app" 2>&1)"
+    case "$ci_sig" in *"adhoc"*) die "the CI artifact is AD-HOC signed";; esac
+    case "$ci_sig" in
+        *"TeamIdentifier=$ci_team"*) ;;
+        *) die "the CI artifact is not signed by team $ci_team";;
+    esac
+    case "$ci_sig" in
+        *"flags=0x10000(runtime)"*) ;;
+        *) die "the CI artifact does not have the hardened runtime enabled";;
+    esac
+    xcrun stapler validate "$ci_app" >/dev/null 2>&1 \
+        || die "the CI artifact is not stapled — Gatekeeper would need the network to admit it"
+    spctl -a -t exec "$ci_app" >/dev/null 2>&1 \
+        || die "Gatekeeper rejects the CI artifact"
+    printf '   %s\n' "$(printf '%s\n' "$ci_sig" | sed -n 's/^Authority=/Authority=/p' | head -n 1)"
+
+    mkdir -p "$DIST_DIR"
+    cp "$ci_zip" "$FINAL_ZIP"
+    rm -rf "$ci_dir"
+elif [ "$SKIP_NOTARIZE" = "1" ]; then
     say "SKIP_NOTARIZE=1 — NOT rebuilding; reusing $FINAL_ZIP as it stands."
     say "  (its version is checked below, but nothing else about it is.)"
 else

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -352,6 +352,26 @@ PY
 
 # Commit and push the appcast prepared above. Split from the preparation so
 # every check runs before the release exists.
+# Whether pull request `$1` actually reached MERGED, waiting up to 30 minutes for
+# the required status check to report.
+#
+# 30 minutes at 30s intervals: `make test` on a hosted runner takes about six, and
+# a bound means a wedged check costs a loud failure rather than a release script
+# that never returns. An empty number — `gh pr list` raced the create, or changed
+# shape — is "unknown", which is treated as not merged.
+appcast_pr_merged() {
+    local num="$1" state
+    [ -n "$num" ] || return 1
+    local i
+    for i in $(seq 1 60); do
+        state="$(gh pr view "$num" --repo "$RELEASE_REPO" --json state -q .state 2>/dev/null || echo "")"
+        [ "$state" = "MERGED" ] && return 0
+        [ "$state" = "CLOSED" ] && return 1
+        sleep 30
+    done
+    return 1
+}
+
 push_sparkle_appcast() {
     # The branch the appcast lives on, read from the clone rather than assumed —
     # `gh repo clone` checks out the remote's default branch, whatever it is.
@@ -383,12 +403,30 @@ push_sparkle_appcast() {
                        --title "Update Sparkle appcast for $TAG" \
                        --body "Published by scripts/publish-release.sh for $TAG." >/dev/null 2>&1
             then
+                # Read before a merge deletes the branch this looks up by.
+                local pr_num
+                pr_num="$(gh pr list --repo "$RELEASE_REPO" --head "$branch" \
+                              --json number -q '.[0].number' 2>/dev/null || echo "")"
                 # `--auto` is what works once a required check exists; a PR with
                 # nothing pending is mergeable immediately and `--auto` refuses
                 # it, which is not a failure. Both forms delete the branch.
                 if gh pr merge "$branch" --repo "$RELEASE_REPO" --squash --delete-branch --auto >/dev/null 2>&1 \
                     || gh pr merge "$branch" --repo "$RELEASE_REPO" --squash --delete-branch >/dev/null 2>&1; then
-                    return 0
+                    # ENABLING auto-merge is not merging. `--auto` returns success
+                    # the moment GitHub accepts the request, minutes before the
+                    # required check reports, so returning here would let the
+                    # release finish and report success over a feed that had not
+                    # been updated — and if the check then went red, nothing would
+                    # ever say so. The whole point of the die below is that this
+                    # failure is loud; it cannot be loud from a promise.
+                    if appcast_pr_merged "$pr_num"; then
+                        return 0
+                    fi
+                    # A pending or rejected check is not repaired by opening a
+                    # second pull request for the same commit, so stop retrying
+                    # and let the operator see it. The retry below exists for a
+                    # different failure — somebody else moved the branch.
+                    break
                 fi
                 say "  appcast PR opened but did not merge (attempt $attempt)"
             else
@@ -399,8 +437,10 @@ push_sparkle_appcast() {
         done
         die "the GitHub Release for $TAG IS LIVE, but the Sparkle appcast could NOT be
   merged. Users will not be offered it until the feed is updated. Look for an open
-  \"Update Sparkle appcast for $TAG\" pull request and merge it, or re-run this
-  script — the release will be updated in place and the appcast retried."
+  \"Update Sparkle appcast for $TAG\" pull request — it may simply still be waiting
+  on the required \`test\` check, in which case it merges itself and nothing more is
+  needed; if that check went red, fix it and merge. Re-running this script also
+  works — the release is updated in place and the appcast retried."
     else
         say "Sparkle appcast already up to date"
     fi

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -155,16 +155,74 @@ prepare_sparkle_appcast() {
     # what was published — `check_signatures_unchanged` (run below, before anything
     # is pushed) refuses the feed if any already-published item's signature moved,
     # which is exactly what a locally rebuilt zip would cause.
-    local asset_dir history
+    # Where those past archives come from. NOT `dirname "$ASSET_ZIP"`, which is this
+    # checkout's own `dist/` — a per-worktree directory that a fresh worktree has
+    # never written to. 0.3.84 was released from one and shipped with **no deltas at
+    # all**: `Appcast: 1 archives available` (the new zip alone), a feed that is
+    # internally consistent, zero errors, and every existing user downloading 12.6 MB
+    # instead of the 692 KB patch. The published assets are the only copy that is
+    # guaranteed to be byte-for-byte what shipped anyway, so ask GitHub for them and
+    # keep them in one cache that does not move with the checkout.
+    local cache_dir asset_dir tag_list archive_name cached count
+    cache_dir="${DUO_RELEASE_ARCHIVE_CACHE:-$HOME/Library/Caches/duo-updater/release-archives}"
+    mkdir -p "$cache_dir"
+
+    # Seed from this checkout's dist/ when it happens to have them: free, and it keeps
+    # working with no network for anyone who has just built several releases in a row.
     asset_dir="$(dirname "$ASSET_ZIP")"
-    history="$(ls -t "$asset_dir"/DuoUpdater-*-macos.zip 2>/dev/null | head -6)"
-    if [ -n "$history" ]; then
-        # `cp -n`: never clobber the asset just copied in, whose bytes are the ones
-        # being released.
-        printf '%s\n' "$history" | while IFS= read -r archive; do
-            [ -f "$archive" ] && cp -n "$archive" "$appcast_archives_dir/" 2>/dev/null || true
-        done
-        say "Appcast: $(printf '%s\n' "$history" | wc -l | tr -d ' ') archives available for delta generation"
+    for archive in "$asset_dir"/DuoUpdater-*-macos.zip; do
+        [ -f "$archive" ] && cp -n "$archive" "$cache_dir/" 2>/dev/null || true
+    done
+
+    # Then fill the gaps from the releases themselves. `--maximum-deltas` is 5, so the
+    # tool wants the new build plus the five before it; anything older is copied,
+    # diffed and then dropped by the cap.
+    tag_list="$(gh release list --repo "$RELEASE_REPO" --limit 8 --json tagName,isDraft,isPrerelease \
+        --jq '.[] | select(.isDraft == false and .isPrerelease == false) | .tagName' 2>/dev/null || true)"
+    # `while read`, not `for tag in $tag_list`: word-splitting an unquoted variable is
+    # a shell-dependent behaviour (zsh does not split by default), and this loop going
+    # around once with all eight tags glued together fails exactly the way the bug it
+    # fixes did — a name that matches nothing, a download that quietly does nothing.
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        [ "$tag" = "$TAG" ] && continue
+        archive_name="DuoUpdater-${tag#v}-macos.zip"
+        [ -f "$cache_dir/$archive_name" ] && continue
+        say "Appcast: fetching $archive_name for delta generation"
+        gh release download "$tag" --repo "$RELEASE_REPO" --pattern "$archive_name" \
+            --dir "$cache_dir" 2>/dev/null || say "Appcast: could not fetch $archive_name — continuing"
+    done <<< "$tag_list"
+
+    # Which six, chosen by RELEASE ORDER and not by file mtime. `ls -t` was the
+    # original rule and it is wrong the moment the cache is filled by downloading:
+    # the files land oldest-tag-last, so newest-mtime-first hands back the six
+    # *oldest* releases — patches from versions almost nobody is running. GitHub
+    # lists releases newest-first, so use that order and stop at six.
+    #
+    # `cp -n` throughout: never clobber the asset copied in above, whose bytes are
+    # the ones being released (its own tag appears in this list on a re-run).
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        archive_name="DuoUpdater-${tag#v}-macos.zip"
+        [ -f "$cache_dir/$archive_name" ] || continue
+        cp -n "$cache_dir/$archive_name" "$appcast_archives_dir/" 2>/dev/null || true
+        [ "$(ls "$appcast_archives_dir"/DuoUpdater-*-macos.zip 2>/dev/null | wc -l | tr -d ' ')" -ge 6 ] && break
+    done <<< "$tag_list"
+    count="$(ls "$appcast_archives_dir"/DuoUpdater-*-macos.zip 2>/dev/null | wc -l | tr -d ' ')"
+    say "Appcast: $count archives available for delta generation (cache: $cache_dir)"
+
+    # One archive means one full download for everyone, which is the failure this
+    # block exists to prevent and which is invisible in the feed afterwards. It is
+    # only legitimate when there is genuinely nothing to patch from — a first publish
+    # into an empty feed. Anything else stops here, before a release is created.
+    if [ "$count" -lt 2 ] && [ -s "$appcast_clone_dir/appcast.xml" ]; then
+        if [ "${ALLOW_NO_DELTAS:-0}" = "1" ]; then
+            say "ALLOW_NO_DELTAS=1 — publishing with no binary patches; every user downloads the full archive."
+        else
+            die "only $count archive available, so this release would ship with no binary patches
+  while the published feed has entries to patch from. Check \`gh release list\` and the
+  cache at $cache_dir, or ALLOW_NO_DELTAS=1 to publish full downloads on purpose."
+        fi
     fi
     sparkle_notes="$appcast_archives_dir/$(basename "${ASSET_ZIP%.*}").md"
     cp "$RELEASE_NOTES_FILE" "$sparkle_notes"
@@ -730,7 +788,17 @@ fi
 # the newest LOCAL git tag, and `gh release create` makes the tag on GitHub. Without
 # a fetch first, that guard holds back the release that was just published, prints
 # one `held back` line, and exits 0 — so `npm run sync` looks like it worked.
-site_repo="${DUO_SITE_REPO:-$REPO_ROOT/../duo-updater-site}"
+#
+# ⚠️ Resolved from the MAIN working tree, not from `$REPO_ROOT`. `$REPO_ROOT` is
+# whatever checkout is publishing, and releasing from a worktree makes the default
+# `.claude/worktrees/<name>/../duo-updater-site` — a path that does not exist, so
+# the whole block below is skipped and prints NOTHING. That is what happened on
+# 0.3.84: neither branch ran, and the safeguard written because this step had been
+# forgotten twice was itself silently absent. `git worktree list` names the main
+# tree first, which is the one with a sibling site checkout.
+main_tree="$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null \
+    | awk '/^worktree /{print $2; exit}')"
+site_repo="${DUO_SITE_REPO:-${main_tree:-$REPO_ROOT}/../duo-updater-site}"
 if [ -d "$site_repo/.git" ]; then
     synced="$(git -C "$site_repo" log -1 --pretty=%s 2>/dev/null || true)"
     case "$synced" in
@@ -753,4 +821,16 @@ $(printf '\033[1;33m! duoupdater.app is NOT synced yet.\033[0m') Its last sync c
 EOF
             ;;
     esac
+else
+    # Saying nothing is what this check did on 0.3.84, and "no output" reads exactly
+    # like "nothing to do". If the site checkout cannot be found, say so.
+    cat <<EOF
+
+$(printf '\033[1;33m! Could not check duoupdater.app.\033[0m') No git checkout at:
+     $site_repo
+
+  The site keeps a committed copy of CHANGELOG.md and will stay on the previous
+  version until someone syncs it. Point DUO_SITE_REPO at the checkout, or sync by
+  hand — see the steps in this script beside this message.
+EOF
 fi

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -283,8 +283,18 @@ PY
     while IFS= read -r d; do
         [ -n "$d" ] && delta_assets+=("$d")
     done < <(find "$appcast_archives_dir" -maxdepth 1 -name '*.delta' -type f | sort)
+    # Count the PATCHES, not the archives. The gate further up asks how many
+    # archives went in, which is the input to this question and not the question:
+    # `generate_appcast` skips a delta that is not meaningfully smaller, that it
+    # cannot sign, or that failed to build — printing a line and carrying on. Six
+    # archives in and zero patches out is exactly as silent as the one-archive
+    # case that shipped 0.3.84 with no patches at all.
     if [ ${#delta_assets[@]} -gt 0 ]; then
         say "Appcast: ${#delta_assets[@]} binary patches to upload alongside the archive"
+    elif [ "$count" -ge 2 ] && [ "${ALLOW_NO_DELTAS:-0}" != "1" ]; then
+        die "$count archives were available but generate_appcast produced no binary
+  patches, so every user would download the full archive. Look for its own
+  \"skipping delta\" lines above, or ALLOW_NO_DELTAS=1 to publish anyway."
     fi
 
     # What the regenerated feed has to look like. `$appcast_clone_dir/appcast.xml`
@@ -514,6 +524,9 @@ if [ "${SKIP_TESTS:-0}" = "1" ]; then
     say "SKIP_TESTS=1 — NOT running the test suite before publishing."
 else
     say "Running tests before publishing (SKIP_TESTS=1 to override)"
+    # Not the only gate any more — .github/workflows/ci.yml runs this same
+    # `make test` on every pull request — but still the only one that runs against
+    # the exact tree being published.
     # `make test`, not one package: this ran only DuoUpdaterCore, so a red CLI
     # suite published. Output is NOT swallowed — some of these tests hit the
     # network, and swallowing makes "the network blipped" and "the suite is red"
@@ -545,11 +558,25 @@ if [ -n "${CI_RUN_ID:-}" ]; then
     # here specifically — a self-hosted runner running as the desktop user is why
     # this repository deleted its previous workflow when it went public.
     say "Verifying the artifact's build provenance"
+    # `--source-digest` is the one that ties the binary to THIS release.
+    # `--signer-workflow` constrains the workflow path and nothing else: it does
+    # not look at the ref or the commit, so without this line an artifact built
+    # from any branch, at any commit, passes. That is not hypothetical — the first
+    # end-to-end run of this path verified an artifact built from
+    # `refs/heads/claude/ci-release-provenance` at a commit that was not the
+    # release commit, and every gate was green.
+    #
+    # The version check further down does NOT cover this. It compares
+    # CFBundleShortVersionString and CFBundleVersion, so every commit between two
+    # version bumps is identical to it: it catches a stale version, never a
+    # different commit.
     gh attestation verify "$ci_zip" --repo "$RELEASE_REPO" \
         --signer-workflow "$RELEASE_REPO/.github/workflows/release-build.yml" \
+        --source-digest "$RELEASE_COMMIT" \
         --deny-self-hosted-runners \
-        || die "the artifact from run $CI_RUN_ID has no valid provenance from
-  $RELEASE_REPO/.github/workflows/release-build.yml — refusing to publish it."
+        || die "the artifact from run $CI_RUN_ID has no valid provenance for commit
+  $RELEASE_COMMIT from $RELEASE_REPO/.github/workflows/release-build.yml.
+  Run that workflow on the commit you are releasing, and use ITS run id."
 
     # `notarize.sh` did not run here, so its gates have not run either. They are
     # not optional just because a green workflow produced the file: this script is
@@ -560,9 +587,18 @@ if [ -n "${CI_RUN_ID:-}" ]; then
     ci_unpack="$ci_dir/unpacked"
     mkdir -p "$ci_unpack"
     ditto -x -k "$ci_zip" "$ci_unpack" || die "could not unpack $ci_zip"
-    ci_app="$(find "$ci_unpack" -maxdepth 1 -name '*.app' -type d | head -n 1)"
-    [ -n "$ci_app" ] || die "no .app inside the artifact from run $CI_RUN_ID"
-    ci_sig="$(codesign -dvv "$ci_app" 2>&1)"
+    # No `| head`: under `pipefail` a closed pipe turns a benign multi-match into a
+    # silent non-zero exit. Count first, then take one, so "more than one .app"
+    # gets a sentence instead of an unexplained death.
+    ci_apps="$(find "$ci_unpack" -maxdepth 1 -name '*.app' -type d)"
+    ci_app_count="$(printf '%s\n' "$ci_apps" | grep -c . || true)"
+    [ "$ci_app_count" -eq 1 ] || die "expected exactly one .app in the artifact from
+  run $CI_RUN_ID, found $ci_app_count."
+    ci_app="$ci_apps"
+    # `|| true`: `codesign -dvv` exits non-zero for a COMPLETELY unsigned bundle,
+    # and under `set -e` that kills the script here with no message at all — before
+    # the four gates below can say which one failed.
+    ci_sig="$(codesign -dvv "$ci_app" 2>&1 || true)"
     case "$ci_sig" in *"adhoc"*) die "the CI artifact is AD-HOC signed";; esac
     case "$ci_sig" in
         *"TeamIdentifier=$ci_team"*) ;;
@@ -571,6 +607,14 @@ if [ -n "${CI_RUN_ID:-}" ]; then
     case "$ci_sig" in
         *"flags=0x10000(runtime)"*) ;;
         *) die "the CI artifact does not have the hardened runtime enabled";;
+    esac
+    # The fourth gate, and the one this path was missing while its own comment
+    # claimed to re-apply "notarize.sh's own gates": a build carrying
+    # get-task-allow is debuggable, which is exactly what must not ship.
+    ci_ents="$(codesign -d --entitlements :- "$ci_app" 2>&1 || true)"
+    case "$ci_ents" in
+        *"com.apple.security.get-task-allow"*)
+            die "the CI artifact carries the get-task-allow entitlement";;
     esac
     xcrun stapler validate "$ci_app" >/dev/null 2>&1 \
         || die "the CI artifact is not stapled — Gatekeeper would need the network to admit it"
@@ -868,8 +912,11 @@ fi
 # 0.3.84: neither branch ran, and the safeguard written because this step had been
 # forgotten twice was itself silently absent. `git worktree list` names the main
 # tree first, which is the one with a sibling site checkout.
+# `|| true` for the same reason the line below it has one: this is a pipeline
+# assignment under `set -e`, so a failing `git worktree list` would end the script
+# silently, right after a successful publish — the shape this block exists to fix.
 main_tree="$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null \
-    | awk '/^worktree /{print $2; exit}')"
+    | awk '/^worktree /{print $2; exit}' || true)"
 site_repo="${DUO_SITE_REPO:-${main_tree:-$REPO_ROOT}/../duo-updater-site}"
 if [ -d "$site_repo/.git" ]; then
     synced="$(git -C "$site_repo" log -1 --pretty=%s 2>/dev/null || true)"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -353,27 +353,54 @@ PY
 # Commit and push the appcast prepared above. Split from the preparation so
 # every check runs before the release exists.
 push_sparkle_appcast() {
+    # The branch the appcast lives on, read from the clone rather than assumed —
+    # `gh repo clone` checks out the remote's default branch, whatever it is.
+    local appcast_base
+    appcast_base="$(git -C "$appcast_clone_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
     cp "$appcast_archives_dir/appcast.xml" "$appcast_clone_dir/appcast.xml"
 
     if [ -n "$(git -C "$appcast_clone_dir" status --short -- appcast.xml)" ]; then
         say "Publishing Sparkle appcast to $RELEASE_REPO"
         git -C "$appcast_clone_dir" add appcast.xml
         git -C "$appcast_clone_dir" commit -m "Update Sparkle appcast for $TAG" >/dev/null
-        # The clone is taken before the release is created and the asset uploaded,
-        # so minutes pass before this runs and another push can land in between.
-        # (When this all lived in one function the window was too small to matter.)
-        local attempt
+        # Through a pull request, not a push to the default branch.
+        #
+        # That branch is protected so nobody can put a rewritten release workflow
+        # on it and dispatch it with the Apple signing key. This function and the
+        # mini's nightly baseline job were the two things that still needed the
+        # direct push; both go through a PR now, so the rule can be turned on.
+        #
+        # The retry keeps its original reason: the clone is taken before the
+        # release is created and the asset uploaded, so minutes pass before this
+        # runs and another commit can land in between. What used to be a rebase
+        # before re-pushing is now a rebase before opening a fresh PR — the
+        # failure it handles (somebody else moved the branch) is the same one.
+        local attempt branch
         for attempt in 1 2 3; do
-            if git -C "$appcast_clone_dir" push origin HEAD >/dev/null 2>&1; then
-                return 0
+            branch="appcast/${TAG}-$(date -u +%Y%m%dT%H%M%SZ)-$attempt"
+            if git -C "$appcast_clone_dir" push origin "HEAD:refs/heads/$branch" >/dev/null 2>&1 \
+                && gh pr create --repo "$RELEASE_REPO" --base "$appcast_base" --head "$branch" \
+                       --title "Update Sparkle appcast for $TAG" \
+                       --body "Published by scripts/publish-release.sh for $TAG." >/dev/null 2>&1
+            then
+                # `--auto` is what works once a required check exists; a PR with
+                # nothing pending is mergeable immediately and `--auto` refuses
+                # it, which is not a failure. Both forms delete the branch.
+                if gh pr merge "$branch" --repo "$RELEASE_REPO" --squash --delete-branch --auto >/dev/null 2>&1 \
+                    || gh pr merge "$branch" --repo "$RELEASE_REPO" --squash --delete-branch >/dev/null 2>&1; then
+                    return 0
+                fi
+                say "  appcast PR opened but did not merge (attempt $attempt)"
+            else
+                say "  appcast branch/PR failed (attempt $attempt) — rebasing onto the current head"
             fi
-            say "  appcast push rejected (attempt $attempt) — rebasing onto the current head"
             git -C "$appcast_clone_dir" fetch origin --quiet 2>/dev/null || true
-            git -C "$appcast_clone_dir" pull --rebase --quiet origin HEAD 2>/dev/null || true
+            git -C "$appcast_clone_dir" pull --rebase --quiet origin "$appcast_base" 2>/dev/null || true
         done
-        die "the GitHub Release for $TAG IS LIVE, but the Sparkle appcast could NOT be pushed.
-  Users will not be offered it until the feed is updated. Re-run this script — the
-  release will be updated in place and the appcast retried."
+        die "the GitHub Release for $TAG IS LIVE, but the Sparkle appcast could NOT be
+  merged. Users will not be offered it until the feed is updated. Look for an open
+  \"Update Sparkle appcast for $TAG\" pull request and merge it, or re-run this
+  script — the release will be updated in place and the appcast retried."
     else
         say "Sparkle appcast already up to date"
     fi


### PR DESCRIPTION
Two silent failures in `publish-release.sh`, both caused by resolving paths from `$REPO_ROOT`, both triggered by releasing 0.3.84 from a worktree. Neither failed; neither printed anything.

**1. 0.3.84 shipped with no binary patches.** Delta source archives came from this checkout's `dist/`. A worktree created that week has never written a release there, so the log read `Appcast: 1 archives available for delta generation` and every existing user downloaded 12.6 MB where the patch from the previous build is 692 KB. The feed was internally consistent afterwards, so nothing could catch it. (Already repaired on the live release by hand — v0.3.84 now carries its five patches.)

Archives now come from a cache outside any checkout, seeded from `dist/` and filled from the **published release assets** — the only copy guaranteed byte-for-byte identical to what shipped, which is what `check_signatures_unchanged` requires anyway. Fewer than two archives, while the published feed has entries to patch from, now **stops the release before it is created** (`ALLOW_NO_DELTAS=1` for a genuine first publish).

**2. The site-sync reminder printed nothing.** It resolved duoupdater.app as `$REPO_ROOT/../duo-updater-site`, which from a worktree does not exist, so the `if [ -d ]` fell through silently. The safeguard written *because* this step had been forgotten twice (0.3.50–0.3.53, then 0.3.56) was itself absent on 0.3.84, the same way. Now resolved from the main working tree, and the not-found case is loud.

Two more shell bugs found while testing the replacement:

- `for tag in $tag_list` relies on word-splitting an unquoted variable, which **zsh does not do** — caught because my first test harness ran under zsh and downloaded nothing.
- `ls -t | head -6` picks by mtime. A cache filled by downloading lands oldest-tag-last, so newest-mtime-first returns the six **oldest** releases. Archives are now chosen in the order GitHub lists releases. Verified: the old rule feeds 0.3.77–0.3.82, the new one feeds 0.3.80–0.3.85.

## CI

First workflow since the repo went public. The previous one was deleted that day because it pointed at a self-hosted runner running as the desktop user; that reasoning still holds, so this is built the other way round — GitHub-hosted only, **no secrets**, `pull_request` and never `pull_request_target`, actions pinned by commit SHA.

No secrets costs nothing here: `make test` already needs none (both xcodebuild calls pass `CODE_SIGNING_ALLOWED=NO`, `DUO_TEAM_ID` has a default). `macos-latest` is arm64 M1, matching the arm64-only product.

Signing, notarization and publishing stay out on purpose — see the discussion in the linked issue for the split.

## Verification

- `make test` green locally on this branch (2255 CLI + 188 Core, App 9/9, four Python gates).
- Fetch loop and archive ordering exercised against the real repository.
- All three branches of the site check exercised from a worktree.
- The CI job itself: **this PR is its first run** — see the checks below.