### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -4,7 +4,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -12,7 +12,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
     },
@@ -20,7 +20,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -28,7 +28,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -36,7 +36,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
     },
@@ -44,7 +44,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
     },
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -60,7 +60,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
     },
@@ -68,7 +68,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -76,7 +76,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -84,7 +84,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -92,7 +92,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.84.0",
       "sweepsSinceComment" : 0
     },
@@ -100,7 +100,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -108,7 +108,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
     },
@@ -116,7 +116,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -132,7 +132,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
     },
@@ -140,7 +140,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
     },
@@ -148,7 +148,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -156,7 +156,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
     },
@@ -164,7 +164,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
     },
@@ -172,7 +172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "152.0.7977.82",
       "sweepsSinceComment" : 0
     },
@@ -180,7 +180,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -188,7 +188,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -196,7 +196,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -204,7 +204,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
     },
@@ -212,7 +212,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -220,7 +220,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
     },
@@ -228,7 +228,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -236,7 +236,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -244,7 +244,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -252,7 +252,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.136",
       "sweepsSinceComment" : 0
     },
@@ -260,7 +260,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
     },
@@ -270,7 +270,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (26.727) trails t"
@@ -279,7 +279,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -287,7 +287,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -295,7 +295,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -303,7 +303,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "12.26.5",
       "sweepsSinceComment" : 0
     },
@@ -311,7 +311,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
     },
@@ -319,7 +319,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
     },
@@ -327,7 +327,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.13.2",
       "sweepsSinceComment" : 0
     },
@@ -335,7 +335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.3.4",
       "sweepsSinceComment" : 0
     },
@@ -343,7 +343,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
     },
@@ -351,7 +351,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -359,7 +359,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -369,7 +369,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "noEntriesExtracted"
@@ -378,7 +378,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -386,7 +386,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -394,7 +394,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -402,7 +402,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
     },
@@ -410,7 +410,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -418,7 +418,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
     },
@@ -426,7 +426,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.7.0-daily.20260904",
       "sweepsSinceComment" : 0
     },
@@ -434,7 +434,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -442,7 +442,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -452,7 +452,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (5.2.7) trails th"
@@ -461,7 +461,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -469,7 +469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -477,7 +477,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
     },
@@ -485,7 +485,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -493,7 +493,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -501,7 +501,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -509,7 +509,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -517,7 +517,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -525,7 +525,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -533,7 +533,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -541,7 +541,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.14.0",
       "sweepsSinceComment" : 0
     },
@@ -549,7 +549,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
     },
@@ -557,15 +557,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
-      "lastGoodVersion" : "0.16.4.1",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
+      "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
     "changelog:net.kovidgoyal.calibre:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
@@ -573,7 +573,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0
     },
@@ -581,7 +581,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
     },
@@ -589,7 +589,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
     },
@@ -597,7 +597,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
     },
@@ -605,7 +605,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
     },
@@ -613,7 +613,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -621,7 +621,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -629,7 +629,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
     },
@@ -637,7 +637,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -645,7 +645,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
     },
@@ -653,7 +653,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
@@ -661,7 +661,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
     },
@@ -669,7 +669,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
@@ -677,7 +677,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.1.17",
       "sweepsSinceComment" : 0
     },
@@ -685,7 +685,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     },
@@ -693,7 +693,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -701,7 +701,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -709,7 +709,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -717,7 +717,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -725,7 +725,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -733,7 +733,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -741,7 +741,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -749,7 +749,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.3.7",
       "sweepsSinceComment" : 0
     },
@@ -757,7 +757,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -765,7 +765,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -773,7 +773,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -781,7 +781,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.135.05934-insider",
       "sweepsSinceComment" : 0
     },
@@ -789,7 +789,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.126.04524",
       "sweepsSinceComment" : 0
     },
@@ -797,7 +797,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -805,7 +805,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -813,7 +813,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.49.0",
       "sweepsSinceComment" : 0
     },
@@ -821,7 +821,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -829,7 +829,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -837,7 +837,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -845,7 +845,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -853,7 +853,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -861,7 +861,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
     },
@@ -869,7 +869,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.0.5",
       "sweepsSinceComment" : 0
     },
@@ -877,7 +877,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -885,7 +885,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -893,7 +893,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -901,7 +901,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -909,7 +909,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -917,7 +917,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -925,7 +925,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -933,7 +933,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -941,7 +941,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -949,7 +949,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
     },
@@ -957,7 +957,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -965,7 +965,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -973,7 +973,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -981,7 +981,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.0.14",
       "sweepsSinceComment" : 0
     },
@@ -989,7 +989,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.20.1",
       "sweepsSinceComment" : 0
     },
@@ -997,7 +997,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1005,7 +1005,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1013,7 +1013,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1021,7 +1021,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1029,7 +1029,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.1.15",
       "sweepsSinceComment" : 0
     },
@@ -1037,7 +1037,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1045,15 +1045,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
-      "lastGoodVersion" : "0.16.4.1",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
+      "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
     "github:janhq\/jan:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1061,7 +1061,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "31.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1069,7 +1069,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1077,7 +1077,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1085,7 +1085,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1093,7 +1093,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1101,7 +1101,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1109,7 +1109,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1117,7 +1117,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1125,7 +1125,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1133,7 +1133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1141,7 +1141,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1149,7 +1149,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1157,7 +1157,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1165,7 +1165,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -1173,7 +1173,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.22.1",
       "sweepsSinceComment" : 0
     },
@@ -1181,7 +1181,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.0.38",
       "sweepsSinceComment" : 0
     },
@@ -1189,15 +1189,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
-      "lastGoodVersion" : "0.0.39-nightly.20260905.1285",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
+      "lastGoodVersion" : "0.0.39-nightly.20260905.1287",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1205,7 +1205,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1213,7 +1213,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1221,7 +1221,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1229,7 +1229,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1237,7 +1237,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1245,7 +1245,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1253,7 +1253,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1261,7 +1261,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1269,7 +1269,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1277,7 +1277,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1285,7 +1285,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1293,7 +1293,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1301,7 +1301,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1309,7 +1309,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1317,8 +1317,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.7.5",
+      "sweepsSinceComment" : 0
+    },
+    "github:vorssaint\/vorssaint-utils:beta" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
+      "lastGoodVersion" : "3.3.3-beta.4",
+      "sweepsSinceComment" : 0
+    },
+    "github:vorssaint\/vorssaint-utils:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
+      "lastGoodVersion" : "3.3.2",
       "sweepsSinceComment" : 0
     },
     "github:vorssaintapp\/vorssaint-utils:beta" : {
@@ -1347,7 +1363,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1355,7 +1371,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1363,7 +1379,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1371,7 +1387,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -1379,7 +1395,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.21.16b",
       "sweepsSinceComment" : 0
     },
@@ -1387,7 +1403,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1395,7 +1411,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -1403,7 +1419,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "151.0.7922.247",
       "sweepsSinceComment" : 0
     },
@@ -1411,7 +1427,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1419,7 +1435,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1427,7 +1443,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1435,7 +1451,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1443,7 +1459,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -1451,7 +1467,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.1",
       "sweepsSinceComment" : 0
     },
@@ -1459,7 +1475,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
     },
@@ -1467,7 +1483,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1475,7 +1491,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.43.0",
       "sweepsSinceComment" : 0
     },
@@ -1483,7 +1499,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1491,7 +1507,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1499,7 +1515,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1507,7 +1523,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1515,7 +1531,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1523,7 +1539,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1531,7 +1547,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1539,7 +1555,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.95.96.0",
       "sweepsSinceComment" : 0
     },
@@ -1547,7 +1563,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.97.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1555,7 +1571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -1563,7 +1579,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.124.1",
       "sweepsSinceComment" : 0
     },
@@ -1571,7 +1587,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.84.2",
       "sweepsSinceComment" : 0
     },
@@ -1579,7 +1595,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1587,7 +1603,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
     },
@@ -1595,7 +1611,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -1603,7 +1619,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.6.774",
       "sweepsSinceComment" : 0
     },
@@ -1611,7 +1627,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.8.20",
       "sweepsSinceComment" : 0
     },
@@ -1619,7 +1635,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -1627,7 +1643,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "126.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1635,7 +1651,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -1643,7 +1659,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "154.0.8037.0",
       "sweepsSinceComment" : 0
     },
@@ -1651,7 +1667,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "155.0.8043.0",
       "sweepsSinceComment" : 0
     },
@@ -1659,7 +1675,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -1667,7 +1683,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "152.0.7977.83",
       "sweepsSinceComment" : 0
     },
@@ -1675,7 +1691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.107.3.828",
       "sweepsSinceComment" : 0
     },
@@ -1683,7 +1699,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -1691,7 +1707,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -1699,7 +1715,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -1707,7 +1723,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -1715,7 +1731,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -1723,7 +1739,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "7.529.3",
       "sweepsSinceComment" : 0
     },
@@ -1731,7 +1747,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1739,7 +1755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.0.410",
       "sweepsSinceComment" : 0
     },
@@ -1747,7 +1763,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.0.1311",
       "sweepsSinceComment" : 0
     },
@@ -1755,7 +1771,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -1763,7 +1779,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -1771,7 +1787,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1779,7 +1795,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -1787,7 +1803,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -1804,7 +1820,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "9.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1812,7 +1828,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -1820,7 +1836,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1828,7 +1844,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -1836,7 +1852,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1844,7 +1860,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -1852,7 +1868,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -1860,7 +1876,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1868,7 +1884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.136.1",
       "sweepsSinceComment" : 0
     },
@@ -1876,7 +1892,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.137.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -1884,7 +1900,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1892,7 +1908,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "153.0.4234.19",
       "sweepsSinceComment" : 0
     },
@@ -1900,7 +1916,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "154.0.4251.0",
       "sweepsSinceComment" : 0
     },
@@ -1908,7 +1924,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -1916,7 +1932,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -1924,7 +1940,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -1932,7 +1948,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -1940,7 +1956,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1948,7 +1964,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -1956,7 +1972,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -1964,7 +1980,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.901.41600",
       "sweepsSinceComment" : 0
     },
@@ -1972,7 +1988,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -1980,7 +1996,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -1988,7 +2004,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -1996,7 +2012,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "12.26.5",
       "sweepsSinceComment" : 0
     },
@@ -2004,7 +2020,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.104.28",
       "sweepsSinceComment" : 0
     },
@@ -2012,7 +2028,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2020,7 +2036,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2028,7 +2044,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2036,7 +2052,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2044,7 +2060,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.2.98.301",
       "sweepsSinceComment" : 0
     },
@@ -2052,7 +2068,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2060,7 +2076,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2068,7 +2084,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2076,7 +2092,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2084,7 +2100,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "7.2.5",
       "sweepsSinceComment" : 0
     },
@@ -2092,7 +2108,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2102,7 +2118,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2111,7 +2127,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0
     },
@@ -2119,7 +2135,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2127,7 +2143,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -2135,7 +2151,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2143,7 +2159,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2151,7 +2167,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2159,7 +2175,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2167,7 +2183,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2175,7 +2191,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.19.13",
       "sweepsSinceComment" : 0
     },
@@ -2183,7 +2199,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.21.1",
       "sweepsSinceComment" : 0
     },
@@ -2191,7 +2207,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "8.2.4133.43",
       "sweepsSinceComment" : 0
     },
@@ -2199,7 +2215,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2207,7 +2223,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2215,7 +2231,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2223,7 +2239,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2231,7 +2247,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2239,7 +2255,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2247,7 +2263,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2255,7 +2271,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2263,7 +2279,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2271,7 +2287,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2279,15 +2295,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
-      "lastGoodVersion" : "0.2026.09.04.08.27.00",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
+      "lastGoodVersion" : "0.2026.09.05.08.23.00",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.warp.Warp-Preview:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2295,7 +2311,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2303,7 +2319,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2311,7 +2327,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2026090401",
       "sweepsSinceComment" : 0
     },
@@ -2319,7 +2335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2327,7 +2343,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2335,7 +2351,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2343,7 +2359,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2351,7 +2367,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.103.176",
       "sweepsSinceComment" : 0
     },
@@ -2359,7 +2375,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2367,7 +2383,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -2375,7 +2391,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2383,7 +2399,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2391,7 +2407,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.35.23",
       "sweepsSinceComment" : 0
     },
@@ -2399,7 +2415,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0
     },
@@ -2407,7 +2423,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2415,7 +2431,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2423,7 +2439,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2431,7 +2447,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2439,7 +2455,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
@@ -2447,7 +2463,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
     },
@@ -2455,7 +2471,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2463,7 +2479,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2471,7 +2487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2479,7 +2495,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2487,7 +2503,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2495,7 +2511,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2503,7 +2519,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2511,7 +2527,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2519,7 +2535,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -2527,7 +2543,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "156.0b2",
       "sweepsSinceComment" : 0
     },
@@ -2535,7 +2551,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -2543,7 +2559,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "15.0.21",
       "sweepsSinceComment" : 0
     },
@@ -2551,7 +2567,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -2559,7 +2575,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -2567,7 +2583,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "8.26.0",
       "sweepsSinceComment" : 0
     },
@@ -2577,7 +2593,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "10.0.1",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2586,7 +2602,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -2594,11 +2610,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T08:23:10Z",
+      "lastGoodAt" : "2026-09-05T14:23:06Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-05T08:23:11Z"
+  "updatedAt" : "2026-09-05T14:23:07Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.