### PR TITLE
docs: move PreInstallGate's incident history to docs/engine-notes (#409)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
@@ -1,29 +1,23 @@
 import Foundation
 
-/// What the defensive re-check immediately before an install concluded.
+/// What the defensive re-check right before an install concluded.
 ///
-/// Clicking Update does NOT install what the row was showing. The row may have
-/// been checked minutes or hours ago; since then the vendor may have published
-/// again, the app may have updated itself, or a package may have been installed by
-/// hand. So the install path re-reads the bundle off disk and re-queries the source
-/// first, and decides from THAT.
+/// Approving an install does NOT mean the disk still needs it: the offer being
+/// acted on may be minutes or hours old — the vendor may have published again,
+/// the app may have updated itself, or a package may have been installed by
+/// hand. So every caller re-reads the bundle off disk and re-queries the source
+/// first, and decides from THAT, through `decision(for:offered:confirmed:)`
+/// below. Two callers do this today: `AppListModel.performInstall` (the
+/// menu-bar click) and the CLI's `Install.reconsider` (#404, added after this
+/// gate already existed).
 ///
-/// The decision used to be a single `guard result.hasUpdate`, which is true only
-/// for `.updateAvailable` — so every other outcome fell into one branch that logged
-/// "already current on disk". Three unrelated endings wore the same sentence:
-///
-///  - genuinely current (the manual-install / self-updater case the branch was
-///    written for),
-///  - the source was tried and FAILED — a timeout, a 404, a rate limit — which is
-///    not a verdict about the app at all and is retryable,
-///  - the app turned out to be managed elsewhere (App Store, Toolbox, TestFlight).
-///
-/// The middle one is the damaging conflation: a network blip while you click Update
-/// produces "already current on disk" in the log, which reads as a fact about the
-/// disk and sends the next person looking at the bundle instead of the network.
-/// `UpdateStatus` already draws exactly this line — `.unknown` is "nothing covers
-/// this app", `.error` is "a source was tried and failed, retryable" — and this is
-/// the install path finally reading it.
+/// Every non-`.updateAvailable` outcome used to collapse into one branch and
+/// one log line, "already current on disk" — including a source that had been
+/// tried and failed, which is not a verdict about the disk at all. See
+/// `docs/engine-notes/pre-install-gate.md` §1 for the three endings that used
+/// to share that sentence. `UpdateStatus` already draws the line this enum
+/// reads (`.unknown` = nothing covers this app, `.error` = tried and failed,
+/// retryable).
 public enum PreInstallDecision: Sendable, Equatable {
     /// A newer version was confirmed just now. Install it.
     case proceed
@@ -38,32 +32,25 @@ public enum PreInstallDecision: Sendable, Equatable {
     /// "there is nothing to find" are different answers, and only one of them is
     /// worth retrying.
     case cannotConfirm(String?)
-    /// The re-check answered with a version OLDER than the one the row was
-    /// offering when the click landed, and called the app current on the strength
-    /// of it. Nothing was installed and nothing is known to be wrong with the
-    /// bundle — the source contradicted itself, one second apart.
+    /// The re-check answered with a version OLDER than what was being offered
+    /// when the install was approved, and called the app current on the
+    /// strength of it. Nothing was installed and nothing is known to be wrong
+    /// with the bundle — the source contradicted itself, one query apart.
     ///
     /// Its own case rather than `alreadyCurrent` because the sentence
-    /// `alreadyCurrent` produces ("already current on disk") is a claim about the
-    /// disk, and here it is false: the disk still carries the older build the row
-    /// was offering to replace.
+    /// `alreadyCurrent` produces ("already current on disk") is a claim about
+    /// the disk, and here it is false: the disk still carries the older build
+    /// that was being offered.
     ///
-    /// Observed 2026-09-06 on Nowdex (an App Store iOS-on-Mac app): four clicks
-    /// over ~40 minutes, every one of them swallowed. Each time the scheduled
-    /// check's batched iTunes lookup answered 1.0.9 and the click's own
-    /// single-bundle lookup answered 1.0.8 seconds later — both live network
-    /// loads, in one process, and the two bodies differed in length, so they were
-    /// two documents and not one document read twice. It turned out to be the
-    /// machine's outbound path handing that one URL a stale copy; the same URL
-    /// from another process on the same machine answered 1.0.9 throughout, and
-    /// re-routing it fixed the install.
+    /// The incident that motivated this case — two live queries seconds apart
+    /// answering different versions for the same app — is not something this
+    /// gate can see the cause of, and the point of this case is that it does
+    /// not have to: an answer that walks backwards is not evidence something
+    /// was already installed, whatever made it walk backwards. See
+    /// `docs/engine-notes/pre-install-gate.md` §2.
     ///
-    /// That cause is not something this gate can see, and the point is that it
-    /// does not have to: an answer that walks backwards is not evidence the user
-    /// already installed something, whatever made it walk backwards.
-    ///
-    /// Carries no message: the two version strings live in `UpdateResult`s the
-    /// caller already holds, and the wording belongs where the rest of the
+    /// Carries no message: the two version strings live in the `UpdateResult`s
+    /// the caller already holds, and the wording belongs where the rest of the
     /// user-facing copy is.
     case answerRegressed
 }
@@ -72,10 +59,11 @@ public enum PreInstallGate {
 
     /// Classify the re-check's outcome.
     ///
-    /// `offered` is what the row was showing when the click landed; `confirmed` is
-    /// what the re-check just answered. Both are ``VersionSide`` pairs and are
-    /// compared with ``VersionComparator/isNewer(_:than:)-(VersionSide,VersionSide)``,
-    /// so a vendor that freezes its marketing string is decided on its build and
+    /// `offered` is what was being offered when the install was approved;
+    /// `confirmed` is what the re-check just answered. Both are ``VersionSide``
+    /// pairs and are compared with
+    /// ``VersionComparator/isNewer(_:than:)-(VersionSide,VersionSide)``, so a
+    /// vendor that freezes its marketing string is decided on its build and
     /// nothing is ever compared across namespaces. Neither is optional: a caller
     /// that does not have one passes an empty ``VersionSide``, which is
     /// incomparable and therefore never regressed — the comparator fails closed —
@@ -88,18 +76,18 @@ public enum PreInstallGate {
         switch status {
         case .updateAvailable:
             // NOT second-guessed, deliberately. A re-check can legitimately come
-            // back with a LOWER version than the row was offering — the user moved
-            // the app off a beta channel in its own settings between the scan and
-            // the click, so the stable release it now resolves is older than the
-            // beta that was on the row and still newer than what is installed.
-            // Refusing that would block the install the user just asked for. The
-            // `.upToDate` arm below is different: there the source is claiming
-            // there is nothing to install at all.
+            // back with a LOWER version than what was offered — e.g. the user
+            // moved the app off a beta channel in its own settings between the
+            // check and the approval, so the stable release it now resolves is
+            // older than the beta that was offered and still newer than what is
+            // installed. Refusing that would block the install just approved.
+            // The `.upToDate` arm below is different: there the source is
+            // claiming there is nothing to install at all.
             return .proceed
         case .upToDate:
             // The only reading of `.upToDate` this gate refuses. Every other way
             // to reach it — a manual pkg install, the app's own updater, a build
-            // that landed between the last scan and the click — leaves `confirmed`
+            // that landed between the check and the approval — leaves `confirmed`
             // at or above what was offered, so this comparison is false and the
             // answer is unchanged.
             return VersionComparator.isNewer(offered, than: confirmed)

--- a/docs/engine-notes/README.md
+++ b/docs/engine-notes/README.md
@@ -62,3 +62,4 @@ what to do when the number has already drifted once.
 ## Index
 
 - [`app-store-page-cache.md`](app-store-page-cache.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift`
+- [`pre-install-gate.md`](pre-install-gate.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift`

--- a/docs/engine-notes/pre-install-gate.md
+++ b/docs/engine-notes/pre-install-gate.md
@@ -51,10 +51,10 @@ fact. What *was* re-checked before moving this out of the code comment:
 `VersionComparator.isNewer(_:than:)` on `VersionSide` pairs — the mechanism
 `.answerRegressed` relies on is unchanged as of this pass (2026-09-08).
 
-The root cause is not something this gate can see, and the point of
-`.answerRegressed` is that it does not have to be: an answer that walks
-backwards is not evidence that something was already installed by another
-path, whatever made it walk backwards.
+The root cause is not something this gate can see — and the invariant that
+follows from that is stated once, on `.answerRegressed` in the source, rather
+than restated here. Two copies of a conclusion is what this migration is
+supposed to remove, not what it should produce.
 
 At the time of this incident, `AppListModel.performInstall` (the menu-bar
 click) was the only caller of this gate. The CLI's own re-check

--- a/docs/engine-notes/pre-install-gate.md
+++ b/docs/engine-notes/pre-install-gate.md
@@ -1,0 +1,74 @@
+# PreInstallGate: incident timeline and rejected designs
+
+Companion to
+`DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift`. The
+source file keeps the current contract; this file keeps *why it looks that
+way* — the design it replaced and the incident that motivated its one
+non-obvious case. Written for issue #409.
+
+---
+
+## §1 Why this exists: three endings used to share one sentence
+
+The decision used to be a single `guard result.hasUpdate`, true only for
+`.updateAvailable` — so every other outcome fell into one branch that logged
+"already current on disk". Three unrelated endings wore that same sentence:
+
+- genuinely current (the manual-install / self-updater case the branch was
+  written for),
+- the source was tried and FAILED — a timeout, a 404, a rate limit — which is
+  not a verdict about the app at all and is retryable,
+- the app turned out to be managed elsewhere (App Store, Toolbox,
+  TestFlight).
+
+The middle one is the damaging conflation: a network blip during an install
+attempt produced "already current on disk" in the log, which reads as a fact
+about the disk and sends the next person looking at the bundle instead of
+the network. `UpdateStatus` already drew exactly this line before this gate
+existed — `.unknown` is "nothing covers this app", `.error` is "a source was
+tried and failed, retryable" — `PreInstallGate` is what finally reads it
+before installing anything, instead of collapsing it back down to one
+branch.
+
+## §2 The Nowdex incident: an answer that walked backwards
+
+Observed 2026-09-06 on Nowdex (an App Store iOS-on-Mac app): four install
+attempts over ~40 minutes, every one swallowed. Each time, the scheduled
+check's batched iTunes lookup answered 1.0.9 and the re-check's own
+single-bundle lookup answered 1.0.8 seconds later — both live network loads,
+in one process, and the two response bodies differed in length, so these
+were two documents, not one document read twice. It turned out to be the
+machine's outbound path handing that one URL a stale copy; the same URL from
+another process on the same machine answered 1.0.9 throughout, and
+re-routing it fixed the install.
+
+⚠️ Quoted from the original source comment, not re-measured for this pass —
+the specific root cause (a stale response on one outbound network path) is a
+live-network observation that cannot be independently re-verified after the
+fact. What *was* re-checked before moving this out of the code comment:
+`PreInstallDecision` still has the same five cases, and
+`decision(for:offered:confirmed:)` still compares via
+`VersionComparator.isNewer(_:than:)` on `VersionSide` pairs — the mechanism
+`.answerRegressed` relies on is unchanged as of this pass (2026-09-08).
+
+The root cause is not something this gate can see, and the point of
+`.answerRegressed` is that it does not have to be: an answer that walks
+backwards is not evidence that something was already installed by another
+path, whatever made it walk backwards.
+
+At the time of this incident, `AppListModel.performInstall` (the menu-bar
+click) was the only caller of this gate. The CLI's own re-check
+(`Install.reconsider`, #404) landed the following night, in PR #434
+(2026-09-07). Both callers now feed the same comparator, so the fix in this
+gate protects both — but the incident itself was observed and diagnosed only
+through the menu-bar path; nobody has reproduced the stale-outbound-copy
+shape against the CLI's own lookup call.
+
+---
+
+Tests: `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PreInstallGateTests.swift`
+(the comparator, pinned against both a synthetic backwards answer and the
+Nowdex shape), `CLI/Tests/DuoKitTests/InstallTests.swift`
+(`answerWalkingBackwardsIsAFailureNotASkip`, pinning
+`PreInstallDecision.answerRegressed` → `ReconsiderOutcome.answerRegressed`
+on the CLI side).


### PR DESCRIPTION
## Summary

Second file in the issue #409 migration (first was #431, `AppStorePageCache.swift`). Only `PreInstallGate.swift` + its new doc + the README Index line are touched — `App/Sources/AppListModel.swift` is intentionally left for a separate pass (per the issue and per a parallel session already working there).

- **Kept in code** (current contract / non-obvious constraint): the five `PreInstallDecision` cases and what each means, `decision(for:offered:confirmed:)`'s `VersionSide` comparison rule (build-decided when marketing is frozen, never cross-namespace, fails closed on an empty side), the `.upToDate`/`.updateAvailable` switch-arm rationale (a channel downgrade between scan and click is not a regression).
- **Moved to `docs/engine-notes/pre-install-gate.md`**: the rejected single-`guard result.hasUpdate` design and the three endings it used to conflate (§1), and the full Nowdex incident timeline — four swallowed install attempts, the two differently-sized response bodies, the stale-outbound-path root cause, the fix (§2).
- **Fixed while migrating**: the type doc and switch-arm comments used GUI-specific language ("the row was showing", "clicking Update", "the click landed") left over from when `AppListModel.performInstall` was this gate's only caller. The CLI's `Install.reconsider` (#404, PR #434) became a second caller the night before this PR, so that language is now generalized to "what was offered when the install was approved" everywhere in this file.

### Re-checked before moving the Nowdex incident (per the migration checklist)
- `PreInstallDecision` still has the same 5 cases — confirmed by reading the current enum.
- `decision(for:offered:confirmed:)` still compares via `VersionComparator.isNewer(_:than:)` on `VersionSide` pairs — confirmed by reading the current function.
- The incident's own root cause (a stale response on one outbound network path) is a one-time live-network observation from 2026-09-06 that cannot be independently re-verified after the fact — the doc labels it "quoted from the original source comment, not re-measured."

### "How many copies" grep sweep
- `"already current on disk"` — appears in: this file (kept, it's the log sentence itself), the new doc, `PreInstallGateTests.swift`'s own "why this test exists" comment (left alone per the checklist — a test's own retelling doesn't have to track the source), and `App/Sources/AppListModel.swift` (both a comment repeating the same conflation and the literal log string) — **left untouched, out of scope**: another session is working on that file per this task's instructions.
- `"the row was showing"` / `"Clicking Update"` — no other occurrences found anywhere in the repo; this phrasing was isolated to `PreInstallGate.swift`.
- The Nowdex timeline details (four clicks, ~40 minutes, stale copy) — no other literal copies found. `MacAppStoreSource.swift` has a related-but-distinct comment (added the same day, explaining why byte-count debug logging exists) that references the same incident from a different angle; left alone as it documents different code, not a copy of the sentence being moved.

## Verification

```
$ python3 scripts/check_engine_notes.py
✓ engine-notes pointers resolve — 481 Swift files scanned, 2 doc(s) indexed

$ python3 scripts/check_prose_claims.py
✓ no machine-population claims in code comments — 481 files
```

`make test` (via `scripts/run-with-hang-report.sh 1800 make test`) — full run, exit 0:
```
✔ Test run with 2433 tests in 201 suites passed after 19.755 seconds with 1 known issue.   (DuoUpdaterCore)
✔ Test run with 256 tests in 32 suites passed after 0.145 seconds.                          (CLI)
✓ App tests — 9 of 9 cases executed
✓ localizable keys agree — 516 in the catalog, all reachable
✓ version comparisons discriminate — 244 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
✓ app audits consistent — 115 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 481 Swift files scanned, 2 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (24 / 24) match the initializers
✓ no machine-population claims in code comments — 481 files
```

`/code-review` (high effort) run on the diff — see PR comment / thread for findings and disposition.

## Test plan
- [x] `make test` green (pasted above)
- [x] `scripts/check_engine_notes.py` passes with the new doc indexed
- [x] `scripts/check_prose_claims.py` passes
- [x] Diff scoped to `PreInstallGate.swift` + `docs/engine-notes/pre-install-gate.md` + one Index line — verified via `git diff origin/main --stat`
- [ ] Not merging / not `--auto` per instructions — leaving for review
