### PR TITLE
CLI: re-check version and route right before each install (#404)

### DIFF
--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -99,7 +99,7 @@ public enum Install {
                 // asked for, so listing it under "Skipping" would be noise.
                 guard options.routes.isEmpty || options.routes.contains(route) else { continue }
                 plan.append(Planned(result: result, route: route))
-            case .refuse(let why):
+            case .refuse(let why, _):
                 refusals.append((result, why))
             }
         }
@@ -162,7 +162,9 @@ public enum Install {
         // process exits immediately after this, and a detached release may never
         // run. (The kernel drops the flock on exit either way — this keeps the
         // reference count honest for anything that runs in between.)
-        let code = await apply(plan, json: options.json, keepBackups: settings.keepBackups)
+        let code = await apply(
+            plan, settings: settings, routes: options.routes,
+            json: options.json, keepBackups: settings.keepBackups)
         await ProcessInstallLock.shared.release()
         return code
     }
@@ -202,7 +204,13 @@ public enum Install {
 
     enum Decision {
         case install(InstallCoordinator.Route)
-        case refuse(String)
+        /// `route` is the freshly-derived route when classification got far
+        /// enough to compute one before refusing (currently only the App
+        /// Store branch below) — `nil` for every earlier refusal, which never
+        /// reaches a `route(for:requiresInstaller:)` call at all. `reconsider`
+        /// forwards this into `ReconsiderOutcome.skip` so `--json`'s `route`
+        /// field is never a stale guess (#404 review #5).
+        case refuse(String, InstallCoordinator.Route?)
     }
 
     /// Whether we may install this, using exactly the app's policy.
@@ -215,7 +223,7 @@ public enum Install {
         guard canAuto || needsInstaller else {
             if result.remote?.sourceName == "App Store" {
                 return .refuse("App Store updates need the menu-bar app (the store's "
-                    + "install path is not reachable from a CLI)")
+                    + "install path is not reachable from a CLI)", nil)
             }
             // #193 originally split this into two messages — "no artefact this
             // time" for a recognised source vs. "no route wired up yet" for one
@@ -232,12 +240,12 @@ public enum Install {
             // (a message asserting something false) to the other bucket. One
             // message, worded to be accurate for both "never has one" and
             // "doesn't have one this time" is available.
-            return .refuse("detection only — this source publishes no installable artefact")
+            return .refuse("detection only — this source publishes no installable artefact", nil)
         }
         if UpdatePolicy.defersToSelfUpdater(
             result, settings: settings.updateSettings, environment: environment) {
             return .refuse("running, and your vendor policy defers to its own updater "
-                + "(quit it, or set Always download & replace)")
+                + "(quit it, or set Always download & replace)", nil)
         }
         // The app's own updater already has bytes coming down for this release.
         // Refused here rather than only in the menu-bar app for the same reason
@@ -253,19 +261,131 @@ public enum Install {
             staged: SelfUpdaterStaging.staged(
                 for: result.app, requireNewerThanInstalled: false)) {
             return .refuse("its own updater has \(result.stagedRelaunchLine(staged).to) staged for the next quit "
-                + "— installing now would be undone (quit it to apply)")
+                + "— installing now would be undone (quit it to apply)", nil)
         }
         if let inFlight = SelfUpdaterStaging.inFlightDownload(for: result.app) {
             let megabytes = Double(inFlight.bytes) / 1_000_000
             return .refuse(String(
                 format: "its own updater is downloading this release (%.1f MB so far) "
-                    + "— left it to finish", megabytes))
+                    + "— left it to finish", megabytes), nil)
         }
         let route = InstallCoordinator.route(for: result, requiresInstaller: needsInstaller)
         if route == .appStore {
-            return .refuse("App Store updates need the menu-bar app")
+            return .refuse("App Store updates need the menu-bar app", route)
         }
         return .install(route)
+    }
+
+    // MARK: - Re-checking before an install actually starts
+
+    /// What the defensive re-check immediately before ONE install concluded, and
+    /// what to do about it.
+    ///
+    /// The plan is built once, from a scan that may be minutes old by the time any
+    /// given item's turn comes: the user held the confirmation prompt, or an
+    /// earlier item in the same batch took a while to download. Between that scan
+    /// and now the app may have updated itself, been installed by hand, or its
+    /// source may have moved to a different artifact — the same reasons
+    /// `AppListModel.performInstall` re-checks before every menu-bar install (see
+    /// `PreInstallGate`). #404: the CLI used to hand the stale plan straight to
+    /// `InstallCoordinator`, skipping all of this.
+    enum ReconsiderOutcome: Sendable, Equatable {
+        /// A newer version was confirmed just now — install THIS `UpdateResult`
+        /// (never `offered`: the disk read may differ, and the source may have
+        /// moved to a different artifact) via this freshly re-derived route.
+        case proceed(UpdateResult, InstallCoordinator.Route)
+        /// The freshly re-derived route isn't one of `--route`'s names. Narrowed,
+        /// not refused — the same rule the planning loop applies before the
+        /// confirmation prompt: an app excluded by `--route` was never asked for.
+        /// Unlike the planning loop, though, `apply` still says so out loud in
+        /// text mode: the plan's route WAS requested, and only stopped matching
+        /// because the re-check moved it — that is new information, not noise
+        /// (#404 review #4).
+        case notRequested(InstallCoordinator.Route)
+        /// Nothing to install, and not a failure. `why` completes "Skipping
+        /// <name>: <why>". Carries the freshly re-derived route when `classify`
+        /// got far enough to produce one before refusing (`Decision.refuse`'s
+        /// second value) — `nil` otherwise, rather than falling back to the
+        /// plan's stale route, which could contradict `why` (#404 review #5: a
+        /// route moving from Vendor to App Store used to emit
+        /// `"route": "vendor"` alongside a `reason` about the App Store).
+        case skip(String, InstallCoordinator.Route?)
+        /// The re-check could not establish whether an update exists — a
+        /// network blip, a rate limit, or a source `UpdatePolicy` has no case
+        /// for. Retryable, and said so, rather than filed as "nothing to do".
+        case cannotConfirm(String?)
+        /// The source's answer walked backwards between the offer and the
+        /// confirm — see `PreInstallDecision.answerRegressed`. Carries no
+        /// message: the caller already holds both `UpdateResult`s, and the two
+        /// version strings are the finding.
+        case answerRegressed
+        /// The re-scan found no bundle it could read at the plan's path right
+        /// now. Deliberately its own case rather than `.cannotConfirm`: unlike a
+        /// source query failing (a network blip, retryable), this is a fact
+        /// about the local disk that a retry cannot change — either the app
+        /// really is gone, or it never will be until whatever broke its
+        /// Info.plist is fixed by hand. `why` states only what was observed,
+        /// not which of those it was: `AppScanner.readApp` returns nil for both
+        /// (#404 review #6).
+        case unreadable(String)
+    }
+
+    /// Pure classification — no I/O. `offered` is what the plan showed when the
+    /// user (or `--yes`) approved it; `confirmed` is a fresh disk read and a
+    /// fresh source query for the SAME app, taken right before backup/replace
+    /// (`recheckOne`, called from `apply`) — `nil` when that re-scan found no
+    /// bundle it could read (see `.unreadable` above). `environment` must be
+    /// re-derived from the current machine state too (`liveEnvironment`), not the
+    /// snapshot the plan was built from — a batch install can take minutes,
+    /// during which another item's install can start or finish.
+    static func reconsider(
+        offered: UpdateResult, confirmed: UpdateResult?, settings: Settings,
+        environment: InstallEnvironment, routes: Set<InstallCoordinator.Route>
+    ) -> ReconsiderOutcome {
+        guard let confirmed else {
+            return .unreadable(
+                "no readable bundle at \(offered.app.path.path) right now — it may have been "
+                + "uninstalled, or its Info.plist could not be parsed")
+        }
+        let decision = PreInstallGate.decision(
+            for: confirmed.status,
+            offered: offered.remote?.versionSide ?? VersionSide(),
+            confirmed: confirmed.remote?.versionSide ?? VersionSide())
+        switch decision {
+        case .proceed:
+            // The route can move too — the same source may now resolve a
+            // different artifact (a vendor cutting a new release between the
+            // scan and now is exactly the case `.proceed` covers) — so this
+            // reclassifies from `confirmed` rather than reusing the plan's route.
+            switch classify(confirmed, settings: settings, environment: environment) {
+            case .install(let route):
+                guard routes.isEmpty || routes.contains(route) else { return .notRequested(route) }
+                return .proceed(confirmed, route)
+            case .refuse(let why, let route):
+                return .skip(why, route)
+            }
+        case .alreadyCurrent:
+            // States only what was observed — the disk is at this version and
+            // there is nothing newer to install. Not WHY: it could be the app's
+            // own updater, a manual install, a vendor pulling the release the
+            // plan was built against, or (with `--yes`) simply that there was
+            // never a confirmation prompt to wait behind at all. The previous
+            // wording ("updated to X while waiting for confirmation") asserted
+            // the first of those unconditionally and was flatly false under
+            // `--yes` (#404 review #1).
+            return .skip(
+                "already at \(confirmed.app.shortVersion ?? confirmed.app.buildVersion ?? "a build") "
+                    + "on disk — nothing to install",
+                nil)
+        case .managedElsewhere:
+            return .skip(
+                "now managed elsewhere (App Store, Toolbox, or TestFlight) — install it there instead",
+                nil)
+        case .cannotConfirm(let message):
+            return .cannotConfirm(message)
+        case .answerRegressed:
+            return .answerRegressed
+        }
     }
 
     static func describe(_ plan: [Planned], refusals: [(UpdateResult, String)]) {
@@ -301,26 +421,192 @@ public enum Install {
         return answer == "y" || answer == "yes"
     }
 
+    // MARK: - Re-checking before an install actually starts (I/O)
+
+    /// Re-read this one bundle off disk and re-query its source, right before
+    /// backup/replace. Scoped to the single bundle (`AppScanner.scan(bundlesAt:)`),
+    /// not a sweep of every scan location — the same reasoning as
+    /// `AppListModel.recheckMany` (issue #226): a batch install re-checking every
+    /// remaining item by sweeping the whole machine would make the disk work scale
+    /// with the plan size for no benefit.
+    ///
+    /// `testflight`/`toolbox`/`checker` are built ONCE for the whole batch by
+    /// `apply`, not per item — see that function's doc comment (#404 review #8).
+    /// This function still does its own per-item work: the bundle re-scan and the
+    /// source re-query, which is the entire point of the re-check and must not be
+    /// hoisted alongside the shared plumbing.
+    ///
+    /// TestFlight-free for the same reason `recheckMany` is: this must never block
+    /// on TestFlight's local database, which lives behind the Sequoia app-data TCC
+    /// gate — with nobody at a prompt mid-install that would hang the batch. The
+    /// next full `duo check`/`duo install` re-applies TestFlight tagging from
+    /// scratch; this single-app recheck just scans without it, so a TestFlight
+    /// build never resolves as `.updateAvailable` here even if it has one.
+    ///
+    /// Returns `nil` when there is nothing to re-confirm against: the plan's
+    /// bundle is missing, its Info.plist failed to parse (`AppScanner.readApp`
+    /// returns nil for both — it cannot say which), or the resolved bundle now
+    /// has a different identity than the plan's (mirroring
+    /// `AppListModel.recheckMany`'s own guard: "a bundle that now resolves
+    /// elsewhere reads as gone, not as a row under another id" — `InstalledApp.id`
+    /// is the resolved path). `reconsider` turns `nil` into `.unreadable`
+    /// (#404 review #6, #7).
+    static func recheckOne(
+        _ result: UpdateResult,
+        testflight: TestFlightInventory, toolbox: ToolboxInventory, checker: UpdateChecker
+    ) async -> UpdateResult? {
+        let apps = AppScanner(toolbox: toolbox, testflight: testflight)
+            .scan(bundlesAt: [result.app.path])
+        guard let app = apps.first, app.id == result.app.id else { return nil }
+        // `freshening: true`, matching `recheckMany`: a recheck is the user (or
+        // `--yes`) insisting on a live answer, and must not be satisfied out of a
+        // source's own memo — see `UpdateChecker.check`'s doc comment.
+        let checked = await checker.check([app], freshening: true)
+        return checked.first ?? UpdateResult(app: app, remote: nil, status: .unknown)
+    }
+
+    /// The machine state `classify`/`UpdatePolicy` need, re-derived fresh for
+    /// THIS app right before its install — not the snapshot the plan (or an
+    /// earlier item's `.deferWhenRunning` re-check) was built from. A batch
+    /// install can take minutes; another item finishing or a self-updater
+    /// starting mid-batch must be visible to the item whose turn has just come up.
+    static func liveEnvironment(for result: UpdateResult, plannedElevation: Set<String>) -> InstallEnvironment {
+        InstallEnvironment(
+            isHelperEnabled: false,
+            runningAppPaths: Check.runningBundlePaths(),
+            stagedSelfUpdates: stagedSelfUpdates(for: [result]),
+            elevationRequiredPaths: plannedElevation,
+            runningBundleIDs: Check.runningBundleIDs())
+    }
+
     // MARK: - Applying
 
-    static func apply(_ plan: [Planned], json: Bool, keepBackups: Bool) async -> Int32 {
+    static func apply(
+        _ plan: [Planned], settings: Settings, routes: Set<InstallCoordinator.Route>,
+        json: Bool, keepBackups: Bool
+    ) async -> Int32 {
         if json { NDJSON.begin("install") }
         let coordinator = InstallCoordinator()
+        // `elevationRequiredPaths` is a fact about the install locations, which
+        // don't move between plan and apply — computed once, like the plan's own
+        // `environment` was, rather than re-stat'd per item.
+        let elevationRequiredPaths = InPlaceSwap.elevationRequiredPaths(for: plan.map(\.result.app.path))
+        // Built ONCE for the whole batch, not once per item: `ToolboxInventory()`
+        // synchronously reads and parses its state.json, and `Inventory.checker`
+        // resolves the whole source stack (GitHub token, Alcove, …) — a plan of N
+        // items must not pay for N reads and N resolves just to answer "is this
+        // one app still what the plan thinks it is?" N times (the same shape
+        // `AppListModel.recheckMany`'s doc comment warns about, #226). Each
+        // item's OWN re-scan and source query — the actual point of this issue —
+        // still happen per item, inside `recheckOne`; only the shared plumbing
+        // around them is hoisted here (#404 review #8).
+        let recheckTestflight = TestFlightInventory(macRows: [], accessible: false)
+        let recheckToolbox = ToolboxInventory()
+        let recheckChecker = Inventory.checker(
+            settings, testflight: recheckTestflight, toolbox: recheckToolbox)
         var failed = 0
+        var installedCount = 0
+        var skippedCount = 0
+        // Declined elevation is a decision, not a failure (see the catch below),
+        // but it must not vanish from the summary either — counted separately
+        // so `installedCount + failed + skippedCount + declinedCount` accounts
+        // for every item in the plan (#404 review #3).
+        var declinedCount = 0
+        // Only items whose bundle was ACTUALLY replaced
+        // (`InstallCoordinator.Outcome.applied`) — a `.notRequested`, `.skip`,
+        // `.unreadable`, `.cannotConfirm`, or `.answerRegressed` item was never
+        // touched, so its bundle running is not "still running the OLD code"
+        // (the phrase below), it is just running, same as before `duo install`
+        // was called at all. And a `.installer` route, or an install that threw,
+        // means `coordinator.perform` returned (or failed) WITHOUT putting the
+        // new version on disk — `applied` is exactly the signal for that, and is
+        // more precise than "the call didn't throw" (#404 review #2).
+        var attempted: [(name: String, path: URL)] = []
         for item in plan {
             let name = item.result.app.name
             if !json { print("→ \(name)") }
+
+            // Defensive re-check: the app may already be current — updated by its
+            // own updater, or installed by hand — since the plan was built, or the
+            // source may have changed its mind. Re-read the bundle and re-query
+            // the source before touching anything. See `PreInstallGate` / #404.
+            let confirmed = await recheckOne(
+                item.result, testflight: recheckTestflight, toolbox: recheckToolbox,
+                checker: recheckChecker)
+            let live = liveEnvironment(
+                for: confirmed ?? item.result, plannedElevation: elevationRequiredPaths)
+            let outcome = reconsider(
+                offered: item.result, confirmed: confirmed, settings: settings,
+                environment: live, routes: routes)
+
+            let toInstall: UpdateResult
+            let route: InstallCoordinator.Route
+            switch outcome {
+            case .proceed(let result, let derivedRoute):
+                toInstall = result
+                route = derivedRoute
+            case .notRequested(let derivedRoute):
+                if !json {
+                    print("   skipping: re-checked route is now \(derivedRoute.rawValue), "
+                        + "no longer requested")
+                }
+                emitSkipped(name: name, route: derivedRoute,
+                            reason: "not requested: --route no longer includes it", json: json)
+                skippedCount += 1
+                continue
+            case .skip(let why, let derivedRoute):
+                if !json { print("   skipping: \(why)") }
+                emitSkipped(name: name, route: derivedRoute, reason: why, json: json)
+                skippedCount += 1
+                continue
+            case .unreadable(let why):
+                // Not counted as `failed`: like `.alreadyCurrent`/`.managedElsewhere`
+                // above, there is nothing here a retry would change — either the
+                // app really is gone, or its Info.plist needs fixing by hand,
+                // and re-running `duo install` answers neither.
+                if !json { print("   skipping: \(why)") }
+                emitSkipped(name: name, route: nil, reason: why, json: json)
+                skippedCount += 1
+                continue
+            case .cannotConfirm(let message):
+                failed += 1
+                let reason = message ?? "no source covers this app"
+                FileHandle.standardError.write(Data(
+                    "   failed: the pre-install re-check could not confirm an update: \(reason)\n".utf8))
+                // `nil`, not `item.route`: `reconsider` returns here BEFORE ever
+                // calling `classify` on a fresh read, so there is no freshly
+                // re-derived route to give — only the plan's stale one, which
+                // is exactly the value #404 review #5 says not to fall back to.
+                // Caught by code review after the first pass only fixed `.skip`.
+                emitSkipped(name: name, route: nil, reason: reason, json: json)
+                continue
+            case .answerRegressed:
+                failed += 1
+                // Both versions in the message, because the pair IS the finding:
+                // either number alone reads as an ordinary check. Same rule
+                // `AppListModel.performInstall` follows for the same case.
+                let was = item.result.remote?.displayVersion ?? "?"
+                let now = confirmed?.remote?.displayVersion ?? "?"
+                FileHandle.standardError.write(Data(
+                    "   failed: the update source answered \(was), then \(now) — nothing was installed.\n".utf8))
+                // `nil` for the same reason as `.cannotConfirm` above: no fresh
+                // route was ever derived for a regressed answer either.
+                emitSkipped(name: name, route: nil,
+                            reason: "answer regressed: offered \(was), confirmed \(now)", json: json)
+                continue
+            }
+
             // The same rollback point the menu-bar app takes, honouring the same
             // preference. Not fatal when it fails — but said out loud, because
             // the alternative is discovering the safety net is gone only when a
             // later rollback finds nothing.
-            if keepBackups, InstallCoordinator.wantsBackup(item.route) {
-                switch await InstallCoordinator.backUp(item.result.app, route: item.route) {
+            if keepBackups, InstallCoordinator.wantsBackup(route) {
+                switch await InstallCoordinator.backUp(toInstall.app, route: route) {
                 case .saved:
-                    if !json { print("   backed up \(item.result.app.shortVersion ?? "current")") }
+                    if !json { print("   backed up \(toInstall.app.shortVersion ?? "current")") }
                 case .savedWithoutRuntimeState(let omitted):
                     if !json {
-                        print("   backed up \(item.result.app.shortVersion ?? "current")"
+                        print("   backed up \(toInstall.app.shortVersion ?? "current")"
                             + " — without \(omitted) file(s) the app wrote inside its own"
                             + " bundle, which it will recreate")
                     }
@@ -334,19 +620,35 @@ public enum Install {
                 }
             }
             do {
-                let outcome = try await coordinator.perform(
-                    item.result, route: item.route,
+                let installOutcome = try await coordinator.perform(
+                    toInstall, route: route,
                     progress: { stage in
                         guard !json else { return }
                         if let text = describe(stage) { print("   \(text)") }
                     })
-                emit(name: name, route: item.route, outcome: outcome, json: json)
+                // Only when the bundle is actually on disk now: an `.installer`
+                // route returns here with `applied == false` while the system
+                // installer window is still open, and the "still running the old
+                // code" summary below must not call that app's running copy
+                // stale (#404 review #2).
+                if installOutcome.applied {
+                    attempted.append((name: name, path: toInstall.app.path))
+                }
+                emit(name: name, route: route, outcome: installOutcome, json: json)
+                installedCount += 1
             } catch is AuthorizationDeclinedError {
                 // Dismissing the password panel is a decision, not a failure — it
                 // does not count toward `failed`, and it is remembered so neither
                 // `duo` nor the menu bar re-raises the panel for this copy until
-                // the user asks. Written to the same suite the app reads.
-                Settings.recordDeclinedElevation(item.result.app)
+                // the user asks. Written to the same suite the app reads. Still
+                // counted (`declinedCount`) and still emitted (`emitSkipped`): the
+                // old code left this item out of every counter and out of the
+                // `--json` stream, so it vanished from the summary entirely
+                // (#404 review #3).
+                Settings.recordDeclinedElevation(toInstall.app)
+                declinedCount += 1
+                emitSkipped(name: name, route: route,
+                            reason: "administrator access was declined", json: json)
                 FileHandle.standardError.write(Data("""
                        skipped: administrator access was declined, so \(name) will no \
                     longer be offered as a one-click. Undo it from the app's row menu, \
@@ -367,24 +669,37 @@ public enum Install {
                 }
             }
         }
-        let installed = plan.count - failed
         if !json {
-            print("\n\(installed) installed, \(failed) failed.")
+            print("\n" + summaryLine(
+                installed: installedCount, failed: failed,
+                skipped: skippedCount, declined: declinedCount))
             // The bundle on disk is new; the process still running is not. The
             // menu-bar app restarts these itself per the user's preference; the
             // CLI does not quit your apps behind your back, but it must not leave
             // you believing the update is already live either. Sampled after the
             // batch, so an app that exited during it is not named.
             let running = Check.runningBundlePaths()
-            let stale = plan
-                .filter { running.contains(UpdatePolicy.runtimeBundlePath($0.result.app.path)) }
-                .map(\.result.app.name)
+            let stale = attempted
+                .filter { running.contains(UpdatePolicy.runtimeBundlePath($0.path)) }
+                .map(\.name)
             if !stale.isEmpty {
                 print("\nStill running the old code: \(stale.joined(separator: ", "))")
                 print("  duo restart \(stale.joined(separator: " "))")
             }
         }
         return failed == 0 ? 0 : 1
+    }
+
+    /// The text-mode summary line, pulled out as a pure function so its exact
+    /// counting and phrasing is testable without driving a real install. Zero
+    /// counts are omitted (a plan with nothing skipped/declined shouldn't say
+    /// "0 skipped, 0 declined" every time) — `declined` did not exist before
+    /// #404 review #3, when a declined-elevation item was silently left out of
+    /// every counter and this line, and so vanished from the summary entirely.
+    static func summaryLine(installed: Int, failed: Int, skipped: Int, declined: Int) -> String {
+        "\(installed) installed, \(failed) failed"
+            + (skipped > 0 ? ", \(skipped) skipped" : "")
+            + (declined > 0 ? ", \(declined) declined" : "") + "."
     }
 
     static func emit(
@@ -408,6 +723,36 @@ public enum Install {
         } else {
             print("   installed.")
         }
+    }
+
+    /// The `--json` record for an item the pre-install re-check did NOT install
+    /// (`reconsider` returned anything but `.proceed`, or the install was declined).
+    /// Without this, `emit` firing only on success means these items vanish from
+    /// the NDJSON stream with no trace — the same shape as `emit`'s row
+    /// (`app`/`applied`), plus `reason` in place of the byte count and staged-
+    /// package fields that only an actual install produces. `route` is omitted
+    /// rather than defaulted to the plan's stale value when the caller has none
+    /// to give — a wrong route in the same row as an accurate `reason` is worse
+    /// than a missing field (#404 review #5). Text-mode printing is the caller's
+    /// job: each outcome has its own wording, so this only ever writes the JSON
+    /// line.
+    static func emitSkipped(
+        name: String, route: InstallCoordinator.Route?, reason: String, json: Bool
+    ) {
+        guard json else { return }
+        NDJSON.emit(skippedPayload(name: name, route: route, reason: reason))
+    }
+
+    /// The row `emitSkipped` writes, pulled out as a pure function so the
+    /// route-omission rule (#404 review #5) is testable directly: `route` is
+    /// left out of the payload entirely when the caller has none to give,
+    /// rather than defaulted to something that could contradict `reason`.
+    static func skippedPayload(
+        name: String, route: InstallCoordinator.Route?, reason: String
+    ) -> [String: Any] {
+        var payload: [String: Any] = ["app": name, "applied": false, "reason": reason]
+        if let route { payload["route"] = route.rawValue }
+        return payload
     }
 
     /// Progress worth a line of terminal output. The fine-grained download

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -660,6 +660,12 @@ public enum Install {
                 let message = (error as? LocalizedError)?.errorDescription
                     ?? error.localizedDescription
                 FileHandle.standardError.write(Data("   failed: \(message)\n".utf8))
+                // The one ending a `--json` consumer most needs to see. Every
+                // other way an approved item can end without being installed
+                // now leaves a row; a failure leaving none would mean the
+                // stream undercounts exactly the failures, which is the
+                // opposite of the property `emitSkipped` was added for.
+                emitSkipped(name: name, route: route, reason: message, json: json)
                 if error is AppManagementRequiredError {
                     FileHandle.standardError.write(Data("""
                            Grant App Management to this binary in System Settings ▸ \

--- a/CLI/Sources/DuoKit/Inventory.swift
+++ b/CLI/Sources/DuoKit/Inventory.swift
@@ -35,14 +35,23 @@ public enum Inventory {
     /// Build the checker the same way the menu-bar app does, so a version
     /// difference between `duo check` and the app is a bug rather than a
     /// configuration difference.
-    public static func checker(_ settings: Settings) -> UpdateChecker {
+    ///
+    /// `testflight`/`toolbox` default to a fresh real read, same as always; the
+    /// pre-install re-check (`Install.apply`) passes in the TestFlight-free
+    /// sentinel and the single `ToolboxInventory` it built once for the whole
+    /// batch — see that function's doc comment (#404 review #8).
+    public static func checker(
+        _ settings: Settings,
+        testflight: TestFlightInventory = TestFlightInventory(),
+        toolbox: ToolboxInventory = ToolboxInventory()
+    ) -> UpdateChecker {
         UpdateChecker(
             sources: SourceStack.make(
                 githubToken: settings.githubToken, alcove: settings.alcove,
                 channelStore: ResolvedChannelStore.shared),
             maxConcurrency: settings.maxConcurrency,
-            toolbox: ToolboxSource(inventory: ToolboxInventory()),
-            testflight: TestFlightInventory(),
+            toolbox: ToolboxSource(inventory: toolbox),
+            testflight: testflight,
             channelStore: ResolvedChannelStore.shared)
     }
 

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -35,11 +35,12 @@ import DuoUpdaterCore
     }
 
     private func settings(
-        vendorPolicy: VendorInstallPolicy = .deferWhenRunning
+        vendorPolicy: VendorInstallPolicy = .deferWhenRunning,
+        appStoreStrategy: AppStoreUpdateStrategy = .full
     ) -> Settings {
         Settings(
             updateSettings: UpdateSettings(
-                appStoreUpdateStrategy: .full, vendorInstallPolicy: vendorPolicy),
+                appStoreUpdateStrategy: appStoreStrategy, vendorInstallPolicy: vendorPolicy),
             ignoredKeys: [], skippedVersions: [:], customScanPaths: [],
             maxConcurrency: 12, keepBackups: true, githubToken: nil, alcove: nil)
     }
@@ -77,18 +78,51 @@ import DuoUpdaterCore
 
     /// The store route is refused up front rather than attempted and failed
     /// halfway: it needs the privileged helper or the Accessibility API, and a
-    /// standalone binary has neither.
+    /// standalone binary has neither. Under `.full` (this test's default
+    /// settings), `canAutoInstall`'s App Store case requires
+    /// `environment.isHelperEnabled` — which the CLI never sets — so this
+    /// refusal comes from the EARLIER guard in `classify`, before a route is
+    /// ever computed. `route` is therefore `nil`, not `.appStore`: see
+    /// `theAppStoreRefusalCarriesTheRouteWhenClassifyComputedOne` below for the
+    /// other refusal branch, which does have one to give.
     @Test func theAppStoreIsRefusedWithAReason() {
         let decision = Install.classify(
             result(source: "App Store",
                    appStore: AppStoreAvailability(
                     trackID: 1, availableRegion: "us", homeRegion: "us", storeName: nil)),
             settings: settings(), environment: environment())
-        guard case .refuse(let why) = decision else {
+        guard case .refuse(let why, let route) = decision else {
             Issue.record("expected a refusal, got \(decision)")
             return
         }
         #expect(why.contains("App Store"))
+        #expect(route == nil)
+    }
+
+    /// #404 review #5: `Decision.refuse`'s second value is the route
+    /// `classify` had already computed before deciding to refuse — used so
+    /// `reconsider`/`emitSkipped` never fall back to a stale plan route that
+    /// could contradict the refusal message. Under `.incremental`,
+    /// `canAutoInstall`'s App Store case returns `true` unconditionally (the
+    /// AX route needs no helper), so this reaches the LATER refusal — the one
+    /// after `InstallCoordinator.route(for:)` has already resolved `.appStore`
+    /// — and that route must come along. Mutation (reverted after running):
+    /// changed `return .refuse("App Store updates need the menu-bar app",
+    /// route)` to `return .refuse("App Store updates need the menu-bar app",
+    /// nil)` in `Install.classify` — this test went red (expected
+    /// `.appStore`, got `nil`).
+    @Test func theAppStoreRefusalCarriesTheRouteWhenClassifyComputedOne() {
+        let decision = Install.classify(
+            result(source: "App Store",
+                   appStore: AppStoreAvailability(
+                    trackID: 1, availableRegion: "us", homeRegion: "us", storeName: nil)),
+            settings: settings(appStoreStrategy: .incremental), environment: environment())
+        guard case .refuse(let why, let route) = decision else {
+            Issue.record("expected a refusal, got \(decision)")
+            return
+        }
+        #expect(why.contains("App Store"))
+        #expect(route == .appStore)
     }
 
     /// Detection-only apps have no artefact we vet, so there is nothing to
@@ -97,7 +131,7 @@ import DuoUpdaterCore
         let decision = Install.classify(
             result(source: "Vendor", vendorKind: nil),
             settings: settings(), environment: environment())
-        guard case .refuse(let why) = decision else {
+        guard case .refuse(let why, _) = decision else {
             Issue.record("expected a refusal, got \(decision)")
             return
         }
@@ -111,7 +145,7 @@ import DuoUpdaterCore
         let decision = Install.classify(
             result(source: "Electron", vendorKind: nil),
             settings: settings(), environment: environment())
-        guard case .refuse(let why) = decision else {
+        guard case .refuse(let why, _) = decision else {
             Issue.record("expected a refusal, got \(decision)")
             return
         }
@@ -135,7 +169,7 @@ import DuoUpdaterCore
         let decision = Install.classify(
             result(source: "Xcode Releases", vendorKind: nil),
             settings: settings(), environment: environment())
-        guard case .refuse(let why) = decision else {
+        guard case .refuse(let why, _) = decision else {
             Issue.record("expected a refusal, got \(decision)")
             return
         }
@@ -180,6 +214,344 @@ import DuoUpdaterCore
             Issue.record("alwaysOverwrite should install anyway")
             return
         }
+    }
+}
+
+/// #404: the CLI used to hand the PLAN's stale `UpdateResult` straight to
+/// `InstallCoordinator`, with no re-check between "the user approved this" and
+/// "this is now being installed" — a window a confirmation prompt or an earlier
+/// item's download can hold open for a long time. `Install.reconsider` is the
+/// pure classification the fix hangs on; `Install.apply` (mostly untested here —
+/// it's I/O around a concrete, unmockable `InstallCoordinator`) does the
+/// re-scan/re-check and calls this right before backup. The `attempted`/
+/// `declinedCount` bookkeeping `apply` does around `coordinator.perform` (#404
+/// review #2, #3) is therefore verified by code reading, not a mutation-tested
+/// unit test here — see the PR description for what was checked by hand.
+///
+/// Each fixture below builds an `offered` (what the plan showed) and a
+/// `confirmed` (what a fresh disk read + source query answers right before
+/// install) independently, the same way `apply` will hold two independently-aged
+/// `UpdateResult`s for the same app.
+@Suite struct InstallReconsiderTests {
+
+    private let fixturePath = "/Applications/Fixture.app"
+
+    private func app(shortVersion: String = "1.0") -> InstalledApp {
+        InstalledApp(
+            name: "Fixture", bundleID: "com.example.fixture",
+            shortVersion: shortVersion, buildVersion: "1",
+            path: URL(fileURLWithPath: fixturePath), isMASApp: false,
+            sparkleFeedURL: nil)
+    }
+
+    private func vendorOffer(latest: String = "1.1") -> UpdateResult {
+        UpdateResult(
+            app: app(),
+            remote: RemoteVersion(
+                shortVersion: latest, version: nil,
+                downloadURL: URL(string: "https://example.com/fixture.dmg"),
+                sourceName: "Vendor", requiresManualInstaller: false,
+                vendorInstallerKind: .dmg),
+            status: .updateAvailable(latest: latest))
+    }
+
+    private func settings() -> Settings {
+        Settings(
+            updateSettings: UpdateSettings(
+                appStoreUpdateStrategy: .full, vendorInstallPolicy: .deferWhenRunning),
+            ignoredKeys: [], skippedVersions: [:], customScanPaths: [],
+            maxConcurrency: 12, keepBackups: true, githubToken: nil, alcove: nil)
+    }
+
+    private func environment() -> InstallEnvironment {
+        InstallEnvironment(isHelperEnabled: false, runningAppPaths: [], stagedSelfUpdates: [:])
+    }
+
+    /// Pins `PreInstallDecision.alreadyCurrent` → `ReconsiderOutcome.skip`, not a
+    /// failure. Mutation (reverted after running): changed
+    /// `case .alreadyCurrent: return .skip(...)` to
+    /// `return .proceed(confirmed, .vendor)` in `Install.reconsider` — this test
+    /// went red (expected `.skip`, got `.proceed`), confirming it actually
+    /// exercises that arm rather than passing by construction.
+    @Test func diskAlreadyUpdatedIsSkippedNotInstalled() {
+        let offered = vendorOffer()
+        // Re-scan finds the disk already at 1.1 and the source agrees there is
+        // nothing newer: `remote: nil` is an empty `VersionSide`, which
+        // `PreInstallGate` treats as "never regressed" (fails closed) — so this
+        // lands on `.alreadyCurrent`, not `.answerRegressed`.
+        let confirmed = UpdateResult(app: app(shortVersion: "1.1"), remote: nil, status: .upToDate)
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [])
+        guard case .skip = outcome else {
+            Issue.record("expected a skip, got \(outcome)")
+            return
+        }
+    }
+
+    /// #404 review #1: the message states only what was observed (the disk is
+    /// at some version, nothing newer to install) and never asserts WHY — the
+    /// old wording ("updated to X while waiting for confirmation") named one
+    /// specific cause unconditionally, which is flatly false under `--yes`
+    /// (there is no confirmation prompt to wait behind at all). Mutation
+    /// (reverted after running): put the old wording back — this test went
+    /// red (the message claimed to have "waited for confirmation").
+    @Test func alreadyCurrentWordingStatesOnlyWhatWasObserved() {
+        let offered = vendorOffer()
+        let confirmed = UpdateResult(app: app(shortVersion: "1.1"), remote: nil, status: .upToDate)
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [])
+        guard case .skip(let why, _) = outcome else {
+            Issue.record("expected a skip, got \(outcome)")
+            return
+        }
+        #expect(!why.contains("waiting for confirmation"))
+        #expect(why.contains("1.1"))
+    }
+
+    /// Pins `PreInstallDecision.cannotConfirm` → `ReconsiderOutcome.cannotConfirm`,
+    /// counted as a failure by `apply` (retryable — the source, not the app, is
+    /// what's in doubt). Mutation: changed
+    /// `case .cannotConfirm(let message): return .cannotConfirm(message)` to
+    /// `return .skip(message ?? "?")` — went red (expected `.cannotConfirm`, got
+    /// `.skip`).
+    @Test func sourceQueryFailureCannotConfirm() {
+        let offered = vendorOffer()
+        let confirmed = UpdateResult(app: app(), remote: nil, status: .error("connection timed out"))
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [])
+        guard case .cannotConfirm(let message) = outcome else {
+            Issue.record("expected cannotConfirm, got \(outcome)")
+            return
+        }
+        #expect(message == "connection timed out")
+    }
+
+    /// Pins `PreInstallDecision.answerRegressed` → `ReconsiderOutcome.answerRegressed`
+    /// (counted as a failure, both versions preserved for the caller to print).
+    /// Mutation: changed `case .answerRegressed: return .answerRegressed` to
+    /// `return .skip("regressed")` — went red (expected `.answerRegressed`, got
+    /// `.skip`).
+    @Test func answerWalkingBackwardsIsAFailureNotASkip() {
+        let offered = vendorOffer(latest: "1.1")
+        // The re-check's OWN answer is older than what it just offered, and
+        // calls the app current on the strength of it — the Nowdex shape
+        // `PreInstallDecision.answerRegressed`'s doc comment describes.
+        let confirmed = UpdateResult(
+            app: app(),
+            remote: RemoteVersion(
+                shortVersion: "1.0", version: nil, downloadURL: nil,
+                sourceName: "Vendor", requiresManualInstaller: false),
+            status: .upToDate)
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [])
+        #expect(outcome == .answerRegressed)
+    }
+
+    /// The case #404 itself is about: while the user held the confirmation
+    /// prompt (or an earlier item in the batch installed), the vendor shipped
+    /// AGAIN — the re-check confirms 1.2, newer than the 1.1 that was offered.
+    /// `reconsider` must install `confirmed` (1.2), never `offered` (1.1) — the
+    /// whole point of re-checking is that the stale plan is not what gets
+    /// installed. Mutation: changed `return .proceed(confirmed, route)` to
+    /// `return .proceed(offered, route)` in the `.install` arm — went red
+    /// (`result.remote?.displayVersion` was "1.1", not the expected "1.2").
+    @Test func updateAppearingDuringTheWaitInstallsTheNewerConfirmedVersion() {
+        let offered = vendorOffer(latest: "1.1")
+        let confirmed = vendorOffer(latest: "1.2")
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [])
+        guard case .proceed(let result, let route) = outcome else {
+            Issue.record("expected a proceed, got \(outcome)")
+            return
+        }
+        #expect(result.remote?.displayVersion == "1.2")
+        #expect(route == .vendor)
+    }
+
+    /// `reconsider` must classify off `confirmed`, not `offered`: the source can
+    /// have moved to a completely different distribution channel while the plan
+    /// sat waiting for confirmation, and the freshly-derived route is the one
+    /// that governs whether this can be installed at all. Mutation: changed
+    /// `classify(confirmed, ...)` to `classify(offered, ...)` in the `.proceed`
+    /// arm — went red (the Vendor `offered` classifies as installable, so the
+    /// outcome became `.proceed` instead of the expected `.skip`).
+    ///
+    /// Also pins #404 review #5: the `route` carried by `.skip` here is `nil`
+    /// (this App Store item hits the SAME early refusal as
+    /// `theAppStoreIsRefusedWithAReason` above, under this suite's `.full`
+    /// settings), never the plan's stale `.vendor` — the bug this review found:
+    /// the `--json` line used to say `"route": "vendor"` right next to a
+    /// `reason` about the App Store. Mutation (reverted after running):
+    /// changed `case .refuse(let why, let route): return .skip(why, route)` to
+    /// `return .skip(why, .vendor)` — this test went red (expected `nil`, got
+    /// `.vendor`).
+    @Test func routeMovingToAppStoreIsSkippedNotInstalled() {
+        let offered = vendorOffer()
+        let confirmed = UpdateResult(
+            app: app(),
+            remote: RemoteVersion(
+                shortVersion: "1.1", version: nil, downloadURL: nil,
+                sourceName: "App Store",
+                appStore: AppStoreAvailability(
+                    trackID: 1, availableRegion: "us", homeRegion: "us", storeName: nil),
+                requiresManualInstaller: false),
+            status: .updateAvailable(latest: "1.1"))
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [])
+        guard case .skip(let why, let route) = outcome else {
+            Issue.record("expected a skip, got \(outcome)")
+            return
+        }
+        #expect(why.contains("App Store"))
+        #expect(route == nil)
+    }
+
+    /// `--route` narrows on the RE-DERIVED route, not the plan's original one —
+    /// the plan's `Vendor` source is still what `confirmed` reports here, so this
+    /// is really pinning that the filter is applied a second time after
+    /// `reconsider` classifies, not that classification moved. Mutation: removed
+    /// the `guard routes.isEmpty || routes.contains(route) else { … }` in the
+    /// `.install` arm (unconditional `.proceed`) — went red (expected
+    /// `.notRequested`, got `.proceed`).
+    @Test func routeFilterAppliesAgainAfterReconsidering() {
+        let offered = vendorOffer()
+        let confirmed = vendorOffer()
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [.homebrew])
+        guard case .notRequested(let route) = outcome else {
+            Issue.record("expected notRequested, got \(outcome)")
+            return
+        }
+        #expect(route == .vendor)
+    }
+
+    /// #404 review #6: a re-scan that found no readable bundle (`recheckOne`
+    /// returning `nil`, whether the app was uninstalled or its Info.plist
+    /// failed to parse — `AppScanner.readApp` returns nil for both, and this
+    /// cannot assert which) must NOT become `.cannotConfirm` — that reads as
+    /// retryable, and re-running `duo install` cannot change whether a bundle
+    /// exists right now. Mutation (reverted after running): changed
+    /// `guard let confirmed else { return .unreadable(...) }` to
+    /// `return .cannotConfirm(nil)` in `Install.reconsider` — this test went
+    /// red (expected `.unreadable`, got `.cannotConfirm`).
+    @Test func noReadableBundleIsUnreadableNotCannotConfirm() {
+        let offered = vendorOffer()
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: nil, settings: settings(),
+            environment: environment(), routes: [])
+        guard case .unreadable(let why) = outcome else {
+            Issue.record("expected unreadable, got \(outcome)")
+            return
+        }
+        // States only what was observed, hedged rather than asserted — not
+        // which of "uninstalled" or "Info.plist failed to parse" it was.
+        #expect(why.contains("may have"))
+        #expect(why.contains(fixturePath))
+    }
+
+    /// #404 review #7: `recheckOne` refuses to treat a bundle that now resolves
+    /// to a DIFFERENT app as a re-confirmation of the plan's app — mirroring
+    /// `AppListModel.recheckMany`'s own guard ("a bundle that now resolves
+    /// elsewhere reads as gone, not as a row under another id"). Built with a
+    /// real symlink rather than asserted in the abstract: `AppScanner.admit`
+    /// resolves symlinks before building `InstalledApp.path` (which is also
+    /// `InstalledApp.id`), so a plan's path that is now a symlink pointing at a
+    /// completely different bundle is exactly the shape that guard exists for.
+    /// Mutation (reverted after running): removed the `app.id == result.app.id`
+    /// half of the guard in `Install.recheckOne` (kept only `apps.first`) —
+    /// this test went red (expected `nil`, got the OTHER app's `UpdateResult`).
+    @Test func aBundleThatNowResolvesElsewhereReadsAsGoneNotAsAnotherApp() async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("recheck-identity-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: root) }
+
+        let otherApp = root.appendingPathComponent("SomeOtherApp.app")
+        let info = otherApp.appendingPathComponent("Contents/Info.plist")
+        try fm.createDirectory(at: info.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let plist: [String: Any] = [
+            "CFBundleDisplayName": "Some Other App",
+            "CFBundleIdentifier": "com.example.other",
+            "CFBundleShortVersionString": "9.9",
+            "CFBundleVersion": "9",
+            "CFBundleExecutable": "SomeOtherApp",
+        ]
+        try PropertyListSerialization
+            .data(fromPropertyList: plist, format: .xml, options: 0)
+            .write(to: info)
+
+        // The plan's path is a symlink — at plan time it may well have
+        // resolved to THIS app, but by the time `recheckOne` runs it points
+        // somewhere else entirely (the scenario the identity guard exists for).
+        let alias = root.appendingPathComponent("Fixture.app")
+        try fm.createSymbolicLink(at: alias, withDestinationURL: otherApp)
+
+        let offered = UpdateResult(
+            app: InstalledApp(
+                name: "Fixture", bundleID: "com.example.fixture", shortVersion: "1.0",
+                buildVersion: "1", path: alias, isMASApp: false, sparkleFeedURL: nil),
+            remote: RemoteVersion(
+                shortVersion: "1.1", version: nil,
+                downloadURL: URL(string: "https://example.com/fixture.dmg"),
+                sourceName: "Vendor", requiresManualInstaller: false, vendorInstallerKind: .dmg),
+            status: .updateAvailable(latest: "1.1"))
+
+        let testflight = TestFlightInventory(macRows: [], accessible: false)
+        let toolbox = ToolboxInventory()
+        let checker = Inventory.checker(settings(), testflight: testflight, toolbox: toolbox)
+        let confirmed = await Install.recheckOne(
+            offered, testflight: testflight, toolbox: toolbox, checker: checker)
+        #expect(confirmed == nil,
+            "a bundle resolving to a DIFFERENT app must read as gone, not as that other app")
+    }
+}
+
+/// #404 review #5 and #3: the `--json` payload for an item the pre-install
+/// re-check did not install, and the text-mode summary line's counts — both
+/// pulled out as pure functions so their exact shape is testable without
+/// capturing stdout or driving a real `InstallCoordinator`.
+@Suite struct InstallApplySummaryTests {
+
+    /// #404 review #5: when `reconsider` had no freshly re-derived route to
+    /// give (the plan's route may already be stale by the time this fires),
+    /// the payload OMITS the field rather than falling back to the plan's own
+    /// route, which could contradict `reason`. Mutation (reverted after
+    /// running): changed `if let route { payload["route"] = route.rawValue }`
+    /// to unconditionally set `payload["route"] = route?.rawValue ?? "vendor"`
+    /// — this test went red (expected no `route` key, found one).
+    @Test func skippedPayloadOmitsRouteWhenThereIsNoneToGive() {
+        let payload = Install.skippedPayload(
+            name: "Fixture", route: nil, reason: "no readable bundle right now")
+        #expect(payload["route"] == nil)
+        #expect(payload["app"] as? String == "Fixture")
+        #expect(payload["applied"] as? Bool == false)
+    }
+
+    @Test func skippedPayloadIncludesTheRouteWhenThereIsOne() {
+        let payload = Install.skippedPayload(
+            name: "Fixture", route: .vendor, reason: "already at 1.1 on disk — nothing to install")
+        #expect(payload["route"] as? String == "vendor")
+    }
+
+    /// #404 review #3: a declined install is not a failure, but it must not
+    /// vanish from the summary either. Mutation (reverted after running):
+    /// dropped the `declined` clause from `Install.summaryLine` — this test
+    /// went red (missing ", 1 declined" from the string).
+    @Test func declinedElevationAppearsInTheSummaryLine() {
+        #expect(Install.summaryLine(installed: 2, failed: 0, skipped: 0, declined: 1)
+            == "2 installed, 0 failed, 1 declined.")
+    }
+
+    @Test func summaryLineOmitsZeroCounts() {
+        #expect(Install.summaryLine(installed: 3, failed: 0, skipped: 0, declined: 0)
+            == "3 installed, 0 failed.")
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ It **respects each app's own update channel**:
 - **Major version upgrades** are gated behind a warning (a commercial app may
   need a new license) instead of a one-click button.
 - **Defensive re-check** before installing, so a stale list never triggers a
-  redundant install.
+  redundant install — the menu-bar app and `duo install` both re-read the
+  bundle and re-query its source immediately before backup/replace, not just
+  when the list was last drawn.
 - **Restart detection**: if an app was updated on disk but is still running an
   older build (compared via LaunchServices), it's surfaced with a Restart action.
 


### PR DESCRIPTION
## Summary

Closes #404. `duo install` used to hand the plan's stale `UpdateResult` straight
to `InstallCoordinator`, with nothing between "the user approved this" and
"this is now being installed" — a window a confirmation prompt, or an earlier
item's download in a batch, can hold open for minutes. This adds the same
defensive re-check the menu-bar app already does before every install
(`PreInstallGate`): right before backup/replace, re-read the bundle off disk
and re-query its source for that one app, then reclassify from the fresh
answer — never from the plan's.

- `Install.reconsider` is the pure classification the fix hangs on (no I/O).
- `Install.apply` does the I/O: `recheckOne` (bundle re-scan + source
  re-query, per item) and `liveEnvironment` (running-apps/staging snapshot,
  per item). `TestFlightInventory`/`ToolboxInventory`/the source stack are
  built once for the whole batch (`Inventory.checker` gained optional
  `testflight`/`toolbox` params) — only each item's own disk re-scan and
  source query still happen per item, which is the entire point of the fix
  (see `AppListModel.recheckMany`'s doc comment on the same cost shape, #226).
- Not the App's own re-check code: this is CLI-only, mirroring the same
  `PreInstallGate` primitive the menu-bar app already uses.

### Exit code / counting semantics

`duo install`'s summary line and `--json` stream now distinguish:

- **Not a failure, not installed** (`skippedCount`): the plan's route no
  longer matches `--route` after reconsidering (`.notRequested`), the disk is
  already current or managed elsewhere (`.skip`), or no readable bundle could
  be found at the plan's path right now (`.unreadable` — could be uninstalled
  or a plist that failed to parse; deliberately doesn't claim to know which,
  and deliberately not retried, since re-running `duo install` can't change
  either of those facts).
- **A decision, not a failure** (`declinedCount`): the user dismissed the
  admin-password prompt. Previously this vanished from every counter and the
  `--json` stream entirely; now it's counted and emitted.
- **Counted as a failure** (`failed`): the pre-install re-check could not
  confirm an update at all (`.cannotConfirm` — a network blip/rate limit,
  retryable), or the source's own answer walked backwards between the offer
  and the confirm (`.answerRegressed` — the Nowdex shape `PreInstallDecision`
  documents).

The `--route` filter is re-applied after reconsidering (on the freshly
re-derived route, not the plan's), matching the same narrowing the planning
loop already does before the confirmation prompt.

**Deliberately kept**: if the vendor ships again while the user is holding the
confirmation prompt (or an earlier batch item is still downloading), the
newer, just-confirmed version is installed — never the one the plan printed.
That's the entire point of #404; `updateAppearingDuringTheWaitInstallsTheNewerConfirmedVersion`
pins it.

### Review findings folded in (this PR started from another agent's
uncommitted draft; I reviewed the diff and made these fixes before committing)

1. `.alreadyCurrent`'s message now states only what was *observed* (disk is at
   some version, nothing newer) instead of asserting a specific cause
   ("updated ... while waiting for confirmation") — that assertion was
   flatly false under `--yes`, which has no confirmation prompt to wait
   behind.
2. `attempted` (which apps get the "still running the old code" nudge) now
   only includes bundles `InstallCoordinator.Outcome.applied` reports as
   actually replaced — not everything `perform()` didn't throw on. An
   `.installer` route returns with `applied == false` while the system
   installer window is still open; the old code would still nudge to restart
   an app whose bundle was never touched.
3. A declined-elevation install is now counted (`declinedCount`) and emitted
   to `--json` (`emitSkipped`) instead of silently disappearing from every
   counter and the JSON stream.
4. `.notRequested` now prints an explanation in text mode instead of leaving a
   bare `→ AppName` header with no follow-up line.
5. `--json`'s `route` field is only ever the freshly re-derived route, or
   omitted — never the plan's stale route, which could contradict the
   `reason` on the same line (a route moving from Vendor to App Store used to
   emit `"route": "vendor"` next to a reason about the App Store). A
   same-shaped bug in the `.cannotConfirm`/`.answerRegressed` branches (which
   never had a fresh route to give either) was caught by `/code-review` after
   the first pass only fixed `.skip`.
6. "No bundle found" is its own outcome (`.unreadable`), not folded into the
   retryable `.cannotConfirm`: it's a fact about local disk state, not a
   source query failure, and `AppScanner.readApp` returns `nil` both when a
   bundle is uninstalled and when its `Info.plist` fails to parse — so the
   message doesn't claim to know which.
7. `recheckOne` now refuses to treat a bundle that currently resolves to a
   *different* app as a re-confirmation of the plan's app (mirroring
   `AppListModel.recheckMany`'s own identity guard — `InstalledApp.id` is the
   symlink-resolved path). Verified with a real filesystem fixture (a symlink
   whose target is a different bundle), not just asserted.
8. `recheckOne`'s `TestFlightInventory`/`ToolboxInventory`/`UpdateChecker` are
   now built once for the whole batch in `apply`, not once per plan item —
   each item's own disk re-scan and source re-query (the actual point of this
   issue) are unchanged.

## Test plan

- [x] `swift test` in `CLI/` — 256 tests / 32 suites, all green.
- [x] Every reconsider/classification/summary assertion mutation-verified
      (each mutation documented inline in the test file, reverted after
      confirming red).
- [x] `make test` (full repo: `DuoUpdaterCore` 2433 tests / `CLI` 256 tests /
      App tests / all python guard scripts) — green.
- [x] `/code-review` on the diff — one real finding (#5's fix was incomplete;
      `.cannotConfirm`/`.answerRegressed` still emitted the stale route),
      fixed before this PR; one style/duplication note (three near-identical
      `InstallEnvironment` literals) noted for a future cleanup, not fixed
      here (pre-existing code, out of this PR's scope).
