### PR TITLE
Release 0.3.86

### DIFF
--- a/App/project.yml
+++ b/App/project.yml
@@ -157,8 +157,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.app
-        MARKETING_VERSION: "0.3.85"
-        CURRENT_PROJECT_VERSION: "94"
+        MARKETING_VERSION: "0.3.86"
+        CURRENT_PROJECT_VERSION: "95"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Info.plist
         # Menu-bar-only app: no Dock icon, no main window.
@@ -270,8 +270,8 @@ targets:
         # plist's BundleProgram points at Contents/MacOS/DuoUpdaterHelper. The bundle
         # *identifier* (for signing / XPC pinning) is com.duoupdater.helper.
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.helper
-        MARKETING_VERSION: "0.3.85"
-        CURRENT_PROJECT_VERSION: "94"
+        MARKETING_VERSION: "0.3.86"
+        CURRENT_PROJECT_VERSION: "95"
         SWIFT_VERSION: "6.0"
         # Embed a generated Info.plist into the binary's __TEXT,__info_plist so the
         # helper has a bundle id/version (Bundle.main reads it) without a wrapper.


### PR DESCRIPTION
`MARKETING_VERSION` → `0.3.86` and `CURRENT_PROJECT_VERSION` → `95`, in both targets (the app and the privileged helper).

The `## 0.3.86` notes are already in `CHANGELOG.md`: they were written by the two PRs that landed in this version and folded into one section when the second rebased onto the first.

- #365 — WhatCable (stable + beta), Qoder IDE, Qoder
- #366 — Yaak (stable + beta)

CotEditor was part of #366 and was withdrawn before it merged, so it is not in the notes. The reason is recorded in `docs/app-audits/com-coteditor-CotEditor.md` and #368.

Also in this version, with no user-facing note because nothing a user can perceive changed: #367, which stopped two appcast tests from measuring whether the host has Rosetta. They had been red on any Mac without it since 2026-08-24, and red at the third line of `make test` — so the CLI suite, the App suite and all four Python gates had not run locally in that time, including the copy of `make test` that `publish-release.sh` runs as its own pre-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)