### PR TITLE
A store copy is not handed a feed we chose for it

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -470,7 +470,20 @@ public struct AppScanner: Sendable {
         // fill-in, not a redirect. Crucially it does NOT make the channel
         // authoritative the way `ChannelBinding` below does, so the channel is
         // still inferred from the feed's own items. See the type's doc comment.
-        if feedURL == nil { feedURL = SparkleFeedCatalog.feed(forBundleID: bundleID) }
+        //
+        // Not for a store copy. Both of the addresses below are OURS, not the
+        // bundle's, and handing one to a copy the App Store owns turns a store
+        // lookup that merely missed into a one-click direct-install download —
+        // `MacAppStoreSource` returns nil rather than throwing when the lookup
+        // finds nothing, and `SourceStack` runs `SparkleAppcastSource` third, so
+        // the fall-through is the normal path, not an error path. Homebrew, GitHub
+        // and the vendor probe each carry the same `guard !app.isMASApp`.
+        //
+        // Deliberately NOT extended to the bundle's own `SUFeedURL` read above: a
+        // store copy that states a feed is speaking for itself and is honoured, as
+        // it is today — Keka is a store copy carrying one, and `UpdateChecker`'s
+        // "all sources exhausted" comment names it for the same reason.
+        if feedURL == nil, !isMAS { feedURL = SparkleFeedCatalog.feed(forBundleID: bundleID) }
         // The narrower gap: the bundle DOES name a feed, and the vendor stopped
         // publishing to it. Matched on the dead address itself, not on the bundle
         // id, so the entry stops applying the moment the app names anything else —
@@ -478,7 +491,13 @@ public struct AppScanner: Sendable {
         // after the fill-in because a fill-in address is ours already and has
         // nothing to supersede, and before `ChannelBinding` below because a
         // binding's `feedOverride` is a channel decision and still outranks this.
-        if let live = SparkleFeedCatalog.replacement(
+        //
+        // `!isMAS` for the reason above, and it bites harder here than on the
+        // fill-in: today's one superseded entry is PDF Expert, which ships on the
+        // Mac App Store as well as direct. Left alone, a store copy naming the dead
+        // address resolves a frozen 2022 feed and reads "up to date"; redirected to
+        // the live one it would be offered a direct .zip instead.
+        if !isMAS, let live = SparkleFeedCatalog.replacement(
             forBundleID: bundleID, declaredFeed: feedURL) {
             feedURL = live
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A copy installed from the Mac App Store must not be handed a feed address
+/// that came from `SparkleFeedCatalog` (#368).
+///
+/// Both of that table's halves supply an address the BUNDLE never stated — the
+/// fill-in invents one outright, the superseded entry redirects one we decided
+/// was dead. For a store copy that turns a store lookup which merely missed
+/// (`MacAppStoreSource` returns nil rather than throwing, and `SourceStack` runs
+/// `SparkleAppcastSource` third) into a one-click direct-install download beside
+/// an app the store owns. `HomebrewCaskSource`, `GitHubReleasesSource` and
+/// `VendorProbeSource` all carry the same `guard !app.isMASApp`.
+///
+/// Driven off the registry, not off a written-down list of bundle ids: a new
+/// catalog entry is covered the day it lands. Every case names the mutation it
+/// catches.
+struct AppScannerStoreCopyTests {
+
+    /// Plants a bundle and returns the row `AppScanner` reads out of it.
+    ///
+    /// `_MASReceipt/receipt` is the store marker the scanner actually looks for.
+    /// Each case asserts `isMASApp` on the result rather than assuming the
+    /// fixture earned it — a fixture that quietly stopped reading as a store copy
+    /// would make every store half of this file vacuously green.
+    private static func scan(
+        bundleID: String, declaringFeed feed: String?, storeReceipt: Bool
+    ) throws -> InstalledApp {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("scanner-store-\(UUID().uuidString)")
+        let bundle = root.appendingPathComponent("Fixture.app")
+        var plist: [String: Any] = [
+            "CFBundleDisplayName": "Fixture",
+            "CFBundleIdentifier": bundleID,
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleVersion": "100",
+        ]
+        if let feed { plist["SUFeedURL"] = feed }
+        let info = bundle.appendingPathComponent("Contents/Info.plist")
+        try fm.createDirectory(at: info.deletingLastPathComponent(),
+                               withIntermediateDirectories: true)
+        try PropertyListSerialization
+            .data(fromPropertyList: plist, format: .xml, options: 0).write(to: info)
+        if storeReceipt {
+            let receipt = bundle.appendingPathComponent("Contents/_MASReceipt/receipt")
+            try fm.createDirectory(at: receipt.deletingLastPathComponent(),
+                                   withIntermediateDirectories: true)
+            try Data("not a real receipt".utf8).write(to: receipt)
+        }
+        defer { try? fm.removeItem(at: root) }
+        return try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+    }
+
+    /// Mutation: `if feedURL == nil, !isMAS` → `if feedURL == nil`. The store half
+    /// then gets the curated address and the row is offered a direct download.
+    @Test func aFilledInFeedGoesToDirectCopiesAndNotToStoreCopies() throws {
+        try #require(!SparkleFeedCatalog.feeds.isEmpty)
+        for (bundleID, feed) in SparkleFeedCatalog.feeds {
+            let direct = try Self.scan(
+                bundleID: bundleID, declaringFeed: nil, storeReceipt: false)
+            #expect(!direct.isMASApp)
+            #expect(direct.sparkleFeedURL == feed,
+                    "\(bundleID): a direct copy stating no feed should get the curated one")
+
+            let store = try Self.scan(
+                bundleID: bundleID, declaringFeed: nil, storeReceipt: true)
+            #expect(store.isMASApp, "\(bundleID): fixture stopped reading as a store copy")
+            #expect(store.sparkleFeedURL == nil,
+                    "\(bundleID): a store copy was handed a feed address it never stated")
+        }
+    }
+
+    /// Mutation: drop `!isMAS,` from the `SparkleFeedCatalog.replacement` guard.
+    /// The store half is then redirected off the frozen feed — which reads
+    /// harmlessly as up-to-date — and onto a live one that offers a .zip.
+    @Test func aSupersededFeedIsRedirectedForDirectCopiesOnly() throws {
+        try #require(!SparkleFeedCatalog.supersededFeeds.isEmpty)
+        for (bundleID, entry) in SparkleFeedCatalog.supersededFeeds {
+            let declared = entry.declared.absoluteString
+            let direct = try Self.scan(
+                bundleID: bundleID, declaringFeed: declared, storeReceipt: false)
+            #expect(!direct.isMASApp)
+            #expect(direct.sparkleFeedURL == entry.live,
+                    "\(bundleID): a direct copy on the dead address should move to the live one")
+
+            let store = try Self.scan(
+                bundleID: bundleID, declaringFeed: declared, storeReceipt: true)
+            #expect(store.isMASApp, "\(bundleID): fixture stopped reading as a store copy")
+            #expect(store.sparkleFeedURL == entry.declared,
+                    "\(bundleID): a store copy was redirected to a feed we chose for it")
+        }
+    }
+
+    /// The other side of the same decision, and the one that keeps this from
+    /// being "store copies never get a Sparkle feed": an address the BUNDLE
+    /// states is the app speaking for itself and is honoured whoever installed
+    /// it. Keka is a real store copy carrying `SUFeedURL`; `UpdateChecker`'s
+    /// "all sources exhausted" comment names it for the same reason.
+    ///
+    /// Mutation: extend the guard to the `SUFeedURL` read and this goes nil.
+    @Test func aStoreCopyKeepsTheFeedItsOwnBundleStates() throws {
+        let stated = "https://example.com/keka-shaped-appcast.xml"
+        let app = try Self.scan(
+            bundleID: "com.example.storecopy", declaringFeed: stated, storeReceipt: true)
+        #expect(app.isMASApp)
+        #expect(app.sparkleFeedURL?.absoluteString == stated)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
@@ -88,6 +88,13 @@ struct AppScannerStoreCopyTests {
             let store = try Self.scan(
                 bundleID: bundleID, declaringFeed: declared, storeReceipt: true)
             #expect(store.isMASApp, "\(bundleID): fixture stopped reading as a store copy")
+            // ⚠️ This pins today's answer, not a settled one. What the store copy
+            // is left with is an address we have OURSELVES recorded as dead, so a
+            // run where the store lookup misses reads a frozen feed and reports
+            // "up to date" rather than "Managed by the App Store". Honouring a
+            // declared feed is the Keka rule; honouring one we know is worthless
+            // is not obviously the same thing. Filed as #385 — if that is settled
+            // the other way, this expectation is the thing to change.
             #expect(store.sparkleFeedURL == entry.declared,
                     "\(bundleID): a store copy was redirected to a feed we chose for it")
         }

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -170,8 +170,9 @@ installed=7.0.9/843        box=on   → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg
   读的是下载包自己的 `LSMinimumSystemVersion`，而两个真包里这个值跟 feed 写的一致
   （7.0.9 → 15.0，7.1.0-beta.6 → 26.0）。差别是「先给按钮、装的时候拦」而不是
   「装了个跑不起来的」。
-- **`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`** 这条老问题还在（#368 的第二半），
-  只是 CotEditor 不再走那条路，所以对它不再有影响。
+- **`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`**（#368 的第二半）已修：
+  fill-in 和 superseded 两个入口都加了 `!isMAS`，bundle 自己声明的 `SUFeedURL` 不受影响
+  （Keka 是真实的商店副本自带 feed）。CotEditor 不走那条路，所以对它本来就没有影响。
 
 ## Changelog
 


### PR DESCRIPTION
Closes #368 — the second half, filed alongside the marketing-downgrade guard
that shipped in #375.

`AppScanner` filled `sparkleFeedURL` from `SparkleFeedCatalog` without looking
at `isMASApp`. Both halves of that table supply an address the **bundle never
stated**: `feeds` invents one outright, `supersededFeeds` redirects one we
decided was dead. Handing either to an App Store copy turns a store lookup that
merely *missed* into a one-click direct-install download — `MacAppStoreSource`
returns `nil` rather than throwing when the lookup finds nothing, and
`SourceStack` runs `SparkleAppcastSource` third, so falling through is the
ordinary path, not an error path. `HomebrewCaskSource`, `GitHubReleasesSource`
and `VendorProbeSource` each already carry `guard !app.isMASApp`.

**Wider than the issue said.** The issue named only the fill-in. Reading the
table showed the superseded entry is the same shape and bites harder: its one
entry is PDF Expert, which ships on the App Store as well as direct. Left alone,
a store copy on the dead address resolves a frozen 2022 feed and reads "up to
date"; redirected to the live one it would be offered a `.zip`.

**Deliberately not extended to the bundle's own `SUFeedURL`.** A store copy that
states a feed is speaking for itself, and one really does — Keka. `UpdateChecker`'s
"all sources exhausted" comment names it for exactly this reason.

**Exposure today is nil, not live**: Helium is not on the App Store, and a store
build of PDF Expert would additionally have to still name the dead address. This
is a guard, not a repair, and the commit says so.

**Tests** (`AppScannerStoreCopyTests`) are driven off the registry rather than a
written-down list, so the next catalog entry is covered on the day it lands. Each
case asserts `isMASApp` on the scanned row instead of assuming the fixture earned
it. Mutations, each red on exactly the named case:

| mutation | red |
|---|---|
| `if feedURL == nil, !isMAS` → `if feedURL == nil` | `aFilledInFeedGoesToDirectCopiesAndNotToStoreCopies` |
| drop `!isMAS,` from the `replacement` guard | `aSupersededFeedIsRedirectedForDirectCopiesOnly` |
| extend the guard to the `SUFeedURL` read | `aStoreCopyKeepsTheFeedItsOwnBundleStates` (+1) |

No CHANGELOG entry: no user can perceive a difference today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)