### PR TITLE
Sweep SparkleFeedCatalog's addresses on the same schedule as the recipes

### DIFF
--- a/CLI/Sources/DuoKit/FeedVerify.swift
+++ b/CLI/Sources/DuoKit/FeedVerify.swift
@@ -36,9 +36,10 @@ extension Verify {
         let source = SparkleAppcastSource()
 
         // Sequential with the same inter-request delay every other sweep uses.
-        // Today's entries sit on a host each, so the delay buys nothing — but a
-        // table this small has no parallelism worth having either, and the two
-        // halves of a superseding entry are on one host by construction.
+        // Today's entries sit on a host each, so the delay buys nothing between
+        // them — but a table this small has no parallelism worth having either,
+        // and a superseding entry's two reads go to the same host back to back,
+        // which is the pair the delay is actually for.
         var findings: [Finding] = []
         for (index, entry) in cases.enumerated() {
             if index > 0 {
@@ -47,15 +48,16 @@ extension Verify {
             }
             // Requests, not probes: a retried entry has cost the endpoint every
             // one of them, and `Finding.attempts` is documented as the number
-            // that cannot understate what the sweep spent.
-            let perProbe = entry.declared == nil ? 1 : 2
+            // that cannot understate what the sweep spent. Carried forward from
+            // each probe rather than multiplied out, because a probe that gave
+            // up after an unreachable live read spent one request, not two.
             var attempt = 0
             var finding = await probe(entry, source: source, requestsAlready: 0)
             while attempt < options.infraRetries, finding.status == .infra {
                 attempt += 1
                 try? await Task.sleep(for: .seconds(attempt))
                 finding = await probe(
-                    entry, source: source, requestsAlready: attempt * perProbe)
+                    entry, source: source, requestsAlready: finding.attempts)
             }
             findings.append(finding)
         }
@@ -75,9 +77,16 @@ extension Verify {
         // what makes the entry's own expiry condition mechanical rather than a
         // note in a comment: it is only justified for as long as the address it
         // overrides is genuinely behind.
+        //
+        // Skipped when the live read already failed: `classifyFeed` returns from
+        // its `.unreachable` branch without ever looking at this one, and the
+        // retry loop above would otherwise spend three extra requests on a host
+        // that is down — the one moment it should be asking for less, not more.
         var declared: FeedObservation.Fetch?
-        if let deadAddress = entry.declared {
+        var requestsSpent = 1
+        if let deadAddress = entry.declared, case .read = live {
             declared = await read(deadAddress, bundleID: entry.bundleID, source: source)
+            requestsSpent += 1
         }
 
         let verdict = classifyFeed(entry, FeedObservation(live: live, declared: declared))
@@ -85,10 +94,11 @@ extension Verify {
             recipeID: entry.recipeID, registry: .feed, bundleID: entry.bundleID,
             channel: entry.kind.rawValue, status: verdict.status, version: verdict.version,
             // The LIVE address's host: it is the one an app is pointed at, and
-            // the one a nightly triage should route by. A superseding entry's
-            // dead address is named in the warning that complains about it.
+            // the one a nightly triage should route by. The dead address is
+            // named in full inside the warning that complains about it, which
+            // is what a reader needs when the two share a host.
             warnings: verdict.warnings, endpointHost: entry.feed.host ?? "-",
-            attempts: requestsAlready + (entry.declared == nil ? 1 : 2),
+            attempts: requestsAlready + requestsSpent,
             elapsedMs: Int(Date().timeIntervalSince(started) * 1000))
     }
 
@@ -191,16 +201,32 @@ extension Verify {
 
         // A superseding entry's expiry condition, made mechanical: it is only
         // justified while the address it overrides is behind the one it points
-        // at. `isNewer` fails closed, so "cannot be compared" reads the same as
-        // "not behind" here — deliberately, for a table this small.
+        // at.
+        //
+        // An empty dead side is NOT that condition failing — it is the condition
+        // at its strongest. A dead address that has stopped offering anything a
+        // default-channel install could use (a retired path answering with a
+        // landing page, or a vendor capping its last uncapped build the way PDF
+        // Expert's feed already caps three of four) offers strictly less than
+        // when the entry was written. Reading `isNewer`'s fail-closed `false`
+        // as a complaint there would file an issue every night against the one
+        // entry behaving perfectly.
+        //
+        // What DOES still complain is two non-empty sides that cannot be ranked
+        // — a dead feed naming only a build against a live feed naming only a
+        // marketing string. `VersionComparator` refuses to cross those
+        // namespaces, and "we can no longer show this entry is justified" is
+        // worth being told however it became true.
         if case .read(let dead)? = observation.declared {
             let liveSide = VersionSide(marketing: marketing, build: live.headBuildVersion)
             let deadSide = VersionSide(
                 marketing: dead.headShortVersion, build: dead.headBuildVersion)
-            if !VersionComparator.isNewer(liveSide, than: deadSide) {
-                // Named in full, not by host: both addresses of a superseding
-                // entry are on the same host by construction, so the PATH is
-                // the only thing that tells a reader which one this is about.
+            if !deadSide.isEmpty, !VersionComparator.isNewer(liveSide, than: deadSide) {
+                // Named in full, not by host. `Finding.endpointHost` carries
+                // the LIVE address's host, and nothing requires the two halves
+                // of an entry to differ in more than their path — today's pair
+                // shares a host and differs only there — so the host alone
+                // would not tell a reader which address this is about.
                 warnings.append(
                     "supersededAddressIsNoLongerBehind — the address this entry redirects "
                         + "away from can no longer be shown to be older than the one it "

--- a/CLI/Sources/DuoKit/FeedVerify.swift
+++ b/CLI/Sources/DuoKit/FeedVerify.swift
@@ -1,0 +1,233 @@
+import Foundation
+import DuoUpdaterCore
+
+// `duo verify`'s sweep of `SparkleFeedCatalog` — the addresses we hand out for
+// apps whose own bundle does not give us a usable one.
+//
+// Why it is a registry at all (#324). The other four sweeps check recipes: a
+// pattern that has to keep matching a page. This one checks an ADDRESS, and an
+// address that has stopped working looks like nothing. `SparkleAppcastSource`
+// answers a dead or unusable feed with nil, and every caller renders nil as "up
+// to date" — which is the exact failure the superseding entry was added to fix,
+// one address further along. The table's two halves fail that way for different
+// reasons:
+//
+//   - a fill-in address is one the bundle never states, so if it moves there is
+//     no second source of truth to fall back on;
+//   - a superseding address overrides one the bundle DOES state, so it keeps
+//     asserting our reading of a vendor's infrastructure over theirs until
+//     somebody checks that the reading still holds.
+//
+// Split into a network half (`probe`/`read`) and a pure decision half
+// (`classifyFeed`), the same split `AppStoreVerify` uses, so every judgement
+// here can be exercised offline against fixtures.
+//
+// Never downloads an enclosure: the head item's download URL is checked for
+// SHAPE only. Whether that artifact is still SERVED is a separate question with
+// a separate cost, and the vendor sweep's `installURLNotFound` — a `Range:
+// bytes=0-0` GET, raised only by the sweep and never by a check — is the
+// precedent for how it would be answered if it is ever worth the request.
+extension Verify {
+
+    static func sweepFeeds(
+        _ cases: [SparkleFeedCatalog.VerificationCase], options: VerifyOptions
+    ) async -> [Finding] {
+        guard !cases.isEmpty else { return [] }
+        let source = SparkleAppcastSource()
+
+        // Sequential with the same inter-request delay every other sweep uses.
+        // Today's entries sit on a host each, so the delay buys nothing — but a
+        // table this small has no parallelism worth having either, and the two
+        // halves of a superseding entry are on one host by construction.
+        var findings: [Finding] = []
+        for (index, entry) in cases.enumerated() {
+            if index > 0 {
+                try? await Task.sleep(
+                    for: options.perHostDelay + .milliseconds(Int.random(in: 0...100)))
+            }
+            // Requests, not probes: a retried entry has cost the endpoint every
+            // one of them, and `Finding.attempts` is documented as the number
+            // that cannot understate what the sweep spent.
+            let perProbe = entry.declared == nil ? 1 : 2
+            var attempt = 0
+            var finding = await probe(entry, source: source, requestsAlready: 0)
+            while attempt < options.infraRetries, finding.status == .infra {
+                attempt += 1
+                try? await Task.sleep(for: .seconds(attempt))
+                finding = await probe(
+                    entry, source: source, requestsAlready: attempt * perProbe)
+            }
+            findings.append(finding)
+        }
+        return findings
+    }
+
+    /// The network half: read the address the catalog hands out, plus — for a
+    /// superseding entry — the dead address it overrides, and hand both to
+    /// `classifyFeed`. Decides nothing itself.
+    private static func probe(
+        _ entry: SparkleFeedCatalog.VerificationCase, source: SparkleAppcastSource,
+        requestsAlready: Int
+    ) async -> Finding {
+        let started = Date()
+        let live = await read(entry.feed, bundleID: entry.bundleID, source: source)
+        // Two requests for a superseding entry, one for a fill-in. The second is
+        // what makes the entry's own expiry condition mechanical rather than a
+        // note in a comment: it is only justified for as long as the address it
+        // overrides is genuinely behind.
+        var declared: FeedObservation.Fetch?
+        if let deadAddress = entry.declared {
+            declared = await read(deadAddress, bundleID: entry.bundleID, source: source)
+        }
+
+        let verdict = classifyFeed(entry, FeedObservation(live: live, declared: declared))
+        return Finding(
+            recipeID: entry.recipeID, registry: .feed, bundleID: entry.bundleID,
+            channel: entry.kind.rawValue, status: verdict.status, version: verdict.version,
+            // The LIVE address's host: it is the one an app is pointed at, and
+            // the one a nightly triage should route by. A superseding entry's
+            // dead address is named in the warning that complains about it.
+            warnings: verdict.warnings, endpointHost: entry.feed.host ?? "-",
+            attempts: requestsAlready + (entry.declared == nil ? 1 : 2),
+            elapsedMs: Int(Date().timeIntervalSince(started) * 1000))
+    }
+
+    private static func read(
+        _ url: URL, bundleID: String, source: SparkleAppcastSource
+    ) async -> FeedObservation.Fetch {
+        do {
+            switch try await source.readFeed(url, bundleID: bundleID) {
+            case .success(let reading): return .read(reading)
+            case .failure(.badStatus(let code)):
+                return .unreachable(httpStatus: code, detail: "HTTP \(code)")
+            }
+        } catch {
+            return .unreachable(httpStatus: nil, detail: error.localizedDescription)
+        }
+    }
+
+    /// What one entry's live reads mean, as a verdict the report can carry.
+    ///
+    /// Warnings are written `<claim> — <explanation>`: `Reconcile.reason` takes
+    /// the claim as the issue title, and `Finding.signature` keys on the first
+    /// 40 characters, so every claim here is fixed text long enough that a
+    /// version or a count moving cannot change the signature.
+    static func classifyFeed(
+        _ entry: SparkleFeedCatalog.VerificationCase, _ observation: FeedObservation
+    ) -> (status: FindingStatus, version: String?, warnings: [String]) {
+        let live: SparkleFeedReading
+        switch observation.live {
+        case .read(let reading):
+            live = reading
+        case .unreachable(_, let detail):
+            // Never `.broken`. An address that does not answer is the network's
+            // word until it has been the network's word for a week, which is
+            // what `Baseline.isInfraReportable` is for.
+            return (.infra, nil, [
+                "feedUnreachable — the address this catalog entry hands out did not answer "
+                    + "(\(detail))",
+            ])
+        }
+
+        // The feed answered. Everything below is about whether what came back
+        // can still do the job the entry was added to do.
+        var warnings: [String] = []
+
+        if live.itemCount == 0 {
+            return (.broken, nil, [
+                "feedParsedToZeroItems — the address answered, with a body carrying no "
+                    + "appcast items at all (\(live.byteCount) bytes). An app fed this "
+                    + "address sees no update and no error.",
+            ])
+        }
+
+        guard live.usableCount > 0 else {
+            // The silent one. `latestVersion` returns nil here and the row reads
+            // as up to date — the same shape as the frozen feed that made a
+            // superseding entry necessary in the first place.
+            let capped = live.itemsDeclaringMaximumSystemVersion
+            return (.broken, nil, [
+                "everyItemFilteredOut — the feed parsed \(live.itemCount) items and none of "
+                    + "them survive the channel, OS-bound and architecture filters for a "
+                    + "default-channel install on macOS \(live.osVersion)"
+                    + (capped > 0
+                        ? " — \(capped) of them declare a maximum system version"
+                        : ""),
+            ])
+        }
+
+        // The marketing string is what the baseline's monotonicity check reads,
+        // and it is the only field on this side that may be compared against the
+        // installed copy's own `CFBundleShortVersionString` (`RemoteVersion`
+        // sets `marketingMatchesBundle` for exactly this source). A feed that
+        // stops publishing it moves `evaluate` onto its build branch and leaves
+        // the baseline nothing it may record without changing namespaces
+        // mid-history, so the version goes nil rather than silently becoming a
+        // build number.
+        guard let marketing = live.headShortVersion, !marketing.isEmpty else {
+            warnings.append(
+                "headItemNamesNoMarketingVersion — the newest usable item declares no "
+                    + "sparkle:shortVersionString, so this feed can no longer be compared "
+                    + "against an installed copy's marketing version"
+                    + (live.headBuildVersion.map { " (build \($0))" } ?? ""))
+            return (.warn, nil, warnings)
+        }
+
+        // Detection still works without a usable enclosure; installing does not.
+        // Same call as the vendor sweep's `installURLUnresolved`, which is a
+        // warning for the same reason.
+        if let enclosure = live.headEnclosure {
+            if enclosure.scheme?.hasPrefix("http") != true || enclosure.host == nil {
+                warnings.append(
+                    "headEnclosureIsNotAbsolute — the newest usable item's download URL did "
+                        + "not resolve to an absolute http(s) address, so the update can be "
+                        + "detected but never installed (\(enclosure.absoluteString))")
+            }
+        } else {
+            warnings.append(
+                "headItemHasNoEnclosure — the newest usable item carries no download URL, so "
+                    + "the update can be detected but never installed")
+        }
+
+        // A superseding entry's expiry condition, made mechanical: it is only
+        // justified while the address it overrides is behind the one it points
+        // at. `isNewer` fails closed, so "cannot be compared" reads the same as
+        // "not behind" here — deliberately, for a table this small.
+        if case .read(let dead)? = observation.declared {
+            let liveSide = VersionSide(marketing: marketing, build: live.headBuildVersion)
+            let deadSide = VersionSide(
+                marketing: dead.headShortVersion, build: dead.headBuildVersion)
+            if !VersionComparator.isNewer(liveSide, than: deadSide) {
+                // Named in full, not by host: both addresses of a superseding
+                // entry are on the same host by construction, so the PATH is
+                // the only thing that tells a reader which one this is about.
+                warnings.append(
+                    "supersededAddressIsNoLongerBehind — the address this entry redirects "
+                        + "away from can no longer be shown to be older than the one it "
+                        + "redirects to, which is the entry's whole justification "
+                        + "(\(entry.declared?.absoluteString ?? "?") at "
+                        + "\(deadSide.text(withBuild: true)), "
+                        + "live \(liveSide.text(withBuild: true)))")
+            }
+        }
+
+        return (warnings.isEmpty ? .ok : .warn, marketing, warnings)
+    }
+}
+
+/// What the live reads of one catalog entry saw — fetch only, no verdict. See
+/// `Verify.classifyFeed(_:_:)`.
+struct FeedObservation: Sendable {
+    enum Fetch: Sendable {
+        case read(SparkleFeedReading)
+        /// Nothing parseable came back. `httpStatus` is nil when the request
+        /// never got an answer at all.
+        case unreachable(httpStatus: Int?, detail: String)
+    }
+
+    /// The address `AppScanner` writes onto the row.
+    let live: Fetch
+    /// The dead address a superseding entry matches on. Nil for a fill-in,
+    /// which overrides nothing and so has no second address to read.
+    let declared: Fetch?
+}

--- a/CLI/Sources/DuoKit/Finding.swift
+++ b/CLI/Sources/DuoKit/Finding.swift
@@ -1,7 +1,7 @@
 import Foundation
 import DuoUpdaterCore
 
-/// Which registry a finding came from. The three are checked the same way and
+/// Which registry a finding came from. They are checked the same way and
 /// reported together, but they break differently and are fixed in different
 /// files, so the report has to keep them apart.
 public enum Registry: String, Codable, Sendable, CaseIterable {
@@ -15,6 +15,13 @@ public enum Registry: String, Codable, Sendable, CaseIterable {
     /// product-page shapes `MacAppStoreSource` parses still look the way its
     /// code assumes — see `MacAppStoreProbeRegistry`'s doc comment.
     case appStore = "appstore"
+    /// `SparkleFeedCatalog` isn't a recipe registry either — it holds
+    /// ADDRESSES, handed to apps whose own bundle does not give us a usable
+    /// one. Nothing on a schedule had ever fetched them (#324), and a feed that
+    /// dies, moves or reshapes its items produces a nil out of
+    /// `SparkleAppcastSource` that every caller renders as "up to date". See
+    /// `FeedVerify.swift`.
+    case feed
 
     public var label: String {
         switch self {
@@ -22,6 +29,7 @@ public enum Registry: String, Codable, Sendable, CaseIterable {
         case .github: return "GitHub rule"
         case .changelog: return "changelog"
         case .appStore: return "App Store probe"
+        case .feed: return "Sparkle feed"
         }
     }
 }

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -50,11 +50,13 @@ public enum Verify {
         let github = filtered(GitHubReleaseRegistry.rules, options) { $0.bundleID }
         let changelog = filtered(ChangelogRecipeRegistry.recipes, options) { $0.bundleID }
         let appStore = filtered(MacAppStoreProbeRegistry.cases, options) { $0.bundleID }
+        let feeds = filtered(SparkleFeedCatalog.verificationCases, options) { $0.bundleID }
 
         let total = (options.registries.contains(.vendor) ? vendor.count : 0)
             + (options.registries.contains(.github) ? github.count : 0)
             + (options.registries.contains(.changelog) ? changelog.count : 0)
             + (options.registries.contains(.appStore) ? appStore.count : 0)
+            + (options.registries.contains(.feed) ? feeds.count : 0)
         guard total > 0 else {
             die("nothing to verify — no recipe matches \(options.only.joined(separator: ", "))",
                 code: 2)
@@ -67,7 +69,8 @@ public enum Verify {
           \(options.registries.contains(.vendor) ? "\(vendor.count) vendor probes  " : "")\
         \(options.registries.contains(.github) ? "\(github.count) GitHub rules  " : "")\
         \(options.registries.contains(.changelog) ? "\(changelog.count) changelogs  " : "")\
-        \(options.registries.contains(.appStore) ? "\(appStore.count) App Store probes" : "")
+        \(options.registries.contains(.appStore) ? "\(appStore.count) App Store probes  " : "")\
+        \(options.registries.contains(.feed) ? "\(feeds.count) Sparkle feeds" : "")
           ─────────────────────────────────────────────
         """)
 
@@ -127,6 +130,9 @@ public enum Verify {
         if options.registries.contains(.appStore) {
             findings += await sweepAppStore(appStore, options: options)
         }
+        if options.registries.contains(.feed) {
+            findings += await sweepFeeds(feeds, options: options)
+        }
 
         findings.sort { $0.recipeID < $1.recipeID }
 
@@ -148,7 +154,8 @@ public enum Verify {
                 + ChangelogRecipeRegistry.recipes.map(\.recipeID)
                 + GitHubReleaseRegistry.rules.map(\.recipeID)
                 + MacAppStoreProbeRegistry.cases.map(\.recipeID)
-                + [MacAppStoreProbeRegistry.batchRecipeID])
+                + [MacAppStoreProbeRegistry.batchRecipeID]
+                + SparkleFeedCatalog.verificationCases.map(\.recipeID))
         let pruned = baseline.prune(keeping: live)
         for id in pruned.removed {
             print("  baseline: dropped \(id) — no recipe produces this id any more")

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -151,12 +151,13 @@ events options:
 
 verify options:
   --only <text>       Restrict to recipes whose bundle id contains <text>.
-                      Comma-separated for several. Without it all four
+                      Comma-separated for several. Without it all five
                       registries are swept (~150 requests, about 3 minutes).
   --vendor            Sweep only the vendor probe recipes.
   --github            Sweep only the GitHub release rules.
   --changelog         Sweep only the changelog recipes.
   --appstore          Sweep only the Mac App Store probe cases.
+  --feed              Sweep only the SparkleFeedCatalog addresses.
   --samples           Print the fetched body sample for each flagged recipe —
                       what you need to re-derive a broken pattern.
   --no-installed      Don't cross-check against locally installed apps. Implied

--- a/CLI/Tests/DuoKitTests/FeedVerifyClassificationTests.swift
+++ b/CLI/Tests/DuoKitTests/FeedVerifyClassificationTests.swift
@@ -1,0 +1,255 @@
+import Testing
+import Foundation
+@testable import DuoKit
+@testable import DuoUpdaterCore
+
+/// `Verify.classifyFeed` is the pure decision half of `duo verify`'s
+/// `SparkleFeedCatalog` sweep (`Verify.probe` does the network half and is not
+/// exercised here — see `FeedVerify.swift`'s doc comment for the split, which
+/// mirrors `Verify.classifyAppStore`).
+///
+/// The entries under test are pulled FROM the catalog rather than written out
+/// here, so a case's kind and addresses cannot drift between the table and what
+/// these tests assume about it — and a new entry is covered the day it lands.
+/// Every case names the mutation it catches.
+@Suite struct FeedVerifyClassificationTests {
+
+    private func fillInEntry() throws -> SparkleFeedCatalog.VerificationCase {
+        try #require(SparkleFeedCatalog.verificationCases.first { $0.kind == .fillIn },
+                     "the catalog no longer has a fill-in entry to test against")
+    }
+
+    private func supersededEntry() throws -> SparkleFeedCatalog.VerificationCase {
+        try #require(SparkleFeedCatalog.verificationCases.first { $0.kind == .superseded },
+                     "the catalog no longer has a superseding entry to test against")
+    }
+
+    /// A feed answering the way both live feeds answer today: several items,
+    /// the newest usable one naming a marketing version and an absolute
+    /// enclosure. The baseline every mutation below starts from.
+    private func healthy(
+        items: Int = 9, usable: Int = 9,
+        short: String? = "3.13.2", build: String? = "1172",
+        enclosure: String? = "https://example.com/app.zip",
+        capped: Int = 0
+    ) -> SparkleFeedReading {
+        SparkleFeedReading(
+            itemCount: items, usableCount: usable,
+            headShortVersion: short, headBuildVersion: build,
+            headEnclosure: enclosure.flatMap { URL(string: $0) },
+            itemsDeclaringMaximumSystemVersion: capped,
+            osVersion: "26.0.0", byteCount: 4_734)
+    }
+
+    // MARK: - baseline
+
+    /// The version recorded is the MARKETING string, which is what
+    /// `Baseline.reconcile` compares run to run.
+    ///
+    /// Mutation: return `live.headBuildVersion` instead and this reads `1172`.
+    /// That is not merely a different label — the baseline would then hold a
+    /// build where it used to hold a marketing version, and
+    /// `VersionComparator` is documented never to compare across those two
+    /// namespaces.
+    @Test func aHealthyFillInFeedIsOKAndRecordsItsMarketingVersion() throws {
+        let verdict = Verify.classifyFeed(
+            try fillInEntry(), FeedObservation(live: .read(healthy()), declared: nil))
+        #expect(verdict.status == .ok)
+        #expect(verdict.version == "3.13.2")
+        #expect(verdict.warnings.isEmpty)
+    }
+
+    /// A superseding entry is healthy when the address it redirects AWAY from
+    /// is still older than the one it redirects to — which is the entry's whole
+    /// justification, and the only thing about it that can expire on its own.
+    @Test func aSupersededEntryIsOKWhileTheDeadAddressIsStillBehind() throws {
+        let dead = healthy(items: 4, usable: 1, short: "2.5.22", build: "764")
+        let verdict = Verify.classifyFeed(
+            try supersededEntry(),
+            FeedObservation(live: .read(healthy()), declared: .read(dead)))
+        #expect(verdict.status == .ok)
+        #expect(verdict.version == "3.13.2")
+        #expect(verdict.warnings.isEmpty)
+    }
+
+    // MARK: - the address itself
+
+    /// Mutation: `.infra` → `.broken` here. A host having a bad minute would
+    /// then open an issue on the first sweep that saw it, which is what
+    /// `Baseline.isInfraReportable`'s week-long window exists to prevent.
+    @Test func anAddressThatDoesNotAnswerIsInfraNotBroken() throws {
+        let verdict = Verify.classifyFeed(
+            try fillInEntry(),
+            FeedObservation(live: .unreachable(httpStatus: 503, detail: "HTTP 503"),
+                            declared: nil))
+        #expect(verdict.status == .infra)
+        #expect(verdict.version == nil)
+        #expect(verdict.warnings.first?.hasPrefix("feedUnreachable") == true)
+    }
+
+    /// A 200 carrying something that is not an appcast — a CDN's HTML error
+    /// page, a redirect landing page, an empty file.
+    ///
+    /// Mutation: fold this into the `usableCount` branch below. The report then
+    /// says the vendor's items were filtered out, sending whoever reads it to
+    /// look at OS bounds and channels when there were never any items at all.
+    @Test func aBodyWithNoItemsIsBroken() throws {
+        let verdict = Verify.classifyFeed(
+            try fillInEntry(),
+            FeedObservation(live: .read(healthy(items: 0, usable: 0)), declared: nil))
+        #expect(verdict.status == .broken)
+        #expect(verdict.version == nil)
+        #expect(verdict.warnings.first?.hasPrefix("feedParsedToZeroItems") == true)
+    }
+
+    /// The silent one, and the reason this sweep exists. Items parse, every one
+    /// of them is filtered, `latestVersion` returns nil, and the row renders as
+    /// up to date — the exact shape of the frozen feed a superseding entry was
+    /// added to escape.
+    ///
+    /// Mutation: drop the `usableCount > 0` guard. The head fields are all nil
+    /// in this state, so the next guard catches it and downgrades the verdict
+    /// to a `.warn` about a missing marketing version — a true statement that
+    /// describes the wrong problem.
+    @Test func aFeedWhoseEveryItemIsFilteredIsBrokenAndSaysWhy() throws {
+        let verdict = Verify.classifyFeed(
+            try fillInEntry(),
+            FeedObservation(
+                live: .read(healthy(items: 4, usable: 0, short: nil, build: nil,
+                                    enclosure: nil, capped: 3)),
+                declared: nil))
+        #expect(verdict.status == .broken)
+        #expect(verdict.version == nil)
+        let warning = try #require(verdict.warnings.first)
+        #expect(warning.hasPrefix("everyItemFilteredOut"))
+        // The hint `latestVersion` itself logs, so the report points the same
+        // way the runtime log does rather than at a re-derived predicate.
+        #expect(warning.contains("3 of them declare a maximum system version"))
+        #expect(warning.contains("26.0.0"))
+    }
+
+    /// A feed whose head item names only `sparkle:version`. Legal Sparkle, but
+    /// it changes what this source can promise: `RemoteVersion` marks a Sparkle
+    /// answer as carrying the bundle's own marketing string, and `evaluate`'s
+    /// downgrade guard reads that.
+    ///
+    /// Mutation: record `headBuildVersion` as a fallback. The finding then
+    /// reads `.ok` with version `1172`, and the baseline silently switches the
+    /// namespace it has been recording in.
+    @Test func aHeadItemWithNoMarketingVersionWarnsAndRecordsNothing() throws {
+        let verdict = Verify.classifyFeed(
+            try fillInEntry(),
+            FeedObservation(live: .read(healthy(short: nil)), declared: nil))
+        #expect(verdict.status == .warn)
+        #expect(verdict.version == nil)
+        let warning = try #require(verdict.warnings.first)
+        #expect(warning.hasPrefix("headItemNamesNoMarketingVersion"))
+        // The build is still worth printing — it is what a reader needs to find
+        // the item being complained about.
+        #expect(warning.contains("1172"))
+    }
+
+    // MARK: - the enclosure
+
+    /// Helium's feed publishes RELATIVE enclosures, resolved against the
+    /// appcast's own address; before that resolution existed they came out
+    /// schemeless and nothing could fetch them. Detection still worked, which
+    /// is why this is a warning rather than a break — and why it needs to be
+    /// said out loud at all.
+    ///
+    /// Mutation: drop the scheme/host check. An entry whose downloads cannot be
+    /// fetched then sweeps green forever, because the version still parses.
+    @Test func aHeadEnclosureThatIsNotAbsoluteWarnsAndStillRecordsTheVersion() throws {
+        let verdict = Verify.classifyFeed(
+            try fillInEntry(),
+            FeedObservation(
+                live: .read(healthy(enclosure: "assets/helium_0.16.5.1_arm64-macos.dmg")),
+                declared: nil))
+        #expect(verdict.status == .warn)
+        // Still recorded: detection is intact, and losing the version history
+        // would cost the one check that catches a feed going backwards.
+        #expect(verdict.version == "3.13.2")
+        #expect(verdict.warnings.first?.hasPrefix("headEnclosureIsNotAbsolute") == true)
+    }
+
+    /// Mutation: treat a nil enclosure as "nothing to check". A detection-only
+    /// feed then reports `.ok` while every Update button on it is dead.
+    @Test func aHeadItemWithNoEnclosureAtAllWarns() throws {
+        let verdict = Verify.classifyFeed(
+            try fillInEntry(),
+            FeedObservation(live: .read(healthy(enclosure: nil)), declared: nil))
+        #expect(verdict.status == .warn)
+        #expect(verdict.version == "3.13.2")
+        #expect(verdict.warnings.first?.hasPrefix("headItemHasNoEnclosure") == true)
+    }
+
+    // MARK: - the superseded half's expiry
+
+    /// The vendor starts publishing current builds at the address we redirect
+    /// away from. The entry is now asserting our 2026 reading of their
+    /// infrastructure over theirs, and nothing else would ever say so.
+    ///
+    /// Mutation: compare with `>=` — i.e. accept "the same version" as still
+    /// behind. The two addresses serving identical builds is precisely the
+    /// state in which the override has stopped buying anything.
+    @Test func aSupersededEntryWarnsWhenTheDeadAddressCaughtUp() throws {
+        let verdict = Verify.classifyFeed(
+            try supersededEntry(),
+            FeedObservation(live: .read(healthy()),
+                            declared: .read(healthy(items: 4, usable: 1))))
+        #expect(verdict.status == .warn)
+        // Recorded anyway: the live half of this entry is healthy, and its
+        // version history is worth keeping while the override is reviewed.
+        #expect(verdict.version == "3.13.2")
+        #expect(verdict.warnings.first?.hasPrefix("supersededAddressIsNoLongerBehind") == true)
+    }
+
+    /// `VersionComparator.isNewer` fails closed, so an address that cannot be
+    /// compared at all reads the same as one that has caught up. Deliberate for
+    /// a table this small: "we can no longer show this entry is justified" is
+    /// the thing worth being told, whichever way it became true.
+    ///
+    /// Mutation: skip the check when either side is empty. The entry then
+    /// outlives the evidence for it without a word.
+    @Test func aSupersededEntryWarnsWhenTheDeadAddressCannotBeCompared() throws {
+        let verdict = Verify.classifyFeed(
+            try supersededEntry(),
+            FeedObservation(
+                live: .read(healthy()),
+                declared: .read(healthy(items: 1, usable: 1, short: nil, build: nil))))
+        #expect(verdict.status == .warn)
+        #expect(verdict.warnings.first?.hasPrefix("supersededAddressIsNoLongerBehind") == true)
+    }
+
+    /// An abandoned address is allowed to be abandoned. A 404 there says
+    /// nothing against the entry — the match is on the address string, not on
+    /// fetching it — and complaining would file an issue every night about the
+    /// entry working exactly as designed.
+    ///
+    /// Mutation: fold `.unreachable` on the declared half into the warning
+    /// above. Nightly noise, on the one entry that is behaving.
+    @Test func anUnreachableDeadAddressIsNotAComplaint() throws {
+        let verdict = Verify.classifyFeed(
+            try supersededEntry(),
+            FeedObservation(live: .read(healthy()),
+                            declared: .unreachable(httpStatus: 404, detail: "HTTP 404")))
+        #expect(verdict.status == .ok)
+        #expect(verdict.version == "3.13.2")
+        #expect(verdict.warnings.isEmpty)
+    }
+
+    /// A fill-in entry overrides no address, so there is no second read to
+    /// compare against and the superseded check must not fire on it.
+    ///
+    /// Mutation: key the check on `entry.kind` instead of on the observation.
+    /// A fill-in has no `declared` address to read, so the check would be
+    /// comparing the live feed against nothing and warning about every
+    /// fill-in entry in the table.
+    @Test func aFillInEntryIsNeverJudgedAgainstADeadAddress() throws {
+        let entry = try fillInEntry()
+        #expect(entry.declared == nil)
+        let verdict = Verify.classifyFeed(
+            entry, FeedObservation(live: .read(healthy()), declared: nil))
+        #expect(verdict.warnings.isEmpty)
+    }
+}

--- a/CLI/Tests/DuoKitTests/FeedVerifyClassificationTests.swift
+++ b/CLI/Tests/DuoKitTests/FeedVerifyClassificationTests.swift
@@ -151,19 +151,29 @@ import Foundation
 
     // MARK: - the enclosure
 
-    /// Helium's feed publishes RELATIVE enclosures, resolved against the
-    /// appcast's own address; before that resolution existed they came out
-    /// schemeless and nothing could fetch them. Detection still worked, which
-    /// is why this is a warning rather than a break — and why it needs to be
-    /// said out loud at all.
+    /// An enclosure `Downloader` has no way to fetch. Detection still works,
+    /// which is why this is a warning rather than a break — and why it needs to
+    /// be said out loud at all.
     ///
-    /// Mutation: drop the scheme/host check. An entry whose downloads cannot be
+    /// ⚠️ The fixture is a non-http SCHEME, not a relative address, and the
+    /// difference is the whole reachability of this branch. A relative
+    /// enclosure cannot arrive here: `SparkleAppcastParser.resolve` is
+    /// `URL(string:relativeTo:)?.absoluteURL` and `readFeed` always passes the
+    /// feed's own address as the base, so Helium's
+    /// `assets/helium_….dmg` reaches `headEnclosure` already resolved to an
+    /// https URL with a host (pinned in
+    /// `SparkleFeedCatalogTests.aCatalogFedAppStillInfersItsChannelFromTheFeed`).
+    /// Writing this case with a base-less relative URL would be asserting on a
+    /// state the sweep cannot produce — a fixture wider than production, which
+    /// leaves the branch that CAN fire untested.
+    ///
+    /// Mutation: drop the scheme/host check. A feed whose downloads cannot be
     /// fetched then sweeps green forever, because the version still parses.
-    @Test func aHeadEnclosureThatIsNotAbsoluteWarnsAndStillRecordsTheVersion() throws {
+    @Test func aHeadEnclosureOnAnUnfetchableSchemeWarnsAndStillRecordsTheVersion() throws {
         let verdict = Verify.classifyFeed(
             try fillInEntry(),
             FeedObservation(
-                live: .read(healthy(enclosure: "assets/helium_0.16.5.1_arm64-macos.dmg")),
+                live: .read(healthy(enclosure: "ftp://updates.example.com/app.dmg")),
                 declared: nil))
         #expect(verdict.status == .warn)
         // Still recorded: detection is intact, and losing the version history
@@ -204,21 +214,44 @@ import Foundation
         #expect(verdict.warnings.first?.hasPrefix("supersededAddressIsNoLongerBehind") == true)
     }
 
-    /// `VersionComparator.isNewer` fails closed, so an address that cannot be
-    /// compared at all reads the same as one that has caught up. Deliberate for
-    /// a table this small: "we can no longer show this entry is justified" is
-    /// the thing worth being told, whichever way it became true.
+    /// Two addresses that both name a version, in namespaces
+    /// `VersionComparator` refuses to cross: the dead feed names only a build,
+    /// the live one only a marketing string. `isNewer` fails closed, and that
+    /// failure is the answer — "we can no longer show this entry is justified"
+    /// is worth being told however it became true.
     ///
-    /// Mutation: skip the check when either side is empty. The entry then
+    /// Mutation: read the fail-closed `false` as "fine". The entry then
     /// outlives the evidence for it without a word.
-    @Test func aSupersededEntryWarnsWhenTheDeadAddressCannotBeCompared() throws {
+    @Test func aSupersededEntryWarnsWhenTheTwoAddressesCannotBeRanked() throws {
+        let verdict = Verify.classifyFeed(
+            try supersededEntry(),
+            FeedObservation(
+                live: .read(healthy(build: nil)),
+                declared: .read(healthy(items: 4, usable: 1, short: nil, build: "764"))))
+        #expect(verdict.status == .warn)
+        #expect(verdict.warnings.first?.hasPrefix("supersededAddressIsNoLongerBehind") == true)
+    }
+
+    /// The other side of that coin, and the one a fail-closed comparison gets
+    /// backwards on its own. A dead address that offers NOTHING a
+    /// default-channel install could use — a retired path answering with a
+    /// landing page, or a vendor capping its last uncapped build — is the
+    /// entry's justification at its strongest, not its expiry.
+    ///
+    /// Mutation: drop the `!deadSide.isEmpty` guard. `isNewer` then answers
+    /// false against an empty side, the sweep warns, `consecutiveActionable`
+    /// climbs, and after two sweeps an issue is opened against the one entry
+    /// behaving perfectly — nightly, forever.
+    @Test func aSupersededEntryIsOKWhenTheDeadAddressOffersNothing() throws {
         let verdict = Verify.classifyFeed(
             try supersededEntry(),
             FeedObservation(
                 live: .read(healthy()),
-                declared: .read(healthy(items: 1, usable: 1, short: nil, build: nil))))
-        #expect(verdict.status == .warn)
-        #expect(verdict.warnings.first?.hasPrefix("supersededAddressIsNoLongerBehind") == true)
+                declared: .read(healthy(items: 4, usable: 0, short: nil, build: nil,
+                                        enclosure: nil, capped: 4))))
+        #expect(verdict.status == .ok)
+        #expect(verdict.version == "3.13.2")
+        #expect(verdict.warnings.isEmpty)
     }
 
     /// An abandoned address is allowed to be abandoned. A 404 there says

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -6,7 +6,10 @@ import Foundation
 public struct SparkleAppcastSource: UpdateSource {
     public let name = "Sparkle"
 
-    private let session: URLSession
+    // Not private: `readFeed` (SparkleFeedProbe.swift) is the same fetch with no
+    // installed copy behind it, and a sweep that opened its own session would be
+    // sweeping a different client than the one that ships.
+    let session: URLSession
 
     public init(session: URLSession = .updates) {
         self.session = session
@@ -15,26 +18,7 @@ public struct SparkleAppcastSource: UpdateSource {
     public func latestVersion(for app: InstalledApp) async throws -> RemoteVersion? {
         guard let feedURL = app.sparkleFeedURL else { return nil }
 
-        var request = URLRequest(url: feedURL)
-        request.timeoutInterval = 15
-        // Always revalidate the appcast against the origin — never serve it from
-        // the shared `URLCache` on max-age freshness alone. Some vendor CDNs stamp
-        // a static feed with an absurd `Cache-Control: max-age` (Fork's fork.dev
-        // sends ~10 years + `Expires: 2037`): under the default `.useProtocolCache`
-        // policy the cached copy stays "fresh" effectively forever, so once we'd
-        // fetched it we'd replay that stale feed and never see a new release — the
-        // exact reason Fork 2.68.0 went undetected. `.reloadRevalidatingCacheData`
-        // ignores freshness and sends a conditional GET (If-None-Match /
-        // If-Modified-Since from the cached ETag/Last-Modified): unchanged → cheap
-        // 304 served from cache, changed → 200 with the new feed. So we keep the
-        // bandwidth win on quiet feeds without ever going blind to an update.
-        request.cachePolicy = URLRequest.versionFeedCachePolicy
-        request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
-        // Header-keyed apps (TablePlus) share one appcast across channels and let
-        // a request header pick which builds the server returns. See `ChannelBinding`.
-        for (field, value) in app.sparkleFeedHeaders {
-            request.setValue(value, forHTTPHeaderField: field)
-        }
+        let request = Self.feedRequest(url: feedURL, headers: app.sparkleFeedHeaders)
 
         let (data, response) = try await session.versionFeedData(
             for: request, label: "Sparkle \(app.name)")
@@ -97,6 +81,38 @@ public struct SparkleAppcastSource: UpdateSource {
             releaseHistory: history,
             deltas: best.deltas
         )
+    }
+
+    /// The one request shape every appcast fetch uses — the live check and
+    /// `duo verify`'s feed sweep alike.
+    ///
+    /// Extracted rather than copied because a sweep that builds its own request
+    /// is not sweeping the request production makes — and every field below is
+    /// load-bearing enough that a second copy drifting from this one would be a
+    /// sweep whose green answer says nothing about the app.
+    ///
+    /// Always revalidate the appcast against the origin — never serve it from
+    /// the shared `URLCache` on max-age freshness alone. Some vendor CDNs stamp
+    /// a static feed with an absurd `Cache-Control: max-age` (Fork's fork.dev
+    /// sends ~10 years + `Expires: 2037`): under the default `.useProtocolCache`
+    /// policy the cached copy stays "fresh" effectively forever, so once we'd
+    /// fetched it we'd replay that stale feed and never see a new release — the
+    /// exact reason Fork 2.68.0 went undetected. `.reloadRevalidatingCacheData`
+    /// ignores freshness and sends a conditional GET (If-None-Match /
+    /// If-Modified-Since from the cached ETag/Last-Modified): unchanged → cheap
+    /// 304 served from cache, changed → 200 with the new feed. So we keep the
+    /// bandwidth win on quiet feeds without ever going blind to an update.
+    ///
+    /// `headers` is for the header-keyed apps (TablePlus) that share one appcast
+    /// across channels and let a request header pick which builds the server
+    /// returns. See `ChannelBinding`.
+    static func feedRequest(url: URL, headers: [String: String]) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        request.cachePolicy = URLRequest.versionFeedCachePolicy
+        request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
+        for (field, value) in headers { request.setValue(value, forHTTPHeaderField: field) }
+        return request
     }
 
     /// Every in-channel item with a parseable vendor date, turned into a

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedCatalog.swift
@@ -108,6 +108,52 @@ public enum SparkleFeedCatalog {
             live: URL(string: "https://downloads.pdfexpert.com/pem3/release/appcast.xml")!),
     ]
 
+    /// One catalog entry, in the shape `duo verify` sweeps registries in.
+    ///
+    /// The catalog is not a recipe registry — there is no pattern to re-derive
+    /// and no version to parse out of a page. What it publishes is an ADDRESS,
+    /// and the thing that rots is whether that address still answers with a
+    /// feed a default-channel install can use. So a case carries the address
+    /// and how we came to hand it out, and nothing else.
+    public struct VerificationCase: Sendable, Equatable {
+        public enum Kind: String, Sendable {
+            /// From ``feeds``: an address the bundle never states.
+            case fillIn = "fill-in"
+            /// From ``supersededFeeds``: an address that overrides one the
+            /// bundle does state.
+            case superseded
+        }
+        public let bundleID: String
+        public let kind: Kind
+        /// The address `AppScanner` would write onto the row.
+        public let feed: URL
+        /// Superseded entries only: the dead address the entry matches on, and
+        /// whose being dead is the entry's whole justification. Nil for a
+        /// fill-in, which overrides nothing.
+        public let declared: URL?
+
+        /// Stable sweep key, same shape as every other registry's, so the
+        /// baseline and the issue history key on it the same way.
+        public var recipeID: String { "feed:\(bundleID)" }
+    }
+
+    /// Every entry, both halves, sorted so a run's output and the baseline it
+    /// writes do not reorder themselves with the dictionaries' hashing.
+    ///
+    /// Derived from the tables rather than written out again beside them: a
+    /// second list is a list that can be short by one, and a catalog entry
+    /// nothing sweeps is precisely the state #324 was filed about.
+    public static var verificationCases: [VerificationCase] {
+        let fillIns = feeds.map {
+            VerificationCase(bundleID: $0.key, kind: .fillIn, feed: $0.value, declared: nil)
+        }
+        let superseded = supersededFeeds.map {
+            VerificationCase(bundleID: $0.key, kind: .superseded,
+                             feed: $0.value.live, declared: $0.value.declared)
+        }
+        return (fillIns + superseded).sorted { $0.recipeID < $1.recipeID }
+    }
+
     /// The curated feed for an app that publishes none of its own, if we have one.
     /// Case-insensitive on bundle id, matching `ChangelogCatalog`'s convention.
     public static func feed(forBundleID bundleID: String?) -> URL? {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedProbe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedProbe.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// What one live read of a Sparkle appcast learned — fetch and parse only, no
+/// verdict. `duo verify`'s feed sweep (`Verify.classifyFeed`) decides what it
+/// means; keeping the two apart is the same split `AppStoreProbeObservation`
+/// and `Verify.classifyAppStore` use, so the judgement can be exercised
+/// offline against fixtures.
+public struct SparkleFeedReading: Sendable {
+    /// `<item>` elements the parser recognised, before any filter.
+    public let itemCount: Int
+    /// How many of them survive `SparkleAppcastSource.usableItems` — the
+    /// channel, minimum/maximum-OS and architecture filters — for a DEFAULT
+    /// CHANNEL install on the machine running the sweep. Zero here is the
+    /// failure the whole sweep exists for: it is what `latestVersion` turns
+    /// into a nil, which every caller renders as "up to date".
+    public let usableCount: Int
+    /// `sparkle:shortVersionString` of the newest usable item, i.e. the
+    /// marketing string this feed would put in front of a user.
+    public let headShortVersion: String?
+    /// `sparkle:version` of the same item — Sparkle's canonical build key.
+    public let headBuildVersion: String?
+    /// Its `<enclosure url>`, already resolved against the feed's own address
+    /// the way `SparkleAppcastParser` does for the live path (Helium publishes
+    /// relative enclosures, so an unresolved one is not a hypothetical).
+    public let headEnclosure: URL?
+    /// Items declaring a non-empty `sparkle:maximumSystemVersion`. Not a
+    /// verdict and not a count of what was filtered: it is the one hint
+    /// `latestVersion` itself logs when a feed goes empty on it, repeated here
+    /// so the sweep's message can point the same way rather than re-deriving a
+    /// filter predicate that would then be free to drift from the real one.
+    public let itemsDeclaringMaximumSystemVersion: Int
+    /// The OS version the filters were evaluated against, so a report read on
+    /// another machine says which Mac's answer it is.
+    public let osVersion: String
+    /// Bytes of appcast fetched.
+    public let byteCount: Int
+}
+
+/// A feed read that never got as far as parsing.
+public enum SparkleFeedReadFailure: Error, Sendable, Equatable {
+    /// The host answered, with something outside 2xx.
+    case badStatus(Int)
+}
+
+public extension SparkleAppcastSource {
+
+    /// Fetch one appcast and report its shape, without an installed copy to
+    /// hang it on.
+    ///
+    /// This is `duo verify`'s read of a `SparkleFeedCatalog` entry. The catalog
+    /// is the one address table nothing on a schedule has ever fetched (#324):
+    /// its fill-in half invents an address the bundle never states, and its
+    /// superseding half overrides one the bundle does state, and both halves
+    /// fail silently — a feed that dies, moves, or reshapes its items produces
+    /// a nil out of `latestVersion`, which is indistinguishable from "you are
+    /// up to date" everywhere it is displayed.
+    ///
+    /// **Whose answer this is.** `usableItems` needs an installed copy to
+    /// decide which channels are allowed, and the sweeping machine is not
+    /// required to have one — `VerifyOptions.useInstalled` is off on a CI
+    /// runner for exactly that reason, so requiring a copy would switch the
+    /// check off where nobody is watching the apps anyway.
+    /// So it asks the question the catalog's promise is actually about: what
+    /// would a FRESH DEFAULT-CHANNEL install see today? The probe app carries
+    /// no version, so `channel(ofInstalled:)` matches nothing and
+    /// `allowedChannels` returns the default channel alone — the floor every
+    /// real install is at or above. A beta-tagged item is therefore not
+    /// counted as usable, which is correct for this question and worth knowing
+    /// when reading a count back (Helium's feed publishes one).
+    ///
+    /// Throws only on transport failure; a non-2xx comes back as
+    /// `.failure(.badStatus)` so the caller can report the code instead of
+    /// unwrapping a localized string.
+    func readFeed(
+        _ feedURL: URL, bundleID: String
+    ) async throws -> Result<SparkleFeedReading, SparkleFeedReadFailure> {
+        let request = Self.feedRequest(url: feedURL, headers: [:])
+        let (data, response) = try await session.versionFeedData(
+            for: request, label: "Sparkle verify \(bundleID)")
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            return .failure(.badStatus(http.statusCode))
+        }
+
+        let items = SparkleAppcastParser.parse(data, relativeTo: feedURL)
+        let osVersion = Self.numericSystemVersion()
+        let usable = Self.usableItems(
+            for: Self.probeApp(bundleID: bundleID, feedURL: feedURL),
+            from: items, osVersion: osVersion)
+        let head = usable.first
+        return .success(SparkleFeedReading(
+            itemCount: items.count,
+            usableCount: usable.count,
+            headShortVersion: head?.shortVersionString,
+            headBuildVersion: head?.version,
+            headEnclosure: head?.enclosureURL,
+            itemsDeclaringMaximumSystemVersion:
+                items.filter { $0.maximumSystemVersion?.isEmpty == false }.count,
+            osVersion: osVersion,
+            byteCount: data.count))
+    }
+
+    /// The stand-in the filters are evaluated for. Deliberately versionless and
+    /// non-authoritative about its channel: those are exactly the two inputs
+    /// that would let the sweeping machine's own installed copy change the
+    /// answer, and a sweep whose verdict moves with what happens to be in
+    /// `/Applications` is not one anybody can act on.
+    private static func probeApp(bundleID: String, feedURL: URL) -> InstalledApp {
+        InstalledApp(
+            name: bundleID, bundleID: bundleID,
+            shortVersion: nil, buildVersion: nil,
+            path: URL(fileURLWithPath: "/Applications/\(bundleID).app"),
+            isMASApp: false, sparkleFeedURL: feedURL,
+            releaseChannel: .stable, channelIsAuthoritative: false)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedProbe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleFeedProbe.swift
@@ -29,8 +29,9 @@ public struct SparkleFeedReading: Sendable {
     /// so the sweep's message can point the same way rather than re-deriving a
     /// filter predicate that would then be free to drift from the real one.
     public let itemsDeclaringMaximumSystemVersion: Int
-    /// The OS version the filters were evaluated against, so a report read on
-    /// another machine says which Mac's answer it is.
+    /// The OS version the filters were evaluated against. The one host input
+    /// left in the answer, and recorded for that reason — the architecture ones
+    /// are pinned, see `SparkleAppcastSource.readFeed`.
     public let osVersion: String
     /// Bytes of appcast fetched.
     public let byteCount: Int
@@ -85,7 +86,21 @@ public extension SparkleAppcastSource {
         let osVersion = Self.numericSystemVersion()
         let usable = Self.usableItems(
             for: Self.probeApp(bundleID: bundleID, feedURL: feedURL),
-            from: items, osVersion: osVersion)
+            from: items, osVersion: osVersion,
+            // Pinned, not taken from the host. `usableItems` defaults these to
+            // `HostArch.current` and `HostArch.canRunIntelBuilds`, and the
+            // second of those is false on a Mac without Rosetta and true on a
+            // GitHub runner — so the same feed could read `broken` on one
+            // machine and `ok` on another while `Baseline` keyed the streak on
+            // the recipe id alone, each host resetting the other's.
+            //
+            // arm64 because DuoUpdater is arm64-only by product decision (see
+            // `App/project.yml`), so there is no other host to ask about.
+            // Translation allowed because the question here is whether the
+            // ADDRESS can still serve a supported install, and an Intel-only
+            // item is one a Mac with Rosetta installs fine; calling that feed
+            // broken would be reporting a per-machine fact as a vendor one.
+            hostArch: .arm64, allowingIntelTranslation: true)
         let head = usable.first
         return .success(SparkleFeedReading(
             itemCount: items.count,
@@ -100,10 +115,12 @@ public extension SparkleAppcastSource {
     }
 
     /// The stand-in the filters are evaluated for. Deliberately versionless and
-    /// non-authoritative about its channel: those are exactly the two inputs
-    /// that would let the sweeping machine's own installed copy change the
-    /// answer, and a sweep whose verdict moves with what happens to be in
-    /// `/Applications` is not one anybody can act on.
+    /// non-authoritative about its channel: those are the two inputs that would
+    /// let the sweeping machine's own installed copy change the answer, and a
+    /// sweep whose verdict moves with what happens to be in `/Applications` is
+    /// not one anybody can act on. The architecture inputs are pinned at the
+    /// call site above for the same reason; `osVersion` is the one host fact
+    /// left in the answer, and it is reported.
     private static func probeApp(bundleID: String, feedURL: URL) -> InstalledApp {
         InstalledApp(
             name: bundleID, bundleID: bundleID,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleFeedCatalogTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleFeedCatalogTests.swift
@@ -275,4 +275,40 @@ struct SparkleFeedCatalogTests {
             "Not PDF Expert", id: "com.example.other", feed: dead)))
         #expect(other.sparkleFeedURL?.absoluteString == dead)
     }
+
+    // MARK: - What `duo verify` sweeps
+
+    /// `verificationCases` is what the nightly sweep iterates (#324). It is
+    /// derived from the two tables rather than written out beside them, and
+    /// this pins the derivation: an entry with no case is an address nothing
+    /// fetches, which is the exact state that issue was filed about.
+    @Test func everyCatalogEntryIsSwept() {
+        let cases = SparkleFeedCatalog.verificationCases
+        #expect(cases.count == SparkleFeedCatalog.feeds.count
+                + SparkleFeedCatalog.supersededFeeds.count)
+        #expect(Set(cases.map(\.recipeID)).count == cases.count,
+                "two entries share a sweep key, so one of them would overwrite the other's baseline row")
+        // Sorted, because the sweep prints in this order and the baseline is
+        // written in it — deriving from a dictionary without sorting would
+        // reshuffle both from run to run.
+        #expect(cases.map(\.recipeID) == cases.map(\.recipeID).sorted())
+
+        for (key, url) in SparkleFeedCatalog.feeds {
+            let entry = cases.first { $0.bundleID == key }
+            #expect(entry?.kind == .fillIn)
+            #expect(entry?.feed == url)
+            // A fill-in overrides nothing, so there is no second address to
+            // read — and the sweep's expiry check keys on this being nil.
+            #expect(entry?.declared == nil)
+        }
+        for (key, superseded) in SparkleFeedCatalog.supersededFeeds {
+            let entry = cases.first { $0.bundleID == key }
+            #expect(entry?.kind == .superseded)
+            // The LIVE address is the one an app is actually pointed at, so it
+            // is the one worth sweeping; `declared` rides along because the
+            // entry is only justified while that address stays behind.
+            #expect(entry?.feed == superseded.live)
+            #expect(entry?.declared == superseded.declared)
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -268,8 +268,9 @@ Two things it deliberately refuses rather than half-doing:
   exits and names the holder rather than swapping a bundle underneath it.
 
 `duo verify`, `duo triage` and `duo reconcile` are the maintenance side: they
-sweep every hand-written recipe against its live endpoint, ask a model why a
-broken one broke, and turn the result into issues. That is what the nightly
+sweep every hand-written recipe — and every Sparkle feed address we hand out for
+an app whose own bundle does not state one — against its live endpoint, ask a
+model why a broken one broke, and turn the result into issues. That is what the nightly
 check runs; they are not needed for ordinary use.
 
 ## Project layout


### PR DESCRIPTION
Closes #324.

`duo verify` swept four registries; `SparkleFeedCatalog` was in none of them, so no scheduled check had ever fetched the addresses it hands out. #323 changed that table's risk shape — `supersededFeeds` lets it assert an address *against* one the bundle explicitly states — and the half that can now be wrong was the half nothing watched.

Every way it fails is quiet. `SparkleAppcastSource` answers a dead, moved, or reshaped feed with nil, and every caller renders nil as "up to date". That is the same silence the PDF Expert entry was added to escape, one address further along.

## What lands

A fifth registry, `--feed`, one finding per catalog entry, keyed `feed:<bundleID>`. Two entries today: two requests for the superseding one (it reads both addresses), one for the fill-in.

**Core** — `SparkleAppcastSource.readFeed` is the production fetch with no installed copy behind it. `usableItems` needs an app to decide which channels are allowed, and a runner with nothing in `/Applications` has none, so it asks the question the catalog's promise is actually about: what would a *fresh default-channel install* see today? The request moves into `feedRequest`, shared with `latestVersion` — a hand-rolled copy that lost `versionFeedCachePolicy` would be a sweep reporting on a request the app never makes.

**CLI** — `FeedVerify.swift`, split network half / pure `classifyFeed`, the same split `AppStoreVerify` uses. In order:

| check | verdict | why it matters |
|---|---|---|
| the address answered | `infra` | a bad minute is not a dead feed; `Baseline.isInfraReportable`'s week-long window decides |
| the body carried items | `broken` | a CDN error page parses to zero items and 200s |
| ≥1 item survives the filters | `broken` | **the silent one** — this is exactly what `latestVersion` turns into "up to date" |
| the head item names a marketing version | `warn` | it is what the baseline records, and the only field this source may compare against a bundle's own |
| its enclosure resolved | `warn` | detection survives, installing does not — same call as `installURLUnresolved` |
| *(superseded only)* the dead address is still behind | `warn` | the entry's own expiry condition |

That last one is the part the issue left open. It sketched comparing against an installed bundle, which neither entry has here and CI never will. Fetching the address we redirect *away from* answers the same question for one request and answers it everywhere.

Never downloads an enclosure — shape only. Whether the artifact is still served is a separate question with a separate cost; `installURLNotFound` is the precedent if it is ever worth the request.

## Measured

Live, today:

```
Sparkle feed  ✓ 2  ⚠ 0  ✗ 0  ~ 0  - 0
feed:com.readdle.pdfexpert-mac  3.13.2  (5 items, 1 usable — the other 4 cap at macOS 11.999)
feed:net.imput.helium           0.16.5.1 (10 items, 9 usable — 1 is beta-tagged)
```

PDF Expert's live feed has **one** usable item on a current Mac. Its margin over "everything filtered, reads as up to date" is that single entry, which is a good argument for the check existing.

Negative controls against the same live endpoints — swap the superseded entry's two addresses, point the fill-in at an HTML page:

```
⚠ supersededAddressIsNoLongerBehind — … (…/pem3/release/appcast.xml at 3.13.2 (1172), live 2.5.22 (764))
✗ feedParsedToZeroItems — the address answered, with a body carrying no appcast items at all (38824 bytes).
```

`make test` green (`MAKE_TEST_RC=0`). 12 new CLI cases, 11 mutations applied and run: all compile, all go red, each hits the case it was written for. `everyCatalogEntryIsSwept` pins the derivation — dropping the superseded half from `verificationCases` fails four expectations.

## Left out, on purpose

The issue's "related, separable" half — `sweepChangelog` recording no entry count, so a lost terminator yields one correctly-versioned entry carrying the whole page and sweeps green. Different registry, different field, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)