### PR TITLE
Refuse a comment whose evidence lives only on the author's disk

### DIFF
--- a/App/project.yml
+++ b/App/project.yml
@@ -8,8 +8,13 @@ options:
 # Apple Silicon only, stated explicitly rather than inherited from whatever the
 # build machine happens to be. This is a product decision, not a build detail:
 # the vendor recipe registry pins arm64 endpoints and arm64 install assets
-# throughout (VendorProbeRecipe's arm64 feed URLs, GitHubReleasesSource's
-# `-aarch64`/`-arm64` asset patterns). A universal DuoUpdater would run on an
+# almost everywhere (VendorProbeRecipe's arm64 feed URLs, GitHubReleasesSource's
+# `-aarch64`/`-arm64` asset patterns). NOT everywhere: 4 of the 61 install
+# patterns are dual-architecture alternations, and
+# `GitHubAssetSelectionTests.multiCandidateCases` requires each of those to be
+# registered — go there rather than trusting this sentence. It said "throughout"
+# until 2026-09-06, and three agents in one day read that as a guarantee and
+# derived a bug from it (#102) that could not exist. A universal DuoUpdater would run on an
 # Intel Mac and then hand that Mac arm64-only builds of every app it updates —
 # the install would "succeed" and leave an app that cannot launch. Shipping
 # arm64-only makes the machine that can't be served also the machine that can't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,23 @@ xcodebuild 的 SQLite 锁**,症状是 `database is locked` 或者干脆卡住—
   有一条从 registry 推导的检查**专门要求**这类 pattern 登记进 `multiCandidateCases`。
   少数派不等于疏漏。
 
+- **「转引一条实测」也是断言,而且是最容易漏的那种。** 引用一句带日期、带数字的实测,
+  等于你自己也说了一遍——现有规矩只管「写新断言前先量」,不管「引用旧断言算不算」。
+  2026-09-06 实测过一次代价:`UpdateChecker` 里一句「measured 2026-08-29, Keka is a store
+  copy carrying `SUFeedURL`, 1 of the 22 store apps on this machine」写下来那天就是错的
+  (Keka 是 Developer ID 签的、没有 `_MASReceipt`,而 `isMAS` 的推导那天和今天逐字相同),
+  它却是「不给 `SparkleAppcastSource` 加商店闸」的**唯一记录理由**,撑了一周,并且被
+  转抄进另外三个文件——其中一次是我,而我当时的行为在旧规矩下完全合规。
+  要么复测,要么写明「转引自 X,未复测」。
+- **复合断言拆开写证据。** 那句话是 `Keka 带 SUFeedURL`(真从 plist 读的)∧
+  `Keka 是商店副本`(推的),合取继承了实测那半边的可信度。**写到"推断"两个字的时候就会暴露。**
+- **有一道闸,但只管一小片。** `scripts/check_prose_claims.py`(挂在 `make test` 里)拒绝
+  「以本机 app 群体为分母的计数」——那种断言 CI、subagent、以后的读者都无法复现或证伪。
+  它**管不了断言真不真**,只管它住在哪、长什么形状;换个说法就绕过去了,这是设计如此。
+  它会拼接连续注释行再匹配(那句话是**换行断开**的,逐行 grep 一条都抓不到),
+  豁免用 `claim-lint:allow-machine-state — <理由>`,理由必填,
+  而且**一条不再匹配任何东西的豁免会让构建失败**(照抄 `mayLookAlike`,躲开 `mayBeBlank` 的 #271)。
+
 **本机这条先记住,省得再翻**:DuoUpdater 是 **arm64-only**,这是产品决策不是构建细节,
 理由写在 `App/project.yml`(`ARCHS: arm64`)——registry 大面积 pin arm64 端点/资源,
 universal 的 DuoUpdater 会在 Intel Mac 上跑起来然后给它装 arm64-only 的包,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
@@ -1412,10 +1412,12 @@ public struct EventRow: Sendable, Hashable {
     ///
     /// **This is the form every dump must print, and it is a property rather
     /// than a line at each call site because the two call sites had already
-    /// drifted.** An event's `appID` is a bundle path, and on a real machine a
-    /// large share of them sit under `/Users/<name>/Applications` — measured:
-    /// 55 of 145 distinct bundles, so a dump framed as something to pipe
-    /// elsewhere carried the account name in every one of those rows. `duo
+    /// drifted.** An event's `appID` is a bundle path, and any bundle under
+    /// `~/Applications` — a location the scanner reads by default — puts the
+    /// account name in the row, so a dump framed as something to pipe elsewhere
+    /// carried it. One such bundle is enough for that; this used to cite a count
+    /// of how many were on the author's own disk, which nobody else could check
+    /// and which the decision never rested on. `duo
     /// events` abbreviated them; `duo requests --json` printed the same rows
     /// from the same store and did not, which meant the same event answered
     /// differently depending on which command you asked. The payload is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -282,9 +282,11 @@ public struct RemoteVersion: Sendable, Hashable {
     public var releaseChannel: ReleaseChannel?
 
     /// Binary patches this release publishes, one per build it can upgrade from.
-    /// Empty for every source that doesn't publish them — which is most: of the
-    /// eleven Sparkle feeds readable on this machine only Keka's carried patches
-    /// usable by the installed build. See `DeltaPatch`.
+    /// Empty for every source that doesn't publish them, which is most of them —
+    /// see `DeltaPatch`, which names the feeds that do and what the patches are
+    /// worth. (This used to say the same thing as a count of the feeds readable
+    /// on one machine. `DeltaPatch`'s version is about the feeds themselves, so
+    /// anyone can go and look.)
     public let deltas: [DeltaPatch]
 
     public init(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -402,6 +402,12 @@ public enum AppRuntimeDetector {
         // read is bounded by the load-command region rather than by file size, so
         // Audacity's 21 MB payload measured 0.12ms, and the whole-library sweep is
         // indistinguishable from the sweep before this existed.
+        //
+        // claim-lint:allow-machine-state — those two ratios ARE the measurement
+        // being reported (how many bundles pay for the extra read), not evidence
+        // for a claim about any app, so there is nothing here for a reader to
+        // re-derive independently. Sampled on two machines for exactly that
+        // reason: one number would have read as a property of the world.
         if let payload = payloadNamedAfterTheBundle(
             bundleAt: bundleURL, declaredExecutable: executable, fm: fm),
            let payloadLibraries = linkedLibraries(payload),

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppRuntimeDetectionTests.swift
@@ -345,8 +345,10 @@ func theProofIsPaidForOncePerBinaryNotOncePerScan() throws {
 
 @Test func swiftUIWithoutAppKitIsStillNative() throws {
     // Not hypothetical: a demo app built for this question links SwiftUI and no
-    // AppKit at all. No *shipping* app on the development machine did — 0 of 77 —
-    // which is why the runtime stays one label and the frameworks stay a set.
+    // AppKit at all, which is why the runtime stays one label and the frameworks
+    // stay a set. (It used to add that no shipping app on the author's machine
+    // did — true when written, uncheckable by anyone else, and the demo app is
+    // the evidence that matters either way.)
     let builder = try BundleBuilder(); defer { builder.cleanUp() }
     let bundle = try builder.app("Pure")
     let reading = AppRuntimeDetector.read(

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DeltaApplierTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DeltaApplierTests.swift
@@ -62,8 +62,8 @@ struct DeltaApplierTests {
         #expect(DeltaApplier.patch(for: app(build: nil), in: r) == nil)
     }
 
-    /// The overwhelmingly common shape: of the eleven Sparkle feeds readable on
-    /// this machine, only Keka's published patches the installed build could use.
+    /// The overwhelmingly common shape — most Sparkle feeds publish no deltas at
+    /// all. `DeltaPatch` names the ones that do.
     @Test func aFeedWithoutPatchesSelectsNothing() {
         #expect(DeltaApplier.patch(for: app(build: "5715"), in: remote(deltas: [])) == nil)
     }

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 test:
 	python3 scripts/test_appcast_edit.py
 	python3 scripts/test_publish_release.py
+	python3 scripts/test_check_prose_claims.py
 	python3 scripts/test_claude_lag_probe.py
 	cd DuoUpdaterCore && swift test
 	swift test --package-path CLI
@@ -25,6 +26,7 @@ test:
 	python3 scripts/check_staged_version_use.py
 	python3 scripts/test_check_staged_version_use.py
 	python3 scripts/check_app_audits.py
+	python3 scripts/check_prose_claims.py
 
 # Render every row state to verify/row-states/*.png. The images are committed:
 # re-run after a UI change and read the diff. Fails if a state draws nothing.

--- a/scripts/check_prose_claims.py
+++ b/scripts/check_prose_claims.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Refuse a code comment whose evidence lives only on the author's disk.
+
+Run by `make test`.
+
+    python3 scripts/check_prose_claims.py
+
+## What this is for
+
+This repository writes its comments as "measured, on <date>, <number>". That is
+a good habit and it is not the target. The target is the subset where the
+measurement is a count of THIS MACHINE's app population — because a claim like
+
+    1 of the 22 store apps on this machine
+
+cannot be reproduced, re-derived or falsified by CI, by a subagent, or by anyone
+reading it later. The only person who can check it is the person who wrote it,
+and they already did. So it reads as measured, is treated as measured, and stays
+standing after it stops being true.
+
+That is not hypothetical. The sentence above was written on 2026-08-29, was
+false on the day it was written (Keka is Developer ID-signed with no
+`_MASReceipt`), and was the sole recorded justification for a real hole in the
+update path. It survived a week and was repeated into three more files, once by
+someone who was being careful and citing a dated measurement.
+
+## What it does NOT do
+
+It cannot tell whether a claim is true. It governs where a claim may LIVE. A
+population count that has to leave a code comment becomes a claim about an app
+or an endpoint — and that kind of claim has a home, `docs/app-audits/`, whose
+format asks how to re-verify it. Reaching for that section is where an author
+discovers they cannot.
+
+Rewriting to dodge the pattern also dodges the check. That is fine and expected:
+the point is to make the shape unwelcome, not to be unfoolable.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOTS = [
+    "DuoUpdaterCore/Sources", "DuoUpdaterCore/Tests",
+    "App/Sources", "App/Tests",
+    "CLI/Sources", "CLI/Tests",
+]
+
+# Deliberately narrow. A broad "this machine" ban is unworkable — 71 occurrences
+# in Sources alone, and most are runtime semantics ("the machine running this"),
+# not claims. A first attempt that also matched "<verified> on this machine
+# <date>" pulled in 20 hits, nearly all of them legitimate dated verifications of
+# a real artifact, which anyone holding that artifact can redo. What is left here
+# is the shape nobody can redo: a count over the local app population.
+#
+# `installed here` was a fourth alternative and is gone: the count alternative
+# already catches the sentence that motivated this file, and on its own it only
+# matched code semantics ("`versions` only ever holds what is installed here").
+MACHINE = r"(?:this|one|another|a real|the development) machine"
+
+# Deliberately narrow, and arrived at by measuring rather than by taste.
+#
+# A bare "this machine" ban is unworkable: 71 occurrences in Sources alone, and
+# most are runtime semantics ("the machine running this"), not claims. A first
+# attempt that also matched "<verified> on this machine <date>" produced 20 hits,
+# nearly all of them legitimate dated verifications of a real artifact — which
+# anyone holding that artifact can redo, so they are not the problem.
+#
+# What is left is the one shape nobody can redo: a count whose denominator is
+# THIS machine's population. The marker may sit on either side of the count
+# ("55 of 145 … on a real machine" and "on a real machine … 55 of 145" both
+# occur), hence the two mirrored alternatives.
+#
+# Measured on the tree the check landed on: 5 hits, all genuine, no false
+# positives — and three real comments that must NOT hit are fixtures in the test
+# file (a dated artifact verification, a runtime "installed here", and a count of
+# a FEED's items rather than a machine's).
+PATTERN = re.compile(
+    rf"\b[0-9]+ of (?:the )?[0-9]+[^.]{{0,90}}?{MACHINE}\b"
+    rf"|{MACHINE}\b[^.]{{0,120}}?\b[0-9]+ of (?:the )?[0-9]+\b"
+    r"|\b(?:feeds|apps|casks|bundles|copies|rows)\s+"
+    r"(?:readable|reachable|installed|present|scanned)\s+on\s+this\s+machine\b"
+    r"|\bof the [0-9]+ [a-z ]{0,30}\b(?:on this machine|here)\b",
+    re.I)
+
+MARKER = "claim-lint:allow-machine-state"
+# The reason is not optional. `check_staged_version_use.py`'s
+# `version-lint:allow-marketing-first` works the same way: an escape hatch that
+# takes no argument is just a way to turn the check off.
+REASON = re.compile(re.escape(MARKER) + r"\s*[—-]\s*(\S.*)")
+
+
+def comment_blocks(path):
+    """Consecutive comment lines, joined, with the line the block starts on.
+
+    Joining is the whole reason this is a script and not a `grep`. The sentence
+    that motivated it wraps:
+
+        /// ... measured 2026-08-29, Keka
+        /// is a store copy carrying `SUFeedURL = ...`, 1 of the 22 store
+        /// apps on this machine).
+
+    A line-based scanner finds nothing there — it would have shipped as a check
+    that had never once gone red, which this repository has deleted before
+    (`make width-check`).
+    """
+    lines = path.read_text(errors="replace").splitlines()
+    buf, start = [], 0
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+        if stripped.startswith("//"):
+            if not buf:
+                start = i + 1
+            buf.append(re.sub(r"^/{2,3}\s?", "", stripped))
+        elif buf:
+            yield start, buf
+            buf = []
+    if buf:
+        yield start, buf
+
+
+def review(root, roots=ROOTS):
+    """Everything the check knows, as data, so the tests can drive it.
+
+    `main` owns only the printing and the two emptiness gates — which is what
+    lets a test point this at a three-file fixture without tripping the floor.
+    """
+    missing = [r for r in roots if not (root / r).is_dir()]
+    scanned, offences, dead = 0, [], []
+    for r in roots:
+        base = root / r
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.swift")):
+            if ".build" in path.parts:
+                continue
+            rel = path.relative_to(root)
+            scanned += 1
+            for start, block in comment_blocks(path):
+                joined = " ".join(block)
+                match = PATTERN.search(joined)
+                reason = REASON.search(joined)
+                exempt = MARKER in joined
+                if match and not exempt:
+                    offences.append((rel, start, match.group(0)))
+                elif match and exempt and not reason:
+                    offences.append((rel, start,
+                                     f"{MARKER} with no reason after it"))
+                elif exempt and not match:
+                    # An exemption that no longer matches anything is a standing
+                    # pass for whatever is written there next. `make gallery`
+                    # fails on a stale `mayLookAlike` for the same reason, and
+                    # CLAUDE.md records (#271) what happens to the one gate that
+                    # skipped it: the exempted case is never inspected again.
+                    dead.append((rel, start))
+    return {"missing": missing, "scanned": scanned,
+            "offences": offences, "dead": dead}
+
+
+def main(root=None, roots=ROOTS, minimum=200):
+    root = root or pathlib.Path(__file__).resolve().parent.parent
+    found = review(root, roots=roots)
+
+    # Fail on a root that is not there, rather than scanning fewer.
+    #
+    # Written after the first run of this file printed "✓ … 0 roots scanned" and
+    # exited 0, from a scratch directory. A rename, a move, or being invoked from
+    # somewhere unexpected would have turned this into a check that passes
+    # because it looked at nothing — the failure mode CLAUDE.md keeps warning
+    # about, produced by the tool built to warn about it.
+    if found["missing"]:
+        print(f"✗ these source roots are not under {root}: "
+              f"{', '.join(found['missing'])}\n"
+              "  Fix the paths rather than dropping them.", file=sys.stderr)
+        return 1
+
+    # The other half of that gate: `rglob` finding nothing inside a directory
+    # that exists is just as silent as the directory being gone.
+    if found["scanned"] < minimum:
+        print(f"✗ only {found['scanned']} Swift files scanned across "
+              f"{len(roots)} roots — too few to be a real run.", file=sys.stderr)
+        return 1
+
+    offences, dead = found["offences"], found["dead"]
+    if not offences and not dead:
+        print(f"✓ no machine-population claims in code comments — "
+              f"{found['scanned']} files")
+        return 0
+
+    for rel, line, text in offences:
+        print(f"✗ {rel}:{line}: this counts THIS MACHINE's apps, so nobody else "
+              f"can check it\n    …{text}…", file=sys.stderr)
+    for rel, line in dead:
+        print(f"✗ {rel}:{line}: `{MARKER}` here no longer exempts anything — "
+              "delete it, or it silently exempts whatever is written next",
+              file=sys.stderr)
+    print(f"\n{len(offences)} claim(s), {len(dead)} stale exemption(s).\n"
+          "Rewrite it as a claim about the app or the endpoint — one anyone can "
+          "re-derive — or, if the count really is the point, add\n"
+          f"    {MARKER} — <why nobody needs to re-derive this>\n"
+          "on a line inside the same comment block.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_prose_claims.py
+++ b/scripts/check_prose_claims.py
@@ -46,16 +46,6 @@ ROOTS = [
     "CLI/Sources", "CLI/Tests",
 ]
 
-# Deliberately narrow. A broad "this machine" ban is unworkable — 71 occurrences
-# in Sources alone, and most are runtime semantics ("the machine running this"),
-# not claims. A first attempt that also matched "<verified> on this machine
-# <date>" pulled in 20 hits, nearly all of them legitimate dated verifications of
-# a real artifact, which anyone holding that artifact can redo. What is left here
-# is the shape nobody can redo: a count over the local app population.
-#
-# `installed here` was a fourth alternative and is gone: the count alternative
-# already catches the sentence that motivated this file, and on its own it only
-# matched code semantics ("`versions` only ever holds what is installed here").
 MACHINE = r"(?:this|one|another|a real|the development) machine"
 
 # Deliberately narrow, and arrived at by measuring rather than by taste.
@@ -70,6 +60,12 @@ MACHINE = r"(?:this|one|another|a real|the development) machine"
 # THIS machine's population. The marker may sit on either side of the count
 # ("55 of 145 … on a real machine" and "on a real machine … 55 of 145" both
 # occur), hence the two mirrored alternatives.
+#
+# A standalone `installed here` alternative was tried and removed: on its own it
+# only matched code semantics ("`versions` only ever holds what is installed
+# here"). The phrase is still caught inside a count — "of the 22 store apps
+# installed here" hits the last alternative — which is the only form that was
+# ever the point.
 #
 # Measured on the tree the check landed on: 5 hits, all genuine, no false
 # positives — and three real comments that must NOT hit are fixtures in the test
@@ -139,8 +135,15 @@ def review(root, roots=ROOTS):
             for start, block in comment_blocks(path):
                 joined = " ".join(block)
                 match = PATTERN.search(joined)
-                reason = REASON.search(joined)
-                exempt = MARKER in joined
+                # The marker has to START a line of the comment. Anywhere-in-the
+                # -block would mean a comment that merely DESCRIBES the
+                # convention reads as invoking it — and, with no claim beside it,
+                # gets reported as a stale exemption, which is neither true nor
+                # actionable.
+                marker_line = next(
+                    (line for line in block if line.startswith(MARKER)), None)
+                exempt = marker_line is not None
+                reason = REASON.search(marker_line) if marker_line else None
                 if match and not exempt:
                     offences.append((rel, start, match.group(0)))
                 elif match and exempt and not reason:

--- a/scripts/test_check_prose_claims.py
+++ b/scripts/test_check_prose_claims.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Regression tests for `check_prose_claims`. Run by `make test`.
+
+    python3 scripts/test_check_prose_claims.py
+
+Every case names the mutation it catches. The must-hit fixture is the real
+sentence that motivated the check, copied verbatim from 38596f7 — including its
+line wrapping, which is the part a `grep` cannot see.
+"""
+
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_prose_claims as cpc  # noqa: E402
+
+# Verbatim from 38596f7, wrapped exactly as it was committed. The wrap is the
+# fixture: "1 of the 22 store" ends one line and "apps on this machine" begins
+# the next, so a line-based scanner sees neither half.
+INSTANCE_3 = """\
+    /// and `SparkleAppcastSource` (feed-url gate only — measured 2026-08-29, Keka
+    /// is a store copy carrying `SUFeedURL = https://u.keka.io`, 1 of the 22 store
+    /// apps on this machine).
+    @Test func witness() {}
+"""
+
+# Real comments from this repo that the check must leave alone.
+LEGITIMATE = """\
+    /// …but only against a version this recipe is FOR. A recipe scoped to an
+    /// older train legitimately trails the installed copy: the machine running
+    /// the sweep is on 2.0.6.0, and `versions` only ever holds what is installed
+    /// here.
+    ///
+    /// One-click verified on this machine 2026-08-09 on 1.9.3: `ImageOptim.app`
+    /// in the archive, bundle id net.pornel.ImageOptim, Team 59KZTZA4XR.
+    ///
+    /// `selectHighest` rather than first-match, because the feed is ASCENDING
+    /// (8.7.0 from 2022 is item 1 of 89) — first-match here would report a
+    /// four-year-old release as current.
+    func f() {}
+"""
+
+
+class ProseClaims(unittest.TestCase):
+    def setUp(self):
+        self.root = pathlib.Path(tempfile.mkdtemp(prefix="duo-claims-"))
+        self.addCleanup(shutil.rmtree, self.root, True)
+        (self.root / "Sources").mkdir()
+
+    def write(self, text, name="Fixture.swift"):
+        (self.root / "Sources" / name).write_text(text)
+
+    def review(self):
+        return cpc.review(self.root, roots=["Sources"])
+
+    # Mutation: drop the line-joining in `comment_blocks` and scan line by line.
+    # This is the whole reason the check is a script — the sentence it exists for
+    # wraps, so a per-line scanner reports zero and ships green forever.
+    def test_the_wrapped_sentence_that_motivated_this_is_caught(self):
+        self.write(INSTANCE_3)
+        found = self.review()
+        self.assertEqual(len(found["offences"]), 1, found)
+        self.assertIn("1 of the 22 store apps on this machine",
+                      found["offences"][0][2])
+
+    # The same claim on one line. Both must hit, or the check would reward
+    # reflowing a comment.
+    def test_the_same_sentence_unwrapped_is_caught_too(self):
+        self.write("    /// Keka is a store copy, 1 of the 22 store apps on this "
+                   "machine.\n    func f() {}\n")
+        self.assertEqual(len(self.review()["offences"]), 1)
+
+    # Mutation: widen PATTERN back to a bare "this machine", or re-add the
+    # `installed here` alternative. Both of these are real comments from this
+    # repo and both would start failing — the direction that turns the check into
+    # an exemption list.
+    # Three real comments from this repo, all of which an earlier version of the
+    # pattern matched: a dated verification of an artifact anyone holding it can
+    # redo, a "here" that means "in this code", and a count of a FEED's 89 items
+    # that a 90-character window bridged to an unrelated "here".
+    def test_a_dated_verification_and_a_runtime_here_are_left_alone(self):
+        self.write(LEGITIMATE)
+        found = self.review()
+        self.assertEqual(found["offences"], [], found)
+        self.assertEqual(found["dead"], [])
+
+    # Mutation: stop honouring MARKER at all.
+    def test_an_exemption_with_a_reason_clears_it(self):
+        self.write("    /// 1 of the 22 store apps on this machine.\n"
+                   "    /// claim-lint:allow-machine-state — the count IS the "
+                   "measurement here\n    func f() {}\n")
+        self.assertEqual(self.review()["offences"], [])
+
+    # Mutation: drop the REASON check and accept a bare marker. An escape hatch
+    # that takes no argument is a way to turn the check off — the same reason
+    # `version-lint:allow-marketing-first` demands one.
+    def test_a_bare_exemption_is_not_an_exemption(self):
+        self.write("    /// 1 of the 22 store apps on this machine.\n"
+                   "    /// claim-lint:allow-machine-state\n    func f() {}\n")
+        found = self.review()
+        self.assertEqual(len(found["offences"]), 1)
+        self.assertIn("no reason", found["offences"][0][2])
+
+    # Mutation: delete the `elif exempt and not match` branch. A marker left
+    # behind after its sentence was rewritten is a standing pass for whatever is
+    # written there next — #271 is what that costs.
+    def test_an_exemption_matching_nothing_fails(self):
+        self.write("    /// Nothing measurable here at all.\n"
+                   "    /// claim-lint:allow-machine-state — stale\n"
+                   "    func f() {}\n")
+        found = self.review()
+        self.assertEqual(len(found["dead"]), 1, found)
+
+    # Mutation: `continue` past a missing root instead of reporting it. The very
+    # first run of the check printed "✓ … 0 roots scanned" and exited 0.
+    def test_a_missing_root_is_a_failure_not_a_smaller_scan(self):
+        self.write(INSTANCE_3)
+        self.assertEqual(cpc.review(self.root, roots=["Nope"])["missing"], ["Nope"])
+        # `roots` passed explicitly: without it `main` reads the module-level
+        # ROOTS, which a temp directory never has, so this case went red for a
+        # reason that had nothing to do with what it names. It was written that
+        # way first and only the clean-tree case below exposed it.
+        self.assertEqual(cpc.main(root=self.root, roots=["Nope"], minimum=1), 1)
+
+    # Mutation: delete the floor. A root that exists but holds no Swift is just
+    # as silent as one that is gone.
+    def test_scanning_almost_nothing_is_a_failure(self):
+        self.write(INSTANCE_3)
+        self.assertEqual(cpc.main(root=self.root, roots=["Sources"], minimum=10_000), 1)
+
+    # The check's own exit code, end to end, on a clean fixture.
+    def test_a_clean_tree_passes(self):
+        self.write(LEGITIMATE)
+        self.assertEqual(cpc.main(root=self.root, roots=["Sources"], minimum=1), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_check_prose_claims.py
+++ b/scripts/test_check_prose_claims.py
@@ -104,6 +104,25 @@ class ProseClaims(unittest.TestCase):
         self.assertEqual(len(found["offences"]), 1)
         self.assertIn("no reason", found["offences"][0][2])
 
+    # Mutation: accept the marker anywhere in the block instead of at the start
+    # of a line. Describing the convention then reads as invoking it, and a
+    # description with no claim beside it is reported as a stale exemption —
+    # a message that is neither true nor actionable.
+    def test_describing_the_marker_is_not_invoking_it(self):
+        self.write("    /// A count like that needs a "
+                   "`claim-lint:allow-machine-state — <reason>` beside it.\n"
+                   "    func f() {}\n")
+        found = self.review()
+        self.assertEqual(found["dead"], [], found)
+        self.assertEqual(found["offences"], [])
+
+    # …and the same mention does NOT exempt a real claim sitting next to it.
+    def test_a_described_marker_does_not_exempt_a_real_claim(self):
+        self.write("    /// 1 of the 22 store apps on this machine. Add a "
+                   "`claim-lint:allow-machine-state — x` if you must.\n"
+                   "    func f() {}\n")
+        self.assertEqual(len(self.review()["offences"]), 1)
+
     # Mutation: delete the `elif exempt and not match` branch. A marker left
     # behind after its sentence was rewritten is a standing pass for whatever is
     # written there next — #271 is what that costs.


### PR DESCRIPTION
Intervention ① of the plan for the error shape that has now bitten five times in
four months, by four different authors including me.

## The shape

A statement is written as if measured, when only part of it was. It becomes
load-bearing justification, and the next reader trusts it instead of
re-measuring.

The costly instance: `UpdateChecker` carried

> measured 2026-08-29, Keka is a store copy carrying `SUFeedURL = https://u.keka.io`, 1 of the 22 store apps on this machine

The `SUFeedURL` half was read from the bundle. The other half was **never true**
— Keka is Developer ID-signed with no `_MASReceipt`, and `AppScanner`'s `isMAS`
derivation was byte-identical then and now. That one sentence was the sole
recorded reason `SparkleAppcastSource` had no store guard. It held for a week,
was copied into three more files, and #389 is what it delayed. One of the copies
is mine, from #383, where I cited a dated measurement and did not check it —
behaviour that was *compliant* under the rules as written.

## What this check does

Refuses a code comment whose **denominator is this machine's app population**.
CI cannot check such a claim; a subagent cannot; the next reader will not. The
only person who could is the one who wrote it, and they already did.

It is **not** aimed at the repo's habit of dating measurements — that habit is
good, and a verification of a real artifact is redoable by anyone holding the
artifact.

## The pattern was measured, not chosen

| attempt | hits | verdict |
|---|---|---|
| bare `this machine` | 71 in Sources alone | unworkable, mostly runtime semantics |
| + `<verified> on this machine <date>` | 20 | nearly all legitimate dated verifications |
| **what ships** | **5, all genuine, 0 false positives** | |

The three real comments an earlier cut got wrong are fixtures in the test file:
a dated artifact verification, a `here` meaning "in this code", and a count of a
*feed's* 89 items that a 90-character window bridged to an unrelated `here`.

**It joins comment lines before matching**, which is why it is a script and not a
`grep`. The sentence it exists for wraps mid-phrase:

```
/// … measured 2026-08-29, Keka
/// is a store copy carrying `SUFeedURL = …`, 1 of the 22 store
/// apps on this machine).
```

A line-based scanner finds **nothing** there. Shipped that way it would have been
a check that had never once gone red — which this repo has deleted before
(`make width-check`).

## What it cannot do, said plainly

It cannot tell whether a claim is true. It governs **where a claim may live**,
and rewriting around it works. That is the design: a count forced out of a code
comment becomes a claim about an app or an endpoint, and that kind has a home
(`docs/app-audits/`) whose format asks how to re-verify it — which is where an
author discovers they cannot.

## Gates

- Exemption is `claim-lint:allow-machine-state — <reason>`, **reason required**
  (same as `version-lint:allow-marketing-first`).
- **A stale exemption fails the build** — copied from `mayLookAlike`, avoiding
  the hole `mayBeBlank` has (#271).
- Missing root, or too few files scanned, fails. Both written after the check's
  own first run printed `✓ … 0 roots scanned` and exited 0 — the failure mode
  the tool exists to warn about, produced by the tool.

| mutation | red |
|---|---|
| drop the line-joining | 3 cases, incl. the wrapped flagship |
| widen the pattern back | the three legitimate-comment fixtures |
| stop honouring the marker | `an_exemption_with_a_reason_clears_it` |
| accept a bare marker | `a_bare_exemption_is_not_an_exemption` |
| delete the stale-exemption branch | `an_exemption_matching_nothing_fails` |
| `continue` past a missing root | `a_missing_root_is_a_failure…` |
| delete the floor | `scanning_almost_nothing_is_a_failure` |

Also verified end to end on the real tree: rewriting the exempted sentence while
leaving its marker fails the check by name.

**A defect the tests caught in themselves**: `main` was not parameterised on
`roots`, so it always read the repo's real paths. The missing-root case passed
for a reason unrelated to what it names, and only the clean-tree case exposed it.

## The five it finds

Three were counts the decision never rested on (the account name is in a path
whether one bundle or fifty sit there; the demo app is the evidence about
SwiftUI-without-AppKit, not the local survey). One was the same sentence written
twice while `DeltaPatch`'s own doc already carries the feed-level version anyone
can go and look at. The fifth is **exempted with its reason** — in `AppRuntime`
those ratios *are* the measurement being reported, not evidence for a claim about
an app, and were sampled on two machines so one number would not read as a
property of the world.

## Also

- `App/project.yml` no longer says the registry pins arm64 "throughout". It does
  not — 4 of 61 install patterns are dual-architecture — and three agents in one
  day read that word as a guarantee and filed a bug from it that could not exist
  (#102). It now points at the test that has required those four to be registered
  all along.
- CLAUDE.md gains **citing a measurement is asserting it**, the rule whose
  absence made my #383 copy compliant, and **split a compound claim's evidence
  per clause** — writing the word "inferred" is where that sentence would have
  exposed itself.

`make test`: rc=0, 468 files scanned clean. No CHANGELOG entry: tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)