### PR TITLE
Let the popover row say how tall it is, so a fast scroll stops dropping frames

### DIFF
--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -233,7 +233,13 @@ struct MenuContentView: View {
     /// Shortest a row can possibly be: the 30pt icon plus its 7pt vertical padding.
     /// A row with an install error or a note is taller, which only makes the list
     /// overflow sooner — so this stays a lower bound in the safe direction.
-    private static let minRowHeight: CGFloat = 44
+    ///
+    /// The row's own height, not a second copy of it. `AppRow` declares that number
+    /// (see `plainRowHeight`), and the two are not independent: this one has to be a
+    /// FLOOR on it, so a row height lowered here-but-not-there would make
+    /// `listOverflows` claim a short list overflows and pin the frame at
+    /// `maxListHeight` with dead space under the last row.
+    private static let minRowHeight: CGFloat = AppRow.plainRowHeight
 
     /// Whether the list must scroll whatever the rows measure. `count * minRowHeight`
     /// is a floor on the content height, so this is only ever true when it genuinely
@@ -787,12 +793,17 @@ private struct AppRow: View {
     /// `.frame` in `body` for why it is fixed and where the number comes from.
     static let plainRowHeight: CGFloat = 44
 
-    /// Whether anything is drawn under the name line — the one thing that makes a
-    /// row taller than `plainRowHeight`. Kept beside the two lookups it reads so a
-    /// third source of second-line content cannot be added without passing here.
-    private var hasSecondaryLine: Bool {
-        installError != nil
-            || (model.installNotes[result.id] ?? model.stagedPackageNote(for: result)) != nil
+    /// The note drawn under the name line when there is no install error — an
+    /// install note, else the staged-package line.
+    ///
+    /// Read TWICE per row, by the view that draws it and by the frame that has to
+    /// know whether the row is taller than `plainRowHeight`, so `body` binds it
+    /// once and passes the value to both. Behind it, `stagedPackageNote` stats the
+    /// disk for a row that has a package staged and builds a localized string;
+    /// asking twice on a per-row, per-repaint path is exactly the cost the frame
+    /// below exists to remove.
+    private var secondaryNote: String? {
+        model.installNotes[result.id] ?? model.stagedPackageNote(for: result)
     }
 
     /// How wide the name line wants to be — the name plus whatever shares its
@@ -949,6 +960,10 @@ private struct AppRow: View {
     }
 
     var body: some View {
+        // Bound here, not read from `secondaryNote` at each of its two use sites —
+        // see that property. Only reached when there is no install error, which
+        // wins the branch below.
+        let note = installError == nil ? secondaryNote : nil
         VStack(spacing: 4) {
             HStack(spacing: 10) {
                 Image(nsImage: AppIconCache.icon(for: result.app.path.path))
@@ -1034,7 +1049,7 @@ private struct AppRow: View {
                         .disabled(model.restartingHelper)
                     }
                 }
-            } else if let note = model.installNotes[result.id] ?? model.stagedPackageNote(for: result) {
+            } else if let note {
                 // The staged-package line is the fallback, not an override: once
                 // an install note exists ("Opened the installer for … — finish it
                 // there") it is the more specific thing to say about the same
@@ -1078,7 +1093,17 @@ private struct AppRow: View {
         // error or a note adds a second line to the `VStack` above, and none of the
         // 161 was in that state, so those rows keep sizing themselves. They are rare
         // and transient, so the fast path still covers essentially the whole list.
-        .frame(height: hasSecondaryLine ? nil : Self.plainRowHeight)
+        //
+        // ⚠️ A frame does not clip: content taller than this OVERFLOWS and draws over
+        // the row below. The condition above only knows the two things that stack
+        // UNDER the name line, so trailing content that grows past the icon's 30pt —
+        // a two-line status, a stacked readout — would overlap silently. Every
+        // inline branch of `PopoverRowAction` is a single-line `HStack` today (the
+        // tall `VStack`s in that file are `.popover` content, not row content), but
+        // that is an audit, not a gate: `make gallery` draws the trailing control
+        // into its own forced 44pt slot, so it would clip such a control too and
+        // still pass. Re-measure the row rather than assume, if one is added.
+        .frame(height: installError == nil && note == nil ? Self.plainRowHeight : nil)
         .contentShape(Rectangle())
         .contextMenu { rowMenu }
     }

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -783,6 +783,18 @@ private struct AppRow: View {
     private var stage: InstallStage? { model.installing[result.id] }
     private var installError: String? { model.installErrors[result.id] }
 
+    /// The row's height when nothing is stacked under the name line. See the
+    /// `.frame` in `body` for why it is fixed and where the number comes from.
+    static let plainRowHeight: CGFloat = 44
+
+    /// Whether anything is drawn under the name line — the one thing that makes a
+    /// row taller than `plainRowHeight`. Kept beside the two lookups it reads so a
+    /// third source of second-line content cannot be added without passing here.
+    private var hasSecondaryLine: Bool {
+        installError != nil
+            || (model.installNotes[result.id] ?? model.stagedPackageNote(for: result)) != nil
+    }
+
     /// How wide the name line wants to be — the name plus whatever shares its
     /// row (the running dot, a channel chip). Measured with AppKit rather than
     /// left to `ViewThatFits`: the progress control is inflexible, so an HStack
@@ -1035,6 +1047,38 @@ private struct AppRow: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 7)
+        // Say how tall this row is instead of making the list work it out.
+        //
+        // A `LazyVStack` asks every row it places for its size, and answering used to
+        // mean descending the whole row — the stack, the two text lines, the trailing
+        // control — which a fast drag pays for in bursts as it realizes rows faster
+        // than they can be sized. That is what dropped frames. A fixed frame answers
+        // from the modifier instead.
+        //
+        // What that actually buys, measured over a 25 s full-range scroll of the
+        // "Show all" list with the runtime tags off (2026-09-07, `sample(1)`, as a
+        // share of wall clock): the main thread goes from 60.0% busy to 42.5%, and
+        // the popover stops dropping frames. The saving is in re-running row bodies
+        // — `ViewBodyAccessor.updateBody` 12.0% -> 3.6%, `AppRow.body` 8.0% -> 3.2%,
+        // AttributeGraph 43.5% -> 27.3%.
+        //
+        // NOT in the stack's own sizing pass, which is where this was expected to
+        // land: `LazyHVStack.lengthAndSpacing` is 14.7% before and 16.7% after. The
+        // stack still asks every row how tall it is. What changed is that answering
+        // no longer runs the row's body. Do not "fix" the remaining 16.7% by
+        // reaching for the frame again — it is already fixed.
+        //
+        // 44 is not a guess and not a target: it is what the row already measures.
+        // A height probe over 161 rows of the real list returned 44.00pt for every
+        // one, including rows carrying a channel chip, a runtime mark or a running
+        // dot, and it is the same 44 the row-state gallery already draws the
+        // trailing control into. Nothing about the row's appearance changes here.
+        //
+        // `nil` — natural height — for the rows this was NOT measured on. An install
+        // error or a note adds a second line to the `VStack` above, and none of the
+        // 161 was in that state, so those rows keep sizing themselves. They are rare
+        // and transient, so the fast path still covers essentially the whole list.
+        .frame(height: hasSecondaryLine ? nil : Self.plainRowHeight)
         .contentShape(Rectangle())
         .contextMenu { rowMenu }
     }


### PR DESCRIPTION
Scrolling the "Show all" list quickly dropped frames. `sample(1)` over a 25 s
full-range scroll, runtime tags off, as a share of wall clock: the main thread
was busy **60.0%**, concentrated in realizing rows in bursts — a `LazyVStack`
asks every row it places how tall it is, and answering meant descending into the
row and running its body.

The row now says. Same scroll after: **42.5% busy**, and it no longer drops
frames.

| % of wall clock | before | after |
|---|---|---|
| main thread busy | 60.0% | 42.5% |
| `ViewBodyAccessor.updateBody` | 12.0% | 3.6% |
| `AppRow.body` | 8.0% | 3.2% |
| AttributeGraph | 43.5% | 27.3% |
| `LazyHVStack.lengthAndSpacing` | 14.7% | 16.7% |

That last row is not a typo and the comment says so: this landed somewhere other
than where it was aimed. The stack still asks every row how tall it is. What
changed is that answering no longer runs the body.

**44 is measured, not chosen.** A height probe over 161 rows of the real list
returned 44.00pt for every one, including rows carrying a channel chip, a
runtime mark or a running dot — and it is the height the row-state gallery
already draws the trailing control into. Rows carrying an install error or a
note keep sizing themselves: they stack a second line under the name, none of
the 161 was in that state, and a height measured without one does not describe
them.

**Appearance is unchanged, verified rather than asserted.** Screenshots of the
pre-change build and this one, aligned on the separator lattice: separator
thickness 2px, row pitch 45.0pt, separator span x 3..736 at luminance 0.2039,
icon extent 29..78, button 58.5x20.0pt, trailing edge 12.0pt, label cap height
8.0pt — identical on both sides, nine of nine.

## What was tried first, so nobody repeats it

A native `List` fixes the frame drops too (49.7% busy) and is what #59 already
concluded for the Release Log. It cannot be taken: a list renders the row's
controls on a smaller metric curve, and **no `controlSize` declaration lands on
the stack's result** — declared `.small` the Update button comes out 48x15pt,
declared `.regular` 56x19pt, against the 58.5x20pt the stack draws; and the
declaration is shared with the short-list branch, where raising it overshoots to
68.5x24pt. Measured and excluded along the way: ambient control size (reads
`regular` in both branches; setting it on the list or the row changes nothing),
width starvation (row 370.0pt and trailing slot 64.0pt in both), negative
`listRowInsets`, an in-row `Divider()`, scroll indicators, row count, modifier
order. None of it reproduces outside a real `MenuBarExtra` popover. That attempt
is kept on `perf/popover-list-recycling`.

## Coverage

None is added, and that is worth saying plainly. `MenuContentView` is outside
the App test target (it reaches `AppListModel`) and the gallery draws
`PopoverRowAction` alone, not the row — so nothing here executes this frame. The
evidence is the measurements above and review.

`/code-review` found three defects, two fixed and the third recorded next to the
frame: a frame does not clip, so trailing content that ever grows past the
icon's 30pt would draw over the row below, and no gate can catch it.

## Verification

- `make test` — green (2433 tests / 201 suites Core, 234 / 29 CLI, App tests 9 of 9 executed, all six python gates)
- `make gallery` — all five gates pass, no image diff. The one tile that reports as modified on every run is byte-different and pixel-identical (zlib compresses the same pixels to a different length); reproduced twice and restored.