### PR TITLE
docs: move AppListModel's install-path comments' incident history to docs/engine-notes (#409)

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2714,25 +2714,22 @@ final class AppListModel {
             return false
         }
         // What the host gate protects is a HOST'S BANDWIDTH, so it belongs to the
-        // download phase and nothing after it. Held for the whole install, it made
-        // two same-host apps serialize across each other's extract, swap, and
-        // relaunch too — which is why splitting the permits only paid off for apps
-        // on different hosts. `performInstall` hands it back the moment its fetch
-        // ends; the handle makes that idempotent so the release below still covers
-        // every path that never got that far (an early-out, a throw, a cancel).
+        // download phase and nothing after it — see
+        // `docs/engine-notes/app-list-model.md` §1 for the earlier design (held for
+        // the whole install) this replaced and why splitting the permits only paid
+        // off once the gate's scope narrowed to the fetch. `performInstall` hands it
+        // back the moment its fetch ends; the handle makes that idempotent so the
+        // release below still covers every path that never got that far (an
+        // early-out, a throw, a cancel).
         //
         // The App Store gate is NOT handed over: it exists to keep two installs off
         // the single store UI (AX/mas), which spans the whole install, not the fetch.
         let hostGate = GateHandle(gate)
         // Machine-wide exclusion, taken here rather than around the whole batch:
-        // a row parked on the host gate must not hold it. Reference-counted
-        // inside the process, so this app's own concurrent installs join one
-        // claim instead of blocking each other (`flock` is exclusive per open
-        // file description, not per process).
-        //
-        // Refused, not queued: the other holder is `duo install`, which may be
-        // part-way through a large download, and a row that spins indefinitely
-        // is worse than one that says who has it.
+        // a row parked on the host gate must not hold it. See `ProcessInstallLock`'s
+        // own doc comment for why it's reference-counted per process rather than
+        // per claim, and `InstallLock`'s for why a claim is refused rather than
+        // queued when another process already holds it.
         do {
             try await ProcessInstallLock.shared.claim()
         } catch {
@@ -2903,10 +2900,13 @@ final class AppListModel {
 
         // The app's own updater may already have this release in flight. Ours would
         // be a second copy of the same bytes, and for a Sparkle app it is worse than
-        // wasteful: whichever finishes second overwrites the first, so a ChatGPT-sized
-        // pair of downloads can settle on the OLDER build (observed 2026-08-22 — we
-        // installed 6971, its own updater then landed the 6962 its backend was
-        // shipping, ~1.8 GB spent to move backwards).
+        // wasteful: whichever finishes second overwrites the first, so the app can
+        // settle on the OLDER build if the other side's transfer lands second. See
+        // `SelfUpdaterStaging.staged`'s and `UpdatePolicy.stagedBlocksInstall`'s doc
+        // comments for the incident this guards against, and for why the check below
+        // asks for ANY staged build (`requireNewerThanInstalled: false`), not just a
+        // newer one: a staged build older than ours still gets applied on the next
+        // quit, undoing whatever we install in the meantime.
         //
         // Deliberately NOT gated on `vendorInstallPolicy`: this isn't a preference
         // about who should apply updates, it's an unconditional "those bytes are
@@ -2917,11 +2917,6 @@ final class AppListModel {
         // way, because the alternative is the user paying twice for one update. The
         // note says so, and the next check installs normally once the transfer has
         // either landed (row goes current) or gone stale (detector stops matching).
-        // Its own updater may already have a build unpacked and parked on the next
-        // quit. Anything we install now is undone when that lands — including when
-        // the staged build is OLDER than ours, which is how the mini ended up back
-        // on 6962 after we installed 6971 twice. So this asks for any staged build,
-        // not just a newer one.
         if let staged = UpdatePolicy.stagedBlocksInstall(
             result,
             staged: SelfUpdaterStaging.staged(
@@ -3255,10 +3250,9 @@ final class AppListModel {
             // returned. The recheck above already knows: it re-read the bundle and
             // re-ran the source, so a row that still offers the same update while
             // the bytes on disk never moved means the download did not carry the
-            // release it was supposed to. Docker shipped exactly that — its appcast
-            // lists 4.86.0 before 4.87.0, the first-match asset pattern fetched the
-            // older image, 574 MB and a 2.26 GB backup later the app was still
-            // 4.86.0, and this code logged "install done" and flashed "Updated ✓".
+            // release it was supposed to — a first-match asset pattern once did
+            // exactly that for Docker (see `VendorProbeRecipe.swift`'s account of
+            // that incident); this code logged "install done" for it regardless.
             //
             // Deliberately narrow, because a false "it didn't work" is its own kind
             // of lie: only routes we apply ourselves and that are finished when

--- a/docs/engine-notes/README.md
+++ b/docs/engine-notes/README.md
@@ -63,3 +63,4 @@ what to do when the number has already drifted once.
 
 - [`app-store-page-cache.md`](app-store-page-cache.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift`
 - [`pre-install-gate.md`](pre-install-gate.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift`
+- [`app-list-model.md`](app-list-model.md) — `App/Sources/AppListModel.swift`'s install path (`install` / `runInstall` / `GateHandle` / `performInstall`)

--- a/docs/engine-notes/app-list-model.md
+++ b/docs/engine-notes/app-list-model.md
@@ -1,0 +1,66 @@
+# AppListModel install path: design history
+
+Companion to the install path in `App/Sources/AppListModel.swift`
+(`install` → `runInstall` → `GateHandle` → `performInstall`). The source file
+keeps the current contract; this file keeps *why it looks that way* where that
+reasoning is a rejected prior design rather than something still true today.
+Written for issue #409, which asked this file to be done in slices rather than
+all at once — this is the first slice, the install path.
+
+This slice is deliberately short. Most of the install path's comments describe
+a **current** contract or a non-obvious constraint (why `offered` and not the
+re-check's own result decides `.answerRegressed`, why `refreshRunningApps()`
+takes a fresh snapshot before deferring to a self-updater, why `GateHandle`
+tolerates a double release) — those stay next to the code, per this issue's
+own classification, and are not repeated here. What follows is the one piece
+of this slice that is a genuine rejected-design retelling with nothing else
+pointing at it.
+
+Two incidents that used to be retold a third time in this slice were trimmed
+instead of copied here, because they already have an authoritative home:
+Docker's 4.86.0-before-4.87.0 first-match bug is `VendorProbeRecipe.swift`'s
+account (and `CHANGELOG.md`'s user-facing one); ChatGPT's 6971→6962
+same-app-race is `SelfUpdaterStaging.staged`'s and
+`UpdatePolicy.stagedBlocksInstall`'s own doc comments. See the PR for this
+slice for the full duplicate count.
+
+---
+
+## §1 Why the per-host gate covers only the download phase
+
+`runInstall` takes a per-host semaphore (GitHub releases, one vendor CDN)
+before the download permit, so a host with several apps updating at once
+doesn't split its bandwidth across all of them and doesn't trip its own rate
+limiter. The gate is released — via `GateHandle`, handed to
+`InstallCoordinator.perform` as `releaseAfterDownload` — the moment the bytes
+are down, not when the whole install finishes.
+
+That release point was not always there. Confirmed against `git log`
+(commit `bab37c82`, "keep every install inside the concurrency budget, and
+free the host gate at end of download"): an earlier version held the host
+gate for the *entire* install, not just the fetch. What that meant in
+practice: two apps sharing one host would serialize across each other's
+extract, swap, and relaunch too, not just their downloads — all of which have
+nothing to do with the host's bandwidth, the thing the gate exists to
+protect. Two GitHub-hosted apps updating at the same time could not extract
+or swap concurrently even though neither step touches the network again.
+
+Splitting the host gate from the "apply" phase (extract/verify/swap, gated
+separately by `Self.installPermits`) only paid off once the release point
+moved to "bytes are down" — narrowing the *scope* of what the gate covers is
+what let two same-host apps stop blocking each other outside their downloads.
+`GateHandle`'s "release twice is a no-op" property is what makes the earlier
+release safe to add: `InstallCoordinator` releases it via the callback as soon
+as the fetch ends, and `runInstall`'s own `defer`-equivalent release after
+`performInstall` returns still covers every path that never reaches that
+callback at all (an early-out before download, a throw, a cancel) without
+double-signaling the semaphore on the paths that do.
+
+---
+
+Tests: `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/` has no dedicated test for
+the host-gate release point itself (it's exercised indirectly by
+`AppListModel`'s own concurrency, which the app-layer test target does not
+construct — see `CLAUDE.md`'s "App 层的测试 target" section for why). The
+per-host/App-Store gate split itself is `hostInstallGate(for:)` and
+`Self.appStoreInstallGate` in `AppListModel.swift`, upstream of this section.


### PR DESCRIPTION
## What

Second slice of #409 — this file's own issue-comment ("Still open, deliberately: ... `App/Sources/AppListModel.swift` — the big one") — scoped to **only the install path**: `install` → `runInstall` → `GateHandle` → `performInstall`, `App/Sources/AppListModel.swift` **L2623–L3417** (795 source lines). Nothing outside that range was touched, and `DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift`, `CLI/Sources/DuoKit/Install.swift`, `AppStorePageCache.swift`, and `scripts/check_engine_notes.py` were left alone per the task brief.

Behavior is unchanged — this is comments only, plus one new doc and one README line.

## Classification

**(a) current contract / non-obvious constraint — stays in code, unchanged.** This is most of the slice. Examples the brief specifically flagged, verified still present and left alone:
- `answerRegressed`/`offered` handling (why the row keeps the *offered* remote, not the re-check's, on a regressed answer) — `performInstall`, right after `PreInstallGate.decision`.
- `refreshRunningApps()` before `defersToSelfUpdater` — App Nap can make `runningAppPaths` stale, so a fresh snapshot is taken before this consequential a decision.
- `GateHandle`'s "release twice is a no-op" — needed because the download-site release and the owner's unconditional release can both fire.
- The App Store "cannot be open during installation" prompt reasoning (no timeout on either side, why no Accessibility grant is needed to show the note).
- The mas-outdated pre-flight fail-safe pairing (`VersionComparator.isNewer` gated by `mas outdated`, never the reverse).
- The "fifth arm/consume site" comment on the cancellation catch — verified: `reopenAfterQuit[id] = nil` appears at 5 sites in this function (permit-wait cancel, AX-not-trusted, pre-flight-skip, incremental-no-AX-no-mas, and this cancellation catch), so "fifth" is accurate, not a stale count.

**(b) incident timeline / rejected design — moved or trimmed with a pointer.**
- **New**, `docs/engine-notes/app-list-model.md` §1: the per-host gate used to be held for the *entire* install, not just the download — serializing same-host apps across extract/swap/relaunch too. Confirmed against `git log -S`: commit `bab37c82` ("keep every install inside the concurrency budget, and free the host gate at end of download"), read in full. The in-code comment (`runInstall`) now points here instead of retelling it.
- **Trimmed, not moved** (found already documented elsewhere — see "Duplicate count" below): the Docker 4.86.0-before-4.87.0 first-match incident and the ChatGPT 6971→6962 self-update race. Both are dated/numbered incidents that were about to become a *third* copy in this repo; the in-code comments now point at the copies that already exist instead.
- **Trimmed**, the `ProcessInstallLock.shared.claim()` call-site comment: the "why reference-counted", "flock is per open file description not per process", and "refused not queued" reasoning already lives on `ProcessInstallLock`/`InstallLock` themselves (in Core, out of this slice's scope to edit) — this comment now keeps only what's specific to *this* call site (taken here, not around the whole batch, because a row parked on the host gate must not hold it) and points there for the rest.

**(c) no longer true — none found in this slice.** I specifically checked for language implying only the menu-bar app does the pre-install re-check (stale after #404/#434 gave the CLI's `duo install` its own `PreInstallGate` caller) — none of this slice's comments claim exclusivity, so nothing needed rewriting there. `README.md`'s "Defensive re-check" bullet already says "the menu-bar app and `duo install` both..." (updated in an earlier PR).

## Duplicate count (checklist step 4)

Grepped for the sentences below before trimming/moving them:
- Docker 4.86.0/4.87.0/"574 MB"/"2.26 GB": found in `CHANGELOG.md` (user-facing release note) and `VendorProbeRecipe.swift` (×2, the actual recipe-detection code) — left both alone, they're the authoritative homes; `AppListModel.swift`'s copy was the third and is now a pointer.
- ChatGPT 6971/6962/"1.8 GB": found in `SelfUpdaterStaging.swift` and `UpdatePolicy.swift` (both Core, both call sites `performInstall` actually uses — `UpdatePolicy.stagedBlocksInstall` and `SelfUpdaterStaging.staged`) and in three test files' own "why this test exists" comments (`StagedBlocksInstallTests.swift`, `RestartStandoffTests.swift`, plus test fixtures) — left the Core copies and all test copies alone (tests document themselves per the checklist), `AppListModel.swift`'s was the extra one.
- "App Store can't replace ... while it's open" prompt text: found in `CHANGELOG.md` (user-facing) and a test file (verifying the string exists) — neither restates the *mechanism* reasoning this file's comment explains, so left both alone and left the code comment as-is.
- `ProcessInstallLock`'s reference-counting/refusal reasoning: found verbatim (near-verbatim) in `InstallLock.swift`/`ProcessInstallLock`'s own doc comments — trimmed the `AppListModel.swift` copy, see above.
- Host-gate "held for the whole install" rejected design: **no other copy found** — this is why it got a new doc section instead of just a pointer.

Also grepped `.claude/skills/`, `.agents/`, and `CLAUDE.md` for these phrases — no copies found there for anything in this slice.

## What I did NOT migrate, and why (the "sounds like an incident but isn't" list)

These read like incident retellings on first pass but are load-bearing current contract, so they stayed in code, unshortened:
- The App Store "false failure — already at target version" catch block (`installer: The upgrade failed`, exit 1, the AX route's `Open`/no-op/timeout dead end): this is a **recurring failure mode**, not a one-time incident — no date, and the reasoning is what stops a real `mas`/AX race from being misfiled as "already current". Removing it would remove the justification for `!isNewer(target, onDisk)` gating a genuine failure back onto the normal error path.
- "A missing cask token used to reset the spinner and return false here; the coordinator throws instead" and "Before this ordering, a wrapped region-locked app... got the dead deep link" — both are one-sentence warnings against reverting an ordering/behavior choice, not incident timelines with measurements. Migrating these would just relocate a warning a maintainer needs at the moment they're about to undo it.
- The PreInstallGate "this used to report them as if they were [the same ending]" line — already short, and the full narrative (with the Nowdex/AX regression example) already lives in `PreInstallGate.swift`'s own doc comment, which this points at by name.

## Verification

`python3 scripts/check_engine_notes.py`:
```
✓ engine-notes pointers resolve — 481 Swift files scanned, 2 doc(s) indexed
```

`python3 scripts/check_prose_claims.py`:
```
✓ no machine-population claims in code comments — 481 files
```

`make test` (via `scripts/run-with-hang-report.sh 1800 make test`) — full output tail:
```
✔ Test run with 256 tests in 32 suites passed after 0.138 seconds.
✓ App tests — 9 of 9 cases executed
python3 scripts/check_localizable_keys.py
✓ localizable keys agree — 516 in the catalog, all reachable
python3 scripts/check_staged_version_use.py
✓ version comparisons discriminate — 244 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
python3 scripts/test_check_staged_version_use.py
Ran 7 tests in 0.000s
OK
python3 scripts/check_app_audits.py
✓ app audits consistent — 115 docs, all indexed, no machine inventory, no pointers into untracked evidence
python3 scripts/check_engine_notes.py
✓ engine-notes pointers resolve — 481 Swift files scanned, 2 doc(s) indexed
python3 scripts/check_skill_docs.py
✓ skill docs consistent — 3 files mirrored, documented parameter counts (24 / 24) match the initializers
python3 scripts/check_prose_claims.py
✓ no machine-population claims in code comments — 481 files
```
No failures anywhere in the full log (2934 passing `✓`/`✔` lines; the two `✗` lines present are deliberate negative-assertions inside `test_check_staged_version_use.py`'s own unit tests, not real failures).

`/code-review` was run against this diff; see PR comments/thread for findings.

Not run (per the task brief): `make install`, `make cli`, `duo verify`.
