### PR TITLE
Fix prewarmDoesNotBlockOnItsOwnBatch: prove non-blocking, not scheduling luck

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
@@ -809,10 +809,12 @@ struct MacAppStorePageCacheTests {
     }
 
     /// Returns `true` if `task` finishes within `seconds`, `false` if the
-    /// timeout wins first. `task` itself is NEVER cancelled or abandoned by
-    /// this call — cancelling it wouldn't stop it anyway (nothing in
-    /// `prewarm` checks `Task.isCancelled`), so callers that need to drain a
-    /// timed-out `task` must still `await task.value` themselves afterward.
+    /// timeout wins first. `task` itself is NEVER cancelled by this call: a
+    /// timed-out `task` is still the caller's to drain (`await task.value`),
+    /// which is what keeps a leaked batch's request out of the next test's
+    /// window — and cancelling it here would race that drain. What
+    /// cancellation would even reach is a question this helper should not have
+    /// to answer.
     ///
     /// Deliberately NOT `withTaskGroup`: that would implicitly await every
     /// child before returning, and a `task` that never finishes (the

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
@@ -734,38 +734,117 @@ struct MacAppStorePageCacheTests {
     /// `lookup` joins it, so only the rows that would otherwise pay for their
     /// own lookup pay its latency.
     ///
-    /// Mutation run: awaiting the task inside `prewarm` (instead of registering
-    /// it) turns this red — `prewarm` no longer returns before the request
-    /// lands.
+    /// The response is held open by `ResponseGate` instead of being served
+    /// instantly: proving `prewarm` returns while the request is still
+    /// *incomplete* is the actual property (a request that merely *started*
+    /// before `prewarm` returned proves nothing — the batch's `Task` can be
+    /// scheduled at any point relative to `prewarm`'s own return, and a
+    /// same-thread coincidence used to make this test pass or fail on
+    /// scheduling luck rather than on what `prewarm` does). Racing the
+    /// `await` against a timeout (`raceAgainstTimeout`) means a regression —
+    /// `prewarm` awaiting its own gated, never-completing request — fails
+    /// this test in bounded time with a readable message instead of hanging
+    /// the whole run.
+    ///
+    /// The gate is safe to block on synchronously from `ScriptedHTTP`'s
+    /// handler: it runs on a URLSession-internal thread, not a Swift
+    /// concurrency cooperative-pool worker (measured 2026-09-07 — see task
+    /// notes: 14 CPU-bound `Task`s, this machine's core count, finished in
+    /// ~0.31s whether or not a `ScriptedHTTP` handler was concurrently
+    /// blocked on the same kind of gate; a pool-consuming block would have
+    /// shown a slowdown proportional to losing one of 14 worker threads).
+    ///
+    /// This test always joins `prewarmTask` before returning — on the happy
+    /// path via `latestVersion` (the only way a caller observes the
+    /// registered `Task`), and on the timeout path directly. An earlier
+    /// version only drained on the happy path; reproduced 2026-09-07 (see
+    /// task notes) that this lets a still-running batch's request land inside
+    /// the NEXT test's window, against the next test's `ScriptedHTTP` handler
+    /// and call log — the second defect the issue named. That risk exists on
+    /// EITHER exit path, so both must drain.
+    ///
+    /// Mutation run: awaiting the task inside `prewarm` (instead of
+    /// registering it) turns this red inside its 5 s timeout budget — see the
+    /// task notes for the raw output.
     @Test func prewarmDoesNotBlockOnItsOwnBatch() async throws {
         ScriptedHTTP.reset()
         let bundleID = "com.example.nonblocking"
-        let gate = AsyncGate()
+        let gate = ResponseGate()
         ScriptedHTTP.serve { request in
             guard let url = request.url, url.host == "itunes.apple.com" else { return nil }
-            gate.markRequestStarted()
+            gate.waitForRelease()
             return (200, Self.lookupJSON(
                 version: "1.0", trackId: 5301, trackViewUrl: "not-a-product-url", bundleId: bundleID))
         }
 
         let source = MacAppStoreSource(session: ScriptedHTTP.session(), region: "us",
                                        pageCache: AppStorePageCache())
-        await source.prewarm([Self.nativeMacApp(bundleID: bundleID)])
-        // If `prewarm` awaited the batch, the request would necessarily have
-        // been served by now. Returning before it is the property under test.
-        #expect(!gate.requestFinishedBeforePrewarmReturned,
-                "prewarm waited for its own batch — the fan-out is blocked behind it again")
+        let app = Self.nativeMacApp(bundleID: bundleID)
+
+        let prewarmTask = Task { await source.prewarm([app]) }
+        let returnedInTime = await Self.raceAgainstTimeout(seconds: 5, task: prewarmTask)
+        guard returnedInTime else {
+            gate.release()          // unblock the stalled handler…
+            _ = await prewarmTask.value  // …and drain it before this test ends
+            Issue.record("prewarm did not return within 5s — it is waiting on its own batch again")
+            return
+        }
+
+        // `prewarm` already returned above, and the gate has not been
+        // released yet — so the request it started is PROVABLY still
+        // incomplete. That is the property under test.
+        gate.release()
+
+        // Drain the batch before this test ends (see doc comment above).
+        _ = try await source.latestVersion(for: app)
     }
 
-    /// Records whether the scripted request had already been served at the
-    /// moment `prewarm` returned. A plain counter would race; this only ever
-    /// moves one way and is read after the fact.
-    final class AsyncGate: @unchecked Sendable {
-        private let lock = NSLock()
-        private var started = false
-        func markRequestStarted() { lock.lock(); started = true; lock.unlock() }
-        var requestFinishedBeforePrewarmReturned: Bool {
-            lock.lock(); defer { lock.unlock() }; return started
+    /// Blocks the calling thread until released — lets a test prove something
+    /// returned before a scripted HTTP response completed, without depending
+    /// on the OS's scheduling of when the request happens to start.
+    final class ResponseGate: @unchecked Sendable {
+        private let semaphore = DispatchSemaphore(value: 0)
+        func waitForRelease() { semaphore.wait() }
+        func release() { semaphore.signal() }
+    }
+
+    /// Returns `true` if `task` finishes within `seconds`, `false` if the
+    /// timeout wins first. `task` itself is NEVER cancelled or abandoned by
+    /// this call — cancelling it wouldn't stop it anyway (nothing in
+    /// `prewarm` checks `Task.isCancelled`), so callers that need to drain a
+    /// timed-out `task` must still `await task.value` themselves afterward.
+    ///
+    /// Deliberately NOT `withTaskGroup`: that would implicitly await every
+    /// child before returning, and a `task` that never finishes (the
+    /// regression this races against) would hang this helper itself. Two
+    /// independent, unstructured `Task`s race to resume a single continuation
+    /// instead. The timeout side is cancelled once `task` wins — cancelling a
+    /// `Task.sleep` ends it immediately — so the common (fast) path doesn't
+    /// leave a sleeper parked for the rest of the budget.
+    private static func raceAgainstTimeout(seconds: TimeInterval, task: Task<Void, Never>) async -> Bool {
+        final class ResumeOnce: @unchecked Sendable {
+            private let lock = NSLock()
+            private var used = false
+            func claim() -> Bool {
+                lock.lock(); defer { lock.unlock() }
+                if used { return false }
+                used = true
+                return true
+            }
+        }
+        let resumeOnce = ResumeOnce()
+        return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            let timeoutTask = Task {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                if resumeOnce.claim() { continuation.resume(returning: false) }
+            }
+            Task {
+                await task.value
+                if resumeOnce.claim() {
+                    timeoutTask.cancel()
+                    continuation.resume(returning: true)
+                }
+            }
         }
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
@@ -754,9 +754,9 @@ struct MacAppStorePageCacheTests {
     /// blocked on the same kind of gate; a pool-consuming block would have
     /// shown a slowdown proportional to losing one of 14 worker threads).
     ///
-    /// This test always joins `prewarmTask` before returning — on the happy
-    /// path via `latestVersion` (the only way a caller observes the
-    /// registered `Task`), and on the timeout path directly. An earlier
+    /// This test always joins `prewarmTask` before returning, on both exit
+    /// paths, by awaiting the task itself — never by relying on
+    /// `latestVersion` having reached `awaitInFlight()` on its way through. An earlier
     /// version only drained on the happy path; reproduced 2026-09-07 (see
     /// task notes) that this lets a still-running batch's request land inside
     /// the NEXT test's window, against the next test's `ScriptedHTTP` handler
@@ -796,7 +796,13 @@ struct MacAppStorePageCacheTests {
         gate.release()
 
         // Drain the batch before this test ends (see doc comment above).
+        // `latestVersion` is what a caller uses to join it, so it is worth
+        // exercising — but the drain itself does NOT ride on it: that call
+        // reaches `awaitInFlight()` only for a MAS app, and a throw on the way
+        // would leave the batch running past this test. The task is right
+        // here; await it.
         _ = try await source.latestVersion(for: app)
+        _ = await prewarmTask.value
     }
 
     /// Blocks the calling thread until released — lets a test prove something


### PR DESCRIPTION
## Summary

Fixes #405: `MacAppStorePageCacheTests.prewarmDoesNotBlockOnItsOwnBatch` was checking the wrong thing and racing against scheduling luck.

- The old test asserted the scripted request "had not started" (a lock-protected `Bool`) after `prewarm()` returned. That proves nothing about whether `prewarm` waited for the request to *complete*, and is itself non-deterministic: the background `Task` could start the request before `prewarm()` even returns, on either implementation.
- The old test also never drained `prewarm`'s background `Task` before ending — a static, shared `ScriptedHTTP` handler could then get overwritten by the next test while that orphaned request was still in flight, landing it inside the next test's window.

## What changed

- A `ResponseGate` holds the scripted HTTP response open (blocks synchronously inside `ScriptedHTTP`'s handler). Verified by direct measurement that this thread is off Swift concurrency's cooperative pool (see doc comment + task notes), so it's safe to block there.
- `prewarm()`'s `await` is raced against a 5s timeout (`raceAgainstTimeout`), so a real regression fails in bounded time with a readable message instead of hanging the test run.
- The test now always joins the background `prewarm` `Task` before returning — on the happy path (via `latestVersion`, the only public way to observe the registered task) and on the timeout path.

## Test plan

- [x] `swift test --filter 'MacAppStorePageCacheTests'` — 21/21 passed
- [x] Mutation test: changed `prewarm()` to `await work.value` instead of registering it — new test goes red in ~5.2s with a readable message; reverted
- [x] Verified the fix drains correctly on both exit paths after a code-review pass flagged the timeout branch leaking the abandoned task and the timeout `Task.sleep` not being cancelled on the happy path
- [x] Full `make test` (via `scripts/run-with-hang-report.sh 1800 make test`) — exit code 0, 2433 + 242 tests passed
