### PR TITLE
Close two coverage gaps left by tonight's install and prewarm work

### DIFF
--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -432,6 +432,34 @@ import DuoUpdaterCore
         #expect(route == .vendor)
     }
 
+    /// The one `PreInstallDecision` arm nothing pinned. Its four siblings each
+    /// have a case here; `.managedElsewhere` had none, so a re-mapping of it to
+    /// `.proceed` — which would install a vendor artefact over a copy the App
+    /// Store, Toolbox or TestFlight owns — compiled and passed the whole suite.
+    ///
+    /// Mutation (reverted after running): `case .managedElsewhere:` returning
+    /// `.proceed(confirmed, .vendor)` in `Install.reconsider` — red here
+    /// (expected a skip, got proceed), and green everywhere else.
+    @Test func anAppThatBecameStoreManagedIsSkippedNotInstalled() {
+        let offered = vendorOffer()
+        // What a re-check answers for a copy the store has taken over between
+        // the plan and this app's turn: not `.upToDate` (that is a claim about
+        // versions), but a different owner for the update entirely.
+        let confirmed = UpdateResult(
+            app: app(), remote: nil, status: .appStoreManaged)
+        let outcome = Install.reconsider(
+            offered: offered, confirmed: confirmed, settings: settings(),
+            environment: environment(), routes: [])
+        guard case .skip(let why, let route) = outcome else {
+            Issue.record("expected a skip, got \(outcome)")
+            return
+        }
+        #expect(why.contains("managed elsewhere"))
+        // No route: `reconsider` returns before `classify` runs, so there is no
+        // freshly-derived route to report and the plan's is stale by then.
+        #expect(route == nil)
+    }
+
     /// #404 review #6: a re-scan that found no readable bundle (`recheckOne`
     /// returning `nil`, whether the app was uninstalled or its Info.plist
     /// failed to parse — `AppScanner.readApp` returns nil for both, and this

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStorePageCacheTests.swift
@@ -780,8 +780,13 @@ struct MacAppStorePageCacheTests {
         let source = MacAppStoreSource(session: ScriptedHTTP.session(), region: "us",
                                        pageCache: AppStorePageCache())
         let app = Self.nativeMacApp(bundleID: bundleID)
+        // A second app nothing ever looks up. It is what makes the vacuity
+        // guard below able to tell a working prewarm from a no-op one: only a
+        // real batch names it, since `batchLookup` joins the ids into one
+        // `bundleId=a,b` query and the single lookup asks for its own id alone.
+        let unqueried = Self.nativeMacApp(bundleID: bundleID + ".unqueried")
 
-        let prewarmTask = Task { await source.prewarm([app]) }
+        let prewarmTask = Task { await source.prewarm([app, unqueried]) }
         let returnedInTime = await Self.raceAgainstTimeout(seconds: 5, task: prewarmTask)
         guard returnedInTime else {
             gate.release()          // unblock the stalled handler…
@@ -801,8 +806,37 @@ struct MacAppStorePageCacheTests {
         // reaches `awaitInFlight()` only for a MAS app, and a throw on the way
         // would leave the batch running past this test. The task is right
         // here; await it.
+        // Joins the batch and drains it: `awaitInFlight()` inside `lookup` is
+        // the only reach a caller has to that registered `Task`. Awaiting
+        // `prewarmTask` would NOT do it — `prewarm` returns before the batch
+        // finishes, which is the very property asserted above.
         _ = try await source.latestVersion(for: app)
         _ = await prewarmTask.value
+
+        // The vacuity guard, and the reason a second app is prewarmed.
+        // Everything above is about WHEN `prewarm` returns, and a `prewarm`
+        // that did nothing at all returns fastest of any — so without this the
+        // whole test passes against a no-op body, which is the one
+        // implementation it must never certify. `batchLookup` joins the ids
+        // into a single `bundleId=a,b` query, so a request naming the app
+        // nobody looked up can only have come from the batch.
+        //
+        // Counted per bundle id rather than per host: `ScriptedHTTP` is static
+        // and this suite's cases run in parallel, so a host-wide count is
+        // other tests' traffic as much as this one's (which is why every other
+        // case here asks `>= 1`). Scoped this way an exact count means
+        // something.
+        let requests: @Sendable (String) -> Int = { id in
+            ScriptedHTTP.count(matching: { $0.host == "itunes.apple.com" && ($0.query ?? "").contains(id) })
+        }
+        #expect(requests(unqueried.bundleID ?? "") == 1,
+                "no request named the app nobody looked up — prewarm batched nothing")
+
+        // And the batch is what ANSWERS the single lookup: joining a warmed
+        // cache costs no second request. That saving is the whole reason this
+        // hook exists, and nothing else in this test asserts it.
+        #expect(requests(bundleID) == 1,
+                "the single lookup re-fetched instead of joining the prewarmed batch")
     }
 
     /// Blocks the calling thread until released — lets a test prove something
@@ -810,8 +844,25 @@ struct MacAppStorePageCacheTests {
     /// on the OS's scheduling of when the request happens to start.
     final class ResponseGate: @unchecked Sendable {
         private let semaphore = DispatchSemaphore(value: 0)
-        func waitForRelease() { semaphore.wait() }
-        func release() { semaphore.signal() }
+        private let lock = NSLock()
+        private var opened = false
+
+        /// Blocks until `release()`, then never again. A plain semaphore would
+        /// hand out exactly one pass, so a SECOND request — which is what a
+        /// regression in the prewarm cache produces — would sit here until
+        /// URLSession's own timeout instead of reaching the assertion written
+        /// to catch it. Measured: that turned a should-be-instant failure into
+        /// a 16 s one whose message named the timeout, not the cause.
+        func waitForRelease() {
+            lock.lock(); let isOpen = opened; lock.unlock()
+            guard !isOpen else { return }
+            semaphore.wait()
+        }
+
+        func release() {
+            lock.lock(); opened = true; lock.unlock()
+            semaphore.signal()
+        }
     }
 
     /// Returns `true` if `task` finishes within `seconds`, `false` if the


### PR DESCRIPTION
Both gaps were found while reviewing what landed tonight, and both are the shape this repo calls vacuity — a test that passes against the very implementation it exists to reject.

### `prewarmDoesNotBlockOnItsOwnBatch` certified a no-op

The test asserts *when* `prewarm` returns. A `prewarm` that does nothing at all returns fastest of any, so a no-op body passed every assertion in it — including after #433 rewrote it.

It now prewarms a second app that nothing ever looks up. `batchLookup` joins ids into a single `bundleId=a,b` query, so a request naming that app can only have come from the batch. The other half — that the single lookup *joins* the warmed cache rather than re-fetching — is asserted too; that saving is the whole reason the hook exists and nothing asserted it before.

Counts are per bundle id, not per host: `ScriptedHTTP` is static and this suite runs its cases in parallel, which is why every other case in the file asks `>= 1`. Scoped this way an exact count means something.

### `ResponseGate` turned a fast failure into a 16-second one

It handed out exactly one pass. A second request — precisely what a regression in the prewarm cache produces — blocked there until URLSession's own timeout: **measured 16 s**, and the failure named the timeout, not the cause. The gate now stays open after `release()`; the same mutation fails in **0.011 s** on the assertion written for it.

### `PreInstallDecision.managedElsewhere` had no test

Its four siblings each have one in `InstallReconsiderTests`. Re-mapping it to `.proceed` — installing a vendor artefact over a copy the App Store, Toolbox or TestFlight owns — compiled and passed the whole suite.

### Mutations run (each applied, run, reverted)

| mutation | result |
|---|---|
| `prewarm` body becomes a no-op | vacuity guard red |
| `prewarm` awaits its own batch | timeout race red at 5 s |
| single lookup stops consulting the prewarm cache | cache-hit assertion red at 0.011 s |
| `.managedElsewhere` returns `.proceed` | new case red, rest green |

`make test` green: 2433 Core / 257 CLI / 9 App, every python gate.