### PR TITLE
docs: make the pkg architecture safety boundary explicit

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -8,6 +8,21 @@ import Darwin
 /// elevate to run the installer — so we download the official package (the same
 /// URL Homebrew would use) and hand it to macOS's own installer, which prompts
 /// for admin itself. The user confirms the install in a trusted, native UI.
+///
+/// Architecture limitation (#205): this route does NOT run
+/// `SignatureVerifier.verifyRunnableArchitecture` (Gate 5) or
+/// `verifyNoArchitectureDowngrade` (Gate 5b). We inspect package metadata, not
+/// the payload's Mach-O executables. Signature, Team ID and destination checks
+/// therefore do not prevent an Intel-only package from replacing a native app.
+/// This applies to every caller, including packages unwrapped from disk images.
+///
+/// We deliberately avoid full payload expansion here: it adds disk space and
+/// unpacking work proportional to the payload, potentially gigabytes. A vendor's
+/// `hostArchitectures` declaration is not proof of the installed app's slices.
+/// Handoff also returns before installation completes, so this actor performs no
+/// post-install architecture verification or automatic architecture rollback.
+/// Architecture compatibility on this route remains dependent on the vendor's
+/// package and system installer; it is not a DuoUpdater architecture guarantee.
 public actor PackageInstaller {
 
     /// The final hand-over keeps its integrity check and `NSWorkspace.open` in one

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ It **respects each app's own update channel**:
 
 ## Install safety
 
+- **Package architecture limitation**: updates handed to the system installer
+  (`.pkg` / `.mpkg`, including those inside disk images) do not pass DuoUpdater's
+  runnable-architecture or native-to-Intel downgrade gates. Package signature,
+  Team ID and destination checks do not inspect payload Mach-O executables, so
+  an Intel-only package can pass those checks. DuoUpdater does not verify or
+  automatically roll back architecture changes after the system installer runs.
 - **Never force-quits** a running app. When an update needs the app restarted to
   take effect, the quit is a plain `terminate()` — the app runs its own save
   prompts and can refuse. One that refuses is left running and keeps a


### PR DESCRIPTION
Closes #205.

Implements option 4 from the issue: document in PackageInstaller and README that pkg/mpkg handoff (including DMG-wrapped packages) does not run Gate 5 or Gate 5b. Signing, Team ID and destination checks do not establish payload architecture, and this route does not verify or automatically roll back architecture after installation.

Records why full payload expansion and vendor architecture declarations are not substitutes for the current Mach-O gates. No runtime behavior changes.

Validation: independent codex review completed with no findings. Full make test passed (Core: 2393 tests with 1 known issue; CLI: 223 tests; App: 9 cases; localization and repository checks passed).