### PR TITLE
Stop two concurrent smoke-test runs from deleting each other's download

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallPipelineSmokeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallPipelineSmokeTests.swift
@@ -80,11 +80,33 @@ private func verifyGates(
     // built a nested `DuoUpdaterTest-/Users/.../Foo.app` tree whose empty parent
     // directories outlived the run. Harmless once a day by hand; not something
     // to leave behind on a runner that now does this for every app, nightly.
+    //
+    // The UUID is what keeps the name from being a SHARED path. `scratchSlug` is
+    // deliberately stable across launches (it is a SHA-256 of the installed app's
+    // path, so a crashed install can reclaim its dir by name), and
+    // `temporaryDirectory` is per-user, not per-process — so without it, every
+    // process on this Mac running this test for the same app names the SAME
+    // directory, and the two lines below are then aimed at each other: each run
+    // deletes the other's in-flight download, and the loser's `Downloader` fails
+    // its final rename with "either the former doesn't exist, or the folder
+    // containing the latter doesn't exist". Measured 2026-09-07: two concurrent
+    // `swift test --filter installPipelineDryRun` (separate `--scratch-path`s, so
+    // SwiftPM's build lock doesn't serialise them) both failed that way, on
+    // `DuoUpdaterTest-net.imput.helium-b233bd2839efd54c`. That is a collision, not
+    // a vendor problem — but it arrives dressed as one, in a test whose whole job
+    // is to report vendor breakage. Concurrent runs are routine here: this repo is
+    // worked in several worktrees at once, which is the same hazard
+    // `scripts/derived_data_path.py` exists to solve for xcodebuild.
     let workDir = FileManager.default.temporaryDirectory
-        .appendingPathComponent("DuoUpdaterTest-\(target.app.scratchSlug)")
-    try? FileManager.default.removeItem(at: workDir)
+        .appendingPathComponent("DuoUpdaterTest-\(target.app.scratchSlug)-\(UUID().uuidString)")
     try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: workDir) }
+    // A unique name means nothing reclaims it by name any more, so a run killed
+    // mid-download (^C, the hang watchdog) would leak ~120 MB per crash instead of
+    // being overwritten next time. Sweep old siblings instead — age-gated, because
+    // "not mine" is exactly the judgement that caused the collision above, and a
+    // live download can legitimately run for a long time on a slow link.
+    sweepStaleScratchDirs(olderThan: 6 * 60 * 60)
 
     // 1. Download
     let downloader = Downloader(destinationDir: workDir) { _ in }
@@ -135,4 +157,20 @@ private func verifyGates(
     try SignatureVerifier.verifyBundleIdentifierMatch(installedApp: target.app.path, downloadedApp: newApp)
     log("✓ code signature valid; Team ID match: \(oldTeam ?? "?") == \(newTeam ?? "?")")
     log("=== ALL GATES PASSED (no install performed) ===")
+}
+
+/// Delete leftover scratch dirs from runs that were killed before their `defer`
+/// could fire. Only dirs older than `seconds` are touched: a newer one may belong
+/// to a run happening right now in another checkout.
+private func sweepStaleScratchDirs(olderThan seconds: TimeInterval) {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory
+    guard let entries = try? fm.contentsOfDirectory(
+        at: tmp, includingPropertiesForKeys: [.contentModificationDateKey]) else { return }
+    for entry in entries where entry.lastPathComponent.hasPrefix("DuoUpdaterTest-") {
+        let modified = (try? entry.resourceValues(forKeys: [.contentModificationDateKey]))?
+            .contentModificationDate
+        guard let modified, Date().timeIntervalSince(modified) > seconds else { continue }
+        try? fm.removeItem(at: entry)
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallPipelineSmokeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallPipelineSmokeTests.swift
@@ -168,9 +168,30 @@ private func sweepStaleScratchDirs(olderThan seconds: TimeInterval) {
     guard let entries = try? fm.contentsOfDirectory(
         at: tmp, includingPropertiesForKeys: [.contentModificationDateKey]) else { return }
     for entry in entries where entry.lastPathComponent.hasPrefix("DuoUpdaterTest-") {
-        let modified = (try? entry.resourceValues(forKeys: [.contentModificationDateKey]))?
-            .contentModificationDate
-        guard let modified, Date().timeIntervalSince(modified) > seconds else { continue }
+        guard let touched = lastTouched(entry),
+              Date().timeIntervalSince(touched) > seconds else { continue }
         try? fm.removeItem(at: entry)
     }
+}
+
+/// The most recent modification anywhere one level inside `dir`, or the dir's own
+/// if it is empty.
+///
+/// A directory's own mtime records changes to its *entries*, not writes into
+/// them: measured 2026-09-07, creating a `.partial` stamps the dir, and appending
+/// 5 MB to that file three seconds later moves the file's mtime and leaves the
+/// dir's exactly where it was. Reading only the dir would therefore date a live
+/// download from the moment it *started*, so a transfer slow enough to run past
+/// the age gate — a large payload on a throttled link, across up to
+/// `Downloader.maxAttempts` resumes — would look abandoned to a run starting
+/// beside it, and get deleted mid-flight. That is the collision this whole change
+/// removes, so the gate has to key on progress rather than on age.
+private func lastTouched(_ dir: URL) -> Date? {
+    let key: URLResourceKey = .contentModificationDateKey
+    let own = (try? dir.resourceValues(forKeys: [key]))?.contentModificationDate
+    let children = (try? FileManager.default.contentsOfDirectory(
+        at: dir, includingPropertiesForKeys: [key])) ?? []
+    return children
+        .compactMap { (try? $0.resourceValues(forKeys: [key]))?.contentModificationDate }
+        .reduce(own) { max($0 ?? $1, $1) }
 }


### PR DESCRIPTION
`installPipelineDryRun` fails intermittently on machines with real Sparkle apps — measured 3 failures in 5 runs — always with the same shape on the Helium candidate:

```
".duo-download-<uuid>.partial" couldn't be moved to
"DuoUpdaterTest-net.imput.helium-b233bd2839efd54c" because either the former
doesn't exist, or the folder containing the latter doesn't exist.
```

## Cause

The scratch directory name is process-independent in **both** halves. `scratchSlug` is deliberately stable across launches (a SHA-256 of the installed app's path, so a crashed install can reclaim its dir by name), and `FileManager.temporaryDirectory` is per-*user*, not per-process. So every test process on the machine running this test for the same app named the **same** directory — and the test's `try? removeItem(at: workDir)` on the way in and its `defer { try? removeItem(at: workDir) }` on the way out were aimed at each other. Each run deletes the other's in-flight download; the loser's `Downloader.finalizePartial()` renames into a directory that is gone.

Concurrent runs are routine here — this repo is worked in several worktrees at once, the same hazard `scripts/derived_data_path.py` exists to solve for xcodebuild.

## Not a timeout, and not the vendor

Every deleter of the `.partial` was traced: the pre-transfer sweep, `startFresh()` (which recreates it immediately), and `download`'s `defer` (which runs after it returns, by which point a successful transfer has already moved the file). `finalizePartial` runs inside `didCompleteWithError` *before* the continuation resumes. No in-process path leaves the partial missing at rename time — the deletion comes from outside the process. The observed correlation with slow runs is a co-symptom: the competing run both halved the bandwidth and destroyed the directory.

Worth calling out separately: the failure is reported as `install path broken for: Helium`. A collision arrives dressed as vendor breakage, in the one test whose job is to report vendor breakage.

## Fix

Per-run UUID in the directory name, so it is nobody else's path, and the destructive pre-clean is gone. A unique name can no longer be reclaimed by name, so a run killed mid-download would leak ~120 MB per crash — stale siblings are swept instead, **age-gated at six hours**, because "not mine" is exactly the judgement that caused the collision, and a live download can legitimately run long on a slow link.

## Verification

- **Red first.** Two concurrent `swift test --filter installPipelineDryRun`, given separate `--scratch-path`s so SwiftPM's build lock doesn't serialise them: both failed with the exact message above, on that exact directory name. (Without separate scratch paths they serialise and both pass — that masked the bug on two earlier attempts.)
- Solo runs before the fix: 4/4 pass, ~20s each.
- **Green after.** Same concurrent pair, run twice: 4/4 pass, 0 leftover scratch dirs in `$TMPDIR`.
- `scripts/run-with-hang-report.sh 1800 make test` → exit 0, 2433 tests in 201 suites + 223 app tests, all python gates green.

## Not verified

Which process was competing during the originally reported 5 runs. Nothing periodic is registered for it (no `DUO_INSTALL_SMOKE` launchd job on this machine), so another worktree's `make test` is the likely partner — inference, not measurement.

This stays invisible to CI either way: the test guards on `!targets.isEmpty` and a GitHub runner has no Sparkle apps installed, so it returns early there.
