### PR TITLE
Fix four defects review found in #401's fallback gate

### DIFF
--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1163,18 +1163,27 @@ private struct ReleaseNotesPane: View {
     /// it — indistinguishable from "no URL at all" at the call site, and worth
     /// telling apart: since the chain takes the first non-nil, a `remote` URL
     /// that fails the policy shadows a usable catalog entry rather than falling
-    /// through to it. `catalogWithheld` is the third way to end up with no URL:
+    /// through to it. `catalog-withheld` is the third way to end up with no URL:
     /// a curated VENDOR page existed and this copy came from the store, so
     /// `ChangelogRecipeSelection` refused it on provenance (see its
     /// `fallbackPage`). Telling that apart from `none` is the whole point —
     /// "nobody publishes notes" and "we had notes and they were the wrong
     /// distribution's" look identical in the pane.
+    ///
+    /// ⚠️ Three of these five tokens are only reachable because `emptyNotes`
+    /// logs. `logWebViewPane` is called from inside `if let url = changelogURL`
+    /// at both of its call sites, so everything routed through it reports
+    /// `remote` or `catalog` and nothing else — the first version of this
+    /// property, and the `??` expression before it, could never emit `none` or
+    /// either `-rejected` form at all. Adding a token without a call site that
+    /// can reach it is how a diagnostic starts describing a distinction the log
+    /// cannot actually make.
     private var changelogURLOrigin: String {
         let page = ChangelogRecipeSelection.fallbackPage(for: result)
-        guard let chosen = page.url else { return page.origin.rawValue }
+        guard let chosen = page.url else { return page.logToken }
         return ChangelogURLPolicy.displayable(chosen) == nil
-            ? "\(page.origin.rawValue)-rejected"
-            : page.origin.rawValue
+            ? "\(page.logToken)-rejected"
+            : page.logToken
     }
 
     /// One line describing what the web view was handed. `Redactor.url` keeps the
@@ -1251,6 +1260,15 @@ private struct ReleaseNotesPane: View {
         }
     }
 
+    /// `.notice` for the same reason `logWebViewPane` is: this is read days after
+    /// a sighting, and `.info` is never persisted for a third-party subsystem.
+    /// Without this line the three no-URL outcomes are indistinguishable in a
+    /// report AND in the pane — the user is told "no release notes" whether the
+    /// vendor publishes none, the URL failed `ChangelogURLPolicy`, or we held a
+    /// vendor page back from a store copy. ⚠️ The pane's own wording still says
+    /// "doesn't publish a changelog we can read", which is untrue in the withheld
+    /// case; correcting it means a new localized string and its translations, so
+    /// it is deliberately left for its own change rather than done half-way here.
     private var emptyNotes: some View {
         ContentUnavailableView {
             Label("No release notes", systemImage: "doc.text.magnifyingglass")
@@ -1262,6 +1280,10 @@ private struct ReleaseNotesPane: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            Log.changelog.notice(
+                "perf pane=empty \(result.app.name, privacy: .public) origin=\(changelogURLOrigin, privacy: .public) src=\(result.remote?.sourceName ?? "?", privacy: .public)")
+        }
     }
 }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
@@ -26,68 +26,108 @@ public enum ChangelogRecipeSelection {
     /// alone, with no provenance in it. So a catalog entry for a bundle id that
     /// also ships on the store would put the vendor's changelog back in front of
     /// a store copy through the web view, which is #388 verbatim, one registry
-    /// over. No entry does that today (measured 2026-09-07: the two registries
-    /// overlap on app.chatwise, com.electron.ollama, com.longbridge.app.desktop,
-    /// com.mitchellh.ghostty and net.imput.helium, and `com.tencent.xinWeChat`
-    /// has no catalog entry at all) — but the catalog's whole purpose is "the
-    /// source shipped no notes", which is exactly the failed-lookup state, so
-    /// this is the next entry away rather than hypothetical.
+    /// over. No entry does that today — `catalogAndRecipeOverlapIsWhatTheCommentSays`
+    /// pins the overlap so this sentence cannot quietly stop being true — but the
+    /// catalog's whole purpose is "the source shipped no notes", which is exactly
+    /// the failed-lookup state, so this is the next entry away rather than
+    /// hypothetical.
     ///
-    /// The catalog half is gated; the `remote` half is not, and deliberately:
-    /// `UpdateChecker` only lets a source with `answersAppStoreCopies` near a
-    /// store copy, and `MacAppStoreSource` is the only one, so a store copy's
-    /// `changelogURL` is a store listing by construction. Gating it here would
-    /// be guessing at a property the checker already guarantees — and if that
-    /// guarantee ever breaks, it should break loudly there, not be papered over
-    /// here.
+    /// The catalog half is gated; the `remote` half is not, and deliberately.
+    /// For every `UpdateSource`, `UpdateChecker` only lets one whose
+    /// `answersAppStoreCopies` is true near a store copy (`UpdateChecker.swift`
+    /// line 252, and line 144 for the batch), and `MacAppStoreSource` is the only
+    /// one — so a store copy's `changelogURL` is a store listing. ⚠️ That is a
+    /// property of the SOURCE LOOP, not of `runSources` as a whole: the Toolbox
+    /// and TestFlight branches return before the loop and pass neither gate. The
+    /// Toolbox one does carry a vendor `changelogURL`, so a hypothetical
+    /// Toolbox-managed store copy would reach a JetBrains page through the
+    /// ungated half. The checker's own comment says a JetBrains IDE is never a
+    /// MAS app, so nothing reaches it today; it is named here because "by
+    /// construction" was the wrong word for it, not because it is live.
     ///
-    /// A store LISTING in the catalog survives the gate, because for a store
-    /// copy that page is the right answer, not the wrong one: `net.whatsapp.whatsapp`
-    /// is an iOS-on-Mac app (hence always `isMASApp`) whose entry exists
-    /// precisely so the store page shows while the check is still running. A
-    /// blanket `!isMASApp` would delete that entry's only reason to exist.
+    /// A store LISTING in the catalog survives the gate, because for a store copy
+    /// that page is the right answer rather than the wrong one — `net.whatsapp.whatsapp`
+    /// is the entry in hand, added so the store page shows while the check is
+    /// still in flight. Gating on the URL rather than on the entry is what makes
+    /// that safe without an allowlist.
+    ///
+    /// ⚠️ **The inverse case is real and is NOT addressed here.** WhatsApp also
+    /// ships a Developer ID build from `web.whatsapp.com` (see its
+    /// `VendorProbeRecipe`, Team `57T9237FN3`, verified 2026-08-09), and a copy
+    /// installed that way has no `_MASReceipt` and no `WrappedBundle`, so
+    /// `isMASApp` is false for it and it is handed the App Store listing's notes
+    /// — the mirror image of #388. That predates this function and survives it
+    /// unchanged; it is written down rather than reasoned away because an earlier
+    /// draft of this comment claimed WhatsApp is "always `isMASApp`", which is
+    /// false, and that claim is what made the case invisible.
     public static func fallbackPage(for result: UpdateResult) -> FallbackPage {
-        if let fromSource = result.remote?.changelogURL {
-            return FallbackPage(url: fromSource, origin: .remote)
-        }
+        if let fromSource = result.remote?.changelogURL { return .fromSource(fromSource) }
         guard let curated = ChangelogCatalog.url(forBundleID: result.app.bundleID) else {
-            return FallbackPage(url: nil, origin: .none)
+            return .none
         }
-        guard !result.app.isMASApp || isAppStoreListing(curated) else {
-            return FallbackPage(url: nil, origin: .catalogWithheld)
-        }
-        return FallbackPage(url: curated, origin: .catalog)
+        guard !result.app.isMASApp || isAppStoreListing(curated) else { return .withheld }
+        return .fromCatalog(curated)
     }
 
-    /// Apple's own listing hosts, matched on the WHOLE host rather than a suffix:
-    /// `apps.apple.com.example.invalid` is a name its owner can point anywhere,
-    /// and a suffix test would call it a store page.
+    /// Apple's own listing hosts, matched on the WHOLE host.
+    ///
+    /// Both ends matter and they fail differently. A suffix test
+    /// (`hasSuffix("apps.apple.com")`) admits `notapps.apple.com`, which anyone
+    /// can register; a prefix test or `contains` admits
+    /// `apps.apple.com.example.invalid`, where the store's name is a label
+    /// inside a domain its owner points wherever they like. Equality is the only
+    /// test that refuses both, and `onlyTheWholeHostCountsAsAStoreListing` pins
+    /// one host for each.
+    ///
+    /// Every way this can be wrong is safe: a host it fails to recognise makes a
+    /// store copy fall through to `.withheld` (no page rather than the wrong
+    /// one), and the one host shape it over-accepts — `https://evil.com@apps.apple.com/`,
+    /// whose `URL.host` is the store — is refused afterwards by
+    /// `ChangelogURLPolicy`'s credential guard before any web view sees it.
     static func isAppStoreListing(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         let bare = host.count > 1 && host.hasSuffix(".") ? String(host.dropLast()) : host
         return bare == "apps.apple.com" || bare == "itunes.apple.com"
     }
 
-    /// Which link of the fallback chain answered, kept beside the URL so the
-    /// pane's log line and the URL it reports cannot disagree — recomputing the
-    /// chain a second time at the call site is how the catalog half came to
-    /// carry a different rule from the recipe half in the first place.
-    public struct FallbackPage: Sendable, Equatable {
-        public let url: URL?
-        public let origin: Origin
+    /// Which link of the fallback chain answered, carrying the URL it answered
+    /// with so the pane's log line cannot name one and show the other.
+    ///
+    /// An enum with the URL attached rather than a struct of `(URL?, origin)`:
+    /// the whole reason this type exists is that the token must not lie about
+    /// the URL, and a struct lets `.withheld` be built with a URL in it. Here
+    /// that pairing is unrepresentable rather than merely conventional.
+    public enum FallbackPage: Sendable, Equatable {
+        /// Neither candidate produced a URL.
+        case none
+        /// The update source supplied one (`RemoteVersion.changelogURL`).
+        case fromSource(URL)
+        /// `ChangelogCatalog`'s curated page.
+        case fromCatalog(URL)
+        /// `ChangelogCatalog` had a vendor page, and this copy came from the Mac
+        /// App Store — so it was withheld rather than shown. Distinct from
+        /// `.none` because "we had a page and refused it" is the state worth
+        /// seeing in a report; `.none` reads as "nobody publishes one".
+        case withheld
 
-        public enum Origin: String, Sendable, Equatable {
-            /// Neither candidate produced a URL.
-            case none
-            /// The update source supplied one (`RemoteVersion.changelogURL`).
-            case remote
-            /// `ChangelogCatalog`'s curated page.
-            case catalog
-            /// `ChangelogCatalog` had a vendor page, and this copy came from the
-            /// Mac App Store — so it was withheld rather than shown. Distinct
-            /// from `.none` because "we had a page and refused it" is the state
-            /// worth seeing in a report; `.none` reads as "nobody publishes one".
-            case catalogWithheld
+        public var url: URL? {
+            switch self {
+            case .fromSource(let url), .fromCatalog(let url): return url
+            case .none, .withheld: return nil
+            }
+        }
+
+        /// Fixed English for a `Log.` line, lowercase to match the tokens already
+        /// in this pane's log format and `ChangelogURLPolicy.RejectionReason.logToken`.
+        /// Never localized, for the reason given there: a log line is read next to
+        /// the source, and translating it breaks grepping across reports.
+        public var logToken: String {
+            switch self {
+            case .none: return "none"
+            case .fromSource: return "remote"
+            case .fromCatalog: return "catalog"
+            case .withheld: return "catalog-withheld"
+            }
         }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogRecipeSelectionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogRecipeSelectionTests.swift
@@ -60,9 +60,7 @@ struct ChangelogRecipeSelectionTests {
         let installed = app(store: true, bundleID: "com.mitchellh.ghostty", version: "1.0")
         let result = UpdateResult(app: installed, remote: nil, status: .unknown)
         #expect(ChangelogRecipeSelection.recipe(for: result) == nil)
-        let page = ChangelogRecipeSelection.fallbackPage(for: result)
-        #expect(page.url == nil)
-        #expect(page.origin == .catalogWithheld)
+        #expect(ChangelogRecipeSelection.fallbackPage(for: result) == .withheld)
     }
 
     /// The same row without a receipt must still get the page — otherwise the
@@ -72,25 +70,38 @@ struct ChangelogRecipeSelectionTests {
         let installed = app(store: false, bundleID: "com.mitchellh.ghostty", version: "1.0")
         let page = ChangelogRecipeSelection.fallbackPage(
             for: UpdateResult(app: installed, remote: nil, status: .unknown))
-        #expect(page.origin == .catalog)
         #expect(page.url?.host == "ghostty.org")
+        #expect(page.logToken == "catalog")
     }
 
     /// Mutation: narrow the guard to a bare `!result.app.isMASApp` and this goes
-    /// red. WhatsApp is iOS-on-Mac, so it is ALWAYS `isMASApp`, and its catalog
-    /// entry exists only to show the store page while the check is in flight —
-    /// a blanket provenance gate deletes that entry's reason to exist.
+    /// red. A store copy SHOULD be shown a store listing — that is the right
+    /// distribution's notes, not the wrong one — and WhatsApp's catalog entry
+    /// exists precisely to show it while the check is still in flight.
+    ///
+    /// ⚠️ The fixture says `store: true` because that is the case under test,
+    /// NOT because WhatsApp is always a store copy. It is not: WhatsApp also
+    /// ships a Developer ID build (`VendorProbeRecipe`, Team `57T9237FN3`), and
+    /// that copy is `isMASApp == false` and gets this same store listing — the
+    /// inverse of #388, pre-existing and untouched here. An earlier version of
+    /// this comment asserted "WhatsApp is iOS-on-Mac, so it is ALWAYS isMASApp",
+    /// which is false and hid that case.
     @Test func aStoreListingSurvivesTheGateForAStoreCopy() {
         let installed = app(store: true, bundleID: "net.whatsapp.whatsapp", version: "2.0")
         let page = ChangelogRecipeSelection.fallbackPage(
             for: UpdateResult(app: installed, remote: nil, status: .unknown))
-        #expect(page.origin == .catalog)
         #expect(page.url?.host == "apps.apple.com")
+        #expect(page.logToken == "catalog")
     }
 
-    /// Mutation: make `isAppStoreListing` a suffix test (`hasSuffix(".apple.com")`
-    /// or `contains`) and this goes red. A host whose owner appended the store's
-    /// name to their own domain is not the store.
+    /// Two mutations, one per direction, because the two ends fail differently
+    /// and an earlier version of this comment named only one of them — and named
+    /// it against the assertion that does not pin it.
+    ///
+    /// Mutation A, `hasSuffix("apps.apple.com")`: `notapps.apple.com` (fourth
+    /// assertion) goes red. Mutation B, `contains` or a prefix test:
+    /// `apps.apple.com.example.invalid` (third assertion) goes red. Neither
+    /// mutation is caught by the other's assertion, which is why both are here.
     @Test func onlyTheWholeHostCountsAsAStoreListing() {
         #expect(ChangelogRecipeSelection.isAppStoreListing(
             URL(string: "https://apps.apple.com/app/id310633997?platform=mac")!))
@@ -102,9 +113,47 @@ struct ChangelogRecipeSelectionTests {
             URL(string: "https://notapps.apple.com/app/id1")!))
     }
 
+    /// Mutation: add `guard !result.app.isMASApp` to the `remote` branch — the
+    /// "tidy" that `fallbackPage`'s comment exists to forbid — and this goes red.
+    /// Without it the claim the comment argues hardest for had no test at all:
+    /// every other case here uses a direct copy, so gating the ungated half was
+    /// a free change.
+    @Test func aStoreCopyStillGetsItsOwnSourcesPage() {
+        let installed = app(store: true, bundleID: "com.mitchellh.ghostty", version: "1.0")
+        let remote = RemoteVersion(
+            shortVersion: "1.1", version: "2", downloadURL: nil, sourceName: "App Store",
+            appStore: AppStoreAvailability(trackID: 1, availableRegion: "us",
+                                           homeRegion: "us", storeName: nil),
+            changelogURL: URL(string: "https://apps.apple.com/app/id1"))
+        let page = ChangelogRecipeSelection.fallbackPage(
+            for: UpdateResult(app: installed, remote: remote, status: .upToDate))
+        #expect(page == .fromSource(URL(string: "https://apps.apple.com/app/id1")!))
+    }
+
+    /// `fallbackPage`'s comment says no catalog entry is a vendor page for a
+    /// bundle id that also has a recipe, and the argument for the whole change is
+    /// that the set is expected to MOVE. A hand-transcribed measurement inside a
+    /// comment drifts silently, so derive it: this fails when the overlap changes,
+    /// pointing the next person at the comment that has to be re-read.
+    ///
+    /// The assertion is on the SET, not a count — a count stays green when one id
+    /// leaves and another arrives, which is exactly the edit worth catching.
+    @Test func catalogAndRecipeOverlapIsWhatTheCommentSays() {
+        let catalog = Set(ChangelogCatalog.pages.keys)
+        let recipes = Set(ChangelogRecipeRegistry.recipes.map { $0.bundleID.lowercased() })
+        #expect(catalog.intersection(recipes) == [
+            "app.chatwise", "com.electron.ollama", "com.longbridge.app.desktop",
+            "com.mitchellh.ghostty", "net.imput.helium",
+        ], "The catalog/recipe overlap moved. Re-read ChangelogRecipeSelection.fallbackPage: a new entry here is a vendor page that a store copy could reach through the web view.")
+        // The case the whole change is about has no catalog entry, so it lands on
+        // "No release notes" rather than a vendor page. If this ever gains one,
+        // the gate above is the only thing standing between a store WeChat and
+        // the official site's notes.
+        #expect(!catalog.contains("com.tencent.xinwechat"))
+    }
+
     /// Mutation: reorder `fallbackPage` to consult the catalog first and this
-    /// goes red. The source's own URL wins — for a store copy that is the store
-    /// listing, which is why the `remote` half needs no gate of its own.
+    /// goes red.
     @Test func theSourcesOwnPageOutranksTheCatalog() {
         let installed = app(store: false, bundleID: "com.mitchellh.ghostty", version: "1.0")
         let remote = RemoteVersion(
@@ -112,7 +161,7 @@ struct ChangelogRecipeSelectionTests {
             changelogURL: URL(string: "https://example.invalid/notes"))
         let page = ChangelogRecipeSelection.fallbackPage(
             for: UpdateResult(app: installed, remote: remote, status: .upToDate))
-        #expect(page.origin == .remote)
         #expect(page.url?.host == "example.invalid")
+        #expect(page.logToken == "remote")
     }
 }


### PR DESCRIPTION
Follow-up to #401, which merged at `be36b32` — one commit before the review
corrections landed. The branch head (`4c6dd5a`) never reached main; this carries
that commit forward onto the merged tree. No behaviour in #401 is reverted: the
gate works and #388 is genuinely fixed. What was missing is the quality half.

Adversarial review of #401's second commit found it asserting four things that
are not true. All four verified against source before fixing.

**1. `catalogWithheld` was unreachable at its only consumer.** The token is read
solely inside `logWebViewPane`, and both call sites invoke it under
`if let url = changelogURL` — so every token surviving to a log line is `remote`
or `catalog`, and `none` and both `-rejected` forms could never be emitted
either. The doc comment claimed a diagnostic distinction the log could not make.
`emptyNotes` now logs at `.notice`, which is what makes the token mean anything.
The dead branch predates #401; that commit inherited it and extended it.

**2. "`net.whatsapp.whatsapp` is iOS-on-Mac, hence always `isMASApp`" is false.**
WhatsApp ships a Developer ID build from `web.whatsapp.com` (`VendorProbeRecipe`,
Team `57T9237FN3`, verified 2026-08-09); that copy has no `_MASReceipt` and no
`WrappedBundle`, so `isMASApp` is false for it — and `UpdateSource.swift` already
records this machine's WhatsApp as the Developer ID build. The comment escalated
a store-*listing* property (`kind == "software"`) into a bundle-*provenance*
absolute. The case it hid is now named: a Developer ID copy is handed the store
listing's notes, the inverse of #388 — pre-existing, out of scope, written down
rather than reasoned away.

**3. The `isAppStoreListing` rationale named the wrong attack**, in both the code
and the test comment. `apps.apple.com.example.invalid` is not admitted by a
suffix test — it ends in `.invalid`. A suffix test admits `notapps.apple.com`; a
prefix test or `contains` admits the other. Both directions are now stated with
one assertion pinned to each.

**4. "by construction" was wrong for the ungated `remote` half.** The
`answersAppStoreCopies` gate is a property of the *source loop*, and `runSources`
returns twice before it — the Toolbox branch carrying a vendor `changelogURL`.
Nothing reaches it (a JetBrains IDE is never a MAS app), but the word was doing
work the code does not do.

Also from the review:

- `FallbackPage` becomes an enum with the URL attached, so a token that disagrees
  with its URL is unrepresentable rather than merely conventional, and `logToken`
  lives beside it the way `RejectionReason.logToken` does.
- `aStoreCopyStillGetsItsOwnSourcesPage` — the claim the comment argues hardest
  for had no test, so gating the `remote` half was a free change.
- `catalogAndRecipeOverlapIsWhatTheCommentSays` derives the overlap from both
  registries instead of trusting the hand-written list in the comment. Asserted
  as a set, not a count: one id leaving as another arrives is the edit worth
  catching.

Not done here, deliberately: the pane still reads "This source doesn't publish a
changelog we can read", which is untrue in the withheld case. Correcting it needs
a new localized string and its translations, so it belongs in its own change
rather than half-done here.

**Mutations** — six run, each red against exactly its own test:

| Mutation | Test that went red |
| --- | --- |
| drop the provenance guard | `aStoreCopyIsNotHandedACuratedVendorPage` |
| blanket `!isMASApp` | `aStoreListingSurvivesTheGateForAStoreCopy` |
| `hasSuffix` (admits `notapps.apple.com`) | `onlyTheWholeHostCountsAsAStoreListing` |
| `contains` (admits `apps.apple.com.example.invalid`) | `onlyTheWholeHostCountsAsAStoreListing` |
| catalog before source | `theSourcesOwnPageOutranksTheCatalog` |
| gate the `remote` branch | `aStoreCopyStillGetsItsOwnSourcesPage` |

**Validation**: full `make test` green on this tree — Core 2403 (1 known issue),
CLI 223, App 9/9 cases executed, localization / version-use / prose-claim / audit
gates all passed.
