### PR TITLE
Open a prerelease rule's list fetch with one row, pay for the page only on a miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.85
+
+**Checking apps that ship through GitHub costs a fraction of the network it did.** Each check used to download every release's full description again even when nothing had been published; it now asks GitHub whether the release has changed since last time and downloads nothing when it has not.
+
 ## 0.3.84
 
 **Request logs you export no longer carry your account name.** Every row for an app installed in your home folder used to spell out the full path; it now shows `~` instead, whichever way you take the log out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Checking apps that ship through GitHub costs a fraction of the network it did.** Each check used to download every release's full description again even when nothing had been published; it now asks GitHub whether the release has changed since last time and downloads nothing when it has not.
 
+**Apps followed on a GitHub beta or nightly track now ask for one release instead of a page of them.** The newest release is the answer almost every time, and the full page is only fetched on the rounds where it is not.
+
 ## 0.3.84
 
 **Request logs you export no longer carry your account name.** Every row for an app installed in your home folder used to spell out the full path; it now shows `~` instead, whichever way you take the log out.

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -505,6 +505,9 @@ public enum Verify {
             }
             out.append(finding)
         }
+        // The store coalesces its disk writes over a couple of seconds; this
+        // process is about to exit, so write now or lose the sweep's memos.
+        await GitHubConditionalCache.shared.flush()
         return out
     }
 

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -441,7 +441,9 @@ public enum Verify {
     ) async -> [Finding] {
         // All 13 rules share api.github.com, so host-grouping would serialize
         // them anyway. That is the correct behaviour — one shared rate limit.
-        let source = GitHubReleasesSource(token: options.githubToken ?? GitHubToken.resolve())
+        let source = GitHubReleasesSource(
+            token: options.githubToken ?? GitHubToken.resolve(),
+            validatorCache: GitHubConditionalCache.shared)
         var out: [Finding] = []
         for (index, rule) in rules.enumerated() {
             if index > 0 { try? await Task.sleep(for: options.perHostDelay) }

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -448,4 +448,10 @@ let status = await run()
 // coalescing timer would fire. Only when something was actually recorded: a
 // command that touched no network should not open a database just to close it.
 if EventStore.hasRecorded { await EventStore.shared.flush() }
+// Same shape, same reason: the GitHub validator store coalesces its writes over
+// two seconds, and a `duo check <app>` is gone in milliseconds — without this
+// its memos would never reach disk and every run would fetch unconditionally.
+// Guarded like the event store: a command that never built a checker should
+// not load the file just to write it back.
+if GitHubConditionalCache.hasShared { await GitHubConditionalCache.shared.flush() }
 exit(status)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/SourceStack.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/SourceStack.swift
@@ -33,7 +33,9 @@ public enum SourceStack {
             HomebrewCaskSource(),
             // GitHub Releases for apps distributed that way (detection only unless
             // a rule names an installable asset).
-            GitHubReleasesSource(token: githubToken, channelStore: channelStore),
+            GitHubReleasesSource(
+                token: githubToken, channelStore: channelStore,
+                validatorCache: GitHubConditionalCache.shared),
         ]
         // Alcove's licensed update channel, ahead of the vendor probe: it's the only
         // surface carrying release notes, an exact publish time and an installable

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
@@ -76,7 +76,23 @@ public actor GitHubConditionalCache {
     /// source directly (the overwhelming majority of them) writes nothing to the
     /// real file. Only `SourceStack.make` and `duo verify`'s GitHub sweep wire
     /// this in.
-    public static let shared = GitHubConditionalCache()
+    public static var shared: GitHubConditionalCache {
+        sharedLock.lock(); defer { sharedLock.unlock() }
+        if let existing = sharedInstance { return existing }
+        let created = GitHubConditionalCache()
+        sharedInstance = created
+        return created
+    }
+    /// Whether anything has touched `shared` in this process — so a CLI exit
+    /// path can flush it without first loading a multi-megabyte file for a
+    /// command that never made a GitHub request (`duo list`). Same shape as
+    /// `EventStore.hasRecorded`, for the same reason.
+    public static var hasShared: Bool {
+        sharedLock.lock(); defer { sharedLock.unlock() }
+        return sharedInstance != nil
+    }
+    private static let sharedLock = NSLock()
+    nonisolated(unsafe) private static var sharedInstance: GitHubConditionalCache?
 
     /// One endpoint's cached validator, keyed by the endpoint URL string.
     ///
@@ -231,7 +247,9 @@ public actor GitHubConditionalCache {
     /// than the gap between one round's fetches and shorter than anything a
     /// user waits for; a process that exits inside the window loses at most
     /// that round's memos, which cost one unconditional fetch each next time —
-    /// `duo verify` flushes explicitly at the end of its sweep for that reason.
+    /// the `duo` CLI, which exits after one run, flushes explicitly before it
+    /// does (`duo verify` at the end of its sweep, every other subcommand at
+    /// exit beside the event store's flush).
     private func scheduleFlush() {
         guard flushTask == nil else { return }
         flushTask = Task { [weak self] in
@@ -241,6 +259,11 @@ public actor GitHubConditionalCache {
     }
 
     private func flushScheduled() {
+        // `flush()` cancels a pending task, but `try? await Task.sleep` returns
+        // early on cancellation instead of throwing out of the task, so a
+        // cancelled task still reaches this line. It must not touch the handle
+        // of whatever task was scheduled after it, nor write again.
+        guard !Task.isCancelled else { return }
         flushTask = nil
         flush()
     }
@@ -250,7 +273,8 @@ public actor GitHubConditionalCache {
     /// still ask for. Without this, a repo whose rule is deleted (renamed app,
     /// retired recipe) leaves its entry behind forever, since nothing else ever
     /// revisits that URL to notice it's dead. Bounded by construction: the set
-    /// this is pruned against has exactly two entries per registered rule.
+    /// this is pruned against has two entries per registered rule, three for a
+    /// rule that probes (`GitHubReleasesSource.validNonTagEndpoints`).
     public func prune(keeping validEndpoints: Set<String>) {
         let before = entries.count
         entries = entries.filter { validEndpoints.contains($0.key) }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
@@ -104,10 +104,26 @@ public actor GitHubConditionalCache {
         /// return it across a mismatch rather than risk serving a body scoped to
         /// someone else's rate limit or visibility.
         var authFingerprint: String
-        /// Diagnostics only, mirroring `ResolvedChannelStore.Entry.provenAt` —
-        /// nothing here reads it back.
+        /// When the 200 this entry holds was received. Load-bearing, not
+        /// diagnostics: `validator(for:authFingerprint:)` refuses an entry older
+        /// than `maxAge`, and a 304 does NOT refresh it — see `maxAge`.
         var storedAt: Date
     }
+
+    /// How long a stored 200 may go on being revalidated before one full,
+    /// unconditional fetch is forced.
+    ///
+    /// `If-Modified-Since` asks "has this changed since <date>", and GitHub
+    /// answers it the RFC 7232 §3.3 way — measured 2026-09-05: a date one DAY
+    /// after the release's `Last-Modified` is still a 304. So a
+    /// `/releases/latest` that comes to point at an OLDER release (the newest
+    /// one deleted, or re-marked prerelease) is "not modified since" our date
+    /// too, and the stored body would keep offering the yanked release until
+    /// something newer appeared. `URLCache`'s `If-None-Match` used to catch that
+    /// case by accident, in the rounds it happened to 304 at all. A day bounds
+    /// the staleness at ~one full body per endpoint per day — 59 endpoints,
+    /// ~500 KB — against the ~50 full bodies a round this store removes.
+    static let maxAge: TimeInterval = 24 * 60 * 60
 
     /// What `fetchReleases` needs to build a conditional request and to recover
     /// if the server actually answers 304.
@@ -134,16 +150,26 @@ public actor GitHubConditionalCache {
 
     private var entries: [String: Entry]
     private let fileURL: URL
+    private let now: @Sendable () -> Date
     private var dirty = false
+    /// The pending coalesced write, if any — see `scheduleFlush()`.
+    private var flushTask: Task<Void, Never>?
 
     /// - Parameter fileURL: defaults to
     ///   `DuoStateDirectory.base/com.duoupdater.app/github-conditional-cache.json`
-    ///   — the same container `ChangelogDiskCache` and the traffic store use, so
-    ///   `duo verify`'s `DUO_STATE_DIR` redirect (see `DuoStateDirectory`) keeps
-    ///   the nightly sweep from reading or writing the running app's copy.
-    public init(fileURL: URL? = nil) {
+    ///   — the same container `ChangelogDiskCache` and the traffic store use.
+    ///   `DUO_STATE_DIR` redirects it like every other store, but nothing in
+    ///   this repository sets that variable outside the tests: a `duo verify`
+    ///   run from a terminal reads and writes the running app's copy. That is
+    ///   acceptable here (both hold public release bodies under the same
+    ///   credential; a mismatched fingerprint just costs one unconditional
+    ///   round) and is stated rather than pretended away.
+    /// - Parameter now: injectable clock so tests can age an entry past
+    ///   `maxAge` without sleeping.
+    public init(fileURL: URL? = nil, now: @escaping @Sendable () -> Date = Date.init) {
         let url = fileURL ?? Self.defaultFileURL()
         self.fileURL = url
+        self.now = now
         self.entries = Self.load(from: url)
     }
 
@@ -170,6 +196,10 @@ public actor GitHubConditionalCache {
         guard let entry = entries[endpoint], entry.authFingerprint == authFingerprint else {
             return nil
         }
+        // Older than a day → no validator → the caller fetches unconditionally
+        // and `store` restamps it. See `maxAge` for the yanked-release case this
+        // bounds.
+        guard now().timeIntervalSince(entry.storedAt) < Self.maxAge else { return nil }
         return Validator(etag: entry.etag, lastModified: entry.lastModified, body: entry.body)
     }
 
@@ -186,8 +216,33 @@ public actor GitHubConditionalCache {
         guard etag != nil || lastModified != nil else { return }
         entries[endpoint] = Entry(
             etag: etag, lastModified: lastModified, body: body,
-            authFingerprint: authFingerprint, storedAt: .now)
+            authFingerprint: authFingerprint, storedAt: now())
         dirty = true
+        scheduleFlush()
+    }
+
+    /// Coalesce a round's writes into one. Every 2xx used to `flush()` on the
+    /// spot, and a flush re-encodes the whole dictionary (3.4 MB of raw bodies
+    /// → base64) and atomically rewrites the ~4.6 MB file — measured on this
+    /// machine's store, 59 entries. Steady state is 4–6 × 200 a round (the
+    /// list endpoints, whose `ETag` churns), i.e. ~25 MB of writes every five
+    /// minutes; a cold round did it 59 times. `ReleaseTimelineStore` batched
+    /// exactly this pattern for exactly this reason. Two seconds is longer
+    /// than the gap between one round's fetches and shorter than anything a
+    /// user waits for; a process that exits inside the window loses at most
+    /// that round's memos, which cost one unconditional fetch each next time —
+    /// `duo verify` flushes explicitly at the end of its sweep for that reason.
+    private func scheduleFlush() {
+        guard flushTask == nil else { return }
+        flushTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            await self?.flushScheduled()
+        }
+    }
+
+    private func flushScheduled() {
+        flushTask = nil
+        flush()
     }
 
     /// Drop every entry whose endpoint is not in `validEndpoints` — the set of
@@ -199,13 +254,17 @@ public actor GitHubConditionalCache {
     public func prune(keeping validEndpoints: Set<String>) {
         let before = entries.count
         entries = entries.filter { validEndpoints.contains($0.key) }
-        if entries.count != before { dirty = true }
+        if entries.count != before { dirty = true; scheduleFlush() }
     }
 
-    /// Clears `dirty` only once the bytes are actually on disk — same reasoning
-    /// as `ResolvedChannelStore.flush()`: an unwritable directory or full volume
-    /// must not silently drop the write AND make the next flush a no-op.
+    /// Write now. Clears `dirty` only once the bytes are actually on disk —
+    /// same reasoning as `ResolvedChannelStore.flush()`: an unwritable
+    /// directory or full volume must not silently drop the write AND make the
+    /// next flush a no-op. Writes are normally coalesced by `scheduleFlush()`;
+    /// call this directly when the process is about to exit.
     public func flush() {
+        flushTask?.cancel()
+        flushTask = nil
         guard dirty else { return }
         guard let data = try? JSONEncoder().encode(entries) else { return }
         do {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubConditionalCache.swift
@@ -1,0 +1,236 @@
+import Foundation
+import CryptoKit
+
+/// Persisted validators (`Last-Modified`, `ETag`) + raw response body for
+/// `GitHubReleasesSource`'s two registry-driven endpoints (`/releases/latest`
+/// and `/releases?per_page=<listPageSize>`), and the conditional GET built
+/// from them.
+///
+/// ## Why this exists, and why `Last-Modified` comes first
+///
+/// `URLSession.updates`' own `URLCache` was measured (not assumed) to almost
+/// never get a 304 for these endpoints: over 36 five-minute rounds on
+/// 2026-09-05, 1348 full 200s against 347 304s across `/releases/latest` for
+/// 49 repos, and 197 against 12 for the 7 `/releases?per_page=N` repos. Per
+/// repo it tracks popularity — VSCodium 34 × 200 / 0 × 304, an obscure repo
+/// 14 / 20 — and the reason is in the body: **GitHub's `ETag` is a hash of the
+/// response, and the response carries `assets[].download_count`.** Two fetches
+/// of VSCodium's `/latest` 240 s apart differed in exactly four
+/// `download_count` values and nothing else, and had different `ETag`s. Any
+/// repo people actually download from mints a new `ETag` every few minutes, so
+/// `If-None-Match` is worthless precisely where the bytes are.
+///
+/// `Last-Modified` is the release's own timestamp (it matched `updated_at`,
+/// not the download counters) and `/releases/latest` honours
+/// `If-Modified-Since` against it — measured the same minute the `ETag` had
+/// just rotated:
+///
+///     If-None-Match: <ETag from 4 min ago>                 → 200, full body
+///     If-Modified-Since: <Last-Modified as served>         → 304
+///     If-None-Match: <stale> + If-Modified-Since: <valid>  → 200, full body
+///     If-Modified-Since: <Last-Modified minus 1 s>         → 200
+///
+/// The third line is why this type exists instead of trusting `URLCache`:
+/// RFC 7232 §6 says a server evaluates `If-None-Match` first and ignores
+/// `If-Modified-Since` when both are present, GitHub does exactly that, and
+/// `URLCache` revalidation sends both whenever it holds both. So the rule
+/// `Validator.conditionalHeaders` encodes is: **when the stored response had a
+/// `Last-Modified`, send `If-Modified-Since` and nothing else; only a response
+/// that had no `Last-Modified` at all is revalidated by `ETag`.** The list
+/// endpoint is the second case — it sends no `Last-Modified` and answers
+/// `If-Modified-Since` with 200 for any date (measured) — so its `ETag` is
+/// kept as the only validator it has, which still buys a 304 for repos whose
+/// counters sit still. The request that carries one of these validators also
+/// bypasses `URLCache` (`.reloadIgnoringLocalCacheData`) so the cache cannot
+/// add its own `If-None-Match` back on top. Issue #357 has the full
+/// measurement.
+///
+/// GitHub confirms a 304 from a *correctly authenticated* conditional request
+/// does not spend the primary rate limit:
+/// <https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api>
+/// ("Making a conditional request does not count against your primary rate
+/// limit if a `304` response is returned and the request was made while
+/// correctly authorized with an `Authorization` header. […] each `304 Not
+/// Modified` response is fast and does not use your rate limit, making
+/// conditional requests especially useful when polling an endpoint.") — matches
+/// what was measured locally (`x-ratelimit-used` did not advance across a 304).
+///
+/// ## What is deliberately NOT here
+///
+/// - **The `/releases/tags/<tag>` channel-discovery lookup.** That endpoint is
+///   minted per *installed version* (`GitHubReleasesSource.ruleFromInstalledRelease`),
+///   not per registry rule — there is no fixed, enumerable set of tag URLs to
+///   prune against the way there is for `/latest` and the list endpoint, so
+///   caching it would accumulate one-off entries forever instead of staying
+///   bounded. It is also not the endpoint the measurement above is about: a
+///   proven channel is already remembered by `ResolvedChannelStore` and the tag
+///   lookup runs at most once per version change, not once per check round. See
+///   `GitHubReleasesSource.fetchReleases` for where this is enforced (the
+///   conditional path is skipped whenever `tag != nil`).
+/// - **Parsed results.** Only the raw HTTP body is stored — see `Entry.body`.
+public actor GitHubConditionalCache {
+
+    /// The instance the app and CLI share. Like `ResolvedChannelStore.shared`,
+    /// nothing defaults to this implicitly — `GitHubReleasesSource`'s own
+    /// `validatorCache` parameter defaults to nil, so a test that constructs a
+    /// source directly (the overwhelming majority of them) writes nothing to the
+    /// real file. Only `SourceStack.make` and `duo verify`'s GitHub sweep wire
+    /// this in.
+    public static let shared = GitHubConditionalCache()
+
+    /// One endpoint's cached validator, keyed by the endpoint URL string.
+    ///
+    /// ⚠️ `body` is the RAW HTTP response body — never a parsed `[Release]` or
+    /// any other derived conclusion. Storing a conclusion would mean a rule
+    /// whose `versionPattern`/`installAssetPattern` changed keeps answering with
+    /// the OLD verdict for as long as GitHub's `ETag` stays unchanged (which can
+    /// be weeks) — recipe fixes would look like they "didn't take". Re-parsing
+    /// the stored body on every 304 is what `GitHubReleasesSource.fetchReleases`
+    /// does, and it is the entire reason this file exists in this shape.
+    struct Entry: Codable, Sendable {
+        /// Both optional so a file written before `lastModified` existed (and
+        /// a response missing either header) still decodes; `store` refuses an
+        /// entry that has neither, so a decoded entry always has at least one.
+        var etag: String?
+        var lastModified: String?
+        var body: Data
+        /// A stable, non-reversible fingerprint of the credential this entry was
+        /// fetched with — see `authFingerprint(_:)`. NEVER the token itself:
+        /// this file lives on disk indefinitely, unlike the in-memory-only
+        /// `URLCache` this replaces. GitHub hands out a different `ETag` to an
+        /// authenticated vs. an anonymous request for the same resource
+        /// (measured), so an entry fetched under one credential is simply wrong
+        /// evidence for another — `validator(for:authFingerprint:)` refuses to
+        /// return it across a mismatch rather than risk serving a body scoped to
+        /// someone else's rate limit or visibility.
+        var authFingerprint: String
+        /// Diagnostics only, mirroring `ResolvedChannelStore.Entry.provenAt` —
+        /// nothing here reads it back.
+        var storedAt: Date
+    }
+
+    /// What `fetchReleases` needs to build a conditional request and to recover
+    /// if the server actually answers 304.
+    public struct Validator: Sendable {
+        public let etag: String?
+        public let lastModified: String?
+        public let body: Data
+
+        /// Every conditional header a request built from this validator sends
+        /// — one, never both. See the type's doc comment for the measurement
+        /// behind the order: a `Last-Modified` wins outright because sending
+        /// the `ETag` alongside it makes GitHub ignore the date and compare the
+        /// (download-count-churned) `ETag` instead.
+        public var conditionalHeaders: [String: String] {
+            if let lastModified { return ["If-Modified-Since": lastModified] }
+            if let etag { return ["If-None-Match": etag] }
+            return [:]
+        }
+
+        /// The header names this layer owns on a request, so the unconditional
+        /// retry can strip exactly these and nothing else.
+        public static let headerNames = ["If-Modified-Since", "If-None-Match"]
+    }
+
+    private var entries: [String: Entry]
+    private let fileURL: URL
+    private var dirty = false
+
+    /// - Parameter fileURL: defaults to
+    ///   `DuoStateDirectory.base/com.duoupdater.app/github-conditional-cache.json`
+    ///   — the same container `ChangelogDiskCache` and the traffic store use, so
+    ///   `duo verify`'s `DUO_STATE_DIR` redirect (see `DuoStateDirectory`) keeps
+    ///   the nightly sweep from reading or writing the running app's copy.
+    public init(fileURL: URL? = nil) {
+        let url = fileURL ?? Self.defaultFileURL()
+        self.fileURL = url
+        self.entries = Self.load(from: url)
+    }
+
+    /// A stable, non-reversible identifier of "which credential" — never the
+    /// token itself. Two tokens (or a token vs. no token) must never be treated
+    /// as interchangeable: GitHub hands out a different `ETag` to an
+    /// authenticated vs. an anonymous request for the same URL (measured), so a
+    /// validator minted under one credential is not valid evidence under
+    /// another — sending it as `If-None-Match` risks a 304 that silently
+    /// resurrects a body fetched under a DIFFERENT identity (e.g. before a token
+    /// was revoked and replaced, or when running without one at all).
+    public static func authFingerprint(_ token: String?) -> String {
+        guard let token, !token.isEmpty else { return "anonymous" }
+        let digest = SHA256.hash(data: Data(token.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// The validator to revalidate `endpoint` with, or nil when nothing is
+    /// cached for this exact endpoint under this exact credential. Validators
+    /// and body are read together as one `Entry` so a caller can never see a
+    /// validator whose matching body has since been evicted or overwritten by
+    /// a concurrent write — they are stored, and read, as one unit.
+    public func validator(for endpoint: String, authFingerprint: String) -> Validator? {
+        guard let entry = entries[endpoint], entry.authFingerprint == authFingerprint else {
+            return nil
+        }
+        return Validator(etag: entry.etag, lastModified: entry.lastModified, body: entry.body)
+    }
+
+    /// Persist a fresh 200's validators + raw body for `endpoint` under this
+    /// credential, replacing whatever (if anything) was there — including an
+    /// entry stored under a different credential, which this simply overwrites
+    /// rather than trying to keep both around. A response with neither
+    /// validator is not stored: there would be nothing to revalidate with, and
+    /// an entry that can only ever miss is a body kept on disk for no reason.
+    public func store(
+        endpoint: String, authFingerprint: String,
+        etag: String?, lastModified: String?, body: Data
+    ) {
+        guard etag != nil || lastModified != nil else { return }
+        entries[endpoint] = Entry(
+            etag: etag, lastModified: lastModified, body: body,
+            authFingerprint: authFingerprint, storedAt: .now)
+        dirty = true
+    }
+
+    /// Drop every entry whose endpoint is not in `validEndpoints` — the set of
+    /// `/latest` and `/releases?per_page=<listPageSize>` URLs the CURRENT registry can
+    /// still ask for. Without this, a repo whose rule is deleted (renamed app,
+    /// retired recipe) leaves its entry behind forever, since nothing else ever
+    /// revisits that URL to notice it's dead. Bounded by construction: the set
+    /// this is pruned against has exactly two entries per registered rule.
+    public func prune(keeping validEndpoints: Set<String>) {
+        let before = entries.count
+        entries = entries.filter { validEndpoints.contains($0.key) }
+        if entries.count != before { dirty = true }
+    }
+
+    /// Clears `dirty` only once the bytes are actually on disk — same reasoning
+    /// as `ResolvedChannelStore.flush()`: an unwritable directory or full volume
+    /// must not silently drop the write AND make the next flush a no-op.
+    public func flush() {
+        guard dirty else { return }
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: fileURL, options: .atomic)
+            dirty = false
+        } catch {
+            Log.source.error(
+                "github-conditional-cache: could not write \(self.fileURL.lastPathComponent, privacy: .public) — \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    static func defaultFileURL() -> URL {
+        DuoStateDirectory.base
+            .appendingPathComponent("com.duoupdater.app", isDirectory: true)
+            .appendingPathComponent("github-conditional-cache.json")
+    }
+
+    /// A corrupt or hand-edited file decodes to nothing — costs one full,
+    /// unconditional fetch per affected endpoint and nothing else. Never thrown.
+    private static func load(from url: URL) -> [String: Entry] {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([String: Entry].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -113,6 +113,22 @@ public struct GitHubReleaseRule: Sendable {
     /// and what it measured.
     public let candidateScope: GitHubCandidateScope
 
+    /// Whether a `usePrereleases` rule with `.newest` scope first asks for a
+    /// page of ONE release and only pays for its full `listPageSize` page when
+    /// that one release cannot answer (wrong tag shape, draft, no macOS asset).
+    /// The list endpoint cannot be revalidated cheaply — it sends no
+    /// `Last-Modified` and its `ETag` churns with download counters, see
+    /// `GitHubConditionalCache` — so the newest release is the whole page
+    /// almost every round, and a page of one is 3-18 KB where the full page is
+    /// 17-75 KB (five installed repos, gzipped, 2026-09-05). Ignored for stable
+    /// rules (they read `/releases/latest`, already one release) and for
+    /// `.installedMajorLineOrNewestStable` (its answer is a window, not the
+    /// newest row). Set false for a rule whose newest release is usually NOT
+    /// the one it wants — Bitwarden's monorepo interleaves web, CLI and browser
+    /// releases ahead of the desktop tag — since the probe then only adds a
+    /// request. Defaults to true.
+    public let probesNewestFirst: Bool
+
     /// Prefix that turns the installed marketing version into its exact GitHub
     /// tag (`"v"` + `5.0.5` → `v5.0.5`). Non-nil only when stable and prerelease
     /// builds share every local identity signal. The source looks up that exact
@@ -153,10 +169,12 @@ public struct GitHubReleaseRule: Sendable {
         installedTagPrefix: String? = nil,
         installAssetPattern: String? = nil,
         installerKind: VendorInstallerKind? = nil,
-        channel: ReleaseChannel = .stable
+        channel: ReleaseChannel = .stable,
+        probesNewestFirst: Bool = true
     ) {
         self.bundleID = bundleID
         self.channel = channel
+        self.probesNewestFirst = probesNewestFirst
         self.owner = owner
         self.repo = repo
         self.usePrereleases = usePrereleases
@@ -180,7 +198,9 @@ public struct GitHubReleaseRule: Sendable {
     /// different reason: it's a request-shaping knob (how many rows to page
     /// through), not part of which repo/tag/asset the rule accepts, so an
     /// anchor could never legitimately be pinned to its digits.
-    static let nonAnchorFields: Set<String> = ["bundleID", "channel", "listPageSize"]
+    /// `probesNewestFirst` is the same kind of knob: it changes how many rows
+    /// the first request asks for, never which release or asset is accepted.
+    static let nonAnchorFields: Set<String> = ["bundleID", "channel", "listPageSize", "probesNewestFirst"]
 
     /// Everything this rule says about WHICH repository it reads and WHICH
     /// releases and assets it will accept — the text a
@@ -485,10 +505,71 @@ public struct GitHubReleasesSource: UpdateSource {
     var validNonTagEndpoints: Set<String> {
         var out = Set<String>()
         for rule in rules.values.flatMap({ $0 }) {
-            out.insert("https://api.github.com/repos/\(rule.slug)/releases/latest")
-            out.insert("https://api.github.com/repos/\(rule.slug)/releases?per_page=\(rule.listPageSize)")
+            out.insert(Self.latestEndpoint(rule))
+            out.insert(Self.listEndpoint(rule, pageSize: rule.listPageSize))
+            // The probe page is a third endpoint with its own validator; a rule
+            // that never probes never fetches it, so it must not be kept either
+            // (a stale one-row body would sit on disk forever).
+            if Self.probesNewestFirst(rule) {
+                out.insert(Self.listEndpoint(rule, pageSize: Self.newestProbePageSize))
+            }
         }
         return out
+    }
+
+    /// The one place both URL shapes are spelled out. `fetchReleases` requests
+    /// exactly these strings and `validNonTagEndpoints` prunes against exactly
+    /// these strings; the two used to be written twice and drifted (see that
+    /// property's doc comment).
+    static func latestEndpoint(_ rule: GitHubReleaseRule) -> String {
+        "https://api.github.com/repos/\(rule.slug)/releases/latest"
+    }
+    static func listEndpoint(_ rule: GitHubReleaseRule, pageSize: Int) -> String {
+        "https://api.github.com/repos/\(rule.slug)/releases?per_page=\(pageSize)"
+    }
+
+    /// One row. The newest release IS the answer for a `.newest` prerelease
+    /// rule on every round that does not land between a platform-partial
+    /// release and the next real one, so one row is the page that pays for
+    /// itself; anything larger just moves the fallback threshold.
+    static let newestProbePageSize = 1
+
+    /// Whether `resolve` may open with a one-row page for this rule at all —
+    /// the static half of the decision. The dynamic half (has the full page
+    /// been fetched once, so the release history is seeded) lives in
+    /// `newestProbeSize(for:)`.
+    static func probesNewestFirst(_ rule: GitHubReleaseRule) -> Bool {
+        rule.usePrereleases && rule.candidateScope == .newest && rule.probesNewestFirst
+    }
+
+    /// The page size `resolve` opens with, or nil to fetch the rule's full page
+    /// straight away.
+    ///
+    /// The full page is fetched at least once before any probing, because it
+    /// is also the release HISTORY: `resolve` back-fills the timeline from
+    /// every release on the page, and the timeline records a version at first
+    /// sighting and keeps it (`ReleaseTimelineStore.record`), so one full page
+    /// seeds the history and one-row pages afterwards lose nothing already
+    /// recorded. "Fetched at least once" is read off the validator store — a
+    /// memo for the full-page endpoint under the current credential — which
+    /// is the only durable record of that. With no store wired in (tests, and
+    /// a source constructed directly) there is nothing to seed, so probing
+    /// starts immediately.
+    ///
+    /// What a one-row page does forgo, by design: a release that lands
+    /// BETWEEN two rounds and is no longer the newest by the next one never
+    /// reaches the timeline. At a five-minute interval that needs two releases
+    /// in five minutes; at the six-hour default it is likelier. The version
+    /// shown is unaffected — the newest release is on both pages.
+    private func newestProbeSize(for rule: GitHubReleaseRule) async -> Int? {
+        guard Self.probesNewestFirst(rule) else { return nil }
+        if let validatorCache {
+            let seeded = await validatorCache.validator(
+                for: Self.listEndpoint(rule, pageSize: rule.listPageSize),
+                authFingerprint: GitHubConditionalCache.authFingerprint(token)) != nil
+            guard seeded else { return nil }
+        }
+        return Self.newestProbePageSize
     }
 
     public func latestVersion(for app: InstalledApp) async throws -> RemoteVersion? {
@@ -827,7 +908,7 @@ public struct GitHubReleasesSource: UpdateSource {
     /// for why `URLCache` alone doesn't revalidate these endpoints, and for why
     /// the tag lookup (`tag != nil`) never participates.
     private func fetchReleases(
-        _ rule: GitHubReleaseRule, list: Bool, tag: String? = nil
+        _ rule: GitHubReleaseRule, list: Bool, tag: String? = nil, pageSize: Int? = nil
     ) async throws -> [Release]? {
         let endpoint: String
         if let tag {
@@ -839,8 +920,8 @@ public struct GitHubReleasesSource: UpdateSource {
             endpoint = "https://api.github.com/repos/\(rule.slug)/releases/tags/\(escaped)"
         } else {
             endpoint = list
-                ? "https://api.github.com/repos/\(rule.slug)/releases?per_page=\(rule.listPageSize)"
-                : "https://api.github.com/repos/\(rule.slug)/releases/latest"
+                ? Self.listEndpoint(rule, pageSize: pageSize ?? rule.listPageSize)
+                : Self.latestEndpoint(rule)
         }
         guard let url = URL(string: endpoint) else { return nil }
 
@@ -1051,10 +1132,46 @@ public struct GitHubReleasesSource: UpdateSource {
         preferring hostArch: HostArch = .current,
         allowingIntelTranslation canRunIntel: Bool = HostArch.canRunIntelBuilds
     ) async throws -> Resolution {
-        guard var releases = try await fetchReleases(rule, list: rule.usePrereleases) else {
+        // One row first, when the rule allows it — see `newestProbeSize(for:)`.
+        // A probe that cannot answer is not a recipe miss (the release it wants
+        // may simply sit below the newest row), so nothing is recorded against
+        // the rule until the full page has had its say. An arch-incompatible
+        // newest row IS the answer — the full page would break on the same
+        // row — so that one does not fall back either.
+        if let probeSize = await newestProbeSize(for: rule) {
+            guard let probed = try await fetchReleases(rule, list: true, pageSize: probeSize) else {
+                return Resolution(remote: nil, tags: [], archIncompatible: false)
+            }
+            let first = try await settle(
+                rule, releases: probed, anchoredTo: installedVersion,
+                preferring: hostArch, allowingIntelTranslation: canRunIntel,
+                recordingMisses: false)
+            if first.remote != nil || first.archIncompatible { return first }
+            Log.source.debug("GitHub \(rule.slug, privacy: .public): the newest release could not answer, paying for the full page of \(rule.listPageSize, privacy: .public)")
+        }
+        guard let releases = try await fetchReleases(rule, list: rule.usePrereleases) else {
             return Resolution(remote: nil, tags: [], archIncompatible: false)
         }
+        return try await settle(
+            rule, releases: releases, anchoredTo: installedVersion,
+            preferring: hostArch, allowingIntelTranslation: canRunIntel,
+            recordingMisses: true)
+    }
 
+    /// Everything `resolve` does once it holds a page: scope ceiling, the
+    /// stable rule's missing-asset fallback, history, the asset walk. Split
+    /// from the fetch so a one-row probe and the full page run the identical
+    /// judgement; `recordingMisses` is the only difference, because a probe
+    /// that finds nothing is not evidence about the recipe.
+    private func settle(
+        _ rule: GitHubReleaseRule,
+        releases: [Release],
+        anchoredTo installedVersion: String?,
+        preferring hostArch: HostArch,
+        allowingIntelTranslation canRunIntel: Bool,
+        recordingMisses: Bool
+    ) async throws -> Resolution {
+        var releases = releases
         // Drafts are never releases, even when an authenticated token can see
         // them, and no scope should be able to offer one.
         releases = releases.filter { !$0.isDraft }
@@ -1217,6 +1334,9 @@ public struct GitHubReleasesSource: UpdateSource {
         // asset rename (tags matched fine, none carried the macOS file). Reported
         // as the same thing, the second reads like the first and gets fixed in
         // the wrong place.
+        guard recordingMisses else {
+            return Resolution(remote: nil, tags: releases.map(\.tag), archIncompatible: false)
+        }
         if !skippedForMissingAsset.isEmpty {
             let tags = skippedForMissingAsset.joined(separator: ", ")
             Log.source.error("GitHub \(rule.slug, privacy: .public): no release carries an asset matching /\(rule.installAssetPattern ?? "", privacy: .public)/ (walked \(tags, privacy: .public))")
@@ -2154,7 +2274,14 @@ public enum GitHubReleaseRegistry {
             listPageSize: 10,
             versionPattern: #"desktop-v([0-9]+(?:\.[0-9]+)+)$"#,
             installAssetPattern: #"^Bitwarden-[0-9.]+-universal\.dmg$"#,
-            installerKind: .dmg),
+            installerKind: .dmg,
+            // The newest release of this monorepo is a web/CLI/browser tag far
+            // more often than the desktop one (measured 2026-09-05: the one-row
+            // page was `web-v…`, and the same shape held across the newest 100
+            // releases, `desktop-v` tags at most 7 apart), so a one-row probe
+            // here would fall back to the full page most rounds and only add a
+            // request. Every other prerelease rule in this registry probes.
+            probesNewestFirst: false),
 
         // VSCodium — VS Code without the Microsoft build. Tags are bare
         // `1.126.04524` (the trailing group is VSCodium's own build stamp and IS

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1028,9 +1028,11 @@ public struct GitHubReleasesSource: UpdateSource {
             body: body)
         // Registry-scoped, not per-request: cheap (a Set filter over at most
         // a couple hundred entries) and keeps a retired rule's entry from
-        // outliving the rule by years. See `validNonTagEndpoints`.
+        // outliving the rule by years. See `validNonTagEndpoints`. The write
+        // to disk is the store's business (`scheduleFlush`), not this
+        // function's — flushing here once per 2xx rewrote a multi-megabyte
+        // file several times a round.
         await validatorCache.prune(keeping: validNonTagEndpoints)
-        await validatorCache.flush()
     }
 
     /// Interpret a non-304 HTTP response: decode a 2xx (walking releases in

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -430,17 +430,65 @@ public struct GitHubReleasesSource: UpdateSource {
     /// the shared instance, and passes the SAME instance to `UpdateChecker` so a
     /// failed check can still read what an earlier one proved.
     private let channelStore: ResolvedChannelStore?
+    /// Where a validator (`Last-Modified` / `ETag` + raw body) for
+    /// `/releases/latest` and `/releases?per_page=<listPageSize>` is remembered
+    /// so `fetchReleases` can revalidate itself — `If-Modified-Since` alone
+    /// wherever the response had a `Last-Modified` — instead of relying on
+    /// `URLCache`, whose `If-None-Match` GitHub answers with a full 200 as soon
+    /// as a download counter moves. See `GitHubConditionalCache`'s doc comment
+    /// for the measurement.
+    /// nil (the default) means "always fetch unconditionally, persist
+    /// nothing" — same convention as `channelStore`, so the many tests that
+    /// construct a source directly cannot accidentally write into the real
+    /// file. `SourceStack.make` and `duo verify`'s GitHub sweep wire in
+    /// `GitHubConditionalCache.shared`.
+    private let validatorCache: GitHubConditionalCache?
 
     public init(
         rules: [GitHubReleaseRule] = GitHubReleaseRegistry.rules,
         token: String? = nil,
         session: URLSession = .updates,
-        channelStore: ResolvedChannelStore? = nil
+        channelStore: ResolvedChannelStore? = nil,
+        validatorCache: GitHubConditionalCache? = nil
     ) {
         self.rules = Dictionary(grouping: rules, by: { $0.bundleID })
         self.token = token
         self.session = session
         self.channelStore = channelStore
+        self.validatorCache = validatorCache
+    }
+
+    /// The `/releases/latest` and `/releases?per_page=<listPageSize>` URLs
+    /// every rule in this instance's registry could ask for — i.e. exactly the
+    /// endpoints `GitHubConditionalCache.prune(keeping:)` is allowed to keep.
+    /// Two per rule regardless of which one that rule actually uses
+    /// (`usePrereleases` picks one for `resolve`, but `channelDiscoveryProbe`
+    /// always fetches the list endpoint for a discoverable rule, so both must
+    /// survive pruning for every rule to avoid punishing the diagnostic path
+    /// for a cache miss on every single sweep).
+    ///
+    /// The list URL must be built with the rule's own `listPageSize`, byte for
+    /// byte the way `fetchReleases` builds it: a first draft hard-coded
+    /// `per_page=20` here after `listPageSize` had made it per-rule, so every
+    /// rule with a smaller page had its list entry stored and then pruned on
+    /// the very same fetch — a cache that could never hit, with no error
+    /// anywhere. `validNonTagEndpointsFollowEachRulesListPageSize` pins it.
+    ///
+    /// Deliberately excludes `/releases/tags/<tag>` — see `GitHubConditionalCache`'s
+    /// doc comment for why that endpoint is not cached at all. This is the set
+    /// `prune(keeping:)` is called with, so it doubles as a second, independent
+    /// backstop: even if `fetchReleases`'s own `tag == nil` gate were ever
+    /// mistakenly dropped, a tag entry that slipped into the store would still
+    /// be deleted the next time any rule's endpoint is fetched, because it can
+    /// never appear in this set. `internal` (not `private`) so
+    /// `GitHubConditionalCacheTests` can assert on it directly.
+    var validNonTagEndpoints: Set<String> {
+        var out = Set<String>()
+        for rule in rules.values.flatMap({ $0 }) {
+            out.insert("https://api.github.com/repos/\(rule.slug)/releases/latest")
+            out.insert("https://api.github.com/repos/\(rule.slug)/releases?per_page=\(rule.listPageSize)")
+        }
+        return out
     }
 
     public func latestVersion(for app: InstalledApp) async throws -> RemoteVersion? {
@@ -767,6 +815,17 @@ public struct GitHubReleasesSource: UpdateSource {
     /// unbuildable, the response wasn't HTTP, or an exact-tag discovery got a
     /// 404; other bad statuses throw so the row surfaces a retryable error rather
     /// than a dead "unknown".
+    ///
+    /// For the two non-tag endpoints (`/releases/latest`, `/releases?per_page=N`),
+    /// sends a conditional GET when `validatorCache` holds a validator for this
+    /// exact endpoint + credential pair — `If-Modified-Since` alone when the
+    /// stored response had a `Last-Modified`, `If-None-Match` only otherwise
+    /// (`Validator.conditionalHeaders`) — and re-parses the STORED RAW BODY on
+    /// a 304 — never a remembered conclusion, so a rule's `versionPattern` /
+    /// `installAssetPattern` edit takes effect on the very next check even if
+    /// the release hasn't moved. See `GitHubConditionalCache`'s doc comment
+    /// for why `URLCache` alone doesn't revalidate these endpoints, and for why
+    /// the tag lookup (`tag != nil`) never participates.
     private func fetchReleases(
         _ rule: GitHubReleaseRule, list: Bool, tag: String? = nil
     ) async throws -> [Release]? {
@@ -793,10 +852,115 @@ public struct GitHubReleasesSource: UpdateSource {
         // Authenticated requests get 5000/hour instead of 60/hour per IP.
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
 
-        Log.source.debug("GitHub GET \(endpoint, privacy: .public) (auth=\(self.token != nil, privacy: .public))")
+        // Conditional-GET layer. `cachedValidator` stays nil (and no
+        // conditional header is sent) for the tag lookup, when no cache is
+        // wired in, and on a plain cache miss — every one of those falls
+        // straight through to an ordinary unconditional fetch below.
+        let authFingerprint = GitHubConditionalCache.authFingerprint(token)
+        var cachedValidator: GitHubConditionalCache.Validator?
+        if tag == nil, let validatorCache {
+            cachedValidator = await validatorCache.validator(
+                for: endpoint, authFingerprint: authFingerprint)
+            if let cachedValidator {
+                for (name, value) in cachedValidator.conditionalHeaders {
+                    request.setValue(value, forHTTPHeaderField: name)
+                }
+                // We are the validator now. Left on `versionFeedCachePolicy`
+                // (`.reloadRevalidatingCacheData`), `URLCache` would add its own
+                // `If-None-Match` from the copy it holds of the last 200 — and
+                // one stale `ETag` on the wire is enough for GitHub to ignore
+                // the `If-Modified-Since` next to it (RFC 7232 §6, measured; see
+                // `GitHubConditionalCache`). Ignoring the local cache for this
+                // one request keeps the header set exactly what
+                // `conditionalHeaders` says it is.
+                request.cachePolicy = .reloadIgnoringLocalCacheData
+            }
+        }
+
+        Log.source.debug("GitHub GET \(endpoint, privacy: .public) (auth=\(self.token != nil, privacy: .public), conditional=\(cachedValidator != nil, privacy: .public))")
         let (data, response) = try await session.versionFeedData(
             for: request, label: "GitHub \(rule.slug)")
         guard let http = response as? HTTPURLResponse else { return nil }
+
+        if http.statusCode == 304 {
+            if let cachedValidator {
+                let decoded = Self.releases(from: cachedValidator.body, list: list)
+                Log.source.debug("GitHub \(rule.slug, privacy: .public): 304, served \(decoded.count, privacy: .public) release(s) from the conditional cache")
+                GitHubEndpointAudit.record(
+                    requestedSlug: rule.slug, requestedURL: url, response: http,
+                    firstReleaseHTMLURL: decoded.first?.htmlURL, sentToken: token != nil)
+                return decoded
+            }
+            // We only ever send a validator when `cachedValidator` is
+            // non-nil, so this should be unreachable — GitHub has no validator
+            // to compare against otherwise. But the rule that MUST hold
+            // regardless of why it happened is: a 304 with nothing to serve it
+            // from is a cache MISS, never "no update" and never an error — so
+            // re-ask unconditionally rather than guess.
+            Log.source.error("GitHub \(rule.slug, privacy: .public): 304 with no cached validator to serve — retrying unconditionally")
+            return try await fetchReleasesUnconditionally(
+                rule: rule, url: url, endpoint: endpoint, list: list, tag: tag,
+                baseRequest: request, authFingerprint: authFingerprint)
+        }
+
+        let decoded = try handleSettledResponse(
+            http, data: data, rule: rule, url: url, list: list, tag: tag)
+        await remember(http, body: data, endpoint: endpoint, tag: tag, authFingerprint: authFingerprint)
+        return decoded
+    }
+
+    /// Cache-miss fallback for the "304 but nothing to serve it from" case —
+    /// see the comment at its one call site. Re-sends `baseRequest` with every
+    /// conditional header removed, so the response can only be a real 2xx or a
+    /// real error status, then runs it through the same settle-and-persist
+    /// logic the primary path uses.
+    private func fetchReleasesUnconditionally(
+        rule: GitHubReleaseRule, url: URL, endpoint: String, list: Bool, tag: String?,
+        baseRequest: URLRequest, authFingerprint: String
+    ) async throws -> [Release]? {
+        var request = baseRequest
+        for name in GitHubConditionalCache.Validator.headerNames {
+            request.setValue(nil, forHTTPHeaderField: name)
+        }
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "GitHub \(rule.slug) (conditional-cache-miss retry)")
+        guard let http = response as? HTTPURLResponse else { return nil }
+        let decoded = try handleSettledResponse(
+            http, data: data, rule: rule, url: url, list: list, tag: tag)
+        await remember(http, body: data, endpoint: endpoint, tag: tag, authFingerprint: authFingerprint)
+        return decoded
+    }
+
+    /// Persist a settled 2xx's validators + raw body for a non-tag endpoint.
+    /// Both `Last-Modified` and `ETag` are stored when present; which one goes
+    /// on the next request is `Validator.conditionalHeaders`' decision, not
+    /// this one's. One function for both fetch paths so they cannot drift on
+    /// what gets remembered.
+    private func remember(
+        _ http: HTTPURLResponse, body: Data, endpoint: String, tag: String?, authFingerprint: String
+    ) async {
+        guard tag == nil, let validatorCache, (200..<300).contains(http.statusCode) else { return }
+        await validatorCache.store(
+            endpoint: endpoint, authFingerprint: authFingerprint,
+            etag: http.value(forHTTPHeaderField: "ETag"),
+            lastModified: http.value(forHTTPHeaderField: "Last-Modified"),
+            body: body)
+        // Registry-scoped, not per-request: cheap (a Set filter over at most
+        // a couple hundred entries) and keeps a retired rule's entry from
+        // outliving the rule by years. See `validNonTagEndpoints`.
+        await validatorCache.prune(keeping: validNonTagEndpoints)
+        await validatorCache.flush()
+    }
+
+    /// Interpret a non-304 HTTP response: decode a 2xx (walking releases in
+    /// document order — GitHub returns newest first — is the caller's job, not
+    /// this one), translate a 404 exact-tag miss into `nil`, and audit + throw
+    /// everything else. Shared by the primary fetch and the conditional-cache-miss
+    /// retry so the two can't drift on what counts as success.
+    private func handleSettledResponse(
+        _ http: HTTPURLResponse, data: Data, rule: GitHubReleaseRule, url: URL,
+        list: Bool, tag: String?
+    ) throws -> [Release]? {
         guard (200..<300).contains(http.statusCode) else {
             let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"
             Log.source.error("GitHub \(rule.slug, privacy: .public): HTTP \(http.statusCode, privacy: .public) (ratelimit-remaining=\(remaining, privacy: .public))")
@@ -819,9 +983,6 @@ public struct GitHubReleasesSource: UpdateSource {
             if tag != nil, http.statusCode == 404 { return nil }
             throw GitHubError.badStatus(http.statusCode)
         }
-        // Walk releases in document order (GitHub returns newest first) and take
-        // the first whose tag the pattern matches — for prerelease channels this
-        // skips interleaved stable releases.
         let decoded = Self.releases(from: data, list: list)
         // Verification-only bookkeeping: notice a slug that GitHub had to redirect,
         // and an authenticated request that came back on the anonymous budget

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DuoStateDirectoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DuoStateDirectoryTests.swift
@@ -43,6 +43,8 @@ struct DuoStateDirectoryTests {
             #expect(ReleaseTimelineStore.defaultFileURL().path
                 == "/tmp/duo-state-test/com.duoupdater.app/releases.json")
             #expect(BackupStore.root.path == "/tmp/duo-state-test/DuoUpdater/Backups")
+            #expect(GitHubConditionalCache.defaultFileURL().path
+                == "/tmp/duo-state-test/com.duoupdater.app/github-conditional-cache.json")
             // Resolved in the initialiser, so it must be constructed inside the
             // override; reading it back is what needs the await.
             return ChangelogDiskCache()

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubChannelProofTests.swift
@@ -261,7 +261,7 @@ struct GitHubChannelProofTests {
     @Test func channelAnchorSurfaceCoversEveryGitHubRuleField() {
         let rule = GitHubReleaseRegistry.rules[0]
         let labels = Mirror(reflecting: rule).children.compactMap(\.label)
-        #expect(labels.count == 11,
+        #expect(labels.count == 12,
                 "GitHubReleaseRule gained or lost a field (now \(labels.count): \(labels.sorted())) — decide whether it belongs in the .recipeAnchor surface or in nonAnchorFields, then update this count")
         for excluded in GitHubReleaseRule.nonAnchorFields {
             #expect(labels.contains(excluded),

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
@@ -1,0 +1,464 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `GitHubReleasesSource.fetchReleases` was measured (see `GitHubConditionalCache`'s
+/// doc comment) to almost never get a `URLCache` revalidation for
+/// `/releases/latest` and `/releases?per_page=N`: GitHub's `ETag` churns with
+/// `assets[].download_count`, and a stale `If-None-Match` on the wire makes the
+/// server ignore the `If-Modified-Since` next to it. These pin the self-maintained
+/// validator store that replaces reliance on `URLCache` for those two endpoints:
+/// which single validator header goes out, what it does with a 304, and what it
+/// refuses to do when the 304 can't be trusted.
+@Suite(.serialized)
+struct GitHubConditionalCacheTests {
+
+    /// Serves scripted (status, etag, lastModified, body) answers in order and
+    /// records every request's two conditional headers and its cache policy, so
+    /// a test can assert "how many times did the network actually get hit",
+    /// "which validator did we send" and "did we keep `URLCache` out of it".
+    private final class ScriptedProtocol: URLProtocol, @unchecked Sendable {
+        struct Answer {
+            let status: Int; let etag: String?; let lastModified: String?; let body: String
+            init(status: Int, etag: String?, lastModified: String? = nil, body: String) {
+                self.status = status; self.etag = etag; self.lastModified = lastModified; self.body = body
+            }
+        }
+        struct Seen { let ifNoneMatch: String?; let ifModifiedSince: String?; let cachePolicy: URLRequest.CachePolicy }
+
+        final class Script: @unchecked Sendable {
+            private let lock = NSLock()
+            private var queue: [Answer] = []
+            private var seen: [Seen] = []
+
+            func load(_ answers: [Answer]) {
+                lock.lock(); queue = answers; seen = []; lock.unlock()
+            }
+
+            func next(_ request: URLRequest) -> Answer {
+                lock.lock(); defer { lock.unlock() }
+                seen.append(Seen(
+                    ifNoneMatch: request.value(forHTTPHeaderField: "If-None-Match"),
+                    ifModifiedSince: request.value(forHTTPHeaderField: "If-Modified-Since"),
+                    cachePolicy: request.cachePolicy))
+                return queue.isEmpty
+                    ? Answer(status: 200, etag: nil, body: "{}") : queue.removeFirst()
+            }
+
+            var requestCount: Int { lock.lock(); defer { lock.unlock() }; return seen.count }
+            var ifNoneMatchSent: [String?] { lock.lock(); defer { lock.unlock() }; return seen.map(\.ifNoneMatch) }
+            var ifModifiedSinceSent: [String?] { lock.lock(); defer { lock.unlock() }; return seen.map(\.ifModifiedSince) }
+            var cachePolicies: [URLRequest.CachePolicy] { lock.lock(); defer { lock.unlock() }; return seen.map(\.cachePolicy) }
+        }
+
+        static let script = Script()
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            let answer = Self.script.next(request)
+            var headers: [String: String] = [:]
+            if let etag = answer.etag { headers["ETag"] = etag }
+            if let lastModified = answer.lastModified { headers["Last-Modified"] = lastModified }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: answer.status,
+                httpVersion: "HTTP/1.1", headerFields: headers)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(answer.body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    private static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ScriptedProtocol.self]
+        // No URLCache at all — every test proves the SOURCE's own conditional
+        // layer, not a lucky assist from the protocol cache.
+        configuration.urlCache = nil
+        return URLSession(configuration: configuration)
+    }
+
+    /// A `/releases/latest` payload with one tag. `tag` is deliberately shaped so
+    /// two different `versionPattern`s can extract two DIFFERENT version strings
+    /// from the exact same bytes — see
+    /// `aRulePatternChangeTakesEffectThroughA304NotACachedConclusion`.
+    private static func body(tag: String) -> String {
+        """
+        {
+          "tag_name": "\(tag)",
+          "assets": [],
+          "prerelease": false,
+          "draft": false
+        }
+        """
+    }
+
+    private static func tempCache() -> GitHubConditionalCache {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("duo-conditional-cache-tests-\(UUID().uuidString)")
+        return GitHubConditionalCache(fileURL: dir.appendingPathComponent("cache.json"))
+    }
+
+    // MARK: - 1. Store raw body, re-parse on every 304 (never a cached conclusion)
+
+    /// Mutation this pins: caching the RESOLVED version (or anything downstream
+    /// of `versionPattern`) instead of the raw HTTP body. Two `GitHubReleasesSource`
+    /// instances share one `GitHubConditionalCache` and the same slug, so the
+    /// second request is answered 304 from the very same script — but the two
+    /// instances use DIFFERENT `versionPattern`s against the identical tag
+    /// `"v1.2.3"`. A correct implementation re-parses the stored bytes under
+    /// whichever pattern is asking right now, so the two calls must disagree.
+    /// An implementation that instead cached (or reused) a parsed conclusion tied
+    /// to the first rule would answer "1.2.3" both times — this test goes red on
+    /// that mutation (verified below).
+    @Test func aRulePatternChangeTakesEffectThroughA304NotACachedConclusion() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "etag-1", body: Self.body(tag: "v1.2.3")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+
+        let ruleOld = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#)   // "v1.2.3" -> "1.2.3"
+        let sourceOld = GitHubReleasesSource(
+            rules: [ruleOld], token: "tok", session: session, validatorCache: cache)
+        let first = await sourceOld.resolveDiagnostic(ruleOld)
+        #expect(first.remote?.shortVersion == "1.2.3")
+        #expect(ScriptedProtocol.script.requestCount == 1)
+
+        // Same slug, same endpoint, same cached bytes — but a rule edit: only the
+        // suffix after "v1." is the version now.
+        let ruleNew = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v1\.([0-9.]+)$"#)   // "v1.2.3" -> "2.3"
+        let sourceNew = GitHubReleasesSource(
+            rules: [ruleNew], token: "tok", session: session, validatorCache: cache)
+        let second = await sourceNew.resolveDiagnostic(ruleNew)
+
+        // The request that went out was a 304 (belt and braces: proves this
+        // exercised the conditional path, not a coincidental fresh 200).
+        #expect(ScriptedProtocol.script.requestCount == 2)
+        #expect(ScriptedProtocol.script.ifNoneMatchSent.last == "etag-1")
+        // The answer reflects the NEW pattern, not the one that was cached under.
+        #expect(second.remote?.shortVersion == "2.3")
+        #expect(second.remote?.shortVersion != first.remote?.shortVersion)
+    }
+
+    /// A response with an `ETag` and no `Last-Modified` — the list endpoint's
+    /// shape — is revalidated by `If-None-Match`, and the value sent is exactly
+    /// the `ETag` the first 200 carried. Pins the wiring, independent of the
+    /// pattern-change scenario above.
+    @Test func theSecondRequestSendsTheEtagFromTheFirst200() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "\"abc123\"", body: Self.body(tag: "v9.9.9")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(bundleID: "com.example.app", owner: "example", repo: "app")
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        _ = await source.resolveDiagnostic(rule)
+        _ = await source.resolveDiagnostic(rule)
+
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, "\"abc123\""])
+        #expect(ScriptedProtocol.script.ifModifiedSinceSent == [nil, nil])
+    }
+
+    // MARK: - 1b. `Last-Modified` wins outright, and the `ETag` stays home
+
+    /// Mutation this pins: sending `If-None-Match` alongside (or instead of)
+    /// `If-Modified-Since` when the stored response had a `Last-Modified`.
+    /// Measured on 2026-09-05 against `VSCodium/vscodium/releases/latest`: the
+    /// `ETag` rotates every few minutes with `assets[].download_count`, and a
+    /// request carrying the stale `ETag` *and* a valid `If-Modified-Since` gets
+    /// a full 200 — GitHub evaluates `If-None-Match` first (RFC 7232 §6) and
+    /// ignores the date. Only `If-Modified-Since` alone gets the 304. So the
+    /// first 200 here carries BOTH headers, and the second request must carry
+    /// exactly one: the date, verbatim.
+    @Test func aLastModifiedIsRevalidatedByDateAloneNeverByTheEtagNextToIt() async throws {
+        let lastModified = "Sat, 11 Jul 2026 21:54:57 GMT"
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "W/\"churns-with-download-count\"", lastModified: lastModified,
+                  body: Self.body(tag: "v1.2.3")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#)
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        let first = await source.resolveDiagnostic(rule)
+        let second = await source.resolveDiagnostic(rule)
+
+        #expect(ScriptedProtocol.script.requestCount == 2)
+        #expect(ScriptedProtocol.script.ifModifiedSinceSent == [nil, lastModified])
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil])
+        // And the 304 was served from the stored body, not read as "nothing".
+        #expect(first.remote?.shortVersion == "1.2.3")
+        #expect(second.remote?.shortVersion == "1.2.3")
+    }
+
+    /// Mutation this pins: leaving a validator-bearing request on
+    /// `versionFeedCachePolicy` (`.reloadRevalidatingCacheData`). On the real
+    /// `URLSession.updates` that lets `URLCache` add its own `If-None-Match`
+    /// from the copy it holds of the last 200, and one stale `ETag` on the wire
+    /// is enough to void the `If-Modified-Since` (see the previous test). The
+    /// first, unconditional request keeps the feed policy — nothing about the
+    /// "never answer a version feed from cache freshness" contract changes.
+    @Test func aValidatorBearingRequestIgnoresTheLocalURLCache() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "e", lastModified: "Sat, 11 Jul 2026 21:54:57 GMT",
+                  body: Self.body(tag: "v1.0.0")),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(bundleID: "com.example.app", owner: "example", repo: "app")
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        _ = await source.resolveDiagnostic(rule)
+        _ = await source.resolveDiagnostic(rule)
+
+        #expect(ScriptedProtocol.script.cachePolicies
+                == [URLRequest.versionFeedCachePolicy, .reloadIgnoringLocalCacheData])
+    }
+
+    /// A store file written before `lastModified` existed (entries with `etag`
+    /// only) must still decode and still revalidate by `ETag` — a format change
+    /// that silently emptied the store would cost one full fetch per endpoint
+    /// with nothing to notice it by. Mutation this pins: making `Entry.etag` /
+    /// `lastModified` non-optional, or renaming a key.
+    @Test func aStoreFileFromBeforeLastModifiedStillDecodes() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("duo-conditional-cache-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("cache.json")
+        let endpoint = "https://api.github.com/repos/old/repo/releases/latest"
+        let legacy = """
+        {"\(endpoint)": {"etag": "\\"legacy\\"", "body": "\(Data("{}".utf8).base64EncodedString())",
+                          "authFingerprint": "fp", "storedAt": 810280008.0}}
+        """
+        try Data(legacy.utf8).write(to: file)
+
+        let cache = GitHubConditionalCache(fileURL: file)
+        let validator = await cache.validator(for: endpoint, authFingerprint: "fp")
+
+        #expect(validator?.etag == "\"legacy\"")
+        #expect(validator?.lastModified == nil)
+        #expect(validator?.conditionalHeaders == ["If-None-Match": "\"legacy\""])
+    }
+
+    // MARK: - 2. Failure retreats to an unconditional request, never "no update"
+
+    /// Mutation this pins: treating an untrustable 304 (nothing cached to serve
+    /// it from) as "no update" or as an error. Nothing was ever stored — the
+    /// cache is empty — so the request cannot legitimately carry `If-None-Match`,
+    /// yet the script answers 304 on the first call anyway (standing in for a
+    /// corrupted/evicted store or a rogue intermediary). The source must not
+    /// interpret that as "nothing changed": it must fall back to a *second*,
+    /// unconditional request and return whatever that one says.
+    @Test func aTrustlessOhThreeOhFourFallsBackToAnUnconditionalRequest() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 304, etag: nil, body: ""),
+            .init(status: 200, etag: "etag-real", body: Self.body(tag: "v3.1.4")),
+        ])
+        let cache = Self.tempCache()   // empty — nothing was ever stored
+        let session = Self.session()
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#)
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        let outcome = await source.resolveDiagnostic(rule)
+
+        // Not nil, not an error — the retry's real answer.
+        #expect(outcome.remote?.shortVersion == "3.1.4")
+        #expect(outcome.failure == nil)
+        #expect(ScriptedProtocol.script.requestCount == 2)
+        // Neither request could have legitimately carried a validator.
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil])
+    }
+
+    // MARK: - 3. Auth context changes invalidate the old validator
+
+    /// Mutation this pins: keying the cache only by endpoint, so a validator
+    /// fetched under one token is reused (as `If-None-Match`) for a DIFFERENT
+    /// token. GitHub hands out different ETags to authenticated vs. anonymous
+    /// requests for the same resource, so this would risk a spurious 304 that
+    /// resurrects a body fetched under someone else's credential.
+    @Test func aDifferentTokenNeverReusesTheOldValidator() async throws {
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "etag-for-tokA", body: Self.body(tag: "v1.0.0")),
+            .init(status: 200, etag: "etag-for-tokB", body: Self.body(tag: "v2.0.0")),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(bundleID: "com.example.app", owner: "example", repo: "app")
+
+        let sourceA = GitHubReleasesSource(
+            rules: [rule], token: "tokA", session: session, validatorCache: cache)
+        let first = await sourceA.resolveDiagnostic(rule)
+        #expect(first.remote?.shortVersion == "1.0.0")
+
+        let sourceB = GitHubReleasesSource(
+            rules: [rule], token: "tokB", session: session, validatorCache: cache)
+        let second = await sourceB.resolveDiagnostic(rule)
+
+        // No validator sent for the different token — a real, unconditional
+        // second request, not a 304.
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil])
+        #expect(second.remote?.shortVersion == "2.0.0")
+        #expect(ScriptedProtocol.script.requestCount == 2)
+    }
+
+    /// Going from a token to no token (or back) is the same hazard as two
+    /// different tokens — `authFingerprint(nil)` must not collide with
+    /// `authFingerprint(_:)` for any real token.
+    @Test func authFingerprintDistinguishesAnonymousFromAnyToken() {
+        let anon = GitHubConditionalCache.authFingerprint(nil)
+        let tokA = GitHubConditionalCache.authFingerprint("tokA")
+        let tokB = GitHubConditionalCache.authFingerprint("tokB")
+        #expect(anon != tokA)
+        #expect(tokA != tokB)
+        // Deterministic, so re-fetching after a process restart still matches.
+        #expect(tokA == GitHubConditionalCache.authFingerprint("tokA"))
+        // Never the raw token — a disk-persisted store must not carry it.
+        #expect(!anon.contains("tok"))
+        #expect(!tokA.contains("tokA"))
+    }
+
+    // MARK: - 4. Bounded: pruning drops what the registry no longer asks for
+
+    @Test func pruneDropsEndpointsOutsideTheKeptSet() async {
+        let cache = Self.tempCache()
+        await cache.store(
+            endpoint: "https://api.github.com/repos/kept/repo/releases/latest",
+            authFingerprint: "fp", etag: "e1", lastModified: nil, body: Data("{}".utf8))
+        await cache.store(
+            endpoint: "https://api.github.com/repos/retired/repo/releases/latest",
+            authFingerprint: "fp", etag: "e2", lastModified: nil, body: Data("{}".utf8))
+
+        await cache.prune(keeping: ["https://api.github.com/repos/kept/repo/releases/latest"])
+
+        #expect(await cache.validator(
+            for: "https://api.github.com/repos/kept/repo/releases/latest",
+            authFingerprint: "fp") != nil)
+        #expect(await cache.validator(
+            for: "https://api.github.com/repos/retired/repo/releases/latest",
+            authFingerprint: "fp") == nil)
+    }
+
+    // MARK: - 5. The tag lookup never participates
+
+    /// `GitHubReleasesSource.fetchReleases` gates the conditional layer on
+    /// `tag == nil` in three places (the lookup, and the two `store` call
+    /// sites), and separately `validNonTagEndpoints` — what `prune(keeping:)`
+    /// is run against — never contains a tag-shaped URL. Both mechanisms
+    /// independently keep a tag entry out of the store, which is deliberate
+    /// defense in depth (see that property's doc comment) but means the two
+    /// need two different tests: mutating away only the `tag == nil` gates
+    /// still gets cleaned up by `prune`, so it does NOT turn this specific
+    /// end-to-end test red (verified: request/response shape is unchanged) —
+    /// that mutation is instead caught by
+    /// `validNonTagEndpointsNeverNamesATagShapedURL` below, which pins the
+    /// *other* mechanism directly. This test pins the CURRENT, observable
+    /// behaviour: the exact-tag lookup never carries `If-None-Match`, on
+    /// either round.
+    @Test func theExactTagLookupNeverSendsAValidator() async throws {
+        ScriptedProtocol.script.load([
+            // channelDiscoveryProbe: list fetch, then the exact-tag fetch.
+            .init(status: 200, etag: "list-etag", body: """
+            [{"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}]
+            """),
+            .init(status: 200, etag: "tag-etag", body: """
+            {"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}
+            """),
+            // Second round: same two lookups again.
+            .init(status: 200, etag: "list-etag", body: """
+            [{"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}]
+            """),
+            .init(status: 200, etag: "tag-etag", body: """
+            {"tag_name": "v1.0.0", "assets": [], "prerelease": true, "draft": false}
+            """),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            versionPattern: #"^v([0-9.]+)$"#,
+            installedTagPrefix: "v", channel: .beta)
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        _ = try await source.channelDiscoveryProbe(rule)
+        _ = try await source.channelDiscoveryProbe(rule)
+
+        // Four real requests. The LIST fetch (`releases?per_page=20`) is one of
+        // the two registry-driven, non-tag endpoints — it IS eligible for the
+        // conditional layer, and correctly carries the validator on its second
+        // round (index 2). The exact-TAG fetch (index 1 and 3) is the one this
+        // test is actually about: it must never carry `If-None-Match`, on
+        // either round — that's the endpoint with no fixed, prunable key space.
+        #expect(ScriptedProtocol.script.requestCount == 4)
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, nil, "list-etag", nil])
+    }
+
+    /// Direct pin on `validNonTagEndpoints` — the set `prune(keeping:)` is
+    /// called with — never containing a `/releases/tags/…` URL for any rule,
+    /// regardless of that rule's other settings. This is the mechanism that
+    /// keeps a tag entry from surviving even if `fetchReleases`'s own
+    /// `tag == nil` gates were ever mistakenly dropped (see the previous
+    /// test's doc comment for why that mutation alone doesn't show up
+    /// end-to-end). Mutation this pins: adding tag URLs into this set (e.g. "so
+    /// pruning doesn't punish a proven install's re-check") — verified red
+    /// below.
+    @Test func validNonTagEndpointsNeverNamesATagShapedURL() {
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            installedTagPrefix: "v", channel: .beta)
+        let source = GitHubReleasesSource(rules: [rule])
+
+        let endpoints = source.validNonTagEndpoints
+        #expect(endpoints == [
+            "https://api.github.com/repos/example/app/releases/latest",
+            "https://api.github.com/repos/example/app/releases?per_page=20",
+        ])
+        #expect(!endpoints.contains { $0.contains("/releases/tags/") })
+    }
+
+    /// Mutation this pins: building the list URL in `validNonTagEndpoints` with
+    /// a literal `per_page=20` instead of the rule's `listPageSize`. That is
+    /// what the first draft did, after `listPageSize` had already made the page
+    /// per-rule (#355): for every rule with a smaller page the list entry was
+    /// stored and then pruned by the very same fetch, so its cache could never
+    /// hit — with no error, no log line and every other test green. The two
+    /// URLs must agree byte for byte with what `fetchReleases` requests.
+    @Test func validNonTagEndpointsFollowEachRulesListPageSize() {
+        let five = GitHubReleaseRule(
+            bundleID: "com.example.five", owner: "example", repo: "five",
+            usePrereleases: true, listPageSize: 5)
+        let twenty = GitHubReleaseRule(
+            bundleID: "com.example.twenty", owner: "example", repo: "twenty",
+            usePrereleases: true)
+        let source = GitHubReleasesSource(rules: [five, twenty])
+
+        #expect(source.validNonTagEndpoints == [
+            "https://api.github.com/repos/example/five/releases/latest",
+            "https://api.github.com/repos/example/five/releases?per_page=5",
+            "https://api.github.com/repos/example/twenty/releases/latest",
+            "https://api.github.com/repos/example/twenty/releases?per_page=20",
+        ])
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
@@ -454,11 +454,17 @@ struct GitHubConditionalCacheTests {
             usePrereleases: true)
         let source = GitHubReleasesSource(rules: [five, twenty])
 
+        // Both rules are prerelease `.newest` rules, so each also keeps its
+        // one-row probe page (`GitHubListProbeTests` pins when that third URL
+        // is and is not present); the point here is the middle URL of each
+        // triple carrying the rule's own page size.
         #expect(source.validNonTagEndpoints == [
             "https://api.github.com/repos/example/five/releases/latest",
             "https://api.github.com/repos/example/five/releases?per_page=5",
+            "https://api.github.com/repos/example/five/releases?per_page=1",
             "https://api.github.com/repos/example/twenty/releases/latest",
             "https://api.github.com/repos/example/twenty/releases?per_page=20",
+            "https://api.github.com/repos/example/twenty/releases?per_page=1",
         ])
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
@@ -259,6 +259,80 @@ struct GitHubConditionalCacheTests {
         #expect(validator?.conditionalHeaders == ["If-None-Match": "\"legacy\""])
     }
 
+    /// The LIST endpoint's 304 must be re-parsed as a list. Mutation this pins:
+    /// hard-coding `list: false` (or `true`) where the stored body is decoded
+    /// on a 304 — every other test scripts the list's second round as a 200,
+    /// so that mutation stayed green while in production every list 304 would
+    /// have decoded to zero rows and recorded a false miss. A prerelease rule
+    /// that does not probe, so the full page is the only list endpoint it
+    /// touches.
+    @Test func aListEndpoint304IsServedFromTheStoredPage() async throws {
+        let page = """
+        [{"tag_name": "v2.0.0-beta.2", "assets": [], "prerelease": true, "draft": false, "published_at": "2026-09-02T00:00:00Z"},
+         {"tag_name": "v2.0.0-beta.1", "assets": [], "prerelease": true, "draft": false, "published_at": "2026-09-01T00:00:00Z"}]
+        """
+        ScriptedProtocol.script.load([
+            .init(status: 200, etag: "list-etag", body: page),
+            .init(status: 304, etag: nil, body: ""),
+        ])
+        let cache = Self.tempCache()
+        let session = Self.session()
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            usePrereleases: true, versionPattern: #"^v([0-9.]+-beta\.[0-9]+)$"#,
+            channel: .beta, probesNewestFirst: false)
+        let source = GitHubReleasesSource(
+            rules: [rule], token: "tok", session: session, validatorCache: cache)
+
+        let first = await source.resolveDiagnostic(rule)
+        let second = await source.resolveDiagnostic(rule)
+
+        #expect(ScriptedProtocol.script.ifNoneMatchSent == [nil, "list-etag"])
+        #expect(first.remote?.shortVersion == "2.0.0-beta.2")
+        #expect(second.remote?.shortVersion == "2.0.0-beta.2")
+        #expect(second.remote?.releaseHistory.count == 2)
+        #expect(second.failure == nil)
+    }
+
+    // MARK: - 1c. A stored 200 is not revalidated forever
+
+    /// Mutation this pins: dropping the `maxAge` check in `validator(for:)`.
+    /// GitHub answers `If-Modified-Since` the RFC way (a date a day AFTER the
+    /// release's `Last-Modified` is still a 304, measured 2026-09-05), so a
+    /// `/latest` re-pointed at an OLDER release is "not modified since" too and
+    /// would be served from the stored body until something newer appeared. An
+    /// entry older than a day yields no validator, the next request goes out
+    /// unconditional, and the fresh 200 restamps it.
+    @Test func aStoredEntryOlderThanADayYieldsNoValidator() async throws {
+        let clock = Clock()
+        let cache = GitHubConditionalCache(
+            fileURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("duo-conditional-cache-tests-\(UUID().uuidString)/cache.json"),
+            now: { clock.now })
+        let endpoint = "https://api.github.com/repos/example/app/releases/latest"
+        await cache.store(endpoint: endpoint, authFingerprint: "fp",
+                          etag: nil, lastModified: "Sat, 11 Jul 2026 21:54:57 GMT", body: Data("{}".utf8))
+
+        clock.now = clock.now.addingTimeInterval(23 * 60 * 60)
+        #expect(await cache.validator(for: endpoint, authFingerprint: "fp") != nil)
+        clock.now = clock.now.addingTimeInterval(2 * 60 * 60)
+        #expect(await cache.validator(for: endpoint, authFingerprint: "fp") == nil)
+        // A fresh 200 restamps it.
+        await cache.store(endpoint: endpoint, authFingerprint: "fp",
+                          etag: nil, lastModified: "Sun, 06 Sep 2026 00:00:00 GMT", body: Data("{}".utf8))
+        #expect(await cache.validator(for: endpoint, authFingerprint: "fp")?.lastModified
+                == "Sun, 06 Sep 2026 00:00:00 GMT")
+    }
+
+    private final class Clock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _now = Date()
+        var now: Date {
+            get { lock.lock(); defer { lock.unlock() }; return _now }
+            set { lock.lock(); _now = newValue; lock.unlock() }
+        }
+    }
+
     // MARK: - 2. Failure retreats to an unconditional request, never "no update"
 
     /// Mutation this pins: treating an untrustable 304 (nothing cached to serve

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubConditionalCacheTests.swift
@@ -251,7 +251,11 @@ struct GitHubConditionalCacheTests {
         """
         try Data(legacy.utf8).write(to: file)
 
-        let cache = GitHubConditionalCache(fileURL: file)
+        // The clock is pinned a minute after the file's `storedAt`: with the
+        // real clock this test would have gone red on its own 24 hours after the
+        // fixture was written (`maxAge`), which is not what it measures.
+        let cache = GitHubConditionalCache(
+            fileURL: file, now: { Date(timeIntervalSinceReferenceDate: 810280008 + 60) })
         let validator = await cache.validator(for: endpoint, authFingerprint: "fp")
 
         #expect(validator?.etag == "\"legacy\"")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListProbeTests.swift
@@ -37,11 +37,15 @@ struct GitHubListProbeTests {
             let answer = Self.script.answer(for: url)
             var headers: [String: String] = [:]
             if let etag = answer?.etag { headers["ETag"] = etag }
+            // A request that presents the answer's own ETag gets the real thing:
+            // a 304 with an empty body, exactly what GitHub sends.
+            let notModified = answer?.etag != nil
+                && request.value(forHTTPHeaderField: "If-None-Match") == answer?.etag
             let response = HTTPURLResponse(
-                url: request.url!, statusCode: answer == nil ? 404 : 200,
+                url: request.url!, statusCode: answer == nil ? 404 : (notModified ? 304 : 200),
                 httpVersion: "HTTP/1.1", headerFields: headers)!
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: Data((answer?.body ?? "{}").utf8))
+            client?.urlProtocol(self, didLoad: Data((notModified ? "" : (answer?.body ?? "{}")).utf8))
             client?.urlProtocolDidFinishLoading(self)
         }
         override func stopLoading() {}
@@ -194,6 +198,56 @@ struct GitHubListProbeTests {
         // carries one row — the timeline keeps what the first round recorded.
         #expect(first.remote?.releaseHistory.count == 2)
         #expect(second.remote?.releaseHistory.count == 1)
+    }
+
+    /// The probe page has its own validator, and its 304 must be re-parsed as a
+    /// LIST of one — a probe decoded as a single object would yield zero rows,
+    /// fall back to the full page, and quietly undo the saving on exactly the
+    /// rounds it exists for. Round three presents the probe's ETag and gets a
+    /// 304; the answer must still be the stored row, with no full-page fetch.
+    @Test func aProbe304IsServedFromTheStoredRow() async throws {
+        ByURLProtocol.script.load([
+            Self.probeURL: .init(body: Self.page([Self.release("v2.0.0-beta.3")]), etag: "p"),
+            Self.fullURL: .init(body: Self.page([Self.release("v2.0.0-beta.3"), Self.release("v2.0.0-beta.2")]), etag: "f"),
+        ])
+        let source = GitHubReleasesSource(
+            rules: [Self.rule()], session: Self.session(), validatorCache: Self.tempCache())
+
+        _ = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+        _ = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+        let third = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+
+        #expect(third.remote?.shortVersion == "2.0.0-beta.3")
+        #expect(third.failure == nil)
+        #expect(ByURLProtocol.script.urls == [Self.fullURL, Self.probeURL, Self.probeURL])
+    }
+
+    /// Mutation this pins: `recordingMisses: true` on the probe. A probe that
+    /// cannot answer is not evidence about the recipe — the release it wants may
+    /// sit below the newest row — so after a probe miss that the full page then
+    /// answers, the recipe's health must show no miss at all, not a miss that a
+    /// later success happens to outrank.
+    @Test func aProbeMissLeavesNoMarkOnRecipeHealth() async throws {
+        let rule = GitHubReleaseRule(
+            bundleID: "com.example.health", owner: "probe-health", repo: "repo",
+            usePrereleases: true, listPageSize: 5,
+            versionPattern: #"^v([0-9]+(?:\.[0-9]+)+(?:-beta\.[0-9]+)?)$"#,
+            installAssetPattern: #"\.zip$"#, installerKind: .zip, channel: .beta)
+        let probe = "https://api.github.com/repos/probe-health/repo/releases?per_page=1"
+        let full = "https://api.github.com/repos/probe-health/repo/releases?per_page=5"
+        ByURLProtocol.script.load([
+            probe: .init(body: Self.page([Self.release("web-v9.9.9")]), etag: nil),
+            full: .init(body: Self.page([Self.release("web-v9.9.9"), Self.release("v1.5.0-beta.1")]), etag: nil),
+        ])
+        let source = GitHubReleasesSource(rules: [rule], session: Self.session())
+
+        let outcome = await source.resolveDiagnostic(rule, preferring: .arm64, allowingIntelTranslation: false)
+
+        #expect(outcome.remote?.shortVersion == "1.5.0-beta.1")
+        let entry = await RecipeHealth.shared.snapshot().first { $0.id == rule.slug && $0.source == source.name }
+        #expect(entry != nil)
+        #expect(entry?.lastMiss == nil)
+        #expect(entry?.lastSuccess != nil)
     }
 
     // MARK: - Rules that never probe

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListProbeTests.swift
@@ -1,0 +1,254 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A `usePrereleases` rule with `.newest` scope opens with a page of ONE
+/// release and only pays for its full `listPageSize` page when that one row
+/// cannot answer (#358). The list endpoint cannot be revalidated cheaply — no
+/// `Last-Modified`, an `ETag` that churns with download counters — so the page
+/// size is the only lever, and the newest row is the whole page almost every
+/// round. These pin which URL goes out first, when the full page is paid for,
+/// when it is deliberately NOT paid for, and which rules never probe at all.
+@Suite(.serialized)
+struct GitHubListProbeTests {
+
+    /// Answers by URL string (query included), so a test states what each page
+    /// size returns and then reads back the exact sequence of URLs requested.
+    private final class ByURLProtocol: URLProtocol, @unchecked Sendable {
+        struct Answer { let body: String; let etag: String? }
+        final class Script: @unchecked Sendable {
+            private let lock = NSLock()
+            private var answers: [String: Answer] = [:]
+            private var requested: [String] = []
+            func load(_ table: [String: Answer]) { lock.lock(); answers = table; requested = []; lock.unlock() }
+            func answer(for url: String) -> Answer? {
+                lock.lock(); defer { lock.unlock() }
+                requested.append(url)
+                return answers[url]
+            }
+            var urls: [String] { lock.lock(); defer { lock.unlock() }; return requested }
+        }
+        static let script = Script()
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            let url = request.url!.absoluteString
+            let answer = Self.script.answer(for: url)
+            var headers: [String: String] = [:]
+            if let etag = answer?.etag { headers["ETag"] = etag }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: answer == nil ? 404 : 200,
+                httpVersion: "HTTP/1.1", headerFields: headers)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data((answer?.body ?? "{}").utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ByURLProtocol.self]
+        configuration.urlCache = nil
+        return URLSession(configuration: configuration)
+    }
+
+    private static func release(_ tag: String, assets: [String] = ["App-arm64.zip"]) -> String {
+        let assetJSON = assets.map {
+            #"{"name": "\#($0)", "browser_download_url": "https://example.com/\#($0)", "size": 10}"#
+        }.joined(separator: ",")
+        return """
+        {"tag_name": "\(tag)", "assets": [\(assetJSON)], "prerelease": true, "draft": false,
+         "published_at": "2026-09-05T00:00:00Z", "html_url": "https://github.com/example/app/releases/tag/\(tag)"}
+        """
+    }
+    private static func page(_ releases: [String]) -> String { "[" + releases.joined(separator: ",") + "]" }
+
+    private static let slug = "example/app"
+    private static let probeURL = "https://api.github.com/repos/\(slug)/releases?per_page=1"
+    private static let fullURL = "https://api.github.com/repos/\(slug)/releases?per_page=5"
+    private static let latestURL = "https://api.github.com/repos/\(slug)/releases/latest"
+
+    /// A prerelease rule whose full page is five rows.
+    private static func rule(
+        probes: Bool = true, scope: GitHubCandidateScope = .newest, assetPattern: String? = #"\.zip$"#
+    ) -> GitHubReleaseRule {
+        GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app",
+            usePrereleases: true, listPageSize: 5,
+            versionPattern: #"^v([0-9]+(?:\.[0-9]+)+(?:-beta\.[0-9]+)?)$"#,
+            candidateScope: scope,
+            installAssetPattern: assetPattern, installerKind: assetPattern == nil ? nil : .zip,
+            channel: .beta, probesNewestFirst: probes)
+    }
+
+    private static func tempCache() -> GitHubConditionalCache {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("duo-list-probe-tests-\(UUID().uuidString)")
+        return GitHubConditionalCache(fileURL: dir.appendingPathComponent("cache.json"))
+    }
+
+    // MARK: - The probe answers, and nothing else is fetched
+
+    /// Mutation this pins: dropping the probe (always fetching the full page).
+    /// With no validator store wired in there is nothing to seed, so the very
+    /// first request is the one-row page — and when that row matches the rule
+    /// and carries the asset, it is the only request.
+    @Test func aProbingRuleOpensWithOneRowAndStopsThere() async throws {
+        ByURLProtocol.script.load([
+            Self.probeURL: .init(body: Self.page([Self.release("v2.0.0-beta.3")]), etag: nil),
+            Self.fullURL: .init(body: Self.page([Self.release("v2.0.0-beta.3"), Self.release("v2.0.0-beta.2")]), etag: nil),
+        ])
+        let source = GitHubReleasesSource(rules: [Self.rule()], session: Self.session())
+
+        let outcome = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+
+        #expect(outcome.remote?.shortVersion == "2.0.0-beta.3")
+        #expect(ByURLProtocol.script.urls == [Self.probeURL])
+    }
+
+    // MARK: - The probe cannot answer, so the full page is paid for
+
+    /// Mutation this pins: treating a probe miss as the rule's answer (Bitwarden's
+    /// shape — the newest row is a `web-v…` tag the pattern rejects). The full
+    /// page must be fetched, and the answer must come from it. Also pins that
+    /// the two pages are requested in that order and nothing else is.
+    @Test func aProbeThatCannotAnswerPaysForTheFullPage() async throws {
+        ByURLProtocol.script.load([
+            Self.probeURL: .init(body: Self.page([Self.release("web-v9.9.9")]), etag: nil),
+            Self.fullURL: .init(body: Self.page([
+                Self.release("web-v9.9.9"), Self.release("v1.5.0-beta.1"), Self.release("v1.4.0"),
+            ]), etag: nil),
+        ])
+        let source = GitHubReleasesSource(rules: [Self.rule()], session: Self.session())
+
+        let outcome = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+
+        #expect(outcome.remote?.shortVersion == "1.5.0-beta.1")
+        #expect(outcome.failure == nil)
+        #expect(ByURLProtocol.script.urls == [Self.probeURL, Self.fullURL])
+    }
+
+    /// The same, for the other way a newest row fails to answer: it matches the
+    /// version pattern but ships no asset the install pattern accepts (a
+    /// platform-partial release). The full page has the real one below it.
+    @Test func aProbeWithoutTheMacOSAssetPaysForTheFullPage() async throws {
+        ByURLProtocol.script.load([
+            Self.probeURL: .init(body: Self.page([Self.release("v3.0.0", assets: ["App.apk"])]), etag: nil),
+            Self.fullURL: .init(body: Self.page([
+                Self.release("v3.0.0", assets: ["App.apk"]), Self.release("v2.9.0"),
+            ]), etag: nil),
+        ])
+        let source = GitHubReleasesSource(rules: [Self.rule()], session: Self.session())
+
+        let outcome = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+
+        #expect(outcome.remote?.shortVersion == "2.9.0")
+        #expect(ByURLProtocol.script.urls == [Self.probeURL, Self.fullURL])
+    }
+
+    // MARK: - A probe that IS the answer, even though it offers nothing
+
+    /// Mutation this pins: falling back whenever the probe yields no remote. A
+    /// newest row that only ships the other architecture is the rule's answer
+    /// — the walk stops on that row on the full page too — so paying for the
+    /// full page would buy the same nothing at ten times the bytes.
+    @Test func aProbeWhoseNewestRowIsArchIncompatibleDoesNotFallBack() async throws {
+        ByURLProtocol.script.load([
+            Self.probeURL: .init(body: Self.page([Self.release("v4.0.0", assets: ["App-x86_64.zip"])]), etag: nil),
+            Self.fullURL: .init(body: Self.page([
+                Self.release("v4.0.0", assets: ["App-x86_64.zip"]), Self.release("v3.9.0"),
+            ]), etag: nil),
+        ])
+        let source = GitHubReleasesSource(rules: [Self.rule()], session: Self.session())
+
+        let outcome = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+
+        #expect(outcome.remote == nil)
+        #expect(ByURLProtocol.script.urls == [Self.probeURL])
+    }
+
+    // MARK: - With a validator store, the full page is fetched once to seed history
+
+    /// Mutation this pins: probing from the first round even when a store is
+    /// wired in (the release history would then be seeded from one row), or
+    /// never probing once one is (the saving would only exist in tests). The
+    /// first resolve must fetch the full page; the second, with that page's
+    /// memo now in the store, must open with the probe and stop there.
+    @Test func aWiredStoreSeedsTheFullPageOnceThenProbes() async throws {
+        ByURLProtocol.script.load([
+            Self.probeURL: .init(body: Self.page([Self.release("v2.0.0-beta.3")]), etag: "p"),
+            Self.fullURL: .init(body: Self.page([Self.release("v2.0.0-beta.3"), Self.release("v2.0.0-beta.2")]), etag: "f"),
+        ])
+        let source = GitHubReleasesSource(
+            rules: [Self.rule()], session: Self.session(), validatorCache: Self.tempCache())
+
+        let first = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+        let second = await source.resolveDiagnostic(Self.rule(), preferring: .arm64, allowingIntelTranslation: false)
+
+        #expect(first.remote?.shortVersion == "2.0.0-beta.3")
+        #expect(second.remote?.shortVersion == "2.0.0-beta.3")
+        #expect(ByURLProtocol.script.urls == [Self.fullURL, Self.probeURL])
+        // The seeding round carried the whole page's history; the probe round
+        // carries one row — the timeline keeps what the first round recorded.
+        #expect(first.remote?.releaseHistory.count == 2)
+        #expect(second.remote?.releaseHistory.count == 1)
+    }
+
+    // MARK: - Rules that never probe
+
+    /// A stable rule reads `/releases/latest` (already one release); a
+    /// line-anchored rule needs the window `lineAnchoredCeiling` walks; an
+    /// opted-out rule has said its newest row is usually the wrong one. None of
+    /// the three may ever request the one-row page.
+    @Test func stableLineAnchoredAndOptedOutRulesNeverProbe() async throws {
+        let stable = GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app", listPageSize: 5)
+        let anchored = Self.rule(scope: .installedMajorLineOrNewestStable)
+        let optedOut = Self.rule(probes: false)
+        let table: [String: ByURLProtocol.Answer] = [
+            Self.latestURL: .init(body: Self.release("v1.0.0"), etag: nil),
+            Self.fullURL: .init(body: Self.page([Self.release("v1.0.0")]), etag: nil),
+            Self.probeURL: .init(body: Self.page([Self.release("v1.0.0")]), etag: nil),
+        ]
+
+        for (rule, expected) in [(stable, Self.latestURL), (anchored, Self.fullURL), (optedOut, Self.fullURL)] {
+            ByURLProtocol.script.load(table)
+            let source = GitHubReleasesSource(rules: [rule], session: Self.session())
+            _ = await source.resolveDiagnostic(rule, preferring: .arm64, allowingIntelTranslation: false)
+            #expect(ByURLProtocol.script.urls.first == expected, "\(rule.candidateScope) probes=\(rule.probesNewestFirst)")
+            #expect(!ByURLProtocol.script.urls.contains(Self.probeURL), "\(rule.candidateScope) probes=\(rule.probesNewestFirst)")
+        }
+    }
+
+    /// The probe page is a third endpoint in the validator store, so the
+    /// pruned set must keep it for a probing rule — and ONLY for one: a rule
+    /// that never probes never fetches it, and a stale one-row body would
+    /// otherwise sit on disk forever. Mutation this pins: keeping it for every
+    /// rule, or for none.
+    @Test func validNonTagEndpointsKeepTheProbePageOnlyForProbingRules() {
+        let probing = GitHubReleasesSource(rules: [Self.rule()])
+        let optedOut = GitHubReleasesSource(rules: [Self.rule(probes: false)])
+        let stable = GitHubReleasesSource(rules: [GitHubReleaseRule(
+            bundleID: "com.example.app", owner: "example", repo: "app", listPageSize: 5)])
+
+        #expect(probing.validNonTagEndpoints == [Self.latestURL, Self.fullURL, Self.probeURL])
+        #expect(optedOut.validNonTagEndpoints == [Self.latestURL, Self.fullURL])
+        #expect(stable.validNonTagEndpoints == [Self.latestURL, Self.fullURL])
+    }
+
+    // MARK: - Registry
+
+    /// Bitwarden is the one rule measured to fall back most rounds (its newest
+    /// release is a web/CLI/browser tag far more often than the desktop one),
+    /// so it is opted out; every other prerelease `.newest` rule probes. A new
+    /// opt-out is a measurement to be written down in the rule's comment, and
+    /// this list is where it is registered.
+    @Test func onlyTheMeasuredRulesAreOptedOutOfProbing() {
+        let optedOut = GitHubReleaseRegistry.rules
+            .filter { $0.usePrereleases && $0.candidateScope == .newest && !$0.probesNewestFirst }
+            .map { "\($0.bundleID)/\($0.channel.rawValue)" }
+        #expect(Set(optedOut) == ["com.bitwarden.desktop/stable"])
+    }
+}


### PR DESCRIPTION
Closes #358. Stacked on #359 (its commit shows in this diff until #359 merges).

## What

A `usePrereleases` rule with `.newest` scope now opens with `per_page=1`, runs the identical judgement (`settle`: scope, drafts, version pattern, asset walk, architecture) on that one row, and only fetches its full `listPageSize` page when the row cannot answer. A probe miss records nothing against the recipe; an arch-incompatible newest row does not fall back (the full page would stop on the same row). With a validator store wired in, the full page is fetched once before probing so the release history is seeded; the timeline keeps versions from first sighting, so one-row pages afterwards lose nothing already recorded.

Stable rules and the line-anchored UTM rule never probe. Bitwarden opts out (`probesNewestFirst: false`): its monorepo's newest release is a web/CLI/browser tag most rounds, so a probe there would only add a request. The knob is registered in `nonAnchorFields` as request shaping, like `listPageSize`.

## Why the list endpoint needs this and `/latest` did not

The list endpoint sends no `Last-Modified`, answers `If-Modified-Since` with 200 for any date (measured 2026-09-05), and its `ETag` churns with download counters — so #359's revalidation cannot help it, and on this machine's ledger the 7 list rules cost as many bytes a round as the other 49 GitHub rules together. Measured against the five installed repos, gzipped: page of 1 is 3–18 KB where the full page is 17–75 KB.

## Verification

- `make test` green (`exit=0`, 0 failures).
- Five mutations, each turning exactly its own tests red: never probing → the four probe tests; falling back on an arch-incompatible row → `aProbeWhoseNewestRowIsArchIncompatibleDoesNotFallBack`; taking a probe miss as the answer → the two fallback tests; probing from round one despite a store → `aWiredStoreSeedsTheFullPageOnceThenProbes`; keeping the probe page for every rule → `validNonTagEndpointsKeepTheProbePageOnlyForProbingRules`.
- Live ledger, this build installed 2026-09-06 00:11, three rounds, `api.github.com` list endpoints (`hadQuery=1`), network requests only:

| app (rule) | per round before | 3 rounds after | what it shows |
|---|---:|---|---|
| Headlamp (page 8) | 75 KB | 2 × 200 = 38 KB, 1 × 304 | probe: 19 KB a hit |
| Zed Preview (page 5) | 27 KB | 3 × 200 = 13 KB | probe: 4.4 KB a hit |
| T3 Code Nightly (page 5) | 21 KB | 3 × 200 = 12 KB | probe: 4 KB a hit |
| Vorssaint (page 5) | 17 KB | 3 × 200 = 28 KB | probe: 9.5 KB a hit |
| Bitwarden (page 10, opted out) | 72 KB | 2 × 200 = 141 KB, 1 × 304 | full page by design |
| UTM (page 20, line-anchored) | 54 KB | 2 × 200 = 104 KB, 1 × 304 | full page by design |

List-endpoint bytes per round went from ~242 KB to 39 / 142 / 160 KB across the three rounds; the `/releases/latest` half stayed at 49 × 304 ≈ 54 KB a round (#359). What is left on the list side is Bitwarden and UTM, both deliberate.

## Review fixes (second commit)

An adversarial review of #359 and this change found three things, fixed in `3cfc5cc`; I confirmed the first against GitHub before believing it:

- **`If-Modified-Since` alone could pin a yanked release.** GitHub answers it the RFC 7232 §3.3 way — a date one day after `Last-Modified` still gets a 304 (measured) — so a `/latest` re-pointed at an older release would be served from the stored body until something newer appeared. Entries older than a day now yield no validator, so one unconditional fetch a day per endpoint restamps them.
- **Every 2xx rewrote the whole 4.6 MB store.** Writes now coalesce over two seconds; `duo verify` flushes explicitly before exit.
- **The list/probe 304 path had no test.** Decoding a 304 body as a single object stayed green while every list 304 would have decoded to zero rows in production. Two tests now answer 304 on the list and the probe endpoint; a third pins that a probe miss records nothing against recipe health.

Mutations: drop the `maxAge` guard → `aStoredEntryOlderThanADayYieldsNoValidator`; decode a 304 body as a single object → both new 304 tests; record misses on the probe → `aProbeMissLeavesNoMarkOnRecipeHealth`. Each red, nothing else.
