### PR TITLE
refactor: share installer app artifact validation

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
@@ -61,6 +61,35 @@ public enum SignatureVerifier {
         }
     }
 
+    /// Shared app-bundle gates for Sparkle and vendor installs, after extraction
+    /// or delta reconstruction and before the bundle swap. Archive signatures,
+    /// checksums and vendor installer-stub validation stay with their callers;
+    /// this entry point does not validate pkg installs.
+    ///
+    /// Keep the entire sequence in one hop: Security calls can block a narrow
+    /// cooperative pool (#351). The first failure determines the reported error.
+    static func verifyInstallArtifact(downloadedApp: URL, installedApp: URL) async throws {
+        try await offCooperativePool {
+            // Gates 2–4 pin a valid signature to this vendor AND this exact app.
+            try verifyCodeSignature(appAt: downloadedApp)
+            try verifyTeamIdentifierMatch(
+                installedApp: installedApp, downloadedApp: downloadedApp)
+            try verifyBundleIdentifierMatch(
+                installedApp: installedApp, downloadedApp: downloadedApp)
+
+            // Gate 5 reads the actual Mach-O slices; artifact filenames cannot
+            // prove that the downloaded build can launch on this Mac.
+            try verifyRunnableArchitecture(appAt: downloadedApp)
+            // Gate 5b must follow gate 5: an unrunnable Intel-only download over
+            // an arm64 install must report "cannot launch", not "would run
+            // translated". Delta output need not share its baseline's slices.
+            try verifyNoArchitectureDowngrade(
+                installedApp: installedApp, downloadedApp: downloadedApp)
+            // Gate 6 reads the bundle's OS floor even when the source omits it.
+            try verifyRunnableSystemVersion(appAt: downloadedApp)
+        }
+    }
+
     // MARK: Gate 1 — EdDSA signature over the downloaded file
 
     /// Verify the Sparkle Ed25519 signature of `fileData` against the app's

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SignatureVerifier.swift
@@ -8,16 +8,18 @@ import Security
 /// Gates 1–4 are about trust (EdDSA signature, code signature, Team ID, bundle
 /// ID); gates 5 and 6 are about liveness — whether the bundle can launch on this
 /// Mac at all, by architecture and by the OS version it declares it needs.
-/// Callers pick the gates that apply to their route: the Sparkle installer runs
-/// all of them, the vendor installer runs 2–6 (no feed signature to check).
+/// Callers pick the gates that apply to their route via `verifyInstallArtifact`
+/// below, the single shared entry point both installers call: the Sparkle
+/// installer runs it after its own EdDSA gate (1), the vendor installer runs it
+/// as its whole gate sequence (no feed signature to check).
 ///
 /// Gate 5b (`verifyNoArchitectureDowngrade`) is a NARROWER liveness check than 5
 /// and 6: not "can this Mac run the download" but "does the download run worse
 /// than what's already installed" (arm64 → x86_64-only, still launchable under
-/// Rosetta, but never natively again). Both installers call it immediately
-/// AFTER gate 5, never before — a package that is both unrunnable and a
-/// downgrade must fail with gate 5's "cannot launch" message (the more severe,
-/// still-true problem), not gate 5b's "this would run translated" (which
+/// Rosetta, but never natively again). `verifyInstallArtifact` calls it
+/// immediately AFTER gate 5, never before — a package that is both unrunnable
+/// and a downgrade must fail with gate 5's "cannot launch" message (the more
+/// severe, still-true problem), not gate 5b's "this would run translated" (which
 /// implies it launches). Like gate 5, it never sees the pkg route: `newApp`
 /// there is handed straight to Installer.app, so `PackageInstaller` stays
 /// gated on signature + Team ID only, same as gate 5. See issue #196.
@@ -68,7 +70,20 @@ public enum SignatureVerifier {
     ///
     /// Keep the entire sequence in one hop: Security calls can block a narrow
     /// cooperative pool (#351). The first failure determines the reported error.
-    static func verifyInstallArtifact(downloadedApp: URL, installedApp: URL) async throws {
+    ///
+    /// `host`, `canRunIntel` and `osVersion` are defaulted to exactly what gates
+    /// 5, 5b and 6 default to on their own (`HostArch.current`,
+    /// `HostArch.canRunIntelBuilds`, `HostOS.numericVersion()`) — both
+    /// installers call this with no extra arguments, so production behavior is
+    /// unchanged. The parameters exist so a test can pin the gate-5/5b ordering
+    /// without needing a real non-arm64 or Rosetta-less machine to do it on.
+    static func verifyInstallArtifact(
+        downloadedApp: URL,
+        installedApp: URL,
+        host: HostArch = .current,
+        canRunIntel: Bool = HostArch.canRunIntelBuilds,
+        osVersion: String = HostOS.numericVersion()
+    ) async throws {
         try await offCooperativePool {
             // Gates 2–4 pin a valid signature to this vendor AND this exact app.
             try verifyCodeSignature(appAt: downloadedApp)
@@ -79,14 +94,15 @@ public enum SignatureVerifier {
 
             // Gate 5 reads the actual Mach-O slices; artifact filenames cannot
             // prove that the downloaded build can launch on this Mac.
-            try verifyRunnableArchitecture(appAt: downloadedApp)
+            try verifyRunnableArchitecture(
+                appAt: downloadedApp, host: host, canRunIntel: canRunIntel)
             // Gate 5b must follow gate 5: an unrunnable Intel-only download over
             // an arm64 install must report "cannot launch", not "would run
             // translated". Delta output need not share its baseline's slices.
             try verifyNoArchitectureDowngrade(
-                installedApp: installedApp, downloadedApp: downloadedApp)
+                installedApp: installedApp, downloadedApp: downloadedApp, host: host)
             // Gate 6 reads the bundle's OS floor even when the source omits it.
-            try verifyRunnableSystemVersion(appAt: downloadedApp)
+            try verifyRunnableSystemVersion(appAt: downloadedApp, osVersion: osVersion)
         }
     }
 
@@ -221,10 +237,12 @@ public enum SignatureVerifier {
 
     /// Belt-and-suspenders on top of the Team ID gate: the downloaded build must
     /// carry the SAME signed identifier as the app it's replacing. Team ID alone
-    /// permits any app from the same vendor (Google's Chrome vs Earth); this pins
-    /// the swap to the exact product. We read the *signed* identifier
-    /// (`kSecCodeInfoIdentifier`), not the raw Info.plist, so it's covered by the
-    /// code seal already verified in Gate 2 and can't be spoofed.
+    /// permits any app from the same vendor (Google's Chrome vs Earth) — or a
+    /// different CHANNEL of the same app sharing that Team, and sometimes the
+    /// bundle id outright; this pins the swap to the exact product. We read the
+    /// *signed* identifier (`kSecCodeInfoIdentifier`), not the raw Info.plist, so
+    /// it's covered by the code seal already verified in Gate 2 and can't be
+    /// spoofed.
     public static func verifyBundleIdentifierMatch(
         installedApp: URL,
         downloadedApp: URL
@@ -370,8 +388,9 @@ public enum SignatureVerifier {
         return downloaded.contains(NSBundleExecutableArchitectureX86_64)
     }
 
-    /// Gate 5b, called by both installers immediately AFTER Gate 5 passes on the
-    /// same `newApp`/`installedApp` pair — never before, and never on its own:
+    /// Gate 5b, called by `verifyInstallArtifact` (both installers' shared entry
+    /// point) immediately AFTER Gate 5 passes on the same
+    /// `newApp`/`installedApp` pair — never before, and never on its own:
     /// a package that Gate 5 would refuse outright (arm64 host, no Rosetta,
     /// Intel-only download) must fail with Gate 5's "cannot launch" message,
     /// not this one's "would run translated", which implies it launches at

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
@@ -245,53 +245,12 @@ public actor SparkleInstaller {
             ) else { throw heldEdFailure }
         }
 
-        // 4. Gate 2 + 3 + 4 — code signature valid, same Team ID, AND same signed
-        // bundle identifier as installed (pins the swap to this exact app, not
-        // just this vendor/Team).
+        // 4. Validate the final app, whether unpacked or reconstructed from a delta.
         onStage(.verifyingCodeSignature)
-        // One hop for the whole gate sequence, not six: each of these blocks its
-        // thread inside Security, and on a narrow cooperative pool that is what
-        // stops the runtime dead (#351). They still run in order, in the same
-        // order, on one queue — the ordering below is load-bearing and a hop per
-        // gate would have been six chances to reorder it by accident.
-        let app = newApp
-        let installed = result.app.path
-        try await offCooperativePool {
-            try SignatureVerifier.verifyCodeSignature(appAt: app)
-            try SignatureVerifier.verifyTeamIdentifierMatch(
-                installedApp: installed,
-                downloadedApp: app
-            )
-            try SignatureVerifier.verifyBundleIdentifierMatch(
-                installedApp: installed,
-                downloadedApp: app
-            )
-            // Gate 5 — and it is a build this Mac can launch. The download was chosen
-            // by filename, which cannot see inside a Mach-O; this reads the real
-            // slices, so a mis-named artifact is refused instead of installed.
-            try SignatureVerifier.verifyRunnableArchitecture(appAt: app)
-            // Gate 5b — and it is not a WORSE build than what's already here. Must run
-            // AFTER gate 5, not before: a package that is both unrunnable and a
-            // downgrade (arm64 host, no Rosetta, Intel-only download) has to fail
-            // with gate 5's "cannot launch" message, the true and more severe
-            // problem — gate 5b's "this would run translated" is only correct once
-            // gate 5 has already confirmed the download CAN launch here. `app`
-            // here is either the unpacked archive or `DeltaApplier.reconstruct`'s
-            // output (step 3 above merges both into one URL), and this runs on
-            // both identically — the patch route's doc comment states its output
-            // "goes through exactly the same gates a downloaded archive does", and
-            // nothing here assumes a patch's architecture set matches the baseline's.
-            try SignatureVerifier.verifyNoArchitectureDowngrade(
-                installedApp: installed,
-                downloadedApp: app
-            )
-            // Gate 6 — and this Mac is not below the OS floor the bundle declares.
-            // Same shape of claim as gate 5 and the same blind spot behind it: the
-            // download was selected from what a source published, and most sources
-            // publish no OS requirement at all, so the artifact's own plist is the
-            // first place the answer exists.
-            try SignatureVerifier.verifyRunnableSystemVersion(appAt: app)
-        }
+        try await SignatureVerifier.verifyInstallArtifact(
+            downloadedApp: newApp,
+            installedApp: result.app.path
+        )
 
         // 5. Swap the bundle into place. We do this even while the app is
         // running: macOS keeps the live process on the code it already mapped,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
@@ -165,8 +165,9 @@ public actor SparkleInstaller {
         // appcast — e.g. Fork) and lean on HTTPS plus the download's own Developer
         // ID code signature for authenticity. For those we fall back to the SAME
         // best-effort gate the Vendor/GitHub paths use: code signature valid +
-        // same Team ID + same bundle id as installed (Gates 2/3/4 below), which
-        // fails closed, so an app we can't verify that way is simply not installed.
+        // same Team ID + same bundle id as installed (Gates 2/3/4, run via
+        // `SignatureVerifier.verifyInstallArtifact` below), which fails closed,
+        // so an app we can't verify that way is simply not installed.
         // We only skip EdDSA when there's NO key at all — a feed that ships a key
         // must still produce a signature (a key'd feed silently dropping its
         // signature is suspicious), so `verifyEdSignature` stays mandatory there.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
@@ -251,54 +251,12 @@ public actor VendorInstaller {
             }
         }
 
-        // 4. Gate 2 + 3 + 4 — code signature valid, same Team ID, AND same signed
-        // bundle identifier as the installed app. The bundle-id pin stops a
-        // same-vendor but different app (or a different channel sharing the Team)
-        // from being swapped in over this exact install.
+        // 4. Validate the final app, whether unpacked or reconstructed from a delta.
         onStage(.verifyingCodeSignature)
-        // One hop for the whole gate sequence, not six: each of these blocks its
-        // thread inside Security, and on a narrow cooperative pool that is what
-        // stops the runtime dead (#351). They still run in order, in the same
-        // order, on one queue — the ordering below is load-bearing and a hop per
-        // gate would have been six chances to reorder it by accident.
-        let app = newApp
-        let installed = result.app.path
-        try await offCooperativePool {
-            try SignatureVerifier.verifyCodeSignature(appAt: app)
-            try SignatureVerifier.verifyTeamIdentifierMatch(
-                installedApp: installed,
-                downloadedApp: app
-            )
-            try SignatureVerifier.verifyBundleIdentifierMatch(
-                installedApp: installed,
-                downloadedApp: app
-            )
-            // Gate 5 — and it is a build this Mac can launch. The download was chosen
-            // by filename, which cannot see inside a Mach-O; this reads the real
-            // slices, so a mis-named artifact is refused instead of installed.
-            try SignatureVerifier.verifyRunnableArchitecture(appAt: app)
-            // Gate 5b — and it is not a WORSE build than what's already here. Must run
-            // AFTER gate 5, not before: a package that is both unrunnable and a
-            // downgrade (arm64 host, no Rosetta, Intel-only download) has to fail
-            // with gate 5's "cannot launch" message, the true and more severe
-            // problem — gate 5b's "this would run translated" is only correct once
-            // gate 5 has already confirmed the download CAN launch here. Runs
-            // identically for both routes above (full archive and delta
-            // reconstruction) — `DeltaApplier.reconstruct` states plainly that its
-            // output "goes through exactly the same gates a downloaded archive
-            // does", and this is one of them; the patch is cut by the vendor and
-            // nothing here assumes its architecture set matches the baseline's.
-            try SignatureVerifier.verifyNoArchitectureDowngrade(
-                installedApp: installed,
-                downloadedApp: app
-            )
-            // Gate 6 — and this Mac is not below the OS floor the bundle declares.
-            // Same shape of claim as gate 5 and the same blind spot behind it: the
-            // download was selected from what a source published, and most sources
-            // publish no OS requirement at all, so the artifact's own plist is the
-            // first place the answer exists.
-            try SignatureVerifier.verifyRunnableSystemVersion(appAt: app)
-        }
+        try await SignatureVerifier.verifyInstallArtifact(
+            downloadedApp: newApp,
+            installedApp: result.app.path
+        )
 
         // 5. Swap the bundle into place. We do this even while the app is
         // running: macOS keeps the live process on the code it already mapped,

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ArchitectureGateTests.swift
@@ -314,11 +314,13 @@ struct ArchitectureDowngradeGateTests {
 /// PROOF that Gate 5b is actually wired into the two installers' real `apply()`
 /// — not just that the predicate is correct in isolation (that's what the two
 /// suites above already cover). Deleting the `verifyNoArchitectureDowngrade`
-/// call from `VendorInstaller`/`SparkleInstaller` must turn these tests red;
-/// nothing else in this file can, because they never call `isArchitectureDowngrade`
-/// or `verifyNoArchitectureDowngrade` directly — only the installers' public
-/// `apply()`. (A gate no code path calls is worse than no gate at all: the next
-/// reader trusts `SignatureVerifier`'s doc comment listing it. Issue #196.)
+/// call from `SignatureVerifier.verifyInstallArtifact` — the single shared
+/// entry point both `VendorInstaller` and `SparkleInstaller` now call — must
+/// turn these tests red; nothing else in this file can, because they never
+/// call `isArchitectureDowngrade` or `verifyNoArchitectureDowngrade` directly
+/// — only the installers' public `apply()`. (A gate no code path calls is
+/// worse than no gate at all: the next reader trusts `SignatureVerifier`'s
+/// doc comment listing it. Issue #196.)
 ///
 /// The trick is a REAL, already-installed, Developer-ID-signed universal
 /// (`x86_64 arm64`) app found on this machine, copied twice:
@@ -633,12 +635,19 @@ struct ArchitectureDowngradeWiringTests {
         #expect(downloaded == "x86_64", "\(label): downloaded side should be exactly x86_64")
     }
 
-    @Test func vendorInstallerApplyRefusesTheDowngrade() async throws {
-        guard HostArch.current == .arm64, HostArch.canRunIntelBuilds else {
-            // Without Rosetta, Gate 5 itself would refuse an Intel-only download
-            // here — that would prove Gate 5 works, not Gate 5b specifically.
-            return
-        }
+    // Skipped (not silently passed) rather than gated by a bare `guard … else {
+    // return }`: without Rosetta on an arm64 host, Gate 5 itself would refuse an
+    // Intel-only download here — that would prove Gate 5 works, not Gate 5b
+    // specifically — and swift-testing's own summary only counts tests it knows
+    // about, not tests that actually ran their body, so a silent early return
+    // reads as a pass indistinguishable from the real thing (see the App-layer
+    // test-coverage notes in CLAUDE.md for the same shape of bug). `.enabled(if:)`
+    // records this as a SKIP, with the reason, instead.
+    @Test(.enabled(
+        if: HostArch.current == .arm64 && HostArch.canRunIntelBuilds,
+        "needs an arm64 host with Rosetta installed, so an Intel-only download still launches translated and Gate 5b (not Gate 5) is what's under test"
+    ))
+    func vendorInstallerApplyRefusesTheDowngrade() async throws {
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent("arch-downgrade-wiring-vendor-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
@@ -659,8 +668,13 @@ struct ArchitectureDowngradeWiringTests {
         }
     }
 
-    @Test func sparkleInstallerApplyRefusesTheDowngrade() async throws {
-        guard HostArch.current == .arm64, HostArch.canRunIntelBuilds else { return }
+    // See the comment on `vendorInstallerApplyRefusesTheDowngrade` above: skipped
+    // with a reason, not silently passed.
+    @Test(.enabled(
+        if: HostArch.current == .arm64 && HostArch.canRunIntelBuilds,
+        "needs an arm64 host with Rosetta installed, so an Intel-only download still launches translated and Gate 5b (not Gate 5) is what's under test"
+    ))
+    func sparkleInstallerApplyRefusesTheDowngrade() async throws {
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent("arch-downgrade-wiring-sparkle-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
@@ -682,6 +696,66 @@ struct ArchitectureDowngradeWiringTests {
             Issue.record("SparkleInstaller.apply must refuse an arm64→x86_64-only swap")
         } catch {
             Self.expectArchitectureDowngrade(error, from: "SparkleInstaller")
+        }
+    }
+
+    /// Issue #410's first acceptance criterion: inside
+    /// `SignatureVerifier.verifyInstallArtifact`, Gate 5
+    /// (`verifyRunnableArchitecture`) must run BEFORE Gate 5b
+    /// (`verifyNoArchitectureDowngrade`), so an Intel-only download this Mac
+    /// cannot even launch is refused as "cannot launch" (Gate 5), never as
+    /// "would run translated" (Gate 5b) — which implies it launches at all.
+    /// The two tests above prove Gate 5b is WIRED IN; this one proves it runs
+    /// in the right ORDER relative to Gate 5, which they cannot: both begin
+    /// `guard HostArch.current == .arm64, HostArch.canRunIntelBuilds`, so on
+    /// this machine (arm64 + Rosetta) Gate 5 always answers "runnable" for an
+    /// Intel-only download and Gate 6 never fires at all — neither test can
+    /// tell "5 then 5b" apart from "5b then 5".
+    ///
+    /// This test does NOT need a Rosetta-less machine to tell them apart: it
+    /// drives `verifyInstallArtifact` directly with `host: .arm64` and
+    /// `canRunIntel: false` — parameters added in this same change precisely so
+    /// the ordering could be pinned without one. That makes an ordinary arm64
+    /// dev/CI host answer Gate 5's "can this launch" the same way a real
+    /// Rosetta-less or Intel-only host would, while gate 5b's OWN "is this a
+    /// downgrade" precondition (`host == .arm64`) still holds — both gates are
+    /// live, so the order between them is the only thing this test can be
+    /// measuring.
+    ///
+    /// Mutation this kills: swapping the `verifyRunnableArchitecture` /
+    /// `verifyNoArchitectureDowngrade` lines inside `verifyInstallArtifact`.
+    /// With the order swapped, Gate 5b runs first on this fixture — a genuine
+    /// arm64→x86_64-only downgrade — and throws `.architectureDowngrade` before
+    /// Gate 5 ever gets a chance to refuse the build as unrunnable, so this test
+    /// would then observe `.architectureDowngrade` instead of
+    /// `.unrunnableArchitecture` and fail. Confirmed red by making that swap and
+    /// running this test alone (see the commit that introduces it); reverted
+    /// immediately after.
+    @Test func verifyInstallArtifactRunsGate5BeforeGate5b() async throws {
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("arch-gate-order-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        guard let fixture = try Self.makeDowngradeFixture(in: scratch) else { return }
+
+        let newApp = try ArchiveExtractor.extractApp(
+            from: fixture.download.archiveURL, workDir: scratch)
+
+        do {
+            try await SignatureVerifier.verifyInstallArtifact(
+                downloadedApp: newApp,
+                installedApp: fixture.installed.path,
+                host: .arm64,
+                canRunIntel: false)
+            Issue.record(
+                "verifyInstallArtifact must refuse an Intel-only download when canRunIntel is false")
+        } catch SignatureVerifier.VerifyError.unrunnableArchitecture {
+            // Gate 5 fired first, as required — the error IS the assertion.
+        } catch {
+            Issue.record("""
+                expected .unrunnableArchitecture (Gate 5), got \(error) — \
+                did Gate 5b run before Gate 5?
+                """)
         }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallPipelineSmokeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallPipelineSmokeTests.swift
@@ -157,6 +157,17 @@ private func verifyGates(
     try SignatureVerifier.verifyBundleIdentifierMatch(installedApp: target.app.path, downloadedApp: newApp)
     log("✓ code signature valid; Team ID match: \(oldTeam ?? "?") == \(newTeam ?? "?")")
     log("=== ALL GATES PASSED (no install performed) ===")
+
+    // Deliberately partial: this calls gates 2–4 directly rather than through
+    // `SignatureVerifier.verifyInstallArtifact` (issue #410), and stops before
+    // gates 5/5b/6 (architecture, architecture-downgrade, OS floor). This test's
+    // whole point is per-stage logging against a REAL vendor download — download,
+    // EdDSA, extract, then each trust gate individually with its own log line —
+    // so it can name which stage a live vendor broke at. Routing it through the
+    // shared entry point would collapse that into one call and lose the stage
+    // that failed; a change to the shared gate 5/5b ordering will not be caught
+    // here, but IS caught by `ArchitectureDowngradeWiringTests` in
+    // `ArchitectureGateTests.swift`, which drives the real installers' `apply()`.
 }
 
 /// Delete leftover scratch dirs from runs that were killed before their `defer`

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -967,4 +967,13 @@ private func checkGate(_ app: InstalledApp, log: @Sendable (String) -> Void) asy
             installedApp: installedPath, downloadedApp: newApp)
     }
     log("✅ gate passed — would swap safely (no swap performed)")
+
+    // Deliberately partial: stops after gate 3 (Team ID), before gate 4 (bundle
+    // id) and gates 5/5b/6 (architecture, architecture-downgrade, OS floor) —
+    // it calls `SignatureVerifier` directly rather than through
+    // `verifyInstallArtifact` (issue #410) so it can log Team ID before/after
+    // each step against a REAL, live vendor download, off the cooperative pool
+    // exactly like the real installers (#351, noted above). A change to the
+    // shared gate ordering downstream of gate 3 will not be caught here, but IS
+    // caught by `ArchitectureDowngradeWiringTests` in `ArchitectureGateTests.swift`.
 }


### PR DESCRIPTION
Closes #410.

Sparkle and vendor installs duplicated the six app-bundle validation gates, making their order and error priority easy to drift. Both now call one internal `SignatureVerifier.verifyInstallArtifact(downloadedApp:installedApp:)` entry point that owns the complete sequence and its single `offCooperativePool` hop.

The order remains code signature → Team ID → bundle ID → runnable architecture → no architecture downgrade → minimum OS version. The existing call sites validate both extracted archives and delta reconstructions before swapping. EdDSA, checksums, nested installer-stub validation, and pkg handling retain their existing paths.

Validation: full `make test` passed on the final rebased commit `d1a7c0e`: Core 2433 tests (1 existing known issue), CLI 234 tests, App 9 cases, and all repository checks. Both installer architecture-downgrade integration tests passed. `git diff --check` passed. GitHub CI is pending.

Review status: independent `codex review` was attempted but interrupted by the CLI workspace credit limit; no completed independent review is claimed.
