### PR TITLE
Fix App Store prewarm comments still describing the old blocking model

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -76,10 +76,12 @@ public struct UpdateChecker: Sendable {
         // begins. "Finished" describes the HOOK returning, not the batch's
         // network work: `MacAppStoreSource.prewarm` starts an unstructured
         // `Task` and returns as soon as that Task is registered with
-        // `AppStoreLookupCache`, so this await is over long before any iTunes
-        // response has arrived. The query that actually needs a result —
-        // `lookup(bundleID:region:)`, via `AppStoreLookupCache.awaitInFlight()`
-        // — is what waits for the batch itself.
+        // `AppStoreLookupCache` — it does not await the Task itself, so this
+        // await never depends on any iTunes response having arrived, whether
+        // or not one happens to beat it back. The query that actually needs
+        // a result — `lookup(bundleID:region:)`, via
+        // `AppStoreLookupCache.awaitInFlight()` — is what waits for the
+        // batch itself.
         await withTaskGroup(of: Void.self) { group in
             for source in sources {
                 let visible = Self.apps(apps, visibleTo: source)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -71,8 +71,15 @@ public struct UpdateChecker: Sendable {
         // once (a single-app recheck still arrives here as a one-element array,
         // so it still prewarms — for just that one app, same as any live
         // lookup would). Explicitly drained rather than left to `withTaskGroup`
-        // to auto-await, so it's unambiguous that every source's prewarm has
-        // finished — not merely been scheduled — before the fan-out begins.
+        // to auto-await, so it's unambiguous that every source's `prewarm(_:)`
+        // call has finished — not merely been scheduled — before the fan-out
+        // begins. "Finished" describes the HOOK returning, not the batch's
+        // network work: `MacAppStoreSource.prewarm` starts an unstructured
+        // `Task` and returns as soon as that Task is registered with
+        // `AppStoreLookupCache`, so this await is over long before any iTunes
+        // response has arrived. The query that actually needs a result —
+        // `lookup(bundleID:region:)`, via `AppStoreLookupCache.awaitInFlight()`
+        // — is what waits for the batch itself.
         await withTaskGroup(of: Void.self) { group in
             for source in sources {
                 let visible = Self.apps(apps, visibleTo: source)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -79,8 +79,9 @@ public struct MacAppStoreSource: UpdateSource {
         // Chunks run CONCURRENTLY, and that is still not a micro-optimisation
         // — just not for the old reason. It no longer keeps a chunk's timeout
         // out of the main fan-out's way; `prewarm` already does that above by
-        // returning once `work` below is registered, before any chunk's
-        // request has even landed. What concurrency still buys is how long
+        // registering `work` below rather than awaiting it — whether a chunk's
+        // request happens to land first is neither ordered nor relevant, which
+        // is the whole point. What concurrency still buys is how long
         // `work` itself takes to finish: `lookup(bundleID:region:)` awaits
         // exactly this Task (via `AppStoreLookupCache.awaitInFlight`), and
         // every App Store row doing so occupies one of `UpdateChecker`'s

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -64,20 +64,31 @@ public struct MacAppStoreSource: UpdateSource {
     /// all, which is the one thing it must never be.
     ///
     /// The batch is registered with `prewarmCache` instead, and
-    /// `lookup(bundleID:region:)` awaits it before reading. So a slow batch now
-    /// delays exactly the rows that would otherwise each pay for their own
-    /// lookup, and nothing else — the pre-hook behaviour, with the saving.
+    /// `lookup(bundleID:region:)` awaits it before reading (the actual wait
+    /// happens in `AppStoreLookupCache.awaitInFlight`). So a slow batch
+    /// removes the global barrier this used to put in front of every
+    /// source — it no longer delays a GitHub or Sparkle row that never
+    /// touches this cache. It does NOT give App Store rows an isolated
+    /// queue: `UpdateChecker` runs the whole fan-out under one shared
+    /// bounded-concurrency window, and a row waiting here still occupies one
+    /// of that window's slots, the same as any other in-flight check would.
     public func prewarm(_ apps: [InstalledApp]) async {
         let bundleIDs = Array(Set(apps.compactMap { $0.isMASApp ? $0.bundleID : nil }))
         guard !bundleIDs.isEmpty else { return }
-        // Chunks run CONCURRENTLY, and that is not a micro-optimisation:
-        // `UpdateChecker.check(_:)` drains this before its per-app fan-out
-        // starts, so a sequential loop puts every chunk's timeout in front of
-        // every app's check. At 15 s per request and 30 MAS apps that is two
-        // chunks = up to 30 s where nothing else is being checked at all —
-        // strictly worse than before this hook existed, when an unreachable
-        // itunes.apple.com delayed only the App Store rows and did it in
-        // parallel with everything else.
+        // Chunks run CONCURRENTLY, and that is still not a micro-optimisation
+        // — just not for the old reason. It no longer keeps a chunk's timeout
+        // out of the main fan-out's way; `prewarm` already does that above by
+        // returning once `work` below is registered, before any chunk's
+        // request has even landed. What concurrency still buys is how long
+        // `work` itself takes to finish: `lookup(bundleID:region:)` awaits
+        // exactly this Task (via `AppStoreLookupCache.awaitInFlight`), and
+        // every App Store row doing so occupies one of `UpdateChecker`'s
+        // shared concurrency slots for as long as it waits. At 15 s per
+        // request and 30 MAS apps, a sequential loop would need two chunks —
+        // up to 30 s for `work` to finish — twice as long as running them at
+        // once, and that difference is spent by App Store rows (and whatever
+        // else queues behind them for a free slot) waiting rather than being
+        // checked.
         // Resolved once, exactly as `lookup(bundleID:region:)` resolves it, and
         // carried into both the request and the cache key.
         let lang = await LanguageSupport.shared.isRejected

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -65,13 +65,14 @@ public struct MacAppStoreSource: UpdateSource {
     ///
     /// The batch is registered with `prewarmCache` instead, and
     /// `lookup(bundleID:region:)` awaits it before reading (the actual wait
-    /// happens in `AppStoreLookupCache.awaitInFlight`). So a slow batch
-    /// removes the global barrier this used to put in front of every
-    /// source — it no longer delays a GitHub or Sparkle row that never
-    /// touches this cache. It does NOT give App Store rows an isolated
-    /// queue: `UpdateChecker` runs the whole fan-out under one shared
-    /// bounded-concurrency window, and a row waiting here still occupies one
-    /// of that window's slots, the same as any other in-flight check would.
+    /// happens in `AppStoreLookupCache.awaitInFlight`). Registering — rather
+    /// than awaiting — is what removes the global barrier this hook used to
+    /// put in front of every source. So a slow batch no longer delays a
+    /// GitHub or Sparkle row that never touches this cache. It does NOT give
+    /// App Store rows an isolated queue: `UpdateChecker` runs the whole
+    /// fan-out under one shared bounded-concurrency window, and a row
+    /// waiting here still occupies one of that window's slots, the same as
+    /// any other in-flight check would.
     public func prewarm(_ apps: [InstalledApp]) async {
         let bundleIDs = Array(Set(apps.compactMap { $0.isMASApp ? $0.bundleID : nil }))
         guard !bundleIDs.isEmpty else { return }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/UpdateSource.swift
@@ -48,6 +48,19 @@ public protocol UpdateSource: Sendable {
     /// point that has the whole list in hand at once. Default is a no-op, so
     /// only a source that actually has a batched endpoint needs to implement it
     /// (see `MacAppStoreSource.prewarm`, which batches iTunes lookups).
+    ///
+    /// **May — and is expected to — return once the batch work is merely
+    /// started or registered, not finished.** `UpdateChecker` drains this
+    /// hook for every source before the per-app fan-out begins, so a hook
+    /// that blocks until its own batch completes puts that batch's full
+    /// latency in front of every OTHER source too, not just its own rows.
+    /// The batch keeps running in the background after the hook returns;
+    /// whichever `latestVersion(for:)` call actually needs its result is
+    /// what waits for it, not this hook. See `MacAppStoreSource.prewarm`,
+    /// which starts an unstructured `Task` and returns as soon as it is
+    /// registered with `AppStoreLookupCache`, and
+    /// `AppStoreLookupCache.awaitInFlight()`, which is what
+    /// `lookup(bundleID:region:)` awaits when it needs that batch's answer.
     func prewarm(_ apps: [InstalledApp]) async
 
     /// Optional hook: drop any memoized answer this source is holding for


### PR DESCRIPTION
## Summary

- App Store prewarm has been non-blocking for a while (starts an unstructured `Task`, registers it with `AppStoreLookupCache`, returns), but two comments still argued from the old blocking model. Rewrote both to describe the current contract: hook completes registration → batch continues in the background → `AppStoreLookupCache.awaitInFlight()` is what a query needing the result waits on.
- Narrowed an absolute claim in `MacAppStoreSource.prewarm`'s doc comment ("delays exactly the rows... and nothing else"): `UpdateChecker` runs the whole fan-out under one shared bounded-concurrency window, so a waiting App Store row still occupies one of that window's slots like any other in-flight check. The hook removes the old global prewarm barrier; it does not isolate the delay.
- Comment-only change. `AppStoreLookupCache.swift`'s `register`/`awaitInFlight` already state the current contract correctly and were left untouched.

Closes #406.

## Test plan
- [x] `make test` (full, via `scripts/run-with-hang-report.sh 1800 make test`) — all green: DuoUpdaterCore 2433 tests / 201 suites, CLI 242 tests / 30 suites, App tests 9/9, all python gates (`check_localizable_keys`, `check_staged_version_use` + its own unit tests, `check_app_audits`, `check_skill_docs`, `check_prose_claims`) pass.
- [x] `/code-review` on the diff — no findings (every claim in the new prose cross-checked against the actual chunk size/timeout/concurrency-window code).
- Not run (per issue scope / instructions): `duo verify`, `make install`, `make cli` — no behavior changed.
