### PR TITLE
Cover CotEditor through GitHub, not through its appcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.87
+
+**CotEditor is now covered, on both its release and its beta line.** Which line a copy follows comes from the version it is running and from CotEditor's own "Update to prereleases when available" setting, so a beta copy is offered the next beta instead of a release that would take it backwards.
+
 ## 0.3.86
 
 **Four more apps are covered: WhatCable, Qoder IDE, Qoder and Yaak.** Each one gets update checks and a one-click install, and their release notes are read into the window as text rather than an embedded page.

--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -219,7 +219,7 @@ tag 与资产名，互不相收。与 WhatCable 的区别是 **Yaak 的 beta rul
       —— **未做真机 diff 确认落盘行为**，按本节规矩不得直接当作 detectable。
       补法是一个 `ChannelBinding`，形状同 `IINAChannel`。
 
-- [ ] **CotEditor** · `com.coteditor.CotEditor` — Settings → **"Check for beta releases"**
+- [x] **CotEditor** · `com.coteditor.CotEditor` — Settings → **"Update to prereleases when available"**
       （`checksUpdatesForBeta`，官方条件是 `Bundle.main.version.isPrerelease || checksUpdatesForBeta`，
       feed 标签 `prerelease`）。**2026-09-06 接过一版又撤了**，撤的原因不是这个开关：
       feed 只保留最新一条 beta，旧 beta 副本在 feed 里找不到自己的 build，`allowedChannels`
@@ -228,12 +228,13 @@ tag 与资产名，互不相收。与 WhatCable 的区别是 **Yaak 的 beta rul
       一道闸拦得住（仓库里只有架构降级守卫）。所以这一格**先欠着的不是 binding，是一条
       「远端 marketing 比装机的旧就不提供」的守卫**，那条落在每个 Sparkle app 的检查路径上，
       要单独走一轮复审。实测与链条见 [审计](docs/app-audits/com-coteditor-CotEditor.md)。
-      **2026-09-06：守卫已落地**（#368，`SparkleAppcastSource.offerableItem` +
-      `UpdateChecker.evaluate`），同一台 `7.1.0-beta.3` 行里仍写着 `7.0.9` 但状态是
-      「已是最新」，不会再被推降级包。但**这一格仍然不能打勾**：挡住 `7.1.0-beta.6` 的是
-      渠道推断（自己的 build 不在 feed 里），守卫没碰那一半；而且
-      `sparkleChannelName(.beta)` 给 `"beta"`、feed 用 `"prerelease"`，binding 那条路
-      也还对不上。
+      **2026-09-06 已接入，但不是走 appcast。** 先补了降级守卫（#368），再换源：
+      两条 GitHub 规则（历史完整、tag 自己说明在哪条轨）+ `CotEditorChannel` 读
+      `checksUpdatesForBeta`（在沙盒容器里）。厂商的判据是
+      `Bundle.main.version.isPrerelease || checksUpdatesForBeta`，所以 binding 只答
+      「框勾了」这一半，没勾时返回 **nil** 让 `detect()` 读版本串——返回 `.stable` 会
+      关掉 `detect()`，把没勾过框的 beta 副本钉在 stable 轨上。四种状态打真实端点验过。
+      `sparkleChannelName(.beta)` 与 feed 的 `prerelease` 对不上这件事随着换源一起消失了。
 
 - [ ] **Docker Desktop — nightly** · `com.docker.docker` — UI 的更新设置代码里存在受
       feature flag 控制的 `useNightlyBuildUpdates`；观测 stable bundle 只给出 `channelID=main`，

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -289,6 +289,20 @@ public enum ChannelProofRegistry {
     public static let githubProofs: [ChannelProofKey: ChannelArtifactProof] = [
         ChannelProofKey("app.yaak.desktop", .beta):
             .artifact(#"/download/v[0-9.]+-beta\.[0-9]+/"#),
+        // CotEditor's tags carry no `v`, and the asset name repeats the tag, so
+        // BOTH halves of the URL name the train:
+        // `…/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg` against
+        // `…/download/7.0.9/CotEditor_7.0.9.dmg`.
+        //
+        // Which means the tag-segment anchor is NOT load-bearing here, unlike in
+        // VSCodium's entry below — there the repository name carries `-insider`
+        // on every URL the rule can resolve, so an unanchored pattern could never
+        // fail; here a stable artifact carries the token in neither half. Kept
+        // anchored for consistency with the entries around it, and said plainly
+        // so the next reader does not copy this one believing the anchor is what
+        // makes it work.
+        ChannelProofKey("com.coteditor.CotEditor", .beta):
+            .artifact(#"/download/[0-9.]+-beta(?:\.[0-9]+)?/"#),
         // `Zed-aarch64.dmg` is byte-identical in name to stable's — the tag is
         // the only discriminator, and it is in the path:
         // `…/download/v1.18.0-pre/Zed-aarch64.dmg`.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -128,6 +128,8 @@ public struct ResolvedChannel: Sendable, Equatable {
 ///   * Tailscale→ `UserDefaults[UnstableUpdatesEnabled]` + `[RCUpdatesEnabled]`
 ///                                                          (two Bools, three tracks)
 ///   * CapCut   → `~/Movies/CapCut/User Data/Config/updateInfo` (`joinBeta` in an INI)
+///   * CotEditor→ `UserDefaults[checksUpdatesForBeta]`, in its sandbox CONTAINER
+///                                     (Bool: true→beta; false→nil, see the type)
 ///
 /// So there is no generic reader. `ChannelBinding` is the single authority the
 /// scanner consults; an app with no resolver returns nil and the generic
@@ -164,6 +166,7 @@ public enum ChannelBinding {
         AlfredChannel.bundleID.lowercased(),
         BetterDisplayChannel.bundleID.lowercased(),
         CapCutChannel.bundleID.lowercased(),
+        CotEditorChannel.bundleID.lowercased(),
     ]
 
     /// The directories holding every preference a resolver above reads, for a
@@ -228,6 +231,12 @@ public enum ChannelBinding {
         // healthy, discriminator is somewhere else" shape the Surge timeline
         // above cost a fix to learn.
         roots.append(CapCutChannel.configDirectoryURL)
+        // CotEditor is sandboxed too, and unlike CapCut it DOES keep its flag in
+        // its container — so neither the shared `~/Library/Preferences` root nor
+        // CapCut's own covers it. Watching the container's Preferences directory
+        // is what makes flipping "Update to prereleases when available" show up
+        // without waiting for a relaunch.
+        roots.append(CotEditorChannel.preferencesDirectoryURL)
         return roots
     }
 
@@ -290,6 +299,7 @@ public enum ChannelBinding {
         case BetterDisplayChannel.bundleID.lowercased():
             return BetterDisplayChannel.resolveCurrent
         case CapCutChannel.bundleID.lowercased():  return CapCutChannel.resolveCurrent
+        case CotEditorChannel.bundleID.lowercased(): return CotEditorChannel.resolveCurrent
         default:                       return nil
         }
     }
@@ -343,6 +353,15 @@ public enum ChannelBinding {
         (GhosttyChannel.bundleID, GhosttyChannel.resolveCurrent()),
     ] + (CleanShotChannel.resolve(activationKey: CleanShotChannel.placeholderActivationKey)
         .map { [(CleanShotChannel.bundleID, $0)] } ?? [])
+    // CotEditor answers for ONE of its two preference values — an unticked box
+    // resolves to nil so `ReleaseChannel.detect()` keeps the other half (see the
+    // type). Enumerated by calling the pure function with both values rather than
+    // by stating which one produces something, so the day that changes this list
+    // changes with it.
+    + [true, false].compactMap { flag in
+        CotEditorChannel.resolve(checksUpdatesForBeta: flag)
+            .map { (bundleID: CotEditorChannel.bundleID, resolved: $0) }
+    }
 
     // CleanShot is enumerated through its PURE resolver with a placeholder key,
     // never `resolveCurrent()`. It keys a personalized feed off the licence, so

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CotEditorChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CotEditorChannel.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// CotEditor (`com.coteditor.CotEditor`) — the first binding whose rule includes
+/// the INSTALLED BUILD, not just a preference.
+///
+/// The vendor's own updater says it in one line
+/// (`UpdaterManager.swift`, read from the published source 2026-09-06):
+///
+/// ```swift
+/// let checksBeta = (Bundle.main.version!.isPrerelease
+///                   || UserDefaults.standard[.checksUpdatesForBeta])
+/// return checksBeta ? ["prerelease"] : []
+/// ```
+///
+/// and its Settings pane says the same thing to the user: "Update to prereleases
+/// when available — **regardless of this setting, new prereleases are always
+/// included while using a prerelease**."
+///
+/// So the two halves are different KINDS of subscription, and only one of them is
+/// this binding's business:
+///
+///  * `isPrerelease` is temporary — it lapses the moment the copy lands on a
+///    release — and it is already answered without any vendor knowledge:
+///    `ReleaseChannel.detect()` reads the `-beta.N` suffix off the version string.
+///  * The preference is a standing opt-in, invisible from the outside, and the
+///    ONLY way to know that a copy running `7.0.9` wants `7.1.0-beta.6`.
+///
+/// Hence the shape: **answer only when the preference says beta, and answer nil
+/// otherwise** so the version string keeps speaking. A binding that returned
+/// `.stable` for an unticked box would be authoritative and would therefore
+/// SILENCE `detect()` — pinning a `7.1.0-beta.3` copy, whose owner never touched
+/// the box, to the stable line. That is the direction #368 was about, arriving
+/// through a different door.
+///
+/// Four states, all four correct with those two halves in place:
+///
+/// | installed | box | resolution | offered |
+/// |---|---|---|---|
+/// | `7.1.0-beta.6` | on  | binding → beta | the beta line |
+/// | `7.1.0-beta.3` | off | nil → `detect()` → beta | the beta line |
+/// | `7.0.9` | on  | binding → beta | `7.1.0-beta.6` |
+/// | `7.0.9` | off | nil → `detect()` → stable | the stable line |
+///
+/// No `feedOverride`, no `sparkleChannelNames`: the channel here selects which
+/// `GitHubReleaseRule` answers, and the appcast — whose single prerelease slot is
+/// what made #368 possible — is deliberately not read at all. See the audit.
+enum CotEditorChannel {
+    static let bundleID = "com.coteditor.CotEditor"
+
+    /// The app is sandboxed and keeps this in its CONTAINER, unlike every other
+    /// `CFPreferencesCopyAppValue` binding here and unlike CapCut, the one other
+    /// sandboxed app in the table (whose flag is an INI outside its container).
+    /// Measured 2026-09-06: `~/Library/Preferences/com.coteditor.CotEditor.plist`
+    /// does not exist, the container copy does, and a shell WITHOUT Full Disk
+    /// Access reads it — the container is the app's own jail, not a wall against
+    /// other processes of the same user.
+    static var preferencesDirectoryURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(
+                "Library/Containers/\(bundleID)/Data/Library/Preferences",
+                isDirectory: true)
+    }
+
+    /// Map the standing opt-in to a resolution. Pure and tested.
+    ///
+    /// nil is a real answer — "this preference has nothing to say about this
+    /// copy" — and it is what keeps `ReleaseChannel.detect()` in charge of the
+    /// half the preference does not cover. Same use of nil as
+    /// `CleanShotChannel.resolve(activationKey:)`.
+    static func resolve(checksUpdatesForBeta: Bool) -> ResolvedChannel? {
+        checksUpdatesForBeta ? ResolvedChannel(channel: .beta) : nil
+    }
+
+    static func resolveCurrent() -> ResolvedChannel? {
+        resolve(checksUpdatesForBeta: readChecksUpdatesForBeta())
+    }
+
+    /// Read `checksUpdatesForBeta` from CotEditor's defaults. False when the key
+    /// is missing, which is also CotEditor's own reading of it — its Settings
+    /// binding defaults the toggle off.
+    static func readChecksUpdatesForBeta() -> Bool {
+        // Same reason IINA's reader synchronizes: this long-running process can
+        // otherwise serve a value cached from before the user flipped the toggle.
+        CFPreferencesAppSynchronize(bundleID as CFString)
+        guard let value = CFPreferencesCopyAppValue(
+            "checksUpdatesForBeta" as CFString, bundleID as CFString
+        ) else { return false }
+        return (value as? NSNumber)?.boolValue ?? false
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1447,6 +1447,51 @@ public enum GitHubReleaseRegistry {
             installerKind: .dmg,
             channel: .beta),
 
+        // CotEditor — read through GitHub DELIBERATELY, not through its appcast.
+        //
+        // The app ships Sparkle and publishes a well-formed feed, and reading it
+        // is what #368 was about: that feed keeps ONE prerelease slot, so every
+        // beta but the newest is trimmed out of it, `channel(ofInstalled:)` then
+        // misses on both passes, and the copy falls back to the default channel —
+        // where the stable line outranks it by build (843 against 840) and is
+        // three marketing versions older. GitHub keeps every release, and the tag
+        // says which train it is on, so the channel needs no lookup that history
+        // can invalidate. `SparkleFeedCatalog` therefore does NOT carry the feed:
+        // Sparkle answers before GitHub in `SourceStack`, and would take this back.
+        //
+        // Measured on the 100 newest releases (2026-09-06): 0 drafts, exactly
+        // three tag shapes — `7.0.9`, `7.1.0-beta`, `7.1.0-beta.6`, no `v` prefix —
+        // and every one of the 100 carries exactly one asset, `CotEditor_<tag>.dmg`,
+        // with no other artifact to disambiguate against.
+        // Mounted the real 7.0.9 dmg: com.coteditor.CotEditor, short `7.0.9`
+        // (== the tag), build 843, `LSMinimumSystemVersion` 15.0 matching the
+        // feed's own `minimumSystemVersion`, Team HT3Z3A72WZ, notarized.
+        GitHubReleaseRule(
+            bundleID: "com.coteditor.CotEditor",
+            owner: "coteditor", repo: "CotEditor",
+            versionPattern: #"^([0-9]+\.[0-9]+\.[0-9]+)$"#,
+            installAssetPattern: #"^CotEditor_[0-9.]+\.dmg$"#,
+            installerKind: .dmg),
+        // The beta train is NEW: all six prereleases in those 100 releases belong
+        // to the 7.1.0 cycle that opened 2026-07-26, and the 94 releases before it
+        // — back to 2022-04 — carry none. Two consequences, both stated rather than left to
+        // be discovered. The `-beta` tag with no number (`7.1.0-beta`, the cycle's
+        // first) is a real shape and the pattern accepts it. And when this cycle
+        // closes, the newest prerelease starts sinking down the list — the default
+        // 20-row window reaches back to 2026-02 today, about seven months of this
+        // vendor's cadence — after which this rule matches nothing and answers nil
+        // rather than erroring. That is the vendor closing the track, and it is
+        // also when the copies on it have been promoted onto 7.1.0 anyway, since a
+        // release outranks its own prerelease tag.
+        GitHubReleaseRule(
+            bundleID: "com.coteditor.CotEditor",
+            owner: "coteditor", repo: "CotEditor",
+            usePrereleases: true,
+            versionPattern: #"^([0-9]+\.[0-9]+\.[0-9]+-beta(?:\.[0-9]+)?)$"#,
+            installAssetPattern: #"^CotEditor_[0-9.]+-beta(?:\.[0-9]+)?\.dmg$"#,
+            installerKind: .dmg,
+            channel: .beta),
+
         // MARK: - AI desktop clients (verified 2026-08-17)
 
         // OpenCode Desktop — the stable tag and the app's marketing/build versions

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// CotEditor's two trains, read through GitHub instead of through its appcast.
+///
+/// The appcast keeps ONE prerelease slot, so a copy on any beta but the newest
+/// cannot find itself in the feed, falls back to the default channel, and is
+/// offered the stable line — which outranks it by build and trails it by three
+/// marketing versions (#368). GitHub keeps every release and the tag names the
+/// train, so the channel needs no lookup that history can invalidate.
+///
+/// Every case is driven off the registry rather than a hand-written list, and
+/// each loop asserts how many rows it saw: a `for … where` over a registry is
+/// green when the entry it protects has been deleted.
+struct CotEditorChannelTests {
+    private static let bundleID = "com.coteditor.CotEditor"
+
+    private static var rules: [GitHubReleaseRule] {
+        GitHubReleaseRegistry.rules.filter { $0.bundleID == bundleID }
+    }
+
+    /// Real tags from the 100 newest releases (2026-09-06), including the shape
+    /// that is easy to miss: the cycle's first prerelease is `7.1.0-beta`, with
+    /// no number after `beta`.
+    private static let tags = [
+        "7.1.0-beta.6", "7.0.9", "7.1.0-beta.5", "7.1.0-beta.4", "7.1.0-beta.3",
+        "7.0.8", "7.1.0-beta.2", "7.1.0-beta", "7.0.7", "7.0.6", "6.2.3", "4.1.5",
+    ]
+
+    /// Both halves of what makes the beta rule a beta rule, asserted against the
+    /// registry rather than restated. Deleting either rule fails here.
+    @Test func bothRulesAreRegisteredAndSplitTheTrains() throws {
+        #expect(Self.rules.count == 2)
+        let stable = try #require(Self.rules.first { $0.channel == .stable })
+        let beta = try #require(Self.rules.first { $0.channel == .beta })
+        #expect(stable.usePrereleases == false)
+        #expect(beta.usePrereleases)
+        for rule in Self.rules {
+            #expect(rule.owner == "coteditor" && rule.repo == "CotEditor")
+            #expect(rule.installerKind == .dmg)
+        }
+    }
+
+    /// The two version patterns must PARTITION the tag space: every real tag
+    /// matched by exactly one of them. A pattern that accepted both trains would
+    /// hand a beta copy the stable release and call it an update — the same
+    /// outcome #368 produced through the appcast, by a different route.
+    ///
+    /// Patterns are read off the registry, so a rule edited to overlap fails here
+    /// rather than in production.
+    @Test func theTwoVersionPatternsPartitionEveryRealTag() throws {
+        let stable = try #require(Self.rules.first { $0.channel == .stable })
+        let beta = try #require(Self.rules.first { $0.channel == .beta })
+        var counts = (stable: 0, beta: 0)
+        for tag in Self.tags {
+            let s = VendorProbeRecipe.extractVersion(from: tag, pattern: stable.versionPattern)
+            let b = VendorProbeRecipe.extractVersion(from: tag, pattern: beta.versionPattern)
+            #expect((s == nil) != (b == nil), "\(tag) matched \(s == nil ? "neither" : "both") rules")
+            if s != nil { counts.stable += 1 } else { counts.beta += 1 }
+            // The capture is the version, not the tag with decoration around it.
+            #expect((s ?? b) == tag)
+        }
+        #expect(counts == (stable: 6, beta: 6))
+    }
+
+    /// The unnumbered `7.1.0-beta` is a real release (the cycle's first, 2026-07-26)
+    /// and it is the one shape a `-beta\.[0-9]+` pattern copied from Yaak would
+    /// silently drop. Kept as its own case so the reason survives.
+    @Test func theCyclesFirstPrereleaseHasNoNumberAndStillMatches() throws {
+        let beta = try #require(Self.rules.first { $0.channel == .beta })
+        #expect(VendorProbeRecipe.extractVersion(
+            from: "7.1.0-beta", pattern: beta.versionPattern) == "7.1.0-beta")
+    }
+
+    /// Each rule's asset pattern selects only its own train's DMG. One asset per
+    /// release, always `CotEditor_<tag>.dmg` (measured over the newest 100).
+    @Test func eachRuleSelectsOnlyItsOwnTrainsDMG() throws {
+        let stable = try #require(Self.rules.first { $0.channel == .stable }.flatMap(\.installAssetPattern))
+        let beta = try #require(Self.rules.first { $0.channel == .beta }.flatMap(\.installAssetPattern))
+        func matches(_ pattern: String, _ name: String) -> Bool {
+            name.range(of: pattern, options: .regularExpression) != nil
+        }
+        #expect(matches(stable, "CotEditor_7.0.9.dmg"))
+        #expect(!matches(stable, "CotEditor_7.1.0-beta.6.dmg"))
+        #expect(matches(beta, "CotEditor_7.1.0-beta.6.dmg"))
+        #expect(matches(beta, "CotEditor_7.1.0-beta.dmg"))
+        #expect(!matches(beta, "CotEditor_7.0.9.dmg"))
+    }
+
+    /// The channel proof has to fail on the other train's artifact, or it proves
+    /// nothing. For this vendor the filename repeats the tag, so a stable URL
+    /// carries `-beta` in neither half — the tag-segment anchor is consistency
+    /// with the neighbouring entries, not the thing that makes this work (see the
+    /// registry comment).
+    @Test func theChannelProofAcceptsOnlyABetaArtifact() throws {
+        let key = ChannelProofKey(Self.bundleID, .beta)
+        let proof = try #require(ChannelProofRegistry.githubProofs[key])
+        let beta = "https://github.com/coteditor/CotEditor/releases/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg"
+        let stable = "https://github.com/coteditor/CotEditor/releases/download/7.0.9/CotEditor_7.0.9.dmg"
+        guard case .artifact(let pattern) = proof else {
+            Issue.record("expected an artifact proof"); return
+        }
+        #expect(beta.range(of: pattern, options: .regularExpression) != nil)
+        #expect(stable.range(of: pattern, options: .regularExpression) == nil)
+    }
+
+    /// Every non-stable GitHub rule carrying an install spec needs a proof, and
+    /// this app now has one — asserted through the registry's own predicate so it
+    /// cannot drift from the rule.
+    @Test func theBetaRuleIsInTheProofPopulation() {
+        #expect(ChannelProofRegistry.channelGitHubRulesWithInstall
+            .contains(ChannelProofKey(Self.bundleID, .beta)))
+    }
+
+    /// The vendor's rule, in the vendor's words:
+    /// `Bundle.main.version.isPrerelease || checksUpdatesForBeta`. Four states,
+    /// and the binding is only responsible for the half a version string cannot
+    /// answer.
+    ///
+    /// The row that matters is the third: an unticked box must resolve to **nil**,
+    /// not to `.stable`. A `.stable` answer is authoritative and would silence
+    /// `detect()`, pinning a `7.1.0-beta.3` copy — whose owner never opened that
+    /// settings pane — to the stable line. That is #368 arriving through the
+    /// binding instead of through the feed.
+    @Test func theBindingCoversOnlyTheHalfTheVersionStringCannot() {
+        func detect(_ version: String) -> ReleaseChannel {
+            ReleaseChannel.detect(name: "CotEditor", bundleID: Self.bundleID,
+                keystoneChannel: nil, version: version)
+        }
+        func effective(installed: String, box: Bool) -> ReleaseChannel {
+            CotEditorChannel.resolve(checksUpdatesForBeta: box)?.channel ?? detect(installed)
+        }
+        #expect(effective(installed: "7.1.0-beta.6", box: true) == .beta)
+        #expect(effective(installed: "7.1.0-beta.3", box: false) == .beta)
+        #expect(effective(installed: "7.0.9", box: true) == .beta)
+        #expect(effective(installed: "7.0.9", box: false) == .stable)
+        // Stated separately: the false case produces NO resolution at all, which
+        // is what leaves `detect()` in charge above.
+        #expect(CotEditorChannel.resolve(checksUpdatesForBeta: false) == nil)
+        #expect(CotEditorChannel.resolve(checksUpdatesForBeta: true)?.feedOverride == nil)
+        #expect(CotEditorChannel.resolve(checksUpdatesForBeta: true)?.sparkleChannelNames.isEmpty == true)
+    }
+
+    /// The binding is registered in the one switch and in the watcher's roots.
+    /// Sandboxed apps keep preferences inside their container, and CapCut — the
+    /// only other sandboxed binding — happens to keep its flag OUTSIDE one, so
+    /// neither existing root covers this app.
+    @Test func theBindingIsRegisteredAndItsContainerIsWatched() {
+        #expect(ChannelBinding.hasResolver(bundleID: Self.bundleID))
+        #expect(ChannelBinding.boundBundleIDs.contains(Self.bundleID.lowercased()))
+        #expect(ChannelBinding.preferenceWatchCandidates.contains {
+            $0.path == CotEditorChannel.preferencesDirectoryURL.path
+        })
+        #expect(CotEditorChannel.preferencesDirectoryURL.path.contains("Library/Containers"))
+    }
+
+    /// ⚠️ The appcast address stays OUT of `SparkleFeedCatalog` on purpose.
+    /// `SourceStack` runs Sparkle before GitHub, so adding it takes this app
+    /// straight back to the feed whose single prerelease slot is what #368 is
+    /// about — and every test above still passes.
+    ///
+    /// Measured rather than asserted: putting the entry back and running a live
+    /// check moved the source from GitHub to Sparkle for all five installed
+    /// states, and this is the only case in the file that noticed.
+    @Test func theAppcastIsDeliberatelyNotInTheCatalog() {
+        #expect(SparkleFeedCatalog.feed(forBundleID: Self.bundleID) == nil)
+        #expect(SparkleFeedCatalog.feed(forBundleID: Self.bundleID.lowercased()) == nil)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListPageSizeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListPageSizeTests.swift
@@ -59,6 +59,14 @@ struct GitHubListPageSizeTests {
         "com.bitwarden.desktop/stable": 8,    // gap 7 (desktop-v2026.6.0→…2026.5.0), +1
         "com.t3tools.t3code/nightly": 3,      // gap 2 (…20260902.1252→…20260901.1250), +1
         "uk.whatcable.whatcable/beta": 1,     // gap 0 (all 100 tags match), +1
+        // CotEditor: latest 100 releases on 2026-09-06 — 6 beta tags, all of them
+        // in the 7.1.0 cycle that opened 2026-07-26, and none in the 94 releases
+        // before it (back to 2022-04). Worst gap 1 (7.1.0-beta.6 → 7.1.0-beta.5, with
+        // 7.0.9 sitting between them), so the floor is 2. Recomputed in Python
+        // from the live JSON with the rule's own patterns, which partition the
+        // page exactly: 94 stable tags + 6 beta, none matched by both and none by
+        // neither, and the same split on the 100 asset names.
+        "com.coteditor.CotEditor/beta": 2,
     ]
 
     private static func key(_ rule: GitHubReleaseRule) -> String {

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -184,7 +184,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 ## Investigated — blocked safely
 
-- [x] [**CotEditor**](com-coteditor-CotEditor.md) · `com.coteditor.CotEditor` — 隐藏的 Sparkle 地址找到了、一键也实测装成功，但 feed 只留最新一条 beta，旧 beta 副本会被推 `7.0.9` 这个 **marketing 降级**包，而 `evaluate` 在两边都有 build 时只比 build；降级守卫已于 2026-09-06 落地（#368），但旧 beta 副本仍看不见自己那一轨 · **故意不接**，见审计 · 2026-09-06
+- [x] [**CotEditor**](com-coteditor-CotEditor.md) · `com.coteditor.CotEditor` — P(stable/beta) B · **两轨全接（GitHub 两条规则 + ChannelBinding，一键 ✓，Team HT3Z3A72WZ 两轨真包核对）**；appcast **故意不读**——它只留一个预发布名额，旧 beta 副本找不到自己会被推 `7.0.9` 这个 marketing 降级包（守卫见 #368），换 GitHub 后渠道由 tag 和 `checksUpdatesForBeta` 决定，盲区消失 · 2026-09-06
 - [x] [**TRAE**](com-trae-app.md) · `com.trae.app` — official API `2.3.61406` != real app `3.5.81`; no comparable remote version, deliberately left unknown · 2026-08-17
 
 ## 未编入分类（补录 2026-08-30）

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -1,13 +1,17 @@
 # CotEditor
 
-审计日期：2026-09-06。**结论：调查完成，暂不接入**——见「为什么没接」。
+审计日期：2026-09-06。**结论：已接入 —— 走 GitHub 两条规则 + 一个 ChannelBinding，
+appcast 故意不读。**
 
-> **2026-09-06 更新**：下面第 5 步描述的降级已经被堵上了（#368）。守卫分两半：
-> `SparkleAppcastSource.offerableItem` 决定**报哪一条**（表头会降级时往下找），
-> `UpdateChecker.evaluate` 决定**它算不算更新**（marketing 倒退就不算）。同一份 feed、
-> 同一台 `7.1.0-beta.3`：现在行里仍然写着 `7.0.9`、release notes 和时间线都在，
-> 但状态是「已是最新」，没有 Update 按钮。**但这不等于可以接了**——feed 里那条
-> `7.1.0-beta.6` 它依旧看不见，见文末「守卫之后还差什么」。
+三次改口，按顺序记着，因为每一步都是量出来的：
+
+1. 第一版补 `SparkleFeedCatalog` 地址走 appcast，端到端 `7.0.8 → 7.0.9` 装成功了，
+   但**旧 beta 会被推降级包**，于是撤回（见「为什么当初没接」）。
+2. 补了降级守卫（#368 / PR #375）。守卫挡住了伤害，但没解决盲区：那台
+   `7.1.0-beta.3` 从「按 Update 就降级」变成「行里写着 7.0.9、状态已是最新」，
+   feed 里的 `7.1.0-beta.6` 它**仍然看不见**。
+3. 现在这一版**换源**：GitHub 保留全部 release，tag 自己说明在哪条轨，
+   渠道判断不再依赖「能不能在 feed 里找到自己」——盲区从根上消失。
 
 ## 基本信息
 
@@ -18,7 +22,7 @@
   `https://coteditor.com/appcast.xml` 在两份签名二进制及官方 `UpdaterManager.swift` 中可确认。
 - 也在 Mac App Store 上架；Homebrew 有 cask，`auto_updates`。
 
-## 为什么没接
+## 为什么当初没接（appcast 那条路）
 
 补一条 `SparkleFeedCatalog` 地址就能让检测跑起来，第一版就是这么做的，端到端
 `7.0.8 → 7.0.9` 也真的装成功了。撤回的原因是**旧 beta 会被推一个降级包**，而且这条路
@@ -71,44 +75,80 @@ INSTALLED 7.1.0-beta.6/845  detect=beta  allowed=[prerelease, nil]
 同时维护 7.0.x stable 和 7.1.0 beta 两条线，所以只要出现一个 build 高于当前 beta 的
 7.0.x 补丁，跑 beta 的副本照样会被喂 stable。
 
-## 接进来需要什么
+## 现在怎么接的
 
-不是补一个 `ChannelBinding` 就够——那只解决「知不知道自己在 beta 轨」，解决不了
-「跨轨按 build 排序」。而且 `SparkleAppcastSource.sparkleChannelName(.beta)` 给的是
-`"beta"`，CotEditor feed 用的标签是 `"prerelease"`，对不上。
+**源：GitHub Releases，两条规则，同一个 bundle id。** `SparkleFeedCatalog` **不加**
+地址——`SourceStack` 里 Sparkle 排在 GitHub 前面，加了就等于把它送回那份 feed。
+`CotEditorChannelTests.theAppcastIsDeliberatelyNotInTheCatalog` 钉住这个决定。
 
-真正缺的是一条**「远端 marketing 比装机的旧就不提供」**的守卫。那条守卫落在每个 Sparkle
-app 都要走的检查路径上，属于 CLAUDE.md 说的「十行改在所有请求都要走的路径上」，该单独
-走一轮对抗复审，不该塞进发版日。
+```
+stable  versionPattern  ^([0-9]+\.[0-9]+\.[0-9]+)$
+        installAsset    ^CotEditor_[0-9.]+\.dmg$
+beta    usePrereleases: true
+        versionPattern  ^([0-9]+\.[0-9]+\.[0-9]+-beta(?:\.[0-9]+)?)$
+        installAsset    ^CotEditor_[0-9.]+-beta(?:\.[0-9]+)?\.dmg$
+```
 
-## 守卫之后还差什么
+最新 100 条 release 实测（2026-09-06，Python 独立复算，不是读 Swift 得出的）：
+0 条草稿；**每条 release 恰好一个资产**（100/100）；tag 只有三种形状
+`7.0.9` / `7.1.0-beta` / `7.1.0-beta.6`，**没有 `v` 前缀**；
+两条 versionPattern 把 100 个 tag **正好切开**——94 stable + 6 beta，没有一个被两条同时
+命中，也没有一个两条都不中；100 个资产名同样切开，命名一律 `CotEditor_<tag>.dmg`。
 
-守卫**只解决"会不会被推降级包"，不解决"能不能拿到自己那一轨"**。同一台
-`7.1.0-beta.3` 机器现在的结局是：`latestVersion` 照常返回 `7.0.9`（版本号、release
-notes、发布时间线都还在），`evaluate` 判 `.upToDate`。没有假的 Update 按钮了，但 feed
-里那条 `7.1.0-beta.6` 它依旧看不见——它被 `allowedChannels` 挡在外面，而挡它的原因
-（自己的 build 不在 feed 里）守卫一个字都没碰。
+`listPageSize` 用默认 20，实测下限是 **2**（beta 之间最坏间隔 1 条：beta.6 和 beta.5
+之间隔着 7.0.9），记在 `GitHubListPageSizeTests.measuredMinimumDepth`。
 
-⚠️ 这里有一个**故意接受的代价**，不是疏漏：跑在一条**已经被放弃的 prerelease 轨**上的
-副本（厂商发了 2.0-beta，砍掉 2.0，继续在 stable 发 1.6、1.7）从此不会被移回维护中的
-那条线。它会一直读作"已是最新"，而 `laggingRemoteVersion` 被限定在 stable 渠道、也不会
-提示它。`RowActionState` 里没有"你这条轨已经停更"这个状态。
+⚠️ **beta 轨是新开的**：这 100 条里 6 个 prerelease 全属于 2026-07-26 开始的 7.1.0 轮，
+它之前的 94 条（一路回到 2022-04）一个都没有。所以等这一轮转正、新一轮没开时，最新的 prerelease 会往下沉，
+20 行窗口大约覆盖这个厂商七个月的节奏，之后 beta 规则会匹配不到东西（**答 nil，不报错**）。
+那时候跑 beta 的副本也已经被 7.1.0 正式版接走了（正式版压过自己的预发布标签）。
 
-所以要接进来，仍然需要**渠道那一半**，两个已知障碍都还在：
+**渠道：`CotEditorChannel`**，还原厂商自己那行
+`Bundle.main.version.isPrerelease || checksUpdatesForBeta`：
 
-1. 旧 beta 副本在 feed 里找不到自己 → `channel(ofInstalled:)` 返回 nil → 退回默认渠道。
-2. 就算改成读 `ReleaseChannel.detect` 的结果，`sparkleChannelName(.beta)` 给 `"beta"`，
-   而这份 feed 的标签是 `"prerelease"`，对不上。
+| 装机 | 框 | 解析 | 结果 |
+|---|---|---|---|
+| `7.1.0-beta.6` | 勾 | binding → beta | beta 轨 |
+| `7.1.0-beta.3` | 没勾 | **nil** → `detect()` → beta | beta 轨 |
+| `7.0.9` | 勾 | binding → beta | `7.1.0-beta.6` |
+| `7.0.9` | 没勾 | nil → `detect()` → stable | stable 轨 |
 
-第三件仍未决的事没有变：`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`
-（与 `GitHubReleasesSource` 的 `guard !app.isMASApp` 和 `HomebrewCaskSource` 不同），
-商店版副本会因为一次商店查询落空而拿到直装包的一键更新。
+关键是第二行：框没勾时**返回 nil 而不是 `.stable`**。返回 `.stable` 是权威的，会把
+`detect()` 关掉，于是一台从没打开过那个设置面板的 `7.1.0-beta.3` 被钉死在 stable 轨上
+——#368 换一扇门又进来一次。
 
-顺带一条，同一条 `SparkleFeedCatalog` 补丁还有第二个副作用需要一起决定：
-`AppScanner` 填这张表时**不看 `isMASApp`**（与 `GitHubReleasesSource.swift:591` 的
-`guard !app.isMASApp` 和 `HomebrewCaskSource.swift:33` 不同），而 `MacAppStoreSource`
-查不到时是 `continue` 而不是终止。CotEditor 有商店版，所以一次商店查询落空就会让商店版
-副本拿到一个直装 DMG 的一键更新。
+那个键在**沙盒容器里**（`~/Library/Containers/com.coteditor.CotEditor/Data/Library/Preferences/`），
+容器外没有 plist。实测：没有完全磁盘访问的 shell 也读得到，`defaults read com.coteditor.CotEditor
+checksUpdatesForBeta` 不指路径就能解析。CapCut 是表里另一个沙盒 app，但它的 flag 在容器
+**外**，所以现有两个监视根都盖不到这里，`preferenceWatchCandidates` 补了第三个。
+
+### 实测（打真实端点，2026-09-06）
+
+```
+installed=7.1.0-beta.3/840 box=off  → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg  updateAvailable
+installed=7.1.0-beta.6/845 box=on   → 7.1.0-beta.6                              upToDate
+installed=7.0.9/843        box=off  → 7.0.9         CotEditor_7.0.9.dmg         upToDate
+installed=7.0.8/842        box=off  → 7.0.9         CotEditor_7.0.9.dmg         updateAvailable
+installed=7.0.9/843        box=on   → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg  updateAvailable
+```
+
+第一行就是 #368 那台机器：以前被推 `7.0.9`（降级），守卫之后是「已是最新」，
+现在拿到的是它本来就该拿的 `7.1.0-beta.6`。
+
+本机 `duo check coteditor`（装着 beta.6）：`source=GitHub`、`latestVersion=7.1.0-beta.6`、
+`status=up-to-date`。
+
+## 还差什么
+
+- **Changelog 没有单独接 recipe**。GitHub 源自己会把 release body 解成结构化条目，
+  所以最新一条的说明是有的；多版本历史需要一条 `ChangelogRecipe`，没做。
+- **丢掉了 appcast 的两样东西**：EdDSA 签名（改由 Developer ID + 公证兜住）和
+  feed 声明的 `minimumSystemVersion`。后者实测被安装时那道闸兜住——`SignatureVerifier`
+  读的是下载包自己的 `LSMinimumSystemVersion`，而两个真包里这个值跟 feed 写的一致
+  （7.0.9 → 15.0，7.1.0-beta.6 → 26.0）。差别是「先给按钮、装的时候拦」而不是
+  「装了个跑不起来的」。
+- **`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`** 这条老问题还在（#368 的第二半），
+  只是 CotEditor 不再走那条路，所以对它不再有影响。
 
 ## Changelog
 


### PR DESCRIPTION
CotEditor is covered again — through GitHub, not through its appcast, and that
choice is the whole point.

## Why not the feed

#368 was measured on `coteditor.com/appcast.xml`: the feed keeps ONE prerelease
slot, so every beta but the newest is trimmed out of it. A copy on
`7.1.0-beta.3` then misses both channel-inference passes, falls back to the
default channel, and lands on the stable line — `7.0.9`, newer by build (843 vs
840) and three marketing versions older.

PR #375 stopped the harm: the row now names `7.0.9` and reads "up to date". It
did not remove the blindness — that copy still could not see `7.1.0-beta.6`,
which is sitting right there in the feed.

GitHub keeps every release and the tag says which train it is on, so the channel
needs no lookup that history can invalidate. `SparkleFeedCatalog` therefore does
**not** carry the address: `SourceStack` runs Sparkle before GitHub and would
take the app straight back to the feed. A test pins that decision, because every
other test in the file passes with the entry added.

## What landed

**Two rules, one bundle id** (the Yaak shape), and a `ChannelBinding` for the
half a version string cannot answer.

The vendor's own updater is one line, read from the published source:

```swift
let checksBeta = (Bundle.main.version!.isPrerelease
                  || UserDefaults.standard[.checksUpdatesForBeta])
return checksBeta ? ["prerelease"] : []
```

So `CotEditorChannel` answers **only** when the box is ticked, and returns
**nil** otherwise — `ReleaseChannel.detect()` reads the `-beta.N` suffix and
covers the rest. A binding that answered `.stable` for an unticked box would be
authoritative, would silence `detect()`, and would pin a `7.1.0-beta.3` copy
whose owner never opened that pane to the stable line: #368 arriving through a
different door.

| installed | box | resolution | offered |
|---|---|---|---|
| `7.1.0-beta.6` | on | binding → beta | the beta line |
| `7.1.0-beta.3` | off | nil → `detect()` → beta | the beta line |
| `7.0.9` | on | binding → beta | `7.1.0-beta.6` |
| `7.0.9` | off | nil → `detect()` → stable | the stable line |

The preference lives in the app's **sandbox container** — a first for this table;
CapCut is sandboxed too but keeps its flag outside one — so the watcher gained a
third root. Measured: a shell without Full Disk Access reads it fine, and
`CFPreferencesCopyAppValue` resolves the domain without naming the path.

## Measured

**Live, five states** (2026-09-06), the first being the copy #368 is about:

```
installed=7.1.0-beta.3/840 box=off  → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg  updateAvailable
installed=7.1.0-beta.6/845 box=on   → 7.1.0-beta.6                              upToDate
installed=7.0.9/843        box=off  → 7.0.9         CotEditor_7.0.9.dmg         upToDate
installed=7.0.8/842        box=off  → 7.0.9         CotEditor_7.0.9.dmg         updateAvailable
installed=7.0.9/843        box=on   → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg  updateAvailable
```

`duo check coteditor` on this machine (running beta.6): `source=GitHub`,
`latestVersion=7.1.0-beta.6`, `up-to-date`.

**Registry shapes, recomputed in Python from the live JSON** (newest 100
releases, not reread out of the Swift rules): 0 drafts; three tag shapes only —
`7.0.9`, `7.1.0-beta`, `7.1.0-beta.6`, no `v` prefix; the two version patterns
partition all 100 tags exactly (94 + 6, none matched by both, none by neither),
and the two asset patterns partition all 100 asset names the same way. Depth
floor for the list rule is 2 (worst gap 1: `7.1.0-beta.6` → `7.1.0-beta.5`, with
`7.0.9` between them), recorded in `measuredMinimumDepth`; `listPageSize` stays
at the default 20.

**The real 7.0.9 dmg, mounted**: `com.coteditor.CotEditor`, short `7.0.9` (== the
tag), build 843, `LSMinimumSystemVersion` 15.0 — the same value the feed states
as `minimumSystemVersion` — Team HT3Z3A72WZ, `source=Notarized Developer ID`.

**10 mutations**, all compiling, each red on a named test.

`duo verify` covers vendor-probe and changelog recipes, not GitHub rules, so the
live check above is the equivalent instrument here rather than a skipped step.

## Stated, not hidden

- **The beta train is new.** All six prereleases in those 100 releases belong to
  the 7.1.0 cycle that opened 2026-07-26; the four and a half years before it
  carry none. When the cycle closes, the newest prerelease sinks down the list
  (the 20-row window covers about seven months of this vendor's cadence), after
  which the beta rule matches nothing and answers nil rather than erroring — by
  which time its copies have been promoted onto `7.1.0` anyway.
- **Two things the appcast gave and GitHub does not**: the EdDSA signature (now
  Developer ID + notarization) and the feed's `minimumSystemVersion` (the
  install-time gate reads the downloaded bundle's own `LSMinimumSystemVersion`,
  which measured identical on both trains).
- **No changelog recipe.** The GitHub source already parses the release body into
  structured entries, so the newest release's notes are there; multi-version
  history would need a recipe and does not have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
