### PR TITLE
Pin the host in the two appcast changelog tests

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppcastHTMLChangelogParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppcastHTMLChangelogParserTests.swift
@@ -171,7 +171,21 @@ final class AppcastHTMLChangelogParserTests: XCTestCase {
             shortVersion: "0.60.1", buildVersion: "113",
             path: URL(fileURLWithPath: "/Applications/TablePro.app"),
             isMASApp: false, sparkleFeedURL: nil)
-        let usable = SparkleAppcastSource.usableItems(for: app, from: parsed, osVersion: "26.0.0")
+        // Pin the host, do not inherit it. Both of TablePro's real items are
+        // single-architecture and one of them is x86_64, so with the defaults
+        // `usableItems` consults `HostArch.canRunIntelBuilds` — and on an Apple
+        // Silicon Mac WITHOUT Rosetta it drops the x86_64 item, leaving one
+        // entry. That is the arch filter behaving correctly (added 2026-08-24,
+        // two days after this test); what is wrong is asking it here at all,
+        // because this test is about how the notes are structured, not about
+        // which build this Mac can run. Unpinned it measures the host: green on
+        // CI's runner, red on any Mac without Rosetta, and red in a way that
+        // stops `make test` before the CLI suite, the App suite and all four
+        // Python gates. `SparkleArchSelectionTests` pins both fields for the
+        // same reason.
+        let usable = SparkleAppcastSource.usableItems(
+            for: app, from: parsed, osVersion: "26.0.0",
+            hostArch: .arm64, allowingIntelTranslation: true)
         XCTAssertEqual(usable.count, 2)
 
         let changelog = try XCTUnwrap(SparkleAppcastSource.structuredChangelog(from: usable))
@@ -214,7 +228,13 @@ final class AppcastHTMLChangelogParserTests: XCTestCase {
             shortVersion: "0.60.1", buildVersion: "113",
             path: URL(fileURLWithPath: "/Applications/TablePro.app"),
             isMASApp: false, sparkleFeedURL: nil)
-        let usable = SparkleAppcastSource.usableItems(for: app, from: parsed, osVersion: "26.0.0")
+        // Pinned for the reason given above, and here the pin is what makes the
+        // test exist at all: the pair this collapses IS an arm64 item and its
+        // x86_64 twin, so a host that cannot run Intel builds filters one of
+        // them out and the dedup path under test never runs.
+        let usable = SparkleAppcastSource.usableItems(
+            for: app, from: parsed, osVersion: "26.0.0",
+            hostArch: .arm64, allowingIntelTranslation: true)
         XCTAssertEqual(usable.count, 2)
 
         let changelog = try XCTUnwrap(SparkleAppcastSource.structuredChangelog(from: usable))


### PR DESCRIPTION
Two `AppcastHTMLChangelogParserTests` cases call `SparkleAppcastSource.usableItems` without pinning `hostArch` / `allowingIntelTranslation`, so they inherit `HostArch.canRunIntelBuilds` and end up measuring the machine they run on rather than the parser.

The fixtures are byte-real TablePro items and single-architecture: each pair has an x86_64 twin. On an Apple Silicon Mac **without Rosetta** the architecture filter drops it, and `usable.count` is 1 where the test asserts 2.

## Why nobody saw it

The architecture filter landed in `cf69c60` (2026-08-24); these tests were written in `3baf41c` / `db24aec` (2026-08-22). GitHub's macOS runner ships Rosetta, so CI has been green throughout.

Locally it is not green, and the place it fails is expensive: `cd DuoUpdaterCore && swift test` is the **third** line of `make test`, so `swift test --package-path CLI`, `scripts/app-tests.sh` and all four Python gates have not run on such a machine since 2026-08-24. `scripts/publish-release.sh` runs the same `make test`, so a release cut from one fails at its own pre-flight check.

```
/…/AppcastHTMLChangelogParserTests.swift:175: XCTAssertEqual failed: ("1") is not equal to ("2")
/…/AppcastHTMLChangelogParserTests.swift:178: XCTAssertEqual failed: ("1") is not equal to ("2")
/…/AppcastHTMLChangelogParserTests.swift:179: XCTAssertEqual failed: ("Optional("0.60.1")") is not equal to ("Optional("0.64.0")") - highest version first
/…/AppcastHTMLChangelogParserTests.swift:218: XCTAssertEqual failed: ("1") is not equal to ("2")
Executed 14 tests, with 4 failures
```

Reproduced on plain `main` (246f977), so it is not carried in by any open branch.

## The fix

Pin both call sites to `hostArch: .arm64, allowingIntelTranslation: true` — what `SparkleArchSelectionTests` already does at every one of its call sites.

For `testPerArchitectureDuplicateItemsCollapseToOneEntry` the pin is what makes the test exist at all: the pair it collapses **is** an arm64 item and its x86_64 twin, so on a host that cannot run Intel builds one of them is filtered out and the dedup path under test never runs.

## Verification

`make test` on an Apple Silicon Mac with no Rosetta, previously red at line 3, now runs to the end:

```
━ Test run with 2332 tests in 191 suites passed after 19.855 seconds with 1 known issue.
✔ Test run with 202 tests in 26 suites passed after 0.056 seconds.
✓ App tests — 9 of 9 cases executed
✓ localizable keys agree — 515 in the catalog, all reachable
✓ version comparisons discriminate — 237 files, 2 ledger call(s) keyed on the build, 7 marketing-first pick(s), all display-only
✓ app audits consistent — 111 docs, all indexed
```

No `CHANGELOG.md` entry: nothing a user can perceive changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)