### PR TITLE
A store copy is answered by the store, or by nobody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **CotEditor is now covered, on both its release and its beta line.** Which line a copy follows comes from the version it is running and from CotEditor's own "Update to prereleases when available" setting, so a beta copy is offered the next beta instead of a release that would take it backwards.
 
-**An app you installed from the App Store is never offered a download from anywhere else.** If the store's own lookup for it fails or comes back empty, the row now simply says the store is managing it. Before, the check could fall through to the app's other distribution — a different build with its own version numbers — and offer to install it over your store copy.
+**An app you installed from the App Store is never offered a download from anywhere else.** When the store's own lookup for it fails or comes back empty, the row now says the store is managing it, without a version number. Before, the check could fall through to the app's other distribution — a different build with its own version numbers — and offer to install that over your store copy.
 
 **A long error on a row no longer pushes the rest of the list down.** It is kept to two lines, with the full text on hover.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **CotEditor is now covered, on both its release and its beta line.** Which line a copy follows comes from the version it is running and from CotEditor's own "Update to prereleases when available" setting, so a beta copy is offered the next beta instead of a release that would take it backwards.
 
+**An app you installed from the App Store is never offered a download from anywhere else.** If the store's own lookup for it fails or comes back empty, the row now simply says the store is managing it. Before, the check could fall through to the app's other distribution — a different build with its own version numbers — and offer to install it over your store copy.
+
 **A long error on a row no longer pushes the rest of the list down.** It is kept to two lines, with the full text on hover.
 
 ## 0.3.86

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -212,6 +212,22 @@ public struct UpdateChecker: Sendable {
         var lastError: String?
 
         for source in sources {
+            // A store copy is answered by the store, or by nobody.
+            //
+            // Not by source ordering: `MacAppStoreSource` is first, but this loop
+            // falls through on a THROWN error as well as on a miss, and the store
+            // lookup misses often enough (region-locked storefront, a 404) that the
+            // fall-through is ordinary. That is how a store WhatsApp was offered the
+            // direct 26.33.19 dmg over its own 26.32.75.
+            //
+            // `answersAppStoreCopies` defaults to false, so this covers sources
+            // nobody has thought about yet — including the four that had no guard
+            // when this landed (Sparkle, Xcode, Electron, Alcove). See its doc
+            // comment for why the default carries the weight.
+            if app.isMASApp, !source.answersAppStoreCopies {
+                Log.check.debug("\(label, privacy: .public): \(source.name, privacy: .public) skipped, the store owns this copy")
+                continue
+            }
             do {
                 guard let remote = try await source.latestVersion(for: app) else {
                     Log.check.debug("\(label, privacy: .public): \(source.name, privacy: .public) miss")
@@ -242,15 +258,21 @@ public struct UpdateChecker: Sendable {
         // Deliberately NOT extended to `.appStoreManaged`/`.testFlightManaged`.
         //
         // A MAS row that reaches `.error` was answered by nobody and failed
-        // somewhere real: three sources can run for a store copy — the store lookup
-        // itself, `XcodeReleasesSource` (bundle-id gate only, and Xcode ships on the
-        // store), and `SparkleAppcastSource` (feed-url gate only; Keka is a store
-        // copy carrying a `SUFeedURL`). Only Homebrew, GitHub and the vendor probe
-        // carry `guard !app.isMASApp`. None of those three is a *borrowed* read the
-        // way Toolbox's is — each one IS this row's update check — so a failure
-        // there has to read as a failed check. Painting it "Managed by the App
-        // Store" would show the user the same row they get when the store is
-        // quietly keeping the app current.
+        // somewhere real: the gate at the top of the loop means the only source
+        // that ran for it was `MacAppStoreSource` — the lookup for the app the
+        // store DOES own. That is not a *borrowed* read the way Toolbox's is; it
+        // IS this row's update check, so a failure has to read as a failed check.
+        // Painting it "Managed by the App Store" would show the user the same row
+        // they get when the store is quietly keeping the app current.
+        //
+        // This used to be an inventory of which sources happened to carry
+        // `guard !app.isMASApp`, kept accurate by hand and re-checked whenever a
+        // source was added. It was wrong twice: once by naming one source when
+        // three could run, and then, in the commit that fixed that, by citing
+        // Keka as a store copy carrying a `SUFeedURL` — Keka is Developer
+        // ID-signed with no `_MASReceipt`, so `isMASApp` was false for it under
+        // the very same derivation both then and now. The gate makes the claim
+        // true by construction instead.
         //
         // TestFlight returns before the loop and never gets here at all.
         if let lastError, !app.isToolboxManaged {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -62,7 +62,7 @@ public struct UpdateChecker: Sendable {
         // day memoizes during `prewarm` doesn't refill what was just dropped —
         // and whoever adds one owes this a test.
         if freshening {
-            for source in sources { await source.invalidateMemo(for: apps) }
+            for source in sources { await source.invalidateMemo(for: Self.apps(apps, visibleTo: source)) }
         }
         // Give every source a chance to do its cheaper-in-bulk work — e.g.
         // MacAppStoreSource batching iTunes lookups — before the per-app
@@ -75,7 +75,8 @@ public struct UpdateChecker: Sendable {
         // finished — not merely been scheduled — before the fan-out begins.
         await withTaskGroup(of: Void.self) { group in
             for source in sources {
-                group.addTask { await source.prewarm(apps) }
+                let visible = Self.apps(apps, visibleTo: source)
+                group.addTask { await source.prewarm(visible) }
             }
             for await _ in group {}
         }
@@ -125,6 +126,22 @@ public struct UpdateChecker: Sendable {
         await channelStore?.flush()
 
         return results.compactMap { $0 }
+    }
+
+    /// The rows a source is allowed to act on: the whole list, minus store
+    /// copies for every source that declines them.
+    ///
+    /// The gate in `runSources` covers `latestVersion`, which is the path that
+    /// can offer a user the wrong package. These two bulk hooks are the other
+    /// way a source touches a row, and leaving them ungated would have left the
+    /// property's promise — that a declining source does not act for a store
+    /// copy — true of one path and false of the other. Nothing implements
+    /// `prewarm` or `invalidateMemo` today except `MacAppStoreSource`, which
+    /// answers store copies and so sees the list unchanged; this is here so the
+    /// second one to implement either does not have to remember.
+    private static func apps(_ apps: [InstalledApp], visibleTo source: any UpdateSource)
+        -> [InstalledApp] {
+        source.answersAppStoreCopies ? apps : apps.filter { !$0.isMASApp }
     }
 
     /// Check one app across all sources in priority order, then label the result
@@ -223,18 +240,15 @@ public struct UpdateChecker: Sendable {
         }
 
         for source in sources {
-            // A store copy is answered by the store, or by nobody.
+            // A store copy is answered by the store, or by nobody. Source ordering
+            // is not enough on its own: this loop falls through on a THROWN error
+            // as well as on a miss.
             //
-            // Not by source ordering: `MacAppStoreSource` is first, but this loop
-            // falls through on a THROWN error as well as on a miss, and the store
-            // lookup misses often enough (region-locked storefront, a 404) that the
-            // fall-through is ordinary. That is how a store WhatsApp was offered the
-            // direct 26.33.19 dmg over its own 26.32.75.
-            //
-            // `answersAppStoreCopies` defaults to false, so this covers sources
-            // nobody has thought about yet — including the four that had no guard
-            // when this landed (Sparkle, Xcode, Electron, Alcove). See its doc
-            // comment for why the default carries the weight.
+            // The evidence, the retraction that goes with it, and why the default
+            // is false live in ONE place — `UpdateSource.answersAppStoreCopies`.
+            // Deliberately not restated here: the first version of this comment
+            // did restate it, and the two halves immediately disagreed, which is
+            // the failure this whole change is about.
             if app.isMASApp, !source.answersAppStoreCopies { continue }
             do {
                 guard let remote = try await source.latestVersion(for: app) else {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -211,6 +211,17 @@ public struct UpdateChecker: Sendable {
 
         var lastError: String?
 
+        // One line for the row, not one per silenced source. `VendorProbeSource`
+        // learned this: a per-source line for sources that were never going to
+        // touch the row "reads as if a recipe had been declined", and here it
+        // would be every store app times every declining source, every round.
+        if app.isMASApp {
+            let silenced = sources.filter { !$0.answersAppStoreCopies }.count
+            if silenced > 0 {
+                Log.check.debug("\(label, privacy: .public): \(silenced, privacy: .public) non-store sources silenced, the store owns this copy")
+            }
+        }
+
         for source in sources {
             // A store copy is answered by the store, or by nobody.
             //
@@ -224,10 +235,7 @@ public struct UpdateChecker: Sendable {
             // nobody has thought about yet — including the four that had no guard
             // when this landed (Sparkle, Xcode, Electron, Alcove). See its doc
             // comment for why the default carries the weight.
-            if app.isMASApp, !source.answersAppStoreCopies {
-                Log.check.debug("\(label, privacy: .public): \(source.name, privacy: .public) skipped, the store owns this copy")
-                continue
-            }
+            if app.isMASApp, !source.answersAppStoreCopies { continue }
             do {
                 guard let remote = try await source.latestVersion(for: app) else {
                     Log.check.debug("\(label, privacy: .public): \(source.name, privacy: .public) miss")
@@ -265,14 +273,18 @@ public struct UpdateChecker: Sendable {
         // Painting it "Managed by the App Store" would show the user the same row
         // they get when the store is quietly keeping the app current.
         //
-        // This used to be an inventory of which sources happened to carry
+        // True by construction of the gate PLUS the registry: it stops holding the
+        // moment a second source declares `answersAppStoreCopies`.
+        // `SourceStorePolicyTests.exactlyOneSourceAnswersStoreCopies` is what makes
+        // that loud, and is the thing to read before changing this paragraph.
+        //
+        // It used to be an inventory of which sources happened to carry
         // `guard !app.isMASApp`, kept accurate by hand and re-checked whenever a
         // source was added. It was wrong twice: once by naming one source when
         // three could run, and then, in the commit that fixed that, by citing
         // Keka as a store copy carrying a `SUFeedURL` — Keka is Developer
         // ID-signed with no `_MASReceipt`, so `isMASApp` was false for it under
-        // the very same derivation both then and now. The gate makes the claim
-        // true by construction instead.
+        // the very same derivation both then and now.
         //
         // TestFlight returns before the loop and never gets here at all.
         if let lastError, !app.isToolboxManaged {
@@ -295,7 +307,10 @@ public struct UpdateChecker: Sendable {
         } else {
             status = .unknown
         }
-        Log.check.info("\(label, privacy: .public): no source applied → \(String(describing: status), privacy: .public)")
+        // "nothing applied" for an ordinary row; for a store row the non-store
+        // sources were not inapplicable, they were forbidden — the line above says
+        // how many.
+        Log.check.info("\(label, privacy: .public): no source answered → \(String(describing: status), privacy: .public)")
         return UpdateResult(app: app, remote: nil, status: status)
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -472,17 +472,21 @@ public struct AppScanner: Sendable {
         // still inferred from the feed's own items. See the type's doc comment.
         //
         // Not for a store copy. Both of the addresses below are OURS, not the
-        // bundle's, and handing one to a copy the App Store owns turns a store
-        // lookup that merely missed into a one-click direct-install download —
-        // `MacAppStoreSource` returns nil rather than throwing when the lookup
-        // finds nothing, and `SourceStack` runs `SparkleAppcastSource` third, so
-        // the fall-through is the normal path, not an error path. Homebrew, GitHub
-        // and the vendor probe each carry the same `guard !app.isMASApp`.
+        // bundle's, and inventing one for a copy the App Store owns is not the
+        // scanner's business.
         //
-        // Deliberately NOT extended to the bundle's own `SUFeedURL` read above: a
-        // store copy that states a feed is speaking for itself and is honoured, as
-        // it is today — Keka is a store copy carrying one, and `UpdateChecker`'s
-        // "all sources exhausted" comment names it for the same reason.
+        // Belt and braces since `UpdateChecker` gained its store gate: a store
+        // copy no longer reaches `SparkleAppcastSource` at all, so the address
+        // would be inert anyway. Kept because these two lines are about what the
+        // scanner is entitled to WRITE DOWN, which is a separate question from
+        // which source is entitled to answer.
+        //
+        // Deliberately NOT extended to the bundle's own `SUFeedURL` read above.
+        // That read records what the bundle says — a fact, not a decision — and
+        // the decision now lives in one place, the gate. (The earlier version of
+        // this comment justified the split with "Keka is a store copy carrying
+        // one". It is not: Developer ID-signed, no `_MASReceipt`. Verified before
+        // repeating it would have taken one `ls`.)
         if feedURL == nil, !isMAS { feedURL = SparkleFeedCatalog.feed(forBundleID: bundleID) }
         // The narrower gap: the bundle DOES name a feed, and the vendor stopped
         // publishing to it. Matched on the dead address itself, not on the bundle

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -7,6 +7,12 @@ import Foundation
 public struct MacAppStoreSource: UpdateSource {
     public let name = "App Store"
 
+    /// The one source that may. It IS the store's own lookup, so answering a
+    /// store copy is the whole job rather than a cross-distribution offer — and
+    /// `latestVersion(for:)` below already declines everything that is NOT a
+    /// store copy, so the two halves meet exactly.
+    public let answersAppStoreCopies = true
+
     private let session: URLSession
     /// The signed-in account's storefront region — what the App Store will
     /// actually let the user install.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
@@ -18,14 +18,18 @@ public protocol UpdateSource: Sendable {
     /// `UpdateChecker` skips every source that says no when the row is
     /// `isMASApp`, so a store copy is answered by the store or by nobody. The
     /// alternative — relying on `MacAppStoreSource` being first in
-    /// `SourceStack` — does not hold: the checker falls through on a THROWN
-    /// error as well as on a miss, and the store lookup misses often enough
-    /// (region-locked storefront, a lookup that 404s) that the fall-through is
-    /// an ordinary state. Measured on a real row: WhatsApp offered 26.32.75 →
-    /// 26.33.19, the store build against the direct download from
+    /// `SourceStack` — does not hold, because the checker falls through on a
+    /// THROWN error as well as on a miss, and the store lookup does both (a
+    /// region-locked storefront, a lookup that 404s).
+    ///
+    /// Not hypothetical: 94a1842 (2026-08-23) recorded WhatsApp offering
+    /// 26.32.75 → 26.33.19, the store build against the direct download from
     /// web.whatsapp.com, whose recipe carries a dmg install spec — so Update
     /// would have replaced the store copy, `_MASReceipt`, sandbox entitlements
-    /// and the store's own update path with it.
+    /// and the store's own update path with it. ⚠️ That row is gone: this
+    /// machine's WhatsApp is now the Developer ID build, so nothing here can
+    /// reproduce it end to end. The case is cited from that commit, not
+    /// re-measured.
     ///
     /// **The default is the safe answer, deliberately.** Three sources learned
     /// this one at a time (Homebrew at the start, GitHub 2026-08-20 via

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
@@ -12,6 +12,29 @@ public protocol UpdateSource: Sendable {
     /// than silently treating it as "not applicable".
     func latestVersion(for app: InstalledApp) async throws -> RemoteVersion?
 
+    /// Whether this source may answer for a copy installed from the Mac App
+    /// Store. Almost always no, which is why the default is false.
+    ///
+    /// `UpdateChecker` skips every source that says no when the row is
+    /// `isMASApp`, so a store copy is answered by the store or by nobody. The
+    /// alternative — relying on `MacAppStoreSource` being first in
+    /// `SourceStack` — does not hold: the checker falls through on a THROWN
+    /// error as well as on a miss, and the store lookup misses often enough
+    /// (region-locked storefront, a lookup that 404s) that the fall-through is
+    /// an ordinary state. Measured on a real row: WhatsApp offered 26.32.75 →
+    /// 26.33.19, the store build against the direct download from
+    /// web.whatsapp.com, whose recipe carries a dmg install spec — so Update
+    /// would have replaced the store copy, `_MASReceipt`, sandbox entitlements
+    /// and the store's own update path with it.
+    ///
+    /// **The default is the safe answer, deliberately.** Three sources learned
+    /// this one at a time (Homebrew at the start, GitHub 2026-08-20 via
+    /// LocalSend, the vendor probe 2026-08-23 via WhatsApp) and four were never
+    /// revisited, because each fix went where the bite was. A property that has
+    /// to be opted OUT of cannot be missed the same way — the same reason
+    /// `RowActions.live` gives its callers no defaults.
+    var answersAppStoreCopies: Bool { get }
+
     /// Optional hook: given the full app list for a scan, do whatever
     /// cheaper-in-bulk work would help `latestVersion(for:)` avoid a request it
     /// would otherwise make per app. `UpdateChecker.check(_ apps:)` calls this
@@ -47,6 +70,7 @@ public protocol UpdateSource: Sendable {
 }
 
 public extension UpdateSource {
+    var answersAppStoreCopies: Bool { false }
     func prewarm(_ apps: [InstalledApp]) async {}
     func invalidateMemo(for apps: [InstalledApp]) async {}
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
@@ -39,7 +39,9 @@ public protocol UpdateSource: Sendable {
     /// `RowActions.live` gives its callers no defaults.
     var answersAppStoreCopies: Bool { get }
 
-    /// Optional hook: given the full app list for a scan, do whatever
+    /// Optional hook: given the apps from a scan that this source is allowed to
+    /// act on — the whole list, minus store copies unless
+    /// `answersAppStoreCopies` — do whatever
     /// cheaper-in-bulk work would help `latestVersion(for:)` avoid a request it
     /// would otherwise make per app. `UpdateChecker.check(_ apps:)` calls this
     /// once, for every source, before its per-app fan-out starts — the only
@@ -50,7 +52,10 @@ public protocol UpdateSource: Sendable {
 
     /// Optional hook: drop any memoized answer this source is holding for
     /// exactly `apps`, so the next `latestVersion(for:)` call for each of them
-    /// hits the network instead of a stale cache. `UpdateChecker.check(_:freshening:)`
+    /// hits the network instead of a stale cache. Same narrowing as `prewarm`:
+    /// `apps` is what this source may act on, not everything being checked — a
+    /// source that declines store copies is never asked to invalidate one,
+    /// because it will never be asked to answer one either. `UpdateChecker.check(_:freshening:)`
     /// calls this, for every source, before the per-app fan-out — and,
     /// defensively, before `prewarm`; see that call site for why no source
     /// today makes that ordering observable. Default

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
@@ -7,11 +7,18 @@ import Foundation
 ///
 /// Both of that table's halves supply an address the BUNDLE never stated — the
 /// fill-in invents one outright, the superseded entry redirects one we decided
-/// was dead. For a store copy that turns a store lookup which merely missed
-/// (`MacAppStoreSource` returns nil rather than throwing, and `SourceStack` runs
-/// `SparkleAppcastSource` third) into a one-click direct-install download beside
-/// an app the store owns. `HomebrewCaskSource`, `GitHubReleasesSource` and
-/// `VendorProbeSource` all carry the same `guard !app.isMASApp`.
+/// was dead. Inventing an address for a copy the store owns is not the scanner's
+/// business whatever happens downstream.
+///
+/// ⚠️ Downstream has since changed, and this file's original framing was wrong
+/// twice over. It said `MacAppStoreSource` "returns nil rather than throwing" —
+/// it does both, and the throw is the case that mattered, because
+/// `UpdateChecker` falls through on a thrown error too. And it said a store copy
+/// reaching `SparkleAppcastSource` was the harm to prevent; that source now
+/// declines store copies along with every other non-store source, via
+/// `UpdateChecker`'s gate (see `SourceStorePolicyTests`). So these two lines are
+/// belt and braces now: what they still decide is what the scanner is entitled
+/// to WRITE DOWN, which is a different question from who may answer.
 ///
 /// Driven off the registry, not off a written-down list of bundle ids: a new
 /// catalog entry is covered the day it lands. Every case names the mutation it
@@ -88,23 +95,28 @@ struct AppScannerStoreCopyTests {
             let store = try Self.scan(
                 bundleID: bundleID, declaringFeed: declared, storeReceipt: true)
             #expect(store.isMASApp, "\(bundleID): fixture stopped reading as a store copy")
-            // ⚠️ This pins today's answer, not a settled one. What the store copy
-            // is left with is an address we have OURSELVES recorded as dead, so a
-            // run where the store lookup misses reads a frozen feed and reports
-            // "up to date" rather than "Managed by the App Store". Honouring a
-            // declared feed is the Keka rule; honouring one we know is worthless
-            // is not obviously the same thing. Filed as #385 — if that is settled
-            // the other way, this expectation is the thing to change.
+            // The store copy keeps the dead address it declared. That used to
+            // matter — it meant a frozen 2022 feed could answer and report "up to
+            // date" — and it was filed as #385 for that reason. The store gate
+            // closed it: no store copy reaches `SparkleAppcastSource` at all, so
+            // the recorded address has no consumer. Kept as an assertion because
+            // it still pins WHICH address the scanner writes down, and a redirect
+            // appearing here would be the scanner making a choice it should not.
             #expect(store.sparkleFeedURL == entry.declared,
                     "\(bundleID): a store copy was redirected to a feed we chose for it")
         }
     }
 
-    /// The other side of the same decision, and the one that keeps this from
-    /// being "store copies never get a Sparkle feed": an address the BUNDLE
-    /// states is the app speaking for itself and is honoured whoever installed
-    /// it. Keka is a real store copy carrying `SUFeedURL`; `UpdateChecker`'s
-    /// "all sources exhausted" comment names it for the same reason.
+    /// The other side of the same decision: the `SUFeedURL` read records what the
+    /// bundle SAYS, which is a fact, not a decision, and the scanner does not
+    /// edit it by install kind.
+    ///
+    /// ⚠️ Do not read this as "a store copy's own feed is honoured" — it is not,
+    /// not any more. `UpdateChecker`'s gate declines every non-store source for a
+    /// store row, so the address recorded here has no consumer. The earlier
+    /// version of this comment justified the split with "Keka is a real store
+    /// copy carrying `SUFeedURL`", which was never true: Developer ID-signed, no
+    /// `_MASReceipt`.
     ///
     /// Mutation: extend the guard to the `SUFeedURL` read and this goes nil.
     @Test func aStoreCopyKeepsTheFeedItsOwnBundleStates() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
@@ -918,7 +918,7 @@ struct MacAppStorePageCacheTests {
 
         #expect(await recorder.wasCalled, "invalidateMemo(for:) must be dispatched to the concrete implementation, not the protocol's empty default")
         #expect(await recorder.calledWithBundleIDs == ["com.example.dispatch.witness"],
-                "invalidateMemo(for:) must receive exactly the array being checked")
+                "invalidateMemo(for:) must receive the rows this source may act on")
     }
 
     /// A minimal `UpdateSource` whose only job is to record whether — and
@@ -927,6 +927,12 @@ struct MacAppStorePageCacheTests {
     /// needing any network stub.
     private actor RecordingSource: UpdateSource {
         let name = "Recording"
+        /// It stands in for `MacAppStoreSource`, so it answers store copies like
+        /// the real one. Load-bearing since the bulk hooks started receiving only
+        /// the rows a source may act on: at the default (false) the witness app —
+        /// which is `isMASApp` — would be filtered out and this case would be
+        /// measuring that filter instead of dynamic dispatch.
+        nonisolated let answersAppStoreCopies = true
         private(set) var wasCalled = false
         private(set) var calledWithBundleIDs: [String] = []
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
@@ -32,10 +32,14 @@ struct SourceStorePolicyTests {
         "MacAppStoreSource": (true,
             "it IS the store's lookup — the one place answering a store copy is the job"),
         "XcodeReleasesSource": (false,
-            "gates on bundle id only, and Xcode ships on the store. Detection-only today "
-            + "(downloadURL nil), so the harm would be a version readout rather than a bad "
-            + "install — but 'detection-only' is a property that can change, and the point of "
-            + "this gate is to stop reasoning per source"),
+            "gates on bundle id only, and Xcode ships on the store. THE ONE SKIP THAT COSTS "
+            + "SOMETHING: it cannot install a store Xcode over itself even in principle — its "
+            + "downloadURL is nil because the endpoint 302s to developer.apple.com/unauthorized/ "
+            + "without an Apple ID session, and its pageURL sends the user to the store — so what "
+            + "the gate removes is a version readout and release notes when the iTunes lookup is "
+            + "flaky, not a bad install. Skipped anyway, because the alternative is keeping a "
+            + "per-source exemption whose justification lives in prose, which is exactly the "
+            + "arrangement that produced the Keka sentence"),
         "SparkleAppcastSource": (false,
             "gates on the feed URL only, so any store copy declaring SUFeedURL reached it"),
         "HomebrewCaskSource": (false,
@@ -74,16 +78,30 @@ struct SourceStorePolicyTests {
 
     /// The registration is a claim about the type; this is what makes it one.
     ///
-    /// Mutation: flip any `answersAppStoreCopies`, or any `answers:` in the
-    /// table, and this names the source.
+    /// Mutation: flip `MacAppStoreSource.answersAppStoreCopies`, or the protocol
+    /// extension's default, or any `answers:` in the table.
+    ///
+    /// ⚠️ Only two of those are independent. The seven declining sources declare
+    /// nothing of their own — they read the extension default — so there is one
+    /// mutation for all seven, not seven. That IS the design (the default is what
+    /// covers a source nobody has thought about), but do not read this case as
+    /// seven separate pins.
     @Test func theRegisteredPolicyIsWhatTheTypeDeclares() {
-        for source in Self.fullStack() {
+        let stack = Self.fullStack()
+        var matched = 0
+        for source in stack {
             let type = String(describing: Swift.type(of: source))
             guard let entry = Self.policy[type] else { continue }  // the case above owns this
+            matched += 1
             #expect(source.answersAppStoreCopies == entry.answers,
                     "\(type) declares \(source.answersAppStoreCopies), registered as \(entry.answers)")
             #expect(!entry.reason.isEmpty)
         }
+        // Without this the whole case passes having asserted NOTHING, should
+        // `String(describing:)` ever start module-qualifying and miss every key.
+        // Its two siblings would still catch that, but a case that can run empty
+        // is not one you want to be relying on them for.
+        #expect(matched == stack.count)
     }
 
     /// Exactly one source is allowed to answer, and it is the store's.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
@@ -121,7 +121,11 @@ struct SourceStorePolicyTests {
     /// rather than inferred from the verdict.
     private actor Ledger {
         private(set) var asked = false
+        private(set) var prewarmed: [String]?
+        private(set) var invalidated: [String]?
         func mark() { asked = true }
+        func record(prewarmed apps: [InstalledApp]) { prewarmed = apps.map(\.name) }
+        func record(invalidated apps: [InstalledApp]) { invalidated = apps.map(\.name) }
     }
 
     private final class Spy: UpdateSource, Sendable {
@@ -138,6 +142,8 @@ struct SourceStorePolicyTests {
             return RemoteVersion(shortVersion: "9.0", version: nil, downloadURL: nil,
                                  sourceName: name)
         }
+        func prewarm(_ apps: [InstalledApp]) async { await ledger.record(prewarmed: apps) }
+        func invalidateMemo(for apps: [InstalledApp]) async { await ledger.record(invalidated: apps) }
     }
 
     private static func app(name: String, isMASApp: Bool) -> InstalledApp {
@@ -171,6 +177,28 @@ struct SourceStorePolicyTests {
         let result = await checker.check(Self.app(name: "DirectCopy", isMASApp: false))
         #expect(await declining.ledger.asked)
         #expect(result.remote?.sourceName == "Elsewhere")
+    }
+
+    /// The bulk hooks are the OTHER way a source touches a row, and the gate in
+    /// the loop does not cover them. A declining source must not be handed a
+    /// store copy to prewarm or to invalidate either — otherwise it can make a
+    /// request on behalf of a row it is forbidden to answer.
+    ///
+    /// Mutation: drop the `visibleTo:` filter from either call site and the
+    /// declining spy is handed "StoreCopy".
+    @Test func aDecliningSourceIsNotEvenHandedAStoreCopyInBulk() async {
+        let declining = Spy(name: "Elsewhere", answersAppStoreCopies: false)
+        let store = Spy(name: "App Store", answersAppStoreCopies: true)
+        let apps = [Self.app(name: "StoreCopy", isMASApp: true),
+                    Self.app(name: "DirectCopy", isMASApp: false)]
+        _ = await UpdateChecker(sources: [declining, store]).check(apps, freshening: true)
+
+        #expect(await declining.ledger.prewarmed == ["DirectCopy"])
+        #expect(await declining.ledger.invalidated == ["DirectCopy"])
+        // The store's own source keeps the whole list — it is the one allowed to
+        // act on both, and its prewarm is what batches the iTunes lookups.
+        #expect(await store.ledger.prewarmed == ["StoreCopy", "DirectCopy"])
+        #expect(await store.ledger.invalidated == ["StoreCopy", "DirectCopy"])
     }
 
     /// A store copy nothing answered is "managed by the store", not "unknown" —

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
@@ -1,0 +1,167 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Which sources may answer for a copy installed from the Mac App Store — as a
+/// table that is executed, rather than as prose that has to be kept accurate.
+///
+/// **Why this exists as a test.** The same rule was learned three times, one
+/// source at a time: Homebrew carried `guard !app.isMASApp` from the first
+/// commit, GitHub got it 2026-08-20 (LocalSend), the vendor probe 2026-08-23
+/// (WhatsApp offered 26.32.75 → 26.33.19 — the store build against the direct
+/// dmg, which Update would have installed over the store copy, `_MASReceipt`
+/// and sandbox entitlements included). Four sources were never revisited,
+/// because each fix went where the bite was.
+///
+/// The prose left behind was an inventory of who carried the guard, and it went
+/// wrong twice. Most recently it justified `SparkleAppcastSource`'s exemption
+/// with "Keka is a store copy carrying a `SUFeedURL`" — measured, dated, and
+/// false on the day it was written: `/Applications/Keka.app` is Developer
+/// ID-signed with no `Contents/_MASReceipt`, and `AppScanner`'s `isMAS`
+/// derivation is byte-identical then and now. That single sentence was the only
+/// recorded reason not to close the hole, and it held for a week.
+///
+/// So: a registered reason per source, checked against what the type actually
+/// declares, plus a behavioural case that runs the real `UpdateChecker`.
+struct SourceStorePolicyTests {
+
+    /// Every source in `SourceStack`, and why it may or may not answer a store
+    /// copy. Registered by type name so a rename fails here rather than
+    /// silently matching nothing.
+    static let policy: [String: (answers: Bool, reason: String)] = [
+        "MacAppStoreSource": (true,
+            "it IS the store's lookup — the one place answering a store copy is the job"),
+        "XcodeReleasesSource": (false,
+            "gates on bundle id only, and Xcode ships on the store. Detection-only today "
+            + "(downloadURL nil), so the harm would be a version readout rather than a bad "
+            + "install — but 'detection-only' is a property that can change, and the point of "
+            + "this gate is to stop reasoning per source"),
+        "SparkleAppcastSource": (false,
+            "gates on the feed URL only, so any store copy declaring SUFeedURL reached it"),
+        "HomebrewCaskSource": (false,
+            "a same-id cask is a different distribution with its own version scheme"),
+        "GitHubReleasesSource": (false,
+            "store and GitHub releases routinely sit a release apart (LocalSend)"),
+        "AlcoveUpdateSource": (false,
+            "a licensed vendor channel with an installable download"),
+        "VendorProbeSource": (false,
+            "cross-distribution installs — the WhatsApp case above"),
+        "ElectronManifestSource": (false,
+            "an electron-builder feed is the vendor's own distribution, not the store's"),
+    ]
+
+    /// The full stack, with Alcove present — it is omitted unless credentials
+    /// exist, and a source that is absent from the array cannot be checked.
+    static func fullStack() -> [any UpdateSource] {
+        SourceStack.make(
+            githubToken: nil,
+            alcove: AlcoveUpdateSource.Credentials(licenseKey: "k", instanceID: "i"))
+    }
+
+    /// Mutation: add a source to `SourceStack` without registering it here.
+    @Test func everySourceInTheStackIsRegistered() {
+        let stack = Self.fullStack()
+        #expect(stack.count == Self.policy.count,
+                "the stack has \(stack.count) sources and the table has \(Self.policy.count)")
+        for source in stack {
+            let type = String(describing: Swift.type(of: source))
+            #expect(Self.policy[type] != nil, """
+                \(type) is in SourceStack but not registered above. Say whether it may answer \
+                an App Store copy and why — the default is no, and it is the safe answer.
+                """)
+        }
+    }
+
+    /// The registration is a claim about the type; this is what makes it one.
+    ///
+    /// Mutation: flip any `answersAppStoreCopies`, or any `answers:` in the
+    /// table, and this names the source.
+    @Test func theRegisteredPolicyIsWhatTheTypeDeclares() {
+        for source in Self.fullStack() {
+            let type = String(describing: Swift.type(of: source))
+            guard let entry = Self.policy[type] else { continue }  // the case above owns this
+            #expect(source.answersAppStoreCopies == entry.answers,
+                    "\(type) declares \(source.answersAppStoreCopies), registered as \(entry.answers)")
+            #expect(!entry.reason.isEmpty)
+        }
+    }
+
+    /// Exactly one source is allowed to answer, and it is the store's.
+    ///
+    /// Separate from the case above because that one would still pass if every
+    /// source declined — an all-false table is self-consistent and useless.
+    @Test func exactlyOneSourceAnswersStoreCopies() {
+        let answering = Self.fullStack()
+            .filter(\.answersAppStoreCopies)
+            .map { String(describing: Swift.type(of: $0)) }
+        #expect(answering == ["MacAppStoreSource"])
+    }
+
+    // MARK: - Behaviour, through the real checker
+
+    /// Records whether it was asked, so "was this source consulted" is observed
+    /// rather than inferred from the verdict.
+    private actor Ledger {
+        private(set) var asked = false
+        func mark() { asked = true }
+    }
+
+    private final class Spy: UpdateSource, Sendable {
+        let name: String
+        let answersAppStoreCopies: Bool
+        let ledger = Ledger()
+
+        init(name: String, answersAppStoreCopies: Bool) {
+            self.name = name
+            self.answersAppStoreCopies = answersAppStoreCopies
+        }
+        func latestVersion(for app: InstalledApp) async throws -> RemoteVersion? {
+            await ledger.mark()
+            return RemoteVersion(shortVersion: "9.0", version: nil, downloadURL: nil,
+                                 sourceName: name)
+        }
+    }
+
+    private static func app(name: String, isMASApp: Bool) -> InstalledApp {
+        InstalledApp(
+            name: name, bundleID: "com.example.\(name)", shortVersion: "1.0",
+            buildVersion: "1", path: URL(fileURLWithPath: "/Applications/\(name).app"),
+            isMASApp: isMASApp, sparkleFeedURL: URL(string: "https://example.invalid/appcast.xml"))
+    }
+
+    /// Mutation: delete the `if app.isMASApp, !source.answersAppStoreCopies`
+    /// block in `UpdateChecker` and the declining spy is asked, and answers.
+    @Test func aStoreCopyIsNotOfferedByANonStoreSource() async {
+        let declining = Spy(name: "Elsewhere", answersAppStoreCopies: false)
+        let store = Spy(name: "App Store", answersAppStoreCopies: true)
+        // Declining source FIRST, so the gate is what stops it rather than the
+        // store simply answering earlier. With the gate deleted this ordering is
+        // what lets it win, which is exactly the WhatsApp shape.
+        let checker = UpdateChecker(sources: [declining, store])
+        let result = await checker.check(Self.app(name: "StoreCopy", isMASApp: true))
+        #expect(await declining.ledger.asked == false, "a non-store source was consulted for a store copy")
+        #expect(await store.ledger.asked)
+        #expect(result.remote?.sourceName == "App Store")
+    }
+
+    /// The other direction. Without this, "the gate works" is also satisfied by
+    /// a gate that declines everything, which would take every non-store app in
+    /// the list down with it.
+    @Test func aDirectCopyStillReachesEverySource() async {
+        let declining = Spy(name: "Elsewhere", answersAppStoreCopies: false)
+        let checker = UpdateChecker(sources: [declining])
+        let result = await checker.check(Self.app(name: "DirectCopy", isMASApp: false))
+        #expect(await declining.ledger.asked)
+        #expect(result.remote?.sourceName == "Elsewhere")
+    }
+
+    /// A store copy nothing answered is "managed by the store", not "unknown" —
+    /// the label the gate now produces for every row it silences.
+    @Test func aStoreCopyNoSourceAnsweredReadsAsManaged() async {
+        let declining = Spy(name: "Elsewhere", answersAppStoreCopies: false)
+        let checker = UpdateChecker(sources: [declining])
+        let result = await checker.check(Self.app(name: "StoreCopy", isMASApp: true))
+        #expect(await declining.ledger.asked == false)
+        #expect(result.status == .appStoreManaged)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
@@ -48,13 +48,21 @@ import Foundation
         }
 
         let name: String
+        /// Must be stated for a store row. `UpdateChecker` skips every source
+        /// that says no when `isMASApp` — inheriting the protocol default here
+        /// silently turned two cases below into tests of the SKIP, one of them
+        /// red and the other passing without measuring anything (caught in
+        /// adversarial review, not by the suite).
+        let answersAppStoreCopies: Bool
         private let behaviour: Behaviour
         private let lock = NSLock()
         private var consultedCount = 0
 
-        init(_ behaviour: Behaviour, name: String = "Scripted") {
+        init(_ behaviour: Behaviour, name: String = "Scripted",
+             answersAppStoreCopies: Bool = false) {
             self.behaviour = behaviour
             self.name = name
+            self.answersAppStoreCopies = answersAppStoreCopies
         }
 
         /// The error a real source raises for the failure this stands in for — a
@@ -215,7 +223,8 @@ import Foundation
     /// If a later change makes this `.appStoreManaged`, that is a decision to
     /// argue for here, not a tidy-up of an inconsistency.
     @Test func anAppStoreAppReportsAFailedStoreLookup() async {
-        let source = ScriptedSource(.throwing, name: "App Store")
+        let source = ScriptedSource(.throwing, name: "App Store",
+                                    answersAppStoreCopies: true)
         let result = await UpdateChecker(sources: [source])
             .check(Self.app(isMASApp: true))
 
@@ -228,10 +237,40 @@ import Foundation
 
     /// A store lookup that merely misses is a different thing from one that
     /// failed, and keeps the managed label.
+    ///
+    /// `answersAppStoreCopies: true` is what makes this measure the MISS. Without
+    /// it the source is skipped by the gate and `.appStoreManaged` arrives from
+    /// the skip path — an answer a wrong implementation (one that turned a store
+    /// miss into `.unknown`) would produce too.
     @Test func anAppStoreAppWithNoAnswerIsManaged() async {
-        let result = await UpdateChecker(sources: [ScriptedSource(.missing)])
-            .check(Self.app(isMASApp: true))
+        let source = ScriptedSource(.missing, name: "App Store",
+                                    answersAppStoreCopies: true)
+        let result = await UpdateChecker(sources: [source]).check(Self.app(isMASApp: true))
+        #expect(source.consulted)
         #expect(result.status == .appStoreManaged)
+    }
+
+    /// The combination the gate creates and neither case above covers: a store
+    /// row whose non-store source is silenced AND whose store lookup throws.
+    /// The silenced one must not contribute to the verdict in either direction —
+    /// it neither supplies an answer nor suppresses the `.error` the store's own
+    /// failure earns.
+    ///
+    /// Ordered with the silenced source FIRST, so a gate that ran it would let it
+    /// answer before the store ever threw.
+    @Test func aSilencedSourceNeitherAnswersNorHidesTheStoresFailure() async {
+        let silenced = ScriptedSource(.answering("9.9"), name: "Elsewhere")
+        let store = ScriptedSource(.throwing, name: "App Store",
+                                   answersAppStoreCopies: true)
+        let result = await UpdateChecker(sources: [silenced, store])
+            .check(Self.app(isMASApp: true))
+
+        #expect(!silenced.consulted)
+        #expect(store.consulted)
+        guard case .error = result.status else {
+            Issue.record("expected .error, got \(result.status)")
+            return
+        }
     }
 
     // MARK: - the gap this file is meant to close

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
@@ -194,19 +194,23 @@ import Foundation
     /// **The deliberate asymmetry.** A store app looks like it deserves the same
     /// treatment as a Toolbox one, and it does not.
     ///
-    /// Only three sources carry `guard !app.isMASApp` — Homebrew, GitHub and the
-    /// vendor probe. Three others can still run for a store copy and can still
-    /// throw: `MacAppStoreSource` (the lookup for the app the store DOES own),
-    /// `XcodeReleasesSource` (bundle-id gate only, and Xcode ships on the store),
-    /// and `SparkleAppcastSource` (feed-url gate only — measured 2026-08-29, Keka
-    /// is a store copy carrying `SUFeedURL = https://u.keka.io`, 1 of the 22 store
-    /// apps on this machine).
+    /// The only source that runs for a store copy is `MacAppStoreSource` — not by
+    /// inspection, but because `UpdateChecker` skips every source whose
+    /// `answersAppStoreCopies` is false, which is all of them bar the store's.
+    /// See `SourceStorePolicyTests`.
     ///
-    /// What none of them is, is a *borrowed* read. Toolbox's probe answers a
-    /// question Toolbox could have answered itself; each of these three IS this
-    /// row's update check. So a failure there has to read as a failed check —
+    /// So the thing that threw here is the lookup for the app the store DOES own.
+    /// That is not a *borrowed* read the way Toolbox's is — Toolbox's probe
+    /// answers a question Toolbox could have answered itself, while this IS the
+    /// row's update check. A failure therefore has to read as a failed check;
     /// painting it "Managed by the App Store" would show the user the same row
     /// they get when the store is quietly keeping the app current.
+    ///
+    /// ⚠️ This paragraph used to be a hand-kept inventory of which sources
+    /// carried `guard !app.isMASApp`, and it was wrong twice — the second time
+    /// citing Keka as a store copy carrying a `SUFeedURL`, which was false on the
+    /// day it was written (Developer ID, no `_MASReceipt`). Do not reintroduce an
+    /// inventory here; the gate and its table are the answer.
     ///
     /// If a later change makes this `.appStoreManaged`, that is a decision to
     /// argue for here, not a tidy-up of an inconsistency.

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -170,9 +170,11 @@ installed=7.0.9/843        box=on   → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg
   读的是下载包自己的 `LSMinimumSystemVersion`，而两个真包里这个值跟 feed 写的一致
   （7.0.9 → 15.0，7.1.0-beta.6 → 26.0）。差别是「先给按钮、装的时候拦」而不是
   「装了个跑不起来的」。
-- **`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`**（#368 的第二半）已修：
-  fill-in 和 superseded 两个入口都加了 `!isMAS`，bundle 自己声明的 `SUFeedURL` 不受影响
-  （Keka 是真实的商店副本自带 feed）。CotEditor 不走那条路，所以对它本来就没有影响。
+- **`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`**（#368 的第二半）已修，
+  fill-in 和 superseded 两个入口都加了 `!isMAS`；随后 `UpdateChecker` 又加了统一的商店闸，
+  商店副本根本到不了 `SparkleAppcastSource`。CotEditor 不走那条路，本来就不受影响。
+  （这条原先写着"Keka 是真实的商店副本自带 feed"——不是，Keka 是 Developer ID 签的、
+  没有 `_MASReceipt`。那句话我是从 `UpdateChecker` 的注释里转引的，没有复核。）
 
 ## Changelog
 


### PR DESCRIPTION
Closes #385 (subsumed — see below). Finishes a fix this repo already made twice.

## The hole

`MacAppStoreSource` is first in `SourceStack`, but `UpdateChecker` falls through
to the next source **on a thrown error as well as on a miss**, and the store
lookup does both (region-locked storefront, a lookup that 404s). So "the store
goes first" was never the guarantee it looked like: a store-installed app could
be answered — and offered an installable download — by a source for its *other*
distribution.

Not hypothetical. `94a1842` (2026-08-23) recorded WhatsApp offering
`26.32.75 → 26.33.19`: the store build against the direct dmg from
web.whatsapp.com, whose recipe carries an install spec, so Update would have
replaced the store copy along with its `_MASReceipt`, its sandbox entitlements
and the store's own update path.

**The same rule was learned three times, one source at a time** — Homebrew from
the first commit, GitHub on 2026-08-20 (LocalSend), the vendor probe on
2026-08-23 (WhatsApp). Four sources were never revisited, because each fix went
where the bite was: `SparkleAppcastSource`, `XcodeReleasesSource`,
`ElectronManifestSource`, `AlcoveUpdateSource`.

## The fix

One gate, in the one place every source passes through — `UpdateChecker` is the
only caller of `latestVersion(for:)` (verified; the other two grep hits are
comments). It reads `UpdateSource.answersAppStoreCopies`, **which defaults to
false**, so a source nobody has thought about yet is covered by omission rather
than exposed by it. Same reasoning as `RowActions.live` giving its callers no
defaults.

The existing three in-source guards stay: the sweeps call sources directly with
synthetic apps, which is a different question from who may answer a real row.

## The prose this retires

The loop's tail used to carry a hand-kept inventory of which sources had the
guard. **That inventory was wrong twice** — first naming one source when three
could run, then, in the very commit that fixed that, justifying
`SparkleAppcastSource`'s exemption with:

> measured 2026-08-29, Keka is a store copy carrying `SUFeedURL = https://u.keka.io`, 1 of the 22 store apps on this machine

The `SUFeedURL` half was read from the bundle and is correct. The other half was
never true, and I checked both ways it could have become false rather than been
born so:

- `/Applications/Keka.app` — no `Contents/_MASReceipt`, `Authority=Developer ID
  Application: Jorge Garcia Armero (4FG648TM2A)`.
- Not replaced since: created 2026-05-29, `Info.plist` written 2026-06-30.
- `AppScanner`'s `isMAS` derivation is byte-identical then and now
  (`!isTestFlight && (isiOSAppOnMac || hasReceipt)`).

So `isMASApp` was false for Keka on the day it was written. That one sentence
was the only recorded reason not to close this hole, and it held for a week —
**and I repeated it myself in #383 without checking.** All four repetitions are
retracted here; the two remaining mentions are the ones that refute it.

## Blast radius, measured

13 copies carrying `_MASReceipt` on this machine. Zero declare `SUFeedURL`; zero
carry `app-update.yml`; none is Alcove. So three of the four newly-gated sources
were already unreachable for every store app here.

**The one live change is Xcode**, which is a store copy and which
`XcodeReleasesSource` gates on bundle id alone. That skip is written down as
costing something: it cannot install over a store Xcode even in principle
(`downloadURL` nil — the endpoint 302s to `developer.apple.com/unauthorized/`),
so what is lost is a version readout and release notes when the iTunes lookup is
flaky. Taken anyway, because the alternative is a per-source exemption justified
in prose — the arrangement that produced the Keka sentence. The CHANGELOG says
the row loses its version number.

## Tests

`SourceStorePolicyTests` enumerates `SourceStack`, so a new source fails until
someone registers whether it may answer a store copy **and why**. Mutations, each
landing on exactly the named case:

| mutation | red |
|---|---|
| delete the gate | 3 cases, across both files |
| invert the gate | `aStoreCopyIsNotOfferedByANonStoreSource` + 1 |
| flip `MacAppStoreSource.answersAppStoreCopies` | `exactlyOneSourceAnswers…` + `theRegisteredPolicy…` |
| flip the protocol default | same two |
| drop a registration | `everySourceInTheStackIsRegistered` |

`make test`: **2388 passed, 1 known issue, rc=0.**

## What adversarial review caught (all fixed here)

1. **`anAppStoreAppReportsAFailedStoreLookup` was RED.** `ScriptedSource`
   inherited the default, so the store-named spy was skipped. I had read my own
   run as green — off the *background shell's* exit code instead of the log,
   which said `rc=2`. Fourth instance today of the shape this branch is about.
2. **`anAppStoreAppWithNoAnswerIsManaged` passed while measuring nothing** — the
   verdict came from the skip path, so an implementation turning a store miss
   into `.unknown` would also have passed. Both now opt in, plus a third case for
   the combination the gate creates.
3. **Four more Keka repetitions survived**, including
   "`MacAppStoreSource` returns nil rather than throwing" — the premise this
   change refutes.
4. **A log line per silenced source per round** — 13 store apps × 7 sources.
   `VendorProbeSource` already learned this reads as if a source had been
   declined. Now one line per row.
5. **Two unmeasured claims of my own**, retracted: the WhatsApp row is gone from
   this machine (it is the Developer ID build now), so the case is cited from
   `94a1842` rather than re-measured; and "the store lookup misses often enough"
   was a frequency claim with no measurement behind it.
6. A vacuous-pass path in `theRegisteredPolicyIsWhatTheTypeDeclares`.

Filed rather than fixed here: **#388** — the changelog path still gates on
"did the store answer" instead of "is this a store copy", so a store WeChat whose
lookup missed reads the official site's notes. One line, but it lives in
`AppListModel`, outside the app test target, so it wants the judgement moved to
Core rather than an untested edit inside a high-risk PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)