### PR TITLE
Refuse a Sparkle update that walks the marketing version backwards

### DIFF
--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -228,6 +228,12 @@ tag 与资产名，互不相收。与 WhatCable 的区别是 **Yaak 的 beta rul
       一道闸拦得住（仓库里只有架构降级守卫）。所以这一格**先欠着的不是 binding，是一条
       「远端 marketing 比装机的旧就不提供」的守卫**，那条落在每个 Sparkle app 的检查路径上，
       要单独走一轮复审。实测与链条见 [审计](docs/app-audits/com-coteditor-CotEditor.md)。
+      **2026-09-06：守卫已落地**（#368，`SparkleAppcastSource.offerableItem` +
+      `UpdateChecker.evaluate`），同一台 `7.1.0-beta.3` 行里仍写着 `7.0.9` 但状态是
+      「已是最新」，不会再被推降级包。但**这一格仍然不能打勾**：挡住 `7.1.0-beta.6` 的是
+      渠道推断（自己的 build 不在 feed 里），守卫没碰那一半；而且
+      `sparkleChannelName(.beta)` 给 `"beta"`、feed 用 `"prerelease"`，binding 那条路
+      也还对不上。
 
 - [ ] **Docker Desktop — nightly** · `com.docker.docker` — UI 的更新设置代码里存在受
       feature flag 控制的 `useNightlyBuildUpdates`；观测 stable bundle 只给出 `channelID=main`，

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -306,6 +306,12 @@ public struct UpdateChecker: Sendable {
     /// build versions (Sparkle's canonical key) when both sides have one; fall
     /// back to the marketing version otherwise.
     ///
+    /// A build that says "newer" is not on its own evidence of DIRECTION, so where
+    /// the source has stated that its marketing string is the bundle's own
+    /// (`RemoteVersion.marketingMatchesBundle`) a build-based verdict is refused
+    /// when the marketing version says backwards — see the block comment below
+    /// and #368.
+    ///
     /// Public so a UI layer can cheaply RE-evaluate a freshly-rescanned app
     /// against an already-fetched remote (no network) — e.g. to notice an app
     /// updated itself in the background.
@@ -330,9 +336,37 @@ public struct UpdateChecker: Sendable {
             // namespace — otherwise the tokenizer ranks the bare side above the
             // prefixed one unconditionally (a text run sorts below a number), which
             // would show a perpetual phantom update even right after installing.
-            return VersionComparator.isNewer(Self.normalizedBuild(rv), than: Self.normalizedBuild(iv))
-                ? .updateAvailable(latest: remote.displayVersion ?? rv)
-                : .upToDate
+            guard VersionComparator.isNewer(Self.normalizedBuild(rv), than: Self.normalizedBuild(iv))
+            else { return .upToDate }
+
+            // The build says newer. Ask the marketing version whether that means
+            // FORWARD, but only where the source has stated its string is the
+            // bundle's own (`marketingMatchesBundle`) — a build number moving is
+            // not, by itself, evidence of direction.
+            //
+            // A vendor whose builds run monotonically ACROSS two trains hands a
+            // prerelease copy a stable build that is numerically newer and three
+            // releases older, and every gate downstream passes it: the package is
+            // the vendor's, signed, notarized, and the only downgrade guard in the
+            // repo (`SignatureVerifier.verifyNoArchitectureDowngrade`) is about
+            // architecture. Measured on coteditor.com/appcast.xml, 2026-09-06: a
+            // copy on 7.1.0-beta.3 (build 840) whose build the vendor has trimmed
+            // out of the feed falls back to the default channel and is offered
+            // 7.0.9 (build 843). Installing it also ends the beta train — the copy
+            // then matches the STABLE item, so the channel inference reads it
+            // `.stable` from then on. See #368.
+            //
+            // Deliberately one-way: this can only settle a row to `.upToDate`,
+            // never raise an update, so the worst it can do to a source that
+            // states the flag wrongly is stop offering — never install something
+            // it should not have. The remote still travels with the row, so the
+            // version readout, the release notes and the timeline are unaffected.
+            if remote.marketingMatchesBundle,
+               VersionComparator.isMarketingDowngrade(
+                   offered: remote.shortVersion, from: installed.shortVersion) {
+                return .upToDate
+            }
+            return .updateAvailable(latest: remote.displayVersion ?? rv)
         }
 
         // Otherwise fall back to the marketing (short) version.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -136,6 +136,25 @@ public struct RemoteVersion: Sendable, Hashable {
     /// namespaces are both bare numbers: compared against each other they do not
     /// error, they answer the same thing forever.
     public let buildNamespace: InstalledApp.BuildNamespace
+    /// Whether ``shortVersion`` is the app's own `CFBundleShortVersionString` —
+    /// the same namespace the installed bundle reports — and may therefore be
+    /// COMPARED against it. `UpdateChecker.evaluate` reads this to refuse an
+    /// update that would walk the marketing version backwards.
+    ///
+    /// Stated rather than inferred, and **false by default meaning "not
+    /// established", not "known different"** — the same discipline
+    /// ``buildNamespace`` follows, for the same reason: a marketing string and a
+    /// display label compared against each other do not error, they answer wrong
+    /// forever. `XcodeReleasesSource` is the proof that the two exist side by
+    /// side: it puts "27.0 beta 6" here against an installed "27.0", and says so
+    /// in its own comment.
+    ///
+    /// Only `SparkleAppcastSource` sets it today, because that is the one source
+    /// where the field is the bundle's own string by construction
+    /// (`sparkle:shortVersionString` is what the vendor's own updater compares)
+    /// and the one measured against every feed this machine reads. Turning it on
+    /// for another source is a measurement, not a default.
+    public let marketingMatchesBundle: Bool
     /// Where to download the new build (Sparkle `enclosure url`). This is the
     /// ARTIFACT — a .dmg/.pkg/.zip the installer fetches. Never surface it as a
     /// link for the user to click: opening it in a browser starts a download
@@ -272,6 +291,7 @@ public struct RemoteVersion: Sendable, Hashable {
         shortVersion: String?,
         version: String?,
         buildNamespace: InstalledApp.BuildNamespace = .bundle,
+        marketingMatchesBundle: Bool = false,
         downloadURL: URL?,
         pageURL: URL? = nil,
         installedDisplayVersion: String? = nil,
@@ -299,6 +319,7 @@ public struct RemoteVersion: Sendable, Hashable {
         self.shortVersion = shortVersion
         self.version = version
         self.buildNamespace = buildNamespace
+        self.marketingMatchesBundle = marketingMatchesBundle
         self.downloadURL = downloadURL
         self.pageURL = pageURL
         self.installedDisplayVersion = installedDisplayVersion

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -44,14 +44,23 @@ public struct SparkleAppcastSource: UpdateSource {
 
         let items = SparkleAppcastParser.parse(data, relativeTo: feedURL)
         let usable = Self.usableItems(for: app, from: items, osVersion: Self.numericSystemVersion())
-        guard let best = usable.first else {
-            // Distinguish "the vendor capped every item for an OS this new" from
-            // "the feed had nothing", which the caller cannot tell apart.
+        guard let best = Self.offerableItem(for: app, from: usable) else {
+            // Three silences the caller sees as one nil: an empty feed, a feed
+            // whose every item this OS is too new for, and a feed whose every item
+            // the channel/arch/minimum-OS filters removed. Name the one we can.
             if items.contains(where: { ($0.maximumSystemVersion?.isEmpty == false) }) {
                 Log.source.info(
                     "sparkle: every item filtered for \(app.bundleID ?? "?", privacy: .public) — feed declares a maximum system version")
             }
             return nil
+        }
+        // The offer is not the head only when the head would walk this copy
+        // backwards (see `offerableItem`). Log it with both builds: without them
+        // this reads exactly like an ordinary "you are ahead of your feed" row,
+        // and it is the build that made the head an OFFER rather than a no-op.
+        if let head = usable.first, head.version != best.version {
+            Log.source.info(
+                "sparkle: \(app.bundleID ?? "?", privacy: .public) — offering \(best.shortVersionString ?? "?", privacy: .public)/\(best.version ?? "?", privacy: .public) instead of the feed's newest \(head.shortVersionString ?? "?", privacy: .public)/\(head.version ?? "?", privacy: .public), which is older than the installed \(app.shortVersion ?? "?", privacy: .public)/\(app.buildVersion ?? "?", privacy: .public)")
         }
 
         // When the feed inlines Markdown notes (e.g. Surge's `<markdownDescription>`)
@@ -69,6 +78,11 @@ public struct SparkleAppcastSource: UpdateSource {
         return RemoteVersion(
             shortVersion: best.shortVersionString,
             version: best.version,
+            // `sparkle:shortVersionString` IS the bundle's own
+            // `CFBundleShortVersionString` — it is the string the vendor's own
+            // Sparkle compares — so `evaluate` may weigh it against the installed
+            // one and refuse a build that walks it backwards. See #368.
+            marketingMatchesBundle: true,
             downloadURL: best.enclosureURL,
             downloadSize: best.enclosureLength,
             edSignature: best.edSignature,
@@ -148,7 +162,9 @@ public struct SparkleAppcastSource: UpdateSource {
     }
 
     /// Pick the best appcast item for an app: the highest-versioned, runnable,
-    /// in-channel entry. Pure (no network) so the selection — especially the
+    /// in-channel entry, stepping over a head that would walk the user's
+    /// marketing version backwards when the feed has something better below it
+    /// (see `offerableItem`). Pure (no network) so the selection — especially the
     /// channel gating — is unit-testable.
     ///
     /// Sparkle gates prerelease items behind a `<sparkle:channel>`. The host app
@@ -169,10 +185,11 @@ public struct SparkleAppcastSource: UpdateSource {
         hostArch: HostArch = .current,
         allowingIntelTranslation canRunIntel: Bool = HostArch.canRunIntelBuilds
     ) -> SparkleAppcastItem? {
-        usableItems(
-            for: app, from: items, osVersion: osVersion,
-            hostArch: hostArch, allowingIntelTranslation: canRunIntel
-        ).first
+        offerableItem(
+            for: app,
+            from: usableItems(
+                for: app, from: items, osVersion: osVersion,
+                hostArch: hostArch, allowingIntelTranslation: canRunIntel))
     }
 
     /// The runnable, in-channel items for an app, highest version first. The head
@@ -266,6 +283,79 @@ public struct SparkleAppcastSource: UpdateSource {
                 return (lhs.enclosureURL?.absoluteString ?? "") < (rhs.enclosureURL?.absoluteString ?? "")
             }
         }
+    }
+
+    /// The item to REPORT out of `usableItems` — its head, unless a lower entry
+    /// is the one this copy should actually be offered.
+    ///
+    /// The list is ranked by `comparisonKey`, i.e. the BUILD, and the ranking is
+    /// cross-channel. So when a vendor's builds run monotonically across two
+    /// trains, the head can be a release that is numerically newer and
+    /// functionally older than what a prerelease copy is running — CotEditor
+    /// publishes 7.0.9 at build 843 above 7.1.0-beta.6 at 845, and a copy on
+    /// 7.1.0-beta.3 whose build the vendor has trimmed out of the feed sees only
+    /// the default channel and lands on 7.0.9 (#368).
+    ///
+    /// Two halves, and the split matters:
+    ///
+    ///  - **Which item to name.** Here. Stepping over a marketing downgrade lets
+    ///    the copy find the entry it should actually take when the feed has one —
+    ///    the next beta sitting BELOW a stable patch in build order, which taking
+    ///    the head unconditionally would hide.
+    ///  - **Whether it is an update.** Not here. `UpdateChecker.evaluate` asks the
+    ///    marketing version again before it puts an Update button on a row, and
+    ///    that is the half that actually protects the user (it also covers the
+    ///    case below, where every entry is a downgrade and there is nothing to
+    ///    step onto).
+    ///
+    /// ⚠️ **It never answers nil for a feed that had usable items.** Being ahead
+    /// of your own feed is ordinary — a vendor pulls a release, or trims the build
+    /// you are running — and those rows read "up to date" beside the feed's newest
+    /// entry today. Withholding the answer instead makes `latestVersion` return
+    /// nil, and nil means `.unknown`, whose own documentation is "no source COVERS
+    /// this app, nothing was tried" — rendered as a dead "—" with no retry. That
+    /// would be a false statement about an app whose feed we just read, and it
+    /// would take the release notes and the release timeline with it. Simulated
+    /// over all 13 Sparkle feeds this Mac reads, with the installed build trimmed
+    /// out of each in turn, withholding hit 12 (app, version) pairs: Bartender
+    /// 6.6.2 against a feed topping out at 6.6.1, six DuoPaste betas, Ghostty,
+    /// IINA, MonitorControl, Rectangle, Surge.
+    ///
+    /// The accepted cost, stated rather than left to be discovered: a copy on an
+    /// ABANDONED prerelease train — vendor ships 2.0-beta, cancels 2.0, keeps
+    /// shipping 1.6, 1.7 on stable — is no longer moved onto the maintained line.
+    /// It reads "up to date" against a version it can see is newer by date and
+    /// older by number, and nothing offers it a way across. That was the one real
+    /// user of the old behaviour, and there is no state in `RowActionState` that
+    /// says "your train was withdrawn".
+    static func offerableItem(
+        for app: InstalledApp, from usable: [SparkleAppcastItem]
+    ) -> SparkleAppcastItem? {
+        guard let head = usable.first else { return nil }
+        guard isMarketingDowngrade(head, for: app) else { return head }
+        // Past a head that walks backwards, "cannot tell" is not good enough, and
+        // neither is an entry that cannot be installed. `usableItems` admits an
+        // item with NO enclosure at all (its filter asks only for a version), and
+        // before this scan existed such an entry was reachable only by topping the
+        // build ranking. Requiring the artifact keeps this from newly promoting
+        // one into an Update button over a nil download.
+        return usable.dropFirst().first {
+            $0.enclosureURL != nil && !isMarketingDowngrade($0, for: app)
+                && VersionComparator.comparableMarketingVersion($0.shortVersionString) != nil
+        } ?? head
+    }
+
+    /// Whether taking `item` would walk this copy's marketing version backwards.
+    ///
+    /// Only `shortVersionString` is read. Fork's feed states none at all — its
+    /// marketing string lives in `sparkle:version` ("2.66.7") — and reaching for
+    /// `shortVersionString ?? version` here would compare a BUILD field against a
+    /// marketing one, the namespace mistake `VersionComparator`'s pair API exists
+    /// to prevent. The shape test that follows is in `VersionComparator`, with the
+    /// Ghostty tip-build label that motivates it.
+    static func isMarketingDowngrade(_ item: SparkleAppcastItem, for app: InstalledApp) -> Bool {
+        VersionComparator.isMarketingDowngrade(
+            offered: item.shortVersionString, from: app.shortVersion)
     }
 
     /// How well an item's download suits this Mac, cheapest-to-worst. Two

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/VersionComparator.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/VersionComparator.swift
@@ -113,6 +113,63 @@ public enum VersionComparator {
         return isSame(VersionSide(marketing: lhs.marketing), as: rhs)
     }
 
+    // MARK: - Marketing downgrades
+
+    /// True when `offered` names a marketing version strictly OLDER than
+    /// `installed` — the one question a build comparison cannot answer, and the
+    /// one a build comparison is routinely asked to stand in for.
+    ///
+    /// It answers false unless BOTH strings are shaped like versions, because the
+    /// field they come from is not always one. Measured on feeds we read today
+    /// (2026-09-06):
+    ///
+    /// - Ghostty publishes its tip builds with a commit hash and a date where the
+    ///   marketing version goes — `663205b5 (2024-12-20)`. Tokenized as a version
+    ///   its leading run is the number 663205, so EVERY real release ("1.3.2")
+    ///   reads as older than it.
+    /// - `XcodeReleasesSource` composes `shortVersion` for display — "27.0 beta 6"
+    ///   against an installed "27.0" — and says so in its own comment. A release
+    ///   outranks its prerelease tag, so that pair reads as a downgrade too.
+    ///
+    /// Both are caught by the same test: a version has no whitespace in it. The
+    /// ASCII requirement is the narrower cousin — `Character.isNumber` is a
+    /// Unicode property, so full-width `１.０.０` would be *accepted* and then
+    /// compared scalar-wise against ASCII digits, which orders it above every
+    /// real release. No feed publishes one today; rejecting it costs nothing and
+    /// the failure it would cause is silent.
+    ///
+    /// "Cannot tell" is false here — never a downgrade — because every caller
+    /// uses this to WITHHOLD, and withholding on a string we cannot read is how
+    /// an app stops updating without anyone noticing.
+    public static func isMarketingDowngrade(offered: String?, from installed: String?) -> Bool {
+        guard let mine = comparableMarketingVersion(installed),
+              let theirs = comparableMarketingVersion(offered)
+        else { return false }
+        // No `VersionSide` here, deliberately: the callers reach this having
+        // already established that the BUILDS say "newer", and this is the second
+        // opinion on that one question. Pairing the build back in would answer the
+        // first question twice and the second one never. (`check_staged_version_use`
+        // does not flag it — measured, not assumed — so there is no exemption
+        // comment to go stale.)
+        return compare(theirs, mine) == .orderedAscending
+    }
+
+    /// A marketing version, when the string is one: non-empty, all-ASCII, no
+    /// whitespace inside it, and starting with a digit once the optional `v` tag
+    /// `tokenize` itself strips is off. `7.1.0-beta.3` and
+    /// `0.3.384-beta.1440+fd58749` pass; `663205b5 (2024-12-20)`, `27.0 beta 6`
+    /// and a bare `v` do not.
+    public static func comparableMarketingVersion(_ raw: String?) -> String? {
+        guard let version = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !version.isEmpty,
+              version.allSatisfy({ $0.isASCII }),
+              !version.contains(where: \.isWhitespace)
+        else { return nil }
+        var head = Substring(version)
+        if head.first == "v" || head.first == "V" { head = head.dropFirst() }
+        return head.first?.isNumber == true ? version : nil
+    }
+
     /// True when `disk` has reached `target` — the landing test for a swap we are
     /// waiting on. Same build, or a newer one (an app may have moved past the
     /// build we were expecting while we waited).

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleChannelTests.swift
@@ -260,8 +260,36 @@ struct SparkleChannelTests {
     }
 
     /// A beta user must still get a newer *stable* release (Sparkle allows the
-    /// default channel to everyone). Feed where stable 1.6/300 tops beta 2.0/200.
+    /// default channel to everyone). Feed where stable 2.1/300 tops beta 2.0/200.
     @Test func betaUserStillGetsNewerStable() {
+        let feed = """
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0"><channel>
+          <item><title>2.1</title><sparkle:version>300</sparkle:version><sparkle:shortVersionString>2.1</sparkle:shortVersionString>
+            <enclosure url="https://example.com/2.1.dmg" sparkle:edSignature="s" length="1" type="application/octet-stream" /></item>
+          <item><title>2.0 beta</title><sparkle:version>200</sparkle:version><sparkle:shortVersionString>2.0-beta</sparkle:shortVersionString>
+            <sparkle:channel>beta</sparkle:channel>
+            <enclosure url="https://example.com/2.0-beta.dmg" sparkle:edSignature="s" length="1" type="application/octet-stream" /></item>
+        </channel></rss>
+        """
+        let parsed = SparkleAppcastParser.parse(Data(feed.utf8))
+        let best = SparkleAppcastSource.bestItem(
+            for: app(short: "2.0-beta", build: "200"), from: parsed, osVersion: "26.0.0")
+        #expect(best?.version == "300")
+        #expect(best?.channel == nil)
+    }
+
+    /// ⚠️ The fixture above used to be stable **1.6**/300 over beta 2.0-beta/200,
+    /// asserting that the beta copy took the 1.6 — which is #368 in miniature: a
+    /// higher build carrying a lower marketing version, offered as an update. The
+    /// rule it was written for ("the default channel is allowed to everyone") is
+    /// real and still holds above; what it cannot mean is that a stable release
+    /// the vendor numbered BELOW the installed one is an update. Kept as its own
+    /// case so the old expectation is visible as a decision rather than deleted.
+    ///
+    /// Promotion still works, and that is the case this could plausibly have
+    /// broken: a 2.0 final over a 2.0-beta reads as newer (a release outranks its
+    /// own prerelease tag), so it is offered — asserted here beside the refusal.
+    @Test func betaUserIsNotDroppedOntoAnOlderStable() {
         let feed = """
         <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0"><channel>
           <item><title>1.6</title><sparkle:version>300</sparkle:version><sparkle:shortVersionString>1.6</sparkle:shortVersionString>
@@ -274,7 +302,16 @@ struct SparkleChannelTests {
         let parsed = SparkleAppcastParser.parse(Data(feed.utf8))
         let best = SparkleAppcastSource.bestItem(
             for: app(short: "2.0-beta", build: "200"), from: parsed, osVersion: "26.0.0")
-        #expect(best?.version == "300")
-        #expect(best?.channel == nil)
+        #expect(best?.version == "200")
+
+        let promoted = SparkleAppcastParser.parse(Data(feed
+            .replacingOccurrences(of: "<title>1.6</title>", with: "<title>2.0</title>")
+            .replacingOccurrences(
+                of: "<sparkle:shortVersionString>1.6</sparkle:shortVersionString>",
+                with: "<sparkle:shortVersionString>2.0</sparkle:shortVersionString>").utf8))
+        let final = SparkleAppcastSource.bestItem(
+            for: app(short: "2.0-beta", build: "200"), from: promoted, osVersion: "26.0.0")
+        #expect(final?.version == "300")
+        #expect(final?.shortVersionString == "2.0")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleMarketingDowngradeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleMarketingDowngradeTests.swift
@@ -1,0 +1,455 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A Sparkle feed must never walk a copy BACKWARDS in marketing version, however
+/// the build numbers read (#368).
+///
+/// `usableItems` ranks items by `sparkle:version` and `UpdateChecker.evaluate`
+/// compares builds whenever both sides have one, so nothing in the offer path had
+/// ever read the marketing string. A vendor whose builds run monotonically across
+/// two trains therefore fed a prerelease copy a stable package that was newer by
+/// build and three releases older by name — signed, notarized, and behind an
+/// Update button.
+///
+/// The fix is in two halves and so are these tests:
+///
+///  - `SparkleAppcastSource.offerableItem` decides WHICH item to name, stepping
+///    over a head that walks backwards so the copy can find the entry it should
+///    actually take. Pinned by `theNextBetaBelowAStablePatchIsFound` and
+///    `theScanNeverPromotesAnEntryWithNoDownload`.
+///  - `UpdateChecker.evaluate` decides whether that item is an UPDATE, and refuses
+///    when the marketing version says backwards. Pinned by
+///    `aTrimmedBetaIsNotOfferedTheOlderStable` and
+///    `aSourceThatNamesItsOwnVersionsIsNotSecondGuessed`.
+///
+/// ⚠️ The rest are one-directional: they fail if the guard OVER-withholds, and
+/// they pass with the guard deleted entirely. That is deliberate (over-withholding
+/// is the failure mode that makes an app stop updating silently) but it means
+/// "nine tests" is not "nine tests of the guard" — the ones above are.
+///
+/// The fixture is CotEditor's real appcast (fetched 2026-09-06, 13 items) cut to
+/// the four that matter: the single `prerelease` entry, the stable line one build
+/// below it, the newest of the legacy compatibility ladder, and the 2014 entry
+/// that states a `sparkle:version` and NO `sparkle:shortVersionString`.
+struct SparkleMarketingDowngradeTests {
+
+    /// CotEditor's own items, verbatim in every field the selection reads.
+    fileprivate static let cotEditorFeed = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+      <channel>
+        <item>
+          <title>CotEditor 7.1.0-beta.6</title>
+          <pubDate>Sat, 05 Sep 2026 10:26:56 +0900</pubDate>
+          <sparkle:channel>prerelease</sparkle:channel>
+          <sparkle:version>845</sparkle:version>
+          <sparkle:shortVersionString>7.1.0-beta.6</sparkle:shortVersionString>
+          <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+          <enclosure url="https://github.com/coteditor/CotEditor/releases/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg" length="26458624" type="application/octet-stream" sparkle:edSignature="sig"/>
+        </item>
+        <item>
+          <title>CotEditor 7.0.9</title>
+          <pubDate>Sat, 05 Sep 2026 09:59:15 +0900</pubDate>
+          <sparkle:version>843</sparkle:version>
+          <sparkle:shortVersionString>7.0.9</sparkle:shortVersionString>
+          <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+          <enclosure url="https://github.com/coteditor/CotEditor/releases/download/7.0.9/CotEditor_7.0.9.dmg" length="25609728" type="application/octet-stream" sparkle:edSignature="sig"/>
+        </item>
+        <item>
+          <title>CotEditor 5.2.3</title>
+          <pubDate>Sat, 20 Jul 2024 12:00:00 +0900</pubDate>
+          <sparkle:version>730</sparkle:version>
+          <sparkle:shortVersionString>5.2.3</sparkle:shortVersionString>
+          <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+          <enclosure url="https://github.com/coteditor/CotEditor/releases/download/5.2.3/CotEditor_5.2.3.dmg" length="21000000" type="application/octet-stream" sparkle:edSignature="sig"/>
+        </item>
+        <item>
+          <title>CotEditor 2.0.3</title>
+          <pubDate>Sun, 14 Dec 2014 21:19:19 +0900</pubDate>
+          <sparkle:version>2.0.3</sparkle:version>
+          <sparkle:minimumSystemVersion>10.7</sparkle:minimumSystemVersion>
+          <enclosure url="https://github.com/coteditor/CotEditor/releases/download/2.0.3/CotEditor_2.0.3.dmg" length="14414610" type="application/octet-stream" sparkle:dsaSignature="sig"/>
+        </item>
+      </channel>
+    </rss>
+    """
+
+    private static let feedURL = URL(string: "https://coteditor.com/appcast.xml")!
+
+    private var cotEditorItems: [SparkleAppcastItem] {
+        SparkleAppcastParser.parse(Data(Self.cotEditorFeed.utf8), relativeTo: Self.feedURL)
+    }
+
+    private func cotEditor(short: String, build: String) -> InstalledApp {
+        InstalledApp(
+            name: "CotEditor", bundleID: "com.coteditor.CotEditor",
+            shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/CotEditor.app"),
+            isMASApp: false, sparkleFeedURL: Self.feedURL)
+    }
+
+    /// A Sparkle remote, as `SparkleAppcastSource.latestVersion` builds it.
+    private func sparkleRemote(_ item: SparkleAppcastItem?) -> RemoteVersion {
+        RemoteVersion(
+            shortVersion: item?.shortVersionString, version: item?.version,
+            marketingMatchesBundle: true,
+            downloadURL: item?.enclosureURL, sourceName: "Sparkle")
+    }
+
+    /// The reported bug. A copy on `7.1.0-beta.3` is not in the feed any more (the
+    /// vendor keeps only the newest prerelease), so `channel(ofInstalled:)` misses
+    /// on both passes, `allowedChannels` falls back to `{nil}`, and the highest
+    /// build left is 843 — `7.0.9`, three marketing versions back. Installing it
+    /// also ends the beta train: the copy then matches the STABLE item, so the
+    /// channel inference reads it `.stable` from then on.
+    ///
+    /// The feed's newest entry is still NAMED (that is the row's version readout),
+    /// it is just not an update.
+    ///
+    /// Mutation: drop the marketing test from `evaluate`'s build branch →
+    /// `.updateAvailable(latest: "7.0.9")`.
+    @Test func aTrimmedBetaIsNotOfferedTheOlderStable() {
+        let app = cotEditor(short: "7.1.0-beta.3", build: "840")
+        let best = SparkleAppcastSource.bestItem(
+            for: app, from: cotEditorItems, osVersion: "26.6.0")
+        #expect(best?.shortVersionString == "7.0.9")
+        #expect(UpdateChecker.evaluate(installed: app, remote: sparkleRemote(best)) == .upToDate)
+    }
+
+    /// The same guard with nothing trimmed: CotEditor maintains 7.0.x and 7.1.0
+    /// side by side, so a 7.0.x patch published above the newest beta reaches a
+    /// beta copy whose own build IS in the feed.
+    ///
+    /// Here the copy's own build IS in the feed, so stepping over the stable head
+    /// lands on it — the row names `7.1.0-beta.6`, the newest thing on this copy's
+    /// train, rather than the stable that outranks it by build.
+    ///
+    /// Mutation: drop the marketing test from `evaluate` AND return the head
+    /// unconditionally → the beta copy is offered `7.0.10`. Either half alone
+    /// already makes this row safe, which is the point of having both.
+    @Test func aStablePublishedAboveTheBetaIsNotAnUpdate() {
+        let items = SparkleAppcastParser.parse(Data(Self.feed(
+            replacing: "5.2.3", withShort: "7.0.10", build: "850", minOS: "15.0").utf8),
+            relativeTo: Self.feedURL)
+        let app = cotEditor(short: "7.1.0-beta.6", build: "845")
+        let best = SparkleAppcastSource.bestItem(for: app, from: items, osVersion: "26.6.0")
+        #expect(best?.shortVersionString == "7.1.0-beta.6")
+        #expect(UpdateChecker.evaluate(installed: app, remote: sparkleRemote(best)) == .upToDate)
+
+        // And the same feed read by a STABLE copy still offers the stable patch.
+        let onStable = cotEditor(short: "7.0.9", build: "843")
+        let forStable = SparkleAppcastSource.bestItem(for: onStable, from: items, osVersion: "26.6.0")
+        #expect(forStable?.version == "850")
+        #expect(UpdateChecker.evaluate(installed: onStable, remote: sparkleRemote(forStable))
+            == .updateAvailable(latest: "7.0.10"))
+    }
+
+    /// What the head-stepping is FOR: the entry this copy should take can sit
+    /// BELOW a stable patch in build order, and naming the head unconditionally
+    /// hides it. Feed: stable `7.0.10`/850 on top, the next beta `7.1.0-beta.7`/846
+    /// under it, the installed `7.1.0-beta.6`/845 under that.
+    ///
+    /// Two mutations, and this is the only test that catches either: return the
+    /// head unconditionally → `7.0.10` and no update; take the LAST provable
+    /// non-downgrade instead of the first → `7.1.0-beta.6`, the build already
+    /// installed, and no update.
+    @Test func theNextBetaBelowAStablePatchIsFound() {
+        let feed = Self.cotEditorFeed
+            .replacingOccurrences(of: "<sparkle:version>730</sparkle:version>", with: "<sparkle:version>850</sparkle:version>")
+            .replacingOccurrences(
+                of: "<sparkle:shortVersionString>5.2.3</sparkle:shortVersionString>",
+                with: "<sparkle:shortVersionString>7.0.10</sparkle:shortVersionString>")
+            .replacingOccurrences(of: "<sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>", with: "<sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>")
+            .replacingOccurrences(of: """
+                    <item>
+                      <title>CotEditor 2.0.3</title>
+                """, with: """
+                    <item>
+                      <title>CotEditor 7.1.0-beta.7</title>
+                      <sparkle:channel>prerelease</sparkle:channel>
+                      <sparkle:version>846</sparkle:version>
+                      <sparkle:shortVersionString>7.1.0-beta.7</sparkle:shortVersionString>
+                      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+                      <enclosure url="https://example.com/CotEditor_7.1.0-beta.7.dmg" length="1" type="application/octet-stream" sparkle:edSignature="sig"/>
+                    </item>
+                    <item>
+                      <title>CotEditor 2.0.3</title>
+                """)
+        let items = SparkleAppcastParser.parse(Data(feed.utf8), relativeTo: Self.feedURL)
+        #expect(items.count == 5)
+
+        let app = cotEditor(short: "7.1.0-beta.6", build: "845")
+        let best = SparkleAppcastSource.bestItem(for: app, from: items, osVersion: "26.6.0")
+        #expect(best?.shortVersionString == "7.1.0-beta.7")
+        #expect(UpdateChecker.evaluate(installed: app, remote: sparkleRemote(best))
+            == .updateAvailable(latest: "7.1.0-beta.7"))
+    }
+
+    /// `usableItems` admits an item with no `<enclosure>` at all — its filter asks
+    /// only for a version — and `archVerdict` reads a nil URL as arch-neutral
+    /// rather than unrunnable. Before the head-stepping existed such an entry was
+    /// reachable only by topping the build ranking; the scan must not newly
+    /// promote one into an Update button over a nil download.
+    ///
+    /// Mutation: drop `enclosureURL != nil` from the scan → `7.1.0-beta.4` is
+    /// named, `evaluate` calls 841 newer than 840, and the row offers an update
+    /// with nothing behind it.
+    @Test func theScanNeverPromotesAnEntryWithNoDownload() {
+        let feed = Self.cotEditorFeed.replacingOccurrences(of: """
+                <item>
+                  <title>CotEditor 5.2.3</title>
+            """, with: """
+                <item>
+                  <title>CotEditor 7.1.0-beta.4</title>
+                  <sparkle:version>841</sparkle:version>
+                  <sparkle:shortVersionString>7.1.0-beta.4</sparkle:shortVersionString>
+                </item>
+                <item>
+                  <title>CotEditor 5.2.3</title>
+            """)
+        let items = SparkleAppcastParser.parse(Data(feed.utf8), relativeTo: Self.feedURL)
+        #expect(items.first(where: { $0.version == "841" })?.enclosureURL == nil)
+
+        let app = cotEditor(short: "7.1.0-beta.3", build: "840")
+        let best = SparkleAppcastSource.bestItem(for: app, from: items, osVersion: "26.6.0")
+        #expect(best?.version == "843")
+        #expect(UpdateChecker.evaluate(installed: app, remote: sparkleRemote(best)) == .upToDate)
+    }
+
+    /// The stable line still updates stable copies — the guard only ever refuses
+    /// something OLDER, and 7.0.9 is not older than 7.0.8.
+    ///
+    /// Mutation: invert the comparison in `isMarketingDowngrade` → nothing updates.
+    @Test func aStableCopyStillGetsItsStableUpdate() {
+        let app = cotEditor(short: "7.0.8", build: "842")
+        let best = SparkleAppcastSource.bestItem(
+            for: app, from: cotEditorItems, osVersion: "26.6.0")
+        #expect(best?.version == "843")
+        #expect(UpdateChecker.evaluate(installed: app, remote: sparkleRemote(best))
+            == .updateAvailable(latest: "7.0.9"))
+    }
+
+    /// An app whose marketing version never moves — Amp shipped ten builds called
+    /// `1.0` in a day — must still be offered its new build. Equal marketing is not
+    /// a downgrade, and this is the case where treating it as one would take the
+    /// app's ONLY comparison away.
+    ///
+    /// Mutation: widen `isMarketingDowngrade` to `!= .orderedDescending` → the
+    /// frozen-marketing app never updates again.
+    @Test func aFrozenMarketingVersionStillUpdates() {
+        let app = InstalledApp(
+            name: "Amp", bundleID: "com.example.amp",
+            shortVersion: "1.0", buildVersion: "10",
+            path: URL(fileURLWithPath: "/Applications/Amp.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"))
+        let remote = RemoteVersion(
+            shortVersion: "1.0", version: "11", marketingMatchesBundle: true,
+            downloadURL: URL(string: "https://example.com/11.zip"), sourceName: "Sparkle")
+        #expect(UpdateChecker.evaluate(installed: app, remote: remote)
+            == .updateAvailable(latest: "1.0"))
+    }
+
+    /// Being AHEAD of your own feed is ordinary — a vendor pulls a release, or
+    /// trims the build you are running — and those rows read "up to date" beside
+    /// the feed's newest entry. Simulated over all 13 Sparkle feeds this Mac reads,
+    /// with the installed build trimmed out of each in turn, that shape hit 12
+    /// (app, version) pairs: Bartender 6.6.2 against a feed topping out at 6.6.1,
+    /// six DuoPaste betas, Ghostty, IINA, MonitorControl, Rectangle, Surge. The
+    /// feed's newest entry must still be NAMED for all of them, because nil means
+    /// `.unknown`, which claims no source covers the app at all.
+    ///
+    /// Mutation: return nil instead of the head when everything is a downgrade →
+    /// eight of thirteen real feeds lose their version readout.
+    @Test func aCopyAheadOfItsFeedKeepsItsUpToDateRow() {
+        let feed = """
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0"><channel>
+          <item><title>6.6.1</title><sparkle:version>661000</sparkle:version><sparkle:shortVersionString>6.6.1</sparkle:shortVersionString>
+            <enclosure url="https://example.com/661000.zip" sparkle:edSignature="s" length="1" type="application/octet-stream" /></item>
+        </channel></rss>
+        """
+        let app = InstalledApp(
+            name: "Bartender 6", bundleID: "com.surteesstudios.Bartender",
+            shortVersion: "6.6.2", buildVersion: "662000",
+            path: URL(fileURLWithPath: "/Applications/Bartender 6.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"))
+        let best = SparkleAppcastSource.bestItem(
+            for: app, from: SparkleAppcastParser.parse(Data(feed.utf8)), osVersion: "26.6.0")
+        #expect(best?.shortVersionString == "6.6.1")
+        #expect(UpdateChecker.evaluate(installed: app, remote: sparkleRemote(best)) == .upToDate)
+    }
+
+    /// Ghostty publishes its tip builds with a commit hash and a date where the
+    /// marketing version goes: `663205b5 (2024-12-20)`. Tokenized as a version its
+    /// leading run is the number 663205, so EVERY real release reads as older than
+    /// it — a tip copy would be offered nothing, ever, and the row would be
+    /// indistinguishable from an app with no updates.
+    ///
+    /// Mutation: drop the whitespace test from `comparableMarketingVersion` →
+    /// 1.3.2 stops being an update for a tip copy.
+    @Test func aLabelShapedVersionIsNeverComparedAsOne() {
+        let app = InstalledApp(
+            name: "Ghostty", bundleID: "com.mitchellh.ghostty",
+            shortVersion: "663205b5 (2024-12-20)", buildVersion: "8346",
+            path: URL(fileURLWithPath: "/Applications/Ghostty.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"))
+        let remote = RemoteVersion(
+            shortVersion: "1.3.2", version: "15300", marketingMatchesBundle: true,
+            downloadURL: URL(string: "https://example.com/1.3.2.zip"), sourceName: "Sparkle")
+        #expect(UpdateChecker.evaluate(installed: app, remote: remote)
+            == .updateAvailable(latest: "1.3.2"))
+    }
+
+    /// `Character.isNumber` is a Unicode property, so a full-width `１.０.０` would
+    /// be accepted as version-shaped and then compared scalar-wise against ASCII
+    /// digits — which orders it above every real release, silently and forever. No
+    /// feed publishes one; rejecting it costs nothing.
+    ///
+    /// Mutation: drop `allSatisfy(\.isASCII)` → this update disappears.
+    @Test func aFullWidthVersionIsNotComparedAgainstAnASCIIOne() {
+        let app = InstalledApp(
+            name: "Widescreen", bundleID: "com.example.widescreen",
+            shortVersion: "１.０.０", buildVersion: "10",
+            path: URL(fileURLWithPath: "/Applications/Widescreen.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"))
+        let remote = RemoteVersion(
+            shortVersion: "1.0.1", version: "11", marketingMatchesBundle: true,
+            downloadURL: URL(string: "https://example.com/11.zip"), sourceName: "Sparkle")
+        #expect(UpdateChecker.evaluate(installed: app, remote: remote)
+            == .updateAvailable(latest: "1.0.1"))
+    }
+
+    /// Fork's feed states no `sparkle:shortVersionString` at all — its marketing
+    /// string lives in `sparkle:version` — and CotEditor's own feed states one on
+    /// twelve items and not on the thirteenth, so a feed that mixes the two is not
+    /// hypothetical. Reaching for `shortVersionString ?? version` would compare a
+    /// BUILD field against a marketing one, the namespace mistake
+    /// `VersionComparator`'s pair API exists to prevent.
+    ///
+    /// Here the head states only a build (70) and the copy's marketing version is a
+    /// year (2026.1), so that substitution reads the head as a downgrade and steps
+    /// off it onto a LOWER build.
+    ///
+    /// Mutation: read `item.shortVersionString ?? item.version` in
+    /// `SparkleAppcastSource.isMarketingDowngrade` → 65 is named instead of 70.
+    @Test func aBuildNumberNeverStandsInForAMarketingVersion() {
+        let feed = """
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0"><channel>
+          <item><title>next</title><sparkle:version>70</sparkle:version>
+            <enclosure url="https://example.com/70.zip" sparkle:edSignature="s" length="1" type="application/octet-stream" /></item>
+          <item><title>2026.5</title><sparkle:version>65</sparkle:version><sparkle:shortVersionString>2026.5</sparkle:shortVersionString>
+            <enclosure url="https://example.com/65.zip" sparkle:edSignature="s" length="1" type="application/octet-stream" /></item>
+        </channel></rss>
+        """
+        let app = InstalledApp(
+            name: "Calver", bundleID: "com.example.calver",
+            shortVersion: "2026.1", buildVersion: "62",
+            path: URL(fileURLWithPath: "/Applications/Calver.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://example.com/appcast.xml"))
+        let best = SparkleAppcastSource.bestItem(
+            for: app, from: SparkleAppcastParser.parse(Data(feed.utf8)), osVersion: "26.6.0")
+        #expect(best?.version == "70")
+    }
+
+    /// A source whose `shortVersion` is not the bundle's own string must not be
+    /// second-guessed — that is what `marketingMatchesBundle` is for, and both
+    /// shapes it protects are live.
+    ///
+    /// `XcodeReleasesSource` composes a display label, "27.0 beta 6" against an
+    /// installed "27.0", and says in its own comment that the pair is not
+    /// comparable. Mozilla's pre-release probes are the sharper case: the endpoint
+    /// names `155.0b5` while the bundle on disk says `155.0`, and a prerelease tag
+    /// sorts BELOW the release it leads — so every beta and nightly build reads as
+    /// a downgrade, with no whitespace or label shape to give it away.
+    ///
+    /// Mutation: apply the marketing test regardless of `marketingMatchesBundle` →
+    /// the Mozilla half goes red here, and `MozillaPreReleaseTests` goes red for
+    /// all seven real pre-release trains. (The Xcode half is protected twice over —
+    /// the flag AND the label shape — so it survives that mutation alone; it is
+    /// here because it is the source whose own comment predicted this.)
+    @Test func aSourceThatDoesNotSpeakTheBundlesVersionsIsNotSecondGuessed() {
+        let xcode = InstalledApp(
+            name: "Xcode", bundleID: "com.apple.dt.Xcode",
+            shortVersion: "27.0", buildVersion: "27A5194q",
+            path: URL(fileURLWithPath: "/Applications/Xcode-beta.app"),
+            isMASApp: false, sparkleFeedURL: nil)
+        // The label really does read as a downgrade — that is the point.
+        #expect(VersionComparator.compare("27.0 beta 6", "27.0") == .orderedAscending)
+        #expect(UpdateChecker.evaluate(installed: xcode, remote: RemoteVersion(
+            shortVersion: "27.0 beta 6", version: "27A5241x",
+            downloadURL: nil, sourceName: "XcodeReleases"))
+            == .updateAvailable(latest: "27.0 beta 6"))
+
+        // Mozilla's shape, in the bundle build namespace its own suite covers with
+        // the real BuildIDs: the marketing string alone says backwards.
+        let firefox = InstalledApp(
+            name: "Firefox", bundleID: "org.mozilla.firefox",
+            shortVersion: "155.0", buildVersion: "100",
+            path: URL(fileURLWithPath: "/Applications/Firefox.app"),
+            isMASApp: false, sparkleFeedURL: nil)
+        #expect(VersionComparator.compare("155.0b5", "155.0") == .orderedAscending)
+        #expect(UpdateChecker.evaluate(installed: firefox, remote: RemoteVersion(
+            shortVersion: "155.0b5", version: "101",
+            downloadURL: nil, sourceName: "Vendor"))
+            == .updateAvailable(latest: "155.0b5"))
+    }
+
+    /// Refusing to OFFER a release is not pretending it does not exist. The whole
+    /// source, not the pure selection: the withheld entry has to come back as the
+    /// row's version readout, with its notes and its timeline entry, and only its
+    /// STATUS held down. Returning nil instead would land the row on `.unknown` —
+    /// "no source covers this app, nothing was tried" — for an app whose feed we
+    /// had just read and parsed.
+    ///
+    /// Mutations: return nil when everything is a downgrade → no version, no
+    /// notes, no history; filter the downgrades out of `usableItems` instead of
+    /// stepping over them → the history loses 7.0.9.
+    @Test func theRefusedReleaseIsStillNamedWithItsNotesAndItsDate() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FeedProtocol.self]
+        let source = SparkleAppcastSource(session: URLSession(configuration: config))
+
+        let app = cotEditor(short: "7.1.0-beta.3", build: "840")
+        let remote = try #require(try await source.latestVersion(for: app))
+        #expect(remote.shortVersion == "7.0.9")
+        #expect(remote.marketingMatchesBundle)
+        #expect(UpdateChecker.evaluate(installed: app, remote: remote) == .upToDate)
+        #expect(remote.releaseHistory.contains { $0.version == "7.0.9" })
+
+        // A stable copy on the same feed still gets the same release as an update.
+        let stable = try #require(
+            try await source.latestVersion(for: cotEditor(short: "7.0.8", build: "842")))
+        #expect(stable.version == "843")
+    }
+
+    /// Swap one item's version fields, keeping the rest of the real feed.
+    private static func feed(
+        replacing short: String, withShort newShort: String, build: String, minOS: String
+    ) -> String {
+        cotEditorFeed
+            .replacingOccurrences(
+                of: "<sparkle:shortVersionString>\(short)</sparkle:shortVersionString>",
+                with: "<sparkle:shortVersionString>\(newShort)</sparkle:shortVersionString>")
+            .replacingOccurrences(of: "<sparkle:version>730</sparkle:version>", with: "<sparkle:version>\(build)</sparkle:version>")
+            .replacingOccurrences(of: "<sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>", with: "<sparkle:minimumSystemVersion>\(minOS)</sparkle:minimumSystemVersion>")
+    }
+
+    private final class FeedProtocol: URLProtocol, @unchecked Sendable {
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/xml"])!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(SparkleMarketingDowngradeTests.cotEditorFeed.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+}

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -184,7 +184,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 ## Investigated — blocked safely
 
-- [x] [**CotEditor**](com-coteditor-CotEditor.md) · `com.coteditor.CotEditor` — 隐藏的 Sparkle 地址找到了、一键也实测装成功，但 feed 只留最新一条 beta，旧 beta 副本会被推 `7.0.9` 这个 **marketing 降级**包，而 `evaluate` 在两边都有 build 时只比 build；仓库里没有版本降级守卫 · **故意不接**，见审计 · 2026-09-06
+- [x] [**CotEditor**](com-coteditor-CotEditor.md) · `com.coteditor.CotEditor` — 隐藏的 Sparkle 地址找到了、一键也实测装成功，但 feed 只留最新一条 beta，旧 beta 副本会被推 `7.0.9` 这个 **marketing 降级**包，而 `evaluate` 在两边都有 build 时只比 build；降级守卫已于 2026-09-06 落地（#368），但旧 beta 副本仍看不见自己那一轨 · **故意不接**，见审计 · 2026-09-06
 - [x] [**TRAE**](com-trae-app.md) · `com.trae.app` — official API `2.3.61406` != real app `3.5.81`; no comparable remote version, deliberately left unknown · 2026-08-17
 
 ## 未编入分类（补录 2026-08-30）

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -2,6 +2,13 @@
 
 审计日期：2026-09-06。**结论：调查完成，暂不接入**——见「为什么没接」。
 
+> **2026-09-06 更新**：下面第 5 步描述的降级已经被堵上了（#368）。守卫分两半：
+> `SparkleAppcastSource.offerableItem` 决定**报哪一条**（表头会降级时往下找），
+> `UpdateChecker.evaluate` 决定**它算不算更新**（marketing 倒退就不算）。同一份 feed、
+> 同一台 `7.1.0-beta.3`：现在行里仍然写着 `7.0.9`、release notes 和时间线都在，
+> 但状态是「已是最新」，没有 Update 按钮。**但这不等于可以接了**——feed 里那条
+> `7.1.0-beta.6` 它依旧看不见，见文末「守卫之后还差什么」。
+
 ## 基本信息
 
 - Bundle ID：`com.coteditor.CotEditor`；Team ID：`HT3Z3A72WZ`（Mineko IMANISHI）。
@@ -74,6 +81,29 @@ INSTALLED 7.1.0-beta.6/845  detect=beta  allowed=[prerelease, nil]
 app 都要走的检查路径上，属于 CLAUDE.md 说的「十行改在所有请求都要走的路径上」，该单独
 走一轮对抗复审，不该塞进发版日。
 
+## 守卫之后还差什么
+
+守卫**只解决"会不会被推降级包"，不解决"能不能拿到自己那一轨"**。同一台
+`7.1.0-beta.3` 机器现在的结局是：`latestVersion` 照常返回 `7.0.9`（版本号、release
+notes、发布时间线都还在），`evaluate` 判 `.upToDate`。没有假的 Update 按钮了，但 feed
+里那条 `7.1.0-beta.6` 它依旧看不见——它被 `allowedChannels` 挡在外面，而挡它的原因
+（自己的 build 不在 feed 里）守卫一个字都没碰。
+
+⚠️ 这里有一个**故意接受的代价**，不是疏漏：跑在一条**已经被放弃的 prerelease 轨**上的
+副本（厂商发了 2.0-beta，砍掉 2.0，继续在 stable 发 1.6、1.7）从此不会被移回维护中的
+那条线。它会一直读作"已是最新"，而 `laggingRemoteVersion` 被限定在 stable 渠道、也不会
+提示它。`RowActionState` 里没有"你这条轨已经停更"这个状态。
+
+所以要接进来，仍然需要**渠道那一半**，两个已知障碍都还在：
+
+1. 旧 beta 副本在 feed 里找不到自己 → `channel(ofInstalled:)` 返回 nil → 退回默认渠道。
+2. 就算改成读 `ReleaseChannel.detect` 的结果，`sparkleChannelName(.beta)` 给 `"beta"`，
+   而这份 feed 的标签是 `"prerelease"`，对不上。
+
+第三件仍未决的事没有变：`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`
+（与 `GitHubReleasesSource` 的 `guard !app.isMASApp` 和 `HomebrewCaskSource` 不同），
+商店版副本会因为一次商店查询落空而拿到直装包的一键更新。
+
 顺带一条，同一条 `SparkleFeedCatalog` 补丁还有第二个副作用需要一起决定：
 `AppScanner` 填这张表时**不看 `isMASApp`**（与 `GitHubReleasesSource.swift:591` 的
 `guard !app.isMASApp` 和 `HomebrewCaskSource.swift:33` 不同），而 `MacAppStoreSource`
@@ -93,3 +123,7 @@ app 都要走的检查路径上，属于 CLAUDE.md 说的「十行改在所有�
 2. 临时给 `SparkleFeedCatalog.feeds` 加回 `"com.coteditor.coteditor"`，构造一个
    `shortVersion: "7.1.0-beta.3", buildVersion: "840"` 的 `InstalledApp`，依次调
    `SparkleAppcastSource.allowedChannels` / `bestItem` / `UpdateChecker.evaluate`。
+   守卫之前 `bestItem` 给 `7.0.9`/843、`evaluate` 给 `updateAvailable`；守卫之后
+   `bestItem` 仍然给 `7.0.9`/843，但 `evaluate` 给 `upToDate`。`allowedChannels`
+   两次都是 `[nil]`——这一步没有被修。同一份 feed 的固定装在
+   `SparkleMarketingDowngradeTests`，不必联网也能复现。


### PR DESCRIPTION
Closes the guard half of #368. A Sparkle feed could offer a copy a package that was
newer by build and older by name, and every gate downstream passed it — the package
is the vendor's, signed, notarized, and the only downgrade guard in the repo is
about architecture.

## Reproduced first, against the real feed

`coteditor.com/appcast.xml` (2026-09-06, 13 items, exactly one `prerelease`):

```
installed 7.1.0-beta.3/840  detect=beta  allowed=[nil]  ->  best=7.0.9/843  updateAvailable("7.0.9")
```

The vendor keeps only the newest prerelease, so `channel(ofInstalled:)` misses on both
passes, `allowedChannels` falls back to `{nil}`, `usableItems` ranks by build, and
`evaluate` compares builds. Nothing in that chain reads the marketing version.

## The fix is two halves, and they answer different questions

**Which item to name** — `SparkleAppcastSource.offerableItem`. When the head would walk
this copy backwards, step over it and take the first installable, provably-not-older
entry below. That is what lets a beta copy find the next beta sitting *under* a stable
patch in build order, which taking the head unconditionally hides.

**Whether it is an update** — `UpdateChecker.evaluate`. When the builds say newer, ask the
marketing version whether that means forward, and refuse if not. One-way: it can only
settle a row to up-to-date, never raise an update.

Gated on a new **stated** fact, `RemoteVersion.marketingMatchesBundle`, default false
meaning *not established*. Only `SparkleAppcastSource` sets it, because
`sparkle:shortVersionString` is the bundle's own `CFBundleShortVersionString` by
construction. Two live sources prove the gate is needed rather than defensive:
`XcodeReleasesSource` puts the display label "27.0 beta 6" in that field against an
installed "27.0", and Mozilla's probes report `155.0b5` against a bundle that says
`155.0` — a prerelease tag sorts below the release it leads, so both read as downgrades.

## ⚠️ The withheld release is still named

`latestVersion` never returns nil for a feed that had usable items. Returning nil lands
the row on `.unknown`, whose own documentation is "no source *covers* this app, nothing
was tried", rendered as a dead "—" with no retry — a false statement about an app whose
feed we had just read, and it takes the release notes and the release timeline with it.
Simulated over all 13 Sparkle feeds this Mac reads, with the installed build trimmed out
of each in turn, withholding the answer hit **12 (app, version) pairs**: Bartender 6.6.2
against a feed topping out at 6.6.1, six DuoPaste betas, Ghostty, IINA, MonitorControl,
Rectangle, Surge. Every one of them had a lower build too, so every one was already
reading "up to date" correctly.

So the CotEditor row now reads: latest 7.0.9, notes and date intact, status up to date,
no Update button.

## Measured

- **Live corpus, zero change.** 13 Sparkle feeds × every version each publishes × (feed
  as-is / installed build trimmed out) = 308 decisions. The guard changes the offered
  item on none of them and the status on none of them.
- **Independent recompute.** The whole selection — channel inference, the filters, the
  build ranking, the guard, and `evaluate`'s verdict — reimplemented in Python from the
  raw feed bytes and run over the same 308 decisions: **0 disagreements**.
- **15 mutations**, all compiling, each landing red on a named test: 9 on the source
  half, 4 on the verdict, 2 on the version-shape test.
- `make test` green (2350 + 202 + 9 + four gates).

## ⚠️ One asserted behaviour changed

`SparkleChannelTests.betaUserStillGetsNewerStable` asserted that a copy on `2.0-beta`/200
takes stable `1.6`/300 — which is #368 in miniature. Its fixture is now `2.1`/300 (the
rule it was written for, "the default channel is allowed to everyone", holds), and the
old fixture is kept as `betaUserIsNotDroppedOntoAnOlderStable` asserting the opposite,
beside the promotion path (`2.0-beta` → `2.0`) that still works.

The cost, stated in the code rather than left to be found: a copy on an **abandoned**
prerelease train — vendor ships 2.0-beta, cancels 2.0, keeps shipping 1.7 on stable — is
no longer moved across to the maintained line. There is no state in `RowActionState` that
says "your train was withdrawn".

## Not in this PR

- **#368's second half** — `AppScanner` fills `SparkleFeedCatalog` without checking
  `isMASApp`. Untouched; #368 stays open for it.
- **Vendor probes that read Sparkle appcasts by regex** (Brave Beta/Nightly, Vivaldi
  Snapshot, VLC, Docker, Bartender, ImageOptim, WeChat) bypass `usableItems`,
  `allowedChannels` and this guard entirely. Filed separately.
- **No CHANGELOG entry**: the guard changes no row on any feed we read today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
