### PR TITLE
Let a CotEditor beta take the release it graduates into

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -672,10 +672,17 @@ public enum ChangelogRecipeRegistry {
         // changelog panel.
         //
         // `per_page=40` with `maxEntries: 20` is the house shape. Measured
-        // 2026-09-06: the newest 40 releases hold 34 stable and 6 prerelease, so
-        // the stable rail fills its 20 and the beta rail renders 6 — the whole
-        // 7.1.0 cycle, which is every prerelease this repo has published in 100
-        // releases going back to 2022.
+        // 2026-09-06: the newest 40 releases hold 34 stable and 6 prerelease.
+        //
+        // ⚠️ BOTH rails therefore fill their 20, and the beta rail's 20 are mostly
+        // STABLE entries — `includesPromotedStable` makes
+        // `StructuredChangelogDecoder.decodeGitHubReleases` want every
+        // non-prerelease, not only the one that graduates, so the beta rail is
+        // simply the newest 20 releases (7.1.0-beta.6, 7.0.9, 7.1.0-beta.5, …).
+        // That is the field's existing behaviour and it is what this rail wants —
+        // the copy can be offered any of them — but it is not "the 6 betas", which
+        // is what an earlier version of this comment claimed. All 6 do fit: they
+        // sit inside the newest 8 releases.
         //
         // ⚠️ `includesPromotedStable: true` on the beta recipe is the OPPOSITE of
         // Yaak's pair above, and the difference is in the rules, not in taste.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -665,6 +665,43 @@ public enum ChangelogRecipeRegistry {
             channel: .beta,
             structuredFormat: .gitHubReleases),
 
+        // CotEditor — the GitHub source already renders the release it is
+        // OFFERING (the bodies are structured Markdown: `## Improvements`,
+        // `## Known Issues`, measured through the source on both rails), so what
+        // these two add is the rest of the rail: the previous releases in the
+        // changelog panel.
+        //
+        // `per_page=40` with `maxEntries: 20` is the house shape. Measured
+        // 2026-09-06: the newest 40 releases hold 34 stable and 6 prerelease, so
+        // the stable rail fills its 20 and the beta rail renders 6 — the whole
+        // 7.1.0 cycle, which is every prerelease this repo has published in 100
+        // releases going back to 2022.
+        //
+        // ⚠️ `includesPromotedStable: true` on the beta recipe is the OPPOSITE of
+        // Yaak's pair above, and the difference is in the rules, not in taste.
+        // Yaak's beta rule cannot resolve a stable artifact, so a promoted entry
+        // there would describe a build that channel never offers. CotEditor's beta
+        // rule can and must — its train runs in cycles and a copy has to be able
+        // to take the release that graduates from it — so without this the panel
+        // would omit the very entry the row is offering, which is UTM's case
+        // exactly (see the field's own doc).
+        ChangelogRecipe(
+            bundleID: "com.coteditor.CotEditor",
+            source: URL(string: "https://api.github.com/repos/coteditor/CotEditor/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            channel: .stable,
+            structuredFormat: .gitHubReleases),
+
+        ChangelogRecipe(
+            bundleID: "com.coteditor.CotEditor",
+            source: URL(string: "https://api.github.com/repos/coteditor/CotEditor/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            channel: .beta,
+            includesPromotedStable: true,
+            structuredFormat: .gitHubReleases),
+
         // Air (JetBrains) — air.dev/changelog is a Vite/React SPA: the HTML is an
         // empty shell and the changelog data is baked into the hashed JS bundle as
         // *compiled JSX* (no clean HTML, no JSON API). Two-stage handles the hash:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -294,8 +294,14 @@ public enum ChannelProofRegistry {
         // has to be able to take the `7.1.0` that graduates from it (see the
         // rule). So an `.artifact` proof is not available — the tag segment is the
         // only place either train names itself, and a pattern anchored to `-beta`
-        // would fire on exactly that legitimate resolution. Same reasoning and
-        // same shape as WhatCable's entry above.
+        // would fire on exactly that legitimate resolution. Same reasoning as
+        // WhatCable's entry above — but NOT the same anchor, and the difference is
+        // load-bearing: WhatCable's is `-beta\.`, which matches the escaped dot in
+        // its own `-beta\.[0-9]+` pattern. CotEditor's cycle opens with an
+        // unnumbered `7.1.0-beta`, so its pattern reads `-beta(?:` — `-beta`
+        // followed by a parenthesis, never by an escaped dot. Tightening this
+        // anchor to WhatCable's literal shape would make the proof report a
+        // correct rule as unanchored.
         //
         // ⚠️ This was an `.artifact(#"/download/[0-9.]+-beta…/"#)` for a day, from
         // when the rule was `-beta`-only. It passed the whole time, and would have

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -289,20 +289,19 @@ public enum ChannelProofRegistry {
     public static let githubProofs: [ChannelProofKey: ChannelArtifactProof] = [
         ChannelProofKey("app.yaak.desktop", .beta):
             .artifact(#"/download/v[0-9.]+-beta\.[0-9]+/"#),
-        // CotEditor's tags carry no `v`, and the asset name repeats the tag, so
-        // BOTH halves of the URL name the train:
-        // `…/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg` against
-        // `…/download/7.0.9/CotEditor_7.0.9.dmg`.
+        // CotEditor's beta rule accepts a plain tag as well as a `-beta` one, on
+        // purpose: its beta train runs in cycles, and a copy on `7.1.0-beta.6`
+        // has to be able to take the `7.1.0` that graduates from it (see the
+        // rule). So an `.artifact` proof is not available — the tag segment is the
+        // only place either train names itself, and a pattern anchored to `-beta`
+        // would fire on exactly that legitimate resolution. Same reasoning and
+        // same shape as WhatCable's entry above.
         //
-        // Which means the tag-segment anchor is NOT load-bearing here, unlike in
-        // VSCodium's entry below — there the repository name carries `-insider`
-        // on every URL the rule can resolve, so an unanchored pattern could never
-        // fail; here a stable artifact carries the token in neither half. Kept
-        // anchored for consistency with the entries around it, and said plainly
-        // so the next reader does not copy this one believing the anchor is what
-        // makes it work.
+        // ⚠️ This was an `.artifact(#"/download/[0-9.]+-beta…/"#)` for a day, from
+        // when the rule was `-beta`-only. It passed the whole time, and would have
+        // gone on passing right up to the release it was wrong about.
         ChannelProofKey("com.coteditor.CotEditor", .beta):
-            .artifact(#"/download/[0-9.]+-beta(?:\.[0-9]+)?/"#),
+            .recipeAnchor(#"^true$|-beta"#, in: ["usePrereleases", "versionPattern"]),
         // `Zed-aarch64.dmg` is byte-identical in name to stable's — the tag is
         // the only discriminator, and it is in the path:
         // `…/download/v1.18.0-pre/Zed-aarch64.dmg`.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CotEditorChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CotEditorChannel.swift
@@ -48,17 +48,25 @@ enum CotEditorChannel {
     static let bundleID = "com.coteditor.CotEditor"
 
     /// The app is sandboxed and keeps this in its CONTAINER, unlike every other
-    /// `CFPreferencesCopyAppValue` binding here and unlike CapCut, the one other
-    /// sandboxed app in the table (whose flag is an INI outside its container).
-    /// Measured 2026-09-06: `~/Library/Preferences/com.coteditor.CotEditor.plist`
-    /// does not exist, the container copy does, and a shell WITHOUT Full Disk
-    /// Access reads it — the container is the app's own jail, not a wall against
-    /// other processes of the same user.
+    /// binding here and unlike CapCut, the one other sandboxed app in the table
+    /// (whose flag is an INI outside its container).
+    /// `~/Library/Preferences/com.coteditor.CotEditor.plist` does not exist; the
+    /// container copy does, and a shell WITHOUT Full Disk Access reads it — the
+    /// container is the app's own jail, not a wall against other processes of the
+    /// same user.
     static var preferencesDirectoryURL: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(
                 "Library/Containers/\(bundleID)/Data/Library/Preferences",
                 isDirectory: true)
+    }
+
+    /// The file `readChecksUpdatesForBeta` reads. Exposed for the same reason
+    /// `SurgeChannel.defaultsFileURL` is: `ChannelBinding.preferenceWatchCandidates`
+    /// has to sit on the directory the reader actually reads, and a watcher aimed
+    /// anywhere else is a guard with the wrong discriminator.
+    static var preferencesFileURL: URL {
+        preferencesDirectoryURL.appendingPathComponent("\(bundleID).plist", isDirectory: false)
     }
 
     /// Map the standing opt-in to a resolution. Pure and tested.
@@ -75,16 +83,39 @@ enum CotEditorChannel {
         resolve(checksUpdatesForBeta: readChecksUpdatesForBeta())
     }
 
-    /// Read `checksUpdatesForBeta` from CotEditor's defaults. False when the key
-    /// is missing, which is also CotEditor's own reading of it — its Settings
-    /// binding defaults the toggle off.
+    /// Read `checksUpdatesForBeta` out of the container plist. False when the file
+    /// or the key is missing, which is also CotEditor's own reading of it — its
+    /// Settings toggle defaults off.
+    ///
+    /// ⚠️ **`CFPreferencesCopyAppValue` does NOT work for this app**, and the first
+    /// version of this binding used it. Measured 2026-09-06 with the box ticked and
+    /// the container plist holding `checksUpdatesForBeta = 1`:
+    ///
+    /// ```
+    /// CFPreferencesCopyAppValue("checksUpdatesForBeta", "com.coteditor.CotEditor") → nil
+    /// Data(contentsOf: <container>/com.coteditor.CotEditor.plist) → the key, true
+    /// ```
+    ///
+    /// A sandboxed app's domain does not resolve to its container for a process
+    /// that is not that app: `CFPreferences` looks in
+    /// `~/Library/Preferences/<id>.plist`, which does not exist here. `defaults
+    /// read com.coteditor.CotEditor checksUpdatesForBeta` DOES print 1 — `defaults`
+    /// searches container paths itself — and that is the trap: the shell command
+    /// used to check this is not the API the code calls. Read the file, the way
+    /// `SurgeChannel` reads its own plist.
     static func readChecksUpdatesForBeta() -> Bool {
-        // Same reason IINA's reader synchronizes: this long-running process can
-        // otherwise serve a value cached from before the user flipped the toggle.
-        CFPreferencesAppSynchronize(bundleID as CFString)
-        guard let value = CFPreferencesCopyAppValue(
-            "checksUpdatesForBeta" as CFString, bundleID as CFString
-        ) else { return false }
-        return (value as? NSNumber)?.boolValue ?? false
+        decodeChecksUpdatesForBeta(at: preferencesFileURL)
+    }
+
+    /// Split out so the decoding is testable against a plist written to a temp
+    /// directory. The path is the part no unit test can pin — only a live read on
+    /// a machine with CotEditor installed says whether it is right, which is how
+    /// the `CFPreferences` version was caught.
+    static func decodeChecksUpdatesForBeta(at url: URL) -> Bool {
+        guard let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(
+                from: data, format: nil) as? [String: Any]
+        else { return false }
+        return (plist["checksUpdatesForBeta"] as? NSNumber)?.boolValue ?? false
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1498,6 +1498,18 @@ public enum GitHubReleaseRegistry {
         //     it "answers nil rather than erroring", which is true of a check and
         //     false of the sweep.
         //
+        // ⚠️ A second consequence of accepting plain tags, and it is a READOUT one
+        // rather than an offer one: `settle` walks the page newest-first and takes
+        // the first tag this pattern accepts, so once a 7.0.x patch ships above the
+        // newest beta — the shape #368 called the secondary form, and one this
+        // vendor really maintains — the beta rail resolves THAT. Nothing is
+        // offered: GitHub sets `version: nil`, so `evaluate` compares marketing and
+        // `7.0.10` is older than `7.1.0-beta.6`. But the row then names 7.0.10 as
+        // the latest version for a copy running a 7.1.0 beta, where a `-beta`-only
+        // pattern named the copy's own build. Accepted: the alternative is the two
+        // failures above, and a row that says "up to date" beside a lower number is
+        // the same shape a copy ahead of its feed already produces.
+        //
         // ⚠️ The cost, one-way and shared with WhatCable: taking that graduation
         // puts the copy on `7.1.0`, `ReleaseChannel.detect` then reads `.stable`,
         // and the stable rule serves it from the next check on — so we stop

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -1472,23 +1472,46 @@ public enum GitHubReleaseRegistry {
             versionPattern: #"^([0-9]+\.[0-9]+\.[0-9]+)$"#,
             installAssetPattern: #"^CotEditor_[0-9.]+\.dmg$"#,
             installerKind: .dmg),
-        // The beta train is NEW: all six prereleases in those 100 releases belong
-        // to the 7.1.0 cycle that opened 2026-07-26, and the 94 releases before it
-        // — back to 2022-04 — carry none. Two consequences, both stated rather than left to
-        // be discovered. The `-beta` tag with no number (`7.1.0-beta`, the cycle's
-        // first) is a real shape and the pattern accepts it. And when this cycle
-        // closes, the newest prerelease starts sinking down the list — the default
-        // 20-row window reaches back to 2026-02 today, about seven months of this
-        // vendor's cadence — after which this rule matches nothing and answers nil
-        // rather than erroring. That is the vendor closing the track, and it is
-        // also when the copies on it have been promoted onto 7.1.0 anyway, since a
-        // release outranks its own prerelease tag.
+        // The beta train is CYCLICAL, and that is what shapes this rule: all six
+        // prereleases in those 100 releases belong to the 7.1.0 cycle that opened
+        // 2026-07-26, and the 94 releases before it — back to 2022-04 — carry
+        // none. The unnumbered `7.1.0-beta` (the cycle's first) is a real shape,
+        // which is why the suffix is optional twice over below.
+        //
+        // **The pattern accepts stable tags too, and that is the design** — the
+        // same call WhatCable's beta rule makes, for the same two reasons, and
+        // both bite harder here because this vendor's train stops between cycles
+        // instead of running continuously:
+        //
+        //   • A copy on `7.1.0-beta.6` would never be offered the plain `7.1.0`
+        //     that graduates from it, and would sit on a superseded prerelease
+        //     until the next cycle opened — while CotEditor's own updater hands it
+        //     that release, since Sparkle allows the default channel to everyone.
+        //     `VersionComparator` ranks the graduation correctly on its own (the
+        //     missing fourth component pads to `.number(0)` and outranks
+        //     `.text("beta")`); the pattern was the only thing in the way.
+        //   • Anchoring to `-beta` is also a fuse. Once the cycle closes and the
+        //     last prerelease scrolls off the page, a `-beta`-only pattern matches
+        //     nothing — and that is not a quiet nil: `duo verify` walks RULES, not
+        //     installs, so it would file a red finding on every machine for a rule
+        //     working exactly as written. An earlier version of this comment said
+        //     it "answers nil rather than erroring", which is true of a check and
+        //     false of the sweep.
+        //
+        // ⚠️ The cost, one-way and shared with WhatCable: taking that graduation
+        // puts the copy on `7.1.0`, `ReleaseChannel.detect` then reads `.stable`,
+        // and the stable rule serves it from the next check on — so we stop
+        // offering it prereleases. Unlike WhatCable, that is recoverable here
+        // without a code change: `CotEditorChannel` reads the vendor's own
+        // "Update to prereleases when available" box, so a user who wants to stay
+        // on the train ticks it and is authoritative `.beta` again whatever the
+        // version string says.
         GitHubReleaseRule(
             bundleID: "com.coteditor.CotEditor",
             owner: "coteditor", repo: "CotEditor",
             usePrereleases: true,
-            versionPattern: #"^([0-9]+\.[0-9]+\.[0-9]+-beta(?:\.[0-9]+)?)$"#,
-            installAssetPattern: #"^CotEditor_[0-9.]+-beta(?:\.[0-9]+)?\.dmg$"#,
+            versionPattern: #"^([0-9]+\.[0-9]+\.[0-9]+(?:-beta(?:\.[0-9]+)?)?)$"#,
+            installAssetPattern: #"^CotEditor_[0-9.]+(?:-beta(?:\.[0-9]+)?)?\.dmg$"#,
             installerKind: .dmg,
             channel: .beta),
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
@@ -159,6 +159,60 @@ struct CotEditorChannelTests {
         #expect(CotEditorChannel.resolve(checksUpdatesForBeta: true)?.sparkleChannelNames.isEmpty == true)
     }
 
+    /// ⚠️ The reader must read the FILE, not the preferences API.
+    ///
+    /// The first version of this binding called
+    /// `CFPreferencesCopyAppValue("checksUpdatesForBeta", "com.coteditor.CotEditor")`
+    /// and shipped. Measured afterwards on a machine with the box ticked and the
+    /// container plist holding the key: that call returns **nil**, because a
+    /// sandboxed app's domain does not resolve to its container for anyone but the
+    /// app — `CFPreferences` looks in `~/Library/Preferences/<id>.plist`, which
+    /// does not exist for it. The evidence I had was `defaults read …`, which
+    /// prints 1 because `defaults` searches container paths itself. Different code
+    /// path, same-looking answer.
+    ///
+    /// This case pins the decoding against a plist written to a temp directory.
+    /// It CANNOT pin the path — only a live read on a machine with CotEditor
+    /// installed does that, which is exactly what caught the API mistake — so the
+    /// case that matters most here is the one below, that the watcher and the
+    /// reader are aimed at the same file.
+    @Test func theReaderDecodesTheContainerPlist() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("coteditor-binding-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("com.coteditor.CotEditor.plist")
+
+        // Missing file → false, the conservative default.
+        #expect(CotEditorChannel.decodeChecksUpdatesForBeta(at: file) == false)
+
+        for (value, expected) in [(true, true), (false, false)] {
+            let data = try PropertyListSerialization.data(
+                fromPropertyList: ["checksUpdatesForBeta": value, "SUHasLaunchedBefore": true],
+                format: .binary, options: 0)
+            try data.write(to: file)
+            #expect(CotEditorChannel.decodeChecksUpdatesForBeta(at: file) == expected)
+        }
+
+        // A plist without the key at all — CotEditor before the pane is opened.
+        try PropertyListSerialization.data(
+            fromPropertyList: ["SUHasLaunchedBefore": true], format: .binary, options: 0)
+            .write(to: file)
+        #expect(CotEditorChannel.decodeChecksUpdatesForBeta(at: file) == false)
+    }
+
+    /// The watcher sits on the directory holding the file the reader reads. Aimed
+    /// anywhere else it is a guard with the wrong discriminator, and nothing about
+    /// it would look wrong — `SurgeChannel` exposes its path for this reason and
+    /// this binding follows it.
+    @Test func theWatchedDirectoryHoldsTheFileTheReaderReads() {
+        #expect(CotEditorChannel.preferencesFileURL.deletingLastPathComponent().path
+            == CotEditorChannel.preferencesDirectoryURL.path)
+        #expect(ChannelBinding.preferenceWatchCandidates.contains {
+            $0.path == CotEditorChannel.preferencesFileURL.deletingLastPathComponent().path
+        })
+    }
+
     /// The binding is registered in the one switch and in the watcher's roots.
     /// Sandboxed apps keep preferences inside their container, and CapCut — the
     /// only other sandboxed binding — happens to keep its flag OUTSIDE one, so

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
@@ -42,24 +42,30 @@ struct CotEditorChannelTests {
         }
     }
 
-    /// The two version patterns must PARTITION the tag space: every real tag
-    /// matched by exactly one of them. A pattern that accepted both trains would
-    /// hand a beta copy the stable release and call it an update — the same
-    /// outcome #368 produced through the appcast, by a different route.
+    /// What the two patterns must do is NOT symmetric, and getting that backwards
+    /// is what shipped for a day.
     ///
-    /// Patterns are read off the registry, so a rule edited to overlap fails here
-    /// rather than in production.
-    @Test func theTwoVersionPatternsPartitionEveryRealTag() throws {
+    /// The stable pattern must refuse every prerelease — a stable copy offered a
+    /// beta is the harm this repo cares most about. The beta pattern must accept
+    /// BOTH, because this vendor's train runs in cycles and a copy on
+    /// `7.1.0-beta.6` has to be able to take the `7.1.0` that graduates from it.
+    ///
+    /// Patterns are read off the registry, so a rule edited in either direction
+    /// fails here rather than in production.
+    @Test func theStablePatternRefusesPrereleasesAndTheBetaOneDoesNot() throws {
         let stable = try #require(Self.rules.first { $0.channel == .stable })
         let beta = try #require(Self.rules.first { $0.channel == .beta })
         var counts = (stable: 0, beta: 0)
         for tag in Self.tags {
             let s = VendorProbeRecipe.extractVersion(from: tag, pattern: stable.versionPattern)
             let b = VendorProbeRecipe.extractVersion(from: tag, pattern: beta.versionPattern)
-            #expect((s == nil) != (b == nil), "\(tag) matched \(s == nil ? "neither" : "both") rules")
+            if tag.contains("-beta") {
+                #expect(s == nil, "the stable pattern accepted a prerelease: \(tag)")
+            } else {
+                #expect(s == tag)
+            }
+            #expect(b == tag, "the beta pattern must accept every tag, including \(tag)")
             if s != nil { counts.stable += 1 } else { counts.beta += 1 }
-            // The capture is the version, not the tag with decoration around it.
-            #expect((s ?? b) == tag)
         }
         #expect(counts == (stable: 6, beta: 6))
     }
@@ -73,9 +79,12 @@ struct CotEditorChannelTests {
             from: "7.1.0-beta", pattern: beta.versionPattern) == "7.1.0-beta")
     }
 
-    /// Each rule's asset pattern selects only its own train's DMG. One asset per
-    /// release, always `CotEditor_<tag>.dmg` (measured over the newest 100).
-    @Test func eachRuleSelectsOnlyItsOwnTrainsDMG() throws {
+    /// The asset patterns follow the version patterns, and are asymmetric for the
+    /// same reason: the stable rule must never install a prerelease build, while
+    /// the beta rule must be able to install the release that graduates from its
+    /// train. One asset per release, always `CotEditor_<tag>.dmg` (measured over
+    /// the newest 100).
+    @Test func theStableAssetPatternRefusesABetaDMGAndTheBetaOneTakesBoth() throws {
         let stable = try #require(Self.rules.first { $0.channel == .stable }.flatMap(\.installAssetPattern))
         let beta = try #require(Self.rules.first { $0.channel == .beta }.flatMap(\.installAssetPattern))
         func matches(_ pattern: String, _ name: String) -> Bool {
@@ -83,26 +92,32 @@ struct CotEditorChannelTests {
         }
         #expect(matches(stable, "CotEditor_7.0.9.dmg"))
         #expect(!matches(stable, "CotEditor_7.1.0-beta.6.dmg"))
+        #expect(!matches(stable, "CotEditor_7.1.0-beta.dmg"))
+
         #expect(matches(beta, "CotEditor_7.1.0-beta.6.dmg"))
         #expect(matches(beta, "CotEditor_7.1.0-beta.dmg"))
-        #expect(!matches(beta, "CotEditor_7.0.9.dmg"))
+        #expect(matches(beta, "CotEditor_7.1.0.dmg"),
+                "the beta rule has to be able to install the release its train graduates into")
     }
 
-    /// The channel proof has to fail on the other train's artifact, or it proves
-    /// nothing. For this vendor the filename repeats the tag, so a stable URL
-    /// carries `-beta` in neither half — the tag-segment anchor is consistency
-    /// with the neighbouring entries, not the thing that makes this work (see the
-    /// registry comment).
-    @Test func theChannelProofAcceptsOnlyABetaArtifact() throws {
-        let key = ChannelProofKey(Self.bundleID, .beta)
-        let proof = try #require(ChannelProofRegistry.githubProofs[key])
-        let beta = "https://github.com/coteditor/CotEditor/releases/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg"
-        let stable = "https://github.com/coteditor/CotEditor/releases/download/7.0.9/CotEditor_7.0.9.dmg"
-        guard case .artifact(let pattern) = proof else {
-            Issue.record("expected an artifact proof"); return
+    /// ⚠️ The proof CANNOT be an `.artifact` one here, and that is a consequence
+    /// of the rule above rather than a preference: the beta rule legitimately
+    /// resolves a stable artifact the day a cycle graduates, and a pattern
+    /// anchored to `-beta` in the download path would fire on exactly that.
+    ///
+    /// It was an artifact proof for a day. It passed the whole time — it would
+    /// have gone on passing right up to the release it was wrong about — which is
+    /// why this case asserts the KIND, not just that some proof exists.
+    @Test func theChannelProofIsAnchoredToTheRecipeNotToTheArtifact() throws {
+        let proof = try #require(
+            ChannelProofRegistry.githubProofs[ChannelProofKey(Self.bundleID, .beta)])
+        guard case .recipeAnchor(let pattern, let fields) = proof else {
+            Issue.record("expected a recipeAnchor proof, got \(proof)"); return
         }
-        #expect(beta.range(of: pattern, options: .regularExpression) != nil)
-        #expect(stable.range(of: pattern, options: .regularExpression) == nil)
+        #expect(fields.contains("usePrereleases") && fields.contains("versionPattern"))
+        let beta = try #require(Self.rules.first { $0.channel == .beta })
+        #expect(beta.versionPattern.range(of: pattern, options: .regularExpression) != nil,
+                "the anchor no longer matches the field it anchors to")
     }
 
     /// Every non-stable GitHub rule carrying an install spec needs a proof, and
@@ -153,6 +168,127 @@ struct CotEditorChannelTests {
             $0.path == CotEditorChannel.preferencesDirectoryURL.path
         })
         #expect(CotEditorChannel.preferencesDirectoryURL.path.contains("Library/Containers"))
+    }
+
+    /// One changelog rail per channel, and the beta one must include the release
+    /// its train graduates into.
+    ///
+    /// `includesPromotedStable` is asserted as a LITERAL rather than read off the
+    /// rule: reading it would make this case agree with whatever the registry
+    /// says. It is true here and false on Yaak's beta recipe, and the difference
+    /// is the rules — Yaak's beta rule cannot resolve a stable artifact, while
+    /// this one can and must, so a prerelease-only history would omit the very
+    /// entry the row is offering.
+    @Test func bothChangelogRailsAreRegisteredAndTheBetaOneKeepsTheGraduation() throws {
+        let recipes = ChangelogRecipeRegistry.recipes.filter { $0.bundleID == Self.bundleID }
+        #expect(recipes.count == 2, "one rail per channel; a deleted recipe must not read as coverage")
+        var seen: Set<ReleaseChannel> = []
+        for recipe in recipes {
+            seen.insert(recipe.channel ?? .stable)
+            #expect(recipe.source.path == "/repos/coteditor/CotEditor/releases")
+            #expect(recipe.structuredFormat == .gitHubReleases)
+            #expect(recipe.includesPromotedStable == (recipe.channel == .beta))
+        }
+        #expect(seen == [.stable, .beta])
+    }
+
+    /// The case the `-beta`-only pattern got wrong, driven through the source with
+    /// the graduation that has not happened yet: `7.1.0` published as stable above
+    /// the `7.1.0-beta.6` a copy is running.
+    ///
+    /// A beta copy must be offered it. Under the shipped-for-a-day pattern the
+    /// beta rule could not see a plain tag at all, so this copy sat on a
+    /// superseded prerelease until the next cycle opened — while CotEditor's own
+    /// updater handed it that release, because Sparkle allows the default channel
+    /// to everyone. Nothing else in this file notices: every other case is about
+    /// tags that exist today, and today the newest tag IS a beta.
+    @Test func aBetaCopyIsOfferedTheReleaseItsTrainGraduatesInto() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GraduationProtocol.self]
+        let source = GitHubReleasesSource(session: URLSession(configuration: config))
+
+        func app(_ short: String, _ build: String) -> InstalledApp {
+            InstalledApp(
+                name: "CotEditor", bundleID: Self.bundleID,
+                shortVersion: short, buildVersion: build,
+                path: URL(fileURLWithPath: "/Applications/CotEditor.app"),
+                isMASApp: false, sparkleFeedURL: nil,
+                releaseChannel: ReleaseChannel.detect(
+                    name: "CotEditor", bundleID: Self.bundleID,
+                    keystoneChannel: nil, version: short))
+        }
+
+        let onBeta = try #require(try await source.latestVersion(for: app("7.1.0-beta.6", "845")))
+        #expect(onBeta.shortVersion == "7.1.0")
+        #expect(onBeta.downloadURL?.lastPathComponent == "CotEditor_7.1.0.dmg")
+        #expect(UpdateChecker.evaluate(installed: app("7.1.0-beta.6", "845"), remote: onBeta)
+            == .updateAvailable(latest: "7.1.0"))
+
+        // And the version comparison behind it, stated rather than assumed: a
+        // release outranks its own prerelease tag.
+        #expect(VersionComparator.isNewer("7.1.0", than: "7.1.0-beta.6"))
+    }
+
+    /// The mirror, on the same fixture: a STABLE copy is not handed the
+    /// prerelease sitting in the same page. The stable rule reads
+    /// `/releases/latest`, which GitHub never answers with a prerelease, and its
+    /// own pattern refuses one anyway.
+    @Test func aStableCopyIsNotHandedThePrereleaseInTheSamePage() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GraduationProtocol.self]
+        let source = GitHubReleasesSource(session: URLSession(configuration: config))
+        let stable = InstalledApp(
+            name: "CotEditor", bundleID: Self.bundleID,
+            shortVersion: "7.0.9", buildVersion: "843",
+            path: URL(fileURLWithPath: "/Applications/CotEditor.app"),
+            isMASApp: false, sparkleFeedURL: nil, releaseChannel: .stable)
+        let remote = try #require(try await source.latestVersion(for: stable))
+        #expect(remote.shortVersion == "7.1.0")
+        #expect(remote.downloadURL?.lastPathComponent == "CotEditor_7.1.0.dmg")
+    }
+
+    /// A releases page with the graduation in it: `7.1.0` stable above the
+    /// `7.1.0-beta.6` it graduates from. Shaped like the real API's fields, with
+    /// one `CotEditor_<tag>.dmg` per release the way this vendor publishes.
+    private final class GraduationProtocol: URLProtocol, @unchecked Sendable {
+        static let releases = """
+        [
+          {"tag_name":"7.1.0","prerelease":false,"draft":false,"published_at":"2026-09-20T01:00:00Z",
+           "html_url":"https://github.com/coteditor/CotEditor/releases/tag/7.1.0","body":"### Improvements\\n- Graduated.",
+           "assets":[{"name":"CotEditor_7.1.0.dmg","browser_download_url":"https://github.com/coteditor/CotEditor/releases/download/7.1.0/CotEditor_7.1.0.dmg","size":26500000}]},
+          {"tag_name":"7.1.0-beta.6","prerelease":true,"draft":false,"published_at":"2026-09-05T01:33:07Z",
+           "html_url":"https://github.com/coteditor/CotEditor/releases/tag/7.1.0-beta.6","body":"### Improvements\\n- Beta six.",
+           "assets":[{"name":"CotEditor_7.1.0-beta.6.dmg","browser_download_url":"https://github.com/coteditor/CotEditor/releases/download/7.1.0-beta.6/CotEditor_7.1.0-beta.6.dmg","size":26458624}]},
+          {"tag_name":"7.0.9","prerelease":false,"draft":false,"published_at":"2026-09-05T01:32:59Z",
+           "html_url":"https://github.com/coteditor/CotEditor/releases/tag/7.0.9","body":"### Improvements\\n- Nine.",
+           "assets":[{"name":"CotEditor_7.0.9.dmg","browser_download_url":"https://github.com/coteditor/CotEditor/releases/download/7.0.9/CotEditor_7.0.9.dmg","size":25609728}]}
+        ]
+        """
+
+        /// `/releases/latest` — GitHub's newest non-prerelease, spelled out rather
+        /// than derived from the list above, so the stub cannot quietly answer
+        /// something malformed and have a test pass for the wrong reason.
+        static let latest = """
+        {"tag_name":"7.1.0","prerelease":false,"draft":false,"published_at":"2026-09-20T01:00:00Z",
+         "html_url":"https://github.com/coteditor/CotEditor/releases/tag/7.1.0","body":"### Improvements\\n- Graduated.",
+         "assets":[{"name":"CotEditor_7.1.0.dmg","browser_download_url":"https://github.com/coteditor/CotEditor/releases/download/7.1.0/CotEditor_7.1.0.dmg","size":26500000}]}
+        """
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            let path = request.url?.path ?? ""
+            // `/releases/latest` is GitHub's newest NON-prerelease; the list
+            // endpoint carries everything, newest first.
+            let body = path.hasSuffix("/releases/latest") ? Self.latest : Self.releases
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
     }
 
     /// ⚠️ The appcast address stays OUT of `SparkleFeedCatalog` on purpose.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CotEditorChannelTests.swift
@@ -55,7 +55,9 @@ struct CotEditorChannelTests {
     @Test func theStablePatternRefusesPrereleasesAndTheBetaOneDoesNot() throws {
         let stable = try #require(Self.rules.first { $0.channel == .stable })
         let beta = try #require(Self.rules.first { $0.channel == .beta })
-        var counts = (stable: 0, beta: 0)
+        // Named for what they now count: the beta pattern matches every tag, so
+        // the second number is the PRERELEASE count, not "tags only beta matched".
+        var counts = (acceptedByStable: 0, refusedByStable: 0)
         for tag in Self.tags {
             let s = VendorProbeRecipe.extractVersion(from: tag, pattern: stable.versionPattern)
             let b = VendorProbeRecipe.extractVersion(from: tag, pattern: beta.versionPattern)
@@ -65,9 +67,9 @@ struct CotEditorChannelTests {
                 #expect(s == tag)
             }
             #expect(b == tag, "the beta pattern must accept every tag, including \(tag)")
-            if s != nil { counts.stable += 1 } else { counts.beta += 1 }
+            if s != nil { counts.acceptedByStable += 1 } else { counts.refusedByStable += 1 }
         }
-        #expect(counts == (stable: 6, beta: 6))
+        #expect(counts == (acceptedByStable: 6, refusedByStable: 6))
     }
 
     /// The unnumbered `7.1.0-beta` is a real release (the cycle's first, 2026-07-26)
@@ -229,23 +231,17 @@ struct CotEditorChannelTests {
         #expect(VersionComparator.isNewer("7.1.0", than: "7.1.0-beta.6"))
     }
 
-    /// The mirror, on the same fixture: a STABLE copy is not handed the
-    /// prerelease sitting in the same page. The stable rule reads
-    /// `/releases/latest`, which GitHub never answers with a prerelease, and its
-    /// own pattern refuses one anyway.
-    @Test func aStableCopyIsNotHandedThePrereleaseInTheSamePage() async throws {
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [GraduationProtocol.self]
-        let source = GitHubReleasesSource(session: URLSession(configuration: config))
-        let stable = InstalledApp(
-            name: "CotEditor", bundleID: Self.bundleID,
-            shortVersion: "7.0.9", buildVersion: "843",
-            path: URL(fileURLWithPath: "/Applications/CotEditor.app"),
-            isMASApp: false, sparkleFeedURL: nil, releaseChannel: .stable)
-        let remote = try #require(try await source.latestVersion(for: stable))
-        #expect(remote.shortVersion == "7.1.0")
-        #expect(remote.downloadURL?.lastPathComponent == "CotEditor_7.1.0.dmg")
-    }
+    /// ⚠️ There is deliberately NO end-to-end mirror of the case above for a
+    /// stable copy ("a stable copy is not handed the prerelease in the same
+    /// page"). One was written and removed: it could not fail. A stable rule reads
+    /// `/releases/latest`, which GitHub computes with prereleases excluded, so any
+    /// stub that answers it honestly returns the stable release whether or not the
+    /// rule's pattern would have accepted a prerelease — widening the stable
+    /// pattern to accept `-beta` left the case green. The property it claimed is
+    /// pinned where it can actually fail, on the pattern itself
+    /// (`theStablePatternRefusesPrereleasesAndTheBetaOneDoesNot`), and the
+    /// list-endpoint fallback that could reach a prerelease is `stableOnly`'s job,
+    /// which is shared machinery this rule does not touch.
 
     /// A releases page with the graduation in it: `7.1.0` stable above the
     /// `7.1.0-beta.6` it graduates from. Shaped like the real API's fields, with

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListPageSizeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListPageSizeTests.swift
@@ -59,14 +59,18 @@ struct GitHubListPageSizeTests {
         "com.bitwarden.desktop/stable": 8,    // gap 7 (desktop-v2026.6.0→…2026.5.0), +1
         "com.t3tools.t3code/nightly": 3,      // gap 2 (…20260902.1252→…20260901.1250), +1
         "uk.whatcable.whatcable/beta": 1,     // gap 0 (all 100 tags match), +1
-        // CotEditor: latest 100 releases on 2026-09-06 — 6 beta tags, all of them
-        // in the 7.1.0 cycle that opened 2026-07-26, and none in the 94 releases
-        // before it (back to 2022-04). Worst gap 1 (7.1.0-beta.6 → 7.1.0-beta.5, with
-        // 7.0.9 sitting between them), so the floor is 2. Recomputed in Python
-        // from the live JSON with the rule's own patterns, which partition the
-        // page exactly: 94 stable tags + 6 beta, none matched by both and none by
-        // neither, and the same split on the 100 asset names.
-        "com.coteditor.CotEditor/beta": 2,
+        // CotEditor: gap 0 — its beta rule accepts plain tags as well as `-beta`
+        // ones (a cyclical train whose copies must be able to take the release
+        // that graduates from them, see the rule), so all 100 tags match and the
+        // first sits at index 0. Floor 1, the same shape and number as WhatCable
+        // above.
+        //
+        // ⚠️ This read 2 for a day, measured against a `-beta`-only pattern: 6
+        // beta tags, worst gap 1 (7.1.0-beta.6 → 7.1.0-beta.5, with 7.0.9 between
+        // them). Correct arithmetic on a rule that was wrong — kept visible,
+        // because a floor recorded here is only ever as sound as the pattern it
+        // was measured against.
+        "com.coteditor.CotEditor/beta": 1,
     ]
 
     private static func key(_ rule: GitHubReleaseRule) -> String {

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -124,9 +124,22 @@ beta    usePrereleases: true
 ——#368 换一扇门又进来一次。
 
 那个键在**沙盒容器里**（`~/Library/Containers/com.coteditor.CotEditor/Data/Library/Preferences/`），
-容器外没有 plist。实测：没有完全磁盘访问的 shell 也读得到，`defaults read com.coteditor.CotEditor
-checksUpdatesForBeta` 不指路径就能解析。CapCut 是表里另一个沙盒 app，但它的 flag 在容器
-**外**，所以现有两个监视根都盖不到这里，`preferenceWatchCandidates` 补了第三个。
+容器外没有 plist。CapCut 是表里另一个沙盒 app，但它的 flag 在容器**外**，所以现有两个监视根
+都盖不到这里，`preferenceWatchCandidates` 补了第三个。
+
+⚠️ **第一版这条 binding 用 `CFPreferencesCopyAppValue` 读，读不到 —— 而且是合并之后才量出来的。**
+在框勾着、容器 plist 里 `checksUpdatesForBeta = 1` 的机器上实测：
+
+```
+CFPreferencesCopyAppValue("checksUpdatesForBeta", "com.coteditor.CotEditor") → nil
+Data(contentsOf: <容器>/com.coteditor.CotEditor.plist)                        → 拿到键，true
+```
+
+沙盒 app 的域**不会**替别的进程解析到它的容器，`CFPreferences` 找的是
+`~/Library/Preferences/<id>.plist`，那个文件这里根本不存在。而 `defaults read
+com.coteditor.CotEditor checksUpdatesForBeta` **能**打印 1 —— `defaults` 自己会去找容器路径。
+我当初拿来当证据的正是这条 shell 命令，**它跟代码走的不是同一条路**。现在按 `SurgeChannel`
+的做法直接读文件，修完在同一台机器上验过：`resolveCurrent() → .beta`。
 
 ### 实测（打真实端点，2026-09-06）
 

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -95,13 +95,19 @@ beta    usePrereleases: true
 两条 versionPattern 把 100 个 tag **正好切开**——94 stable + 6 beta，没有一个被两条同时
 命中，也没有一个两条都不中；100 个资产名同样切开，命名一律 `CotEditor_<tag>.dmg`。
 
-`listPageSize` 用默认 20，实测下限是 **2**（beta 之间最坏间隔 1 条：beta.6 和 beta.5
-之间隔着 7.0.9），记在 `GitHubListPageSizeTests.measuredMinimumDepth`。
+`listPageSize` 用默认 20，实测下限是 **1**（放宽后 100 个 tag 全部命中，首命中在第 0 行），
+记在 `GitHubListPageSizeTests.measuredMinimumDepth`。
 
-⚠️ **beta 轨是新开的**：这 100 条里 6 个 prerelease 全属于 2026-07-26 开始的 7.1.0 轮，
-它之前的 94 条（一路回到 2022-04）一个都没有。所以等这一轮转正、新一轮没开时，最新的 prerelease 会往下沉，
-20 行窗口大约覆盖这个厂商七个月的节奏，之后 beta 规则会匹配不到东西（**答 nil，不报错**）。
-那时候跑 beta 的副本也已经被 7.1.0 正式版接走了（正式版压过自己的预发布标签）。
+⚠️ **beta 轨是周期性的，这决定了上面那个形状**：这 100 条里 6 个 prerelease 全属于
+2026-07-26 开始的 7.1.0 轮，它之前的 94 条（一路回到 2022-04）一个都没有。第一版照 Yaak
+抄成 `-beta` 锚死，在周期轨上错两次：跑 beta 的副本**永远转不了正**；而且这一轮结束、最后
+一个 prerelease 滑出页面之后，pattern 匹配不到任何东西 —— 那不是安静的 nil，
+**`duo verify` 走的是规则不是装机，会在每台机器上报红**。两条在 WhatCable 的规则注释里都
+写过，是我抄错了模板。
+
+⚠️ 转正的代价是单向的：装上 `7.1.0` 之后 `detect` 判 `.stable`，之后由 stable 规则应答。
+和 WhatCable 不同的是这里**不用改代码就能回去** —— `CotEditorChannel` 读的正是厂商那个
+"Update to prereleases when available"，想留在轨上的用户勾上它就重新是权威 `.beta`。
 
 **渠道：`CotEditorChannel`**，还原厂商自己那行
 `Bundle.main.version.isPrerelease || checksUpdatesForBeta`：
@@ -140,8 +146,12 @@ installed=7.0.9/843        box=on   → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg
 
 ## 还差什么
 
-- **Changelog 没有单独接 recipe**。GitHub 源自己会把 release body 解成结构化条目，
-  所以最新一条的说明是有的；多版本历史需要一条 `ChangelogRecipe`，没做。
+- ~~Changelog 没有单独接 recipe~~ **已接**（2026-09-06）：两条 `ChangelogRecipe`，一轨
+  一条，`structuredFormat: .gitHubReleases`，`per_page=40` / `maxEntries: 20`。实测最新
+  40 条里 34 stable + 6 prerelease，所以 stable 轨渲染满 20 条、beta 轨渲染现存的 6 条。
+  beta 那条带 `includesPromotedStable`（与 Yaak 相反）—— 它的规则能且必须解出转正版，
+  不带的话面板会漏掉行里正在提供的那一条。**正在提供的那一条**的说明仍由 GitHub 源自己
+  解 release body 得到（实测两轨都出结构化条目）。
 - **丢掉了 appcast 的两样东西**：EdDSA 签名（改由 Developer ID + 公证兜住）和
   feed 声明的 `minimumSystemVersion`。后者实测被安装时那道闸兜住——`SignatureVerifier`
   读的是下载包自己的 `LSMinimumSystemVersion`，而两个真包里这个值跟 feed 写的一致


### PR DESCRIPTION
A correction to #377, plus the changelog rails that were missing.

## The defect

#377's beta rule anchored its version pattern to `-beta`, copied from Yaak's
pair. Yaak publishes betas continuously. **CotEditor publishes them in cycles**:
all six prereleases in its newest 100 releases belong to the 7.1.0 cycle that
opened 2026-07-26, and the 94 releases before it — back to 2022 — carry none.

On a cyclical train that anchor is wrong twice, and WhatCable's beta rule in this
same file had already documented both:

1. **A beta copy can never graduate.** A copy on `7.1.0-beta.6` cannot be offered
   the plain `7.1.0` that graduates from it — the beta rule cannot see a tag
   without `-beta`, and the channel gate only lets the beta rule answer for a
   beta copy. It would sit on a superseded prerelease until the next cycle
   opened, while CotEditor's own updater hands it that release (Sparkle allows
   the default channel to everyone).
2. **It is a fuse.** Once the cycle closes and the last prerelease scrolls off the
   page, a `-beta`-only pattern matches nothing — and that is not the quiet nil
   #377's comment claimed. `duo verify` walks RULES, not installs, so it would
   file a red finding on **every machine** for a rule working exactly as written.

## The fix

The pattern accepts a plain tag too, and the asset pattern with it.
`VersionComparator` already ranks the graduation correctly on its own — the
missing fourth component pads to `.number(0)` and outranks `.text("beta")` — so
the pattern was the only thing in the way.

**The channel proof had to change with it.** An `.artifact` proof anchored to
`-beta` in the download path would fire on exactly that legitimate resolution, so
it is now a `.recipeAnchor` on `usePrereleases` + `versionPattern` — the same
shape WhatCable uses, for the same reason. The artifact proof it replaces passed
the whole time it existed, and would have gone on passing right up to the release
it was wrong about.

The measured depth floor moves with the pattern: all 100 tags now match, first at
index 0, so the floor is 1 rather than 2. The old figure was correct arithmetic on
a rule that was wrong, and the table now says so.

## And the changelog rails

Two recipes, one per rail. The GitHub source already renders the release being
offered (measured on both rails: the bodies are structured Markdown and come back
as native entries), so these add the rest of the rail's history.

`includesPromotedStable: true` on the beta recipe is the **opposite** of Yaak's
pair, and the difference is in the rules: Yaak's beta rule cannot resolve a stable
artifact, so a promoted entry there would describe a build that channel never
offers; CotEditor's beta rule can and must, so without it the panel would omit the
very entry the row is offering. Note what that flag actually does — the decoder
wants EVERY non-prerelease, not only the graduation — so the beta rail renders 20
entries, most of them stable, rather than the 6 betas.

## Measured

- **The graduation, end to end**: a stubbed releases page carrying `7.1.0` above
  the `7.1.0-beta.6` a copy is running. It is the only case in the file that fails
  under the shipped pattern — every other one is about tags that exist today, and
  today the newest tag is a beta.
- **Live**: `duo verify --only coteditor` → 2 GitHub rules ✓, 2 changelogs ✓.
- **Patterns, recomputed in Python from the live JSON**: the beta pattern matches
  all 100 tags (first at index 0, worst gap 0 → floor 1); the stable pattern
  matches the 94 non-prereleases and none of the 6 prereleases; the asset patterns
  split the same way.
- **5 mutations**, all compiling, each red on its named case.
- `make test` green.

## The binding shipped in #377 could not work either

`CotEditorChannel` read the opt-in with `CFPreferencesCopyAppValue`. Measured on a
machine with the box ticked and the container plist holding the key:

```
CFPreferencesCopyAppValue("checksUpdatesForBeta", "com.coteditor.CotEditor") → nil
Data(contentsOf: <container>/com.coteditor.CotEditor.plist)                  → true
```

A sandboxed app's domain does not resolve to its container for anyone but the app.
`resolveCurrent()` therefore always answered nil, so the one state the binding
exists for — a RELEASE copy whose owner ticked the box — never got its
prereleases. The failure direction was safe (nil leaves `detect()` in charge), which
is why nothing looked wrong.

The evidence behind the original claim was `defaults read com.coteditor.CotEditor
checksUpdatesForBeta` printing 1 — `defaults` searches container paths itself. A
different code path from the one the code takes, with the same-looking answer.

Now it reads the file, the way `SurgeChannel` does. Verified after the change on
the same machine: `resolveCurrent() → .beta`.

## Review pass

`/code-review 379 high` on this branch turned up 5 findings, all fixed in the last
commit — including a case that could not fail (`/releases/latest` never returns a
prerelease, so the stable-copy test passed even with the stable pattern widened to
accept betas) and a comment stating a measured number that was wrong (the beta
rail renders 20, not 6).

## Two things I got wrong, recorded rather than quietly fixed

- **#377's PR body said `duo verify` does not cover GitHub rules.** It does —
  `duo verify --only coteditor` sweeps 2 GitHub rules and reports on them. That
  claim came from reading the filter at the top of `Verify.swift` and not the rest.
- While swapping the proof I replaced a span **by index** and deleted four
  neighbouring entries (Zed Preview, GitHub Desktop, VSCodium Insiders, T3 Code
  nightly). It compiled, and the filtered tests I was running passed; the full
  mutation run surfaced it through unrelated reds. Restored and redone by exact
  match — the registry has all 58 entries.

Refs #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
