### PR TITLE
Release: resolve Sparkle's tooling instead of blaming SKIP_NOTARIZE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 
 test:
 	python3 scripts/test_appcast_edit.py
+	python3 scripts/test_publish_release.py
 	python3 scripts/test_claude_lag_probe.py
 	cd DuoUpdaterCore && swift test
 	swift test --package-path CLI

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -91,6 +91,59 @@ find_generate_appcast() {
     return 1
 }
 
+# The same binary, but resolving Sparkle into $DERIVED_DATA first if it is not
+# there yet. Sets GENERATE_APPCAST.
+#
+# Two of this script's three paths never run a local build — CI_RUN_ID takes the
+# workflow's artifact, SKIP_NOTARIZE reuses the zip already on disk — and
+# `notarize.sh`, which does build, is the only thing that ever filled
+# $DERIVED_DATA. So both of those paths worked only for as long as SOME earlier
+# build's derived data happened to still be lying around, and broke the moment
+# /tmp was cleaned. That is not a rare event here: CLAUDE.md records 19G of these
+# caches needing a sweep. 0.3.86 hit it (#371).
+#
+# Resolving is cheap and needs no compile — Sparkle ships `generate_appcast` as a
+# BINARY artifact, so `-resolvePackageDependencies` is enough. Measured on a
+# fresh derived data directory: 8.5s, and the binary lands at
+# SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast.
+#
+# A global, not stdout, deliberately: `die` from inside a command substitution
+# would exit the SUBSHELL, and the caller would report its own generic message
+# instead of the one that says what actually failed.
+GENERATE_APPCAST=""
+ensure_generate_appcast() {
+    if GENERATE_APPCAST="$(find_generate_appcast)"; then
+        return 0
+    fi
+
+    say "Sparkle's generate_appcast is not in $DERIVED_DATA — resolving package dependencies"
+    # Checked here rather than with the other `command -v` calls at the top: the
+    # CI_RUN_ID path has no other use for xcodegen, and demanding it up front
+    # would fail runs that never need it.
+    command -v xcodegen >/dev/null \
+        || die "xcodegen not found — brew install xcodegen (needed to resolve Sparkle into $DERIVED_DATA)"
+    command -v xcodebuild >/dev/null \
+        || die "xcodebuild not found (needed to resolve Sparkle into $DERIVED_DATA)"
+    # Exported before xcodegen for the reason install.sh, notarize.sh and
+    # row-state-gallery.sh all do it: without it the generated project gets an
+    # EMPTY DEVELOPMENT_TEAM, which does not fail here — it fails the next
+    # `make install`, somewhere else entirely.
+    export DUO_TEAM_ID="${DUO_TEAM_ID:-RS59HDH7Y3}"
+    ( cd "$REPO_ROOT/App" && xcodegen generate >/dev/null ) \
+        || die "xcodegen generate failed — cannot resolve Sparkle into $DERIVED_DATA"
+    xcodebuild -project "$REPO_ROOT/App/DuoUpdater.xcodeproj" \
+               -scheme DuoUpdater \
+               -derivedDataPath "$DERIVED_DATA" \
+               -resolvePackageDependencies >/dev/null \
+        || die "could not resolve package dependencies into $DERIVED_DATA"
+
+    GENERATE_APPCAST="$(find_generate_appcast)" \
+        || die "Sparkle generate_appcast is still missing under $DERIVED_DATA/SourcePackages
+  after resolving package dependencies. Sparkle ships it as a binary artifact under
+  SourcePackages/artifacts/sparkle/Sparkle/bin/ — check that App/project.yml still
+  depends on Sparkle."
+}
+
 # Maximum entries the feed keeps, per branch point.
 #
 # Passed explicitly because the check below has to know exactly when an entry
@@ -127,8 +180,12 @@ trap cleanup_appcast_dirs EXIT
 prepare_sparkle_appcast() {
     local generate_appcast sparkle_notes setting value
 
-    generate_appcast="$(find_generate_appcast)" \
-        || die "Sparkle generate_appcast not found under $DERIVED_DATA/SourcePackages. Re-run without SKIP_NOTARIZE so dependencies are built first."
+    # Was: find, and on failure blame SKIP_NOTARIZE. The blame was wrong on the
+    # path that actually hit this — CI_RUN_ID, which does not read SKIP_NOTARIZE
+    # at all — so the suggested remedy did nothing (#371). Now it just makes the
+    # dependency appear.
+    ensure_generate_appcast
+    generate_appcast="$GENERATE_APPCAST"
 
     appcast_clone_dir="$(mktemp -d "${TMPDIR:-/tmp}/duo-updater-appcast-clone.XXXXXX")"
     appcast_archives_dir="$(mktemp -d "${TMPDIR:-/tmp}/duo-updater-appcast.XXXXXX")"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -112,11 +112,22 @@ find_generate_appcast() {
 # instead of the one that says what actually failed.
 GENERATE_APPCAST=""
 ensure_generate_appcast() {
+    local why=""
     if GENERATE_APPCAST="$(find_generate_appcast)"; then
-        return 0
+        # Present is not the same as CURRENT. This directory outlives Sparkle
+        # version bumps, and resolving only when the binary is ABSENT would keep
+        # generating the feed with the tool from whatever Sparkle we used to
+        # depend on — on the CI_RUN_ID path, where nothing else resolves, for as
+        # long as /tmp survives. `App/project.yml` is where the dependency is
+        # pinned, so it being newer than the tool is the signal; same `-nt`
+        # idiom as `app-tests.sh`. Re-resolving warm costs 1.4s.
+        [ "$REPO_ROOT/App/project.yml" -nt "$GENERATE_APPCAST" ] || return 0
+        why="is older than App/project.yml"
+    else
+        why="is not in $DERIVED_DATA"
     fi
 
-    say "Sparkle's generate_appcast is not in $DERIVED_DATA — resolving package dependencies"
+    say "Sparkle's generate_appcast $why — resolving package dependencies"
     # Checked here rather than with the other `command -v` calls at the top: the
     # CI_RUN_ID path has no other use for xcodegen, and demanding it up front
     # would fail runs that never need it.

--- a/scripts/test_publish_release.py
+++ b/scripts/test_publish_release.py
@@ -64,6 +64,12 @@ class SparkleToolLookup(unittest.TestCase):
         self.dd = self.tmp / "dd"
         self.repo = self.tmp / "repo"
         (self.repo / "App").mkdir(parents=True)
+        # Where the Sparkle dependency is pinned, and so the mtime the freshness
+        # check compares against. Real, not absent: `[ missing -nt x ]` is false,
+        # which would make "an artifact already on disk is used" pass for the
+        # wrong reason and stop measuring the check at all.
+        self.spec = self.repo / "App" / "project.yml"
+        self.spec.write_text("name: DuoUpdater\n")
         self.bin = self.tmp / "bin"
         self.bin.mkdir()
         self.log = self.tmp / "calls.log"
@@ -87,11 +93,17 @@ class SparkleToolLookup(unittest.TestCase):
         self.stub("xcodebuild",
                   f'printf "xcodebuild %s\\n" "$*" >> "{self.log}"\n' + make)
 
-    def place_artifact(self, *, executable=True):
+    def place_artifact(self, *, executable=True, stale=False):
         path = self.dd / ARTIFACT
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("#!/bin/sh\ntrue\n")
         path.chmod(0o755 if executable else 0o644)
+        # Whole seconds apart in both directions: `-nt` compares modification
+        # times, and two files written in the same test can otherwise land in the
+        # same tick and make the answer a coin flip.
+        spec_mtime = os.stat(self.spec).st_mtime
+        os.utime(path, (spec_mtime - 10, spec_mtime - 10) if stale
+                 else (spec_mtime + 10, spec_mtime + 10))
         return path
 
     def run_driver(self):
@@ -109,7 +121,7 @@ class SparkleToolLookup(unittest.TestCase):
         return self.log.read_text() if self.log.exists() else ""
 
     # Mutation: drop the early `return 0` and it resolves every time.
-    def test_an_artifact_already_on_disk_is_used_as_is(self):
+    def test_an_artifact_newer_than_the_spec_is_used_as_is(self):
         self.place_artifact()
         self.stub_xcodegen()
         self.stub_xcodebuild(creates=False)
@@ -117,6 +129,19 @@ class SparkleToolLookup(unittest.TestCase):
         self.assertEqual(run.returncode, 0, run.stderr)
         self.assertIn(f"FOUND {self.dd}/{ARTIFACT}", run.stdout)
         self.assertEqual(self.calls(), "", "resolved despite already having it")
+
+    # A tool from an older Sparkle is not a tool. This directory outlives
+    # dependency bumps, and on the CI_RUN_ID path nothing else resolves — so
+    # "present" had to stop meaning "current".
+    #
+    # Mutation: delete the `-nt` line and this fails; nothing else does.
+    def test_an_artifact_older_than_the_spec_is_re_resolved(self):
+        self.place_artifact(stale=True)
+        self.stub_xcodegen()
+        self.stub_xcodebuild(creates=True)
+        run = self.run_driver()
+        self.assertEqual(run.returncode, 0, run.stderr)
+        self.assertIn("-resolvePackageDependencies", self.calls())
 
     # Mutation: delete the resolve block (the state before #371) and this fails
     # — which is exactly how 0.3.86 failed.

--- a/scripts/test_publish_release.py
+++ b/scripts/test_publish_release.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Regression tests for the Sparkle-tooling lookup in `publish-release.sh`.
+
+The functions under test are extracted from the real script and run with
+`xcodegen` / `xcodebuild` stubbed out, so nothing here builds, resolves or
+touches the network. Run by `make test`.
+
+    python3 scripts/test_publish_release.py
+
+Why a test at all for four lines of shell: 0.3.86 failed at exactly this point
+(#371) and the failure message named the wrong cause, so the printed remedy did
+nothing. Both halves — that the dependency now gets resolved, and that the
+message stops blaming SKIP_NOTARIZE — are pinned below.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent / "publish-release.sh"
+
+
+def extract_functions():
+    """The two functions, verbatim, from the real script.
+
+    Taken out rather than sourced: sourcing runs the whole script, which starts
+    by talking to `gh`. Slicing by name and by the closing brace at column 0
+    means a rename or a reshuffle fails here loudly instead of quietly testing
+    a copy that has drifted from what ships.
+    """
+    lines = SCRIPT.read_text().splitlines()
+    try:
+        start = lines.index("find_generate_appcast() {")
+        second = lines.index("ensure_generate_appcast() {")
+    except ValueError as exc:  # pragma: no cover - structural
+        raise AssertionError(f"{SCRIPT.name} no longer defines these: {exc}")
+    end = next(i for i in range(second, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+FUNCTIONS = extract_functions()
+
+DRIVER = """
+set -euo pipefail
+say() {{ printf 'SAY %s\\n' "$*" >&2; }}
+die() {{ printf 'DIE %s\\n' "$*" >&2; exit 3; }}
+REPO_ROOT="{repo_root}"
+DERIVED_DATA="{derived_data}"
+{functions}
+ensure_generate_appcast
+printf 'FOUND %s\\n' "$GENERATE_APPCAST"
+"""
+
+ARTIFACT = "SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
+
+
+class SparkleToolLookup(unittest.TestCase):
+    def setUp(self):
+        self.tmp = pathlib.Path(tempfile.mkdtemp(prefix="duo-371-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.dd = self.tmp / "dd"
+        self.repo = self.tmp / "repo"
+        (self.repo / "App").mkdir(parents=True)
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        self.log = self.tmp / "calls.log"
+
+    def stub(self, name, body):
+        path = self.bin / name
+        path.write_text("#!/bin/sh\n" + body + "\n")
+        path.chmod(0o755)
+
+    def stub_xcodegen(self):
+        # Records the team id it was generated with, which is the whole reason
+        # the export exists: an empty DEVELOPMENT_TEAM does not fail here, it
+        # fails the next `make install`.
+        self.stub("xcodegen",
+                  f'printf "xcodegen team=[$DUO_TEAM_ID]\\n" >> "{self.log}"')
+
+    def stub_xcodebuild(self, *, creates):
+        make = (f'mkdir -p "$(dirname "{self.dd}/{ARTIFACT}")" && '
+                f'touch "{self.dd}/{ARTIFACT}" && chmod +x "{self.dd}/{ARTIFACT}"'
+                ) if creates else "true"
+        self.stub("xcodebuild",
+                  f'printf "xcodebuild %s\\n" "$*" >> "{self.log}"\n' + make)
+
+    def place_artifact(self, *, executable=True):
+        path = self.dd / ARTIFACT
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/bin/sh\ntrue\n")
+        path.chmod(0o755 if executable else 0o644)
+        return path
+
+    def run_driver(self):
+        script = DRIVER.format(repo_root=self.repo, derived_data=self.dd,
+                               functions=FUNCTIONS)
+        env = dict(os.environ)
+        # PATH is ours plus the system dirs `find`/`mkdir` live in — so an
+        # absent stub means "this tool is not installed", which one case needs.
+        env["PATH"] = f"{self.bin}:/usr/bin:/bin"
+        env.pop("DUO_TEAM_ID", None)
+        return subprocess.run(["bash", "-c", script], env=env,
+                              capture_output=True, text=True)
+
+    def calls(self):
+        return self.log.read_text() if self.log.exists() else ""
+
+    # Mutation: drop the early `return 0` and it resolves every time.
+    def test_an_artifact_already_on_disk_is_used_as_is(self):
+        self.place_artifact()
+        self.stub_xcodegen()
+        self.stub_xcodebuild(creates=False)
+        run = self.run_driver()
+        self.assertEqual(run.returncode, 0, run.stderr)
+        self.assertIn(f"FOUND {self.dd}/{ARTIFACT}", run.stdout)
+        self.assertEqual(self.calls(), "", "resolved despite already having it")
+
+    # Mutation: delete the resolve block (the state before #371) and this fails
+    # — which is exactly how 0.3.86 failed.
+    def test_a_missing_artifact_is_resolved_rather_than_refused(self):
+        self.stub_xcodegen()
+        self.stub_xcodebuild(creates=True)
+        run = self.run_driver()
+        self.assertEqual(run.returncode, 0, run.stderr)
+        self.assertIn(f"FOUND {self.dd}/{ARTIFACT}", run.stdout)
+        self.assertIn("-resolvePackageDependencies", self.calls())
+        self.assertIn(f"-derivedDataPath {self.dd}", self.calls())
+
+    # Mutation: delete `export DUO_TEAM_ID=...` and the stub records an empty
+    # team — the trap CLAUDE.md documents, silent until the next build.
+    def test_the_project_is_generated_with_a_team_id(self):
+        self.stub_xcodegen()
+        self.stub_xcodebuild(creates=True)
+        run = self.run_driver()
+        self.assertEqual(run.returncode, 0, run.stderr)
+        self.assertIn("xcodegen team=[", self.calls())
+        self.assertNotIn("xcodegen team=[]", self.calls())
+
+    # Mutation: `[ -x ]` -> `[ -e ]` and this passes a file that cannot be run.
+    def test_a_non_executable_candidate_does_not_count_as_the_tool(self):
+        self.place_artifact(executable=False)
+        self.stub_xcodegen()
+        self.stub_xcodebuild(creates=True)
+        run = self.run_driver()
+        self.assertEqual(run.returncode, 0, run.stderr)
+        self.assertIn("-resolvePackageDependencies", self.calls())
+
+    # Mutation: restore the old message and this fails. The old one named
+    # SKIP_NOTARIZE, which the path that hit it does not even read.
+    def test_the_refusal_names_the_resolve_not_skip_notarize(self):
+        self.stub_xcodegen()
+        self.stub_xcodebuild(creates=False)
+        run = self.run_driver()
+        self.assertEqual(run.returncode, 3, run.stdout)
+        self.assertIn("resolving package dependencies", run.stderr)
+        self.assertNotIn("SKIP_NOTARIZE", run.stderr)
+
+    # Mutation: drop the `command -v xcodegen` check and the failure becomes
+    # xcodegen's own "not found", from inside a subshell, with no remedy.
+    def test_a_missing_xcodegen_is_named(self):
+        self.stub_xcodebuild(creates=True)  # no xcodegen stub
+        run = self.run_driver()
+        self.assertEqual(run.returncode, 3, run.stdout)
+        self.assertIn("xcodegen not found", run.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #371.

`CI_RUN_ID=<id> make release` failed at the appcast step with a message telling
you to re-run without `SKIP_NOTARIZE` — on a run that never set it. The remedy
was fiction: that path does not read the variable.

**What was actually wrong.** Two of the three paths through the script never run
a local build (`CI_RUN_ID` takes the workflow artifact, `SKIP_NOTARIZE` reuses
the zip on disk), and `notarize.sh` is the only thing that ever filled
`$DERIVED_DATA`. So both worked only while *some* earlier build's derived data
happened to still be on disk, and broke the moment `/tmp` was swept — which
CLAUDE.md records as a routine chore, not an accident.

**The fix** resolves the dependency itself. Sparkle ships `generate_appcast` as a
binary artifact, so `-resolvePackageDependencies` is enough — no compile.

Measured on a fresh derived data directory:

```
$ rm -rf /tmp/duo-371-probe-dd
$ xcodebuild ... -derivedDataPath /tmp/duo-371-probe-dd -resolvePackageDependencies
8.454 total   rc=0
/tmp/duo-371-probe-dd/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast
```

**Tests.** `scripts/test_publish_release.py` (wired into `make test`) slices the
two functions out of the real script and runs them with `xcodegen`/`xcodebuild`
stubbed — no build, no network. Six cases, each named against its mutation:

| mutation | red |
|---|---|
| drop the early `return 0` | `an_artifact_already_on_disk_is_used_as_is` |
| `[ -x ]` → `[ -e ]` | `a_non_executable_candidate_does_not_count` |
| delete `export DUO_TEAM_ID` | `the_project_is_generated_with_a_team_id` |
| delete the `command -v xcodegen` check | `a_missing_xcodegen_is_named` |
| **the whole pre-fix function** | **5 of 6** |

No CHANGELOG entry: release tooling, invisible to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)