### PR TITLE
fix: remove unreachable iOS-on-Mac page URL fallback

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -283,9 +283,8 @@ public struct MacAppStoreSource: UpdateSource {
             shortVersion: info.version,
             version: nil,
             downloadURL: lookupResult.trackViewUrl.flatMap { URL(string: $0) },
-            // Prefer the Mac-specific product page over the lookup's generic
-            // trackViewUrl, which lands on the iOS listing for wrapped apps.
-            pageURL: pageURL ?? lookupResult.trackViewUrl.flatMap { URL(string: $0) },
+            // Use the Mac-specific product page constructed and unwrapped above.
+            pageURL: pageURL,
             sourceName: name,
             appStore: availability,
             releaseNotesHTML: (notes?.isEmpty == false) ? notes : nil,


### PR DESCRIPTION
Closes #411.

`iosOnMacVersion` already unwraps its constructed Mac product-page URL with `guard let`, so the `trackViewUrl` fallback could never execute and emitted a compiler warning. Pass the unwrapped `pageURL` directly and describe that behavior in the adjacent comment.

URL construction or page parsing failure still returns nil; this introduces no fallback to the iOS listing. No new test is needed for removing the unreachable expression.

Validation: compilation no longer reports the nil-coalescing warning, and the existing `iosOnMacVersionIgnoresTrackViewUrl` test passed. Full `make test` passed on commit `47d0821`: Core 2433 tests (1 existing known issue), CLI 234 tests, App 9 cases, and all repository checks. `git diff --check` passed. GitHub CI is still running. Diff review found no actionable issues; the independent CLI review service remains unavailable due to its workspace credit limit.
