### PR TITLE
Revalidate GitHub releases by Last-Modified, not by an ETag that churns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.85
+
+**Checking apps that ship through GitHub costs a fraction of the network it did.** Each check used to download every release's full description again even when nothing had been published; it now asks GitHub whether the release has changed since last time and downloads nothing when it has not.
+
 ## 0.3.84
 
 **Request logs you export no longer carry your account name.** Every row for an app installed in your home folder used to spell out the full path; it now shows `~` instead, whichever way you take the log out.

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -441,7 +441,9 @@ public enum Verify {
     ) async -> [Finding] {
         // All 13 rules share api.github.com, so host-grouping would serialize
         // them anyway. That is the correct behaviour — one shared rate limit.
-        let source = GitHubReleasesSource(token: options.githubToken ?? GitHubToken.resolve())
+        let source = GitHubReleasesSource(
+            token: options.githubToken ?? GitHubToken.resolve(),
+            validatorCache: GitHubConditionalCache.shared)
         var out: [Finding] = []
         for (index, rule) in rules.enumerated() {
             if index > 0 { try? await Task.sleep(for: options.perHostDelay) }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/SourceStack.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/SourceStack.swift
@@ -33,7 +33,9 @@ public enum SourceStack {
             HomebrewCaskSource(),
             // GitHub Releases for apps distributed that way (detection only unless
             // a rule names an installable asset).
-            GitHubReleasesSource(token: githubToken, channelStore: channelStore),
+            GitHubReleasesSource(
+                token: githubToken, channelStore: channelStore,
+                validatorCache: GitHubConditionalCache.shared),
         ]
         // Alcove's licensed update channel, ahead of the vendor probe: it's the only
         // surface carrying release notes, an exact publish time and an installable

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
@@ -1,0 +1,236 @@
+import Foundation
+import CryptoKit
+
+/// Persisted validators (`Last-Modified`, `ETag`) + raw response body for
+/// `GitHubReleasesSource`'s two registry-driven endpoints (`/releases/latest`
+/// and `/releases?per_page=<listPageSize>`), and the conditional GET built
+/// from them.
+///
+/// ## Why this exists, and why `Last-Modified` comes first
+///
+/// `URLSession.updates`' own `URLCache` was measured (not assumed) to almost
+/// never get a 304 for these endpoints: over 36 five-minute rounds on
+/// 2026-09-05, 1348 full 200s against 347 304s across `/releases/latest` for
+/// 49 repos, and 197 against 12 for the 7 `/releases?per_page=N` repos. Per
+/// repo it tracks popularity — VSCodium 34 × 200 / 0 × 304, an obscure repo
+/// 14 / 20 — and the reason is in the body: **GitHub's `ETag` is a hash of the
+/// response, and the response carries `assets[].download_count`.** Two fetches
+/// of VSCodium's `/latest` 240 s apart differed in exactly four
+/// `download_count` values and nothing else, and had different `ETag`s. Any
+/// repo people actually download from mints a new `ETag` every few minutes, so
+/// `If-None-Match` is worthless precisely where the bytes are.
+///
+/// `Last-Modified` is the release's own timestamp (it matched `updated_at`,
+/// not the download counters) and `/releases/latest` honours
+/// `If-Modified-Since` against it — measured the same minute the `ETag` had
+/// just rotated:
+///
+///     If-None-Match: <ETag from 4 min ago>                 → 200, full body
+///     If-Modified-Since: <Last-Modified as served>         → 304
+///     If-None-Match: <stale> + If-Modified-Since: <valid>  → 200, full body
+///     If-Modified-Since: <Last-Modified minus 1 s>         → 200
+///
+/// The third line is why this type exists instead of trusting `URLCache`:
+/// RFC 7232 §6 says a server evaluates `If-None-Match` first and ignores
+/// `If-Modified-Since` when both are present, GitHub does exactly that, and
+/// `URLCache` revalidation sends both whenever it holds both. So the rule
+/// `Validator.conditionalHeaders` encodes is: **when the stored response had a
+/// `Last-Modified`, send `If-Modified-Since` and nothing else; only a response
+/// that had no `Last-Modified` at all is revalidated by `ETag`.** The list
+/// endpoint is the second case — it sends no `Last-Modified` and answers
+/// `If-Modified-Since` with 200 for any date (measured) — so its `ETag` is
+/// kept as the only validator it has, which still buys a 304 for repos whose
+/// counters sit still. The request that carries one of these validators also
+/// bypasses `URLCache` (`.reloadIgnoringLocalCacheData`) so the cache cannot
+/// add its own `If-None-Match` back on top. Issue #357 has the full
+/// measurement.
+///
+/// GitHub confirms a 304 from a *correctly authenticated* conditional request
+/// does not spend the primary rate limit:
+/// <https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api>
+/// ("Making a conditional request does not count against your primary rate
+/// limit if a `304` response is returned and the request was made while
+/// correctly authorized with an `Authorization` header. […] each `304 Not
+/// Modified` response is fast and does not use your rate limit, making
+/// conditional requests especially useful when polling an endpoint.") — matches
+/// what was measured locally (`x-ratelimit-used` did not advance across a 304).
+///
+/// ## What is deliberately NOT here
+///
+/// - **The `/releases/tags/<tag>` channel-discovery lookup.** That endpoint is
+///   minted per *installed version* (`GitHubReleasesSource.ruleFromInstalledRelease`),
+///   not per registry rule — there is no fixed, enumerable set of tag URLs to
+///   prune against the way there is for `/latest` and the list endpoint, so
+///   caching it would accumulate one-off entries forever instead of staying
+///   bounded. It is also not the endpoint the measurement above is about: a
+///   proven channel is already remembered by `ResolvedChannelStore` and the tag
+///   lookup runs at most once per version change, not once per check round. See
+///   `GitHubReleasesSource.fetchReleases` for where this is enforced (the
+///   conditional path is skipped whenever `tag != nil`).
+/// - **Parsed results.** Only the raw HTTP body is stored — see `Entry.body`.
+public actor GitHubConditionalCache {
+
+    /// The instance the app and CLI share. Like `ResolvedChannelStore.shared`,
+    /// nothing defaults to this implicitly — `GitHubReleasesSource`'s own
+    /// `validatorCache` parameter defaults to nil, so a test that constructs a
+    /// source directly (the overwhelming majority of them) writes nothing to the
+    /// real file. Only `SourceStack.make` and `duo verify`'s GitHub sweep wire
+    /// this in.
+    public static let shared = GitHubConditionalCache()
+
+    /// One endpoint's cached validator, keyed by the endpoint URL string.
+    ///
+    /// ⚠️ `body` is the RAW HTTP response body — never a parsed `[Release]` or
+    /// any other derived conclusion. Storing a conclusion would mean a rule
+    /// whose `versionPattern`/`installAssetPattern` changed keeps answering with
+    /// the OLD verdict for as long as GitHub's `ETag` stays unchanged (which can
+    /// be weeks) — recipe fixes would look like they "didn't take". Re-parsing
+    /// the stored body on every 304 is what `GitHubReleasesSource.fetchReleases`
+    /// does, and it is the entire reason this file exists in this shape.
+    struct Entry: Codable, Sendable {
+        /// Both optional so a file written before `lastModified` existed (and
+        /// a response missing either header) still decodes; `store` refuses an
+        /// entry that has neither, so a decoded entry always has at least one.
+        var etag: String?
+        var lastModified: String?
+        var body: Data
+        /// A stable, non-reversible fingerprint of the credential this entry was
+        /// fetched with — see `authFingerprint(_:)`. NEVER the token itself:
+        /// this file lives on disk indefinitely, unlike the in-memory-only
+        /// `URLCache` this replaces. GitHub hands out a different `ETag` to an
+        /// authenticated vs. an anonymous request for the same resource
+        /// (measured), so an entry fetched under one credential is simply wrong
+        /// evidence for another — `validator(for:authFingerprint:)` refuses to
+        /// return it across a mismatch rather than risk serving a body scoped to
+        /// someone else's rate limit or visibility.
+        var authFingerprint: String
+        /// Diagnostics only, mirroring `ResolvedChannelStore.Entry.provenAt` —
+        /// nothing here reads it back.
+        var storedAt: Date
+    }
+
+    /// What `fetchReleases` needs to build a conditional request and to recover
+    /// if the server actually answers 304.
+    public struct Validator: Sendable {
+        public let etag: String?
+        public let lastModified: String?
+        public let body: Data
+
+        /// Every conditional header a request built from this validator sends
+        /// — one, never both. See the type's doc comment for the measurement
+        /// behind the order: a `Last-Modified` wins outright because sending
+        /// the `ETag` alongside it makes GitHub ignore the date and compare the
+        /// (download-count-churned) `ETag` instead.
+        public var conditionalHeaders: [String: String] {
+            if let lastModified { return ["If-Modified-Since": lastModified] }
+            if let etag { return ["If-None-Match": etag] }
+            return [:]
+        }
+
+        /// The header names this layer owns on a request, so the unconditional
+        /// retry can strip exactly these and nothing else.
+        public static let headerNames = ["If-Modified-Since", "If-None-Match"]
+    }
+
+    private var entries: [String: Entry]
+    private let fileURL: URL
+    private var dirty = false
+
+    /// - Parameter fileURL: defaults to
+    ///   `DuoStateDirectory.base/com.duoupdater.app/github-conditional-cache.json`
+    ///   — the same container `ChangelogDiskCache` and the traffic store use, so
+    ///   `duo verify`'s `DUO_STATE_DIR` redirect (see `DuoStateDirectory`) keeps
+    ///   the nightly sweep from reading or writing the running app's copy.
+    public init(fileURL: URL? = nil) {
+        let url = fileURL ?? Self.defaultFileURL()
+        self.fileURL = url
+        self.entries = Self.load(from: url)
+    }
+
+    /// A stable, non-reversible identifier of "which credential" — never the
+    /// token itself. Two tokens (or a token vs. no token) must never be treated
+    /// as interchangeable: GitHub hands out a different `ETag` to an
+    /// authenticated vs. an anonymous request for the same URL (measured), so a
+    /// validator minted under one credential is not valid evidence under
+    /// another — sending it as `If-None-Match` risks a 304 that silently
+    /// resurrects a body fetched under a DIFFERENT identity (e.g. before a token
+    /// was revoked and replaced, or when running without one at all).
+    public static func authFingerprint(_ token: String?) -> String {
+        guard let token, !token.isEmpty else { return "anonymous" }
+        let digest = SHA256.hash(data: Data(token.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// The validator to revalidate `endpoint` with, or nil when nothing is
+    /// cached for this exact endpoint under this exact credential. Validators
+    /// and body are read together as one `Entry` so a caller can never see a
+    /// validator whose matching body has since been evicted or overwritten by
+    /// a concurrent write — they are stored, and read, as one unit.
+    public func validator(for endpoint: String, authFingerprint: String) -> Validator? {
+        guard let entry = entries[endpoint], entry.authFingerprint == authFingerprint else {
+            return nil
+        }
+        return Validator(etag: entry.etag, lastModified: entry.lastModified, body: entry.body)
+    }
+
+    /// Persist a fresh 200's validators + raw body for `endpoint` under this
+    /// credential, replacing whatever (if anything) was there — including an
+    /// entry stored under a different credential, which this simply overwrites
+    /// rather than trying to keep both around. A response with neither
+    /// validator is not stored: there would be nothing to revalidate with, and
+    /// an entry that can only ever miss is a body kept on disk for no reason.
+    public func store(
+        endpoint: String, authFingerprint: String,
+        etag: String?, lastModified: String?, body: Data
+    ) {
+        guard etag != nil || lastModified != nil else { return }
+        entries[endpoint] = Entry(
+            etag: etag, lastModified: lastModified, body: body,
+            authFingerprint: authFingerprint, storedAt: .now)
+        dirty = true
+    }
+
+    /// Drop every entry whose endpoint is not in `validEndpoints` — the set of
+    /// `/latest` and `/releases?per_page=<listPageSize>` URLs the CURRENT registry can
+    /// still ask for. Without this, a repo whose rule is deleted (renamed app,
+    /// retired recipe) leaves its entry behind forever, since nothing else ever
+    /// revisits that URL to notice it's dead. Bounded by construction: the set
+    /// this is pruned against has exactly two entries per registered rule.
+    public func prune(keeping validEndpoints: Set<String>) {
+        let before = entries.count
+        entries = entries.filter { validEndpoints.contains($0.key) }
+        if entries.count != before { dirty = true }
+    }
+
+    /// Clears `dirty` only once the bytes are actually on disk — same reasoning
+    /// as `ResolvedChannelStore.flush()`: an unwritable directory or full volume
+    /// must not silently drop the write AND make the next flush a no-op.
+    public func flush() {
+        guard dirty else { return }
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: fileURL, options: .atomic)
+            dirty = false
+        } catch {
+            Log.source.error(
+                "github-conditional-cache: could not write \(self.fileURL.lastPathComponent, privacy: .public) — \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    static func defaultFileURL() -> URL {
+        DuoStateDirectory.base
+            .appendingPathComponent("com.duoupdater.app", isDirectory: true)
+            .appendingPathComponent("github-conditional-cache.json")
+    }
+
+    /// A corrupt or hand-edited file decodes to nothing — costs one full,
+    /// unconditional fetch per affected endpoint and nothing else. Never thrown.
+    private static func load(from url: URL) -> [String: Entry] {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([String: Entry].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -430,17 +430,65 @@ public struct GitHubReleasesSource: UpdateSource {
     /// the shared instance, and passes the SAME instance to `UpdateChecker` so a
     /// failed check can still read what an earlier one proved.
     private let channelStore: ResolvedChannelStore?
+    /// Where a validator (`Last-Modified` / `ETag` + raw body) for
+    /// `/releases/latest` and `/releases?per_page=<listPageSize>` is remembered
+    /// so `fetchReleases` can revalidate itself — `If-Modified-Since` alone
+    /// wherever the response had a `Last-Modified` — instead of relying on
+    /// `URLCache`, whose `If-None-Match` GitHub answers with a full 200 as soon
+    /// as a download counter moves. See `GitHubConditionalCache`'s doc comment
+    /// for the measurement.
+    /// nil (the default) means "always fetch unconditionally, persist
+    /// nothing" — same convention as `channelStore`, so the many tests that
+    /// construct a source directly cannot accidentally write into the real
+    /// file. `SourceStack.make` and `duo verify`'s GitHub sweep wire in
+    /// `GitHubConditionalCache.shared`.
+    private let validatorCache: GitHubConditionalCache?
 
     public init(
         rules: [GitHubReleaseRule] = GitHubReleaseRegistry.rules,
         token: String? = nil,
         session: URLSession = .updates,
-        channelStore: ResolvedChannelStore? = nil
+        channelStore: ResolvedChannelStore? = nil,
+        validatorCache: GitHubConditionalCache? = nil
     ) {
         self.rules = Dictionary(grouping: rules, by: { $0.bundleID })
         self.token = token
         self.session = session
         self.channelStore = channelStore
+        self.validatorCache = validatorCache
+    }
+
+    /// The `/releases/latest` and `/releases?per_page=<listPageSize>` URLs
+    /// every rule in this instance's registry could ask for — i.e. exactly the
+    /// endpoints `GitHubConditionalCache.prune(keeping:)` is allowed to keep.
+    /// Two per rule regardless of which one that rule actually uses
+    /// (`usePrereleases` picks one for `resolve`, but `channelDiscoveryProbe`
+    /// always fetches the list endpoint for a discoverable rule, so both must
+    /// survive pruning for every rule to avoid punishing the diagnostic path
+    /// for a cache miss on every single sweep).
+    ///
+    /// The list URL must be built with the rule's own `listPageSize`, byte for
+    /// byte the way `fetchReleases` builds it: a first draft hard-coded
+    /// `per_page=20` here after `listPageSize` had made it per-rule, so every
+    /// rule with a smaller page had its list entry stored and then pruned on
+    /// the very same fetch — a cache that could never hit, with no error
+    /// anywhere. `validNonTagEndpointsFollowEachRulesListPageSize` pins it.
+    ///
+    /// Deliberately excludes `/releases/tags/<tag>` — see `GitHubConditionalCache`'s
+    /// doc comment for why that endpoint is not cached at all. This is the set
+    /// `prune(keeping:)` is called with, so it doubles as a second, independent
+    /// backstop: even if `fetchReleases`'s own `tag == nil` gate were ever
+    /// mistakenly dropped, a tag entry that slipped into the store would still
+    /// be deleted the next time any rule's endpoint is fetched, because it can
+    /// never appear in this set. `internal` (not `private`) so
+    /// `GitHubConditionalCacheTests` can assert on it directly.
+    var validNonTagEndpoints: Set<String> {
+        var out = Set<String>()
+        for rule in rules.values.flatMap({ $0 }) {
+            out.insert("https://api.github.com/repos/\(rule.slug)/releases/latest")
+            out.insert("https://api.github.com/repos/\(rule.slug)/releases?per_page=\(rule.listPageSize)")
+        }
+        return out
     }
 
     public func latestVersion(for app: InstalledApp) async throws -> RemoteVersion? {
@@ -767,6 +815,17 @@ public struct GitHubReleasesSource: UpdateSource {
     /// unbuildable, the response wasn't HTTP, or an exact-tag discovery got a
     /// 404; other bad statuses throw so the row surfaces a retryable error rather
     /// than a dead "unknown".
+    ///
+    /// For the two non-tag endpoints (`/releases/latest`, `/releases?per_page=N`),
+    /// sends a conditional GET when `validatorCache` holds a validator for this
+    /// exact endpoint + credential pair — `If-Modified-Since` alone when the
+    /// stored response had a `Last-Modified`, `If-None-Match` only otherwise
+    /// (`Validator.conditionalHeaders`) — and re-parses the STORED RAW BODY on
+    /// a 304 — never a remembered conclusion, so a rule's `versionPattern` /
+    /// `installAssetPattern` edit takes effect on the very next check even if
+    /// the release hasn't moved. See `GitHubConditionalCache`'s doc comment
+    /// for why `URLCache` alone doesn't revalidate these endpoints, and for why
+    /// the tag lookup (`tag != nil`) never participates.
     private func fetchReleases(
         _ rule: GitHubReleaseRule, list: Bool, tag: String? = nil
     ) async throws -> [Release]? {
@@ -793,10 +852,115 @@ public struct GitHubReleasesSource: UpdateSource {
         // Authenticated requests get 5000/hour instead of 60/hour per IP.
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
 
-        Log.source.debug("GitHub GET \(endpoint, privacy: .public) (auth=\(self.token != nil, privacy: .public))")
+        // Conditional-GET layer. `cachedValidator` stays nil (and no
+        // conditional header is sent) for the tag lookup, when no cache is
+        // wired in, and on a plain cache miss — every one of those falls
+        // straight through to an ordinary unconditional fetch below.
+        let authFingerprint = GitHubConditionalCache.authFingerprint(token)
+        var cachedValidator: GitHubConditionalCache.Validator?
+        if tag == nil, let validatorCache {
+            cachedValidator = await validatorCache.validator(
+                for: endpoint, authFingerprint: authFingerprint)
+            if let cachedValidator {
+                for (name, value) in cachedValidator.conditionalHeaders {
+                    request.setValue(value, forHTTPHeaderField: name)
+                }
+                // We are the validator now. Left on `versionFeedCachePolicy`
+                // (`.reloadRevalidatingCacheData`), `URLCache` would add its own
+                // `If-None-Match` from the copy it holds of the last 200 — and
+                // one stale `ETag` on the wire is enough for GitHub to ignore
+                // the `If-Modified-Since` next to it (RFC 7232 §6, measured; see
+                // `GitHubConditionalCache`). Ignoring the local cache for this
+                // one request keeps the header set exactly what
+                // `conditionalHeaders` says it is.
+                request.cachePolicy = .reloadIgnoringLocalCacheData
+            }
+        }
+
+        Log.source.debug("GitHub GET \(endpoint, privacy: .public) (auth=\(self.token != nil, privacy: .public), conditional=\(cachedValidator != nil, privacy: .public))")
         let (data, response) = try await session.versionFeedData(
             for: request, label: "GitHub \(rule.slug)")
         guard let http = response as? HTTPURLResponse else { return nil }
+
+        if http.statusCode == 304 {
+            if let cachedValidator {
+                let decoded = Self.releases(from: cachedValidator.body, list: list)
+                Log.source.debug("GitHub \(rule.slug, privacy: .public): 304, served \(decoded.count, privacy: .public) release(s) from the conditional cache")
+                GitHubEndpointAudit.record(
+                    requestedSlug: rule.slug, requestedURL: url, response: http,
+                    firstReleaseHTMLURL: decoded.first?.htmlURL, sentToken: token != nil)
+                return decoded
+            }
+            // We only ever send a validator when `cachedValidator` is
+            // non-nil, so this should be unreachable — GitHub has no validator
+            // to compare against otherwise. But the rule that MUST hold
+            // regardless of why it happened is: a 304 with nothing to serve it
+            // from is a cache MISS, never "no update" and never an error — so
+            // re-ask unconditionally rather than guess.
+            Log.source.error("GitHub \(rule.slug, privacy: .public): 304 with no cached validator to serve — retrying unconditionally")
+            return try await fetchReleasesUnconditionally(
+                rule: rule, url: url, endpoint: endpoint, list: list, tag: tag,
+                baseRequest: request, authFingerprint: authFingerprint)
+        }
+
+        let decoded = try handleSettledResponse(
+            http, data: data, rule: rule, url: url, list: list, tag: tag)
+        await remember(http, body: data, endpoint: endpoint, tag: tag, authFingerprint: authFingerprint)
+        return decoded
+    }
+
+    /// Cache-miss fallback for the "304 but nothing to serve it from" case —
+    /// see the comment at its one call site. Re-sends `baseRequest` with every
+    /// conditional header removed, so the response can only be a real 2xx or a
+    /// real error status, then runs it through the same settle-and-persist
+    /// logic the primary path uses.
+    private func fetchReleasesUnconditionally(
+        rule: GitHubReleaseRule, url: URL, endpoint: String, list: Bool, tag: String?,
+        baseRequest: URLRequest, authFingerprint: String
+    ) async throws -> [Release]? {
+        var request = baseRequest
+        for name in GitHubConditionalCache.Validator.headerNames {
+            request.setValue(nil, forHTTPHeaderField: name)
+        }
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "GitHub \(rule.slug) (conditional-cache-miss retry)")
+        guard let http = response as? HTTPURLResponse else { return nil }
+        let decoded = try handleSettledResponse(
+            http, data: data, rule: rule, url: url, list: list, tag: tag)
+        await remember(http, body: data, endpoint: endpoint, tag: tag, authFingerprint: authFingerprint)
+        return decoded
+    }
+
+    /// Persist a settled 2xx's validators + raw body for a non-tag endpoint.
+    /// Both `Last-Modified` and `ETag` are stored when present; which one goes
+    /// on the next request is `Validator.conditionalHeaders`' decision, not
+    /// this one's. One function for both fetch paths so they cannot drift on
+    /// what gets remembered.
+    private func remember(
+        _ http: HTTPURLResponse, body: Data, endpoint: String, tag: String?, authFingerprint: String
+    ) async {
+        guard tag == nil, let validatorCache, (200..<300).contains(http.statusCode) else { return }
+        await validatorCache.store(
+            endpoint: endpoint, authFingerprint: authFingerprint,
+            etag: http.value(forHTTPHeaderField: "ETag"),
+            lastModified: http.value(forHTTPHeaderField: "Last-Modified"),
+            body: body)
+        // Registry-scoped, not per-request: cheap (a Set filter over at most
+        // a couple hundred entries) and keeps a retired rule's entry from
+        // outliving the rule by years. See `validNonTagEndpoints`.
+        await validatorCache.prune(keeping: validNonTagEndpoints)
+        await validatorCache.flush()
+    }
+
+    /// Interpret a non-304 HTTP response: decode a 2xx (walking releases in
+    /// document order — GitHub returns newest first — is the caller's job, not
+    /// this one), translate a 404 exact-tag miss into `nil`, and audit + throw
+    /// everything else. Shared by the primary fetch and the conditional-cache-miss
+    /// retry so the two can't drift on what counts as success.
+    private func handleSettledResponse(
+        _ http: HTTPURLResponse, data: Data, rule: GitHubReleaseRule, url: URL,
+        list: Bool, tag: String?
+    ) throws -> [Release]? {
         guard (200..<300).contains(http.statusCode) else {
             let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"
             Log.source.error("GitHub \(rule.slug, privacy: .public): HTTP \(http.statusCode, privacy: .public) (ratelimit-remaining=\(remaining, privacy: .public))")
@@ -819,9 +983,6 @@ public struct GitHubReleasesSource: UpdateSource {
             if tag != nil, http.statusCode == 404 { return nil }
             throw GitHubError.badStatus(http.statusCode)
         }
-        // Walk releases in document order (GitHub returns newest first) and take
-        // the first whose tag the pattern matches — for prerelease channels this
-        // skips interleaved stable releases.
         let decoded = Self.releases(from: data, list: list)
         // Verification-only bookkeeping: notice a slug that GitHub had to redirect,
         // and an authenticated request that came back on the anonymous budget

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DuoStateDirectoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DuoStateDirectoryTests.swift
@@ -43,6 +43,8 @@ struct DuoStateDirectoryTests {
             #expect(ReleaseTimelineStore.defaultFileURL().path
                 == "/tmp/duo-state-test/com.duoupdater.app/releases.json")
             #expect(BackupStore.root.path == "/tmp/duo-state-test/DuoUpdater/Backups")
+            #expect(GitHubConditionalCache.defaultFileURL().path
+                == "/tmp/duo-state-test/com.duoupdater.app/github-conditional-cache.json")
             // Resolved in the initialiser, so it must be constructed inside the
             // override; reading it back is what needs the await.
             return ChangelogDiskCache()

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
@@ -1,0 +1,464 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `GitHubReleasesSource.fetchReleases` was measured (see `GitHubConditionalCache`'s
+/// doc comment) to almost never get a `URLCache` revalidation for
+/// `/releases/latest` and `/releases?per_page=N`: GitHub's `ETag` churns with
+/// `assets[].download_count`, and a stale `If-None-Match` on the wire makes the
+/// server ignore the `If-Modified-Since` next to it. These pin the self-maintained
+/// validator store that replaces reliance on `URLCache` for those two endpoints:
+/// which single validator header goes out, what it does with a 304, and what it
+/// refuses to do when the 304 can't be trusted.
+@Suite(.serialized)
+struct GitHubConditionalCacheTests {
+
+    /// Serves scripted (status, etag, lastModified, body) answers in order and
+    /// records every request's two conditional headers and its cache policy, so
+    /// a test can assert "how many times did the network actually get hit",
+    /// "which validator did we send" and "did we keep `URLCache` out of it".
+    private final class ScriptedProtocol: URLProtocol, @unchecked Sendable {
+        struct Answer {
+            let status: Int; let etag: String?; let lastModified: String?; let body: String
+            init(status: Int, etag: String?, lastModified: String? = nil, body: String) {
+                self.status = status; self.etag = etag; self.lastModified = lastModified; self.body = body
+            }
+        }
+        struct Seen { let ifNoneMatch: String?; let ifModifiedSince: String?; let cachePolicy: URLRequest.CachePolicy }
+
+        final class Script: @unchecked Sendable {
+            private let lock = NSLock()
+            private var queue: [Answer] = []
+            private var seen: [Seen] = []
+
+            func load(_ answers: [Answer]) {
+                lock.lock(); queue = answers; seen = []; lock.unlock()
+            }
+
+            func next(_ request: URLRequest) -> Answer {
+                lock.lock(); defer { lock.unlock() }
+                seen.append(Seen(
+                    ifNoneMatch: request.value(forHTTPHeaderField: "If-None-Match"),
+                    ifModifiedSince: request.value(forHTTPHeaderField: "If-Modified-Since"),
+                    cachePolicy: request.cachePolicy))
+                return queue.isEmpty
+                    ? Answer(status: 200, etag: nil, body: "{}") : queue.removeFirst()
+            }
+
+            var requestCount: Int { lock.lock(); defer { lock.unlock() }; return seen.count }
+            var ifNoneMatchSent: [String?] { lock.lock(); defer { lock.unlock() }; return seen.map(\.ifNoneMatch) }
+            var ifModifiedSinceSent: [String?] { lock.lock(); defer { lock.unlock() }; return seen.map(\.ifModifiedSince) }
+            var cachePolicies: [URLRequest.CachePolicy] { lock.lock(); defer { lock.unlock() }; return seen.map(\.cachePolicy) }
+        }
+
+        static let script = Script()
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            let answer = Self.script.next(request)
+            var headers: [String: String] = [:]
+            if let etag = answer.etag { headers["ETag"] = etag }
+            if let lastModified = answer.lastModified { headers["Last-Modified"] = lastModified }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: answer.status,
+                httpVersion: "HTTP/1.1", headerFields: headers)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(answer.body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    private static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ScriptedProtocol.self]
+        // No URLCache at all — every test proves the SOURCE's own conditional
+        // layer, not a lucky assist from the protocol cache.
+        configuration.urlCache = nil
+        return URLSession(configuration: configuration)
+    }
+
+    /// A `/releases/latest` payload with one tag. `tag` is deliberately shaped so
+    /// two different `versionPattern`s can extract two DIFFERENT version strings
+    /// from the exact same bytes — see
+    /// `aRulePatternChangeTakesEffectThroughA304NotACachedConclusion`.
+    private static func body(tag: String) -> String {
+        """
+        {
+          "tag_name": "\(tag)",
+          "assets": [],
+          "prerelease": false,
+          "draft": false
+        }
+        """
+    }
+
+    private static func tempCache() -> GitHubConditionalCache {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("duo-conditional-cache-tests-\(UUID().uuidString)")
+        return GitHubConditionalCache(fileURL: dir.appendingPathComponent("cache.json"))
+    }
+
+    // MARK: - 1. Store raw body, re-parse on every 304 (never a cached conclusion)
+
+    /// Mutation this pins: caching the RESOLVED version (or anything downstream
+    /// of `versionPattern`) instead of the raw HTTP body. Two `GitHubReleasesSource`
+    /// instances share one `GitHubConditionalCache` and the same slug, so the
+    /// second request is answered 304 from the very same script — but the two
+    /// instances use DIFFERENT `versionPattern`s against the identical tag
+    /// `"v1.2.3"`. A correct implementation re-parses the stored bytes under
+    /// whichever pattern is asking right now, so the two calls must disagree.
+    /// An implementation that instead cached (or reused) a parsed conclusion tied
+    /// to the first rule would answer "1.2.3" both times — this test goes red on
+    /// that mutation (verified below).
+    @Test func aRulePatternChangeTakesEffectThroughA304NotACachedConclusion() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "etag-1", body: Self.body(tag: "v1.2.3")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+
+        let ruleOld = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#)   // "v1.2.3" -> "1.2.3"
+        let sourceOld = GitHubReleasesSource(
+            rules: [ruleOld], token: "tok", session: session, validatorCache: cache)
+        let first = await sourceOld.resolveDiagnostic(ruleOld)
+        #expect(first.remote?.shortVersion == "1.2.3")
+        #expect(ScriptedProtocol.script.requestCount == 1)
+
+        // Same slug, same endpoint, same cached bytes — but a rule edit: only the
+        // suffix after "v1." is the version now.
+        let ruleNew = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v1\.([0-9.]+)$"#)   // "v1.2.3" -> "2.3"
+        let sourceNew = GitHubReleasesSource(
+            rules: [ruleNew], token: "tok", session: session, validatorCache: cache)
+        let second = await sourceNew.resolveDiagnostic(ruleNew)
+
+        // The request that went out was a 304 (belt and braces: proves this
+        // exercised the conditional path, not a coincidental fresh 200).
+        #expect(ScriptedProtocol.script.requestCount == 2)
+        #expect(ScriptedProtocol.script.ifNoneMatchSent.last == "etag-1")
+        // The answer reflects the NEW pattern, not the one that was cached under.
+        #expect(second.remote?.shortVersion == "2.3")
+        #expect(second.remote?.shortVersion != first.remote?.shortVersion)
+    }
+
+    /// A response with an `ETag` and no `Last-Modified` — the list endpoint's
+    /// shape — is revalidated by `If-None-Match`, and the value sent is exactly
+    /// the `ETag` the first 200 carried. Pins the wiring, independent of the
+    /// pattern-change scenario above.
+    @Test func theSecondRequestSendsTheEtagFromTheFirst200() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "\"abc123\"", body: Self.body(tag: "v9.9.9")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(bundleID: "com.example.app", owner: "example", repo: "app")
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        _ = await source.resolveDiagnostic(rule)
+        _ = await source.resolveDiagnostic(rule)
+
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, "\"abc123\""])
+        #expect(ScriptedProtocol.script.ifModifiedSinceSent == [nil, nil])
+    }
+
+    // MARK: - 1b. `Last-Modified` wins outright, and the `ETag` stays home
+
+    /// Mutation this pins: sending `If-None-Match` alongside (or instead of)
+    /// `If-Modified-Since` when the stored response had a `Last-Modified`.
+    /// Measured on 2026-09-05 against `VSCodium/vscodium/releases/latest`: the
+    /// `ETag` rotates every few minutes with `assets[].download_count`, and a
+    /// request carrying the stale `ETag` *and* a valid `If-Modified-Since` gets
+    /// a full 200 — GitHub evaluates `If-None-Match` first (RFC 7232 §6) and
+    /// ignores the date. Only `If-Modified-Since` alone gets the 304. So the
+    /// first 200 here carries BOTH headers, and the second request must carry
+    /// exactly one: the date, verbatim.
+    @Test func aLastModifiedIsRevalidatedByDateAloneNeverByTheEtagNextToIt() async throws {
+        let lastModified = "Sat, 11 Jul 2026 21:54:57 GMT"
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "W/\"churns-with-download-count\"", lastModified: lastModified,
+                  body: Self.body(tag: "v1.2.3")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#)
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        let first = await source.resolveDiagnostic(rule)
+        let second = await source.resolveDiagnostic(rule)
+
+        #expect(ScriptedProtocol.script.requestCount == 2)
+        #expect(ScriptedProtocol.script.ifModifiedSinceSent == [nil, lastModified])
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil])
+        // And the 304 was served from the stored body, not read as "nothing".
+        #expect(first.remote?.shortVersion == "1.2.3")
+        #expect(second.remote?.shortVersion == "1.2.3")
+    }
+
+    /// Mutation this pins: leaving a validator-bearing request on
+    /// `versionFeedCachePolicy` (`.reloadRevalidatingCacheData`). On the real
+    /// `URLSession.updates` that lets `URLCache` add its own `If-None-Match`
+    /// from the copy it holds of the last 200, and one stale `ETag` on the wire
+    /// is enough to void the `If-Modified-Since` (see the previous test). The
+    /// first, unconditional request keeps the feed policy — nothing about the
+    /// "never answer a version feed from cache freshness" contract changes.
+    @Test func aValidatorBearingRequestIgnoresTheLocalURLCache() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "e", lastModified: "Sat, 11 Jul 2026 21:54:57 GMT",
+                  body: Self.body(tag: "v1.0.0")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(bundleID: "com.example.app", owner: "example", repo: "app")
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        _ = await source.resolveDiagnostic(rule)
+        _ = await source.resolveDiagnostic(rule)
+
+        #expect(ScriptedProtocol.script.cachePolicies
+                == [URLRequest.versionFeedCachePolicy, .reloadIgnoringLocalCacheData])
+    }
+
+    /// A store file written before `lastModified` existed (entries with `etag`
+    /// only) must still decode and still revalidate by `ETag` — a format change
+    /// that silently emptied the store would cost one full fetch per endpoint
+    /// with nothing to notice it by. Mutation this pins: making `Entry.etag` /
+    /// `lastModified` non-optional, or renaming a key.
+    @Test func aStoreFileFromBeforeLastModifiedStillDecodes() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("duo-conditional-cache-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("cache.json")
+        let endpoint = "https://api.github.com/repos/old/repo/releases/latest"
+        let legacy = """
+        {"\(endpoint)": {"etag": "\\"legacy\\"", "body": "\(Data("{}".utf8).base64EncodedString())",
+                          "authFingerprint": "fp", "storedAt": 810280008.0}}
+        """
+        try Data(legacy.utf8).write(to: file)
+
+        let cache = GitHubConditionalCache(fileURL: file)
+        let validator = await cache.validator(for: endpoint, authFingerprint: "fp")
+
+        #expect(validator?.etag == "\"legacy\"")
+        #expect(validator?.lastModified == nil)
+        #expect(validator?.conditionalHeaders == ["If-None-Match": "\"legacy\""])
+    }
+
+    // MARK: - 2. Failure retreats to an unconditional request, never "no update"
+
+    /// Mutation this pins: treating an untrustable 304 (nothing cached to serve
+    /// it from) as "no update" or as an error. Nothing was ever stored — the
+    /// cache is empty — so the request cannot legitimately carry `If-None-Match`,
+    /// yet the script answers 304 on the first call anyway (standing in for a
+    /// corrupted/evicted store or a rogue intermediary). The source must not
+    /// interpret that as "nothing changed": it must fall back to a *second*,
+    /// unconditional request and return whatever that one says.
+    @Test func aTrustlessOhThreeOhFourFallsBackToAnUnconditionalRequest() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 304, etag: nil, body: ""),
+            .init(status: 200, etag: "etag-real", body: Self.body(tag: "v3.1.4")),
+        ])
+        let cache = Self.tempCache()   // empty — nothing was ever stored
+        let session = Self.session()
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#)
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        let outcome = await source.resolveDiagnostic(rule)
+
+        // Not nil, not an error — the retry's real answer.
+        #expect(outcome.remote?.shortVersion == "3.1.4")
+        #expect(outcome.failure == nil)
+        #expect(ScriptedProtocol.script.requestCount == 2)
+        // Neither request could have legitimately carried a validator.
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil])
+    }
+
+    // MARK: - 3. Auth context changes invalidate the old validator
+
+    /// Mutation this pins: keying the cache only by endpoint, so a validator
+    /// fetched under one token is reused (as `If-None-Match`) for a DIFFERENT
+    /// token. GitHub hands out different ETags to authenticated vs. anonymous
+    /// requests for the same resource, so this would risk a spurious 304 that
+    /// resurrects a body fetched under someone else's credential.
+    @Test func aDifferentTokenNeverReusesTheOldValidator() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "etag-for-tokA", body: Self.body(tag: "v1.0.0")),
+            .init(status: 200, etag: "etag-for-tokB", body: Self.body(tag: "v2.0.0")),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(bundleID: "com.example.app", owner: "example", repo: "app")
+
+        let sourceA = GitHubReleasesSource(
+            rules: [rule], token: "tokA", session: session, validatorCache: cache)
+        let first = await sourceA.resolveDiagnostic(rule)
+        #expect(first.remote?.shortVersion == "1.0.0")
+
+        let sourceB = GitHubReleasesSource(
+            rules: [rule], token: "tokB", session: session, validatorCache: cache)
+        let second = await sourceB.resolveDiagnostic(rule)
+
+        // No validator sent for the different token — a real, unconditional
+        // second request, not a 304.
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil])
+        #expect(second.remote?.shortVersion == "2.0.0")
+        #expect(ScriptedProtocol.script.requestCount == 2)
+    }
+
+    /// Going from a token to no token (or back) is the same hazard as two
+    /// different tokens — `authFingerprint(nil)` must not collide with
+    /// `authFingerprint(_:)` for any real token.
+    @Test func authFingerprintDistinguishesAnonymousFromAnyToken() {
+        let anon = GitHubConditionalCache.authFingerprint(nil)
+        let tokA = GitHubConditionalCache.authFingerprint("tokA")
+        let tokB = GitHubConditionalCache.authFingerprint("tokB")
+        #expect(anon != tokA)
+        #expect(tokA != tokB)
+        // Deterministic, so re-fetching after a process restart still matches.
+        #expect(tokA == GitHubConditionalCache.authFingerprint("tokA"))
+        // Never the raw token — a disk-persisted store must not carry it.
+        #expect(!anon.contains("tok"))
+        #expect(!tokA.contains("tokA"))
+    }
+
+    // MARK: - 4. Bounded: pruning drops what the registry no longer asks for
+
+    @Test func pruneDropsEndpointsOutsideTheKeptSet() async {
+        let cache = Self.tempCache()
+        await cache.store(
+            endpoint: "https://api.github.com/repos/kept/repo/releases/latest",
+            authFingerprint: "fp", etag: "e1", lastModified: nil, body: Data("{}".utf8))
+        await cache.store(
+            endpoint: "https://api.github.com/repos/retired/repo/releases/latest",
+            authFingerprint: "fp", etag: "e2", lastModified: nil, body: Data("{}".utf8))
+
+        await cache.prune(keeping: ["https://api.github.com/repos/kept/repo/releases/latest"])
+
+        #expect(await cache.validator(
+            for: "https://api.github.com/repos/kept/repo/releases/latest",
+            authFingerprint: "fp") != nil)
+        #expect(await cache.validator(
+            for: "https://api.github.com/repos/retired/repo/releases/latest",
+            authFingerprint: "fp") == nil)
+    }
+
+    // MARK: - 5. The tag lookup never participates
+
+    /// `GitHubReleasesSource.fetchReleases` gates the conditional layer on
+    /// `tag == nil` in three places (the lookup, and the two `store` call
+    /// sites), and separately `validNonTagEndpoints` — what `prune(keeping:)`
+    /// is run against — never contains a tag-shaped URL. Both mechanisms
+    /// independently keep a tag entry out of the store, which is deliberate
+    /// defense in depth (see that property's doc comment) but means the two
+    /// need two different tests: mutating away only the `tag == nil` gates
+    /// still gets cleaned up by `prune`, so it does NOT turn this specific
+    /// end-to-end test red (verified: request/response shape is unchanged) —
+    /// that mutation is instead caught by
+    /// `validNonTagEndpointsNeverNamesATagShapedURL` below, which pins the
+    /// *other* mechanism directly. This test pins the CURRENT, observable
+    /// behaviour: the exact-tag lookup never carries `If-None-Match`, on
+    /// either round.
+    @Test func theExactTagLookupNeverSendsAValidator() async throws {
+        ScriptedProtocol.script.load([
+            // channelDiscoveryProbe: list fetch, then the exact-tag fetch.
+            .init(status: 200, etag: "list-etag", body: """
+            [{"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}]
+            """),
+            .init(status: 200, etag: "tag-etag", body: """
+            {"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}
+            """),
+            // Second round: same two lookups again.
+            .init(status: 200, etag: "list-etag", body: """
+            [{"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}]
+            """),
+            .init(status: 200, etag: "tag-etag", body: """
+            {"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}
+            """),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#,
+            installedTagPrefix: "v", channel: .beta)
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        _ = try await source.channelDiscoveryProbe(rule)
+        _ = try await source.channelDiscoveryProbe(rule)
+
+        // Four real requests. The LIST fetch (`releases?per_page=20`) is one of
+        // the two registry-driven, non-tag endpoints — it IS eligible for the
+        // conditional layer, and correctly carries the validator on its second
+        // round (index 2). The exact-TAG fetch (index 1 and 3) is the one this
+        // test is actually about: it must never carry `If-None-Match`, on
+        // either round — that's the endpoint with no fixed, prunable key space.
+        #expect(ScriptedProtocol.script.requestCount == 4)
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil, "list-etag", nil])
+    }
+
+    /// Direct pin on `validNonTagEndpoints` — the set `prune(keeping:)` is
+    /// called with — never containing a `/releases/tags/…` URL for any rule,
+    /// regardless of that rule's other settings. This is the mechanism that
+    /// keeps a tag entry from surviving even if `fetchReleases`'s own
+    /// `tag == nil` gates were ever mistakenly dropped (see the previous
+    /// test's doc comment for why that mutation alone doesn't show up
+    /// end-to-end). Mutation this pins: adding tag URLs into this set (e.g. "so
+    /// pruning doesn't punish a proven install's re-check") — verified red
+    /// below.
+    @Test func validNonTagEndpointsNeverNamesATagShapedURL() {
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            installedTagPrefix: "v", channel: .beta)
+        let source = GitHubReleasesSource(rules: [rule])
+
+        let endpoints = source.validNonTagEndpoints
+        #expect(endpoints == [
+            "https://api.github.com/repos/example/app/releases/latest",
+            "https://api.github.com/repos/example/app/releases?per_page=20",
+        ])
+        #expect(!endpoints.contains { $0.contains("/releases/tags/") })
+    }
+
+    /// Mutation this pins: building the list URL in `validNonTagEndpoints` with
+    /// a literal `per_page=20` instead of the rule's `listPageSize`. That is
+    /// what the first draft did, after `listPageSize` had already made the page
+    /// per-rule (#355): for every rule with a smaller page the list entry was
+    /// stored and then pruned by the very same fetch, so its cache could never
+    /// hit — with no error, no log line and every other test green. The two
+    /// URLs must agree byte for byte with what `fetchReleases` requests.
+    @Test func validNonTagEndpointsFollowEachRulesListPageSize() {
+        let five = GitHubReleaseRule(
+            bundleID: "com.example.five", owner: "example", repo: "five",
+            usePrereleases: true, listPageSize: 5)
+        let twenty = GitHubReleaseRule(
+            bundleID: "com.example.twenty", owner: "example", repo: "twenty",
+            usePrereleases: true)
+        let source = GitHubReleasesSource(rules: [five, twenty])
+
+        #expect(source.validNonTagEndpoints == [
+            "https://api.github.com/repos/example/five/releases/latest",
+            "https://api.github.com/repos/example/five/releases?per_page=5",
+            "https://api.github.com/repos/example/twenty/releases/latest",
+            "https://api.github.com/repos/example/twenty/releases?per_page=20",
+        ])
+    }
+}


### PR DESCRIPTION
Closes #357.

## What

`GitHubReleasesSource` keeps its own validator store for `/releases/latest` and `/releases?per_page=N` and revalidates them itself: **`If-Modified-Since` alone** when the stored response had a `Last-Modified`, `If-None-Match` only when it had none. A 304 is served by re-parsing the stored raw body. The request that carries a validator ignores the local `URLCache` so the cache cannot add its own `If-None-Match` back.

## Why one header, not both

GitHub's `ETag` hashes the body, and the body carries `assets[].download_count`, so for any repo with a steady trickle of downloads the `ETag` rotates every few minutes. `URLCache` sends `If-None-Match` and `If-Modified-Since` together, and per RFC 7232 §6 the server then ignores the date. Measured against `VSCodium/vscodium/releases/latest` on 2026-09-05, same minute:

```
If-None-Match: <ETag from 4 min ago>                 → 200, 24006 bytes
If-Modified-Since: <Last-Modified as served>         → 304
If-None-Match: <stale> + If-Modified-Since: <valid>  → 200, 24006 bytes
If-Modified-Since: <Last-Modified minus 1 s>         → 200
```

The list endpoint sends no `Last-Modified` and answers `If-Modified-Since` with 200 for any date, so it keeps the `ETag` as its only validator (which still 304s for repos whose counters sit still). Page size stays the lever there — #358.

## Provenance

The store (`GitHubConditionalCache`: raw body, credential fingerprint, prune-to-registry bound, 304-without-validator retry) is taken over from an uncommitted draft in another worktree. Two fixes on top of the validator order: the pruned set now builds the list URL with the rule's own `listPageSize` (the draft hard-coded `per_page=20` after #355 had made it per-rule, so every smaller page's entry was stored and pruned by the same fetch — a cache that could never hit, no error anywhere), and the doc comments describe the download-counter cause instead of a suspected `Vary` mismatch.

## Verification

- `make test` green on this branch (`exit=0`, 202 core tests, 9 app tests, all script gates).
- Three mutations, each turning exactly its own test red: send both headers → `aLastModifiedIsRevalidatedByDateAloneNeverByTheEtagNextToIt`; leave the validator-bearing request on `versionFeedCachePolicy` → `aValidatorBearingRequestIgnoresTheLocalURLCache`; hard-code `per_page=20` in `validNonTagEndpoints` → `validNonTagEndpointsFollowEachRulesListPageSize`.
- A store file written before `lastModified` existed still decodes and still revalidates by `ETag` (`aStoreFileFromBeforeLastModifiedStillDecodes`).
- Live: installed on this machine at 23:52; the ledger read after two scan rounds is below.

## Live ledger

Installed on this machine 2026-09-05 23:52 (binary carries `GitHubConditionalCache`, 384 symbols; the previous build had 0). `events.sqlite`, network requests to `api.github.com`, 5-minute rounds:

| round | endpoint | 200 | 304 | bytes |
|---|---|---:|---:|---:|
| first after install (seeds the store) | `/releases/latest` etc., 49 repos | 49 | 0 | 293,473 |
| | `/releases?per_page=N`, 7 repos | 6 | 0 | 259,456 |
| next round | `/releases/latest` etc., 49 repos | **0** | **49** | **53,753** |
| | `/releases?per_page=N`, 7 repos | 5 | 1 | 242,071 |

Before this change the same 49 endpoints ran at 1348 × 200 / 347 × 304 over 36 rounds (~37 full bodies a round, ~240 KB). The list endpoints are unchanged by design and are #358.
