### PR TITLE
CLAUDE.md: the recipe sweep runs in your checkout and switches branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,17 +479,26 @@ vendor 换 DNS、改 manifest 结构、端点开始要 license,都发生过。�
 
 - 本仓库常有多个 worktree 同时开着(`.claude/worktrees/*`),而且 `main` 可能在你干活时已经前进。
   `git stash` / `merge` / `commit` 前先 `git status` + `git stash list`,确认没有另一个会话的在途改动。
-- ⚠️ **定时任务会在你的 checkout 里换分支,而且不换回来。** 夜间 baseline 和发版 appcast
-  那两条自动流程跑在这个工作副本上,不是在单独的 worktree 里。2026-09-06 实测:baseline
-  任务从我当时的**特性分支**拉了 `verify/baseline-<时间戳>`、提交、开 PR 并 `--auto` 上膛,
-  于是那个 PR 的 diff 里躺着我三个没复审的文件(#386),CI 一绿就会 squash 进 main ——
-  正是「每个 PR 合并前跑复审」那条闸的一个绕行口。同一次里它切走之后没切回来,我下一条
-  `git commit` 因此落在了它的分支上。
-  规矩:**跑完任何长命令、或隔了一段时间之后,`commit` / `push` 前先 `git branch --show-current`**,
-  别假设还在自己那条分支上(`git status` 不显示分支名的那个输出形态尤其骗人)。
-  撞上了先 `gh pr merge <n> --disable-auto` 止损 —— 这一步不需要 force-push、也不动
-  别人的分支;分支已经和 main 分叉的(比如你的 PR 已经单独 squash 合了),关掉让它重跑,
-  别去 rebase 另一个进程的分支。
+- ⚠️ **recipe 巡检任务跑在这个 checkout 里,一天四次,会换你的分支。**
+  `com.bobby.duo-recipe-verify`(launchd,`WorkingDirectory` 就是这个工作副本,
+  04:17 / 10:17 / 16:17 / 22:17,日志 `~/Library/Logs/duo-recipe-verify.log`)。
+  它**开头 `git checkout main`**,然后跑完整轮扫(几分钟),**最后才**
+  `git checkout -b verify/baseline-<时间戳>` —— 而那一步是从**当时的 HEAD** 切的,
+  不是从 main 切的,尽管脚本自己的注释写着"$BRANCH is left exactly where origin has it"。
+  于是有一个几分钟的窗口,两个方向都会出事,2026-09-06 一次跑里两个都出了:
+  1. 它开头切走 main,**不切回来** —— 我随后的 `git commit` 落在了它的分支上。
+  2. 我在窗口里切回自己的特性分支,它的 PR 就从**我的分支**切了出去 ——
+     #386 的 diff 里因此躺着我三个没复审的文件,而它开了 `--auto` squash,
+     CI 一绿就会进 main。**这是「每个 PR 合并前跑复审」那条闸的一个绕行口。**
+  规矩:**跑完任何长命令、或隔了一段时间之后,`commit` / `push` 前先
+  `git branch --show-current`**,别假设还在自己那条分支上。
+  撞上了先 `gh pr merge <n> --disable-auto` 止损 —— 这一步不需要 force-push、
+  也不动别人的分支;分支已经和 main 分叉的(比如你的 PR 已经单独 squash 合了),
+  关掉让它重跑,别去 rebase 另一个进程的分支。
+  ⚠️ 顺带把没量的那半边说清楚:**发版那条自动流程不在这里面**。
+  `publish-release.sh` 刻意把 appcast 放进一个临时 clone 改,理由写在它自己的注释里
+  ——"Committing the appcast into the working tree would mean the release touches
+  whatever branch happens to be checked out"。**同一个坑,那边防住了,这边没有。**
 - 找不到某个文件或命令时,先考虑"它在另一个 checkout 里还没提交",不要断言"它不存在"。
 - 解冲突就在冲突块里改,不要把内容追加到文件末尾。
 - 分组提交(引擎 / CLI / 测试 / 文档 / CHANGELOG),提交前先把分组方案给用户过目。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,17 @@ vendor 换 DNS、改 manifest 结构、端点开始要 license,都发生过。�
 
 - 本仓库常有多个 worktree 同时开着(`.claude/worktrees/*`),而且 `main` 可能在你干活时已经前进。
   `git stash` / `merge` / `commit` 前先 `git status` + `git stash list`,确认没有另一个会话的在途改动。
+- ⚠️ **定时任务会在你的 checkout 里换分支,而且不换回来。** 夜间 baseline 和发版 appcast
+  那两条自动流程跑在这个工作副本上,不是在单独的 worktree 里。2026-09-06 实测:baseline
+  任务从我当时的**特性分支**拉了 `verify/baseline-<时间戳>`、提交、开 PR 并 `--auto` 上膛,
+  于是那个 PR 的 diff 里躺着我三个没复审的文件(#386),CI 一绿就会 squash 进 main ——
+  正是「每个 PR 合并前跑复审」那条闸的一个绕行口。同一次里它切走之后没切回来,我下一条
+  `git commit` 因此落在了它的分支上。
+  规矩:**跑完任何长命令、或隔了一段时间之后,`commit` / `push` 前先 `git branch --show-current`**,
+  别假设还在自己那条分支上(`git status` 不显示分支名的那个输出形态尤其骗人)。
+  撞上了先 `gh pr merge <n> --disable-auto` 止损 —— 这一步不需要 force-push、也不动
+  别人的分支;分支已经和 main 分叉的(比如你的 PR 已经单独 squash 合了),关掉让它重跑,
+  别去 rebase 另一个进程的分支。
 - 找不到某个文件或命令时,先考虑"它在另一个 checkout 里还没提交",不要断言"它不存在"。
 - 解冲突就在冲突块里改,不要把内容追加到文件末尾。
 - 分组提交(引擎 / CLI / 测试 / 文档 / CHANGELOG),提交前先把分组方案给用户过目。

--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -42,7 +42,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
     },
@@ -50,7 +50,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -58,7 +58,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -66,7 +66,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -74,7 +74,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -82,7 +82,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
     },
@@ -90,7 +90,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
     },
@@ -98,7 +98,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
     },
@@ -114,7 +114,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -122,7 +122,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -130,7 +130,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -138,7 +138,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.84.0",
       "sweepsSinceComment" : 0
     },
@@ -146,15 +146,31 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.5.0",
+      "sweepsSinceComment" : 0
+    },
+    "changelog:com.coteditor.CotEditor:beta" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "7.1.0-beta.6",
+      "sweepsSinceComment" : 0
+    },
+    "changelog:com.coteditor.CotEditor:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
     "changelog:com.docker.docker:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
     },
@@ -162,7 +178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -170,7 +186,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -178,7 +194,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
     },
@@ -186,7 +202,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
     },
@@ -194,7 +210,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -202,7 +218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
     },
@@ -210,7 +226,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
     },
@@ -218,7 +234,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "152.0.7977.82",
       "sweepsSinceComment" : 0
     },
@@ -226,7 +242,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -234,7 +250,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -242,7 +258,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -250,7 +266,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
     },
@@ -258,7 +274,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -266,7 +282,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
     },
@@ -274,7 +290,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -282,7 +298,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -290,7 +306,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -298,7 +314,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.136",
       "sweepsSinceComment" : 0
     },
@@ -306,7 +322,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
     },
@@ -316,7 +332,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (26.727) trails t"
@@ -325,7 +341,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -333,7 +349,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -341,7 +357,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -349,7 +365,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "12.26.5",
       "sweepsSinceComment" : 0
     },
@@ -357,7 +373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.1.8",
       "sweepsSinceComment" : 0
     },
@@ -365,7 +381,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.28.0",
       "sweepsSinceComment" : 0
     },
@@ -373,7 +389,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
     },
@@ -381,7 +397,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
     },
@@ -389,7 +405,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.13.2",
       "sweepsSinceComment" : 0
     },
@@ -397,7 +413,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -405,7 +421,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
     },
@@ -413,7 +429,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -421,7 +437,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -431,7 +447,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "noEntriesExtracted"
@@ -440,7 +456,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -448,7 +464,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -456,7 +472,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -464,7 +480,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
     },
@@ -472,7 +488,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -480,7 +496,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
     },
@@ -488,7 +504,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.7.0-daily.20260904",
       "sweepsSinceComment" : 0
     },
@@ -496,7 +512,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -504,7 +520,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -514,7 +530,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (5.2.7) trails th"
@@ -523,7 +539,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -531,7 +547,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -539,7 +555,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
     },
@@ -547,7 +563,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -555,7 +571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -563,7 +579,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -571,7 +587,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -579,7 +595,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -587,7 +603,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -595,7 +611,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -603,7 +619,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.14.0",
       "sweepsSinceComment" : 0
     },
@@ -611,7 +627,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
     },
@@ -619,7 +635,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
@@ -627,7 +643,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
@@ -635,7 +651,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0
     },
@@ -643,7 +659,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
     },
@@ -651,7 +667,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
     },
@@ -659,7 +675,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
     },
@@ -675,7 +691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -683,7 +699,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -691,7 +707,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
     },
@@ -699,7 +715,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -707,7 +723,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
     },
@@ -715,7 +731,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
@@ -723,7 +739,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
     },
@@ -731,7 +747,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
@@ -739,15 +755,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.1.17",
+      "sweepsSinceComment" : 0
+    },
+    "changelog:uk.co.bzwrd.macperfmonitor:-" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "1.7.1",
       "sweepsSinceComment" : 0
     },
     "changelog:xyz.chatboxapp.app:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     },
@@ -755,7 +779,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -763,7 +787,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -771,7 +795,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -779,7 +803,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -787,7 +811,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -795,7 +819,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -803,7 +827,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -811,15 +835,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
-      "lastGoodVersion" : "0.3.8",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "0.3.9",
       "sweepsSinceComment" : 0
     },
     "github:MarkEdit-app\/MarkEdit:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -827,7 +851,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -835,7 +859,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -843,7 +867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.135.05934-insider",
       "sweepsSinceComment" : 0
     },
@@ -851,7 +875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.126.04524",
       "sweepsSinceComment" : 0
     },
@@ -859,7 +883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -867,7 +891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -875,7 +899,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.49.0",
       "sweepsSinceComment" : 0
     },
@@ -883,7 +907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -891,7 +915,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -899,7 +923,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -907,7 +931,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -915,7 +939,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -923,7 +947,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
     },
@@ -931,7 +955,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.0.5",
       "sweepsSinceComment" : 0
     },
@@ -939,7 +963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -947,7 +971,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -955,7 +979,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -963,7 +987,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -971,7 +995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -979,15 +1003,31 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.5.2",
+      "sweepsSinceComment" : 0
+    },
+    "github:coteditor\/CotEditor:beta" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "7.1.0-beta.6",
+      "sweepsSinceComment" : 0
+    },
+    "github:coteditor\/CotEditor:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
     "github:crystalidea\/macs-fan-control:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -995,7 +1035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1003,7 +1043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1011,7 +1051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1019,7 +1059,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1027,7 +1067,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
     },
@@ -1035,7 +1075,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1043,7 +1083,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1051,7 +1091,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1059,15 +1099,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
-      "lastGoodVersion" : "3.0.14",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
     "github:farion1231\/cc-switch:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.20.1",
       "sweepsSinceComment" : 0
     },
@@ -1075,7 +1115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1083,7 +1123,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1091,7 +1131,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1099,7 +1139,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1107,7 +1147,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.1.15",
       "sweepsSinceComment" : 0
     },
@@ -1115,7 +1155,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1123,7 +1163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1131,7 +1171,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1139,15 +1179,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
-      "lastGoodVersion" : "31.4.2",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "31.4.4",
       "sweepsSinceComment" : 0
     },
     "github:keepassxreboot\/keepassxc:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1155,7 +1195,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1163,7 +1203,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1171,7 +1211,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1179,7 +1219,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1187,7 +1227,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1195,7 +1235,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1203,7 +1243,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1211,7 +1251,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1219,7 +1259,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1227,7 +1267,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -1235,7 +1275,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1243,7 +1283,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1251,7 +1291,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1259,7 +1299,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -1267,7 +1307,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.22.2",
       "sweepsSinceComment" : 0
     },
@@ -1275,7 +1315,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.0.38",
       "sweepsSinceComment" : 0
     },
@@ -1283,15 +1323,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
-      "lastGoodVersion" : "0.0.39-nightly.20260906.1293",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "0.0.39-nightly.20260906.1303",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1299,7 +1339,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1307,7 +1347,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1315,7 +1355,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1323,7 +1363,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1331,7 +1371,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1339,7 +1379,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1347,7 +1387,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1355,7 +1395,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1363,7 +1403,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1371,7 +1411,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1379,7 +1419,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1387,7 +1427,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1395,7 +1435,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1403,7 +1443,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1411,7 +1451,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1419,7 +1459,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1427,7 +1467,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.3.2",
       "sweepsSinceComment" : 0
     },
@@ -1457,7 +1497,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1465,7 +1505,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1473,7 +1513,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1481,7 +1521,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -1489,7 +1529,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1497,7 +1537,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1505,7 +1545,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -1513,7 +1553,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "151.0.7922.247",
       "sweepsSinceComment" : 0
     },
@@ -1521,7 +1561,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1529,7 +1569,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1537,7 +1577,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1545,7 +1585,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1553,7 +1593,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -1561,7 +1601,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.1",
       "sweepsSinceComment" : 0
     },
@@ -1569,7 +1609,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
     },
@@ -1577,7 +1617,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1585,7 +1625,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.43.0",
       "sweepsSinceComment" : 0
     },
@@ -1593,7 +1633,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1601,7 +1641,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1609,7 +1649,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1617,7 +1657,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1625,7 +1665,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1633,7 +1673,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1641,7 +1681,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1649,7 +1689,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.95.96.0",
       "sweepsSinceComment" : 0
     },
@@ -1657,7 +1697,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.97.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1665,7 +1705,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -1673,7 +1713,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.124.1",
       "sweepsSinceComment" : 0
     },
@@ -1681,7 +1721,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.84.2",
       "sweepsSinceComment" : 0
     },
@@ -1689,7 +1729,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1697,7 +1737,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
     },
@@ -1705,7 +1745,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -1713,7 +1753,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.6.774",
       "sweepsSinceComment" : 0
     },
@@ -1721,7 +1761,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.8.20",
       "sweepsSinceComment" : 0
     },
@@ -1729,7 +1769,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -1737,7 +1777,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "126.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1745,7 +1785,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -1753,7 +1793,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "154.0.8037.0",
       "sweepsSinceComment" : 0
     },
@@ -1761,7 +1801,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "155.0.8043.0",
       "sweepsSinceComment" : 0
     },
@@ -1769,7 +1809,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -1777,7 +1817,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "152.0.7977.83",
       "sweepsSinceComment" : 0
     },
@@ -1785,7 +1825,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.107.3.828",
       "sweepsSinceComment" : 0
     },
@@ -1793,7 +1833,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -1801,7 +1841,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -1809,7 +1849,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -1817,7 +1857,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -1825,7 +1865,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -1833,7 +1873,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "7.529.3",
       "sweepsSinceComment" : 0
     },
@@ -1841,7 +1881,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1849,7 +1889,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.0.410",
       "sweepsSinceComment" : 0
     },
@@ -1857,7 +1897,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.0.1311",
       "sweepsSinceComment" : 0
     },
@@ -1865,7 +1905,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -1873,7 +1913,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -1881,7 +1921,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1889,7 +1929,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -1897,7 +1937,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -1914,7 +1954,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "9.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1922,7 +1962,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.19.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -1930,7 +1970,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1938,7 +1978,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -1946,7 +1986,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1954,7 +1994,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -1962,7 +2002,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -1970,7 +2010,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -1978,7 +2018,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.136.1",
       "sweepsSinceComment" : 0
     },
@@ -1986,7 +2026,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.137.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -1994,7 +2034,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2002,7 +2042,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "153.0.4234.19",
       "sweepsSinceComment" : 0
     },
@@ -2010,7 +2050,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "154.0.4251.0",
       "sweepsSinceComment" : 0
     },
@@ -2018,7 +2058,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -2026,7 +2066,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2034,7 +2074,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2042,7 +2082,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2050,7 +2090,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2058,7 +2098,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2066,7 +2106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2074,7 +2114,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.901.51231",
       "sweepsSinceComment" : 0
     },
@@ -2082,7 +2122,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -2090,7 +2130,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2098,7 +2138,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2106,7 +2146,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "12.26.5",
       "sweepsSinceComment" : 0
     },
@@ -2114,7 +2154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.1.8",
       "sweepsSinceComment" : 0
     },
@@ -2122,7 +2162,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.28.0",
       "sweepsSinceComment" : 0
     },
@@ -2130,7 +2170,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.104.28",
       "sweepsSinceComment" : 0
     },
@@ -2138,7 +2178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2146,7 +2186,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2154,7 +2194,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2162,7 +2202,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2170,7 +2210,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.2.98.301",
       "sweepsSinceComment" : 0
     },
@@ -2178,7 +2218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2186,7 +2226,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2194,7 +2234,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2202,7 +2242,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2210,7 +2250,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "7.2.5",
       "sweepsSinceComment" : 0
     },
@@ -2218,7 +2258,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2228,7 +2268,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2237,7 +2277,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0
     },
@@ -2245,7 +2285,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2253,7 +2293,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -2261,7 +2301,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2269,7 +2309,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2277,7 +2317,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2285,7 +2325,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2293,7 +2333,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2301,7 +2341,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.19.13",
       "sweepsSinceComment" : 0
     },
@@ -2309,7 +2349,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.21.1",
       "sweepsSinceComment" : 0
     },
@@ -2317,7 +2357,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "8.2.4133.43",
       "sweepsSinceComment" : 0
     },
@@ -2325,7 +2365,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2333,7 +2373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2341,7 +2381,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2349,7 +2389,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2357,7 +2397,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2365,7 +2405,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2373,7 +2413,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2381,7 +2421,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2389,7 +2429,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2397,7 +2437,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2405,15 +2445,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
-      "lastGoodVersion" : "0.2026.09.05.08.23.00",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
+      "lastGoodVersion" : "0.2026.09.06.08.23.00",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.warp.Warp-Preview:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2421,7 +2461,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2429,7 +2469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2437,7 +2477,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2026090401",
       "sweepsSinceComment" : 0
     },
@@ -2445,7 +2485,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2453,7 +2493,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2461,7 +2501,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2469,7 +2509,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2477,7 +2517,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.103.176",
       "sweepsSinceComment" : 0
     },
@@ -2485,7 +2525,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2493,7 +2533,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2501,7 +2541,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2509,7 +2549,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2517,7 +2557,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.35.23",
       "sweepsSinceComment" : 0
     },
@@ -2525,7 +2565,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "7.32.1",
       "sweepsSinceComment" : 0
     },
@@ -2533,7 +2573,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2541,7 +2581,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2549,7 +2589,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2557,7 +2597,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2565,23 +2605,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
+      "infraSince" : "2026-09-06T14:23:52Z",
       "lastGoodAt" : "2026-09-06T08:23:36Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 0
+      "sweepsSinceComment" : 1
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2589,7 +2630,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2597,7 +2638,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2605,7 +2646,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2613,7 +2654,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2621,7 +2662,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2629,7 +2670,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2637,7 +2678,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2645,7 +2686,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -2653,7 +2694,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "156.0b2",
       "sweepsSinceComment" : 0
     },
@@ -2661,7 +2702,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -2669,7 +2710,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "15.0.21",
       "sweepsSinceComment" : 0
     },
@@ -2677,7 +2718,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -2685,7 +2726,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -2693,7 +2734,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "8.26.0",
       "sweepsSinceComment" : 0
     },
@@ -2703,7 +2744,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "10.0.1",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2712,7 +2753,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -2720,11 +2761,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-06T14:23:52Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-06T08:23:37Z"
+  "updatedAt" : "2026-09-06T14:23:52Z"
 }


### PR DESCRIPTION
Documentation only.

Measured today, and it very nearly cost something.

`com.bobby.duo-recipe-verify` (launchd, `WorkingDirectory` = this working copy,
04:17 / 10:17 / 16:17 / 22:17) checks out `main` first thing, then runs the full
sweep — minutes — and only at the end does `git checkout -b
verify/baseline-<ts>`. That last step branches from **whatever HEAD has become**,
not from main, despite the script's own comment promising "$BRANCH is left
exactly where origin has it".

Both directions of that window bit in a single run:

1. It switched me off my branch at the start and never switched back, so my next
   `git commit` landed on its branch.
2. I switched back inside the window, so its PR (#386) was cut from **my**
   branch and carried three files belonging to an unmerged, unreviewed PR — with
   `--auto` squash armed. **That is a way around the "every PR gets a
   `/code-review`" gate this file adds one section above**, and nothing here
   warned about it.

Recorded, with the agent's label, schedule and log path so the next person can
find it rather than hunting for "a nightly job":

- The check that catches it: `git branch --show-current` before committing after
  any long-running command. `git status` is not a substitute — the form of its
  output that omits the branch line is exactly the misleading one.
- Containment needs no force-push: `gh pr merge <n> --disable-auto` touches
  neither the branch nor anyone else's process. Once your own PR has been
  squash-merged separately the branch has diverged for good — close it and let
  the job re-run, rather than rebasing another process's branch.
- **And the half I first got wrong**: the release flow is *not* exposed to this.
  `publish-release.sh` prepares the appcast in a throwaway clone on purpose, and
  its comment gives this exact reason — "Committing the appcast into the working
  tree would mean the release touches whatever branch happens to be checked out."
  Same trap, defended there and not here. My first draft asserted both flows ran
  in the tree; the second commit is the correction, and the contrast is the more
  useful fact anyway.

**There is also a one-line fix outside this repo**, which I have not made because
the script is the user's (`~/.local/bin/duo-recipe-verify.sh`, line ~340):

```sh
git checkout -b "$pr_branch" "origin/$BRANCH"   # instead of: git checkout -b "$pr_branch"
```

That pins the PR branch to `origin/main` whatever HEAD has drifted to, which is
what the surrounding comment already says the job intends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)