### PR TITLE
A Fork copy on Develop is no longer sent to the Stable feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Clicking Update no longer does nothing when an update source contradicts itself.** If the check that runs the moment you click comes back with an older version than the one the row was offering, Duo Updater now says so and keeps the update on offer. It used to report the app as already up to date and drop it from the list, and the same update reappeared on the next check.
 
+**Fork updates are offered again when Fork is set to its Develop channel.** Duo Updater read Fork's channel setting backwards and followed its Stable feed, which sits well behind — so a Develop copy was listed as up to date while Fork itself was offering a newer version.
+
 **Mac Performance Monitor now shows its release notes.** The app publishes them in its repository rather than in the feed we read, so the window had nothing to show for it.
 
 **CotEditor is now covered, on both its release and its beta line.** Which line a copy follows comes from the version it is running and from CotEditor's own "Update to prereleases when available" setting, so a beta copy is offered the next beta instead of a release that would take it backwards.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -118,7 +118,7 @@ public struct ResolvedChannel: Sendable, Equatable {
 /// is a delegate the host app computes at runtime; vendors keep the choice
 /// wherever they like. Four apps, four encodings, none alike:
 ///   * DuoPaste → `UserDefaults[sparkleIncludePrereleases]`           (Bool: true→beta)
-///   * Fork     → `UserDefaults[applicationUpdateChannel]`            (Int: 2→stable)
+///   * Fork     → `UserDefaults[applicationUpdateChannel]`            (Int: 1→stable)
 ///   * Surge    → `…/Application Support/<id>/KDDefaults.plist`        (`IncludeBetaBuilds` Bool)
 ///   * OrbStack → `UserDefaults[updates_optinChannel]`               (String: the channel name)
 ///   * TablePlus→ `UserDefaults[ViewSetting][IsReceiveBetaBuild]`     (Bool: true→beta, via header)
@@ -327,9 +327,20 @@ public enum ChannelBinding {
     public static let allResolutions: [(bundleID: String, resolved: ResolvedChannel)] = [
         (DuoPasteChannel.bundleID, DuoPasteChannel.resolve(includePrereleases: false)),
         (DuoPasteChannel.bundleID, DuoPasteChannel.resolve(includePrereleases: true)),
-        // Fork's pref is an Int with 2 == stable; anything else (including absent,
-        // the shipped default) is the "Developer" train.
-        (ForkChannel.bundleID, ForkChannel.resolve(channelPref: 2)),
+        // Fork's pref is an Int with 1 == stable; anything else (including 2, which
+        // is what its "Develop" menu item writes, and absent, the shipped default)
+        // is the Develop train. Both explicit values are listed for the same
+        // reason BetterDisplay lists all four toggle combinations — they are the
+        // values the resolver accepts — and `channelBindingsNeedingProof` folds
+        // the two Develop ones into one key.
+        //
+        // It buys no protection, and saying so is the point: when this was
+        // inverted, `resolve(2)` answered `.stable`, and that population drops
+        // `.stable` outright, so listing 2 would have produced no proof key and no
+        // red test. Nothing here gates the direction of the mapping; only
+        // `ForkChannelTests` and the disassembly it cites do.
+        (ForkChannel.bundleID, ForkChannel.resolve(channelPref: ForkChannel.stablePrefValue)),
+        (ForkChannel.bundleID, ForkChannel.resolve(channelPref: ForkChannel.developerPrefValue)),
         (ForkChannel.bundleID, ForkChannel.resolve(channelPref: nil)),
         (SurgeChannel.bundleID, SurgeChannel.resolve(includeBeta: false)),
         (SurgeChannel.bundleID, SurgeChannel.resolve(includeBeta: true)),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ForkChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ForkChannel.swift
@@ -4,21 +4,49 @@ import Foundation
 /// one per channel, and picks between them at runtime from its own preference.
 /// The channel is invisible the usual ways:
 ///   * the feeds carry no `<sparkle:channel>` elements, and
-///   * the code-signed Info.plist `SUFeedURL` is always the Developer feed.
+///   * the code-signed Info.plist `SUFeedURL` is always the Develop feed.
 ///
-/// The Updates popup (`UpdatesPreferencesController.nib`) has exactly two items:
-/// "Developer" (beta — the shipped default) and "Stable (delayed 1 week)".
-/// Selecting Stable writes `applicationUpdateChannel = 2`; the Developer default
-/// leaves the key unset (or non-2). We treat 2 as Stable, everything else as
-/// Developer/beta.
+/// The Updates pane popup (`UpdatesPreferencesController.nib`) has two items,
+/// "Develop" (the shipped default) and "Stable (delayed 1 week)". Their actions
+/// write an Int into `applicationUpdateChannel`: `enableStableChannel(_:)` writes
+/// **1**, `enableDevelopChannel(_:)` writes **2**. The feed picker is a single
+/// comparison against 1, so 1 takes the stable feed and *everything else* — 2,
+/// absent, junk — takes the Develop feed.
+///
+/// This file used to say 2 was Stable, which is exactly backwards, and it cost a
+/// user their updates: with the pref at 2 (Develop, chosen in Fork's own UI) we
+/// retargeted the install to the stable feed, whose head sat at 2.66.7 while the
+/// installed copy was 2.69.0. A head *older* than installed reads as "up to date",
+/// so 2.70.0 never surfaced — while Fork's own Sparkle dialog was offering it.
+///
+/// The original claim came from `channel-verify --scan`, which runs *our*
+/// `detect()`: writing 2 and watching us answer "stable" only proved we were
+/// self-consistent. The mapping below is read from Fork 2.69.0's arm64 slice
+/// instead (2026-09-07) — `Contents/MacOS/Fork`, the feed picker at `0x1002156fc`:
+///
+///     bl   -[NSUserDefaults integerForKey:]   // "applicationUpdateChannel" -> x21
+///     cmp  x21, #0x1
+///     csel x20, <…/feed-stable.xml>, <…/feed.xml>, eq
+///
+/// and the two writers, each a `setInteger:forKey:` with an immediate:
+/// `enableStableChannel(_:)` at `0x10030e888` moves `#0x1`,
+/// `enableDevelopChannel(_:)` at `0x10030e774` moves `#0x2`.
 enum ForkChannel {
     static let bundleID = "com.DanPristupov.Fork"
 
     static let developerFeed = URL(string: "https://fork.dev/update/feed.xml")!
     static let stableFeed = URL(string: "https://fork.dev/update/feed-stable.xml")!
 
-    /// The integer Fork stores for the Stable channel.
-    static let stablePrefValue = 2
+    /// The integer Fork stores for the Stable channel. Fork compares against this
+    /// one value and treats every other value as Develop, so mirroring the
+    /// comparison — not enumerating the values — is what keeps us in step.
+    static let stablePrefValue = 1
+
+    /// The integer Fork's "Develop" menu item writes. Not used by `resolve` (the
+    /// fallback already covers it) but named so a test can pin the value that
+    /// actually appears in a Develop user's defaults, which is the case we got
+    /// wrong.
+    static let developerPrefValue = 2
 
     /// Map Fork's `applicationUpdateChannel` to a resolution. Pure and tested.
     static func resolve(channelPref: Int?) -> ResolvedChannel {
@@ -34,9 +62,32 @@ enum ForkChannel {
     /// Read `applicationUpdateChannel` from Fork's defaults via CFPreferences, so
     /// the value is authoritative even while Fork is running. nil if unreadable.
     static func readChannelPref() -> Int? {
-        guard let raw = CFPreferencesCopyAppValue(
+        channelPref(from: CFPreferencesCopyAppValue(
             "applicationUpdateChannel" as CFString, bundleID as CFString
-        ) else { return nil }
-        return (raw as? NSNumber)?.intValue
+        ))
+    }
+
+    /// The typed half of the read, split out so it can be tested without touching
+    /// the real preference domain.
+    ///
+    /// A string is accepted because Fork reads the key with `integerForKey:`,
+    /// which parses one. This used to take `NSNumber` only, and the difference is
+    /// not academic in the direction it fails: a `applicationUpdateChannel` stored
+    /// as the string "1" is Stable to Fork and unreadable to us, and unreadable
+    /// falls through to Develop — pushing a Develop build at a copy its owner put
+    /// on Stable, the mirror of the bug this file was written for. Fork's own UI
+    /// writes an integer, so nothing observed produces a string; the point is that
+    /// "we mirror Fork's comparison" is now true of the whole read and not just of
+    /// the `== 1`.
+    static func channelPref(from raw: Any?) -> Int? {
+        switch raw {
+        case let number as NSNumber: return number.intValue
+        // `integerForKey:` on a non-numeric string yields 0, which is not 1 and so
+        // is Develop. nil lands on the same branch of `resolve`, so returning nil
+        // rather than 0 keeps "we could not read it" distinguishable at the call
+        // site without changing the resolution.
+        case let text as String: return Int(text.trimmingCharacters(in: .whitespaces))
+        default: return nil
+        }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ForkChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ForkChannelTests.swift
@@ -2,16 +2,34 @@ import Testing
 import Foundation
 @testable import DuoUpdaterCore
 
-/// Fork hides its channel in `applicationUpdateChannel` (2 == Stable). The pure
-/// mapping is the one piece worth pinning down — getting it backwards would
-/// offer a beta build to a Stable user.
+/// Fork hides its channel in `applicationUpdateChannel`. Getting the mapping
+/// backwards is not a cosmetic mislabel — it retargets the feed, and because the
+/// stable feed's head (2.66.7) is *older* than a Develop user's installed copy,
+/// "wrong feed" surfaces as "no update available" rather than as an error. That
+/// is what shipped: the constant said 2 == Stable when Fork writes 2 for Develop.
+///
+/// The values below are read out of Fork 2.69.0's binary, not out of our own
+/// resolver — see `ForkChannel`'s doc comment for the disassembly. Pinning them
+/// against `resolve` alone would repeat the mistake that produced the bug.
 
-@Test func forkStablePrefRetargetsToStableFeed() {
-    let r = ForkChannel.resolve(channelPref: 2)
+@Test func forkStableIsPrefOneAndRetargetsToStableFeed() {
+    let r = ForkChannel.resolve(channelPref: 1)
+    #expect(ForkChannel.stablePrefValue == 1)
     #expect(r.channel == .stable)
     #expect(r.feedOverride == ForkChannel.stableFeed)
 }
 
+/// The regression itself. 2 is what Fork's "Develop" menu item writes, so this
+/// is the value a real Develop user has on disk; we answered `.stable` for it.
+@Test func forkDeveloperPrefIsTwoAndKeepsTheDeveloperFeed() {
+    let r = ForkChannel.resolve(channelPref: ForkChannel.developerPrefValue)
+    #expect(ForkChannel.developerPrefValue == 2)
+    #expect(r.channel == .beta)
+    #expect(r.feedOverride == ForkChannel.developerFeed)
+}
+
+/// Absent is Develop because Fork's picker is a bare `cmp #1` against
+/// `integerForKey:`, which yields 0 for an unset key.
 @Test func forkAbsentPrefIsDeveloperDefault() {
     let r = ForkChannel.resolve(channelPref: nil)
     #expect(r.channel == .beta)
@@ -19,9 +37,35 @@ import Foundation
 }
 
 @Test func forkUnexpectedPrefFallsBackToDeveloper() {
-    for v in [0, 1, 3, -1, 99] {
+    for v in [0, 2, 3, -1, 99] {
         let r = ForkChannel.resolve(channelPref: v)
-        #expect(r.channel == .beta, "pref \(v) should resolve to Developer/beta")
+        #expect(r.channel == .beta, "pref \(v) should resolve to Develop/beta")
         #expect(r.feedOverride == ForkChannel.developerFeed)
     }
+}
+
+/// The two feeds must not collapse into one, or every assertion above passes
+/// while the retargeting does nothing.
+@Test func forkFeedsAreDistinct() {
+    #expect(ForkChannel.stableFeed != ForkChannel.developerFeed)
+    #expect(ForkChannel.stablePrefValue != ForkChannel.developerPrefValue)
+}
+
+/// `readChannelPref`'s typed half. Fork reads the key with `integerForKey:`,
+/// which parses a string, so a string-typed pref must not read as "unset" —
+/// unset falls through to Develop, which would push a Develop build at a copy
+/// its owner put on Stable.
+@Test func forkChannelPrefAcceptsWhatIntegerForKeyAccepts() {
+    #expect(ForkChannel.channelPref(from: NSNumber(value: 1)) == 1)
+    #expect(ForkChannel.channelPref(from: "1") == 1)
+    #expect(ForkChannel.resolve(channelPref: ForkChannel.channelPref(from: "1")).channel
+            == .stable)
+
+    // Not numeric and not present both mean "not 1", which is Develop — the same
+    // answer `integerForKey:` produces by returning 0.
+    #expect(ForkChannel.channelPref(from: "develop") == nil)
+    #expect(ForkChannel.channelPref(from: nil) == nil)
+    #expect(ForkChannel.channelPref(from: Date()) == nil)
+    #expect(ForkChannel.resolve(channelPref: ForkChannel.channelPref(from: "develop")).channel
+            == .beta)
 }

--- a/docs/app-audits/com-DanPristupov-Fork.md
+++ b/docs/app-audits/com-DanPristupov-Fork.md
@@ -1,6 +1,8 @@
 # Fork
 
-> 审计日期 2026-06-04 · 模式 REPORT（已接入）· 结论：**stable/beta 两 channel，ChannelBinding + Changelog，Sparkle feed-swap**
+> 审计日期 2026-06-04 · 复审 2026-09-07 · 模式 REPORT（已接入）· 结论：**stable/beta 两 channel，ChannelBinding + Changelog，Sparkle feed-swap**
+>
+> ⚠️ **2026-09-07 更正**：`applicationUpdateChannel` 的映射原来写反了（写的 2→stable，实际 **1→stable、2→Develop**）。后果和复验方法见下文「2026-09-07：映射写反」。
 
 ## 基本信息
 - Bundle ID: `com.DanPristupov.Fork`（两 channel **共用**同一 bundle id）
@@ -21,10 +23,12 @@
 
 | Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
 |---------|-----------|----------|---------|---------|------|
-| stable  | `com.DanPristupov.Fork` | 共享 | `applicationUpdateChannel` pref = 2 | feed-swap → `fork.dev/update/feed-stable.xml` | ✓ |
-| beta    | `com.DanPristupov.Fork` | 共享 | pref ≠ 2（默认 unset = Developer） | feed-swap → `fork.dev/update/feed.xml` | ✓ |
+| stable  | `com.DanPristupov.Fork` | 共享 | `applicationUpdateChannel` pref = **1** | feed-swap → `fork.dev/update/feed-stable.xml` | ✓ |
+| beta    | `com.DanPristupov.Fork` | 共享 | pref ≠ 1（**2 = Develop 菜单项写的值**；unset 也是 Develop） | feed-swap → `fork.dev/update/feed.xml` | ✓ |
 
-Fork 命名反直觉：UI 称"Developer"为 beta 轨道（shipped default），"Stable（delayed 1 week）"为 stable。`applicationUpdateChannel = 2` → stable；unset/其他 → beta（Developer）。
+Fork 命名反直觉：UI 称"Develop"为 beta 轨道（shipped default），"Stable (delayed 1 week)"为 stable。
+`applicationUpdateChannel = 1` → stable；**2 / unset / 其他** → beta（Develop）。
+Fork 的选择逻辑是对 1 的单次比较，不是枚举，所以我们也照着比 1、其余全落 Develop。
 
 ## 更新检测
 - `ForkChannel.resolveCurrent()` 读 `CFPreferencesCopyAppValue("applicationUpdateChannel", "com.DanPristupov.Fork")` → Int
@@ -38,8 +42,55 @@ Fork 命名反直觉：UI 称"Developer"为 beta 轨道（shipped default），"
 ## 一键安装
 - Sparkle 自更新（stable/beta 各自 feed 带 `<enclosure>`），duo-updater 不额外覆盖安装
 
+## 2026-09-07：映射写反
+
+**现象**：用户 Fork 2.69.0，Fork 自己的 Sparkle 弹窗提示 2.70.0，DuoUpdater 一声不吭。
+
+**根因**：`applicationUpdateChannel = 2`（Fork 的 Updates 面板显示 "Develop"）。我们把 2 读成
+stable，于是把这台机器重定向到 `feed-stable.xml`；那份 feed 的 head 是 **2.66.7**，比装着的
+2.69.0 还旧。**"比装着的还旧"渲染成"已是最新"，不是错误**，所以整条链路全绿、2.70.0 从不出现。
+
+**原验证为什么没抓到**：`channel-verify --scan` 跑的是**我们自己的** `detect()`。把 pref 设成 2、
+看我们答 "stable"，证明的只是我们自我一致——`f(X) == f(X)`。它对"Fork 认为 2 是什么"一无所知。
+这正是 CLAUDE.md 里那条「先核 issue／别把自己的实现当证人」的形状。
+
+**这次的证据（读 Fork 2.69.0 arm64 slice，不是读我们的 Swift）**：
+
+```
+# feed 选择，0x1002156fc
+bl   -[NSUserDefaults integerForKey:]   # "applicationUpdateChannel" -> x21
+cmp  x21, #0x1
+csel x20, <…/feed-stable.xml>, <…/feed.xml>, eq
+
+# 两个写入点，各是一条 setInteger:forKey: 的立即数
+enableStableChannel(_:)   0x10030e888   mov w2, #0x1
+enableDevelopChannel(_:)  0x10030e774   mov w2, #0x2
+```
+
+复现命令（只读，不动 Fork 的偏好）：
+
+```
+lipo -thin arm64 /Applications/Fork.app/Contents/MacOS/Fork -output /tmp/Fork.arm64
+otool -tV /tmp/Fork.arm64 | sed -n '/00000001002156dc/,/0000000100215708/p'
+```
+
+**旁证（各自独立）**：`defaults read com.DanPristupov.Fork applicationUpdateChannel` = 2，
+而 Fork 自己的 Updates 面板把它显示成 "Develop"；同一台机器上 Fork 弹出的是 2.70.0，
+而 2.70.0 **只存在于** `feed.xml`。
+
+**留下的坑**：`feed-stable.xml` 的 head 长期停在 2.66.7（`Last-Modified` 却是最近的），
+所以任何真的切到 Stable 的 Fork 用户，在我们这里都会看到"已是最新"。这是厂商行为，
+不是我们的 bug，但下一个人看到"stable 无更新"时先查这个。
+
 ## channel-verify 状态
-- ✓ **已验证 2026-06-04**（`--scan` 跑生产 `AppScanner`→`ChannelBinding`）。`applicationUpdateChannel` 未设时 Fork 默认走 **Developer/beta**（非 stable），developer feed head=2.67.0=installed。VendorProbe 故意无应答（机制是 Sparkle feed-swap）。**stable 也已在真实 bundle 上验证**（`applicationUpdateChannel=2` 时 `--scan` 结果=stable；验证用的临时改动已还原，无需退出 Fork）。证据见下文「如何复验」。
+- ⚠️ **2026-06-04 那次的 stable 一半是无效的**（见上）。`--scan` 能验"这台机器当前解析到哪个
+  channel"，**不能**验"pref 的数值语义"——后者只能读 Fork 的二进制或在 Fork UI 里切一次再读
+  `defaults`。
+- ✓ beta/Develop 侧仍然有效：`applicationUpdateChannel` 未设或为 2 时走 **Develop/beta**。
+  VendorProbe 故意无应答（机制是 Sparkle feed-swap）。
+  ⚠️ 2026-06-04 那条写的是「feed head 与 installed 一致（2.67.0）」——**那是当天的观测，不是判据**。
+  2026-09-07 实测 head=2.70.0、installed=2.69.0，正好相反。判据是「解析到哪个 channel」，
+  不是「head 等不等于 installed」；后者只说明那天厂商没发新版。
 
 ## 如何复验
 


### PR DESCRIPTION
Fork's own Sparkle dialog was offering 2.70.0 while Duo Updater showed nothing.

## What was wrong

`ForkChannel` mapped `applicationUpdateChannel == 2` to Stable. Fork writes **2 for Develop** and **1 for Stable**, so every Develop copy was retargeted to `feed-stable.xml` — whose head is **2.66.7**, older than any current install.

A head *older* than installed renders as "up to date", not as an error, so nothing anywhere went red:

```
$ duo check Fork --all          # before
  Fork  2.69.0  (latest 2.66.7)  [Sparkle]
  0 updates available of 1 app shown.

$ duo check Fork --all          # after
  Fork  2.69.0  →  2.70.0  [Sparkle, in-place]
  1 update available of 1 app shown.
```

## Why the original audit said otherwise

It cited `channel-verify --scan`, which runs **our own** `detect()`. Writing 2 and watching us answer "stable" only proved we were self-consistent — `f(X) == f(X)`. It says nothing about what Fork means by the value.

The mapping here is read out of Fork 2.69.0's arm64 slice instead:

```
# feed picker, 0x1002156fc
bl   -[NSUserDefaults integerForKey:]   # "applicationUpdateChannel" -> x21
cmp  x21, #0x1
csel x20, <…/feed-stable.xml>, <…/feed.xml>, eq

# the two writers, each a setInteger:forKey: immediate
enableStableChannel(_:)   0x10030e888   mov w2, #0x1
enableDevelopChannel(_:)  0x10030e774   mov w2, #0x2
```

Two independent corroborations: Fork's own Updates pane labels this machine's pref-2 copy "Develop", and 2.70.0 exists only in the unsuffixed feed. The read-only command to redo it is in the audit doc.

## Also in here

- **`readChannelPref` now mirrors the whole read, not just the `== 1`.** It took `NSNumber` only, while `integerForKey:` also parses a string — and the gap failed in the worse direction: `applicationUpdateChannel` stored as `"1"` is Stable to Fork and unreadable to us, and unreadable falls through to Develop. Split into a testable `channelPref(from:)`.
- **`allResolutions` says plainly that it gates nothing.** It now enumerates both explicit values, but `channelBindingsNeedingProof` drops `.stable` resolutions, so under the old constant a listed 2 would *still* have produced no proof key and no red test. The comment says so rather than implying cover that does not exist.
- **The audit doc records the circular check by name**, plus one live trap: `feed-stable.xml` has sat at 2.66.7 for months despite a recent `Last-Modified`, so a genuine Stable user sees "up to date" here too. Vendor behaviour, not ours — noted so the next person does not re-derive this bug.

## Verification

```
make test                                  exit=0
  Core   2392 tests in 198 suites passed (1 known issue)
  CLI    202 tests in 26 suites passed
  App    9 of 9 cases executed
  gates  localizable keys / version comparisons / app audits — all green

channel-verify --scan com.DanPristupov.Fork --expect beta   → detected channel → beta ✓
```

The new `channelPref(from:)` case was mutation-checked: deleting `case let text as String` turns it red and names the value.

`/code-review` ran on this diff and produced three findings, all against my own work; all three are fixed in the commits above rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)