### PR TITLE
fix: keep store copies out of vendor changelog recipes

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1567,14 +1567,10 @@ final class AppListModel {
     /// own "What's New" (`releaseNotesHTML` / the store page). WeChat is the live
     /// case: the official-site copy and the App Store copy share
     /// `com.tencent.xinWeChat`, but the official site's per-version page doesn't
-    /// describe the App Store build. So gate the recipe out for App-Store-sourced
-    /// results (only `MacAppStoreSource` attaches `appStore`) and let them fall
-    /// through to the store notes.
+    /// describe the App Store build. Core gates on the installed copy as well as
+    /// the remote answer, so a failed store lookup cannot select vendor notes.
     private func applicableRecipe(for result: UpdateResult) -> ChangelogRecipe? {
-        guard result.remote?.appStore == nil else { return nil }
-        return ChangelogRecipeRegistry.recipe(
-            forBundleID: result.app.bundleID, channel: result.effectiveReleaseChannel,
-            version: changelogTargetVersion(for: result))
+        ChangelogRecipeSelection.recipe(for: result)
     }
 
     /// The version whose notes this row is about: the offered update if there is
@@ -1586,7 +1582,7 @@ final class AppListModel {
     /// so if the lookup judged a different version than the one being fetched and
     /// cached, we would fetch one train's page and file it under the other's key.
     private func changelogTargetVersion(for result: UpdateResult) -> String? {
-        result.remote?.displayVersion ?? result.app.shortVersion
+        ChangelogRecipeSelection.targetVersion(for: result)
     }
 
     /// Kick off a background load for an app's recipe-backed changelog if one isn't

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -999,8 +999,7 @@ private struct DetailHeader: View {
 
     /// The vendor page to link out to.
     private var changelogURL: URL? {
-        ChangelogURLPolicy.displayable(
-            result.remote?.changelogURL ?? ChangelogCatalog.url(forBundleID: result.app.bundleID))
+        ChangelogURLPolicy.displayable(ChangelogRecipeSelection.fallbackPage(for: result).url)
     }
 
     var body: some View {
@@ -1148,8 +1147,7 @@ private struct ReleaseNotesPane: View {
     @Bindable var model: AppListModel
 
     private var changelogURL: URL? {
-        ChangelogURLPolicy.displayable(
-            result.remote?.changelogURL ?? ChangelogCatalog.url(forBundleID: result.app.bundleID))
+        ChangelogURLPolicy.displayable(ChangelogRecipeSelection.fallbackPage(for: result).url)
     }
 
     /// Which link of the fallback chain produced `changelogURL`, for the log.
@@ -1163,15 +1161,20 @@ private struct ReleaseNotesPane: View {
     ///
     /// `-rejected` means the chain picked a URL and `ChangelogURLPolicy` refused
     /// it — indistinguishable from "no URL at all" at the call site, and worth
-    /// telling apart: since `??` takes the first non-nil, a `remote` URL that
-    /// fails the policy shadows a usable catalog entry rather than falling
-    /// through to it.
+    /// telling apart: since the chain takes the first non-nil, a `remote` URL
+    /// that fails the policy shadows a usable catalog entry rather than falling
+    /// through to it. `catalogWithheld` is the third way to end up with no URL:
+    /// a curated VENDOR page existed and this copy came from the store, so
+    /// `ChangelogRecipeSelection` refused it on provenance (see its
+    /// `fallbackPage`). Telling that apart from `none` is the whole point —
+    /// "nobody publishes notes" and "we had notes and they were the wrong
+    /// distribution's" look identical in the pane.
     private var changelogURLOrigin: String {
-        let remote = result.remote?.changelogURL
-        let chosen = remote ?? ChangelogCatalog.url(forBundleID: result.app.bundleID)
-        guard let chosen else { return "none" }
-        let link = remote != nil ? "remote" : "catalog"
-        return ChangelogURLPolicy.displayable(chosen) == nil ? "\(link)-rejected" : link
+        let page = ChangelogRecipeSelection.fallbackPage(for: result)
+        guard let chosen = page.url else { return page.origin.rawValue }
+        return ChangelogURLPolicy.displayable(chosen) == nil
+            ? "\(page.origin.rawValue)-rejected"
+            : page.origin.rawValue
     }
 
     /// One line describing what the web view was handed. `Redactor.url` keeps the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Select vendor notes using the installed copy's provenance, even when an
+/// update lookup has not answered or has failed.
+public enum ChangelogRecipeSelection {
+    public static func recipe(for result: UpdateResult) -> ChangelogRecipe? {
+        guard !result.app.isMASApp, result.remote?.appStore == nil else { return nil }
+        return ChangelogRecipeRegistry.recipe(
+            forBundleID: result.app.bundleID, channel: result.effectiveReleaseChannel,
+            version: targetVersion(for: result))
+    }
+
+    /// Lookup, fetching and caching must all use the same version window.
+    public static func targetVersion(for result: UpdateResult) -> String? {
+        result.remote?.displayVersion ?? result.app.shortVersion
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
@@ -14,4 +14,80 @@ public enum ChangelogRecipeSelection {
     public static func targetVersion(for result: UpdateResult) -> String? {
         result.remote?.displayVersion ?? result.app.shortVersion
     }
+
+    /// The page the notes pane falls back to — and the header links out to —
+    /// when no recipe applies.
+    ///
+    /// This exists because `recipe(for:)` is only HALF of "a store copy must not
+    /// be shown another distribution's release notes". Refusing the recipe stops
+    /// the *parsed* vendor notes; the view then falls through to a URL, and one
+    /// of the two candidates for that URL comes from `ChangelogCatalog` — a
+    /// second registry of hand-curated **vendor** pages, keyed by bundle id
+    /// alone, with no provenance in it. So a catalog entry for a bundle id that
+    /// also ships on the store would put the vendor's changelog back in front of
+    /// a store copy through the web view, which is #388 verbatim, one registry
+    /// over. No entry does that today (measured 2026-09-07: the two registries
+    /// overlap on app.chatwise, com.electron.ollama, com.longbridge.app.desktop,
+    /// com.mitchellh.ghostty and net.imput.helium, and `com.tencent.xinWeChat`
+    /// has no catalog entry at all) — but the catalog's whole purpose is "the
+    /// source shipped no notes", which is exactly the failed-lookup state, so
+    /// this is the next entry away rather than hypothetical.
+    ///
+    /// The catalog half is gated; the `remote` half is not, and deliberately:
+    /// `UpdateChecker` only lets a source with `answersAppStoreCopies` near a
+    /// store copy, and `MacAppStoreSource` is the only one, so a store copy's
+    /// `changelogURL` is a store listing by construction. Gating it here would
+    /// be guessing at a property the checker already guarantees — and if that
+    /// guarantee ever breaks, it should break loudly there, not be papered over
+    /// here.
+    ///
+    /// A store LISTING in the catalog survives the gate, because for a store
+    /// copy that page is the right answer, not the wrong one: `net.whatsapp.whatsapp`
+    /// is an iOS-on-Mac app (hence always `isMASApp`) whose entry exists
+    /// precisely so the store page shows while the check is still running. A
+    /// blanket `!isMASApp` would delete that entry's only reason to exist.
+    public static func fallbackPage(for result: UpdateResult) -> FallbackPage {
+        if let fromSource = result.remote?.changelogURL {
+            return FallbackPage(url: fromSource, origin: .remote)
+        }
+        guard let curated = ChangelogCatalog.url(forBundleID: result.app.bundleID) else {
+            return FallbackPage(url: nil, origin: .none)
+        }
+        guard !result.app.isMASApp || isAppStoreListing(curated) else {
+            return FallbackPage(url: nil, origin: .catalogWithheld)
+        }
+        return FallbackPage(url: curated, origin: .catalog)
+    }
+
+    /// Apple's own listing hosts, matched on the WHOLE host rather than a suffix:
+    /// `apps.apple.com.example.invalid` is a name its owner can point anywhere,
+    /// and a suffix test would call it a store page.
+    static func isAppStoreListing(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        let bare = host.count > 1 && host.hasSuffix(".") ? String(host.dropLast()) : host
+        return bare == "apps.apple.com" || bare == "itunes.apple.com"
+    }
+
+    /// Which link of the fallback chain answered, kept beside the URL so the
+    /// pane's log line and the URL it reports cannot disagree — recomputing the
+    /// chain a second time at the call site is how the catalog half came to
+    /// carry a different rule from the recipe half in the first place.
+    public struct FallbackPage: Sendable, Equatable {
+        public let url: URL?
+        public let origin: Origin
+
+        public enum Origin: String, Sendable, Equatable {
+            /// Neither candidate produced a URL.
+            case none
+            /// The update source supplied one (`RemoteVersion.changelogURL`).
+            case remote
+            /// `ChangelogCatalog`'s curated page.
+            case catalog
+            /// `ChangelogCatalog` had a vendor page, and this copy came from the
+            /// Mac App Store — so it was withheld rather than shown. Distinct
+            /// from `.none` because "we had a page and refused it" is the state
+            /// worth seeing in a report; `.none` reads as "nobody publishes one".
+            case catalogWithheld
+        }
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogRecipeSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogRecipeSelectionTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+struct ChangelogRecipeSelectionTests {
+    private func app(store: Bool, bundleID: String = "com.tencent.xinWeChat",
+                     version: String = "4.0") -> InstalledApp {
+        InstalledApp(name: "Fixture", bundleID: bundleID, shortVersion: version,
+                     buildVersion: "100", path: URL(fileURLWithPath: "/Applications/Fixture.app"),
+                     isMASApp: store, sparkleFeedURL: nil)
+    }
+
+    @Test func storeCopiesNeverSelectVendorNotes() {
+        let storeAnswer = RemoteVersion(
+            shortVersion: "4.1", version: "101", downloadURL: nil, sourceName: "App Store",
+            appStore: AppStoreAvailability(trackID: 1, availableRegion: "cn",
+                                           homeRegion: "cn", storeName: nil))
+        let vendorAnswer = RemoteVersion(
+            shortVersion: "4.1", version: "101", downloadURL: nil, sourceName: "Vendor")
+        // Include an inconsistent vendor answer: local receipt provenance wins.
+        for remote in [nil, storeAnswer, vendorAnswer] {
+            for status in [UpdateStatus.unknown, .error("store lookup failed"), .upToDate] {
+                let result = UpdateResult(app: app(store: true), remote: remote, status: status)
+                #expect(ChangelogRecipeSelection.recipe(for: result) == nil)
+            }
+        }
+        // Retain the old remote-answer defense even without a local receipt.
+        let result = UpdateResult(app: app(store: false), remote: storeAnswer, status: .upToDate)
+        #expect(ChangelogRecipeSelection.recipe(for: result) == nil)
+    }
+
+    @Test func directCopyKeepsNotesWhenLookupMissesOrFails() {
+        for status in [UpdateStatus.unknown, .error("lookup failed"), .upToDate] {
+            let result = UpdateResult(app: app(store: false), remote: nil, status: status)
+            #expect(ChangelogRecipeSelection.recipe(for: result) != nil)
+            #expect(ChangelogRecipeSelection.targetVersion(for: result) == "4.0")
+        }
+    }
+
+    @Test func offeredVersionSelectsTheMatchingRecipeWindow() throws {
+        let installed = app(store: false, bundleID: "com.raycast.macos", version: "1.99.0")
+        let remote = RemoteVersion(shortVersion: "2.0.0", version: "200",
+                                   downloadURL: nil, sourceName: "Vendor")
+        let before = UpdateResult(app: installed, remote: nil, status: .unknown)
+        let after = UpdateResult(app: installed, remote: remote, status: .updateAvailable(latest: "2.0.0"))
+        let old = try #require(ChangelogRecipeSelection.recipe(for: before))
+        let new = try #require(ChangelogRecipeSelection.recipe(for: after))
+        #expect(old.source != new.source)
+        #expect(ChangelogRecipeSelection.targetVersion(for: after) == "2.0.0")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogRecipeSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogRecipeSelectionTests.swift
@@ -48,4 +48,71 @@ struct ChangelogRecipeSelectionTests {
         #expect(old.source != new.source)
         #expect(ChangelogRecipeSelection.targetVersion(for: after) == "2.0.0")
     }
+
+    // MARK: - The fallback page, which is the other half of the same rule
+
+    /// Mutation: drop the `!result.app.isMASApp || isAppStoreListing(curated)`
+    /// guard in `fallbackPage` and this goes red — a store copy is handed the
+    /// vendor page the recipe half just refused.
+    @Test func aStoreCopyIsNotHandedACuratedVendorPage() {
+        // Ghostty is in BOTH registries, so it is the shape the guard is about:
+        // refusing the recipe alone still leaves a vendor URL behind it.
+        let installed = app(store: true, bundleID: "com.mitchellh.ghostty", version: "1.0")
+        let result = UpdateResult(app: installed, remote: nil, status: .unknown)
+        #expect(ChangelogRecipeSelection.recipe(for: result) == nil)
+        let page = ChangelogRecipeSelection.fallbackPage(for: result)
+        #expect(page.url == nil)
+        #expect(page.origin == .catalogWithheld)
+    }
+
+    /// The same row without a receipt must still get the page — otherwise the
+    /// test above would pass just as well against a `fallbackPage` that returns
+    /// nil for everything.
+    @Test func aDirectCopyStillGetsItsCuratedVendorPage() {
+        let installed = app(store: false, bundleID: "com.mitchellh.ghostty", version: "1.0")
+        let page = ChangelogRecipeSelection.fallbackPage(
+            for: UpdateResult(app: installed, remote: nil, status: .unknown))
+        #expect(page.origin == .catalog)
+        #expect(page.url?.host == "ghostty.org")
+    }
+
+    /// Mutation: narrow the guard to a bare `!result.app.isMASApp` and this goes
+    /// red. WhatsApp is iOS-on-Mac, so it is ALWAYS `isMASApp`, and its catalog
+    /// entry exists only to show the store page while the check is in flight —
+    /// a blanket provenance gate deletes that entry's reason to exist.
+    @Test func aStoreListingSurvivesTheGateForAStoreCopy() {
+        let installed = app(store: true, bundleID: "net.whatsapp.whatsapp", version: "2.0")
+        let page = ChangelogRecipeSelection.fallbackPage(
+            for: UpdateResult(app: installed, remote: nil, status: .unknown))
+        #expect(page.origin == .catalog)
+        #expect(page.url?.host == "apps.apple.com")
+    }
+
+    /// Mutation: make `isAppStoreListing` a suffix test (`hasSuffix(".apple.com")`
+    /// or `contains`) and this goes red. A host whose owner appended the store's
+    /// name to their own domain is not the store.
+    @Test func onlyTheWholeHostCountsAsAStoreListing() {
+        #expect(ChangelogRecipeSelection.isAppStoreListing(
+            URL(string: "https://apps.apple.com/app/id310633997?platform=mac")!))
+        #expect(ChangelogRecipeSelection.isAppStoreListing(
+            URL(string: "https://ITUNES.Apple.com/app/id1")!))
+        #expect(!ChangelogRecipeSelection.isAppStoreListing(
+            URL(string: "https://apps.apple.com.example.invalid/app/id1")!))
+        #expect(!ChangelogRecipeSelection.isAppStoreListing(
+            URL(string: "https://notapps.apple.com/app/id1")!))
+    }
+
+    /// Mutation: reorder `fallbackPage` to consult the catalog first and this
+    /// goes red. The source's own URL wins — for a store copy that is the store
+    /// listing, which is why the `remote` half needs no gate of its own.
+    @Test func theSourcesOwnPageOutranksTheCatalog() {
+        let installed = app(store: false, bundleID: "com.mitchellh.ghostty", version: "1.0")
+        let remote = RemoteVersion(
+            shortVersion: "1.1", version: "2", downloadURL: nil, sourceName: "Vendor",
+            changelogURL: URL(string: "https://example.invalid/notes"))
+        let page = ChangelogRecipeSelection.fallbackPage(
+            for: UpdateResult(app: installed, remote: remote, status: .upToDate))
+        #expect(page.origin == .remote)
+        #expect(page.url?.host == "example.invalid")
+    }
 }


### PR DESCRIPTION
Closes #388.

When a Mac App Store lookup misses or fails, remote is nil and the workbench previously selected the vendor recipe for a same-bundle-ID app such as WeChat. ChangelogRecipeSelection now gates on installed isMASApp as well as remote appStore metadata. AppListModel delegates recipe selection and target-version selection to Core, keeping fetch, prewarm and cache lookup on the same policy.

Regression tests cover missing, successful and inconsistent remote answers for store copies; the existing remote-store guard for copies without a local receipt; direct-copy notes after a lookup miss/error; and installed versus offered Raycast version windows.

Validation: full make test passed (Core: 2396 tests with 1 known issue; CLI: 223 tests; App: 9 cases; localization and repository checks passed). Independent codex review completed with no actionable defects.

---

## Follow-up: the fallback page was the other half of the same rule (be36b32)

Review of the first commit found that refusing the recipe only closes half of
"a store copy must not be shown another distribution's release notes". The pane
then falls through to a URL, and one of the two candidates comes from
`ChangelogCatalog` — a second registry of hand-curated **vendor** pages keyed by
bundle id alone, with no provenance in it. A catalog entry for a bundle id that
also ships on the store puts the vendor changelog back in front of a store copy
through the web view: #388 verbatim, one registry over.

No entry does that today (measured 2026-09-07: the two registries overlap on
ChatWise, Ollama, Longbridge, Ghostty and Helium, and `com.tencent.xinWeChat` has
no catalog entry, so the reported case already lands on "No release notes"). But
the catalog exists for "the source shipped no notes", which is exactly the
failed-lookup state this PR is about — so it is the next entry away, not
hypothetical.

`ChangelogRecipeSelection.fallbackPage(for:)` moves the whole chain into Core
beside `recipe(for:)`, which also collapses the expression the two view structs
had each spelled out separately — that duplication is why the catalog half never
picked up the rule the recipe half got.

- A store **listing** survives the gate: `net.whatsapp.whatsapp` is iOS-on-Mac,
  hence always `isMASApp`, and its entry exists precisely so the store page shows
  while the check is in flight. A blanket `!isMASApp` would delete its reason to
  exist — that is one of the pinned mutations.
- The `remote` half stays ungated on purpose: `UpdateChecker` only lets a source
  with `answersAppStoreCopies` near a store copy and `MacAppStoreSource` is the
  only one, so that URL is a store listing by construction.
- The log's origin token now comes from the same call as the URL, so the two
  cannot disagree, and gains `catalogWithheld` to tell "we had a page and refused
  it" apart from "nobody publishes one".

Five added tests, each naming the mutation it pins. All four claimed mutations
run and verified red against exactly their own test:

| Mutation | Test that went red |
| --- | --- |
| drop the provenance guard | `aStoreCopyIsNotHandedACuratedVendorPage` |
| narrow to blanket `!isMASApp` | `aStoreListingSurvivesTheGateForAStoreCopy` |
| suffix host match | `onlyTheWholeHostCountsAsAStoreListing` |
| catalog before source | `theSourcesOwnPageOutranksTheCatalog` |

Validation: full `make test` green — Core 2401 tests (1 known issue), CLI 223,
App 9/9 cases executed, localization / version-use / prose-claim / audit gates
all passed.
