### PR TITLE
A note's link out of docs/engine-notes/ must not fail the build

### DIFF
--- a/scripts/check_engine_notes.py
+++ b/scripts/check_engine_notes.py
@@ -83,6 +83,21 @@ DOC_POINTER = re.compile(r"`([\w.-]+\.md)`" + SECTION_RUN)
 LINK = re.compile(r"\]\(([A-Za-z0-9._/-]+\.md)\)")
 
 
+def tracked_repo_files():
+    """Every path `git` tracks, anywhere in the repo.
+
+    `check_doc_links` needs this rather than the notes-directory subset: a note
+    may legitimately link OUT of `docs/engine-notes/` — an audit under
+    `docs/app-audits/`, the root README — and judging those against the subset
+    called a real, tracked file untracked and failed the build on it.
+    """
+    out = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout
+    return set(out.splitlines())
+
+
 def tracked_files():
     """Every path `git` actually tracks under docs/engine-notes/.
 
@@ -227,6 +242,7 @@ def check_doc_links(problems, tracked):
     link from a mention. Targets are read relative to the linking file, the
     way a reader's editor follows them.
     """
+    repo = tracked_repo_files()
     for doc in sorted(tracked):
         if not doc.endswith(".md"):
             continue
@@ -234,7 +250,11 @@ def check_doc_links(problems, tracked):
         for target in LINK.findall(text):
             resolved = os.path.normpath(
                 os.path.join(os.path.dirname(doc), target))
-            if resolved not in tracked:
+            # Against the whole repo, not this directory: a link OUT of
+            # docs/engine-notes/ is legitimate, and judging it against the
+            # notes subset reported a tracked file as untracked (verified:
+            # a link to docs/app-audits/org-mozilla-firefox.md failed here).
+            if resolved not in repo:
                 problems.append(
                     f"{doc}: links to `{target}`, which is not a tracked file"
                 )


### PR DESCRIPTION
`check_doc_links` (added in #431) resolved every markdown link in an engine note against `tracked`, which holds only the files under `docs/engine-notes/`. A link to any tracked file elsewhere in the repo therefore failed `make test` — with a message asserting something false about it.

Verified before the fix:

    docs/engine-notes/README.md: links to `../app-audits/org-mozilla-firefox.md`, which is not a tracked file

while `git ls-files docs/app-audits/org-mozilla-firefox.md` lists it. Links into `docs/app-audits/` are exactly what a note explaining a source file reaches for, and `check_app_audits.py` — the precedent `check_doc_links` names in its own docstring — resolves audit links without that restriction.

This is the same false-positive family as the bare-backticked-filename bug fixed in the very commit that introduced this one (a filename in prose was being resolved as a pointer): the tracked set was scoped to the directory while the resolution was not.

Mutations run:
- link to a real audit (`../app-audits/org-mozilla-firefox.md`) → green
- typo'd link inside the directory (`app-store-page-cache-typo.md`) → red
- link to a path that exists nowhere (`../app-audits/does-not-exist.md`) → red

`make test` green.

Found while reviewing my own follow-up commits on the five PRs merged tonight — the only content in them nobody but me had read.