### PR TITLE
Update Sparkle appcast for v0.3.87

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -17,6 +17,37 @@
           private, and are not carried over.
         -->
         <item>
+            <title>0.3.87</title>
+            <pubDate>Mon, 07 Sep 2026 02:00:30 +0800</pubDate>
+            <link>https://github.com/jizhi0v0/duo-updater/releases/tag/v0.3.87</link>
+            <sparkle:version>96</sparkle:version>
+            <sparkle:shortVersionString>0.3.87</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <description sparkle:format="markdown"><![CDATA[**Clicking Update no longer does nothing when an update source contradicts itself.** If the check that runs the moment you click comes back with an older version than the one the row was offering, Duo Updater now says so and keeps the update on offer. It used to report the app as already up to date and drop it from the list, and the same update reappeared on the next check.
+
+**Fork updates are offered again when Fork is set to its Develop channel.** Duo Updater read Fork's channel setting backwards and followed its Stable feed, which sits well behind — so a Develop copy was listed as up to date while Fork itself was offering a newer version.
+
+**Mac Performance Monitor now shows its release notes.** The app publishes them in its repository rather than in the feed we read, so the window had nothing to show for it.
+
+**CotEditor is now covered, on both its release and its beta line.** Which line a copy follows comes from the version it is running and from CotEditor's own "Update to prereleases when available" setting, so a beta copy is offered the next beta instead of a release that would take it backwards.
+
+**An app you installed from the App Store is never offered a download from anywhere else.** When the store's own lookup for it fails or comes back empty, the row now says the store is managing it, without a version number. Before, the check could fall through to the app's other distribution — a different build with its own version numbers — and offer to install that over your store copy.
+
+**An app is never offered an update that would move it to an older version.** Some feeds list a stable release above a prerelease that is in fact further along, and taking it would have moved the app backwards.
+
+**A long error on a row no longer pushes the rest of the list down.** It is kept to two lines, with the full text on hover.
+]]></description>
+            <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.87/DuoUpdater-0.3.87-macos.zip" length="12855370" type="application/octet-stream" sparkle:edSignature="mHrJ+kOUoOzqlJ1s5VmLqvUE8aeon3zskJjLE+GRyoXOhTGPgW609DvNUtHNkBNZdudeiOnd6dNxFSfMtQOrCg=="/>
+            <sparkle:deltas>
+                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.87/DuoUpdater96-95.delta" sparkle:deltaFrom="95" length="683258" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="+7/ArR6Sgi5H/vhsb9rCcB6hxf8egAJlOXoionuFi+wCRgziJSSwhsxi35LK9UkCHUQ2g+aHJmYDHjKiYIhCCg=="/>
+                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.87/DuoUpdater96-94.delta" sparkle:deltaFrom="94" length="712958" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="D7FHzlfxw7sVRXc2zgfeHeXgxBlOyD0yGvVOxkblaamO/EcSVzaoMD9PzXVOZPtVqfe+1dlcG1WF0otrEcJ8BQ=="/>
+                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.87/DuoUpdater96-93.delta" sparkle:deltaFrom="93" length="2017074" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="KlRY7PZOQEmhyRz76ux0aEoddz0FTqqXd+qiKLIHYtPsCM7Q4y1JVHbxDCpWXn/zcwyAPq3iLAe1xRxKl+T7DQ=="/>
+                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.87/DuoUpdater96-92.delta" sparkle:deltaFrom="92" length="2070370" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="tmCna9CgNa4EC5APQT5AKxCBWUBmDVnvKV34ZNQh5OOnkfIi2kKWH8nYY0cP7MBTsNntMEdcc6EF3fJuLPUFCw=="/>
+                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.87/DuoUpdater96-91.delta" sparkle:deltaFrom="91" length="2328062" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="kJmqPlkCZ7TOUB0Xi8hqhA+8vGFfDCmJ0ciETzhjZ+5qYdRQK9zoCCkh1mrMvARoFcuDR3x08FGvyKZyNtCwDw=="/>
+            </sparkle:deltas>
+        </item>
+        <item>
             <title>0.3.86</title>
             <pubDate>Sun, 06 Sep 2026 15:54:55 +0800</pubDate>
             <link>https://github.com/jizhi0v0/duo-updater/releases/tag/v0.3.86</link>
@@ -24,12 +55,6 @@
             <sparkle:shortVersionString>0.3.86</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <description sparkle:format="markdown"><![CDATA[**Four more apps are covered: WhatCable, Qoder IDE, Qoder and Yaak.** Each one gets update checks and a one-click install, and their release notes are read into the window as text rather than an embedded page.
-
-**Qoder's two Mac apps are told apart.** The IDE and the desktop app share a name and a download page but ship on separate version lines, so each is now followed on its own.
-
-**Beta builds of WhatCable and Yaak are followed on their own track.** A copy running a beta used to have no source at all and sat on "Failed"; it is now offered the next beta, with release notes kept apart from the stable ones. For WhatCable that also includes the stable release a beta eventually graduates into — taking that one moves the copy onto the stable track.
-]]></description>
             <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.86/DuoUpdater-0.3.86-macos.zip" length="12740404" type="application/octet-stream" sparkle:edSignature="6uQikRQ3z4GNTBJcPmxT36iuesD8ZobgDLMUsiAMeRO8hkeaK1GGZE3p1rGzLMDHFs2oPVQ+jJ1TwSQ5909BBg=="/>
             <sparkle:deltas>
                 <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.86/DuoUpdater95-94.delta" sparkle:deltaFrom="94" length="323810" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="OlOiuXI32yFsWGqossB29ESu51aNoQrDNTBRC4mY4Zs3TyvKFHf3vNsgQyPOKqJrWq/yz22q2qw6xoTNAnQkAA=="/>
@@ -88,23 +113,6 @@
                 <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.83/DuoUpdater92-87.delta" sparkle:deltaFrom="87" length="1513950" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="ORy25x1sOwXyfwYNBooUQKQUqA8Wl06RGEpiEUPM6LxOpnYrFI0YkO0SusSZ+OT7nux3sjER7DqdwNmAaSlfDg=="/>
                 <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.83/DuoUpdater92-86.delta" sparkle:deltaFrom="86" length="1531694" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="wIyQfaOztAcC0qI4HSf/JxgFfDs51SGRNNGtIbD22zCUHcaE3agO1+isQG94sMw37GG91Nn+WfCYOGHlxudwCg=="/>
                 <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.83/DuoUpdater92-85.delta" sparkle:deltaFrom="85" length="1627826" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="c26mPw83eW2byN0x+3y2jX6G2kQOWr+M92O2I4q3ohDFnIyqLwva9IbVmX8NQa1h+xHXuNbCxbOyDHehubIMAw=="/>
-            </sparkle:deltas>
-        </item>
-        <item>
-            <title>0.3.82</title>
-            <pubDate>Thu, 03 Sep 2026 15:48:04 +0800</pubDate>
-            <link>https://github.com/jizhi0v0/duo-updater/releases/tag/v0.3.82</link>
-            <sparkle:version>91</sparkle:version>
-            <sparkle:shortVersionString>0.3.82</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.82/DuoUpdater-0.3.82-macos.zip" length="12212865" type="application/octet-stream" sparkle:edSignature="VIuqOIWCqfcs4IlxuY913xSt0dtsROLZ1KqEsrJS2ah6LN3Cf1ledL9rpj93zSU4dncVLLKyR6alm6AR6SmBAg=="/>
-            <sparkle:deltas>
-                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.82/DuoUpdater91-90.delta" sparkle:deltaFrom="90" length="457698" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="QcaxJJGkyQDIsdVNC2koxj8kYS/3N/gO6wdetfu/1cQssdF4N6AC2uw9ZEXa2l+S5VClpdatd80bL5URlHvvCQ=="/>
-                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.82/DuoUpdater91-89.delta" sparkle:deltaFrom="89" length="794814" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="oiJpPss+Mlwo8PO9uPtHe+DLgMpul/TLnMEMdX32Nseo2jKW2T/jn2x86Up4kiZdu2+423CmMwfscujf1o4cDA=="/>
-                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.82/DuoUpdater91-88.delta" sparkle:deltaFrom="88" length="986090" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="18iO6UrrHh+JcbOuNXo5GN6yuk6rPJaEoijDjIYYrcNYE7sR/PbcC+hyB4sUNsaLB5m8pLVUXO7VXa0JqzdDDQ=="/>
-                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.82/DuoUpdater91-87.delta" sparkle:deltaFrom="87" length="1024894" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="m1xkqIYbFrJ0I+K7yy4sMwz+AJ3beQlOgk+9K48nBbEEd8rehvH3DC846jxkafZ2ONaPCmT1Hp9aZsrADTfFDQ=="/>
-                <enclosure url="https://github.com/jizhi0v0/duo-updater/releases/download/v0.3.82/DuoUpdater91-86.delta" sparkle:deltaFrom="86" length="1051206" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977808" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="ZYcmMRixdwQL6u3J6kdyVsoQgQWS7w2EpDEwmlO4vM9C3S5gbLNOFLPLIzOEEHmBuBJPWlJlJ3O7hQjB5iX9DA=="/>
             </sparkle:deltas>
         </item>
     </channel>


### PR DESCRIPTION
Published by scripts/publish-release.sh for v0.3.87.