### PR TITLE
Re-point Vorssaint at the slug GitHub actually answers to

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -325,7 +325,8 @@ public enum ChannelProofRegistry {
         // release carries it too (`Vorssaint-3.3.3-beta.3.dmg`). Anchored on the
         // tag segment of the download path rather than a bare `-beta`, for the
         // reason spelled out on VSCodium above: neither the owner
-        // (`vorssaintapp`) nor the repo (`vorssaint-utils`) contains the token
+        // (`vorssaint`, `vorssaintapp` before the 2026-09-05 rename) nor the repo
+        // (`vorssaint-utils`) contains the token
         // today, but a proof that could be satisfied by a fixed part of every URL
         // this rule can ever build is a proof that cannot fail. Stable's artifact
         // (`Vorssaint-3.3.2.dmg`, under `/download/v3.3.2/`) fails this pattern,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1626,15 +1626,21 @@ public enum GitHubReleaseRegistry {
         // `-beta.N` is what `ReleaseChannel.detect` reads — stable and beta share
         // both the bundle id and the app name, so nothing else distinguishes
         // them), and `duo install` landed it on the beta build.
+        // Renamed upstream; re-pointed 2026-09-05 (was vorssaintapp/vorssaint-utils).
+        // The nightly sweep caught it as `staleSlug` + `anonymousDespiteToken` on both
+        // channels (#340, #341): URLSession drops `Authorization` following GitHub's
+        // 301, so the rule was silently competing for the anonymous 60/hour per-IP
+        // budget. Verified 2026-09-05: `repos/vorssaintapp/vorssaint-utils` answers
+        // 301 and `full_name` reads `vorssaint/vorssaint-utils`.
         GitHubReleaseRule(
             bundleID: "com.vorssaint.utils",
-            owner: "vorssaintapp", repo: "vorssaint-utils",
+            owner: "vorssaint", repo: "vorssaint-utils",
             versionPattern: #"^v([0-9]+(?:\.[0-9]+)+)$"#,
             installAssetPattern: #"^Vorssaint-[0-9.]+\.dmg$"#,
             installerKind: .dmg),
         GitHubReleaseRule(
             bundleID: "com.vorssaint.utils",
-            owner: "vorssaintapp", repo: "vorssaint-utils",
+            owner: "vorssaint", repo: "vorssaint-utils",
             usePrereleases: true,
             versionPattern: #"^v([0-9]+(?:\.[0-9]+)+-beta\.[0-9]+)$"#,
             installAssetPattern: #"^Vorssaint-[0-9.]+-beta\.[0-9]+\.dmg$"#,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubChannelProofTests.swift
@@ -172,8 +172,9 @@ struct GitHubChannelProofTests {
     /// it covers the next one automatically.
     ///
     /// Caught in practice: writing the Vorssaint beta proof, a mutation to the
-    /// bare token `vorssaint` — which sits in BOTH the owner (`vorssaintapp`) and
-    /// the repo (`vorssaint-utils`), so it matches every URL this rule builds —
+    /// bare token `vorssaint` — which sits in BOTH the owner (`vorssaint`, and
+    /// `vorssaintapp` before the 2026-09-05 rename) and the repo
+    /// (`vorssaint-utils`), so it matches every URL this rule builds —
     /// passed the entire suite. It fails here.
     @Test func anArtifactProofCannotMatchItsRulesInvariantURLPrefix() {
         for (key, proof) in ChannelProofRegistry.githubProofs {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -879,7 +879,8 @@ private func matches(
     let expected: [String: String] = [
         "com.ccswitch.desktop": "farion1231/cc-switch",
         "com.usebruno.app": "usebruno/bruno",
-        "com.vorssaint.utils": "vorssaintapp/vorssaint-utils",
+        // Renamed upstream; re-pinned 2026-09-05 (was vorssaintapp/vorssaint-utils). #340
+        "com.vorssaint.utils": "vorssaint/vorssaint-utils",
         "org.openlogi.openlogi": "AprilNEA/OpenLogi",
         "org.localsend.localsendApp": "localsend/localsend",
         "com.utmapp.UTM": "utmapp/UTM",


### PR DESCRIPTION
Closes #340. Closes #341. One slug serves both channels, so one fix clears both. Verified live: `GitHub rule ✓ 2 ⚠ 0`, previously two warnings on each for two consecutive sweeps.