### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -42,7 +42,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
     },
@@ -50,7 +50,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -58,7 +58,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -66,7 +66,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
     },
@@ -74,7 +74,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
     },
@@ -82,7 +82,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -90,15 +90,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
-      "lastGoodVersion" : "Xcode 27 Beta 6",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
+      "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
     },
     "changelog:com.baidu.BaiduNetdisk-mac:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -114,7 +114,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -122,7 +122,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.84.0",
       "sweepsSinceComment" : 0
     },
@@ -130,7 +130,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -138,7 +138,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
     },
@@ -146,7 +146,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -154,7 +154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -162,7 +162,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
     },
@@ -170,7 +170,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
     },
@@ -178,7 +178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -186,7 +186,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
     },
@@ -194,7 +194,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
     },
@@ -202,7 +202,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "152.0.7977.82",
       "sweepsSinceComment" : 0
     },
@@ -210,7 +210,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -218,7 +218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -226,7 +226,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -234,7 +234,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
     },
@@ -242,7 +242,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -250,7 +250,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
     },
@@ -258,7 +258,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -266,7 +266,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -274,23 +274,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
     "changelog:com.microsoft.VSCode:-" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
+      "infraSince" : "2026-09-05T20:24:08Z",
       "lastGoodAt" : "2026-09-05T15:40:17Z",
       "lastGoodVersion" : "1.136",
-      "sweepsSinceComment" : 0
+      "sweepsSinceComment" : 1
     },
     "changelog:com.mitchellh.ghostty:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
     },
@@ -300,7 +301,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (26.727) trails t"
@@ -309,7 +310,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -317,7 +318,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -325,7 +326,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -333,7 +334,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "12.26.5",
       "sweepsSinceComment" : 0
     },
@@ -341,7 +342,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
     },
@@ -349,7 +350,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
     },
@@ -357,7 +358,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.13.2",
       "sweepsSinceComment" : 0
     },
@@ -365,7 +366,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.3.4",
       "sweepsSinceComment" : 0
     },
@@ -373,7 +374,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
     },
@@ -381,7 +382,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -389,7 +390,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -399,7 +400,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "noEntriesExtracted"
@@ -408,7 +409,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -416,7 +417,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -424,7 +425,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -432,7 +433,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
     },
@@ -440,7 +441,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -448,7 +449,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
     },
@@ -456,7 +457,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.7.0-daily.20260904",
       "sweepsSinceComment" : 0
     },
@@ -464,7 +465,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -472,7 +473,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -482,7 +483,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (5.2.7) trails th"
@@ -491,7 +492,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -499,7 +500,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -507,7 +508,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
     },
@@ -515,7 +516,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -523,7 +524,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -531,7 +532,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -539,7 +540,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -547,7 +548,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -555,7 +556,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -563,7 +564,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -571,7 +572,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.14.0",
       "sweepsSinceComment" : 0
     },
@@ -579,7 +580,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
     },
@@ -587,7 +588,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
@@ -595,7 +596,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
@@ -603,7 +604,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0
     },
@@ -611,7 +612,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
     },
@@ -619,7 +620,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
     },
@@ -627,7 +628,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
     },
@@ -635,7 +636,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
     },
@@ -643,7 +644,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -651,7 +652,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -659,7 +660,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
     },
@@ -667,7 +668,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -675,7 +676,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
     },
@@ -683,7 +684,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
@@ -691,7 +692,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
     },
@@ -699,7 +700,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
@@ -707,7 +708,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.1.17",
       "sweepsSinceComment" : 0
     },
@@ -715,7 +716,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     },
@@ -723,7 +724,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -731,7 +732,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -739,7 +740,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -747,7 +748,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -755,7 +756,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -763,7 +764,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -771,7 +772,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -779,7 +780,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.3.7",
       "sweepsSinceComment" : 0
     },
@@ -787,7 +788,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -795,7 +796,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -803,7 +804,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -811,7 +812,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.135.05934-insider",
       "sweepsSinceComment" : 0
     },
@@ -819,7 +820,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.126.04524",
       "sweepsSinceComment" : 0
     },
@@ -827,7 +828,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -835,7 +836,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -843,7 +844,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.49.0",
       "sweepsSinceComment" : 0
     },
@@ -851,7 +852,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -859,7 +860,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -867,7 +868,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -875,7 +876,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -883,7 +884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -891,7 +892,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
     },
@@ -899,7 +900,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.0.5",
       "sweepsSinceComment" : 0
     },
@@ -907,7 +908,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -915,7 +916,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -923,7 +924,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -931,7 +932,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -939,7 +940,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -947,7 +948,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -955,7 +956,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -963,7 +964,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -971,7 +972,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -979,7 +980,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
     },
@@ -987,7 +988,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -995,7 +996,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1003,7 +1004,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1011,7 +1012,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.0.14",
       "sweepsSinceComment" : 0
     },
@@ -1019,7 +1020,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.20.1",
       "sweepsSinceComment" : 0
     },
@@ -1027,7 +1028,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1035,7 +1036,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1043,7 +1044,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1051,7 +1052,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1059,7 +1060,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.1.15",
       "sweepsSinceComment" : 0
     },
@@ -1067,7 +1068,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1075,7 +1076,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1083,7 +1084,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1091,7 +1092,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "31.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1099,7 +1100,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1107,7 +1108,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1115,7 +1116,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1123,7 +1124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1131,7 +1132,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1139,7 +1140,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1147,7 +1148,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1155,7 +1156,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1163,7 +1164,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1171,7 +1172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1179,7 +1180,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1187,7 +1188,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1195,7 +1196,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -1203,15 +1204,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
-      "lastGoodVersion" : "1.22.1",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
+      "lastGoodVersion" : "1.22.2",
       "sweepsSinceComment" : 0
     },
     "github:pingdotgg\/t3code:alpha" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.0.38",
       "sweepsSinceComment" : 0
     },
@@ -1219,15 +1220,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
-      "lastGoodVersion" : "0.0.39-nightly.20260905.1287",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
+      "lastGoodVersion" : "0.0.39-nightly.20260905.1289",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1235,7 +1236,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1243,7 +1244,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1251,7 +1252,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1259,7 +1260,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1267,7 +1268,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1275,7 +1276,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1283,7 +1284,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1291,7 +1292,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1299,7 +1300,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1307,7 +1308,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1315,7 +1316,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1323,7 +1324,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1331,7 +1332,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1339,7 +1340,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1347,7 +1348,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1355,7 +1356,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1363,7 +1364,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.3.2",
       "sweepsSinceComment" : 0
     },
@@ -1393,7 +1394,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1401,7 +1402,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1409,7 +1410,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1417,7 +1418,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -1425,15 +1426,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
-      "lastGoodVersion" : "1.21.16b",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
+      "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
     "vendor:MstyStudio:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1441,7 +1442,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -1449,7 +1450,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "151.0.7922.247",
       "sweepsSinceComment" : 0
     },
@@ -1457,7 +1458,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1465,7 +1466,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1473,7 +1474,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1481,7 +1482,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1489,7 +1490,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -1497,7 +1498,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.1",
       "sweepsSinceComment" : 0
     },
@@ -1505,7 +1506,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
     },
@@ -1513,7 +1514,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1521,7 +1522,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.43.0",
       "sweepsSinceComment" : 0
     },
@@ -1529,7 +1530,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1537,7 +1538,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1545,7 +1546,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1553,7 +1554,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1561,7 +1562,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1569,7 +1570,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1577,7 +1578,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1585,7 +1586,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.95.96.0",
       "sweepsSinceComment" : 0
     },
@@ -1593,7 +1594,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.97.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1601,7 +1602,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -1609,7 +1610,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.124.1",
       "sweepsSinceComment" : 0
     },
@@ -1617,7 +1618,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.84.2",
       "sweepsSinceComment" : 0
     },
@@ -1625,7 +1626,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1633,7 +1634,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
     },
@@ -1641,7 +1642,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -1649,7 +1650,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.6.774",
       "sweepsSinceComment" : 0
     },
@@ -1657,7 +1658,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.8.20",
       "sweepsSinceComment" : 0
     },
@@ -1665,7 +1666,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -1673,7 +1674,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "126.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1681,15 +1682,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
-      "lastGoodVersion" : "268.4.4124",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
+      "lastGoodVersion" : "270.3.3209",
       "sweepsSinceComment" : 0
     },
     "vendor:com.google.Chrome.beta:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "154.0.8037.0",
       "sweepsSinceComment" : 0
     },
@@ -1697,7 +1698,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "155.0.8043.0",
       "sweepsSinceComment" : 0
     },
@@ -1705,7 +1706,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -1713,7 +1714,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "152.0.7977.83",
       "sweepsSinceComment" : 0
     },
@@ -1721,7 +1722,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.107.3.828",
       "sweepsSinceComment" : 0
     },
@@ -1729,7 +1730,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -1737,7 +1738,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -1745,7 +1746,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -1753,7 +1754,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -1761,7 +1762,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -1769,7 +1770,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "7.529.3",
       "sweepsSinceComment" : 0
     },
@@ -1777,7 +1778,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1785,7 +1786,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.0.410",
       "sweepsSinceComment" : 0
     },
@@ -1793,7 +1794,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.0.1311",
       "sweepsSinceComment" : 0
     },
@@ -1801,7 +1802,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -1809,7 +1810,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -1817,7 +1818,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1825,7 +1826,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -1833,7 +1834,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -1850,7 +1851,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "9.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1858,7 +1859,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -1866,7 +1867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1874,7 +1875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -1882,7 +1883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1890,7 +1891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -1898,7 +1899,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -1906,7 +1907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1914,7 +1915,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.136.1",
       "sweepsSinceComment" : 0
     },
@@ -1922,7 +1923,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.137.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -1930,7 +1931,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1938,7 +1939,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "153.0.4234.19",
       "sweepsSinceComment" : 0
     },
@@ -1946,7 +1947,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "154.0.4251.0",
       "sweepsSinceComment" : 0
     },
@@ -1954,7 +1955,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -1962,7 +1963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -1970,7 +1971,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -1978,7 +1979,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -1986,7 +1987,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1994,7 +1995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2002,7 +2003,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2010,7 +2011,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.901.41600",
       "sweepsSinceComment" : 0
     },
@@ -2018,7 +2019,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -2026,7 +2027,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2034,7 +2035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2042,7 +2043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "12.26.5",
       "sweepsSinceComment" : 0
     },
@@ -2050,7 +2051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.104.28",
       "sweepsSinceComment" : 0
     },
@@ -2058,7 +2059,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2066,7 +2067,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2074,7 +2075,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2082,7 +2083,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2090,7 +2091,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.2.98.301",
       "sweepsSinceComment" : 0
     },
@@ -2098,7 +2099,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2106,7 +2107,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2114,7 +2115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2122,7 +2123,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2130,7 +2131,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "7.2.5",
       "sweepsSinceComment" : 0
     },
@@ -2138,7 +2139,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2148,7 +2149,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2157,7 +2158,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0
     },
@@ -2165,7 +2166,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2173,7 +2174,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -2181,7 +2182,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2189,7 +2190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2197,7 +2198,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2205,7 +2206,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2213,7 +2214,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2221,7 +2222,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.19.13",
       "sweepsSinceComment" : 0
     },
@@ -2229,7 +2230,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.21.1",
       "sweepsSinceComment" : 0
     },
@@ -2237,7 +2238,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "8.2.4133.43",
       "sweepsSinceComment" : 0
     },
@@ -2245,7 +2246,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2253,7 +2254,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2261,7 +2262,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2269,7 +2270,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2277,7 +2278,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2285,7 +2286,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2293,7 +2294,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2301,7 +2302,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2309,7 +2310,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2317,7 +2318,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2325,7 +2326,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.2026.09.05.08.23.00",
       "sweepsSinceComment" : 0
     },
@@ -2333,7 +2334,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2341,7 +2342,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2349,7 +2350,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2357,7 +2358,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2026090401",
       "sweepsSinceComment" : 0
     },
@@ -2365,7 +2366,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2373,7 +2374,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2381,7 +2382,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2389,7 +2390,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2397,7 +2398,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.103.176",
       "sweepsSinceComment" : 0
     },
@@ -2405,7 +2406,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2413,15 +2414,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
-      "lastGoodVersion" : "155.0",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
+      "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
     "vendor:net.pornel.ImageOptim:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2429,7 +2430,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2437,7 +2438,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.35.23",
       "sweepsSinceComment" : 0
     },
@@ -2445,15 +2446,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
-      "lastGoodVersion" : "7.32.0",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
+      "lastGoodVersion" : "7.32.1",
       "sweepsSinceComment" : 0
     },
     "vendor:now.typeless.desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2461,7 +2462,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2469,7 +2470,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2477,7 +2478,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2485,7 +2486,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
@@ -2493,24 +2494,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
     },
     "vendor:org.libreoffice.script:stable" : {
-      "consecutiveActionable" : 1,
+      "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "26.8.0",
-      "lastSignature" : "remote is BEHIND the installed copy (26.",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 0
     },
     "vendor:org.mozilla.firefox:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2518,7 +2518,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2526,7 +2526,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2534,7 +2534,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2542,7 +2542,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2550,7 +2550,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2558,7 +2558,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2566,7 +2566,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -2574,7 +2574,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "156.0b2",
       "sweepsSinceComment" : 0
     },
@@ -2582,7 +2582,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -2590,7 +2590,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "15.0.21",
       "sweepsSinceComment" : 0
     },
@@ -2598,7 +2598,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -2606,7 +2606,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -2614,7 +2614,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "8.26.0",
       "sweepsSinceComment" : 0
     },
@@ -2624,7 +2624,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "10.0.1",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2633,7 +2633,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -2641,11 +2641,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-05T15:40:17Z",
+      "lastGoodAt" : "2026-09-05T20:24:08Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-05T15:40:17Z"
+  "updatedAt" : "2026-09-05T20:24:08Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.