### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
@@ -133,7 +133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
@@ -142,7 +142,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -151,7 +151,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.84.0",
       "sweepsSinceComment" : 0
@@ -160,7 +160,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -169,7 +169,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
@@ -178,7 +178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -187,7 +187,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
@@ -196,7 +196,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
@@ -205,7 +205,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -214,7 +214,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -223,7 +223,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
@@ -232,7 +232,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -241,7 +241,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -250,7 +250,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -259,7 +259,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 3,
       "lastGoodVersion" : "152.0.7977.82",
       "sweepsSinceComment" : 0
@@ -268,7 +268,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
@@ -277,7 +277,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
@@ -286,7 +286,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -295,7 +295,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -304,7 +304,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -313,7 +313,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -322,16 +322,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
-      "lastGoodVersion" : "0.19.0-preview.1",
+      "lastGoodVersion" : "1.0.0-preview.0",
       "sweepsSinceComment" : 0
     },
     "changelog:com.longbridge.app.desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
@@ -340,7 +340,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -349,7 +349,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.136",
       "sweepsSinceComment" : 0
@@ -358,7 +358,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -369,7 +369,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
@@ -379,7 +379,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
@@ -388,7 +388,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -397,7 +397,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -406,16 +406,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 30,
-      "lastGoodVersion" : "12.26.5",
+      "lastGoodVersion" : "12.27.0",
       "sweepsSinceComment" : 0
     },
     "changelog:com.qoder.app:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.1.8",
       "sweepsSinceComment" : 0
@@ -424,7 +424,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.28.0",
       "sweepsSinceComment" : 0
@@ -433,7 +433,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -442,7 +442,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -451,7 +451,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.2",
       "sweepsSinceComment" : 0
@@ -460,7 +460,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -469,7 +469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -478,7 +478,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -487,7 +487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -498,7 +498,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0,
@@ -508,7 +508,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -517,7 +517,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
@@ -526,7 +526,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -535,7 +535,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -544,7 +544,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -553,7 +553,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
@@ -562,7 +562,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260904",
       "sweepsSinceComment" : 0
@@ -571,7 +571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -580,9 +580,36 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
+      "sweepsSinceComment" : 0
+    },
+    "changelog:com.windscribe.client:beta" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodEntryCount" : 20,
+      "lastGoodVersion" : "2.24.12",
+      "sweepsSinceComment" : 0
+    },
+    "changelog:com.windscribe.client:guineaPig" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodEntryCount" : 20,
+      "lastGoodVersion" : "2.24.12",
+      "sweepsSinceComment" : 0
+    },
+    "changelog:com.windscribe.client:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodEntryCount" : 9,
+      "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
     "changelog:com.workbuddy.workbuddy-ai:-" : {
@@ -591,7 +618,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -601,7 +628,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
@@ -610,7 +637,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -619,7 +646,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -628,7 +655,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
@@ -637,7 +664,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
@@ -646,7 +673,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
@@ -655,7 +682,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
@@ -664,7 +691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -673,7 +700,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -682,7 +709,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
@@ -691,7 +718,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.0",
       "sweepsSinceComment" : 0
@@ -700,7 +727,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -709,7 +736,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
@@ -718,7 +745,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
@@ -727,7 +754,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0
@@ -736,7 +763,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
@@ -745,7 +772,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -754,7 +781,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -763,7 +790,8 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
     },
@@ -771,7 +799,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -780,7 +808,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
@@ -789,7 +817,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -798,7 +826,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -807,7 +835,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -816,7 +844,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -825,7 +853,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
@@ -834,7 +862,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -843,7 +871,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "0.1.17",
       "sweepsSinceComment" : 0
@@ -852,7 +880,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 17,
       "lastGoodVersion" : "1.7.1",
       "sweepsSinceComment" : 0
@@ -861,7 +889,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
@@ -870,7 +898,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.13.2",
       "sweepsSinceComment" : 0
     },
@@ -878,7 +906,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
@@ -886,7 +914,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -894,7 +922,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -902,7 +930,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -910,7 +938,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -918,7 +946,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -926,7 +954,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -934,7 +962,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -942,7 +970,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.3.9",
       "sweepsSinceComment" : 0
     },
@@ -950,7 +978,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -958,7 +986,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -966,7 +994,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -974,7 +1002,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.135.05934-insider",
       "sweepsSinceComment" : 0
     },
@@ -982,7 +1010,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.126.04524",
       "sweepsSinceComment" : 0
     },
@@ -990,7 +1018,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -998,7 +1026,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1006,7 +1034,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.49.0",
       "sweepsSinceComment" : 0
     },
@@ -1014,7 +1042,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1022,7 +1050,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1030,7 +1058,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1038,7 +1066,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1046,7 +1074,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1054,7 +1082,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.18.29",
       "sweepsSinceComment" : 0
     },
@@ -1062,7 +1090,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1070,7 +1098,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1078,7 +1106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1086,7 +1114,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1094,7 +1122,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1102,7 +1130,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1110,7 +1138,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1118,7 +1146,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1126,7 +1154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1134,7 +1162,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1142,7 +1170,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1150,7 +1178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1158,7 +1186,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1166,7 +1194,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1174,7 +1202,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.6.5-beta2",
       "sweepsSinceComment" : 0
     },
@@ -1182,7 +1210,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1190,7 +1218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1198,7 +1226,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1206,7 +1234,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1214,7 +1242,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.20.1",
       "sweepsSinceComment" : 0
     },
@@ -1222,7 +1250,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1230,7 +1258,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1238,7 +1266,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1246,7 +1274,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1254,7 +1282,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.1.15",
       "sweepsSinceComment" : 0
     },
@@ -1262,7 +1290,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1270,7 +1298,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.16.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1278,7 +1306,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1286,7 +1314,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "31.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1294,7 +1322,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1302,7 +1330,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1310,7 +1338,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1318,7 +1346,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1326,7 +1354,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1334,7 +1362,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1342,7 +1370,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1350,7 +1378,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1358,7 +1386,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1366,7 +1394,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1374,7 +1402,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -1382,7 +1410,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1390,7 +1418,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1398,7 +1426,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1406,7 +1434,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -1414,7 +1442,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.22.2",
       "sweepsSinceComment" : 0
     },
@@ -1422,23 +1450,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
-      "lastGoodVersion" : "0.0.38",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "0.0.39",
       "sweepsSinceComment" : 0
     },
     "github:pingdotgg\/t3code:nightly" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
-      "lastGoodVersion" : "0.0.39-nightly.20260906.1316",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "0.0.39-nightly.20260907.1332",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1446,7 +1474,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1454,7 +1482,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1462,7 +1490,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1470,7 +1498,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1478,7 +1506,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1486,7 +1514,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1494,7 +1522,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1502,7 +1530,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1510,7 +1538,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1518,7 +1546,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1526,7 +1554,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1534,7 +1562,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1542,7 +1570,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1550,7 +1578,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1558,7 +1586,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1566,7 +1594,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1574,8 +1602,8 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
-      "lastGoodVersion" : "3.3.3",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
     "github:vorssaintapp\/vorssaint-utils:beta" : {
@@ -1604,7 +1632,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1612,7 +1640,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1620,7 +1648,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1628,7 +1656,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -1636,15 +1664,147 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.22b",
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:cc.ffitch.shottr:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.Excel:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.OneDrive:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.Outlook:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.Powerpoint:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.Word:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.edgemac.Beta:beta" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.edgemac.Dev:dev" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.edgemac:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.m365copilot:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.onenote.mac:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.microsoft.teams2:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.netease.uuremote:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.oray.sunlogin.macclient:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.tclementdev.timemachineeditor.application:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.tencent.wechatdevtools:nightly" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.tencent.wechatdevtools:rc" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.tencent.wechatdevtools:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:com.youqu.todesk.mac:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:io.tailscale.ipn.macsys:rc" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:io.tailscale.ipn.macsys:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "sweepsSinceComment" : 0
+    },
+    "pkgarch:io.tailscale.ipn.macsys:unstable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
       "sweepsSinceComment" : 0
     },
     "vendor:MstyStudio:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1652,7 +1812,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.4.23",
       "sweepsSinceComment" : 0
     },
@@ -1660,7 +1820,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "151.0.7922.247",
       "sweepsSinceComment" : 0
     },
@@ -1668,7 +1828,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1676,7 +1836,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1684,7 +1844,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1692,7 +1852,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1700,7 +1860,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "8.12.34",
       "sweepsSinceComment" : 0
     },
@@ -1708,7 +1868,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.2.1",
       "sweepsSinceComment" : 0
     },
@@ -1716,7 +1876,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.46388.4",
       "sweepsSinceComment" : 0
     },
@@ -1724,7 +1884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1732,7 +1892,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.44.0",
       "sweepsSinceComment" : 0
     },
@@ -1740,7 +1900,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1748,7 +1908,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1756,7 +1916,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1764,7 +1924,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1772,7 +1932,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1780,7 +1940,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1788,7 +1948,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1796,7 +1956,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.95.96.0",
       "sweepsSinceComment" : 0
     },
@@ -1804,7 +1964,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.97.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1812,7 +1972,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -1820,7 +1980,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.124.1",
       "sweepsSinceComment" : 0
     },
@@ -1828,7 +1988,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.84.2",
       "sweepsSinceComment" : 0
     },
@@ -1836,7 +1996,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1844,7 +2004,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.89.0",
       "sweepsSinceComment" : 0
     },
@@ -1852,7 +2012,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -1860,7 +2020,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.6.774",
       "sweepsSinceComment" : 0
     },
@@ -1868,7 +2028,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.8.20",
       "sweepsSinceComment" : 0
     },
@@ -1876,7 +2036,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -1884,7 +2044,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "126.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1892,7 +2052,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -1900,7 +2060,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "154.0.8037.0",
       "sweepsSinceComment" : 0
     },
@@ -1908,7 +2068,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "155.0.8043.0",
       "sweepsSinceComment" : 0
     },
@@ -1916,7 +2076,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -1924,7 +2084,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "152.0.7977.83",
       "sweepsSinceComment" : 0
     },
@@ -1932,7 +2092,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.107.3.828",
       "sweepsSinceComment" : 0
     },
@@ -1940,7 +2100,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -1948,7 +2108,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -1956,7 +2116,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -1964,7 +2124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -1972,7 +2132,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -1980,7 +2140,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.529.3",
       "sweepsSinceComment" : 0
     },
@@ -1988,7 +2148,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1996,7 +2156,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.0.410",
       "sweepsSinceComment" : 0
     },
@@ -2004,7 +2164,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.0.1311",
       "sweepsSinceComment" : 0
     },
@@ -2012,7 +2172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -2020,7 +2180,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -2028,7 +2188,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2036,7 +2196,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2044,7 +2204,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2061,7 +2221,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "9.4.0",
       "sweepsSinceComment" : 0
     },
@@ -2069,15 +2229,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
-      "lastGoodVersion" : "0.19.0-preview.1",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "1.0.0-preview.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.longbridge.app.desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -2085,7 +2245,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2093,7 +2253,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2101,7 +2261,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -2109,7 +2269,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2117,7 +2277,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2125,7 +2285,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.136.1",
       "sweepsSinceComment" : 0
     },
@@ -2133,7 +2293,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.137.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -2141,7 +2301,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2149,7 +2309,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "153.0.4234.19",
       "sweepsSinceComment" : 0
     },
@@ -2157,7 +2317,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "154.0.4251.0",
       "sweepsSinceComment" : 0
     },
@@ -2165,7 +2325,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -2173,7 +2333,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2181,7 +2341,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2189,7 +2349,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2197,7 +2357,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2205,7 +2365,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2213,7 +2373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2221,7 +2381,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26.901.51231",
       "sweepsSinceComment" : 0
     },
@@ -2229,7 +2389,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -2237,7 +2397,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2245,7 +2405,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2253,15 +2413,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
-      "lastGoodVersion" : "12.26.5",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "12.27.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.qoder.app:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.1.8",
       "sweepsSinceComment" : 0
     },
@@ -2269,7 +2429,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.28.0",
       "sweepsSinceComment" : 0
     },
@@ -2277,7 +2437,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.104.28",
       "sweepsSinceComment" : 0
     },
@@ -2285,7 +2445,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.2.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2293,7 +2453,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2301,7 +2461,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2309,7 +2469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2317,15 +2477,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
-      "lastGoodVersion" : "1.2.98.301",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
     "vendor:com.sublimemerge:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2333,7 +2493,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2341,7 +2501,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2349,7 +2509,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2357,7 +2517,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.2.5",
       "sweepsSinceComment" : 0
     },
@@ -2365,7 +2525,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2375,7 +2535,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2384,7 +2544,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.02.2609032",
       "sweepsSinceComment" : 0
     },
@@ -2392,7 +2552,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2400,7 +2560,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.02.2608060",
       "sweepsSinceComment" : 0
     },
@@ -2408,7 +2568,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2416,7 +2576,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2424,7 +2584,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2432,7 +2592,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2440,7 +2600,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2448,7 +2608,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.19.13",
       "sweepsSinceComment" : 0
     },
@@ -2456,7 +2616,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.21.1",
       "sweepsSinceComment" : 0
     },
@@ -2464,15 +2624,39 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "8.2.4133.43",
+      "sweepsSinceComment" : 0
+    },
+    "vendor:com.windscribe.client:beta" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "2.24.12",
+      "sweepsSinceComment" : 0
+    },
+    "vendor:com.windscribe.client:guineaPig" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "2.24.12",
+      "sweepsSinceComment" : 0
+    },
+    "vendor:com.windscribe.client:stable" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
+      "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
     "vendor:com.workbuddy.workbuddy-ai:stable:arm64" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2480,7 +2664,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2488,7 +2672,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2496,7 +2680,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2504,7 +2688,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2512,7 +2696,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2520,7 +2704,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2528,7 +2712,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2536,7 +2720,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2544,7 +2728,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2552,7 +2736,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.2026.09.06.08.23.00",
       "sweepsSinceComment" : 0
     },
@@ -2560,7 +2744,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2568,7 +2752,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2576,7 +2760,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2584,7 +2768,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2026090401",
       "sweepsSinceComment" : 0
     },
@@ -2592,7 +2776,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2600,7 +2784,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2608,7 +2792,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2616,7 +2800,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2624,7 +2808,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.103.176",
       "sweepsSinceComment" : 0
     },
@@ -2632,7 +2816,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2640,7 +2824,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2648,7 +2832,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2656,7 +2840,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2664,7 +2848,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26.35.23",
       "sweepsSinceComment" : 0
     },
@@ -2672,7 +2856,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "7.32.1",
       "sweepsSinceComment" : 0
     },
@@ -2680,7 +2864,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "2.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2688,7 +2872,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2696,7 +2880,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2704,7 +2888,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2712,24 +2896,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 2,
+      "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "infraSince" : "2026-09-06T14:23:52Z",
-      "lastGoodAt" : "2026-09-06T08:23:36Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 2
+      "sweepsSinceComment" : 0
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2737,7 +2920,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2745,7 +2928,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2753,7 +2936,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2761,7 +2944,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -2769,7 +2952,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2777,7 +2960,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2785,7 +2968,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2793,7 +2976,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -2801,7 +2984,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "156.0b2",
       "sweepsSinceComment" : 0
     },
@@ -2809,7 +2992,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -2817,7 +3000,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "15.0.21",
       "sweepsSinceComment" : 0
     },
@@ -2825,7 +3008,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -2833,7 +3016,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -2841,7 +3024,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "8.26.0",
       "sweepsSinceComment" : 0
     },
@@ -2851,7 +3034,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "10.0.1",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2860,7 +3043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -2868,11 +3051,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-06T20:24:03Z",
+      "lastGoodAt" : "2026-09-07T08:23:58Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-06T20:24:04Z"
+  "updatedAt" : "2026-09-07T08:23:59Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.