### PR TITLE
Fix the two traps left over from the popover-scrolling work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,17 @@ duo verify --only <bundle-id-片段>        # 只验一个,快
 - 修 recipe 要先复现红:拿到坏掉的原始响应体(`--samples`),确认新规则在**那份真实响应**上过,再跑全量。
 - 新增/改 recipe **必须补一条回归测试**;凡是该由「每条 recipe 都得满足」来表达的性质,用例要**从 registry 推导**,不要手写一份会漂移的清单。范式是 `ChangelogURLPolicyTests` 的「Derived from the registries」一节(遍历 `VendorProbeRegistry.recipes` / `ChangelogRecipeRegistry.recipes`),`AppAuditCoverageTests`、`ChannelGuardTests` 同理。⚠️ **`RecipeHealthTests` / `RecipeVerificationTests` 不是这个范式**——2026-09-07 实测:前者 `grep -c Registry` 为 0,测的是 `RecipeHealth` 这个 actor、id 是合成的;后者是 2026-08-08 两个真实故障的回放套件。这条以前指着它们,照着看的人找不到可抄的东西。
 - 全量 `duo verify` 约 150 个请求 / 3 分钟,别为了省时间只验一个就宣布全绿。
+- **`duo verify` 现在自己会拒绝跑陈旧二进制,不用再靠记性。** recipe 是编译进二进制的,
+  而 `duo` 跑的是 `~/.local/libexec/duo` 不是你的工作树,所以一次陈旧的 sweep 会给出
+  一份**完全正常**的报告——有分数、有 pass/warn/fail、有响应体样本——讲的却是几个钟头前
+  就被替换掉的规则。`scripts/build-cli.sh` 现在把源码摘要写在二进制旁边
+  (`~/.local/libexec/duo.built-from`),`Verify.run` 开头拿它跟**你所在的这个 checkout**
+  的摘要比,对不上就退 2 并让你 `make cli`。
+  按**内容**比不按 mtime 比,两个方向都要防:mtime 只抓得住"二进制比树旧"那一半,
+  而 2026-08-27 咬人的是另一半——`~/.local` 是全局的,另一个 worktree 的会话 `make cli`
+  把二进制换成了**更新的、但没有你那条 recipe 的**那个,mtime 看它是新的就放行了。
+  确实要拿旧二进制跑就 `--allow-stale-binary`,它会把理由印在报告顶上。
+  不在 checkout 里跑(普通用户)不受影响,这道闸直接不参与。
 - **`make test` 本机一轮约 25 MB / 20 秒**,那道真下厂商包的闸默认关着(`DUO_DOWNLOAD_GATE`,
   见「发布」和「CI」两节)。想在本机过一遍就 `DUO_DOWNLOAD_GATE=1 make test`,约 185 MB。
 - **卡住的时候用 `scripts/run-with-hang-report.sh 1800 make test`**,超时会抓线程栈再杀树

--- a/CLI/Sources/DuoKit/SourceStamp.swift
+++ b/CLI/Sources/DuoKit/SourceStamp.swift
@@ -1,0 +1,220 @@
+import Foundation
+import CryptoKit
+
+/// Whether the `duo` binary now running was built from the checkout it is standing in.
+///
+/// `duo verify` sweeps the recipes, and the recipes are **compiled into the binary**.
+/// The binary on PATH (`~/.local/bin/duo` → `~/.local/libexec/duo`) is not the working
+/// tree, so a sweep can report a full, normal-looking result — scores, pass/warn/fail,
+/// captured response bodies — for rules that were replaced hours ago. Nothing in the
+/// output says which rules it used.
+///
+/// That has cost real time twice, in two different directions, which is why the check
+/// here is on content rather than on timestamps:
+///
+///  - **Binary older than the tree.** 2026-08-26, verifying before 0.3.64: one red and
+///    one amber, both false, both already fixed in the tree — and the app the release
+///    was *for* had no recipe in that binary at all, so "246 green" had never looked at
+///    it. A modification-time check would have caught this one.
+///  - **Binary newer than the tree, and from somewhere else.** 2026-08-27: `duo verify
+///    --only canva` passed, then the same command answered "nothing to verify — no
+///    recipe matches canva" with no source change in between. `~/.local` is global and
+///    this repository usually has a dozen worktrees open; a concurrent session's `make
+///    cli` had replaced the binary with one built from a tree that had no Canva recipe.
+///    A modification-time check calls that binary fresh and lets it through.
+///
+/// So the stamp is a digest of the sources the binary was built from, written beside it
+/// by `scripts/build-cli.sh` and compared against a digest of the checkout `duo verify`
+/// is run in. Both digests come from `digest(ofCheckoutAt:)` below — the build script
+/// asks the freshly built binary for its own, rather than reimplementing the hash in
+/// shell where the two could drift apart.
+///
+/// Outside a checkout there is nothing to compare against and the check says so and
+/// stands down: `duo verify` from an arbitrary directory is a legitimate thing to do.
+public enum SourceStamp {
+
+    /// Everything `duo` is compiled from. `App/Sources` is deliberately absent: the CLI
+    /// does not link it, so an app-only edit does not make this binary wrong.
+    static let sourceRoots = ["DuoUpdaterCore/Sources", "CLI/Sources"]
+
+    /// A floor, in the spirit of `check_prose_claims.py`'s: a digest computed over a
+    /// handful of files would be a check that passes because it looked at almost
+    /// nothing, and it would agree with itself on both sides while doing it. Set well
+    /// under the real count (188 on 2026-09-07) so ordinary growth never trips it —
+    /// this is here to catch a moved or renamed source root, not to count files.
+    static let minimumFiles = 100
+
+    /// Name chosen to be read, not parsed: it sits next to the binary in
+    /// `~/.local/libexec/` and answers the question someone standing there is asking.
+    static let stampSuffix = ".built-from"
+
+    public enum Verdict: Sendable, Equatable {
+        /// Not run from a checkout, so there is nothing this could be stale against.
+        case notApplicable
+        case matches
+        /// Built from different sources than the ones here — or from none we can name.
+        case stale(String)
+    }
+
+    // MARK: - Digest
+
+    public enum StampError: Error, CustomStringConvertible {
+        case tooFewFiles(Int)
+        public var description: String {
+            switch self {
+            case .tooFewFiles(let n):
+                return "only \(n) Swift files under \(SourceStamp.sourceRoots.joined(separator: ", "))"
+                     + " — expected at least \(SourceStamp.minimumFiles), so the source roots have moved"
+            }
+        }
+    }
+
+    /// A digest of every Swift file under `sourceRoots`, by content.
+    ///
+    /// Content, not modification time. Timestamps move whenever git rewrites a file —
+    /// `git checkout` of a branch with the same sources gives every one of them a new
+    /// mtime — so a timestamp check reports stale builds that are in fact correct, and
+    /// people who are told that learn to pass the override. It also misses the second
+    /// incident above outright, where the wrong binary was the newer one.
+    ///
+    /// The path is hashed alongside the bytes, and the length alongside both: without
+    /// the path a file rename is invisible, and without the length two files could be
+    /// re-split at a different boundary for the same digest.
+    public static func digest(ofCheckoutAt root: URL) throws -> String {
+        var files: [(String, URL)] = []
+        for relative in sourceRoots {
+            let base = root.appendingPathComponent(relative)
+            guard let walk = FileManager.default.enumerator(
+                at: base, includingPropertiesForKeys: nil) else { continue }
+            for case let url as URL in walk where url.pathExtension == "swift" {
+                let path = url.standardizedFileURL.path
+                let rootPath = root.standardizedFileURL.path
+                files.append((String(path.dropFirst(rootPath.count)), url))
+            }
+        }
+        guard files.count >= minimumFiles else { throw StampError.tooFewFiles(files.count) }
+
+        var hasher = SHA256()
+        // Sorted, because `enumerator` makes no ordering promise and a digest that
+        // depends on directory order would differ between two identical checkouts.
+        for (relative, url) in files.sorted(by: { $0.0 < $1.0 }) {
+            let bytes = try Data(contentsOf: url)
+            hasher.update(data: Data("\(relative)\n\(bytes.count)\n".utf8))
+            hasher.update(data: bytes)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Locating the two sides
+
+    /// The checkout `cwd` sits in, if it sits in one.
+    ///
+    /// Identified by carrying every source root, not by `.git`: a worktree's `.git` is a
+    /// file pointing elsewhere, and a checkout missing a source root is not one this can
+    /// compare against anyway.
+    public static func checkoutRoot(
+        from cwd: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    ) -> URL? {
+        var directory = cwd.standardizedFileURL
+        while true {
+            let complete = sourceRoots.allSatisfy {
+                var isDirectory: ObjCBool = false
+                let path = directory.appendingPathComponent($0).path
+                return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+                    && isDirectory.boolValue
+            }
+            if complete { return directory }
+            // `.standardizedFileURL` is what makes this terminate, and without it the
+            // failure is a hang, not a wrong answer.
+            //
+            // Measured 2026-09-07: whether `deletingLastPathComponent()` stops at `/`
+            // depends on how the URL was built. Descend from
+            // `URL(fileURLWithPath:)` — what `checkoutRoot` does by default, from
+            // `currentDirectoryPath` — and `/` is its own parent, so the plain
+            // comparison fires. Descend from `FileManager.default.temporaryDirectory`
+            // and it does not: `/` becomes `/..`, then `/../..`, and the loop climbs
+            // forever at 99% CPU. So production was safe only by accident of one
+            // constructor, and `aPartialTreeIsNotACheckout` — which starts in the
+            // temporary directory, as any caller might — hung until this line existed.
+            // Standardizing collapses `/..` back to `/`, and the path then strictly
+            // shortens every turn.
+            let parent = directory.deletingLastPathComponent().standardizedFileURL
+            if parent.path == directory.path { return nil }
+            directory = parent
+        }
+    }
+
+    /// The file `build-cli.sh` wrote beside the binary that is running.
+    ///
+    /// Resolved through the symlink on purpose. `~/.local/bin/duo` is a link to
+    /// `~/.local/libexec/duo` and the stamp lives beside the real file; measured
+    /// 2026-09-07, `Bundle.main.executableURL` returns the link path and
+    /// `resolvingSymlinksInPath()` the target. `CommandLine.arguments[0]` is not usable
+    /// for this — invoked through PATH it is the bare word `duo`.
+    public static var stampURL: URL? {
+        guard let executable = Bundle.main.executableURL?.resolvingSymlinksInPath()
+        else { return nil }
+        return executable.deletingLastPathComponent()
+            .appendingPathComponent(executable.lastPathComponent + stampSuffix)
+    }
+
+    // MARK: - The check
+
+    public static func verdict(
+        root: URL? = checkoutRoot(), stamp: URL? = stampURL
+    ) -> Verdict {
+        guard let root else { return .notApplicable }
+        let here: String
+        do { here = try digest(ofCheckoutAt: root) } catch {
+            return .stale("this checkout cannot be digested: \(error)")
+        }
+        guard let stamp, let recorded = try? String(contentsOf: stamp, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines), !recorded.isEmpty
+        else {
+            return .stale("""
+                this `duo` carries no record of what it was built from, so whether its \
+                recipes match \(root.path) cannot be established
+                """)
+        }
+        guard recorded == here else {
+            return .stale("""
+                this `duo` was built from different sources than \(root.path) \
+                (built \(recorded.prefix(12))…, here \(here.prefix(12))…)
+                """)
+        }
+        return .matches
+    }
+
+    /// Print the digest of the checkout this is run in, for `scripts/build-cli.sh` to
+    /// store beside the binary it just installed. The build script asks the new binary
+    /// rather than hashing in shell so that there is exactly one definition of the
+    /// digest, and the writer and the reader cannot drift apart.
+    public static func printDigest() -> Int32 {
+        guard let root = checkoutRoot() else {
+            FileHandle.standardError.write(Data(
+                "not inside a checkout: no DuoUpdaterCore/Sources and CLI/Sources above \(FileManager.default.currentDirectoryPath)\n".utf8))
+            return 2
+        }
+        do { print(try digest(ofCheckoutAt: root)) } catch {
+            FileHandle.standardError.write(Data("\(error)\n".utf8))
+            return 2
+        }
+        return 0
+    }
+
+    /// The whole point, phrased for someone who is about to spend three minutes and
+    /// ~150 requests on an answer that would be about the wrong rules.
+    public static func complaint(_ reason: String) -> String {
+        """
+        stale `duo`: \(reason).
+
+          The recipes are compiled in, so this sweep would report on the rules in the
+          binary, not the ones in your tree — and it would look completely normal doing
+          it. Rebuild first:
+
+              make cli
+
+          Pass --allow-stale-binary to sweep anyway, once you know that is what you want.
+        """
+    }
+}

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -28,6 +28,9 @@ public struct VerifyOptions: Sendable {
     /// Cross-check against the locally installed copy where there is one. Off on
     /// a CI runner, where nothing is installed.
     public var useInstalled = true
+    /// Sweep even when this binary was not built from the checkout it is standing in.
+    /// See `SourceStamp` for what that costs and why it is refused by default.
+    public var allowStaleBinary = false
     public var githubToken: String?
     public var baselinePath: URL?
     public var jsonPath: URL?
@@ -46,6 +49,16 @@ struct InstalledVersion: Sendable {
 public enum Verify {
 
     public static func run(_ options: VerifyOptions) async -> Int32 {
+        // Before anything is counted or requested. The recipes below are the ones
+        // compiled into THIS binary, and the whole report is worthless — while looking
+        // entirely normal — if that is not the tree the reader has open.
+        if case .stale(let reason) = SourceStamp.verdict() {
+            guard options.allowStaleBinary else {
+                die(SourceStamp.complaint(reason), code: 2)
+            }
+            print("\n  ⚠︎ \(reason).\n    Sweeping anyway because --allow-stale-binary was passed.\n")
+        }
+
         let vendor = filtered(VendorProbeRegistry.recipes, options) { $0.bundleID }
         let github = filtered(GitHubReleaseRegistry.rules, options) { $0.bundleID }
         let changelog = filtered(ChangelogRecipeRegistry.recipes, options) { $0.bundleID }

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -177,6 +177,15 @@ verify options:
   --markdown <path>   Write the findings as Markdown.
   --max-concurrency N Hosts probed in parallel (default 4). One request at a
                       time per host regardless.
+  --allow-stale-binary
+                      Sweep even though this `duo` was not built from the
+                      checkout it is standing in. Refused by default: the
+                      recipes are compiled in, so such a sweep reports on the
+                      rules in the binary rather than the ones in your tree and
+                      looks entirely normal doing it. `make cli` is the fix.
+  --source-digest     Print what the sources in this checkout hash to and exit.
+                      What `scripts/build-cli.sh` records beside the binary so
+                      the check above has something to compare against.
 
 triage options:
   --report <path>     The JSON written by `duo verify --report`. Required.
@@ -392,12 +401,19 @@ case "doctor":
     run = { await Doctor.run(json: json) }
 
 case "verify":
+    // Answered before any option is read: this prints what the sources here hash to and
+    // exits, and `scripts/build-cli.sh` stores the answer beside the binary it installs.
+    if args.has("source-digest") {
+        run = { SourceStamp.printDigest() }
+        break
+    }
     var options = VerifyOptions()
     options.only = (args.value("only") ?? "")
         .split(separator: ",")
         .map { $0.trimmingCharacters(in: .whitespaces) }
         .filter { !$0.isEmpty }
     options.showSamples = args.has("samples")
+    options.allowStaleBinary = args.has("allow-stale-binary")
     options.useInstalled = !args.has("no-installed")
     if let concurrency = args.int("max-concurrency") {
         options.hostConcurrency = max(1, concurrency)

--- a/CLI/Tests/DuoKitTests/SourceStampTests.swift
+++ b/CLI/Tests/DuoKitTests/SourceStampTests.swift
@@ -1,0 +1,151 @@
+import Testing
+import Foundation
+@testable import DuoKit
+
+/// `SourceStamp` decides whether a `duo verify` sweep is about the reader's recipes or
+/// about whatever was compiled into the binary on PATH. Every case below names the line
+/// it pins and was run against that line removed — see the comment on each.
+@Suite struct SourceStampTests {
+
+    /// A checkout-shaped tree: every source root present, and enough files to clear the
+    /// floor. The bodies are unique so a digest that skipped content still gets a
+    /// different byte count, which would let `contentChangeMovesTheDigest` pass for the
+    /// wrong reason — so that test rewrites a file to the SAME length.
+    private func makeTree(files: Int = SourceStamp.minimumFiles + 5) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SourceStampTest-\(UUID().uuidString)")
+        for (index, relative) in SourceStamp.sourceRoots.enumerated() {
+            let directory = root.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+            // Only the first root is filled: the floor is about the total, and a case
+            // below empties one root entirely to check the root is still required.
+            guard index == 0 else { continue }
+            for i in 0..<files {
+                try "let n\(i) = \(String(format: "%06d", i))\n"
+                    .write(to: directory.appendingPathComponent("F\(i).swift"),
+                           atomically: true, encoding: .utf8)
+            }
+        }
+        return root
+    }
+
+    /// The point of the whole file. Mutation: hash only the path and the length, not the
+    /// bytes — this goes green while the digest stops noticing edited recipes, which is
+    /// the exact failure it exists to catch.
+    @Test func contentChangeMovesTheDigest() throws {
+        let root = try makeTree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let before = try SourceStamp.digest(ofCheckoutAt: root)
+
+        // Same length, different bytes: a digest that only weighed sizes would miss it.
+        let file = root.appendingPathComponent(SourceStamp.sourceRoots[0] + "/F3.swift")
+        let original = try String(contentsOf: file, encoding: .utf8)
+        try original.replacingOccurrences(of: "000003", with: "999999")
+            .write(to: file, atomically: true, encoding: .utf8)
+        #expect(try original.count == String(contentsOf: file, encoding: .utf8).count)
+
+        #expect(try SourceStamp.digest(ofCheckoutAt: root) != before)
+    }
+
+    /// Mutation: drop `relative` from the hashed preamble. Renaming a recipe file — or
+    /// moving one between roots — then leaves the digest unchanged, so a binary built
+    /// before the move reads as current.
+    @Test func renamingAFileMovesTheDigest() throws {
+        let root = try makeTree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let before = try SourceStamp.digest(ofCheckoutAt: root)
+
+        let directory = root.appendingPathComponent(SourceStamp.sourceRoots[0])
+        try FileManager.default.moveItem(
+            at: directory.appendingPathComponent("F3.swift"),
+            to: directory.appendingPathComponent("Renamed.swift"))
+
+        #expect(try SourceStamp.digest(ofCheckoutAt: root) != before)
+    }
+
+    /// Two trees with identical content must agree even though they were created in a
+    /// different order and live at different paths. Mutation: remove `.sorted` — this
+    /// goes red as soon as `enumerator` hands the two trees back differently, which is
+    /// the flake that would teach everyone to pass `--allow-stale-binary`. Paths are
+    /// relative for the same reason: absolute ones would make every worktree disagree.
+    @Test func twoIdenticalCheckoutsAgree() throws {
+        let a = try makeTree()
+        let b = try makeTree()
+        defer {
+            try? FileManager.default.removeItem(at: a)
+            try? FileManager.default.removeItem(at: b)
+        }
+        #expect(try SourceStamp.digest(ofCheckoutAt: a)
+                == SourceStamp.digest(ofCheckoutAt: b))
+    }
+
+    /// Mutation: delete the `files.count >= minimumFiles` guard. A renamed source root
+    /// then digests zero files — and, being empty on both sides, agrees with itself, so
+    /// the gate reports "matches" forever while checking nothing.
+    @Test func aTreeThatLostItsSourcesIsAnError() throws {
+        let root = try makeTree(files: 3)
+        defer { try? FileManager.default.removeItem(at: root) }
+        #expect(throws: SourceStamp.StampError.self) {
+            try SourceStamp.digest(ofCheckoutAt: root)
+        }
+    }
+
+    /// Mutation: return `directory` on the first iteration instead of walking up. `duo
+    /// verify` is normally run from the repository root, so a test that only checked the
+    /// root would pass — this one starts three levels down, which is where the skill's
+    /// recipe work happens.
+    @Test func theCheckoutIsFoundFromASubdirectory() throws {
+        let root = try makeTree()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let deep = root.appendingPathComponent(SourceStamp.sourceRoots[0] + "/a/b")
+        try FileManager.default.createDirectory(at: deep, withIntermediateDirectories: true)
+
+        #expect(SourceStamp.checkoutRoot(from: deep)?.standardizedFileURL.path
+                == root.standardizedFileURL.path)
+    }
+
+    /// A directory carrying only one source root is not a checkout this can compare
+    /// against. Mutation: `allSatisfy` -> `contains` — a stray `CLI/Sources` anywhere
+    /// above then claims to be the repository and the digest is taken over a fragment.
+    @Test func aPartialTreeIsNotACheckout() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SourceStampPartial-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(SourceStamp.sourceRoots[0]),
+            withIntermediateDirectories: true)
+
+        #expect(SourceStamp.checkoutRoot(from: root) == nil)
+    }
+
+    /// Run from anywhere that is not a checkout there is nothing to be stale against,
+    /// and refusing would break `duo verify` for everyone who is not developing it.
+    @Test func outsideACheckoutTheGateStandsDown() {
+        #expect(SourceStamp.verdict(root: nil, stamp: nil) == .notApplicable)
+    }
+
+    /// The three verdicts that matter, over one tree. `.stale` for a missing stamp is
+    /// the case that upgrades every binary built before this existed: unknown provenance
+    /// is not the same as good provenance, and the fix for both is one `make cli`.
+    @Test func theStampDecidesTheVerdict() throws {
+        let root = try makeTree()
+        let stamp = root.appendingPathComponent("duo.built-from")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(SourceStamp.verdict(root: root, stamp: stamp) != .matches)
+
+        try SourceStamp.digest(ofCheckoutAt: root)
+            .write(to: stamp, atomically: true, encoding: .utf8)
+        #expect(SourceStamp.verdict(root: root, stamp: stamp) == .matches)
+
+        // Whitespace is not drift: the stamp is written by a shell redirect, which
+        // leaves a trailing newline that `verdict` has to tolerate.
+        try (try SourceStamp.digest(ofCheckoutAt: root) + "\n")
+            .write(to: stamp, atomically: true, encoding: .utf8)
+        #expect(SourceStamp.verdict(root: root, stamp: stamp) == .matches)
+
+        try "not a digest".write(to: stamp, atomically: true, encoding: .utf8)
+        #expect(SourceStamp.verdict(root: root, stamp: stamp) != .matches)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
@@ -62,7 +62,6 @@ struct BrewFormulaReleaseActorTests {
 
         // A prewarm-sized batch of uncached formulae, each paying a full `brew info`.
         let batch = 4
-        let batchStart = Date()
         let inFlight = (0..<batch).map { i in
             Task {
                 _ = await service.release(
@@ -72,33 +71,53 @@ struct BrewFormulaReleaseActorTests {
         defer { for task in inFlight { task.cancel() } }
 
         // Let the batch enter the actor before timing the interactive read.
-        try await Task.sleep(nanoseconds: 100_000_000)
+        let settle = 0.1
+        try await Task.sleep(nanoseconds: UInt64(settle * 1_000_000_000))
 
-        let bound = 0.2
         let start = Date()
         let hit = await service.cached(for: cachedName, version: cachedVersion)
         let elapsed = Date().timeIntervalSince(start)
-
         #expect(hit == seeded)
-        // Under ONE subprocess (~0.55s), not under the whole batch. Actors make no FIFO
-        // admission promise, so a bound of 4x-a-subprocess would still pass if `cached`
-        // happened to be admitted after only one `brewInfo` — which is the bug.
-        #expect(elapsed < bound, "cached() waited \(elapsed)s behind the brew info batch")
 
         for task in inFlight { await task.value }
-        let batchElapsed = Date().timeIntervalSince(batchStart)
 
-        // Vacuity guard on this test's own premise. It can only tell "actor held" from
-        // "actor free" while `brew info` is genuinely slow; if it ever gets fast, the
-        // serialized form drops under `bound` and this test passes while proving
-        // nothing. The batch runs concurrently, so its wall clock ~= one subprocess and
-        // the serialized cost ~= batch x that. Fail loudly the day that stops being
-        // true, rather than going quietly green.
-        let serializedEstimate = Double(batch) * batchElapsed
-        #expect(serializedEstimate > 3 * bound, """
-            premise gone: `brew info` is now fast enough that the serialized form \
-            (~\(serializedEstimate)s) no longer clears the \(bound)s bound, so a pass \
-            here proves nothing. Re-tune or delete this test.
+        // What one `brew info` costs on THIS host, measured with nothing else on the
+        // actor — which is the whole point of taking it here rather than reusing the
+        // batch's wall clock. A bound derived from the batch would inflate ~4x in
+        // exactly the case this test exists to catch (the batch is serialized when the
+        // bug is present), so `batchElapsed / 2` would be ~2 subprocesses of room — and a
+        // `cached()` admitted after only one `brewInfo` is the bug, per the reasoning
+        // below. Measured 2026-09-07 by reverting the hop: `solo` moved 0.563s -> 0.571s
+        // while `batchElapsed` went to 2.459s. The batch is over when this runs, so
+        // nothing contends and the number does not inflate with the bug.
+        let soloStart = Date()
+        _ = await service.release(for: "duo-uncached-formula-solo", version: "9.9.9", token: nil)
+        let solo = Date().timeIntervalSince(soloStart)
+
+        // Half a subprocess. The floor of the broken case is `solo - settle`: the batch
+        // has been running for `settle` when the read starts, so a `cached()` that has
+        // to wait for the actor waits out at least the remainder of the subprocess
+        // holding it. Half sits under that floor with room at every host speed the
+        // guard below admits, and unlike the old hard-coded 0.2s it means the same
+        // thing on a 14-core laptop and a 3-core runner — where 0.2s is a much thinner
+        // slice of a much slower subprocess, and went red on a healthy build (#394).
+        let bound = solo / 2
+        #expect(elapsed < bound, """
+            cached() waited \(elapsed)s behind the brew info batch, over the \(bound)s \
+            bound derived from a \(solo)s `brew info` on this host
+            """)
+
+        // Vacuity guard on this test's own premise, and it has to be an absolute floor
+        // now: the old ratio guard (`batch * batchElapsed > 3 * bound`) becomes a
+        // tautology once the bound is derived from the same measurement. What actually
+        // has to hold is that a subprocess outlasts `settle` by enough to be visible —
+        // at `solo == 4 * settle` the broken case still floors at 3x `settle` against a
+        // 2x-`settle` bound. Below that the two cases stop being separable and a pass
+        // proves nothing.
+        #expect(solo > 4 * settle, """
+            premise gone: one `brew info` now takes \(solo)s, too close to the \(settle)s \
+            the batch is given to settle, so "actor held" and "actor free" are no longer \
+            distinguishable here. Re-tune or delete this test.
             """)
     }
 }

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -61,6 +61,23 @@ ln -sf "$DEST" "$LINK"
 codesign --verify --strict "$DEST" 2>/dev/null \
     || die "the deployed copy failed signature verification"
 
+# What this binary was built from, beside the binary, so `duo verify` can refuse to
+# sweep with recipes that are not the ones in the reader's tree. The recipes are
+# compiled in and the report gives no sign of which ones it used, so a stale binary
+# produces a full, normal-looking answer about rules that were replaced hours ago --
+# twice now, in both directions. See CLI/Sources/DuoKit/SourceStamp.swift.
+#
+# Asked of the binary rather than hashed here: one definition of the digest, so the
+# side that writes it and the side that checks it cannot drift apart. Written via a
+# temporary file so a failure leaves the previous stamp rather than an empty one --
+# an empty stamp reads as "no record", which is a refusal the next person would have
+# to debug instead of just rebuilding.
+say "Recording the sources it was built from"
+STAMP="$DEST.built-from"
+( cd "$REPO" && "$DEST" verify --source-digest ) > "$STAMP.new" \
+    || die "could not digest the sources under $REPO"
+mv -f "$STAMP.new" "$STAMP"
+
 say "Installed"
 printf '   %s\n   %s -> %s\n\n' "$DEST" "$LINK" "$DEST"
 


### PR DESCRIPTION
Two developer-facing traps, both raised in the popover-scrolling session.

## 1. `#394` — the brew-actor test measured the host as much as the code

`cachedStaysResponsiveWhileUncachedFormulaeAreComputing` asserted a hard-coded
0.2s, chosen against a ~0.55s subprocess on a 14-core laptop. On the 3-core
runner that is a much thinner slice of a much slower subprocess: it went red on
a healthy build during #392 (0.227s) and passed on a re-run of the same commit.

The bound is now **half of one `brew info`, measured on the host** after the
batch drains.

The issue suggested deriving it from `batchElapsed`; that source is the wrong
one and the reason is now written into the test. When the bug is present the
batch is *serialized*, so `batchElapsed / 2` is ~2 subprocesses of room — and a
`cached()` admitted after only one `brewInfo` is exactly the bug the existing
comment rules out. Measured by reverting the executor hop: `solo` moved
`0.563s -> 0.571s` while `batchElapsed` went to `2.459s`. The solo reading does
not inflate with the bug.

The vacuity guard had to change with it — the old ratio guard becomes a
tautology once both sides come from the same measurement — so it is now an
absolute floor tied to the settle sleep.

**Verified:** mutation applied (`brewInfoOffActor` -> synchronous `brewInfo`) →
`elapsed 2.358s` against a `0.285s` bound, **red**. Reverted → three consecutive
runs green, `elapsed 0.00023s`.

## 2. `make cli` — a stale `duo` now refuses to sweep

The recipes are compiled into the binary, and `duo verify` runs the installed
`~/.local/libexec/duo`, not the working tree. A stale binary produces a full,
ordinary-looking report — scores, pass/warn/fail, captured bodies — about rules
that were replaced hours ago, and nothing in the output says which rules it used.
Twice, in opposite directions:

- **Binary older than the tree** (before 0.3.64): one red and one amber, both
  false and both already fixed, and the app the release was *for* had no recipe
  in that binary at all.
- **Binary newer, and from somewhere else**: `--only canva` passed, then the same
  command answered "nothing to verify" with no source change — a concurrent
  worktree's `make cli` had replaced the shared binary.

So the comparison is **on content, not modification time**. A timestamp check
catches only the first case, and reports stale builds that are in fact correct
every time git rewrites a file — which teaches people to pass the override.

`scripts/build-cli.sh` now stores a digest of the sources beside the binary it
installs; `Verify.run` compares it against the checkout it is standing in before
counting or requesting anything. The build script asks the freshly built binary
for that digest rather than hashing in shell, so the writer and the reader cannot
drift apart.

**Verified end-to-end with the installed binary** after a real `make cli`:

| from | result |
| --- | --- |
| the worktree it was built from | sweeps |
| the main checkout (the Canva case) | refused, exit 2, names both digests |
| same, `--allow-stale-binary` | sweeps, reason printed above the report |
| outside any checkout (an ordinary user) | gate stands down, sweeps |

The gate refuses **before** any request or any `--report` write, so a stale run
cannot leave a half-written report behind.

While writing the tests, `checkoutRoot` turned out to **hang** rather than answer
wrongly: whether `deletingLastPathComponent()` stops at `/` depends on how the
URL was constructed, and production was safe only by accident of using
`URL(fileURLWithPath:)`. Measured and fixed; the comment on that line says what
was measured.

## The nightly sweep on the mini: checked, and already satisfied

Any **unattended** `duo verify` now needs a matching `make cli` first. The one that
matters is `com.bobby.duo-recipe-verify` — and it does not run on the development
machine, it runs on the **mini** (`~/Developer/duo-updater`, every 6h at :17).

Checked there directly rather than reasoned about:

- The job is live — `launchctl list` shows it, and `~/Library/Logs/duo-recipe-verify.log`
  was last written 17:18 today.
- `~/.local/bin/duo-recipe-verify.sh:231` runs **`scripts/build-cli.sh` immediately
  before** `"$DUO" verify`, with cwd `cd "$REPO"` at line 107. So the binary is built
  from the very tree it then sweeps, the stamp is written by that build, and the gate
  passes. Nothing about the job needs changing.
- The first run after this merges is self-healing in either direction: if the pull
  lands, the new script writes a stamp for the new binary; if the pull fails, the old
  script and old binary have no gate at all.

The mini is macOS 26.6 / Swift 6.3.3 against this machine's macOS 27 / Xcode-beta, so
the branch was rsync'd to `/tmp` there and built on that toolchain: **`swift build`
clean, `SourceStampTests` 8/8**, and the gate proved out live — it swept from the tree
it was built from and refused from `~/Developer/duo-updater`. `build-cli.sh` was
deliberately **not** run on the mini: it would have repointed the real
`~/.local/libexec/duo.built-from` at `/tmp` and broken the 22:17 sweep. The temporary
copy has been removed (the mini has 14 GiB free).

Unrelated and pre-existing, noted in passing: that 17:18 run ended `failed=1` on
`ERROR: install path dry-run failed`, from the `DUO_INSTALL_SMOKE` step. Not touched
here.

## Gates

- `make test` — full, green (2433 core + 242 CLI tests, app tests 9/9, all six
  Python checkers).
- `make cli` — green; the stamp lands at `~/.local/libexec/duo.built-from`.
- `/code-review` on this diff — no correctness defects; the note above is the one
  finding.

`make gallery` was not run: nothing here touches a row view.
