### PR TITLE
PreInstallGate: share the 'nothing came back' arm between hosts

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -13084,43 +13084,43 @@
         }
       }
     },
-    "No readable bundle was found at %@ right now — it may have been uninstalled, or its Info.plist could not be parsed.": {
+    "No readable bundle was found right now — it may have been uninstalled, or its Info.plist could not be parsed.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Am Pfad %@ wurde gerade kein lesbares Bundle gefunden – es wurde möglicherweise deinstalliert, oder seine Info.plist ließ sich nicht parsen."
+            "value": "Gerade wurde kein lesbares Bundle gefunden – es wurde möglicherweise deinstalliert, oder seine Info.plist ließ sich nicht parsen."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se encontró ningún paquete legible en %@ en este momento — puede que se haya desinstalado, o que su Info.plist no se pudiera analizar."
+            "value": "No se encontró ningún paquete legible en este momento — puede que se haya desinstalado, o que su Info.plist no se pudiera analizar."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aucun bundle lisible n'a été trouvé à %@ pour le moment — il a peut-être été désinstallé, ou son Info.plist n'a pas pu être analysé."
+            "value": "Aucun bundle lisible n'a été trouvé pour le moment — il a peut-être été désinstallé, ou son Info.plist n'a pas pu être analysé."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ に読み取り可能なバンドルが見つかりませんでした — アンインストールされたか、Info.plist を解析できなかった可能性があります。"
+            "value": "読み取り可能なバンドルが見つかりませんでした — アンインストールされたか、Info.plist を解析できなかった可能性があります。"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "По пути %@ сейчас не найден читаемый пакет приложения — возможно, его удалили, либо не удалось разобрать его Info.plist."
+            "value": "Сейчас не найден читаемый пакет приложения — возможно, его удалили, либо не удалось разобрать его Info.plist."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "现在在 %@ 找不到可读取的应用包 — 可能已被卸载，或者其 Info.plist 无法解析。"
+            "value": "现在找不到可读取的应用包 — 可能已被卸载，或者其 Info.plist 无法解析。"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -288,6 +288,88 @@
         }
       }
     },
+    "%@ could not be read back at its path after the install.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ konnte nach der Installation an seinem Pfad nicht wieder gelesen werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo volver a leer %@ en su ruta después de la instalación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de relire %@ à son emplacement après l'installation."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール後、%@ をそのパスから読み直せませんでした。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось повторно прочитать %@ по его пути после установки."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装后无法在其路径重新读取 %@。"
+          }
+        }
+      }
+    },
+    "%@ could not be read back at its path after the rollback.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ konnte nach dem Zurücksetzen an seinem Pfad nicht wieder gelesen werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo volver a leer %@ en su ruta después de la reversión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de relire %@ à son emplacement après la restauration."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロールバック後、%@ をそのパスから読み直せませんでした。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось повторно прочитать %@ по его пути после отката."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回滚后无法在其路径重新读取 %@。"
+          }
+        }
+      }
+    },
     "%@ didn’t quit — it has a window waiting for you (a save prompt, a sign-in sheet, a dialog). Switch to it, deal with that window, then quit it or click Relaunch again. Nothing was changed and the new version is already installed.": {
       "extractionState": "manual",
       "localizations": {
@@ -12998,6 +13080,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "没有已忽略的应用。可在应用菜单中使用“忽略此应用”将其从更新检查中隐藏。"
+          }
+        }
+      }
+    },
+    "No readable bundle was found at %@ right now — it may have been uninstalled, or its Info.plist could not be parsed.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Am Pfad %@ wurde gerade kein lesbares Bundle gefunden – es wurde möglicherweise deinstalliert, oder seine Info.plist ließ sich nicht parsen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró ningún paquete legible en %@ en este momento — puede que se haya desinstalado, o que su Info.plist no se pudiera analizar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun bundle lisible n'a été trouvé à %@ pour le moment — il a peut-être été désinstallé, ou son Info.plist n'a pas pu être analysé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に読み取り可能なバンドルが見つかりませんでした — アンインストールされたか、Info.plist を解析できなかった可能性があります。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По пути %@ сейчас не найден читаемый пакет приложения — возможно, его удалили, либо не удалось разобрать его Info.plist."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "现在在 %@ 找不到可读取的应用包 — 可能已被卸载，或者其 Info.plist 无法解析。"
           }
         }
       }

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2356,7 +2356,15 @@ final class AppListModel {
     /// touched row is replaced here, so the concurrently-installing app's spinner row
     /// is left intact.
     private func refreshRow(_ result: UpdateResult) async {
-        let updated = await recheck(result)
+        // A nil recheck means the re-scan found no readable bundle at this
+        // row's own path right now — gone, unparseable, or resolved to a
+        // different identity, and it cannot say which (`PreInstallDecision
+        // .unreadable`). This function and the three others that only paint a
+        // row (`recheckAfterUnignore`, `recheckChannelSwitches`, `retry`) all
+        // keep the existing row on nil rather than dropping it: removing rows
+        // is the next full scan's job, and dropping this one on what may be a
+        // transient read would make the app blink out of the list.
+        guard let updated = await recheck(result) else { return }
         replaceRow(updated)
         await computeRestartInfo()
         await computeSelfUpdateStaging()
@@ -2801,16 +2809,30 @@ final class AppListModel {
         // legitimately finds the app current, and after the next line the older
         // value is gone. See `PreInstallDecision.answerRegressed`.
         let offered = result
-        let result = await recheck(result)
+        let confirmed = await recheck(result)
         // Only `.updateAvailable` installs. The other endings all stop here, but
         // they are NOT the same ending, and this used to report them as if they
         // were: a source that timed out while you clicked Update was logged as
         // "already current on disk", which reads as a fact about the bundle and
         // sends the next person to the wrong place. See `PreInstallGate`.
-        let decision = PreInstallGate.decision(
-            for: result.status,
-            offered: offered.remote?.versionSide ?? VersionSide(),
-            confirmed: result.remote?.versionSide ?? VersionSide())
+        let decision = PreInstallGate.decision(offered: offered, confirmed: confirmed)
+        // `.unreadable` has nothing to shadow `result` with — the re-check found
+        // no readable bundle at this row's own path at all (gone, unparseable, or
+        // resolved to a different identity; see `PreInstallDecision.unreadable`)
+        // — so it is handled here, before the shadow below, and it never reaches
+        // `replaceRow`: there is nothing to write into the row. `decision ==
+        // .unreadable` exactly when `confirmed == nil` (see
+        // `PreInstallGate.decision(offered:confirmed:)`), so this unwraps
+        // `confirmed` for the rest of the function at the same time.
+        guard decision != .unreadable, let result = confirmed else {
+            Log.install.error(
+                "install aborted: \(offered.app.name, privacy: .public) — the pre-install re-check found no readable bundle at \(offered.app.path.path, privacy: .public)")
+            installErrors[id] = String(
+                localized: "No readable bundle was found at \(offered.app.path.path) right now — it may have been uninstalled, or its Info.plist could not be parsed.")
+            await computeRestartInfo()
+            installing[id] = nil
+            return false
+        }
         // A regressed answer must NOT become the row. Writing it in replaces a
         // real "1.0.9 available" with "1.0.8, up to date", and an up-to-date row
         // filters out of the list entirely — which is exactly how a swallowed
@@ -2860,6 +2882,8 @@ final class AppListModel {
                 // the tooltip, so the two version numbers have to survive the clamp
                 // and everything else has to go.
                 installErrors[id] = String(localized: "The update source answered \(was), then \(now) — nothing was installed.")
+            case .unreadable:
+                break  // unreachable: guarded above, before `result` was bound
             case .proceed:
                 break  // unreachable: guarded above
             }
@@ -3228,7 +3252,26 @@ final class AppListModel {
             // Restart flag by comparing each running instance's launch version
             // to what's now on disk. In-place installs (Homebrew) leave the old
             // process running stale code; Sparkle relaunches, so it won't show.
-            let updated = await recheck(result)
+            guard let updated = await recheck(result) else {
+                // No readable bundle at this path right after we just installed
+                // into it — gone, unparseable, or resolved to a different
+                // identity (`PreInstallDecision.unreadable`). Unlike the
+                // display-only sites (`refreshRow` and friends), falling back to
+                // the pre-install `result` here would be actively wrong: the
+                // `appliedNothing` check just below would then compare that
+                // stale row against itself and report "X on disk is still
+                // 4.86.0" — a claim about a bundle nothing could actually read.
+                // So this skips that check, the icon/changelog invalidation, and
+                // every success disposition below, and reports only what was
+                // observed.
+                Log.install.error(
+                    "install done, but could not read back: \(result.app.name, privacy: .public) at \(result.app.path.path, privacy: .public)")
+                installErrors[id] = String(
+                    localized: "\(result.app.name) could not be read back at its path after the install.")
+                installing[id] = nil
+                relaunching.remove(id)
+                return false
+            }
             // The bundle was replaced in place (same path); drop its cached icon so
             // the row re-reads the new one instead of showing the old until restart.
             AppIconCache.invalidate(updated.app.path.path)
@@ -5018,7 +5061,19 @@ final class AppListModel {
             // rescan (same reasoning as the apply permit in `performInstall`).
             await ProcessInstallLock.shared.release()
             AppIconCache.invalidate(target.path)
-            let updated = await recheck(result)
+            guard let updated = await recheck(result) else {
+                // See the post-install recheck in `performInstall` for why this
+                // does not fall back to the pre-rollback `result`.
+                Log.install.error(
+                    "rollback done, but could not read back: \(result.app.name, privacy: .public) at \(result.app.path.path, privacy: .public)")
+                installErrors[id] = String(
+                    localized: "\(result.app.name) could not be read back at its path after the rollback.")
+                await computeRestartInfo()
+                await computeSelfUpdateStaging()
+                await refreshBackupIndex()
+                installing[id] = nil
+                return
+            }
             replaceRow(updated)
             await computeRestartInfo()
             await computeSelfUpdateStaging()
@@ -5411,7 +5466,14 @@ final class AppListModel {
     private func recheckAfterUnignore(_ result: UpdateResult) async {
         guard installing[result.id] == nil else { return }
         installing[result.id] = .checking
-        let updated = await recheck(result)
+        // See `refreshRow`'s comment: a nil recheck keeps the existing row
+        // rather than dropping it.
+        guard let updated = await recheck(result) else {
+            installing[result.id] = nil
+            Log.app.info(
+                "unignore re-check: \(result.app.name, privacy: .public) — no readable bundle found; row kept")
+            return
+        }
         installing[result.id] = nil
         replaceRow(updated)
         syncDockBadge()
@@ -5914,8 +5976,15 @@ final class AppListModel {
     /// Re-read one app from disk and re-check it across all sources. Cheap
     /// enough to run right before installing, as a guard against acting on a
     /// stale row.
-    private func recheck(_ result: UpdateResult) async -> UpdateResult {
-        await recheckMany([result]).first ?? result
+    ///
+    /// Returns `nil` when the re-scan found no readable bundle at this row's
+    /// own path at all — see `PreInstallDecision.unreadable` for what that can
+    /// mean and why it cannot say which. The caller must decide what nil means
+    /// for its own ending; this used to paper over it with `?? result`, which
+    /// silently reused the stale offer and cancelled out the identity guard
+    /// `recheckMany` stands behind it for (#440).
+    private func recheck(_ result: UpdateResult) async -> UpdateResult? {
+        await recheckMany([result]).first
     }
 
     /// The batch form: one disk read and one `UpdateChecker` for the whole set,
@@ -6277,6 +6346,12 @@ final class AppListModel {
             guard !Task.isCancelled else { break }
             installing[result.id] = nil
             outstanding.remove(result.id)
+            guard let updated else {
+                // See `refreshRow`'s comment: a nil recheck keeps the existing
+                // row rather than dropping it, and leaves this id unbooked so a
+                // later fingerprint pass can retry it.
+                continue
+            }
             replaceRow(updated)
             if let id = result.app.bundleID?.lowercased() { completed.insert(id) }
             Log.app.info(
@@ -6317,7 +6392,13 @@ final class AppListModel {
         Log.app.info("retry: re-checking \(result.app.name, privacy: .public)")
         refreshRunningApps()
         installing[id] = .checking
-        let updated = await recheck(result)
+        // See `refreshRow`'s comment: a nil recheck keeps the existing row
+        // rather than dropping it.
+        guard let updated = await recheck(result) else {
+            installing[id] = nil
+            Log.app.info("retry done: \(result.app.name, privacy: .public) — no readable bundle found; row kept")
+            return
+        }
         installing[id] = nil
         replaceRow(updated)
         Log.app.info("retry done: \(updated.app.name, privacy: .public) → \(String(describing: updated.status), privacy: .public)")

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2364,7 +2364,20 @@ final class AppListModel {
         // keep the existing row on nil rather than dropping it: removing rows
         // is the next full scan's job, and dropping this one on what may be a
         // transient read would make the app blink out of the list.
-        guard let updated = await recheck(result) else { return }
+        //
+        // The two recomputes below still run on nil, even though the row
+        // itself doesn't change: they're whole-set sweeps, not row-scoped, so
+        // "this one row was unreadable just now" says nothing about whether
+        // they still have work to do. `relaunchStagedUpdate` calls this right
+        // after a vendor updater has been rewriting the bundle — exactly when
+        // a transient unreadable is most likely — and its own comment counts
+        // on `computeSelfUpdateStaging`'s departed-id sweep to clear the
+        // staged flag and reminder banner once the swap has landed.
+        guard let updated = await recheck(result) else {
+            await computeRestartInfo()
+            await computeSelfUpdateStaging()
+            return
+        }
         replaceRow(updated)
         await computeRestartInfo()
         await computeSelfUpdateStaging()
@@ -2827,8 +2840,15 @@ final class AppListModel {
         guard decision != .unreadable, let result = confirmed else {
             Log.install.error(
                 "install aborted: \(offered.app.name, privacy: .public) — the pre-install re-check found no readable bundle at \(offered.app.path.path, privacy: .public)")
+            // No path here, unlike the log line just above and the CLI's own
+            // wording (`Install.reconsider`'s `.unreadable`): the row already
+            // says which app this is, and a full filesystem path pushed the
+            // only actionable half of this sentence (the "may have been
+            // uninstalled" diagnosis) past the popover's one-line clamp —
+            // measured for en/fr/es, the path starts around character 32-41,
+            // so the user saw the path and not the diagnosis.
             installErrors[id] = String(
-                localized: "No readable bundle was found at \(offered.app.path.path) right now — it may have been uninstalled, or its Info.plist could not be parsed.")
+                localized: "No readable bundle was found right now — it may have been uninstalled, or its Info.plist could not be parsed.")
             await computeRestartInfo()
             installing[id] = nil
             return false
@@ -3268,6 +3288,20 @@ final class AppListModel {
                     "install done, but could not read back: \(result.app.name, privacy: .public) at \(result.app.path.path, privacy: .public)")
                 installErrors[id] = String(
                     localized: "\(result.app.name) could not be read back at its path after the install.")
+                // Parity with the rollback arm (`rollback`'s own recheck-nil
+                // branch): the bytes on disk changed even though we can't read
+                // them back, so the same three whole-set sweeps still have
+                // work to do — most importantly `refreshBackupIndex`, since
+                // `backupCurrent` just ran and this is exactly the situation
+                // where the user most wants the Rollback affordance to appear.
+                // Deferred in a batch like the success path above, so each
+                // row's failure doesn't hold the next install behind a
+                // per-app `lsappinfo`/staging/backup pass.
+                if !deferBookkeeping {
+                    await computeRestartInfo()
+                    await computeSelfUpdateStaging()
+                    await refreshBackupIndex()
+                }
                 installing[id] = nil
                 relaunching.remove(id)
                 return false

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -1008,15 +1008,14 @@ private struct AppRow: View {
             }
             if let installError {
                 VStack(alignment: .leading, spacing: 3) {
-                    // Two lines, with the whole message on hover. This note used
+                    // One line, with the whole message on hover. This note used
                     // to be unbounded, so a long one grew the row by three or four
                     // lines and pushed everything below it down — and the popover
                     // is 370pt wide, the narrowest place any of this copy is shown.
-                    // Two rather than one because the clamp applies to every
-                    // install error, not just the short ones written for it: at one
-                    // line the existing post-install verification message loses the
-                    // half that names what actually landed. Two keeps that legible
-                    // and still bounds the row.
+                    // The clamp applies to every install error, not just the short
+                    // ones written for it, so a longer message (the post-install
+                    // verification note, say) loses whatever falls past one line —
+                    // the tooltip is what keeps the rest reachable.
                     Text(installError)
                         .font(.caption2)
                         .foregroundStyle(.red)

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -342,15 +342,16 @@ public enum Install {
         offered: UpdateResult, confirmed: UpdateResult?, settings: Settings,
         environment: InstallEnvironment, routes: Set<InstallCoordinator.Route>
     ) -> ReconsiderOutcome {
-        guard let confirmed else {
+        let decision = PreInstallGate.decision(offered: offered, confirmed: confirmed)
+        // `decision == .unreadable` exactly when `confirmed == nil` (see
+        // `PreInstallGate.decision(offered:confirmed:)`), so this unwraps
+        // `confirmed` for every arm below at once, rather than each of them
+        // re-deriving the same fact.
+        guard decision != .unreadable, let confirmed else {
             return .unreadable(
                 "no readable bundle at \(offered.app.path.path) right now — it may have been "
                 + "uninstalled, or its Info.plist could not be parsed")
         }
-        let decision = PreInstallGate.decision(
-            for: confirmed.status,
-            offered: offered.remote?.versionSide ?? VersionSide(),
-            confirmed: confirmed.remote?.versionSide ?? VersionSide())
         switch decision {
         case .proceed:
             // The route can move too — the same source may now resolve a
@@ -385,6 +386,11 @@ public enum Install {
             return .cannotConfirm(message)
         case .answerRegressed:
             return .answerRegressed
+        case .unreadable:
+            // Unreachable: guarded above, before `confirmed` was unwrapped.
+            return .unreadable(
+                "no readable bundle at \(offered.app.path.path) right now — it may have been "
+                + "uninstalled, or its Info.plist could not be parsed")
         }
     }
 

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -330,6 +330,18 @@ public enum Install {
         case unreadable(String)
     }
 
+    /// The `.unreadable` wording, single-sourced: it used to appear twice in
+    /// `reconsider` below — once in the guard that actually produces it, once
+    /// in the `case .unreadable:` arm that can't (see the comment there) —
+    /// verbatim, so a future reword could hit one copy and leave the other.
+    /// `why` states only what was observed, not which of "uninstalled" or
+    /// "Info.plist failed to parse" it was: `AppScanner.readApp` returns nil
+    /// for both (#404 review #6).
+    private static func unreadableMessage(path: String) -> String {
+        "no readable bundle at \(path) right now — it may have been "
+            + "uninstalled, or its Info.plist could not be parsed"
+    }
+
     /// Pure classification — no I/O. `offered` is what the plan showed when the
     /// user (or `--yes`) approved it; `confirmed` is a fresh disk read and a
     /// fresh source query for the SAME app, taken right before backup/replace
@@ -348,9 +360,7 @@ public enum Install {
         // `confirmed` for every arm below at once, rather than each of them
         // re-deriving the same fact.
         guard decision != .unreadable, let confirmed else {
-            return .unreadable(
-                "no readable bundle at \(offered.app.path.path) right now — it may have been "
-                + "uninstalled, or its Info.plist could not be parsed")
+            return .unreadable(unreadableMessage(path: offered.app.path.path))
         }
         switch decision {
         case .proceed:
@@ -388,9 +398,7 @@ public enum Install {
             return .answerRegressed
         case .unreadable:
             // Unreachable: guarded above, before `confirmed` was unwrapped.
-            return .unreadable(
-                "no readable bundle at \(offered.app.path.path) right now — it may have been "
-                + "uninstalled, or its Info.plist could not be parsed")
+            return .unreadable(unreadableMessage(path: offered.app.path.path))
         }
     }
 

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -432,7 +432,7 @@ import DuoUpdaterCore
         #expect(route == .vendor)
     }
 
-    /// The one `PreInstallDecision` arm nothing pinned. Its four siblings each
+    /// The one `PreInstallDecision` arm nothing pinned. Its five siblings each
     /// have a case here; `.managedElsewhere` had none, so a re-mapping of it to
     /// `.proceed` — which would install a vendor artefact over a copy the App
     /// Store, Toolbox or TestFlight owns — compiled and passed the whole suite.
@@ -465,10 +465,11 @@ import DuoUpdaterCore
     /// failed to parse — `AppScanner.readApp` returns nil for both, and this
     /// cannot assert which) must NOT become `.cannotConfirm` — that reads as
     /// retryable, and re-running `duo install` cannot change whether a bundle
-    /// exists right now. Mutation (reverted after running): changed
-    /// `guard let confirmed else { return .unreadable(...) }` to
-    /// `return .cannotConfirm(nil)` in `Install.reconsider` — this test went
-    /// red (expected `.unreadable`, got `.cannotConfirm`).
+    /// exists right now. Mutation (reverted after running): in
+    /// `Install.reconsider`, changed the `guard decision != .unreadable, let
+    /// confirmed else { return .unreadable(...) }` at the top to
+    /// `return .cannotConfirm(nil)` — this test went red (expected
+    /// `.unreadable`, got `.cannotConfirm(nil)`).
     @Test func noReadableBundleIsUnreadableNotCannotConfirm() {
         let offered = vendorOffer()
         let outcome = Install.reconsider(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
@@ -53,6 +53,21 @@ public enum PreInstallDecision: Sendable, Equatable {
     /// the caller already holds, and the wording belongs where the rest of the
     /// user-facing copy is.
     case answerRegressed
+    /// The re-check found no readable bundle at the row's own path at all.
+    ///
+    /// This can mean three different things, and it cannot say which:
+    /// the bundle was uninstalled, its `Info.plist` no longer parses, or the
+    /// path now resolves to a bundle with a different identity.
+    /// `AppScanner.readApp` returns `nil` for the first two alike and cannot
+    /// distinguish them; the third is caught upstream by the id filter in
+    /// `AppListModel.recheckMany` / `Install.recheckOne`, which also answers
+    /// with nothing rather than with the other app's row.
+    ///
+    /// Carries no message, unlike `.cannotConfirm`: the CLI's sentence names
+    /// the path in plain text, and the App's has to go through
+    /// `String(localized:)`, so the wording belongs to each host. What is
+    /// shared here is only the classification.
+    case unreadable
 }
 
 public enum PreInstallGate {
@@ -100,5 +115,33 @@ public enum PreInstallGate {
         case .unknown:
             return .cannotConfirm(nil)
         }
+    }
+
+    /// Classify the re-check's outcome when the re-check itself may have come
+    /// back with nothing.
+    ///
+    /// This overload exists because "the re-check came back with nothing" is
+    /// part of the same decision as everything `decision(for:offered:confirmed:)`
+    /// already classifies, and each host used to make that call for itself —
+    /// which let the two drift. The CLI grew a `.unreadable` case for it in
+    /// #434; the menu bar's `recheck` kept `?? result`, silently falling back to
+    /// the stale offer, which cancelled out exactly the identity guard
+    /// `recheckMany` stands behind it for (#440). Both hosts now call this
+    /// overload instead of branching on their own optional first, so the arm
+    /// cannot be handled on one side and forgotten on the other.
+    ///
+    /// `nil` confirmed classifies as `.unreadable`; otherwise this delegates to
+    /// `decision(for:offered:confirmed:)` with both sides' `versionSide`s (or an
+    /// empty one when a result carries no remote), exactly as each host already
+    /// did at its own call site.
+    public static func decision(
+        offered: UpdateResult,
+        confirmed: UpdateResult?
+    ) -> PreInstallDecision {
+        guard let confirmed else { return .unreadable }
+        return decision(
+            for: confirmed.status,
+            offered: offered.remote?.versionSide ?? VersionSide(),
+            confirmed: confirmed.remote?.versionSide ?? VersionSide())
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PreInstallGateTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PreInstallGateTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import DuoUpdaterCore
 
 /// The re-check that runs when you click Update, and what each of its outcomes
@@ -11,6 +12,27 @@ struct PreInstallGateTests {
     /// comparison. Empty is incomparable, so it can never read as regressed —
     /// which is what every pre-existing case here assumes.
     private static let nothing = VersionSide()
+
+    /// Minimal fixtures for the `decision(offered:confirmed:)` overload below,
+    /// which takes whole `UpdateResult`s rather than bare `VersionSide`s.
+    private static func fixtureApp() -> InstalledApp {
+        InstalledApp(
+            name: "Fixture",
+            bundleID: "com.example.fixture",
+            shortVersion: "1.0",
+            buildVersion: "1",
+            path: URL(fileURLWithPath: "/Applications/Fixture.app"),
+            isMASApp: false,
+            sparkleFeedURL: nil)
+    }
+
+    private static func fixtureResult(marketing: String?, status: UpdateStatus) -> UpdateResult {
+        UpdateResult(
+            app: fixtureApp(),
+            remote: RemoteVersion(
+                shortVersion: marketing, version: nil, downloadURL: nil, sourceName: "Test"),
+            status: status)
+    }
 
     @Test("a confirmed newer version installs")
     func newerVersionProceeds() {
@@ -179,5 +201,50 @@ struct PreInstallGateTests {
             for: .upToDate,
             offered: VersionSide(marketing: "1.0.9"),
             confirmed: VersionSide(marketing: "1.0.8")) != .proceed)
+    }
+
+    // MARK: - decision(offered:confirmed:) — the shared "nothing came back" arm (#440)
+
+    /// The menu bar's `recheck` used to fold "the re-scan found nothing" into
+    /// `?? result`, silently reusing the stale offer and cancelling out
+    /// `recheckMany`'s identity guard. This overload is what both hosts now call
+    /// instead, so that arm can't be handled on one side and forgotten on the
+    /// other.
+    ///
+    /// Mutation: make the overload return `.cannotConfirm(nil)` for a `nil`
+    /// confirmed — this case goes red.
+    @Test("a nil confirmed classifies as unreadable")
+    func nilConfirmedIsUnreadable() {
+        let offered = Self.fixtureResult(marketing: "1.0", status: .updateAvailable(latest: "2.0"))
+        #expect(PreInstallGate.decision(offered: offered, confirmed: nil) == .unreadable)
+    }
+
+    /// A non-nil confirmed must still reach the same status ladder
+    /// `decision(for:offered:confirmed:)` already implements — this overload is a
+    /// thin front for that, not a second copy of it.
+    ///
+    /// Mutation: make the overload always return `.unreadable`, nil or not — this
+    /// case goes red while `nilConfirmedIsUnreadable` above stays green.
+    @Test("a non-nil confirmed still reaches the status ladder")
+    func confirmedReachesTheStatusLadder() {
+        let offered = Self.fixtureResult(marketing: "1.0", status: .updateAvailable(latest: "2.0"))
+        let confirmed = Self.fixtureResult(marketing: "2.0", status: .updateAvailable(latest: "2.0"))
+        #expect(PreInstallGate.decision(offered: offered, confirmed: confirmed) == .proceed)
+    }
+
+    /// The overload must pull BOTH version sides off the two `UpdateResult`s it
+    /// was actually handed, not pass empty `VersionSide`s through to the ladder
+    /// — an empty pair is incomparable and can never read as regressed (see
+    /// `anIncomparablePairIsNotRegressed` above), so a bug that dropped either
+    /// side would go undetected by every other test in this file.
+    ///
+    /// Mutation: pass `VersionSide()` for `offered` in the delegation — the
+    /// comparison becomes incomparable, the answer becomes `.alreadyCurrent`,
+    /// and this case goes red.
+    @Test("both version sides are pulled from the results handed in")
+    func bothSidesComeFromTheResultsThemselves() {
+        let offered = Self.fixtureResult(marketing: "1.0.9", status: .updateAvailable(latest: "1.0.9"))
+        let confirmed = Self.fixtureResult(marketing: "1.0.8", status: .upToDate)
+        #expect(PreInstallGate.decision(offered: offered, confirmed: confirmed) == .answerRegressed)
     }
 }

--- a/docs/engine-notes/pre-install-gate.md
+++ b/docs/engine-notes/pre-install-gate.md
@@ -80,9 +80,10 @@ stale pre-install offer — which cancelled out the very identity guard
 `recheckMany` exists to enforce, and would have let an install proceed
 against a bundle that no longer resolves to the same app (#440).
 
-Found by review of #409's third step (this file, moving the incident
-history out of the source comments) — not by a user, and not by the
-gap actually firing in the field.
+Found by review of #409's third step (PR #439, moving `AppListModel`'s
+own install-path comments out of the source — not this file, which was
+the second step) — not by a user, and not by the gap actually firing in
+the field.
 
 The fix adds a `PreInstallDecision.unreadable` case and a second entry
 point, `PreInstallGate.decision(offered:confirmed:)`, which takes the two
@@ -98,7 +99,11 @@ host makes — and can silently un-make — on its own.
 
 Tests: `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PreInstallGateTests.swift`
 (the comparator, pinned against both a synthetic backwards answer and the
-Nowdex shape), `CLI/Tests/DuoKitTests/InstallTests.swift`
+Nowdex shape, plus — for §3's `decision(offered:confirmed:)` overload —
+"a nil confirmed classifies as unreadable", "a non-nil confirmed still
+reaches the status ladder", and "both version sides are pulled from the
+results handed in"), `CLI/Tests/DuoKitTests/InstallTests.swift`
 (`answerWalkingBackwardsIsAFailureNotASkip`, pinning
 `PreInstallDecision.answerRegressed` → `ReconsiderOutcome.answerRegressed`
-on the CLI side).
+on the CLI side; `noReadableBundleIsUnreadableNotCannotConfirm`, pinning
+§3's `.unreadable` wording on the same side).

--- a/docs/engine-notes/pre-install-gate.md
+++ b/docs/engine-notes/pre-install-gate.md
@@ -46,10 +46,11 @@ re-routing it fixed the install.
 the specific root cause (a stale response on one outbound network path) is a
 live-network observation that cannot be independently re-verified after the
 fact. What *was* re-checked before moving this out of the code comment:
-`PreInstallDecision` still has the same five cases, and
 `decision(for:offered:confirmed:)` still compares via
 `VersionComparator.isNewer(_:than:)` on `VersionSide` pairs — the mechanism
 `.answerRegressed` relies on is unchanged as of this pass (2026-09-08).
+(`PreInstallDecision` no longer has the same five cases described here —
+see §3, added the same day: a sixth, `.unreadable`, was added for #440.)
 
 The root cause is not something this gate can see — and the invariant that
 follows from that is stated once, on `.answerRegressed` in the source, rather
@@ -63,6 +64,35 @@ click) was the only caller of this gate. The CLI's own re-check
 gate protects both — but the incident itself was observed and diagnosed only
 through the menu-bar path; nobody has reproduced the stale-outbound-copy
 shape against the CLI's own lookup call.
+
+## §3 Why "nothing came back" lives here, not in each host
+
+`decision(for:offered:confirmed:)` never sees the case where the re-check
+itself found nothing to classify — every caller re-reads the bundle off disk
+first, and that read can come back empty (uninstalled, an `Info.plist` that
+no longer parses, or a path that now resolves to a different identity —
+`AppScanner.readApp` can't tell the first two apart, and the third is caught
+upstream by an id filter before it ever reaches this gate). Each host used
+to decide what that meant for itself, and the two drifted: the CLI grew a
+`.unreadable` outcome for it in #434, worded to state only what was
+observed; the menu bar's `recheck` kept `?? result`, silently reusing the
+stale pre-install offer — which cancelled out the very identity guard
+`recheckMany` exists to enforce, and would have let an install proceed
+against a bundle that no longer resolves to the same app (#440).
+
+Found by review of #409's third step (this file, moving the incident
+history out of the source comments) — not by a user, and not by the
+gap actually firing in the field.
+
+The fix adds a `PreInstallDecision.unreadable` case and a second entry
+point, `PreInstallGate.decision(offered:confirmed:)`, which takes the two
+whole `UpdateResult`s (one of them optional) instead of two `VersionSide`s
+and a `UpdateStatus`. `nil` confirmed classifies as `.unreadable`; otherwise
+it delegates to `decision(for:offered:confirmed:)` exactly as each host
+already did at its own call site. Both `AppListModel.performInstall` and
+`Install.reconsider` now call this overload, so "the re-check found
+nothing" is decided once, in Core, rather than being a judgment call each
+host makes — and can silently un-make — on its own.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #440. `AppListModel.recheck` was `await recheckMany([result]).first ?? result` —
when the pre-install re-scan found no readable bundle at a row's own path
(uninstalled, an `Info.plist` that no longer parses, or a path that now
resolves to a different identity), it silently fell back to the stale
pre-install `UpdateResult`. That cancelled out `recheckMany`'s own identity
guard on the way back out, and let `performInstall` see a `result.status`
that was still the stale `.updateAvailable` from when the click landed —
`PreInstallGate.decision` would then answer `.proceed` and the install would
run against a path that no longer resolves to the same app. The CLI had
already grown its own answer for this shape in #434 (`ReconsiderOutcome
.unreadable`), so the two hosts had reached the same problem separately and
drifted.

**What's now shared.** `PreInstallDecision` gains a `.unreadable` case, and
`PreInstallGate` gains a second entry point,
`decision(offered: UpdateResult, confirmed: UpdateResult?)`, that takes the
two whole `UpdateResult`s (one optional) instead of two `VersionSide`s and a
`UpdateStatus`. A `nil` confirmed classifies as `.unreadable`; a non-nil one
delegates to the existing `decision(for:offered:confirmed:)` exactly as each
host already did at its own call site — that overload is unchanged. Both
`AppListModel.performInstall` and CLI's `Install.reconsider` now call the
new overload, so "the re-check found nothing" is decided once in Core rather
than being a judgment call each host makes (and can silently un-make) on its
own. `.unreadable` carries no message: the CLI's sentence names the path in
plain text and the App's has to go through `String(localized:)`, so the
wording stays with each host.

`AppListModel.recheck` now returns `UpdateResult?`. All seven call sites
handle `nil` explicitly:

- **`performInstall`** (the site the issue is about) calls
  `PreInstallGate.decision(offered:confirmed:)` and, on `.unreadable`, does
  not touch the row (nothing to write), logs the path, and sets a localized
  error stating only what was observed.
- **The post-install re-read and the post-rollback re-read** deliberately do
  *not* fall back to the pre-change row on `nil` — the `appliedNothing`
  check (and its rollback equivalent) would otherwise compare that stale row
  against itself and report a bundle nothing could actually read.
- **`refreshRow`, `recheckAfterUnignore`, `recheckChannelSwitches`, and
  `retry`** only ever paint a row, and deliberately keep the existing one on
  `nil`: removing rows is the next full scan's job, and dropping one on what
  may be a transient read would make the app blink out of the list.
  `recheckAfterUnignore` and `retry` additionally log that the row was kept,
  since both already log their outcome either way.

`docs/engine-notes/pre-install-gate.md` gets a short §3 recording why this
arm lives in Core, and a correction to a since-false claim ("`PreInstallDecision`
still has the same five cases") the previous pass left behind.

**No App-side test, and there can't be one.** `DuoUpdaterAppTests` compiles
only the files it's told to and can't construct `AppListModel` (its `init`
registers notification permissions, starts timers, and installs FS watchers
— exactly what CLAUDE.md's "App layer test target" section says to avoid).
Core carries the classification logic and its tests; the App-side wiring is
covered by review, same as every other `AppListModel` change today.

## Mutation results (all run and confirmed red, then reverted)

1. `nil` confirmed → `.unreadable`. Mutation: make the new overload return
   `.cannotConfirm(nil)` for `nil`.
   ```
   ✘ Test "a nil confirmed classifies as unreadable" ... 
     PreInstallGate.decision(offered: offered, confirmed: nil) == .unreadable → false
       PreInstallGate.decision(offered: offered, confirmed: nil) → .cannotConfirm(nil)
   ```
2. A non-nil confirmed still reaches the status ladder. Mutation: make the
   overload always return `.unreadable`.
   ```
   ✘ Test "a non-nil confirmed still reaches the status ladder" ...
     PreInstallGate.decision(offered: offered, confirmed: confirmed) == .proceed
   ✘ Test "both version sides are pulled from the results handed in" ...
     PreInstallGate.decision(offered: offered, confirmed: confirmed) == .answerRegressed
   ```
   (the third test also goes red under this mutation, as expected — the
   first test above stays green, which is the point of that pairing)
3. Both version sides are pulled from the two results, not passed empty.
   Mutation: pass `VersionSide()` for `offered` in the delegation.
   ```
   ✘ Test "both version sides are pulled from the results handed in" ...
     PreInstallGate.decision(offered: offered, confirmed: confirmed) == .answerRegressed → false
       PreInstallGate.decision(offered: offered, confirmed: confirmed) → .alreadyCurrent
   ```

## Test plan

- [x] `make test` passes (Core: 16 `PreInstallGateTests` including the 3
  new ones, plus the rest of the suite; CLI:
  `aBundleThatNowResolvesElsewhereReadsAsGoneNotAsAnotherApp` stays green
  untouched; App: 9/9 `DuoUpdaterAppTests` cases; localizable-keys,
  staged-version-use, app-audits, engine-notes, skill-docs, and
  prose-claims checks all green)
- [x] All three mutations above run and confirmed red, then reverted
- [x] `git diff` reviewed before committing
