### PR TITLE
Sweep the pkg route's declared hostArchitectures

### DIFF
--- a/CLI/Sources/DuoKit/Finding.swift
+++ b/CLI/Sources/DuoKit/Finding.swift
@@ -22,6 +22,15 @@ public enum Registry: String, Codable, Sendable, CaseIterable {
     /// `SparkleAppcastSource` that every caller renders as "up to date". See
     /// `FeedVerify.swift`.
     case feed
+    /// Not a recipe registry either — this sweeps the `hostArchitectures`
+    /// DECLARATION of every package the pkg install route hands to macOS's
+    /// installer. That route runs neither architecture gate (#205, #400), and
+    /// measuring the declaration is how we established it cannot stand in for
+    /// them (#415): every declaration in the registry is universal, and the only
+    /// architecture-specific packages declare nothing. So this watches for drift
+    /// — a spec that stops declaring, or starts declaring one architecture — and
+    /// is not an installability check. See `PackageArchitectureProbe`.
+    case pkgArch = "pkgarch"
 
     public var label: String {
         switch self {
@@ -30,6 +39,10 @@ public enum Registry: String, Codable, Sendable, CaseIterable {
         case .changelog: return "changelog"
         case .appStore: return "App Store probe"
         case .feed: return "Sparkle feed"
+        // Eight characters: `Report` pads labels to 14 and `padding(toLength:)`
+        // TRUNCATES anything longer, so a descriptive name would print as
+        // "pkg architectu" in the per-registry summary.
+        case .pkgArch: return "pkg arch"
         }
     }
 }

--- a/CLI/Sources/DuoKit/PackageArchitectureProbe.swift
+++ b/CLI/Sources/DuoKit/PackageArchitectureProbe.swift
@@ -33,6 +33,16 @@ import DuoUpdaterCore
 /// against its own unit tests.
 public enum PackageArchitectureProbe {
 
+    /// The endpoint answered without honouring `Range`. Surfaces as `infra` — it
+    /// is a vendor/CDN property, not a recipe defect — but it must NOT be
+    /// mistaken for a reading of the package.
+    struct RangeUnsupported: LocalizedError {
+        let status: Int
+        var errorDescription: String? {
+            "server ignored the Range request (HTTP \(status), expected 206)"
+        }
+    }
+
     /// What one package said about itself.
     public enum Declaration: Equatable, Sendable {
         /// `hostArchitectures` named every architecture we care about.
@@ -40,8 +50,9 @@ public enum PackageArchitectureProbe {
         /// It named exactly one. The event this sweep exists to notice.
         case single(String)
         /// No declaration in `Distribution` or `PackageInfo`. The common case,
-        /// and NOT a defect — 7 of 22 measured, including all three Edge
-        /// channels. Reported, never warned on.
+        /// and NOT a defect — 7 of the 22 this sweep reads, including all three
+        /// Edge channels and all three WeChat DevTools channels. Reported, never
+        /// warned on.
         case absent
         /// The URL did not serve a flat package: a DMG-wrapped pkg, or a vendor
         /// serving an HTML interstitial. Not a finding either — `kind: .pkg`
@@ -59,9 +70,14 @@ public enum PackageArchitectureProbe {
 
     /// A xar file is a 28-byte header, a zlib-compressed table of contents, then
     /// the heap. The TOC carries each member's offset and length inside the heap,
-    /// so two Range requests reach `Distribution` without the payload behind it.
-    /// Measured: 22 packages for ~197 KB, against GB-scale Office packages if the
-    /// payload were expanded — which is why #400 ruled expansion out.
+    /// so `Distribution` is reachable without the payload behind it.
+    ///
+    /// **THREE** range requests per package — header, TOC, member — and four when
+    /// `Distribution` exists but carries no declaration and `PackageInfo` is tried
+    /// after it. So the pkg route costs 66–88 requests, not the "two small
+    /// requests" an earlier version of this comment claimed. Bytes are what stays
+    /// small: ~197 KB for all 22, against GB-scale Office packages if the payload
+    /// were expanded — which is why #400 ruled expansion out.
     static let headerLength = 28
     /// Caps a hostile or corrupt endpoint. Every Distribution in this registry is
     /// far under it; Edge's is 716 bytes.
@@ -75,7 +91,16 @@ public enum PackageArchitectureProbe {
     ) async -> Result<Declaration, any Error> {
         do {
             let head = try await bytes(url, 0, headerLength - 1, session)
-            guard head.count >= 24, head.prefix(4) == Data("xar!".utf8) else {
+            // An empty or short body is its own story and must not be reported as
+            // a wrong magic number. Measured on Sunlogin 2026-09-07: its install
+            // URL 302s to the vendor's download page, which answers 206 with a
+            // ZERO-length body to `URLSession` while `curl` gets 28 bytes of HTML
+            // from the same request — so "we read nothing" is the true finding, and
+            // `magic=0x` alone would have read as "we saw bytes and they were odd".
+            guard head.count >= 24 else {
+                return .success(.notAFlatPackage("short body (\(head.count) bytes)"))
+            }
+            guard head.prefix(4) == Data("xar!".utf8) else {
                 // Hex, not the bytes themselves. A vendor serving an HTML
                 // interstitial here starts the body `<!DO`, and `Redactor` — which
                 // every `Finding` string goes through — strips markup, so the raw
@@ -83,17 +108,26 @@ public enum PackageArchitectureProbe {
                 // Sunlogin: `NOT-XAR(magic=)`, which says nothing at all. Hex
                 // survives redaction and still identifies what arrived.
                 let magic = head.prefix(4).map { String(format: "%02x", $0) }.joined()
-                return .success(.notAFlatPackage("bytes=\(head.count) magic=0x\(magic)"))
+                return .success(.notAFlatPackage("magic=0x\(magic)"))
             }
             let headerSize = Int(head.withUnsafeBytes {
                 UInt16(bigEndian: $0.loadUnaligned(fromByteOffset: 4, as: UInt16.self))
             })
-            let tocCompressed = Int(head.withUnsafeBytes {
+            // ⚠️ Range-check as UInt64 and only then narrow. `Int(someUInt64)` TRAPS
+            // above `Int.max`, and a trap is not catchable — so a file whose first
+            // four bytes are `xar!` and whose length field has the high bit set
+            // would kill `duo verify` outright, from vendor-controlled bytes. The
+            // Python witness gets this right by construction (`struct.unpack(">Q")`
+            // is unsigned and its bound check runs on that value), and the two
+            // disagreeing on a hostile input is exactly what a second witness is
+            // for. Verified: 0x8000000000000000 now reports, rather than crashing.
+            let tocRawLength = head.withUnsafeBytes {
                 UInt64(bigEndian: $0.loadUnaligned(fromByteOffset: 8, as: UInt64.self))
-            })
-            guard tocCompressed > 0, tocCompressed <= maxMemberBytes else {
-                return .success(.notAFlatPackage("toc=\(tocCompressed)"))
             }
+            guard tocRawLength > 0, tocRawLength <= UInt64(maxMemberBytes) else {
+                return .success(.notAFlatPackage("toc=\(tocRawLength)"))
+            }
+            let tocCompressed = Int(tocRawLength)
             let tocRaw = try await bytes(url, headerSize, headerSize + tocCompressed - 1, session)
             guard let toc = Inflate.zlib(tocRaw) else {
                 return .success(.notAFlatPackage("toc-not-deflate"))
@@ -103,8 +137,16 @@ public enum PackageArchitectureProbe {
             // that carries the declaration, and a component PackageInfo beside it
             // need not repeat it.
             for name in ["Distribution", "PackageInfo"] {
+                // `offset` and `length` are parsed out of vendor-controlled XML, so
+                // they are attacker input in the same sense the header is. A
+                // NEGATIVE length passed the old `<= maxMemberBytes` check and then
+                // reached `prefix(-1)`, whose precondition failure is another
+                // uncatchable trap; a huge offset overflowed the `heap + offset +
+                // length` arithmetic. Both are bounded here, before any of it runs.
                 guard let member = XarTOC.member(named: name, in: toc),
-                      member.length <= maxMemberBytes else { continue }
+                      (0...maxMemberBytes).contains(member.length),
+                      member.offset >= 0,
+                      member.offset <= Int.max - heap - member.length else { continue }
                 let raw = try await bytes(
                     url, heap + member.offset, heap + member.offset + member.length - 1, session)
                 let body = member.isCompressed ? (Inflate.zlib(raw) ?? raw) : raw
@@ -118,9 +160,19 @@ public enum PackageArchitectureProbe {
     }
 
     /// Universal vs single is decided by counting the architectures named, not by
-    /// matching a spelling: the registry carries BOTH `arm64,x86_64` (9) and
-    /// `x86_64,arm64` (6), so the order means nothing and a string comparison
-    /// against one of them would call the other single-architecture.
+    /// matching a spelling. Both orders are live — measured 2026-09-07, the
+    /// PACKAGES declare `arm64,x86_64` 9 times and `x86_64,arm64` 6 times — so the
+    /// order means nothing and a string comparison against one spelling would call
+    /// the other single-architecture.
+    ///
+    /// ⚠️ Those counts are a property of the vendors' packages, not of this
+    /// repository: `grep hostArchitectures` over the registry returns nothing. An
+    /// earlier version of this comment said "the registry carries both", which
+    /// sends a reader looking for something that is not there.
+    ///
+    /// An empty declaration (`hostArchitectures=""`) names nothing, so it counts as
+    /// single and warns. That is deliberate — a vendor publishing an empty
+    /// architecture list is worth a human look — but it has never been seen.
     static func classify(_ value: String) -> Declaration {
         let names = value.split(whereSeparator: { $0 == "," || $0 == " " })
             .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
@@ -170,7 +222,17 @@ public enum PackageArchitectureProbe {
         var request = URLRequest(url: url)
         request.setValue("bytes=\(start)-\(end)", forHTTPHeaderField: "Range")
         let limit = end - start + 1
-        let (stream, _) = try await session.countedBytes(for: request, purpose: .other)
+        let (stream, response) = try await session.countedBytes(for: request, purpose: .other)
+        // ⚠️ A server that ignores `Range` answers **200 with the whole file**, and
+        // the first `limit` bytes of a package are not the bytes that were asked
+        // for. Reading them anyway is the worst outcome available: the TOC read
+        // would get the file's opening bytes, fail to inflate, and the package
+        // would be filed `notAFlatPackage` — status `ok`. A green verdict produced
+        // by reading the wrong bytes, with the drift check silently off for that
+        // vendor. Partial Content or nothing.
+        if let http = response as? HTTPURLResponse, http.statusCode != 206 {
+            throw PackageArchitectureProbe.RangeUnsupported(status: http.statusCode)
+        }
         var out = Data()
         out.reserveCapacity(min(limit, maxMemberBytes))
         for try await byte in stream {
@@ -205,8 +267,18 @@ enum XarTOC {
 }
 
 enum Inflate {
-    /// zlib-wrapped first, then raw deflate: xar writes the former, but a member
-    /// whose encoding says gzip can carry either.
+    /// ⚠️ Read the order carefully, because the obvious reading is backwards.
+    /// Apple's `NSData.CompressionAlgorithm.zlib` is **raw DEFLATE** (RFC 1951,
+    /// `windowBits = -15`), NOT the RFC 1950 zlib wrapper its name suggests. xar
+    /// writes the RFC 1950 form, so the FIRST call here is the raw-deflate attempt
+    /// — which fails on xar's 2-byte header — and the `dropFirst(2)` fallback is
+    /// what actually reads a real package. The ordering is correct; an earlier
+    /// version of this comment described it as "zlib-wrapped first", which inverts
+    /// what each branch does and would mislead anyone trying to simplify it.
+    ///
+    /// Not verbatim-verified against Apple's documentation (those pages render as
+    /// SPA shells); rests on Apple's Archive-format docs plus developer-forums
+    /// thread 712115, and on the round-trip the unit tests exercise both ways.
     static func zlib(_ data: Data) -> Data? {
         if let out = try? (data as NSData).decompressed(using: .zlib) as Data { return out }
         if data.count > 2, let out = try? (data.dropFirst(2) as NSData)

--- a/CLI/Sources/DuoKit/PackageArchitectureProbe.swift
+++ b/CLI/Sources/DuoKit/PackageArchitectureProbe.swift
@@ -1,0 +1,203 @@
+import Foundation
+import DuoUpdaterCore
+
+/// Reads a flat `.pkg`'s declared `hostArchitectures` straight off the vendor's
+/// server, without downloading the package.
+///
+/// **What this is for, and what it is emphatically not.** `PackageInstaller`
+/// hands packages to macOS's own installer and never sees a `.app`, so the pkg
+/// route runs neither Gate 5 (`verifyRunnableArchitecture`) nor Gate 5b — see
+/// that actor's architecture-limitation comment, and #205/#415. The obvious
+/// repair is "read the package's own `hostArchitectures` declaration instead",
+/// and measuring it is how we learned that repair does not work:
+///
+///   - Measured 2026-09-07 across the whole pkg route (22 vendor specs + XQuartz):
+///     **15 declared, all universal; 7 declared nothing; 1 unreadable** (Sunlogin
+///     serves HTML at its install URL, and is a DMG-wrapped pkg besides).
+///   - **The declaration has never once said "Intel-only" here**, so a gate built
+///     on it would not have fired a single time.
+///   - ⚠️ **The only architecture-specific packages in the registry are exactly
+///     the ones that declare nothing**: WeChat DevTools ships
+///     `wechat_devtools_..._darwin_arm64.pkg` with no `hostArchitectures` in its
+///     `PackageInfo`. Where architecture varies the declaration is blind; where
+///     the declaration exists architecture does not vary.
+///
+/// So this sweeps for DRIFT — a spec that stops declaring, or starts declaring a
+/// single architecture — and must never be described as an installability check.
+/// A vendor's claim is not the payload's slices; only reading the real Mach-O
+/// answers that, which is Gate 5's whole point and what this cannot do.
+///
+/// `scripts/pkg_host_architectures.py` reads the same bytes in Python. It is kept
+/// as the second witness, per CLAUDE.md: a rule this fiddly is worth checking
+/// against an independent implementation on the real registry rather than
+/// against its own unit tests.
+public enum PackageArchitectureProbe {
+
+    /// What one package said about itself.
+    public enum Declaration: Equatable, Sendable {
+        /// `hostArchitectures` named every architecture we care about.
+        case universal(String)
+        /// It named exactly one. The event this sweep exists to notice.
+        case single(String)
+        /// No declaration in `Distribution` or `PackageInfo`. The common case,
+        /// and NOT a defect — 7 of 22 measured, including all three Edge
+        /// channels. Reported, never warned on.
+        case absent
+        /// The URL did not serve a flat package: a DMG-wrapped pkg, or a vendor
+        /// serving an HTML interstitial. Not a finding either — `kind: .pkg`
+        /// legitimately covers a `.dmg` that PackageInstaller unwraps.
+        case notAFlatPackage(String)
+
+        public var value: String {
+            switch self {
+            case .universal(let v), .single(let v): return v
+            case .absent: return "ABSENT"
+            case .notAFlatPackage(let why): return "NOT-XAR(\(why))"
+            }
+        }
+    }
+
+    /// A xar file is a 28-byte header, a zlib-compressed table of contents, then
+    /// the heap. The TOC carries each member's offset and length inside the heap,
+    /// so two Range requests reach `Distribution` without the payload behind it.
+    /// Measured: 22 packages for ~197 KB, against GB-scale Office packages if the
+    /// payload were expanded — which is why #400 ruled expansion out.
+    static let headerLength = 28
+    /// Caps a hostile or corrupt endpoint. Every Distribution in this registry is
+    /// far under it; Edge's is 716 bytes.
+    static let maxMemberBytes = 4 << 20
+
+    /// Read one package. Vendor-side trouble comes back as a value, never as a
+    /// throw: this runs inside a sweep whose job is to report, and an endpoint
+    /// that hangs up is `infra`, not a recipe defect.
+    public static func declaration(
+        at url: URL, session: URLSession = .updates
+    ) async -> Result<Declaration, any Error> {
+        do {
+            let head = try await bytes(url, 0, headerLength - 1, session)
+            guard head.count >= 24, head.prefix(4) == Data("xar!".utf8) else {
+                // Hex, not the bytes themselves. A vendor serving an HTML
+                // interstitial here starts the body `<!DO`, and `Redactor` — which
+                // every `Finding` string goes through — strips markup, so the raw
+                // spelling reaches the report as an EMPTY diagnostic. Measured on
+                // Sunlogin: `NOT-XAR(magic=)`, which says nothing at all. Hex
+                // survives redaction and still identifies what arrived.
+                let magic = head.prefix(4).map { String(format: "%02x", $0) }.joined()
+                return .success(.notAFlatPackage("bytes=\(head.count) magic=0x\(magic)"))
+            }
+            let headerSize = Int(head.withUnsafeBytes {
+                UInt16(bigEndian: $0.loadUnaligned(fromByteOffset: 4, as: UInt16.self))
+            })
+            let tocCompressed = Int(head.withUnsafeBytes {
+                UInt64(bigEndian: $0.loadUnaligned(fromByteOffset: 8, as: UInt64.self))
+            })
+            guard tocCompressed > 0, tocCompressed <= maxMemberBytes else {
+                return .success(.notAFlatPackage("toc=\(tocCompressed)"))
+            }
+            let tocRaw = try await bytes(url, headerSize, headerSize + tocCompressed - 1, session)
+            guard let toc = Inflate.zlib(tocRaw) else {
+                return .success(.notAFlatPackage("toc-not-deflate"))
+            }
+            let heap = headerSize + tocCompressed
+            // Distribution before PackageInfo: on a product archive it is the file
+            // that carries the declaration, and a component PackageInfo beside it
+            // need not repeat it.
+            for name in ["Distribution", "PackageInfo"] {
+                guard let member = XarTOC.member(named: name, in: toc),
+                      member.length <= maxMemberBytes else { continue }
+                let raw = try await bytes(
+                    url, heap + member.offset, heap + member.offset + member.length - 1, session)
+                let body = member.isCompressed ? (Inflate.zlib(raw) ?? raw) : raw
+                guard let value = hostArchitecturesAttribute(in: body) else { continue }
+                return .success(classify(value))
+            }
+            return .success(.absent)
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// Universal vs single is decided by counting the architectures named, not by
+    /// matching a spelling: the registry carries BOTH `arm64,x86_64` (9) and
+    /// `x86_64,arm64` (6), so the order means nothing and a string comparison
+    /// against one of them would call the other single-architecture.
+    static func classify(_ value: String) -> Declaration {
+        let names = value.split(whereSeparator: { $0 == "," || $0 == " " })
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            .filter { !$0.isEmpty }
+        return Set(names).count <= 1 ? .single(value) : .universal(value)
+    }
+
+    /// Whitespace around `=` is allowed because the attribute is XML, not a fixed
+    /// vendor spelling — `xmllint --format` and hand edits both produce it.
+    ///
+    /// Built per call rather than held in a `static let`: `Regex` is not
+    /// `Sendable`, and this runs from a concurrent sweep. Compiling one small
+    /// pattern per package is nothing beside the two network round trips it sits
+    /// between.
+    static func hostArchitecturesAttribute(in body: Data) -> String? {
+        guard let text = String(data: body, encoding: .utf8)
+            ?? String(data: body, encoding: .isoLatin1) else { return nil }
+        guard let pattern = try? NSRegularExpression(
+            pattern: #"hostArchitectures\s*=\s*"([^"]*)""#) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = pattern.firstMatch(in: text, range: range),
+              let captured = Range(match.range(at: 1), in: text) else { return nil }
+        return String(text[captured])
+    }
+
+    private static func bytes(
+        _ url: URL, _ start: Int, _ end: Int, _ session: URLSession
+    ) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.setValue("bytes=\(start)-\(end)", forHTTPHeaderField: "Range")
+        // `.other`, not a purpose of its own, and deliberately. These bytes are
+        // produced only by `duo verify --pkgarch` — the app never makes this
+        // request — and every row is already tagged `RequestClient.cli`, so they
+        // are separable without a new category. A new `RequestPurpose` case would
+        // have to be spelled in `RequestLogPane`'s three exhaustive switches,
+        // one of which is a `String(localized:)` legend, putting a new
+        // user-facing string (and 7 translations) in front of every user for a
+        // bucket only a developer sweep can fill. Revisit if the app itself ever
+        // reads installer metadata.
+        let (data, _) = try await session.countedData(for: request, purpose: .other)
+        // A server that ignores Range answers 200 with the whole file. Truncating
+        // to what was asked for is what keeps an Office package out of memory —
+        // the request header alone is not a guarantee.
+        return data.prefix(end - start + 1)
+    }
+}
+
+/// The two TOC fields this needs, so the XML walk lives in one place rather than
+/// inline in the reader.
+enum XarTOC {
+    struct Member { let offset: Int; let length: Int; let isCompressed: Bool }
+
+    static func member(named name: String, in toc: Data) -> Member? {
+        guard let doc = try? XMLDocument(data: toc) else { return nil }
+        guard let nodes = try? doc.nodes(
+            forXPath: "//file[name='\(name)']/data") else { return nil }
+        for node in nodes {
+            guard let element = node as? XMLElement,
+                  let offset = Int(element.elements(forName: "offset").first?.stringValue ?? ""),
+                  let length = Int(element.elements(forName: "length").first?.stringValue ?? "")
+            else { continue }
+            let style = element.elements(forName: "encoding").first?
+                .attribute(forName: "style")?.stringValue ?? ""
+            return Member(offset: offset, length: length,
+                          isCompressed: style.contains("gzip") || style.contains("zlib"))
+        }
+        return nil
+    }
+}
+
+enum Inflate {
+    /// zlib-wrapped first, then raw deflate: xar writes the former, but a member
+    /// whose encoding says gzip can carry either.
+    static func zlib(_ data: Data) -> Data? {
+        if let out = try? (data as NSData).decompressed(using: .zlib) as Data { return out }
+        if data.count > 2, let out = try? (data.dropFirst(2) as NSData)
+            .decompressed(using: .zlib) as Data { return out }
+        return nil
+    }
+}

--- a/CLI/Sources/DuoKit/PackageArchitectureProbe.swift
+++ b/CLI/Sources/DuoKit/PackageArchitectureProbe.swift
@@ -146,25 +146,38 @@ public enum PackageArchitectureProbe {
         return String(text[captured])
     }
 
+    /// Reads AT MOST the requested range, and stops the transfer rather than
+    /// truncating after the fact.
+    ///
+    /// ⚠️ This must not go back to `countedData`. That buffers the whole response
+    /// before returning, so `data.prefix(n)` on the result protects nothing: a
+    /// server that ignores `Range` answers 200 with the entire file, and these
+    /// URLs are installers measured in gigabytes. An earlier version of this
+    /// function did exactly that and carried a comment claiming the prefix was
+    /// what kept an Office package out of memory — it was not.
+    ///
+    /// `.other` rather than a purpose of its own, deliberately. These bytes are
+    /// produced only by `duo verify --pkgarch` — the app never makes this request
+    /// — and every row is already tagged `RequestClient.cli`, so they are
+    /// separable without a new category. A new `RequestPurpose` case would have to
+    /// be spelled in `RequestLogPane`'s three exhaustive switches, one of which is
+    /// a `String(localized:)` legend, putting a new user-facing string and seven
+    /// translations in front of every user for a bucket only a developer sweep can
+    /// fill. Revisit if the app itself ever reads installer metadata.
     private static func bytes(
         _ url: URL, _ start: Int, _ end: Int, _ session: URLSession
     ) async throws -> Data {
         var request = URLRequest(url: url)
         request.setValue("bytes=\(start)-\(end)", forHTTPHeaderField: "Range")
-        // `.other`, not a purpose of its own, and deliberately. These bytes are
-        // produced only by `duo verify --pkgarch` — the app never makes this
-        // request — and every row is already tagged `RequestClient.cli`, so they
-        // are separable without a new category. A new `RequestPurpose` case would
-        // have to be spelled in `RequestLogPane`'s three exhaustive switches,
-        // one of which is a `String(localized:)` legend, putting a new
-        // user-facing string (and 7 translations) in front of every user for a
-        // bucket only a developer sweep can fill. Revisit if the app itself ever
-        // reads installer metadata.
-        let (data, _) = try await session.countedData(for: request, purpose: .other)
-        // A server that ignores Range answers 200 with the whole file. Truncating
-        // to what was asked for is what keeps an Office package out of memory —
-        // the request header alone is not a guarantee.
-        return data.prefix(end - start + 1)
+        let limit = end - start + 1
+        let (stream, _) = try await session.countedBytes(for: request, purpose: .other)
+        var out = Data()
+        out.reserveCapacity(min(limit, maxMemberBytes))
+        for try await byte in stream {
+            out.append(byte)
+            if out.count >= limit { break }
+        }
+        return out
     }
 }
 

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -180,14 +180,7 @@ public enum Verify {
         // REGISTRIES rather than on what this run swept: `--only` and
         // `--changelog` narrow the sweep, and pruning against a narrowed run
         // would delete every row the filter excluded.
-        let live = Set(
-            VendorProbeRegistry.recipes.map(\.recipeID)
-                + ChangelogRecipeRegistry.recipes.map(\.recipeID)
-                + GitHubReleaseRegistry.rules.map(\.recipeID)
-                + MacAppStoreProbeRegistry.cases.map(\.recipeID)
-                + [MacAppStoreProbeRegistry.batchRecipeID]
-                + SparkleFeedCatalog.verificationCases.map(\.recipeID))
-        let pruned = baseline.prune(keeping: live)
+        let pruned = baseline.prune(keeping: liveRecipeIDs())
         for id in pruned.removed {
             print("  baseline: dropped \(id) — no recipe produces this id any more")
         }
@@ -340,7 +333,11 @@ public enum Verify {
     private static func sweepVendor(
         _ recipes: [VendorProbeRecipe], options: VerifyOptions,
         installed: [String: InstalledVersion],
-        collecting installURLs: ResolvedInstallURLs? = nil
+        // Not optional and not defaulted: an omitted collector compiles and
+        // silently collects nothing, leaving the pkgarch sweep reporting every
+        // package as skipped with no error anywhere. Same rule as
+        // `RowActions.live` in CLAUDE.md.
+        collecting installURLs: ResolvedInstallURLs
     ) async -> [Finding] {
         await byHost(recipes, host: { $0.url.host ?? "-" }, options: options) { recipe in
             // A credential-bearing recipe is never fetched by the sweep: its URL,
@@ -407,7 +404,8 @@ public enum Verify {
             // Hand the pkgarch sweep the URL this probe already resolved. Doing it
             // here rather than re-probing is the difference between 44 small Range
             // reads and hitting 22 vendor endpoints a second time in one run.
-            await installURLs?.record(recipe.recipeID, outcome.remote?.downloadURL)
+            await installURLs.record(
+                recipe.recipeID, installArtifactURL(outcome))
             return finding
         }
     }
@@ -425,6 +423,54 @@ public enum Verify {
             urls[recipeID] = url
         }
         func all() -> [String: URL] { urls }
+    }
+
+    /// Every recipe id the registries can still produce, which is what `Baseline`
+    /// keeps and everything else it prunes.
+    ///
+    /// Extracted so it can be tested: an id missing here is not a compile error
+    /// and not a failing sweep — it is an entry silently deleted on every run.
+    /// For `pkgarch:` that meant a single-architecture warn's
+    /// `consecutiveActionable` was wiped before it was saved, so it could never
+    /// reach `actionableThreshold` and the sweep's only actionable branch was
+    /// structurally unable to file an issue.
+    ///
+    /// Derived from the registries, never from this run's `--only` filter: a
+    /// narrowed sweep must not prune the entries it did not look at.
+    static func liveRecipeIDs() -> Set<String> {
+        Set(
+            VendorProbeRegistry.recipes.map(\.recipeID)
+                + ChangelogRecipeRegistry.recipes.map(\.recipeID)
+                + GitHubReleaseRegistry.rules.map(\.recipeID)
+                + MacAppStoreProbeRegistry.cases.map(\.recipeID)
+                + [MacAppStoreProbeRegistry.batchRecipeID]
+                + SparkleFeedCatalog.verificationCases.map(\.recipeID)
+                + VendorProbeRegistry.recipes
+                    .filter { $0.install?.kind == .pkg }
+                    .map { pkgArchID($0) })
+    }
+
+    /// The resolved install artifact, or nil when the probe fell back.
+    ///
+    /// ⚠️ `remote.downloadURL` is NOT always an installer. When the install plan
+    /// fails to resolve, `VendorProbeSource.makeRemoteVersion` is called with
+    /// `install: nil, plan: nil` and fills `downloadURL` with
+    /// `recipe.downloadURL` — the vendor's HUMAN download page. Handing that to
+    /// the pkgarch sweep makes it range-read an HTML page and file
+    /// `notAFlatPackage` as `ok`: a green verdict on a recipe whose install spec
+    /// just died, which is precisely the drift this is supposed to notice.
+    ///
+    /// The probe already says so in its own vocabulary, so read that rather than
+    /// guessing from the URL's shape.
+    static func installArtifactURL(_ outcome: ProbeOutcome) -> URL? {
+        let unresolved: Set<String> = [
+            ProbeWarning.installURLUnresolved.kind,
+            ProbeWarning.installURLTransient(status: nil).kind,
+            ProbeWarning.installURLNotFound(status: nil, host: nil).kind,
+        ]
+        guard !outcome.warnings.contains(where: { unresolved.contains($0.kind) })
+        else { return nil }
+        return outcome.remote?.downloadURL
     }
 
     /// A pkgarch finding's own id, namespaced like every other registry's

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -52,11 +52,23 @@ public enum Verify {
         let appStore = filtered(MacAppStoreProbeRegistry.cases, options) { $0.bundleID }
         let feeds = filtered(SparkleFeedCatalog.verificationCases, options) { $0.bundleID }
 
-        let total = (options.registries.contains(.vendor) ? vendor.count : 0)
-            + (options.registries.contains(.github) ? github.count : 0)
-            + (options.registries.contains(.changelog) ? changelog.count : 0)
-            + (options.registries.contains(.appStore) ? appStore.count : 0)
-            + (options.registries.contains(.feed) ? feeds.count : 0)
+        // The pkg install specs the pkgarch sweep reads. Counted here like every
+        // other registry: without it `duo verify --pkgarch` computes a total of
+        // zero and dies with "nothing to verify - no recipe matches", blaming an
+        // `--only` the user never typed.
+        let pkgs = vendor.filter { $0.install?.kind == .pkg }
+        // Written as a loop rather than a chain of ternaries: at six registries
+        // the chained form exceeded the type checker's budget outright ("unable to
+        // type-check this expression in reasonable time"), and a seventh registry
+        // would hit it again.
+        let counts: [(Registry, Int)] = [
+            (.vendor, vendor.count), (.github, github.count),
+            (.changelog, changelog.count), (.appStore, appStore.count),
+            (.feed, feeds.count), (.pkgArch, pkgs.count),
+        ]
+        let total = counts.reduce(0) { sum, entry in
+            sum + (options.registries.contains(entry.0) ? entry.1 : 0)
+        }
         guard total > 0 else {
             die("nothing to verify — no recipe matches \(options.only.joined(separator: ", "))",
                 code: 2)
@@ -70,9 +82,20 @@ public enum Verify {
         \(options.registries.contains(.github) ? "\(github.count) GitHub rules  " : "")\
         \(options.registries.contains(.changelog) ? "\(changelog.count) changelogs  " : "")\
         \(options.registries.contains(.appStore) ? "\(appStore.count) App Store probes  " : "")\
-        \(options.registries.contains(.feed) ? "\(feeds.count) Sparkle feeds" : "")
+        \(options.registries.contains(.feed) ? "\(feeds.count) Sparkle feeds  " : "")\
+        \(options.registries.contains(.pkgArch) ? "\(pkgs.count) pkg architectures" : "")
           ─────────────────────────────────────────────
         """)
+        // Said once, up front, rather than left for the reader to infer from a
+        // column of `skipped`: this sweep reads the install URLs the vendor sweep
+        // resolves, so on its own it has none. Making `--pkgarch` silently imply
+        // `--vendor` would be worse - it would spend ~150 vendor requests the user
+        // did not ask for.
+        if options.registries.contains(.pkgArch), !options.registries.contains(.vendor) {
+            print("  ⚠︎ --pkgarch reads the install URLs the vendor sweep resolves, "
+                  + "and --vendor\n    was not selected, so every package reports skipped. "
+                  + "Add --vendor.\n")
+        }
 
         let started = Date()
         var findings: [Finding] = []
@@ -404,6 +427,19 @@ public enum Verify {
         func all() -> [String: URL] { urls }
     }
 
+    /// A pkgarch finding's own id, namespaced like every other registry's
+    /// (`appstore:`, `feed:`, `github:`, `vendor:`).
+    ///
+    /// ⚠️ Not `recipe.recipeID`. That is already `vendor:<bundle>:<channel>`, and
+    /// `Baseline` keys its entries on the id alone — so reusing it would file this
+    /// sweep's verdict and the vendor sweep's into ONE baseline entry for the same
+    /// recipe, mixing their `consecutiveActionable` streaks and sharing the issue
+    /// number attached to it. Two registries reporting on one recipe is exactly
+    /// what the namespace is for.
+    static func pkgArchID(_ recipe: VendorProbeRecipe) -> String {
+        "pkgarch:\(recipe.bundleID):\(recipe.channel.rawValue)"
+    }
+
     /// Read the declared `hostArchitectures` of every package the pkg install
     /// route would hand to macOS's installer.
     ///
@@ -433,42 +469,59 @@ public enum Verify {
         guard !pkgs.isEmpty else { return [] }
         return await byHost(pkgs, host: { urls[$0.recipeID]?.host ?? ($0.url.host ?? "-") },
                             options: options) { recipe in
+            // Keyed by the VENDOR id, because that is what `sweepVendor` recorded
+            // under. Only the finding gets the pkgarch namespace.
             let host = urls[recipe.recipeID]?.host ?? (recipe.url.host ?? "-")
             guard let url = urls[recipe.recipeID] else {
                 // The vendor sweep did not resolve an install URL for this recipe
                 // — it already filed why. Skipped, so the gap is visible without
                 // being counted as this sweep's failure.
-                return Finding(
-                    recipeID: recipe.recipeID, registry: .pkgArch, bundleID: recipe.bundleID,
-                    channel: recipe.channel.rawValue, status: .skipped,
-                    failureDetail: "no install URL resolved this run",
-                    endpointHost: host)
+                return pkgArchFinding(recipe, host: host, outcome: nil, elapsedMs: 0)
             }
             let started = Date()
             let outcome = await PackageArchitectureProbe.declaration(at: url)
-            let elapsed = Int(Date().timeIntervalSince(started) * 1000)
-            switch outcome {
-            case .failure(let error):
-                return Finding(
-                    recipeID: recipe.recipeID, registry: .pkgArch, bundleID: recipe.bundleID,
-                    channel: recipe.channel.rawValue, status: .infra,
-                    failureKind: "packageUnreadable",
-                    failureDetail: error.localizedDescription,
-                    endpointHost: host, elapsedMs: elapsed)
-            case .success(let declaration):
-                let single: Bool
-                if case .single = declaration { single = true } else { single = false }
-                return Finding(
-                    recipeID: recipe.recipeID, registry: .pkgArch, bundleID: recipe.bundleID,
-                    channel: recipe.channel.rawValue,
-                    status: single ? .warn : .ok,
-                    failureKind: single ? "singleArchitecturePackage" : nil,
-                    failureDetail: single
-                        ? "declares \(declaration.value) — the pkg route runs no architecture gate"
-                        : nil,
-                    warnings: ["hostArchitectures=\(declaration.value)"],
-                    endpointHost: host, elapsedMs: elapsed)
-            }
+            return pkgArchFinding(recipe, host: host, outcome: outcome,
+                                  elapsedMs: Int(Date().timeIntervalSince(started) * 1000))
+        }
+    }
+
+    /// Turn one package's verdict into a `Finding`. Pure and non-private so the
+    /// status mapping can be tested without a network: the `warn` branch is the
+    /// only actionable one this sweep has and no real package produces it
+    /// (measured — every declaration in the registry is universal), so a test
+    /// that cannot construct it would leave the branch unexercised end to end.
+    ///
+    /// `outcome: nil` means the vendor sweep resolved no install URL.
+    static func pkgArchFinding(
+        _ recipe: VendorProbeRecipe, host: String,
+        outcome: Result<PackageArchitectureProbe.Declaration, any Error>?, elapsedMs: Int
+    ) -> Finding {
+        guard let outcome else {
+            return Finding(
+                recipeID: pkgArchID(recipe), registry: .pkgArch, bundleID: recipe.bundleID,
+                channel: recipe.channel.rawValue, status: .skipped,
+                failureDetail: "no install URL resolved this run", endpointHost: host)
+        }
+        switch outcome {
+        case .failure(let error):
+            return Finding(
+                recipeID: pkgArchID(recipe), registry: .pkgArch, bundleID: recipe.bundleID,
+                channel: recipe.channel.rawValue, status: .infra,
+                failureKind: "packageUnreadable", failureDetail: error.localizedDescription,
+                endpointHost: host, elapsedMs: elapsedMs)
+        case .success(let declaration):
+            let single: Bool
+            if case .single = declaration { single = true } else { single = false }
+            return Finding(
+                recipeID: pkgArchID(recipe), registry: .pkgArch, bundleID: recipe.bundleID,
+                channel: recipe.channel.rawValue,
+                status: single ? .warn : .ok,
+                failureKind: single ? "singleArchitecturePackage" : nil,
+                failureDetail: single
+                    ? "declares \(declaration.value) — the pkg route runs no architecture gate"
+                    : nil,
+                warnings: ["hostArchitectures=\(declaration.value)"],
+                endpointHost: host, elapsedMs: elapsedMs)
         }
     }
 

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -80,8 +80,11 @@ public enum Verify {
         // Vendor and GitHub first: their answers are the reference the changelog
         // sweep compares against, and they resolve the `{version}` that
         // templated changelog URLs need.
+        let resolvedInstallURLs = ResolvedInstallURLs()
         if options.registries.contains(.vendor) {
-            findings += await sweepVendor(vendor, options: options, installed: installed)
+            findings += await sweepVendor(
+                vendor, options: options, installed: installed,
+                collecting: resolvedInstallURLs)
             // The pages `sweepChangelog` will GET and parse below are excluded:
             // its answer is better evidence than a HEAD, and two checks on one URL
             // in one report can contradict each other. When the changelog registry
@@ -132,6 +135,14 @@ public enum Verify {
         }
         if options.registries.contains(.feed) {
             findings += await sweepFeeds(feeds, options: options)
+        }
+        // After the vendor sweep, always: it reads the install URLs that sweep
+        // resolved. Selecting `--pkgarch` without `--vendor` therefore resolves
+        // nothing and every package reports `skipped`, which is the honest answer
+        // — the alternative is this sweep quietly re-probing every vendor.
+        if options.registries.contains(.pkgArch) {
+            findings += await sweepPackageArchitecture(
+                vendor, urls: await resolvedInstallURLs.all(), options: options)
         }
 
         findings.sort { $0.recipeID < $1.recipeID }
@@ -305,7 +316,8 @@ public enum Verify {
 
     private static func sweepVendor(
         _ recipes: [VendorProbeRecipe], options: VerifyOptions,
-        installed: [String: InstalledVersion]
+        installed: [String: InstalledVersion],
+        collecting installURLs: ResolvedInstallURLs? = nil
     ) async -> [Finding] {
         await byHost(recipes, host: { $0.url.host ?? "-" }, options: options) { recipe in
             // A credential-bearing recipe is never fetched by the sweep: its URL,
@@ -369,7 +381,94 @@ public enum Verify {
                 finding = finding.observing(
                     Finding.machineNotePrefix + "oneClickCandidate: " + candidate)
             }
+            // Hand the pkgarch sweep the URL this probe already resolved. Doing it
+            // here rather than re-probing is the difference between 44 small Range
+            // reads and hitting 22 vendor endpoints a second time in one run.
+            await installURLs?.record(recipe.recipeID, outcome.remote?.downloadURL)
             return finding
+        }
+    }
+
+    /// Install URLs the vendor sweep already resolved, so the pkgarch sweep can
+    /// read those packages without probing the same vendor endpoints a second
+    /// time. Collected as a side effect rather than returned, because
+    /// `sweepVendor` runs its recipes through `byHost`, whose contract is
+    /// recipe-in/finding-out — widening that to carry an unrelated value would
+    /// put this sweep's needs into every other sweep's signature.
+    actor ResolvedInstallURLs {
+        private var urls: [String: URL] = [:]
+        func record(_ recipeID: String, _ url: URL?) {
+            guard let url else { return }
+            urls[recipeID] = url
+        }
+        func all() -> [String: URL] { urls }
+    }
+
+    /// Read the declared `hostArchitectures` of every package the pkg install
+    /// route would hand to macOS's installer.
+    ///
+    /// Statuses are deliberately quiet, because the measurement behind this sweep
+    /// (#415) found the declaration has no discriminating power today:
+    ///
+    ///   - a **single-architecture** declaration is the one `warn`. It is the
+    ///     event worth waking someone for — a package that used to be universal
+    ///     now naming one architecture is how an Intel-only pkg would arrive.
+    ///   - **universal** and **absent** are both `ok`. Absent is the norm, not a
+    ///     defect: 7 of 22 declare nothing, including all three Edge channels.
+    ///     Warning on it would file seven issues on day one and train the reader
+    ///     to ignore the sweep — which `FindingStatus.infra`'s comment already
+    ///     warns about.
+    ///   - a URL that is not a flat package is `ok` too: `kind: .pkg` legitimately
+    ///     covers a `.dmg` that `PackageInstaller` unwraps (Sunlogin), and a
+    ///     vendor serving HTML there is the vendor sweep's finding to make, not
+    ///     this one's — filing it twice would put two verdicts on one URL.
+    ///
+    /// The declaration is recorded on every finding, `ok` included, so the value
+    /// lands in `report.json` and drift shows up as a diff rather than depending
+    /// on someone re-reading a comment.
+    private static func sweepPackageArchitecture(
+        _ recipes: [VendorProbeRecipe], urls: [String: URL], options: VerifyOptions
+    ) async -> [Finding] {
+        let pkgs = recipes.filter { $0.install?.kind == .pkg }
+        guard !pkgs.isEmpty else { return [] }
+        return await byHost(pkgs, host: { urls[$0.recipeID]?.host ?? ($0.url.host ?? "-") },
+                            options: options) { recipe in
+            let host = urls[recipe.recipeID]?.host ?? (recipe.url.host ?? "-")
+            guard let url = urls[recipe.recipeID] else {
+                // The vendor sweep did not resolve an install URL for this recipe
+                // — it already filed why. Skipped, so the gap is visible without
+                // being counted as this sweep's failure.
+                return Finding(
+                    recipeID: recipe.recipeID, registry: .pkgArch, bundleID: recipe.bundleID,
+                    channel: recipe.channel.rawValue, status: .skipped,
+                    failureDetail: "no install URL resolved this run",
+                    endpointHost: host)
+            }
+            let started = Date()
+            let outcome = await PackageArchitectureProbe.declaration(at: url)
+            let elapsed = Int(Date().timeIntervalSince(started) * 1000)
+            switch outcome {
+            case .failure(let error):
+                return Finding(
+                    recipeID: recipe.recipeID, registry: .pkgArch, bundleID: recipe.bundleID,
+                    channel: recipe.channel.rawValue, status: .infra,
+                    failureKind: "packageUnreadable",
+                    failureDetail: error.localizedDescription,
+                    endpointHost: host, elapsedMs: elapsed)
+            case .success(let declaration):
+                let single: Bool
+                if case .single = declaration { single = true } else { single = false }
+                return Finding(
+                    recipeID: recipe.recipeID, registry: .pkgArch, bundleID: recipe.bundleID,
+                    channel: recipe.channel.rawValue,
+                    status: single ? .warn : .ok,
+                    failureKind: single ? "singleArchitecturePackage" : nil,
+                    failureDetail: single
+                        ? "declares \(declaration.value) — the pkg route runs no architecture gate"
+                        : nil,
+                    warnings: ["hostArchitectures=\(declaration.value)"],
+                    endpointHost: host, elapsedMs: elapsed)
+            }
         }
     }
 

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -151,13 +151,21 @@ events options:
 
 verify options:
   --only <text>       Restrict to recipes whose bundle id contains <text>.
-                      Comma-separated for several. Without it all five
+                      Comma-separated for several. Without it all six
                       registries are swept (~150 requests, about 3 minutes).
   --vendor            Sweep only the vendor probe recipes.
   --github            Sweep only the GitHub release rules.
   --changelog         Sweep only the changelog recipes.
   --appstore          Sweep only the Mac App Store probe cases.
   --feed              Sweep only the SparkleFeedCatalog addresses.
+  --pkgarch           Sweep only the declared hostArchitectures of the packages
+                      the pkg install route hands to macOS's installer. Reads
+                      each package's xar table of contents by HTTP range rather
+                      than downloading it (~200 KB for the whole route), and
+                      reuses the install URLs the vendor sweep resolved — so on
+                      its own it has none and reports every package as skipped.
+                      Watches for drift, NOT installability: the declaration is
+                      the vendor's claim, not the payload's slices (#415).
   --samples           Print the fetched body sample for each flagged recipe —
                       what you need to re-derive a broken pattern.
   --no-installed      Don't cross-check against locally installed apps. Implied

--- a/CLI/Tests/DuoKitTests/PackageArchitectureProbeTests.swift
+++ b/CLI/Tests/DuoKitTests/PackageArchitectureProbeTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import DuoKit
+@testable import DuoUpdaterCore
+
+/// The `warn` path has no live example — measured 2026-09-07, every declaration
+/// in the registry is universal (#415) — so the classifier is tested directly
+/// rather than against a real package. A check whose only interesting branch is
+/// unreachable in production is exactly the kind this repo asks to be pinned by
+/// construction instead of by fixture.
+struct PackageArchitectureProbeTests {
+
+    /// Mutation: compare against a literal `"arm64,x86_64"` instead of counting
+    /// names, and the `x86_64,arm64` cases go red. Both spellings are live —
+    /// 9 recipes use one order, 6 the other — so order carries no meaning and a
+    /// string comparison would call half the registry single-architecture.
+    @Test(arguments: [
+        ("arm64,x86_64", false), ("x86_64,arm64", false),
+        ("arm64, x86_64", false), ("x86_64", true), ("arm64", true),
+        ("arm64,arm64", true),
+    ])
+    func universalIsDecidedByCountingNamesNotBySpelling(value: String, isSingle: Bool) {
+        let declaration = PackageArchitectureProbe.classify(value)
+        if case .single = declaration {
+            #expect(isSingle, "\(value) was read as single-architecture")
+        } else {
+            #expect(!isSingle, "\(value) was read as universal")
+        }
+        #expect(declaration.value == value)   // the vendor's spelling is preserved verbatim
+    }
+
+    /// Mutation: drop the `\s*` around `=` and the formatted spelling goes red.
+    /// This is an XML attribute, not a fixed vendor string — a reformatted
+    /// Distribution is the same declaration.
+    @Test func theAttributeIsReadWhateverTheXMLSpacing() {
+        let bodies = [
+            #"<options hostArchitectures="arm64,x86_64"/>"#,
+            #"<options hostArchitectures = "arm64,x86_64" />"#,
+            "<options\n    hostArchitectures=\"arm64,x86_64\"\n/>",
+        ]
+        for body in bodies {
+            #expect(PackageArchitectureProbe.hostArchitecturesAttribute(
+                in: Data(body.utf8)) == "arm64,x86_64", "failed on: \(body)")
+        }
+        // Absent must read as nil, not as an empty declaration — `.absent` and
+        // `.single("")` are different findings.
+        #expect(PackageArchitectureProbe.hostArchitecturesAttribute(
+            in: Data(#"<options rootVolumeOnly="true"/>"#.utf8)) == nil)
+    }
+
+    /// The declaration text a report shows must not lose the case that produced
+    /// it. `NOT-XAR` with an empty reason was a real defect: the raw `<!DO` a
+    /// vendor's HTML interstitial starts with is stripped by `Redactor`, so the
+    /// diagnostic arrived empty (measured on Sunlogin).
+    @Test func anUnreadablePackageSaysWhatArrived() {
+        let declaration = PackageArchitectureProbe.Declaration
+            .notAFlatPackage("bytes=28 magic=0x3c21444f")
+        #expect(declaration.value.contains("3c21444f"))
+        #expect(!declaration.value.hasSuffix("()"))
+    }
+
+    /// Registry-derived, not a hand-written list: every pkg spec must be one the
+    /// sweep can name. A recipe flipping `.tar` → `.pkg` silently moves an app
+    /// onto the gate-less install route (#415), and this is what notices.
+    @Test func everyPkgSpecIsCoveredBySweepAndScript() {
+        let pkgs = VendorProbeRegistry.recipes.filter { $0.install?.kind == .pkg }
+        #expect(!pkgs.isEmpty, "no pkg specs found — the filter, not the registry, is wrong")
+        // Guards the count the docs and #415 quote, so the prose cannot drift away
+        // from the registry without something going red.
+        #expect(pkgs.count == 22, """
+            The pkg install route changed size (\(pkgs.count) specs, was 22). That is \
+            worth reading, not just re-pinning: every one of these is installed with \
+            no architecture gate. Re-run scripts/pkg_host_architectures.py and update \
+            #415 before changing this number.
+            """)
+        #expect(Set(pkgs.map(\.recipeID)).count == pkgs.count, "recipeIDs must be unique")
+    }
+}

--- a/CLI/Tests/DuoKitTests/PackageArchitectureProbeTests.swift
+++ b/CLI/Tests/DuoKitTests/PackageArchitectureProbeTests.swift
@@ -75,4 +75,65 @@ struct PackageArchitectureProbeTests {
             """)
         #expect(Set(pkgs.map(\.recipeID)).count == pkgs.count, "recipeIDs must be unique")
     }
+
+    /// Mutation: use `recipe.recipeID` instead of `pkgArchID(recipe)` inside
+    /// `pkgArchFinding` and this goes red.
+    ///
+    /// `Baseline` keys its entries on the id ALONE, so a pkgarch finding sharing
+    /// the vendor recipe's id lands in the vendor recipe's baseline entry: one
+    /// `consecutiveActionable` streak fed by two sweeps, and one issue number for
+    /// both. Every other registry namespaces for this reason (`appstore:`,
+    /// `feed:`, `github:`, `vendor:`).
+    ///
+    /// ⚠️ Asserted through `pkgArchFinding`, NOT by calling `pkgArchID` directly.
+    /// The first version of this test did the latter and the mutation stayed
+    /// GREEN — reverting the call site cannot be seen by a test that never goes
+    /// through the call site.
+    @Test func pkgArchFindingsGetTheirOwnBaselineKey() throws {
+        let pkgs = VendorProbeRegistry.recipes.filter { $0.install?.kind == .pkg }
+        let recipe = try #require(pkgs.first)
+        let finding = Verify.pkgArchFinding(
+            recipe, host: "example.invalid",
+            outcome: .success(.universal("arm64,x86_64")), elapsedMs: 1)
+        #expect(finding.recipeID.hasPrefix("pkgarch:"))
+        #expect(finding.recipeID != recipe.recipeID)
+        // Across the whole route, no pkgarch id may collide with any vendor id.
+        let pkgArchIDs = Set(pkgs.map {
+            Verify.pkgArchFinding($0, host: "-", outcome: nil, elapsedMs: 0).recipeID
+        })
+        let vendorIDs = Set(VendorProbeRegistry.recipes.map(\.recipeID))
+        #expect(pkgArchIDs.isDisjoint(with: vendorIDs))
+        #expect(pkgArchIDs.count == pkgs.count, "ids must stay unique per channel")
+    }
+
+    /// The sweep's status mapping, which no real package can exercise: measured
+    /// 2026-09-07, every declaration in the registry is universal, so `.warn` —
+    /// its only actionable branch — has no live example. Without this the branch
+    /// would ship having never produced a finding.
+    ///
+    /// Mutation: flip `single ? .warn : .ok` either way and this goes red.
+    /// Mutation: warn on `.absent` (the tempting "we should know about these")
+    /// and this goes red too — 7 of 22 declare nothing, so that would file seven
+    /// findings on day one.
+    @Test func onlyASingleArchitectureDeclarationWarns() throws {
+        let recipe = try #require(
+            VendorProbeRegistry.recipes.first { $0.install?.kind == .pkg })
+        func status(_ d: PackageArchitectureProbe.Declaration) -> FindingStatus {
+            Verify.pkgArchFinding(recipe, host: "-", outcome: .success(d), elapsedMs: 0).status
+        }
+        #expect(status(.single("x86_64")) == .warn)
+        #expect(status(.universal("arm64,x86_64")) == .ok)
+        #expect(status(.absent) == .ok)
+        #expect(status(.notAFlatPackage("bytes=28 magic=0x3c21444f")) == .ok)
+        // A vendor hanging up is infra, never a recipe defect — filing those
+        // trains the reader to ignore the sweep.
+        #expect(Verify.pkgArchFinding(
+            recipe, host: "-", outcome: .failure(URLError(.timedOut)), elapsedMs: 0)
+            .status == .infra)
+        // The declaration is recorded even when nothing is wrong, so drift shows
+        // up as a report diff rather than needing someone to re-read a comment.
+        let ok = Verify.pkgArchFinding(
+            recipe, host: "-", outcome: .success(.universal("arm64,x86_64")), elapsedMs: 0)
+        #expect(ok.warnings.contains("hostArchitectures=arm64,x86_64"))
+    }
 }

--- a/CLI/Tests/DuoKitTests/PackageArchitectureProbeTests.swift
+++ b/CLI/Tests/DuoKitTests/PackageArchitectureProbeTests.swift
@@ -48,32 +48,62 @@ struct PackageArchitectureProbeTests {
             in: Data(#"<options rootVolumeOnly="true"/>"#.utf8)) == nil)
     }
 
-    /// The declaration text a report shows must not lose the case that produced
-    /// it. `NOT-XAR` with an empty reason was a real defect: the raw `<!DO` a
-    /// vendor's HTML interstitial starts with is stripped by `Redactor`, so the
-    /// diagnostic arrived empty (measured on Sunlogin).
-    @Test func anUnreadablePackageSaysWhatArrived() {
-        let declaration = PackageArchitectureProbe.Declaration
-            .notAFlatPackage("bytes=28 magic=0x3c21444f")
-        #expect(declaration.value.contains("3c21444f"))
-        #expect(!declaration.value.hasSuffix("()"))
-    }
-
-    /// Registry-derived, not a hand-written list: every pkg spec must be one the
-    /// sweep can name. A recipe flipping `.tar` → `.pkg` silently moves an app
-    /// onto the gate-less install route (#415), and this is what notices.
-    @Test func everyPkgSpecIsCoveredBySweepAndScript() {
-        let pkgs = VendorProbeRegistry.recipes.filter { $0.install?.kind == .pkg }
-        #expect(!pkgs.isEmpty, "no pkg specs found — the filter, not the registry, is wrong")
-        // Guards the count the docs and #415 quote, so the prose cannot drift away
-        // from the registry without something going red.
-        #expect(pkgs.count == 22, """
-            The pkg install route changed size (\(pkgs.count) specs, was 22). That is \
-            worth reading, not just re-pinning: every one of these is installed with \
-            no architecture gate. Re-run scripts/pkg_host_architectures.py and update \
-            #415 before changing this number.
+    /// Registry-derived: the SET of pkg specs, not a count.
+    ///
+    /// ⚠️ A count pin is the trap CLAUDE.md's `app_test_coverage.py` lesson names
+    /// ("比名字集合,不要比两个总数"): remove one pkg spec, add another, and 22
+    /// still holds. The first version of this test pinned the count AND
+    /// re-implemented the filter inline, so deleting `sweepPackageArchitecture`
+    /// entirely left it green.
+    ///
+    /// It also spans BOTH registries that can produce a pkg install, because a
+    /// GitHub rule flipping `installerKind` to `.pkg` is the same silent move onto
+    /// the gate-less route as a vendor recipe flipping `kind`.
+    @Test func thePkgRouteIsExactlyWhatTheDocsSayItIs() {
+        let vendorPkgs = Set(VendorProbeRegistry.recipes
+            .filter { $0.install?.kind == .pkg }
+            .map { Verify.pkgArchFinding($0, host: "-", outcome: nil, elapsedMs: 0).recipeID })
+        #expect(vendorPkgs == [
+            "pkgarch:cc.ffitch.shottr:stable",
+            "pkgarch:com.microsoft.Excel:stable",
+            "pkgarch:com.microsoft.OneDrive:stable",
+            "pkgarch:com.microsoft.Outlook:stable",
+            "pkgarch:com.microsoft.Powerpoint:stable",
+            "pkgarch:com.microsoft.Word:stable",
+            "pkgarch:com.microsoft.edgemac.Beta:beta",
+            "pkgarch:com.microsoft.edgemac.Dev:dev",
+            "pkgarch:com.microsoft.edgemac:stable",
+            "pkgarch:com.microsoft.m365copilot:stable",
+            "pkgarch:com.microsoft.onenote.mac:stable",
+            "pkgarch:com.microsoft.teams2:stable",
+            "pkgarch:com.netease.uuremote:stable",
+            "pkgarch:com.oray.sunlogin.macclient:stable",
+            "pkgarch:com.tclementdev.timemachineeditor.application:stable",
+            "pkgarch:com.tencent.wechatdevtools:nightly",
+            "pkgarch:com.tencent.wechatdevtools:rc",
+            "pkgarch:com.tencent.wechatdevtools:stable",
+            "pkgarch:com.youqu.todesk.mac:stable",
+            "pkgarch:io.tailscale.ipn.macsys:rc",
+            "pkgarch:io.tailscale.ipn.macsys:stable",
+            "pkgarch:io.tailscale.ipn.macsys:unstable",
+        ], """
+            The pkg install route changed. Every one of these installs with NO \
+            architecture gate, so this is worth reading rather than re-pinning: \
+            re-run scripts/pkg_host_architectures.py and update #415 and \
+            PackageInstaller's comment before changing this set.
             """)
-        #expect(Set(pkgs.map(\.recipeID)).count == pkgs.count, "recipeIDs must be unique")
+        // ⚠️ The GitHub side is NOT swept — `sweepPackageArchitecture` takes
+        // `[VendorProbeRecipe]` only. XQuartz was measured by hand for #415 and is
+        // universal. This assertion exists so that gap stays a KNOWN one: a second
+        // GitHub pkg rule makes it go red rather than joining the unswept set
+        // silently.
+        let githubPkgs = Set(GitHubReleaseRegistry.rules
+            .filter { $0.installerKind == .pkg }
+            .map(\.bundleID))
+        #expect(githubPkgs == ["org.xquartz.X11"], """
+            A GitHub rule now ships a pkg that the pkgarch sweep does not read. \
+            Either extend the sweep to GitHubReleaseRegistry or record why not.
+            """)
     }
 
     /// Mutation: use `recipe.recipeID` instead of `pkgArchID(recipe)` inside
@@ -136,4 +166,203 @@ struct PackageArchitectureProbeTests {
             recipe, host: "-", outcome: .success(.universal("arm64,x86_64")), elapsedMs: 0)
         #expect(ok.warnings.contains("hostArchitectures=arm64,x86_64"))
     }
+
+    /// Mutation: drop the `pkgarch:` ids from `liveRecipeIDs()` and this goes red.
+    ///
+    /// Nothing else would. `Baseline.prune` removes every entry whose id is not
+    /// live, and the pruned baseline is what gets SAVED — so a pkgarch warn's
+    /// streak is wiped before the next run reads it, `isReportable` never reaches
+    /// `actionableThreshold`, and the sweep's only actionable branch can never
+    /// file an issue. No test failed, no sweep failed; the id simply printed
+    /// "dropped — no recipe produces this id any more" 22 times a run.
+    @Test func pkgArchEntriesSurviveBaselinePruning() throws {
+        let live = Verify.liveRecipeIDs()
+        let recipe = try #require(
+            VendorProbeRegistry.recipes.first { $0.install?.kind == .pkg })
+        let id = Verify.pkgArchFinding(recipe, host: "-", outcome: nil, elapsedMs: 0).recipeID
+        #expect(live.contains(id), "\(id) is not live, so prune deletes it every run")
+
+        var baseline = Baseline()
+        baseline.reconcile(Verify.pkgArchFinding(
+            recipe, host: "-", outcome: .success(.single("x86_64")), elapsedMs: 0))
+        let pruned = baseline.prune(keeping: live)
+        #expect(!pruned.removed.contains(id))
+        // And the streak it just recorded is still there to be built on.
+        #expect(baseline.streak(id) == 1)
+    }
+
+    /// A synthetic flat package, so the parts that only ever ran against the
+    /// network get exercised: the header parse, `XarTOC.member`, `Inflate`, and
+    /// the Distribution-before-PackageInfo preference.
+    ///
+    /// ⚠️ These existed nowhere before. Swapping `bigEndian` for `littleEndian` in
+    /// the header read passed the ENTIRE file — the classifier tests never touch a
+    /// byte of a package.
+    private static func xar(
+        members: [(name: String, body: String)], compress: Bool = true,
+        magic: String = "xar!", headerSize: UInt16 = 28
+    ) -> Data {
+        var heap = Data()
+        var entries = ""
+        for member in members {
+            let raw = Data(member.body.utf8)
+            let stored = compress
+                ? (try! (raw as NSData).compressed(using: .zlib) as Data)
+                : raw
+            entries += """
+                <file id="\(entries.count)"><name>\(member.name)</name>                <data><offset>\(heap.count)</offset><length>\(stored.count)</length>                <size>\(raw.count)</size>                <encoding style="\(compress ? "application/x-gzip" : "")"/></data></file>
+                """
+            heap.append(stored)
+        }
+        let toc = Data("<xar><toc>\(entries)</toc></xar>".utf8)
+        let tocZ = try! (toc as NSData).compressed(using: .zlib) as Data
+        var out = Data(magic.utf8)
+        out.append(contentsOf: withUnsafeBytes(of: headerSize.bigEndian) { Array($0) })
+        out.append(contentsOf: withUnsafeBytes(of: UInt16(1).bigEndian) { Array($0) })
+        out.append(contentsOf: withUnsafeBytes(of: UInt64(tocZ.count).bigEndian) { Array($0) })
+        out.append(contentsOf: withUnsafeBytes(of: UInt64(toc.count).bigEndian) { Array($0) })
+        out.append(contentsOf: withUnsafeBytes(of: UInt32(0).bigEndian) { Array($0) })
+        out.append(tocZ)
+        out.append(heap)
+        return out
+    }
+
+    /// Mutation: `bigEndian` → `littleEndian` on either header field, and this
+    /// goes red. Nothing else in this file reads a package byte.
+    @Test func aSyntheticPackageIsParsedEndToEnd() async throws {
+        let pkg = Self.xar(members: [
+            ("Distribution", #"<installer-gui-script><options hostArchitectures="arm64,x86_64"/></installer-gui-script>"#),
+        ])
+        let url = try StubURLProtocol.serve(pkg)
+        defer { StubURLProtocol.reset() }
+        let result = await PackageArchitectureProbe.declaration(at: url, session: StubURLProtocol.session)
+        #expect(try result.get() == .universal("arm64,x86_64"))
+    }
+
+    /// Mutation: try `PackageInfo` before `Distribution` and this goes red. On a
+    /// product archive the Distribution is the file that carries the declaration,
+    /// and a component `PackageInfo` beside it may say something narrower.
+    @Test func distributionWinsOverPackageInfo() async throws {
+        let pkg = Self.xar(members: [
+            ("PackageInfo", #"<pkg-info hostArchitectures="x86_64"/>"#),
+            ("Distribution", #"<options hostArchitectures="arm64,x86_64"/>"#),
+        ])
+        let url = try StubURLProtocol.serve(pkg)
+        defer { StubURLProtocol.reset() }
+        let result = await PackageArchitectureProbe.declaration(at: url, session: StubURLProtocol.session)
+        #expect(try result.get() == .universal("arm64,x86_64"))
+    }
+
+    /// A package with neither file, and one whose members carry no declaration:
+    /// both are `.absent`, which is the registry's majority answer and must never
+    /// become a warn.
+    @Test func aPackageWithNoDeclarationIsAbsentNotSingle() async throws {
+        for members in [[("Bom", "x")], [("Distribution", "<options rootVolumeOnly=\"true\"/>")]] {
+            let url = try StubURLProtocol.serve(Self.xar(members: members))
+            defer { StubURLProtocol.reset() }
+            let result = await PackageArchitectureProbe.declaration(at: url, session: StubURLProtocol.session)
+            #expect(try result.get() == .absent)
+        }
+    }
+
+    /// Hostile input must REPORT, never trap. `Int(someUInt64)` traps above
+    /// `Int.max` and a trap is not catchable, so a vendor-controlled length field
+    /// with the high bit set would have killed `duo verify` outright.
+    @Test func aHostileHeaderIsReportedRatherThanCrashing() async throws {
+        var pkg = Data("xar!".utf8)
+        pkg.append(contentsOf: withUnsafeBytes(of: UInt16(28).bigEndian) { Array($0) })
+        pkg.append(contentsOf: withUnsafeBytes(of: UInt16(1).bigEndian) { Array($0) })
+        pkg.append(contentsOf: withUnsafeBytes(of: UInt64(0x8000_0000_0000_0000).bigEndian) { Array($0) })
+        pkg.append(contentsOf: withUnsafeBytes(of: UInt64(1).bigEndian) { Array($0) })
+        pkg.append(contentsOf: withUnsafeBytes(of: UInt32(0).bigEndian) { Array($0) })
+        let url = try StubURLProtocol.serve(pkg)
+        defer { StubURLProtocol.reset() }
+        let result = await PackageArchitectureProbe.declaration(at: url, session: StubURLProtocol.session)
+        guard case .notAFlatPackage(let why) = try result.get() else {
+            Issue.record("expected notAFlatPackage"); return
+        }
+        #expect(why.contains("toc="))
+    }
+
+    /// A server that ignores `Range` and answers 200 with the whole file must be
+    /// refused, not read. Reading its first bytes would file `notAFlatPackage` as
+    /// `ok` — a green verdict produced from the wrong bytes.
+    @Test func aServerIgnoringRangeIsRefused() async throws {
+        let url = try StubURLProtocol.serve(Self.xar(members: [
+            ("Distribution", #"<options hostArchitectures="arm64,x86_64"/>"#),
+        ]), status: 200)
+        defer { StubURLProtocol.reset() }
+        let result = await PackageArchitectureProbe.declaration(at: url, session: StubURLProtocol.session)
+        #expect(throws: (any Error).self) { try result.get() }
+    }
+}
+
+/// Serves a fixture per URL, so the reader can be driven without a vendor.
+///
+/// ⚠️ Keyed by URL and lock-guarded, NOT a single static body. swift-testing runs
+/// these in parallel, and the first version held one `static var body` that
+/// concurrent tests overwrote — three tests failed against a fixture another test
+/// had just installed. A stub that works only when run alone is a flaky test
+/// waiting to be blamed on the code under test.
+final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+    private struct Fixture { let body: Data; let status: Int }
+    nonisolated(unsafe) private static var fixtures: [String: Fixture] = [:]
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var counter = 0
+
+    static var session: URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    /// Returns a URL unique to this fixture, so parallel tests cannot collide.
+    static func serve(_ data: Data, status: Int = 206) throws -> URL {
+        lock.lock()
+        defer { lock.unlock() }
+        counter += 1
+        let path = "/fixture-\(counter).pkg"
+        fixtures[path] = Fixture(body: data, status: status)
+        return URL(string: "https://stub.invalid\(path)")!
+    }
+
+    static func reset() {}
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "stub.invalid"
+    }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let path = request.url?.path else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL)); return
+        }
+        Self.lock.lock()
+        let fixture = Self.fixtures[path]
+        Self.lock.unlock()
+        guard let fixture else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist)); return
+        }
+        // Honour Range the way a correct server does, so the reader's three
+        // sequential reads land on the bytes they asked for.
+        var slice = fixture.body
+        var headers = ["Content-Type": "application/octet-stream"]
+        if fixture.status == 206,
+           let raw = request.value(forHTTPHeaderField: "Range")?
+               .replacingOccurrences(of: "bytes=", with: ""),
+           case let parts = raw.split(separator: "-"), parts.count == 2,
+           let lo = Int(parts[0]), let hi = Int(parts[1]), lo <= hi, lo < fixture.body.count {
+            let upper = min(hi, fixture.body.count - 1)
+            slice = fixture.body.subdata(in: lo..<(upper + 1))
+            headers["Content-Range"] = "bytes \(lo)-\(upper)/\(fixture.body.count)"
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: fixture.status, httpVersion: "HTTP/1.1",
+            headerFields: headers)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: slice)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -19,6 +19,19 @@ import Darwin
 /// We deliberately avoid full payload expansion here: it adds disk space and
 /// unpacking work proportional to the payload, potentially gigabytes. A vendor's
 /// `hostArchitectures` declaration is not proof of the installed app's slices.
+///
+/// ⚠️ **That declaration has now been measured, and it cannot stand in for the
+/// gates** — worth knowing before reaching for it, because "just read
+/// `hostArchitectures`" is the obvious repair and it does not work. Across the
+/// whole pkg route on 2026-09-07 (#415): 15 packages declared, **every one of
+/// them universal**, 7 declared nothing, 1 was not a flat package. The
+/// declaration has never once said "Intel-only" here, so a gate on it would not
+/// have fired. And the only architecture-specific packages in the registry are
+/// exactly the ones that declare nothing — WeChat DevTools ships
+/// `wechat_devtools_..._darwin_arm64.pkg` with no declaration at all. Where
+/// architecture varies the declaration is blind; where it exists architecture
+/// does not vary. `duo verify --pkgarch` now tracks it for DRIFT on that basis,
+/// which is not the same claim as checking what will be installed.
 /// Handoff also returns before installation completes, so this actor performs no
 /// post-install architecture verification or automatic architecture rollback.
 /// Architecture compatibility on this route remains dependent on the vendor's

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Traffic/RequestMetricsRecorder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Traffic/RequestMetricsRecorder.swift
@@ -190,4 +190,21 @@ public extension URLSession {
         try await data(for: request, delegate: RequestMetricsRecorder(
             purpose, appID: RequestAttribution.appID, store: store))
     }
+
+    /// `bytes(for:)` with the same recording, for a caller that must stop reading
+    /// before the body ends.
+    ///
+    /// `countedData` is not a substitute there and the difference is not stylistic:
+    /// it buffers the WHOLE response before returning, so a caller that asks for a
+    /// byte range and then truncates what came back has protected nothing — a
+    /// server that ignores `Range` answers 200 with the entire file and it is in
+    /// memory before the truncation runs. `PackageArchitectureProbe` range-reads
+    /// installers that are gigabytes on disk, which is exactly that hazard.
+    /// Breaking out of the returned sequence cancels the transfer.
+    func countedBytes(
+        for request: URLRequest, purpose: RequestPurpose, store: EventStore = .shared
+    ) async throws -> (URLSession.AsyncBytes, URLResponse) {
+        try await bytes(for: request, delegate: RequestMetricsRecorder(
+            purpose, appID: RequestAttribution.appID, store: store))
+    }
 }

--- a/scripts/pkg_host_architectures.py
+++ b/scripts/pkg_host_architectures.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Read `hostArchitectures` out of remote flat `.pkg` installers, without
+downloading them.
+
+This is the second witness for `duo verify`'s `pkgarch` sweep (CLAUDE.md:
+"凡是正确性落在一条规则上的,把规则移植到 Python 打真实响应体"). The Swift
+implementation in `CLI/Sources/DuoKit/PackageArchitectureProbe.swift` reads the
+same bytes; this one exists so the two can be diffed against the real registry
+rather than against each other's assumptions.
+
+Why range reads: a flat package is a xar archive — a 28-byte header, then a
+zlib-compressed table of contents, then the heap. The TOC carries every file's
+offset and length inside the heap, so `Distribution` / `PackageInfo` come out in
+two small Range requests. Expanding the payload instead (`pkgutil --expand-full`)
+is what #400 rejected as unaffordable: the Office packages are GB-scale, and this
+path reads all of them for a couple of hundred kilobytes.
+
+    scripts/pkg_host_architectures.py < urls.tsv        # bundleID<TAB>channel<TAB>version<TAB>url
+    duo verify --pkgarch --report r.json                # the same check, in Swift
+
+Output is TSV: bundleID, channel, version, value, where-it-was-found.
+`value` is the declaration verbatim, or `ABSENT` (no declaration in either file
+— the common case, 7 of 22 measured 2026-09-07), or `NOT-XAR` (the URL did not
+serve a flat package: a DMG-wrapped pkg, or a vendor serving HTML).
+
+⚠️ The declaration is the VENDOR'S CLAIM, not the payload's real slices. It is
+not a substitute for Gate 5, which reads the actual Mach-O — see
+`PackageInstaller`'s architecture-limitation comment. Measured 2026-09-07, every
+one of the 15 declarations in this registry is universal, and the only packages
+that are architecture-specific (WeChat DevTools, `..._darwin_arm64.pkg`) declare
+nothing at all. So this reads drift, not installability.
+"""
+import argparse, re, struct, sys, urllib.error, urllib.request, zlib
+import xml.etree.ElementTree as ET
+
+XAR_MAGIC = b"xar!"
+UA = "duo-updater pkg_host_architectures (+https://github.com/jizhi0v0/duo-updater)"
+# Enough for any Distribution seen in this registry; Edge's is 716 bytes. Caps a
+# hostile or broken endpoint rather than streaming whatever it offers.
+MAX_MEMBER = 4 << 20
+
+
+class Fetcher:
+    """Range reader that keeps a byte total, so the cost of a sweep is a number
+    rather than an impression."""
+
+    def __init__(self, timeout=90):
+        self.timeout = timeout
+        self.bytes = 0
+
+    def range(self, url, start, end):
+        req = urllib.request.Request(url, headers={"User-Agent": UA})
+        req.add_header("Range", f"bytes={start}-{end}")
+        with urllib.request.urlopen(req, timeout=self.timeout) as r:
+            # A server that ignores Range answers 200 with the whole file. Reading
+            # only what was asked for keeps an Office package from arriving here.
+            data = r.read(end - start + 1)
+        self.bytes += len(data)
+        return data
+
+
+def _inflate(raw, style):
+    if not style or ("gzip" not in style and "zlib" not in style and "bzip2" not in style):
+        return raw
+    try:
+        return zlib.decompress(raw)
+    except zlib.error:
+        try:
+            return zlib.decompressobj(-15).decompress(raw)   # raw deflate
+        except zlib.error:
+            return raw                                        # leave it; regex just misses
+
+
+def host_architectures(url, fetch):
+    """(value, where) for one package URL. Never raises for a vendor-side
+    problem — the caller files that as data, not as a crash."""
+    head = fetch.range(url, 0, 27)
+    if head[:4] != XAR_MAGIC:
+        return "NOT-XAR", f"magic={head[:4]!r}"
+    header_size = struct.unpack(">H", head[4:6])[0]
+    toc_compressed = struct.unpack(">Q", head[8:16])[0]
+    if toc_compressed <= 0 or toc_compressed > MAX_MEMBER:
+        return "NOT-XAR", f"toc={toc_compressed}"
+    toc = zlib.decompress(fetch.range(url, header_size, header_size + toc_compressed - 1))
+    root = ET.fromstring(toc)
+    heap = header_size + toc_compressed
+
+    members = {}
+    for f in root.iter("file"):
+        name = f.findtext("name") or ""
+        if name not in ("Distribution", "PackageInfo") or name in members:
+            continue
+        data = f.find("data")
+        if data is None:
+            continue
+        enc = data.find("encoding")
+        members[name] = (int(data.findtext("offset")), int(data.findtext("length")),
+                         enc.get("style") if enc is not None else "")
+
+    # Distribution first: on a product archive it is the file that carries the
+    # declaration, and a component PackageInfo beside it may not repeat it.
+    for name in ("Distribution", "PackageInfo"):
+        if name not in members:
+            continue
+        offset, length, style = members[name]
+        if length > MAX_MEMBER:
+            continue
+        body = _inflate(fetch.range(url, heap + offset, heap + offset + length - 1), style)
+        found = re.search(rb'hostArchitectures\s*=\s*"([^"]*)"', body)
+        if found:
+            return found.group(1).decode("utf-8", "replace"), name
+    return "ABSENT", "+".join(sorted(members)) or "no Distribution/PackageInfo"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--timeout", type=float, default=90)
+    args = ap.parse_args()
+
+    fetch = Fetcher(timeout=args.timeout)
+    rows = 0
+    for line in sys.stdin:
+        line = line.rstrip("\n")
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 4:
+            print(f"✗ expected 4 tab-separated fields, got {len(parts)}: {line[:80]}",
+                  file=sys.stderr)
+            return 2
+        bundle_id, channel, version, url = parts
+        try:
+            value, where = host_architectures(url, fetch)
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError,
+                zlib.error, ET.ParseError, struct.error, ValueError) as exc:
+            value, where = "ERROR", f"{type(exc).__name__}: {exc}"[:70]
+        print(f"{bundle_id}\t{channel}\t{version}\t{value}\t{where}", flush=True)
+        rows += 1
+    print(f"# {rows} package(s), {fetch.bytes / 1024:.1f} KB fetched", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pkg_host_architectures.py
+++ b/scripts/pkg_host_architectures.py
@@ -18,7 +18,9 @@ path reads all of them for a couple of hundred kilobytes.
     scripts/pkg_host_architectures.py < urls.tsv        # bundleID<TAB>channel<TAB>version<TAB>url
     duo verify --pkgarch --report r.json                # the same check, in Swift
 
-Output is TSV: bundleID, channel, version, value, where-it-was-found.
+Output is TSV: bundleID, channel, version, value, verdict, where-it-was-found.
+`verdict` is UNIVERSAL / SINGLE / ABSENT / NOT-XAR - the same call the Swift
+sweep turns into ok / warn.
 `value` is the declaration verbatim, or `ABSENT` (no declaration in either file
 — the common case, 7 of 22 measured 2026-09-07), or `NOT-XAR` (the URL did not
 serve a flat package: a DMG-wrapped pkg, or a vendor serving HTML).
@@ -71,6 +73,23 @@ def _inflate(raw, style):
             return raw                                        # leave it; regex just misses
 
 
+def classify(value):
+    """UNIVERSAL / SINGLE, by counting the architectures named.
+
+    This mirrors `PackageArchitectureProbe.classify`, and it is the half that
+    actually decides something: the Swift sweep warns on SINGLE and stays quiet on
+    UNIVERSAL. Without it this script witnessed only the string extraction, so the
+    one rule with a consequence had no independent implementation at all — the
+    opposite of the reason a second witness exists.
+
+    Order carries no meaning: the packages spell it `arm64,x86_64` 9 times and
+    `x86_64,arm64` 6 times (measured 2026-09-07), so a comparison against either
+    spelling calls the other single-architecture.
+    """
+    names = {n.strip().lower() for n in re.split(r"[,\s]+", value) if n.strip()}
+    return "SINGLE" if len(names) <= 1 else "UNIVERSAL"
+
+
 def host_architectures(url, fetch):
     """(value, where) for one package URL. Never raises for a vendor-side
     problem — the caller files that as data, not as a crash."""
@@ -79,6 +98,9 @@ def host_architectures(url, fetch):
         return "NOT-XAR", f"magic={head[:4]!r}"
     header_size = struct.unpack(">H", head[4:6])[0]
     toc_compressed = struct.unpack(">Q", head[8:16])[0]
+    # Bound-checked on the UNSIGNED value, before anything narrows it. Swift's
+    # `Int(someUInt64)` traps above Int.max and a trap is not catchable, so the
+    # two implementations agreeing here is load-bearing, not cosmetic.
     if toc_compressed <= 0 or toc_compressed > MAX_MEMBER:
         return "NOT-XAR", f"toc={toc_compressed}"
     toc = zlib.decompress(fetch.range(url, header_size, header_size + toc_compressed - 1))
@@ -135,7 +157,9 @@ def main():
         except (urllib.error.URLError, urllib.error.HTTPError, OSError,
                 zlib.error, ET.ParseError, struct.error, ValueError) as exc:
             value, where = "ERROR", f"{type(exc).__name__}: {exc}"[:70]
-        print(f"{bundle_id}\t{channel}\t{version}\t{value}\t{where}", flush=True)
+        verdict = classify(value) if value not in ("ABSENT", "ERROR") \
+            and not value.startswith("NOT-XAR") else value
+        print(f"{bundle_id}\t{channel}\t{version}\t{value}\t{verdict}\t{where}", flush=True)
         rows += 1
     print(f"# {rows} package(s), {fetch.bytes / 1024:.1f} KB fetched", file=sys.stderr)
     return 0


### PR DESCRIPTION
Answers acceptance criterion 1 of #415 and wires the check in, rather than leaving
the numbers in an issue comment where they go stale.

## What the measurement said

Across the whole pkg install route, 2026-09-07 — 22 vendor specs + XQuartz:

| | count |
| --- | --- |
| declared, universal | **15** |
| declared nothing | **7** (all three Edge channels, all three WeChat DevTools channels, Shottr) |
| not a flat package | 1 (Sunlogin serves HTML at its install URL, and is a DMG-wrapped pkg) |

Two conclusions, and they are why this sweep is shaped the way it is:

1. **The declaration has never once said "Intel-only" here.** A gate built on it
   would not have fired a single time.
2. ⚠️ **The only architecture-specific packages in the registry are exactly the
   ones that declare nothing.** WeChat DevTools ships
   `wechat_devtools_..._darwin_arm64.pkg` with no `hostArchitectures` in its
   `PackageInfo`. Where architecture varies the declaration is blind; where the
   declaration exists architecture does not vary.

So this is a **drift** sweep, not an installability check. Statuses follow:
single-architecture is the one `warn`; universal and absent are both `ok`. Absent
is the norm — warning on it would file seven findings on day one and train the
reader to ignore the sweep, which `FindingStatus.infra`'s own comment warns about.
The declaration is recorded on every finding including `ok`, so it lands in
`report.json` and drift shows as a diff.

## How it reads packages without downloading them

A flat `.pkg` is a xar archive: 28-byte header, zlib-compressed TOC, then the
heap. The TOC carries every member's offset, so `Distribution` comes out in two
small Range requests. **22 packages for ~197 KB**, against the GB-scale
`pkgutil --expand-full` that #400 ruled out. Install URLs are reused from the
vendor sweep rather than re-probed, so a full run costs no extra vendor requests
— probing 22 endpoints twice in one sweep would be both wasteful and rude.

`scripts/pkg_host_architectures.py` reads the same bytes in Python and is kept as
the second witness (CLAUDE.md's two-independent-witnesses rule). **The two agree
on all 22 real packages.**

Also written into `PackageInstaller`, because "just read `hostArchitectures`" is
the obvious repair and the next person will reach for it.

## Deliberately not done — both noted in comments

- **The bytes are charged to `RequestPurpose.other`, not a new case.** A new case
  must be spelled in `RequestLogPane`'s three exhaustive switches, one of which is
  a `String(localized:)` legend — so it would put a new user-facing string and 7
  translations in front of every user for a bucket only a CLI sweep can fill. The
  rows are already tagged `RequestClient.cli` and separable without it. Happy to
  do it properly if you'd rather have the category.
- **Nothing here reads payload Mach-O**, which remains the only real answer to
  "what will actually be installed" (#415 options b/c).

## Validation

`make test` green — Core 2430, CLI 227, App 9/9 cases executed, all four gates.

Three mutations run, each red on exactly its own test:

| Mutation | Test |
| --- | --- |
| compare a literal spelling instead of counting architecture names | `universalIsDecidedByCountingNamesNotBySpelling` |
| drop `\s*` around `=` in the attribute regex | `theAttributeIsReadWhateverTheXMLSpacing` |
| a `.tar` → `.pkg` flip (spec count changes) | `everyPkgSpecIsCoveredBySweepAndScript` |

Live run: `duo verify --vendor --pkgarch` → `pkg arch ✓ 22  ⚠ 0  ✗ 0  ~ 0  - 0`.