### PR TITLE
Add Yaak stable and beta updates with structured changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.86
 
-**Three more apps are covered: WhatCable, Qoder IDE, and Qoder.** All three get update checks and a one-click install, and their release notes are read into the window as text rather than an embedded page.
+**Five more apps are covered: WhatCable, Qoder IDE, Qoder, Yaak and CotEditor.** Each one gets update checks and a one-click install, and their release notes are read into the window as text rather than an embedded page.
 
 **Qoder's two Mac apps are told apart.** The IDE and the desktop app share a name and a download page but ship on separate version lines, so each is now followed on its own.
 
-**WhatCable's beta track is followed too.** A copy on a beta build is offered the next beta, and the stable release that beta eventually graduates into; taking that one moves the copy onto the stable track.
+**Beta builds of WhatCable and Yaak are followed on their own track.** A copy running a beta used to have no source at all and sat on "Failed"; it is now offered the next beta, with release notes kept apart from the stable ones. For WhatCable that also includes the stable release a beta eventually graduates into — taking that one moves the copy onto the stable track.
 
 ## 0.3.85
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.86
 
-**Five more apps are covered: WhatCable, Qoder IDE, Qoder, Yaak and CotEditor.** Each one gets update checks and a one-click install, and their release notes are read into the window as text rather than an embedded page.
+**Four more apps are covered: WhatCable, Qoder IDE, Qoder and Yaak.** Each one gets update checks and a one-click install, and their release notes are read into the window as text rather than an embedded page.
 
 **Qoder's two Mac apps are told apart.** The IDE and the desktop app share a name and a download page but ship on separate version lines, so each is now followed on its own.
 

--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -18,9 +18,6 @@
 
 ## §1 已覆盖（从代码提取，权威）
 
-- **Yaak**（2026-09-06）：stable/beta 共享 `app.yaak.desktop`，真包保留 `-beta.N` 后缀，GitHub 两轨及结构化日志已接；stable 一键升级实测通过。见 [审计](docs/app-audits/app-yaak-desktop.md)。
-
-
 ### Pattern A — 独立 bundle id（各 channel 自带身份，最干净）
 
 | Family | 非 stable channel → bundle id | 源 |
@@ -123,6 +120,14 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 - 同 bundle id 还有一份 **MAS 副本（adamId 1500855883，版本 19.2.0）**，版本方案完全不同；
   两边不串全靠 `_MASReceipt`（`VendorProbeSource` 拒 MAS、`MacAppStoreSource` 拒非 MAS）。
 
+### 版本后缀分流 续 — Yaak（2026-09-06 接）
+
+共享 `app.yaak.desktop`，两轨都是 GitHub。beta 包的 `CFBundleShortVersionString` 原样
+带 `-beta.N`，`ReleaseChannel.detect` 第 4 步判成 `.beta`，两条 rule 各自用 `$` 锚死
+tag 与资产名，互不相收。与 WhatCable 的区别是 **Yaak 的 beta rule 不收 stable tag**：
+它的 channel proof 锚在下载路径的 `-beta.N` 上，所以不存在「毕业版」那条路，跑 beta 的
+副本一直留在 beta 轨。见 [审计](docs/app-audits/app-yaak-desktop.md)。
+
 ### Pattern A 续 — VS Code Insiders（2026-06-06 接）
 
 - **VS Code Insiders** `com.microsoft.VSCodeInsiders`（显示名 "Code - Insiders" → detect
@@ -179,9 +184,6 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 
 ## §2b TODO — Pattern B/C 候选（app 内切换，需真机验证信号）
 
-- **CotEditor**（2026-09-06）：已补隐藏 Sparkle 地址及 stable/beta 结构化日志，stable 一键升级实测通过。仍需接入 `checksUpdatesForBeta || Bundle.main.version.isPrerelease`，对应 feed 标签 `prerelease`；当前依赖 feed 中已知 build 推断，旧 beta 被裁掉后退回 stable。见 [审计](docs/app-audits/com-coteditor-CotEditor.md)。
-
-
 > 以下 app 有明确 in-app channel toggle，但切换后是否留下可读的本地信号（defaults/plist）
 > 仍需真机 diff 确认。不要直接标为 detectable。
 
@@ -216,6 +218,16 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
       "keeps hitting releases/latest, which GitHub never returns a pre-release from"）
       —— **未做真机 diff 确认落盘行为**，按本节规矩不得直接当作 detectable。
       补法是一个 `ChannelBinding`，形状同 `IINAChannel`。
+
+- [ ] **CotEditor** · `com.coteditor.CotEditor` — Settings → **"Check for beta releases"**
+      （`checksUpdatesForBeta`，官方条件是 `Bundle.main.version.isPrerelease || checksUpdatesForBeta`，
+      feed 标签 `prerelease`）。**2026-09-06 接过一版又撤了**，撤的原因不是这个开关：
+      feed 只保留最新一条 beta，旧 beta 副本在 feed 里找不到自己的 build，`allowedChannels`
+      退回默认渠道，而 `bestItem` 按 build 跨轨排序、`evaluate` 两边都有 build 时只比 build
+      —— 于是 `7.1.0-beta.3`（840）被推 `7.0.9`（843），**marketing 上是降级**，且没有任何
+      一道闸拦得住（仓库里只有架构降级守卫）。所以这一格**先欠着的不是 binding，是一条
+      「远端 marketing 比装机的旧就不提供」的守卫**，那条落在每个 Sparkle app 的检查路径上，
+      要单独走一轮复审。实测与链条见 [审计](docs/app-audits/com-coteditor-CotEditor.md)。
 
 - [ ] **Docker Desktop — nightly** · `com.docker.docker` — UI 的更新设置代码里存在受
       feature flag 控制的 `useNightlyBuildUpdates`；观测 stable bundle 只给出 `channelID=main`，

--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -18,6 +18,9 @@
 
 ## §1 已覆盖（从代码提取，权威）
 
+- **Yaak**（2026-09-06）：stable/beta 共享 `app.yaak.desktop`，真包保留 `-beta.N` 后缀，GitHub 两轨及结构化日志已接；stable 一键升级实测通过。见 [审计](docs/app-audits/app-yaak-desktop.md)。
+
+
 ### Pattern A — 独立 bundle id（各 channel 自带身份，最干净）
 
 | Family | 非 stable channel → bundle id | 源 |
@@ -175,6 +178,9 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 ---
 
 ## §2b TODO — Pattern B/C 候选（app 内切换，需真机验证信号）
+
+- **CotEditor**（2026-09-06）：已补隐藏 Sparkle 地址及 stable/beta 结构化日志，stable 一键升级实测通过。仍需接入 `checksUpdatesForBeta || Bundle.main.version.isPrerelease`，对应 feed 标签 `prerelease`；当前依赖 feed 中已知 build 推断，旧 beta 被裁掉后退回 stable。见 [审计](docs/app-audits/com-coteditor-CotEditor.md)。
+
 
 > 以下 app 有明确 in-app channel toggle，但切换后是否留下可读的本地信号（defaults/plist）
 > 仍需真机 diff 确认。不要直接标为 detectable。

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -631,9 +631,24 @@ private let betterDisplayContributorRosters = [
 /// landing it here.
 public enum ChangelogRecipeRegistry {
     public static let recipes: [ChangelogRecipe] = [
-        // Official GitHub release bodies, fetched 2026-09-06. Decode JSON and
-        // Markdown through the existing structured path; stable excludes beta
-        // and draft releases. CotEditor's Sparkle feed allows promotion to stable.
+        // Yaak — official GitHub release bodies, fetched 2026-09-06. Decoded as
+        // JSON + Markdown through the existing structured path; the stable
+        // recipe excludes beta and draft releases.
+        //
+        // `per_page=40` with `maxEntries: 20` is the registry's house shape (Zed
+        // and UTM's channel-split pairs are identical), and 20 is a CEILING, not
+        // a target: measured 2026-09-06, the newest 40 releases hold 12 stable
+        // and 28 beta, so the stable rail renders 12 entries and the beta rail
+        // fills its 20. Raising the page to reach 20 stable would mean fetching
+        // ~72 releases on every changelog read, which no other entry here does.
+        //
+        // `includesPromotedStable` is deliberately absent (false) on the beta
+        // recipe, and this is not the same decision UTM's pair makes. Yaak's beta
+        // rule cannot resolve a stable artifact — `installAssetPattern` requires
+        // `-beta.<N>` in the asset name and the channel proof requires it in the
+        // download path — so a promoted-stable entry would describe a build this
+        // channel never offers. `yaakBetaNotesDoNotPromiseAStableWeCannotInstall`
+        // pins the value against the shape of the rule.
         ChangelogRecipe(
             bundleID: "app.yaak.desktop",
             source: URL(string: "https://api.github.com/repos/mountain-loop/yaak/releases?per_page=40")!,
@@ -648,23 +663,6 @@ public enum ChangelogRecipeRegistry {
             mode: .json,
             maxEntries: 20,
             channel: .beta,
-            structuredFormat: .gitHubReleases),
-
-        ChangelogRecipe(
-            bundleID: "com.coteditor.CotEditor",
-            source: URL(string: "https://api.github.com/repos/coteditor/CotEditor/releases?per_page=40")!,
-            mode: .json,
-            maxEntries: 20,
-            channel: .stable,
-            structuredFormat: .gitHubReleases),
-
-        ChangelogRecipe(
-            bundleID: "com.coteditor.CotEditor",
-            source: URL(string: "https://api.github.com/repos/coteditor/CotEditor/releases?per_page=40")!,
-            mode: .json,
-            maxEntries: 20,
-            channel: .beta,
-            includesPromotedStable: true,
             structuredFormat: .gitHubReleases),
 
         // Air (JetBrains) — air.dev/changelog is a Vite/React SPA: the HTML is an

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -631,6 +631,42 @@ private let betterDisplayContributorRosters = [
 /// landing it here.
 public enum ChangelogRecipeRegistry {
     public static let recipes: [ChangelogRecipe] = [
+        // Official GitHub release bodies, fetched 2026-09-06. Decode JSON and
+        // Markdown through the existing structured path; stable excludes beta
+        // and draft releases. CotEditor's Sparkle feed allows promotion to stable.
+        ChangelogRecipe(
+            bundleID: "app.yaak.desktop",
+            source: URL(string: "https://api.github.com/repos/mountain-loop/yaak/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            channel: .stable,
+            structuredFormat: .gitHubReleases),
+
+        ChangelogRecipe(
+            bundleID: "app.yaak.desktop",
+            source: URL(string: "https://api.github.com/repos/mountain-loop/yaak/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            channel: .beta,
+            structuredFormat: .gitHubReleases),
+
+        ChangelogRecipe(
+            bundleID: "com.coteditor.CotEditor",
+            source: URL(string: "https://api.github.com/repos/coteditor/CotEditor/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            channel: .stable,
+            structuredFormat: .gitHubReleases),
+
+        ChangelogRecipe(
+            bundleID: "com.coteditor.CotEditor",
+            source: URL(string: "https://api.github.com/repos/coteditor/CotEditor/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            channel: .beta,
+            includesPromotedStable: true,
+            structuredFormat: .gitHubReleases),
+
         // Air (JetBrains) — air.dev/changelog is a Vite/React SPA: the HTML is an
         // empty shell and the changelog data is baked into the hashed JS bundle as
         // *compiled JSX* (no clean HTML, no JSON API). Two-stage handles the hash:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -287,6 +287,8 @@ public enum ChannelProofRegistry {
     /// because its artifact is allowed to be stable's. See each entry for what its
     /// anchor does and does not cover.
     public static let githubProofs: [ChannelProofKey: ChannelArtifactProof] = [
+        ChannelProofKey("app.yaak.desktop", .beta):
+            .artifact(#"/download/v[0-9.]+-beta\.[0-9]+/"#),
         // `Zed-aarch64.dmg` is byte-identical in name to stable's — the tag is
         // the only discriminator, and it is in the path:
         // `…/download/v1.18.0-pre/Zed-aarch64.dmg`.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1426,6 +1426,27 @@ public struct GitHubReleasesSource: UpdateSource {
 /// the live Releases API to yield the app's current version.
 public enum GitHubReleaseRegistry {
     public static let rules: [GitHubReleaseRule] = [
+        // Yaak — real stable and beta DMGs retain their full tag version in
+        // both plist version fields; same app.yaak.desktop and Team 7PU3P6ELJ8.
+        // Verified notarized 2026-09-06. Pin arm64 DMGs, excluding updater
+        // tarballs, detached signatures, Intel and Windows/Linux packages.
+        GitHubReleaseRule(
+            bundleID: "app.yaak.desktop",
+            owner: "mountain-loop", repo: "yaak",
+            versionPattern: #"^v([0-9]+\.[0-9]+\.[0-9]+)$"#,
+            installAssetPattern: #"^Yaak_[0-9.]+_aarch64\.dmg$"#,
+            installerKind: .dmg),
+        GitHubReleaseRule(
+            bundleID: "app.yaak.desktop",
+            owner: "mountain-loop", repo: "yaak",
+            usePrereleases: true,
+            // Latest 100 releases: 72 beta tags, worst gap 5 (2026-09-06).
+            // Keep the default 20-row window above the measured 6-row floor.
+            versionPattern: #"^v([0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+)$"#,
+            installAssetPattern: #"^Yaak_[0-9.]+-beta\.[0-9]+_aarch64\.dmg$"#,
+            installerKind: .dmg,
+            channel: .beta),
+
         // MARK: - AI desktop clients (verified 2026-08-17)
 
         // OpenCode Desktop — the stable tag and the app's marketing/build versions

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedCatalog.swift
@@ -48,6 +48,10 @@ public enum SparkleFeedCatalog {
     /// lowercases its argument, so a key with a capital is unreachable — the same
     /// trap `ChangelogCatalog` shipped once and now guards against.
     static let feeds: [String: URL] = [
+        // CotEditor 7.0.9 / 7.1.0-beta.6 (verified 2026-09-06): Sparkle and
+        // SUPublicEDKey are present, but SUFeedURL is not. This literal is in
+        // both signed executables. Preserve the feed's OS and channel gates.
+        "com.coteditor.coteditor": URL(string: "https://coteditor.com/appcast.xml")!,
         // Helium — Chromium-based browser (imputnet/helium-macos). Ships Sparkle
         // but no `SUFeedURL`; the address is in the binary alongside a
         // `custom-update-server-url` flag. One feed PER ARCHITECTURE

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedCatalog.swift
@@ -48,10 +48,6 @@ public enum SparkleFeedCatalog {
     /// lowercases its argument, so a key with a capital is unreachable — the same
     /// trap `ChangelogCatalog` shipped once and now guards against.
     static let feeds: [String: URL] = [
-        // CotEditor 7.0.9 / 7.1.0-beta.6 (verified 2026-09-06): Sparkle and
-        // SUPublicEDKey are present, but SUFeedURL is not. This literal is in
-        // both signed executables. Preserve the feed's OS and channel gates.
-        "com.coteditor.coteditor": URL(string: "https://coteditor.com/appcast.xml")!,
         // Helium — Chromium-based browser (imputnet/helium-macos). Ships Sparkle
         // but no `SUFeedURL`; the address is in the binary alongside a
         // `custom-update-server-url` flag. One feed PER ARCHITECTURE

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ActiveAppsIntegrationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ActiveAppsIntegrationTests.swift
@@ -1,0 +1,351 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// Trimmed official API/appcast responses fetched 2026-09-06. Iterate the
+/// registered channels so adding one cannot silently escape fixture coverage.
+struct ActiveAppsIntegrationTests {
+    @Test func releaseHistoriesRespectEveryRegisteredChannel() throws {
+        for recipe in ChangelogRecipeRegistry.recipes where
+            recipe.source.path == "/repos/mountain-loop/yaak/releases"
+            || recipe.source.path == "/repos/coteditor/CotEditor/releases" {
+            let isYaak = recipe.bundleID == "app.yaak.desktop"
+            let fixture = isYaak ? yaakReleases : coteditorReleases
+            let parsed = try #require(ChangelogService.parse(recipe, body: fixture))
+            let stable = isYaak ? "2026.7.1" : "7.0.9"
+            let beta = isYaak ? "2026.8.0-beta.1" : "7.1.0-beta.6"
+            #expect(parsed.entries.first?.version == (recipe.channel == .stable ? stable : beta))
+            #expect(parsed.entries.allSatisfy { !$0.items.isEmpty && $0.date != nil })
+            if recipe.channel == .stable {
+                #expect(!parsed.entries.contains { $0.version == beta })
+                #expect(parsed.entries.first?.items.contains {
+                    $0.contains(isYaak ? "Fix param edits" : "Avoid unnecessary scroll")
+                } == true)
+            } else {
+                #expect(parsed.entries.contains { $0.version == stable } == recipe.includesPromotedStable)
+            }
+            // Unpublished notes must never appear, on either channel.
+            let objects = try #require(JSONSerialization.jsonObject(with: Data(fixture.utf8)) as? [[String: Any]])
+            let drafts = objects.map { $0.merging(["draft": true]) { _, new in new } }
+            let draftBody = String(decoding: try JSONSerialization.data(withJSONObject: drafts), as: UTF8.self)
+            #expect(ChangelogService.parse(recipe, body: draftBody) == nil)
+        }
+    }
+
+    @Test func yaakRulesSelectOnlyTheirOwnSignedMacArtifact() throws {
+        let releases = try #require(JSONSerialization.jsonObject(with: Data(yaakReleases.utf8)) as? [[String: Any]])
+        for rule in GitHubReleaseRegistry.rules where rule.bundleID == "app.yaak.desktop" {
+            let pattern = try #require(rule.installAssetPattern)
+            #expect(rule.installerKind == .dmg)
+            for release in releases {
+                let tag = try #require(release["tag_name"] as? String)
+                let beta = try #require(release["prerelease"] as? Bool)
+                let version = VendorProbeRecipe.extractVersion(from: tag, pattern: rule.versionPattern)
+                #expect((version != nil) == (beta == (rule.channel == .beta)))
+                let assets = try #require(release["assets"] as? [[String: Any]])
+                let matching = assets.compactMap { $0["name"] as? String }.filter {
+                    $0.range(of: pattern, options: .regularExpression) != nil
+                }
+                #expect(matching.count == (version == nil ? 0 : 1))
+                if let name = matching.first {
+                    #expect(name.hasSuffix("_aarch64.dmg"))
+                }
+            }
+            #expect(VendorProbeRecipe.extractVersion(from: "v2026.8.0-beta.1-junk", pattern: rule.versionPattern) == nil)
+        }
+    }
+
+    @Test func coteditorCatalogPreservesStableBetaAndOSGates() throws {
+        let feed = try #require(SparkleFeedCatalog.feed(forBundleID: "com.coteditor.CotEditor"))
+        #expect(feed.absoluteString == "https://coteditor.com/appcast.xml")
+        let items = SparkleAppcastParser.parse(Data(coteditorAppcast.utf8), relativeTo: feed)
+        for (version, build, expected) in [("7.0.8", "830", "7.0.9"), ("7.1.0-beta.6", "845", "7.1.0-beta.6")] {
+            let channel = ReleaseChannel.detect(name: "CotEditor", bundleID: "com.coteditor.CotEditor", keystoneChannel: nil, version: version)
+            let app = InstalledApp(name: "CotEditor", bundleID: "com.coteditor.CotEditor",
+                shortVersion: version, buildVersion: build, path: URL(fileURLWithPath: "/fixture/CotEditor.app"),
+                isMASApp: false, sparkleFeedURL: feed, releaseChannel: channel)
+            let best = try #require(SparkleAppcastSource.bestItem(for: app, from: items, osVersion: "27.0"))
+            #expect(best.shortVersionString == expected)
+            #expect(best.edSignature != nil)
+            #expect(SparkleAppcastSource.bestItem(for: app, from: items, osVersion: "14.0")?.shortVersionString == "5.2.3")
+        }
+    }
+}
+
+private let yaakReleases = #"""
+[
+  {
+    "tag_name": "v2026.8.0-beta.1",
+    "body": "\n### 🎁 New\n\n- 🔄 Import into Existing Workspaces ([#618](https://github.com/mountain-loop/yaak/pull/618), [feedback](https://yaak.app/feedback/posts/update-current-workspace-during-import))\n- Preview imports and choose their destination before anything is applied ([#571](https://github.com/mountain-loop/yaak/pull/571))\n- Generate an example gRPC message from the method schema ([#613](https://github.com/mountain-loop/yaak/pull/613), [feedback](https://yaak.app/feedback/posts/grpc-message-example-from-proto))\n\n### 💄 Improved\n\n- Faster search match counting in large responses ([#612](https://github.com/mountain-loop/yaak/pull/612), [feedback](https://yaak.app/feedback/posts/improve-search-performance-for-large-responses))\n- Windows open faster by not waiting for the plugin runtime to boot ([#616](https://github.com/mountain-loop/yaak/pull/616))\n\n### 🛠️ Fixed\n\n- Disable macOS Writing Tools suggestions inside editors\n- Remove the broken Refresh item from the gRPC method picker\n\n<!-- generated-by-yaak-releases -->\n",
+    "published_at": "2026-09-01T19:14:18Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "latest.json"
+      },
+      {
+        "name": "yaak-2026.8.0-beta.1-1.aarch64.rpm"
+      },
+      {
+        "name": "yaak-2026.8.0-beta.1-1.aarch64.rpm.sig"
+      },
+      {
+        "name": "yaak-2026.8.0-beta.1-1.x86_64.rpm"
+      },
+      {
+        "name": "yaak-2026.8.0-beta.1-1.x86_64.rpm.sig"
+      },
+      {
+        "name": "yaak-cef_2026.8.0-beta.1_amd64.deb"
+      },
+      {
+        "name": "yaak-cef_2026.8.0-beta.1_arm64.deb"
+      },
+      {
+        "name": "yaak-cef_2026.8.0-beta.1_linux_arm64.tar.gz"
+      },
+      {
+        "name": "yaak-cef_2026.8.0-beta.1_linux_x64.tar.gz"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_aarch64.AppImage"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_aarch64.AppImage.sig"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_aarch64.dmg"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_amd64.AppImage"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_amd64.AppImage.sig"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_amd64.deb"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_amd64.deb.sig"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_arm64-setup-machine.exe"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_arm64-setup-machine.exe.sig"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_arm64-setup.exe"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_arm64-setup.exe.sig"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_arm64.deb"
+      },
+      {
+        "name": "yaak_2026.8.0-beta.1_arm64.deb.sig"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_x64-setup-machine.exe"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_x64-setup-machine.exe.sig"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_x64-setup.exe"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_x64-setup.exe.sig"
+      },
+      {
+        "name": "Yaak_2026.8.0-beta.1_x64.dmg"
+      },
+      {
+        "name": "Yaak_aarch64.app.tar.gz"
+      },
+      {
+        "name": "Yaak_aarch64.app.tar.gz.sig"
+      },
+      {
+        "name": "Yaak_x64.app.tar.gz"
+      },
+      {
+        "name": "Yaak_x64.app.tar.gz.sig"
+      }
+    ]
+  },
+  {
+    "tag_name": "v2026.7.1",
+    "body": "Full changelog: https://yaak.app/changelog/2026.7.1\n\n### 🛠️ Fixed\n\n- Fix param edits from one request appearing on its duplicate when switching between them ([#617](https://github.com/mountain-loop/yaak/pull/617), [feedback](https://yaak.app/feedback/posts/if-i-duplicate-request-and-modify-one-the-other-one-gets-modified-as-well))\n\n<!-- generated-by-yaak-releases -->\n",
+    "published_at": "2026-09-01T17:00:59Z",
+    "prerelease": false,
+    "draft": false,
+    "assets": [
+      {
+        "name": "latest.json"
+      },
+      {
+        "name": "yaak-2026.7.1-1.aarch64.rpm"
+      },
+      {
+        "name": "yaak-2026.7.1-1.aarch64.rpm.sig"
+      },
+      {
+        "name": "yaak-2026.7.1-1.x86_64.rpm"
+      },
+      {
+        "name": "yaak-2026.7.1-1.x86_64.rpm.sig"
+      },
+      {
+        "name": "yaak-cef_2026.7.1_amd64.deb"
+      },
+      {
+        "name": "yaak-cef_2026.7.1_arm64.deb"
+      },
+      {
+        "name": "yaak-cef_2026.7.1_linux_arm64.tar.gz"
+      },
+      {
+        "name": "yaak-cef_2026.7.1_linux_x64.tar.gz"
+      },
+      {
+        "name": "yaak_2026.7.1_aarch64.AppImage"
+      },
+      {
+        "name": "yaak_2026.7.1_aarch64.AppImage.sig"
+      },
+      {
+        "name": "Yaak_2026.7.1_aarch64.dmg"
+      },
+      {
+        "name": "yaak_2026.7.1_amd64.AppImage"
+      },
+      {
+        "name": "yaak_2026.7.1_amd64.AppImage.sig"
+      },
+      {
+        "name": "yaak_2026.7.1_amd64.deb"
+      },
+      {
+        "name": "yaak_2026.7.1_amd64.deb.sig"
+      },
+      {
+        "name": "Yaak_2026.7.1_arm64-setup-machine.exe"
+      },
+      {
+        "name": "Yaak_2026.7.1_arm64-setup-machine.exe.sig"
+      },
+      {
+        "name": "Yaak_2026.7.1_arm64-setup.exe"
+      },
+      {
+        "name": "Yaak_2026.7.1_arm64-setup.exe.sig"
+      },
+      {
+        "name": "yaak_2026.7.1_arm64.deb"
+      },
+      {
+        "name": "yaak_2026.7.1_arm64.deb.sig"
+      },
+      {
+        "name": "Yaak_2026.7.1_x64-setup-machine.exe"
+      },
+      {
+        "name": "Yaak_2026.7.1_x64-setup-machine.exe.sig"
+      },
+      {
+        "name": "Yaak_2026.7.1_x64-setup.exe"
+      },
+      {
+        "name": "Yaak_2026.7.1_x64-setup.exe.sig"
+      },
+      {
+        "name": "Yaak_2026.7.1_x64.dmg"
+      },
+      {
+        "name": "Yaak_aarch64.app.tar.gz"
+      },
+      {
+        "name": "Yaak_aarch64.app.tar.gz.sig"
+      },
+      {
+        "name": "Yaak_x64.app.tar.gz"
+      },
+      {
+        "name": "Yaak_x64.app.tar.gz.sig"
+      }
+    ]
+  }
+]
+"""#
+
+private let coteditorReleases = #"""
+[
+  {
+    "tag_name": "7.1.0-beta.6",
+    "body": "system requirements: __macOS 26__ and later\r\n\r\n\r\n### Improvements\r\n\r\n- Apply the current theme’s text color to the text restored by undo even when the theme has changed since the deletion.\r\n- Remove the Bulgarian localization.\r\n- [beta] Reflect all changes in CotEditor 7.0.9.\r\n\r\n\r\n### Known Issues\r\n\r\n- In some cases, a sandboxed URL is passed when folder search results are dropped onto another app (FB23578716).\r\n- In full-screen mode, an unnecessary separator appears above the pane switcher in the Inspector (FB24552348).\r\n\r\n**Full Changelog**: https://github.com/coteditor/CotEditor/compare/7.1.0-beta.5...7.1.0-beta.6",
+    "published_at": "2026-09-05T01:33:07Z",
+    "prerelease": true,
+    "draft": false,
+    "assets": [
+      {
+        "name": "CotEditor_7.1.0-beta.6.dmg"
+      }
+    ]
+  },
+  {
+    "tag_name": "7.0.9",
+    "body": "system requirements: __macOS 15__ and later\r\n\r\n### Improvements\r\n\r\n- Avoid unnecessary scroll after inserting a snippet when the range is already visible.\r\n- Update the Markdown syntax to improve headings highlight.\r\n- Update tree-sitter-scala to 0.26.2.\r\n- [non-AppStore ver.] Update Sparkle from 2.9.5 to 2.9.6.\r\n\r\n\r\n### Fixes\r\n\r\n- Fix an issue in the regular expression replacement with the “Unescape replacement text” option where escaped backslashes in the replacement string were unexpectedly removed instead of being unescaped to literal backslashes.\r\n- Fix an issue in the LaTeX syntax where custom environment definitions were incorrectly extracted as outline items.\r\n- Fix an issue in the LaTeX syntax where the opening braces of arguments of some commands, such as `\\cite`, were highlighted in the wrong color.\r\n- Fix an issue in the Scala syntax where string interpolators, such as `s` in `s\"…\"`, were highlighted in the same color as the string body.\r\n- Fix typos in Dutch and French localizations.\r\n\r\n**Full Changelog**: https://github.com/coteditor/CotEditor/compare/7.0.8...7.0.9",
+    "published_at": "2026-09-05T01:32:59Z",
+    "prerelease": false,
+    "draft": false,
+    "assets": [
+      {
+        "name": "CotEditor_7.0.9.dmg"
+      }
+    ]
+  }
+]
+"""#
+
+private let coteditorAppcast = #"""
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0"><channel>
+<item>
+            <title>CotEditor 7.1.0-beta.6</title>
+            <pubDate>Sat, 05 Sep 2026 10:26:56 +0900</pubDate>
+            <sparkle:channel>prerelease</sparkle:channel>
+            <sparkle:version>845</sparkle:version>
+            <sparkle:shortVersionString>7.1.0-beta.6</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:releaseNotesLink xml:lang="en">https://coteditor.com/releasenotes/7.1.0-beta.en.html</sparkle:releaseNotesLink>
+            <sparkle:releaseNotesLink xml:lang="ja">https://coteditor.com/releasenotes/7.1.0-beta.ja.html</sparkle:releaseNotesLink>
+            <enclosure url="https://github.com/coteditor/CotEditor/releases/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg" length="26458624" type="application/octet-stream" sparkle:edSignature="RbaJg/M9shdtcYkT0Z5gsd5OkZTTa1M8lVq2OAHoJuIHTWoKkxE8zcu0Qw10eRiuQ6Pq2SQdkpnnxvs9tlVuBA=="></enclosure>
+        </item>
+<item>
+            <title>CotEditor 7.0.9</title>
+            <pubDate>Sat, 05 Sep 2026 09:59:15 +0900</pubDate>
+            <sparkle:version>843</sparkle:version>
+            <sparkle:shortVersionString>7.0.9</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <sparkle:releaseNotesLink xml:lang="en">https://coteditor.com/releasenotes/7.0.9.en.html</sparkle:releaseNotesLink>
+            <sparkle:releaseNotesLink xml:lang="ja">https://coteditor.com/releasenotes/7.0.9.ja.html</sparkle:releaseNotesLink>
+            <enclosure url="https://github.com/coteditor/CotEditor/releases/download/7.0.9/CotEditor_7.0.9.dmg" length="25609728" type="application/octet-stream" sparkle:edSignature="ck7WNGbpjxXaDls7GSePbZEFw6FIyPcHxk10HKKzU2a5OeUPVyJbO4v0tBd/Xv7ZnleRjd06wzVbYZAjN2sDAg=="/>
+        </item>
+<item>
+            <title>CotEditor 5.2.3</title>
+            <pubDate>Sat, 23 Aug 2025 17:28:00 +0900</pubDate>
+            
+            <sparkle:version>730</sparkle:version>
+            <sparkle:shortVersionString>5.2.3</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <sparkle:releaseNotesLink xml:lang="en">https://coteditor.com/releasenotes/5.2.3.en.html</sparkle:releaseNotesLink>
+            <sparkle:releaseNotesLink xml:lang="ja">https://coteditor.com/releasenotes/5.2.3.ja.html</sparkle:releaseNotesLink>
+            <enclosure url="https://github.com/coteditor/CotEditor/releases/download/5.2.3/CotEditor_5.2.3.dmg"
+                       length="17555057"
+                       type="application/octet-stream"
+                        sparkle:edSignature="VceO3Okj5sPcnnIgk+EfB1w4/UU/g7LANyC360GPGTTtCdtnKfHrsjcjf2tE2xO8uaZl/6/EdMObEbqO5+GOAg=="/>
+        </item>
+</channel></rss>
+"""#

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ActiveAppsIntegrationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ActiveAppsIntegrationTests.swift
@@ -2,38 +2,79 @@ import Foundation
 import Testing
 @testable import DuoUpdaterCore
 
-/// Trimmed official API/appcast responses fetched 2026-09-06. Iterate the
-/// registered channels so adding one cannot silently escape fixture coverage.
+/// Trimmed official GitHub API responses for Yaak, fetched 2026-09-06. Every
+/// case is driven off the registry rather than a hand-written list, so adding a
+/// channel cannot silently escape fixture coverage — and each loop asserts how
+/// many rows it saw, because a `for … where` over a registry is green when the
+/// registry entry it is meant to protect has been deleted.
 struct ActiveAppsIntegrationTests {
+    /// Both halves of what makes the beta rule a beta rule, asserted against the
+    /// registry rather than restated. Deleting either Yaak rule fails here, which
+    /// nothing else in the suite does: measured 2026-09-06 by removing the stable
+    /// rule and running the whole Core package — 2335 tests, all green.
+    @Test func bothYaakRulesAreRegisteredAndSplitTheTrains() throws {
+        let rules = GitHubReleaseRegistry.rules.filter { $0.bundleID == "app.yaak.desktop" }
+        #expect(rules.count == 2)
+        let stable = try #require(rules.first { $0.channel == .stable })
+        let beta = try #require(rules.first { $0.channel == .beta })
+        #expect(stable.usePrereleases == false)
+        #expect(beta.usePrereleases)
+        for rule in rules { #expect(rule.owner == "mountain-loop" && rule.repo == "yaak") }
+    }
+
+    /// The premise the whole beta track rests on: a Yaak beta bundle keeps the
+    /// `-beta.N` suffix in `CFBundleShortVersionString`, and `detect` has to read
+    /// that as `.beta` or the channel gate in `GitHubReleasesSource` hands a beta
+    /// copy the stable rule's DMG. Asserted directly, because reaching it through
+    /// an `InstalledApp` does not: `channelIsAuthoritative` defaults to false, so
+    /// the Sparkle path never reads `releaseChannel` and a test that builds one
+    /// passes just as well with `.stable` written in by hand (measured).
+    @Test func aBetaVersionStringResolvesToTheBetaChannel() {
+        func detect(_ version: String) -> ReleaseChannel {
+            ReleaseChannel.detect(name: "Yaak", bundleID: "app.yaak.desktop",
+                keystoneChannel: nil, version: version)
+        }
+        #expect(detect("2026.8.0-beta.1") == .beta)
+        #expect(detect("2026.7.1") == .stable)
+    }
+
     @Test func releaseHistoriesRespectEveryRegisteredChannel() throws {
-        for recipe in ChangelogRecipeRegistry.recipes where
-            recipe.source.path == "/repos/mountain-loop/yaak/releases"
-            || recipe.source.path == "/repos/coteditor/CotEditor/releases" {
-            let isYaak = recipe.bundleID == "app.yaak.desktop"
-            let fixture = isYaak ? yaakReleases : coteditorReleases
-            let parsed = try #require(ChangelogService.parse(recipe, body: fixture))
-            let stable = isYaak ? "2026.7.1" : "7.0.9"
-            let beta = isYaak ? "2026.8.0-beta.1" : "7.1.0-beta.6"
+        let recipes = ChangelogRecipeRegistry.recipes.filter { $0.bundleID == "app.yaak.desktop" }
+        #expect(recipes.count == 2, "one rail per channel; a deleted recipe must not read as coverage")
+        var seen: Set<ReleaseChannel> = []
+        for recipe in recipes {
+            seen.insert(recipe.channel ?? .stable)
+            #expect(recipe.source.path == "/repos/mountain-loop/yaak/releases")
+            let parsed = try #require(ChangelogService.parse(recipe, body: yaakReleases))
+            let stable = "2026.7.1"
+            let beta = "2026.8.0-beta.1"
             #expect(parsed.entries.first?.version == (recipe.channel == .stable ? stable : beta))
             #expect(parsed.entries.allSatisfy { !$0.items.isEmpty && $0.date != nil })
             if recipe.channel == .stable {
                 #expect(!parsed.entries.contains { $0.version == beta })
-                #expect(parsed.entries.first?.items.contains {
-                    $0.contains(isYaak ? "Fix param edits" : "Avoid unnecessary scroll")
-                } == true)
+                #expect(parsed.entries.first?.items.contains { $0.contains("Fix param edits") } == true)
             } else {
-                #expect(parsed.entries.contains { $0.version == stable } == recipe.includesPromotedStable)
+                // See the recipe's comment: the beta rule can only ever resolve a
+                // `-beta.N` artifact, so its notes must not advertise the stable
+                // release it graduates into. Asserted as a literal — reading the
+                // flag off the recipe under test would self-adjust to whatever
+                // value someone wrote there.
+                #expect(recipe.includesPromotedStable == false)
+                #expect(!parsed.entries.contains { $0.version == stable })
             }
             // Unpublished notes must never appear, on either channel.
-            let objects = try #require(JSONSerialization.jsonObject(with: Data(fixture.utf8)) as? [[String: Any]])
+            let objects = try #require(JSONSerialization.jsonObject(with: Data(yaakReleases.utf8)) as? [[String: Any]])
             let drafts = objects.map { $0.merging(["draft": true]) { _, new in new } }
             let draftBody = String(decoding: try JSONSerialization.data(withJSONObject: drafts), as: UTF8.self)
             #expect(ChangelogService.parse(recipe, body: draftBody) == nil)
         }
+        #expect(seen == [.stable, .beta])
     }
 
     @Test func yaakRulesSelectOnlyTheirOwnSignedMacArtifact() throws {
         let releases = try #require(JSONSerialization.jsonObject(with: Data(yaakReleases.utf8)) as? [[String: Any]])
+        #expect(releases.count == 2, "one release per train, or the loop below proves nothing")
+        var checked = 0
         for rule in GitHubReleaseRegistry.rules where rule.bundleID == "app.yaak.desktop" {
             let pattern = try #require(rule.installAssetPattern)
             #expect(rule.installerKind == .dmg)
@@ -50,24 +91,28 @@ struct ActiveAppsIntegrationTests {
                 if let name = matching.first {
                     #expect(name.hasSuffix("_aarch64.dmg"))
                 }
+                checked += 1
             }
             #expect(VendorProbeRecipe.extractVersion(from: "v2026.8.0-beta.1-junk", pattern: rule.versionPattern) == nil)
         }
+        #expect(checked == 4, "two rules x two releases")
     }
 
-    @Test func coteditorCatalogPreservesStableBetaAndOSGates() throws {
-        let feed = try #require(SparkleFeedCatalog.feed(forBundleID: "com.coteditor.CotEditor"))
-        #expect(feed.absoluteString == "https://coteditor.com/appcast.xml")
-        let items = SparkleAppcastParser.parse(Data(coteditorAppcast.utf8), relativeTo: feed)
-        for (version, build, expected) in [("7.0.8", "830", "7.0.9"), ("7.1.0-beta.6", "845", "7.1.0-beta.6")] {
-            let channel = ReleaseChannel.detect(name: "CotEditor", bundleID: "com.coteditor.CotEditor", keystoneChannel: nil, version: version)
-            let app = InstalledApp(name: "CotEditor", bundleID: "com.coteditor.CotEditor",
-                shortVersion: version, buildVersion: build, path: URL(fileURLWithPath: "/fixture/CotEditor.app"),
-                isMASApp: false, sparkleFeedURL: feed, releaseChannel: channel)
-            let best = try #require(SparkleAppcastSource.bestItem(for: app, from: items, osVersion: "27.0"))
-            #expect(best.shortVersionString == expected)
-            #expect(best.edSignature != nil)
-            #expect(SparkleAppcastSource.bestItem(for: app, from: items, osVersion: "14.0")?.shortVersionString == "5.2.3")
+    /// The vendor renamed its macOS artifact, and the patterns are pinned to the
+    /// name in use now. Measured over the newest 100 releases on 2026-09-06: the
+    /// 92 at or newer than `v2025.9.0-beta.5` (2025-11-11) publish
+    /// `Yaak_<version>_aarch64.dmg`; the 8 before it published
+    /// `Yaak_<version>_aarch64_darwin.dmg`, which neither pattern accepts. That
+    /// is inert — both rules resolve newest-first and the beta rule reads a
+    /// 20-row page — but it is the boundary, and a vendor who reverted the name
+    /// would take both trains out at once rather than one.
+    @Test func theSupersededDarwinSuffixIsNotAccepted() throws {
+        for rule in GitHubReleaseRegistry.rules where rule.bundleID == "app.yaak.desktop" {
+            let pattern = try #require(rule.installAssetPattern)
+            let old = rule.channel == .beta
+                ? "Yaak_2025.9.0-beta.4_aarch64_darwin.dmg"
+                : "Yaak_2025.8.2_aarch64_darwin.dmg"
+            #expect(old.range(of: pattern, options: .regularExpression) == nil)
         }
     }
 }
@@ -281,71 +326,3 @@ private let yaakReleases = #"""
 ]
 """#
 
-private let coteditorReleases = #"""
-[
-  {
-    "tag_name": "7.1.0-beta.6",
-    "body": "system requirements: __macOS 26__ and later\r\n\r\n\r\n### Improvements\r\n\r\n- Apply the current theme’s text color to the text restored by undo even when the theme has changed since the deletion.\r\n- Remove the Bulgarian localization.\r\n- [beta] Reflect all changes in CotEditor 7.0.9.\r\n\r\n\r\n### Known Issues\r\n\r\n- In some cases, a sandboxed URL is passed when folder search results are dropped onto another app (FB23578716).\r\n- In full-screen mode, an unnecessary separator appears above the pane switcher in the Inspector (FB24552348).\r\n\r\n**Full Changelog**: https://github.com/coteditor/CotEditor/compare/7.1.0-beta.5...7.1.0-beta.6",
-    "published_at": "2026-09-05T01:33:07Z",
-    "prerelease": true,
-    "draft": false,
-    "assets": [
-      {
-        "name": "CotEditor_7.1.0-beta.6.dmg"
-      }
-    ]
-  },
-  {
-    "tag_name": "7.0.9",
-    "body": "system requirements: __macOS 15__ and later\r\n\r\n### Improvements\r\n\r\n- Avoid unnecessary scroll after inserting a snippet when the range is already visible.\r\n- Update the Markdown syntax to improve headings highlight.\r\n- Update tree-sitter-scala to 0.26.2.\r\n- [non-AppStore ver.] Update Sparkle from 2.9.5 to 2.9.6.\r\n\r\n\r\n### Fixes\r\n\r\n- Fix an issue in the regular expression replacement with the “Unescape replacement text” option where escaped backslashes in the replacement string were unexpectedly removed instead of being unescaped to literal backslashes.\r\n- Fix an issue in the LaTeX syntax where custom environment definitions were incorrectly extracted as outline items.\r\n- Fix an issue in the LaTeX syntax where the opening braces of arguments of some commands, such as `\\cite`, were highlighted in the wrong color.\r\n- Fix an issue in the Scala syntax where string interpolators, such as `s` in `s\"…\"`, were highlighted in the same color as the string body.\r\n- Fix typos in Dutch and French localizations.\r\n\r\n**Full Changelog**: https://github.com/coteditor/CotEditor/compare/7.0.8...7.0.9",
-    "published_at": "2026-09-05T01:32:59Z",
-    "prerelease": false,
-    "draft": false,
-    "assets": [
-      {
-        "name": "CotEditor_7.0.9.dmg"
-      }
-    ]
-  }
-]
-"""#
-
-private let coteditorAppcast = #"""
-<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0"><channel>
-<item>
-            <title>CotEditor 7.1.0-beta.6</title>
-            <pubDate>Sat, 05 Sep 2026 10:26:56 +0900</pubDate>
-            <sparkle:channel>prerelease</sparkle:channel>
-            <sparkle:version>845</sparkle:version>
-            <sparkle:shortVersionString>7.1.0-beta.6</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:releaseNotesLink xml:lang="en">https://coteditor.com/releasenotes/7.1.0-beta.en.html</sparkle:releaseNotesLink>
-            <sparkle:releaseNotesLink xml:lang="ja">https://coteditor.com/releasenotes/7.1.0-beta.ja.html</sparkle:releaseNotesLink>
-            <enclosure url="https://github.com/coteditor/CotEditor/releases/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg" length="26458624" type="application/octet-stream" sparkle:edSignature="RbaJg/M9shdtcYkT0Z5gsd5OkZTTa1M8lVq2OAHoJuIHTWoKkxE8zcu0Qw10eRiuQ6Pq2SQdkpnnxvs9tlVuBA=="></enclosure>
-        </item>
-<item>
-            <title>CotEditor 7.0.9</title>
-            <pubDate>Sat, 05 Sep 2026 09:59:15 +0900</pubDate>
-            <sparkle:version>843</sparkle:version>
-            <sparkle:shortVersionString>7.0.9</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <sparkle:releaseNotesLink xml:lang="en">https://coteditor.com/releasenotes/7.0.9.en.html</sparkle:releaseNotesLink>
-            <sparkle:releaseNotesLink xml:lang="ja">https://coteditor.com/releasenotes/7.0.9.ja.html</sparkle:releaseNotesLink>
-            <enclosure url="https://github.com/coteditor/CotEditor/releases/download/7.0.9/CotEditor_7.0.9.dmg" length="25609728" type="application/octet-stream" sparkle:edSignature="ck7WNGbpjxXaDls7GSePbZEFw6FIyPcHxk10HKKzU2a5OeUPVyJbO4v0tBd/Xv7ZnleRjd06wzVbYZAjN2sDAg=="/>
-        </item>
-<item>
-            <title>CotEditor 5.2.3</title>
-            <pubDate>Sat, 23 Aug 2025 17:28:00 +0900</pubDate>
-            
-            <sparkle:version>730</sparkle:version>
-            <sparkle:shortVersionString>5.2.3</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:releaseNotesLink xml:lang="en">https://coteditor.com/releasenotes/5.2.3.en.html</sparkle:releaseNotesLink>
-            <sparkle:releaseNotesLink xml:lang="ja">https://coteditor.com/releasenotes/5.2.3.ja.html</sparkle:releaseNotesLink>
-            <enclosure url="https://github.com/coteditor/CotEditor/releases/download/5.2.3/CotEditor_5.2.3.dmg"
-                       length="17555057"
-                       type="application/octet-stream"
-                        sparkle:edSignature="VceO3Okj5sPcnnIgk+EfB1w4/UU/g7LANyC360GPGTTtCdtnKfHrsjcjf2tE2xO8uaZl/6/EdMObEbqO5+GOAg=="/>
-        </item>
-</channel></rss>
-"""#

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListPageSizeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListPageSizeTests.swift
@@ -41,6 +41,9 @@ struct GitHubListPageSizeTests {
     /// `ruleWithLineAnchoredScopeIsExcludedOnPurpose` pins that this is a
     /// decision, not an oversight.
     static let measuredMinimumDepth: [String: Int] = [
+        // Yaak: latest 100 releases on 2026-09-06, 72 beta tags; worst gap 5
+        // (v2025.8.0-beta.1 → v2025.7.0-beta.5), so the floor is 6.
+        "app.yaak.desktop/beta": 6,
         // Tag gap + 1, and nothing else. An earlier version added
         // `maxReleasesWithoutMacOSAsset` (5) to every floor, on the belief that
         // the walk past assetless releases had to fit inside the page or the

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -199,3 +199,8 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 - [Issue #111 — Sparkle appcast channel population](issue-111-appcast-channel-population.md) ·
   一次性测量任务的产出，不是 app 审计。留在此目录是历史原因。
+
+## 新增覆盖（2026-09-06）
+
+- [x] [**Yaak**](app-yaak-desktop.md) · `app.yaak.desktop` — GitHub stable/beta，一键 DMG、结构化 changelog；stable 旧版→新版生产安装验证通过。
+- [x] [**CotEditor**](com-coteditor-CotEditor.md) · `com.coteditor.CotEditor` — 补 Sparkle 隐藏地址、结构化 stable/beta 日志；stable 一键实测通过，beta 偏好与历史裁剪限制见审计。

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -126,6 +126,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**Qoder IDE**](com-qoder-ide.md) · `com.qoder.ide` — P C (one-click arm64 zip) · VS Code fork，走 VS Code 更新协议（`center.qoder.sh/algo`），**端点是条件式的**（当前 commit → 204 空 body），故用 `latest` 哨兵 · 真包 1.28.0 解包验证 ✓（Team T27K5A5ZWD）· changelog 走 docs 站（正则匹到 108 条，面板按 `maxEntries` 默认显示 40 条），**不用** `qoder.com/changelog`（RSC payload 混了所有产品和两种语言）· 2026-09-06
 - [x] [**Qoder**](com-qoder-app.md) · `com.qoder.app` — P C (one-click arm64 zip) · **与 Qoder IDE 是两个 app，不是改名**（官方论坛证实并存），Team 也不同（B6U242QL73）· 版本读厂商自己的 `manifest.json` · 一键装的是不套壳的 `Qoder-mac-arm64.zip`，不是下载页给人的 installer 壳 · changelog 与 IDE 共用一个 entry pattern（同一套 docs 构建）· 2026-09-06
 - [x] [**WhatCable**](uk-whatcable-whatcable.md) · `uk.whatcable.whatcable` — G(stable/beta，两轨一键 zip) · 共享 bundle id **和资产名**（两轨都叫 `WhatCable.zip`），beta 由版本后缀 `-beta.N` 分流；beta rule **也收 stable tag**（毕业版 + 防「厂商停发 beta 就永久红」），所以 channel proof 锚的是请求（`usePrereleases` + `versionPattern`）而不是 artifact · 真包 1.4.0 + 1.5.0-beta.8 解包验证 ✓（Team M4RUJ7W6MP）· changelog 走 GitHub release body，无需 recipe · app 内 `receiveBetaUpdates` 开关未读，缺口记在 CHANNEL_COVERAGE_TODO §2b · 2026-09-06
+- [x] [**Yaak**](app-yaak-desktop.md) · `app.yaak.desktop` — G(stable/beta，两轨一键 arm64 dmg) · 共享 bundle id，beta 由版本后缀 `-beta.N` 分流（`detect` 第 4 步），两轨各自锚死资产名 · changelog 走 GitHub release body 的结构化解码，两轨分开 · ⚠️ 厂商 2025-11-11 改过 macOS 资产名（此前是 `_aarch64_darwin.dmg`），最新 100 条里最老的 8 条是旧名，现有 pattern 不收——按新旧边界钉在用例里 · 2026-09-06
 - [x] [**Chatbox**](xyz-chatboxapp-app.md) · `xyz.chatboxapp.app` — P (one-click arm64 dmg + feed sha512) · **端到端验过**：装 1.22.6 → 一键到 1.23.1，日志里 `verifyingSignature` 证明 sha512 闸真的跑了 ✓ · **已接 changelog**（厂商 changelog 页，30 条，验过不吃 download 链接）· 2026-09-03
 - [x] [**AnythingLLM**](com-anythingllm.md) · `com.anythingllm` — P (one-click arm64 dmg) · 真包 1.16.1 挂载验证 ✓ · **已接 changelog**（GitHub releases，`version.txt` 与 tag 同号；`docs.anythingllm.com/changelog` 404 不是源）· 2026-09-03
 - [x] [**T3 Code**](com-t3tools-t3code.md) · `com.t3tools.t3code` — G(alpha/nightly) · 2 channels，共享 bundle id，app 名渠道词 + GitHub 双 rule · **两轨一键 ✓**（Team ARK85ZXQ4Z，真包挂载验证）· 2026-08-30
@@ -183,6 +184,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 ## Investigated — blocked safely
 
+- [x] [**CotEditor**](com-coteditor-CotEditor.md) · `com.coteditor.CotEditor` — 隐藏的 Sparkle 地址找到了、一键也实测装成功，但 feed 只留最新一条 beta，旧 beta 副本会被推 `7.0.9` 这个 **marketing 降级**包，而 `evaluate` 在两边都有 build 时只比 build；仓库里没有版本降级守卫 · **故意不接**，见审计 · 2026-09-06
 - [x] [**TRAE**](com-trae-app.md) · `com.trae.app` — official API `2.3.61406` != real app `3.5.81`; no comparable remote version, deliberately left unknown · 2026-08-17
 
 ## 未编入分类（补录 2026-08-30）
@@ -199,8 +201,3 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 - [Issue #111 — Sparkle appcast channel population](issue-111-appcast-channel-population.md) ·
   一次性测量任务的产出，不是 app 审计。留在此目录是历史原因。
-
-## 新增覆盖（2026-09-06）
-
-- [x] [**Yaak**](app-yaak-desktop.md) · `app.yaak.desktop` — GitHub stable/beta，一键 DMG、结构化 changelog；stable 旧版→新版生产安装验证通过。
-- [x] [**CotEditor**](com-coteditor-CotEditor.md) · `com.coteditor.CotEditor` — 补 Sparkle 隐藏地址、结构化 stable/beta 日志；stable 一键实测通过，beta 偏好与历史裁剪限制见审计。

--- a/docs/app-audits/app-yaak-desktop.md
+++ b/docs/app-audits/app-yaak-desktop.md
@@ -1,0 +1,42 @@
+# Yaak
+
+审计日期：2026-09-06。
+
+## 基本信息
+
+- Bundle ID：`app.yaak.desktop`；Team ID：`7PU3P6ELJ8`（Gregory Schier）。
+- 官方真包观测：stable `2026.7.1`，beta `2026.8.0-beta.1`；两个 plist 版本字段均保留完整版本，包括 beta 后缀。
+- 两轨 Apple Silicon DMG 均通过 Gatekeeper：`Notarized Developer ID`，同一 Team ID。
+- 官方发布：[mountain-loop/yaak](https://github.com/mountain-loop/yaak/releases)，stable 发布于 2026-09-01。
+- Tauri 自更新，无 Sparkle；Homebrew cask 标记 `auto_updates: true`，不能把 cask 元数据当作有效检测源。
+
+## 覆盖矩阵
+
+| Channel | Sparkle | Homebrew | GitHub | VendorProbe | 一键安装 | 结构化日志 |
+|---|---|---|---|---|---|---|
+| stable | — | 元数据 | ✓ | — | ✓ arm64 DMG | ✓ |
+| beta | — | — | ✓ | — | ✓ arm64 DMG | ✓ |
+
+本次验证的是官网/GitHub 直装分发；未扩展商店或其他渠道。
+
+## 更新检测与渠道
+
+生产源链由 GitHub 应答。stable 使用 `/releases/latest`，仅接受完整数字 tag；beta 使用 releases 列表，仅接受完整 `v…-beta.N` tag。相同 bundle ID，以真包保留的版本后缀识别 beta。资源规则只接受对应渠道的 `_aarch64.dmg`，排除 x64、Windows/Linux、更新器 tarball 和签名附件。
+
+beta 安装的渠道证明锚定下载 URL 的 beta tag 路径；stable tag 不能通过该证明。最近 100 条发布中 72 条匹配 beta，最大相邻匹配间距 5，查询最低深度为 6；保留默认 20 条窗口。beta 跟随 beta train，本次未实现 beta 自动转入正式版的候选策略。
+
+## Changelog
+
+官方 releases JSON 经现有 `gitHubReleases` 解码器和 Markdown parser 输出版本、日期及逐项说明。两条 recipe 显式区分 stable/beta，排除 draft；stable 不显示预发布说明。真实响应 fixture 经 `ChangelogService.parse` 验证。
+
+## 一键更新验证
+
+使用生产 `AppScanner → UpdateChecker → InstallCoordinator → AppScanner → UpdateChecker`，官方 `2026.7.0` 副本成功升级到 `2026.7.1`。下载 66,472,915 bytes，代码签名门控、替换完成，重新检查为 `upToDate`。stable/beta 最新真包分别运行 `channel-verify --expect stable/beta`，GitHub 版本与本地版本一致，无幻影更新。beta 验证到包和检测链，未执行 beta 旧版到新版替换。
+
+## 如何复验
+
+1. 从官方 releases 下载对应 arm64 DMG，检查 `Info.plist` 两个版本字段与 bundle ID。
+2. `spctl --assess --type execute -vv <app>`：应为上述 Team ID 的公证构建。
+3. `swift run --package-path application-test channel-verify <dmg> --expect <stable或beta>`。
+4. `swift test --package-path DuoUpdaterCore --filter ActiveAppsIntegrationTests`。
+5. `duo verify --only app.yaak.desktop --samples`：2 GitHub + 2 changelog 全通过。

--- a/docs/app-audits/app-yaak-desktop.md
+++ b/docs/app-audits/app-yaak-desktop.md
@@ -23,7 +23,22 @@
 
 生产源链由 GitHub 应答。stable 使用 `/releases/latest`，仅接受完整数字 tag；beta 使用 releases 列表，仅接受完整 `v…-beta.N` tag。相同 bundle ID，以真包保留的版本后缀识别 beta。资源规则只接受对应渠道的 `_aarch64.dmg`，排除 x64、Windows/Linux、更新器 tarball 和签名附件。
 
-beta 安装的渠道证明锚定下载 URL 的 beta tag 路径；stable tag 不能通过该证明。最近 100 条发布中 72 条匹配 beta，最大相邻匹配间距 5，查询最低深度为 6；保留默认 20 条窗口。beta 跟随 beta train，本次未实现 beta 自动转入正式版的候选策略。
+beta 安装的渠道证明锚定下载 URL 的 beta tag 路径；stable tag 不能通过该证明。最近 100 条发布中 72 条匹配 beta，最大相邻匹配间距 5，查询最低深度为 6；保留默认 20 条窗口。beta 跟随 beta train，本次未实现 beta 自动转入正式版的候选策略——这一点和 WhatCable 相反，
+且是有意的：Yaak 的 beta rule 连 channel proof 一起锚在下载路径的 `-beta.N` 上，收不了 stable
+产物，所以 beta 那条 changelog recipe 也**不能**开 `includesPromotedStable`（否则会展示一个
+这条轨道永远装不上的版本）。
+
+⚠️ **厂商改过 macOS 资产名，现在的 pattern 钉的是新名字。** 独立复算（2026-09-06，`gh api`
+拉最新 100 条）：`72 条 beta / 最大间距 5 / 最低深度 6` 一致复现；同时量出**最老的 8 条**
+（`v2025.8.0-beta.1` ~ `v2025.9.0-beta.4`，2025-10-31 ~ 2025-11-11）用的是
+`Yaak_<版本>_aarch64_darwin.dmg`，从 `v2025.9.0-beta.5` 起才是现在的
+`Yaak_<版本>_aarch64.dmg`。旧名两条 rule 都不收。这是**惰性的**——两轨都是最新优先解析，
+beta 只读 20 行窗口，走不到第 82 条——但它是边界，而且厂商一旦改回去会**同时**打掉两条轨，
+不是一条。`theSupersededDarwinSuffixIsNotAccepted` 把这个边界钉住了。
+
+另一条量出来的：`per_page=40` 的窗口里只有 12 条 stable、28 条 beta，所以 stable 那条
+changelog 的 `maxEntries: 20` 是够不到的上限、不是目标值。这与 Zed、UTM 的分轨 recipe 同形，
+不是缺陷；要真取到 20 条 stable 得每次拉约 72 条发布，registry 里没有先例。
 
 ## Changelog
 

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -1,0 +1,42 @@
+# CotEditor
+
+审计日期：2026-09-06。
+
+## 基本信息
+
+- Bundle ID：`com.coteditor.CotEditor`；Team ID：`HT3Z3A72WZ`（Mineko IMANISHI）。
+- 官方真包观测：stable `7.0.9` / build `843`；beta `7.1.0-beta.6` / build `845`。
+- 两轨 universal DMG 均通过 Gatekeeper：`Notarized Developer ID`。
+- [官方发布](https://github.com/coteditor/CotEditor/releases)：两轨最新版本均发布于 2026-09-05。
+- 直装版内置 Sparkle，带 `SUPublicEDKey`，但没有 `SUFeedURL`。地址 `https://coteditor.com/appcast.xml` 可在两份签名二进制及官方 `UpdaterManager.swift` 中确认。
+
+## 覆盖矩阵
+
+| Channel / 分发 | Sparkle | Homebrew | Mac App Store | 一键更新 | 结构化日志 |
+|---|---|---|---|---|---|
+| stable 直装 | ✓ | 元数据，auto_updates | — | ✓ | ✓ |
+| beta 直装 | 当前 feed 可推断，有限覆盖 | — | — | 包及检测已验证 | ✓，含可晋升 stable |
+| stable 商店版 | — | — | 通用 MAS 源 | 现有 MAS 路径，本次未验证 | stable recipe |
+
+## 更新检测
+
+`SparkleFeedCatalog` 填补缺失地址，生产源链由 Sparkle 应答。保留真实 EdDSA 密钥、最低系统版本、渠道标签和安装门控；无需新增易漂移的版本爬取。7.0.9 要求 macOS 15，7.1 beta 要求 macOS 26；feed 保留旧系统版本。回归测试验证 macOS 14 只能选 5.2.3，stable 不能选 beta。
+
+## Beta 范围限制
+
+官方更新器允许 beta 的条件是 `Bundle.main.version.isPrerelease || checksUpdatesForBeta`，标签为 `prerelease`。本次沿用现有 Sparkle 按 feed 中已知 build 推断渠道：当前 beta build 845 可以识别，但不读取 `checksUpdatesForBeta`；旧 beta 一旦从 feed 移除，会保守退回默认渠道。因此不宣称完整 beta 偏好支持。后续需将偏好与实际 bundle 版本一起传入渠道解析，不能用单独的偏好覆盖 beta 包的默认行为。
+
+## Changelog
+
+官方 GitHub releases JSON 通过现有结构化解码器输出版本、日期与 Markdown 条目。stable 排除预发布；beta 包含 beta 及 stable，和 Sparkle 允许晋升正式版一致。draft 在两轨均排除。无须嵌入官方 HTML release-notes 页面。
+
+## 一键更新验证
+
+生产 `AppScanner → UpdateChecker → InstallCoordinator` 将官方 `7.0.8` 副本升级到 `7.0.9`，下载 25,609,728 bytes；Sparkle EdDSA、代码签名与替换阶段通过，重新扫描检查为 `upToDate`。两个最新真包运行 `channel-verify` 均由 Sparkle 应答，版本与包一致，无幻影更新。beta 未执行旧版到新版替换。
+
+## 如何复验
+
+1. 从官方 releases 获取 DMG，读取 `Info.plist`、运行 `codesign -dv` 与 `spctl --assess --type execute -vv <app>`。
+2. `swift run --package-path application-test channel-verify <dmg> --expect <stable或beta>`。
+3. `swift test --package-path DuoUpdaterCore --filter ActiveAppsIntegrationTests`。
+4. `duo verify --only com.coteditor.CotEditor --samples`：2 changelog 全通过；Sparkle 由真包 harness 验证。

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -1,42 +1,95 @@
 # CotEditor
 
-审计日期：2026-09-06。
+审计日期：2026-09-06。**结论：调查完成，暂不接入**——见「为什么没接」。
 
 ## 基本信息
 
 - Bundle ID：`com.coteditor.CotEditor`；Team ID：`HT3Z3A72WZ`（Mineko IMANISHI）。
 - 官方真包观测：stable `7.0.9` / build `843`；beta `7.1.0-beta.6` / build `845`。
 - 两轨 universal DMG 均通过 Gatekeeper：`Notarized Developer ID`。
-- [官方发布](https://github.com/coteditor/CotEditor/releases)：两轨最新版本均发布于 2026-09-05。
-- 直装版内置 Sparkle，带 `SUPublicEDKey`，但没有 `SUFeedURL`。地址 `https://coteditor.com/appcast.xml` 可在两份签名二进制及官方 `UpdaterManager.swift` 中确认。
+- 直装版内置 Sparkle，带 `SUPublicEDKey`，但**没有 `SUFeedURL`**。地址
+  `https://coteditor.com/appcast.xml` 在两份签名二进制及官方 `UpdaterManager.swift` 中可确认。
+- 也在 Mac App Store 上架；Homebrew 有 cask，`auto_updates`。
 
-## 覆盖矩阵
+## 为什么没接
 
-| Channel / 分发 | Sparkle | Homebrew | Mac App Store | 一键更新 | 结构化日志 |
-|---|---|---|---|---|---|
-| stable 直装 | ✓ | 元数据，auto_updates | — | ✓ | ✓ |
-| beta 直装 | 当前 feed 可推断，有限覆盖 | — | — | 包及检测已验证 | ✓，含可晋升 stable |
-| stable 商店版 | — | — | 通用 MAS 源 | 现有 MAS 路径，本次未验证 | stable recipe |
+补一条 `SparkleFeedCatalog` 地址就能让检测跑起来，第一版就是这么做的，端到端
+`7.0.8 → 7.0.9` 也真的装成功了。撤回的原因是**旧 beta 会被推一个降级包**，而且这条路
+是所有闸都放行的。
 
-## 更新检测
+真实 `coteditor.com/appcast.xml`（2026-09-06 取）一共 13 条 item，其中只有 **1 条**
+prerelease：
 
-`SparkleFeedCatalog` 填补缺失地址，生产源链由 Sparkle 应答。保留真实 EdDSA 密钥、最低系统版本、渠道标签和安装门控；无需新增易漂移的版本爬取。7.0.9 要求 macOS 15，7.1 beta 要求 macOS 26；feed 保留旧系统版本。回归测试验证 macOS 14 只能选 5.2.3，stable 不能选 beta。
+| build | short | channel | minimumSystemVersion |
+|---|---|---|---|
+| 845 | `7.1.0-beta.6` | `prerelease` | 26.0 |
+| 843 | `7.0.9` | （默认） | 15.0 |
+| 730 | `5.2.3` | （默认） | 14.0 |
+| …余下 10 条是给旧系统的兼容梯子 | | | |
 
-## Beta 范围限制
+也就是说 `7.1.0-beta.1` ~ `beta.5` **不在 feed 里**。而 build 号是跨两轨单调的，7.0.9 是
+843、beta.6 是 845，中间只剩一个 844，所以那几条旧 beta 的 build **必然低于当前 stable**。
 
-官方更新器允许 beta 的条件是 `Bundle.main.version.isPrerelease || checksUpdatesForBeta`，标签为 `prerelease`。本次沿用现有 Sparkle 按 feed 中已知 build 推断渠道：当前 beta build 845 可以识别，但不读取 `checksUpdatesForBeta`；旧 beta 一旦从 feed 移除，会保守退回默认渠道。因此不宣称完整 beta 偏好支持。后续需将偏好与实际 bundle 版本一起传入渠道解析，不能用单独的偏好覆盖 beta 包的默认行为。
+拿真实响应体跑生产代码（`SparkleAppcastParser` → `allowedChannels` → `bestItem` →
+`UpdateChecker.evaluate`）：
+
+```
+INSTALLED 7.1.0-beta.3/840  detect=beta  allowed=[nil]
+  → best=7.0.9/843  status=updateAvailable(latest: "7.0.9")
+INSTALLED 7.1.0-beta.6/845  detect=beta  allowed=[prerelease, nil]
+  → best=7.1.0-beta.6/845  status=upToDate
+```
+
+链条是这样的：
+
+1. `SparkleAppcastSource.channel(ofInstalled:)` 按 build、再按 shortVersion 去 feed 里找
+   自己那一条。旧 beta 被裁掉了，两次都落空，返回 nil。
+2. 于是 `allowedChannels` 只剩默认渠道 `{nil}`——PR 原文把这一步写成
+   "conservatively falls back to stable"，**前提不成立**：它不是保守，它是把这台机器
+   在 beta 轨这件事忘了。
+3. `bestItem` 按 `comparisonKey`（`version ?? shortVersionString`，即 **build**）排序，
+   给出 843 / `7.0.9`。
+4. `UpdateChecker.evaluate` 在两边都有 build 时**只比 build、完全不看 marketing**
+   （`UpdateChecker.swift:326`）：`isNewer("843", than: "840")` 为真。
+5. 结果：`7.1.0-beta.3` 的用户看到写着 Update 的按钮，装下去是 `7.0.9`。marketing 上
+   这是**降级**。包是厂商真包、EdDSA 用 bundle 自己的 `SUPublicEDKey` 验得过、Team 一致、
+   公证正常，**没有任何一道闸会拦**——仓库里唯一的降级守卫是
+   `SignatureVerifier.verifyNoArchitectureDowngrade`，只管架构。
+6. 装完之后副本报 `7.0.9`，`ReleaseChannel.detect` 判 `.stable`，beta 轨从此消失。
+
+`UpdatePolicy.laggingRemoteVersion`（「你比远端新，没事」那条静默提示）帮不上忙：它被
+限定在 `effectiveReleaseChannel == .stable`（`UpdatePolicy.swift:432`），beta 副本走不到。
+
+次生的同一机制：即使 build 在 feed 里，排序也是**跨轨取最高 build**。CotEditor 现在
+同时维护 7.0.x stable 和 7.1.0 beta 两条线，所以只要出现一个 build 高于当前 beta 的
+7.0.x 补丁，跑 beta 的副本照样会被喂 stable。
+
+## 接进来需要什么
+
+不是补一个 `ChannelBinding` 就够——那只解决「知不知道自己在 beta 轨」，解决不了
+「跨轨按 build 排序」。而且 `SparkleAppcastSource.sparkleChannelName(.beta)` 给的是
+`"beta"`，CotEditor feed 用的标签是 `"prerelease"`，对不上。
+
+真正缺的是一条**「远端 marketing 比装机的旧就不提供」**的守卫。那条守卫落在每个 Sparkle
+app 都要走的检查路径上，属于 CLAUDE.md 说的「十行改在所有请求都要走的路径上」，该单独
+走一轮对抗复审，不该塞进发版日。
+
+顺带一条，同一条 `SparkleFeedCatalog` 补丁还有第二个副作用需要一起决定：
+`AppScanner` 填这张表时**不看 `isMASApp`**（与 `GitHubReleasesSource.swift:591` 的
+`guard !app.isMASApp` 和 `HomebrewCaskSource.swift:33` 不同），而 `MacAppStoreSource`
+查不到时是 `continue` 而不是终止。CotEditor 有商店版，所以一次商店查询落空就会让商店版
+副本拿到一个直装 DMG 的一键更新。
 
 ## Changelog
 
-官方 GitHub releases JSON 通过现有结构化解码器输出版本、日期与 Markdown 条目。stable 排除预发布；beta 包含 beta 及 stable，和 Sparkle 允许晋升正式版一致。draft 在两轨均排除。无须嵌入官方 HTML release-notes 页面。
-
-## 一键更新验证
-
-生产 `AppScanner → UpdateChecker → InstallCoordinator` 将官方 `7.0.8` 副本升级到 `7.0.9`，下载 25,609,728 bytes；Sparkle EdDSA、代码签名与替换阶段通过，重新扫描检查为 `upToDate`。两个最新真包运行 `channel-verify` 均由 Sparkle 应答，版本与包一致，无幻影更新。beta 未执行旧版到新版替换。
+官方 GitHub releases JSON 走现有结构化解码器即可，两轨都验证过能出版本、日期和 Markdown
+条目，draft 两轨均排除。这部分没有问题，只是没有单独接入的价值——检测不接，日志接了也
+没有入口。
 
 ## 如何复验
 
-1. 从官方 releases 获取 DMG，读取 `Info.plist`、运行 `codesign -dv` 与 `spctl --assess --type execute -vv <app>`。
-2. `swift run --package-path application-test channel-verify <dmg> --expect <stable或beta>`。
-3. `swift test --package-path DuoUpdaterCore --filter ActiveAppsIntegrationTests`。
-4. `duo verify --only com.coteditor.CotEditor --samples`：2 changelog 全通过；Sparkle 由真包 harness 验证。
+1. `curl -s https://coteditor.com/appcast.xml` — 数一下有几条 `sparkle:channel` 是
+   `prerelease`，以及 stable 与 beta 的 `sparkle:version` 差多少。
+2. 临时给 `SparkleFeedCatalog.feeds` 加回 `"com.coteditor.coteditor"`，构造一个
+   `shortVersion: "7.1.0-beta.3", buildVersion: "840"` 的 `InstalledApp`，依次调
+   `SparkleAppcastSource.allowedChannels` / `bestItem` / `UpdateChecker.evaluate`。


### PR DESCRIPTION
Yaak (`app.yaak.desktop`) gets GitHub update detection and one-click arm64 DMG updates on **both** its stable and beta trains, plus channel-separated release histories decoded from its official GitHub release bodies.

**CotEditor was in this PR and has been taken back out** — see "Why CotEditor is not here" below. Its investigation is preserved in `docs/app-audits/com-coteditor-CotEditor.md` and tracked in `CHANNEL_COVERAGE_TODO` §2b.

## Yaak

Two `GitHubReleaseRule`s sharing one bundle id. A beta build keeps `-beta.N` in `CFBundleShortVersionString`, which `ReleaseChannel.detect` step 4 resolves to `.beta`, so the trains are told apart by the version string and each rule anchors its own tag and asset name end to end. The beta rule carries an `.artifact` channel proof on the `-beta.N` segment of the download path.

Unlike WhatCable's beta rule, this one does **not** accept stable tags: the proof and the asset pattern both require `-beta.N`, so a beta copy stays on the beta train. That is also why its changelog recipe deliberately leaves `includesPromotedStable` off — advertising the graduated stable would name a build this channel can never install.

### Measured independently this round

- `72 beta tags in the newest 100 / worst gap 5 / floor 6` reproduces exactly against a fresh `gh api` pull. `listPageSize` keeps the default 20.
- **The vendor renamed its macOS artifact.** The oldest 8 of the newest 100 releases (`v2025.8.0-beta.1` … `v2025.9.0-beta.4`, up to 2025-11-11) publish `Yaak_<version>_aarch64_darwin.dmg`, which neither pattern accepts. Inert — both trains resolve newest-first — but it is the boundary, and reverting the name would take out both trains at once. Pinned by `theSupersededDarwinSuffixIsNotAccepted`.
- `per_page=40` holds 12 stable and 28 beta releases, so the stable rail's `maxEntries: 20` is a ceiling it cannot reach. Same arithmetic as Zed's and UTM's channel-split pairs; recorded rather than changed.
- Exactly one asset matches per release across all 31 assets of each (`.sig`, `x64`, `amd64`, `.deb`, `.AppImage` and the Tauri updater tarball all excluded), and `yaak-cli-0.6.2` matches neither rule.

## What review changed

The new cases were vacuous. Both `for … where` loops iterated a registry with no count assertion, so **deleting the entries they exist to protect left them green** — measured: 2335 tests passing with both Yaak rules and both changelog recipes removed. The `ReleaseChannel.detect` call was dead for a related reason (`channelIsAuthoritative` defaults false, so the Sparkle path never reads `releaseChannel`); writing `.stable` in by hand kept the suite green.

Every mutation below was run, and each lands red only on the case named for it:

| mutation | case that fails |
|---|---|
| delete the Yaak stable rule | `bothYaakRulesAreRegisteredAndSplitTheTrains`, `yaakRulesSelectOnlyTheirOwnSignedMacArtifact` |
| delete both changelog recipes | `releaseHistoriesRespectEveryRegisteredChannel` |
| flip `includesPromotedStable` to true | `releaseHistoriesRespectEveryRegisteredChannel` |
| accept the superseded `_darwin` asset | `theSupersededDarwinSuffixIsNotAccepted` |

`detect` is now asserted directly — it is the load-bearing premise of the beta track, since the channel gate hands a beta copy the stable rule's DMG if a Yaak beta string ever reads as stable.

## Why CotEditor is not here

Adding its missing Sparkle address made detection work and a `7.0.8 → 7.0.9` install really did succeed. It was withdrawn because **an older beta copy gets offered a downgrade**, and every gate passes it.

The real `coteditor.com/appcast.xml` (2026-09-06) carries 13 items, exactly **one** of them a prerelease: `7.1.0-beta.6` build 845, `7.0.9` build 843, and 11 compatibility-ladder items for older macOS. Builds are monotonic across both trains and only 844 lies between, so `7.1.0-beta.1`…`beta.5` — all trimmed from the feed — necessarily carry builds *below* the current stable. Running the production path against that body:

```
INSTALLED 7.1.0-beta.3/840  detect=beta  allowed=[nil]
  -> best=7.0.9/843  status=updateAvailable(latest: "7.0.9")
INSTALLED 7.1.0-beta.6/845  detect=beta  allowed=[prerelease, nil]
  -> best=7.1.0-beta.6/845  status=upToDate
```

`channel(ofInstalled:)` looks the copy up by build then by short version; a trimmed beta misses both, so `allowedChannels` collapses to the default channel. `bestItem` sorts by `comparisonKey` — the **build** — and `UpdateChecker.evaluate` compares builds alone whenever both sides have one, never consulting marketing. The DMG is the vendor's own, its EdDSA signature verifies against the bundle's own `SUPublicEDKey`, the team matches, and the only downgrade guard in the repo is `SignatureVerifier.verifyNoArchitectureDowngrade`. `UpdatePolicy.laggingRemoteVersion` cannot mute it either — it is gated to `effectiveReleaseChannel == .stable`.

The earlier description called this "conservatively falls back to stable". It is not conservative; it is the check forgetting which train the copy is on. Closing it needs a "never offer a remote older by marketing than the installed copy" guard, which sits on the path **every** Sparkle app takes and deserves its own review round rather than a release-day patch.

## Verification

```
━ Test run with 2337 tests in 192 suites passed after 19.870 seconds with 1 known issue.
✔ Test run with 202 tests in 26 suites passed after 0.064 seconds.
✓ App tests — 9 of 9 cases executed
✓ localizable keys agree — 515 in the catalog, all reachable
✓ version comparisons discriminate — 237 files
✓ app audits consistent — 113 docs, all indexed
```

`duo verify --only app.yaak.desktop --samples` → 2 GitHub rules ✓, 2 changelogs ✓.

Full sweep against the baseline, on this tree rebased onto current `main`:

```
vendor probe  ✓ 152   GitHub rule ✓ 90   changelog ✓ 89   App Store ✓ 5
total          ✓ 336  ⚠ 0  ✗ 0  ~ 0  - 1      190s
```

The one skip is CapCut's beta track having no current build, which is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)