### PR TITLE
duo install: distinguish opened-installer from installed, and tag every --json row with an outcome

### DIFF
--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -509,9 +509,18 @@ public enum Install {
         var skippedCount = 0
         // Declined elevation is a decision, not a failure (see the catch below),
         // but it must not vanish from the summary either — counted separately
-        // so `installedCount + failed + skippedCount + declinedCount` accounts
-        // for every item in the plan (#404 review #3).
+        // so `installedCount + failed + skippedCount + declinedCount +
+        // openedInstallerCount` accounts for every item in the plan (#404
+        // review #3, #435).
         var declinedCount = 0
+        // The `.installer` route's `perform` returns without throwing, but with
+        // `applied == false`: the bytes were fetched and verified and a system
+        // installer window is open, but nothing has replaced the app on disk
+        // yet. Kept apart from `installedCount` (which would be false at the
+        // moment the summary line prints) and from `skippedCount` (real work
+        // already happened here, unlike an actual skip) — see `summaryLine`
+        // (#435).
+        var openedInstallerCount = 0
         // Only items whose bundle was ACTUALLY replaced
         // (`InstallCoordinator.Outcome.applied`) — a `.notRequested`, `.skip`,
         // `.unreadable`, `.cannotConfirm`, or `.answerRegressed` item was never
@@ -551,12 +560,13 @@ public enum Install {
                         + "no longer requested")
                 }
                 emitSkipped(name: name, route: derivedRoute,
-                            reason: "not requested: --route no longer includes it", json: json)
+                            reason: "not requested: --route no longer includes it",
+                            outcome: .skipped, json: json)
                 skippedCount += 1
                 continue
             case .skip(let why, let derivedRoute):
                 if !json { print("   skipping: \(why)") }
-                emitSkipped(name: name, route: derivedRoute, reason: why, json: json)
+                emitSkipped(name: name, route: derivedRoute, reason: why, outcome: .skipped, json: json)
                 skippedCount += 1
                 continue
             case .unreadable(let why):
@@ -565,7 +575,7 @@ public enum Install {
                 // app really is gone, or its Info.plist needs fixing by hand,
                 // and re-running `duo install` answers neither.
                 if !json { print("   skipping: \(why)") }
-                emitSkipped(name: name, route: nil, reason: why, json: json)
+                emitSkipped(name: name, route: nil, reason: why, outcome: .skipped, json: json)
                 skippedCount += 1
                 continue
             case .cannotConfirm(let message):
@@ -578,7 +588,7 @@ public enum Install {
                 // re-derived route to give — only the plan's stale one, which
                 // is exactly the value #404 review #5 says not to fall back to.
                 // Caught by code review after the first pass only fixed `.skip`.
-                emitSkipped(name: name, route: nil, reason: reason, json: json)
+                emitSkipped(name: name, route: nil, reason: reason, outcome: .failed, json: json)
                 continue
             case .answerRegressed:
                 failed += 1
@@ -592,7 +602,8 @@ public enum Install {
                 // `nil` for the same reason as `.cannotConfirm` above: no fresh
                 // route was ever derived for a regressed answer either.
                 emitSkipped(name: name, route: nil,
-                            reason: "answer regressed: offered \(was), confirmed \(now)", json: json)
+                            reason: "answer regressed: offered \(was), confirmed \(now)",
+                            outcome: .failed, json: json)
                 continue
             }
 
@@ -630,12 +641,17 @@ public enum Install {
                 // route returns here with `applied == false` while the system
                 // installer window is still open, and the "still running the old
                 // code" summary below must not call that app's running copy
-                // stale (#404 review #2).
+                // stale (#404 review #2). The same `applied` bit is what keeps
+                // `installedCount` and `openedInstallerCount` apart (#435) —
+                // keyed off the outcome, not off `route == .installer`, since
+                // `applied` is the documented, already-in-scope signal.
                 if installOutcome.applied {
                     attempted.append((name: name, path: toInstall.app.path))
+                    installedCount += 1
+                } else {
+                    openedInstallerCount += 1
                 }
                 emit(name: name, route: route, outcome: installOutcome, json: json)
-                installedCount += 1
             } catch is AuthorizationDeclinedError {
                 // Dismissing the password panel is a decision, not a failure — it
                 // does not count toward `failed`, and it is remembered so neither
@@ -648,7 +664,8 @@ public enum Install {
                 Settings.recordDeclinedElevation(toInstall.app)
                 declinedCount += 1
                 emitSkipped(name: name, route: route,
-                            reason: "administrator access was declined", json: json)
+                            reason: "administrator access was declined",
+                            outcome: .declined, json: json)
                 FileHandle.standardError.write(Data("""
                        skipped: administrator access was declined, so \(name) will no \
                     longer be offered as a one-click. Undo it from the app's row menu, \
@@ -665,7 +682,7 @@ public enum Install {
                 // now leaves a row; a failure leaving none would mean the
                 // stream undercounts exactly the failures, which is the
                 // opposite of the property `emitSkipped` was added for.
-                emitSkipped(name: name, route: route, reason: message, json: json)
+                emitSkipped(name: name, route: route, reason: message, outcome: .failed, json: json)
                 if error is AppManagementRequiredError {
                     FileHandle.standardError.write(Data("""
                            Grant App Management to this binary in System Settings ▸ \
@@ -678,7 +695,8 @@ public enum Install {
         if !json {
             print("\n" + summaryLine(
                 installed: installedCount, failed: failed,
-                skipped: skippedCount, declined: declinedCount))
+                skipped: skippedCount, declined: declinedCount,
+                openedInstaller: openedInstallerCount))
             // The bundle on disk is new; the process still running is not. The
             // menu-bar app restarts these itself per the user's preference; the
             // CLI does not quit your apps behind your back, but it must not leave
@@ -702,10 +720,46 @@ public enum Install {
     /// "0 skipped, 0 declined" every time) — `declined` did not exist before
     /// #404 review #3, when a declined-elevation item was silently left out of
     /// every counter and this line, and so vanished from the summary entirely.
-    static func summaryLine(installed: Int, failed: Int, skipped: Int, declined: Int) -> String {
+    ///
+    /// `openedInstaller` is the fifth bucket, added by #435: an `.installer`
+    /// route's `perform` returns without throwing, yet `applied == false` — the
+    /// bytes are fetched and verified and a system installer window is open,
+    /// but nothing has replaced the app on disk yet. Before this it was folded
+    /// into `installed`, which made "N installed" false at the exact moment it
+    /// printed. Counting it as `installed` is wrong for that reason; folding it
+    /// into `skipped` would also be wrong, in the other direction — real work
+    /// (a full download, a verified package) already happened, unlike an
+    /// actual skip. Every item in the plan lands in exactly one of the five:
+    /// `installed + failed + skipped + declined + openedInstaller == plan.count`.
+    static func summaryLine(
+        installed: Int, failed: Int, skipped: Int, declined: Int, openedInstaller: Int
+    ) -> String {
         "\(installed) installed, \(failed) failed"
             + (skipped > 0 ? ", \(skipped) skipped" : "")
-            + (declined > 0 ? ", \(declined) declined" : "") + "."
+            + (declined > 0 ? ", \(declined) declined" : "")
+            + (openedInstaller > 0 ? ", \(openedInstaller) opened in the installer" : "") + "."
+    }
+
+    /// The machine-readable category every `--json` row (`emit`'s and
+    /// `emitSkipped`'s alike) carries, alongside `applied` — which is kept
+    /// exactly as it was, so an existing reader does not break; `outcome` is
+    /// additive, not a replacement (#436). Before this, `emitSkipped` wrote the
+    /// same `{applied: false, reason: …}` shape for a real failure, a skip, and
+    /// a decline alike, and only the English prose in `reason` told them apart
+    /// — rewording a message would silently reclassify a row. A small enum
+    /// rather than a raw string, so a typo at a call site cannot reach the
+    /// stream as a new, unrecognised category — the same principle as
+    /// `RowActions.live` in the menu-bar app: a call site must say which
+    /// bucket it is, not fall into a defaulted guess.
+    enum RowOutcome: String {
+        case installed
+        /// The `.installer` route only, today: bytes fetched and verified, a
+        /// system installer window is open, nothing replaced yet. See
+        /// `summaryLine` for why this is neither `.installed` nor `.skipped`.
+        case openedInstaller
+        case skipped
+        case declined
+        case failed
     }
 
     static func emit(
@@ -713,22 +767,39 @@ public enum Install {
         outcome: InstallCoordinator.Outcome, json: Bool
     ) {
         if json {
-            var payload: [String: Any] = [
-                "app": name, "route": route.rawValue,
-                "bytesDownloaded": outcome.bytesDownloaded,
-                "applied": outcome.applied,
-            ]
-            // Omitted rather than null when there is no staged package: a `.pkg`
-            // is the only route that produces one, and `NSNull` in a stream of
-            // otherwise-typed values trips naive readers.
-            if let staged = outcome.stagedPackageURL { payload["stagedPackage"] = staged.path }
-            NDJSON.emit(payload)
+            NDJSON.emit(installedPayload(name: name, route: route, outcome: outcome))
         } else if let package = outcome.stagedPackageURL {
             print("   opened the installer for you: \(package.lastPathComponent)")
             print("   finish it in the window macOS just opened.")
         } else {
             print("   installed.")
         }
+    }
+
+    /// The row `emit` writes for an item `InstallCoordinator.perform` returned
+    /// from without throwing — pulled out as a pure function, mirroring
+    /// `skippedPayload`, so the `outcome` category is testable directly rather
+    /// than only by capturing stdout. `outcome` (the JSON field) is keyed off
+    /// `outcome.applied` (the parameter), NOT off `route == .installer`:
+    /// `applied` is the documented signal ("is the new version on disk now"),
+    /// and today `.installer` is the only route whose `perform` returns
+    /// without throwing yet `applied == false` — verified against
+    /// `InstallCoordinator.performRoute` rather than assumed (#435).
+    static func installedPayload(
+        name: String, route: InstallCoordinator.Route, outcome: InstallCoordinator.Outcome
+    ) -> [String: Any] {
+        let category: RowOutcome = outcome.applied ? .installed : .openedInstaller
+        var payload: [String: Any] = [
+            "app": name, "route": route.rawValue,
+            "bytesDownloaded": outcome.bytesDownloaded,
+            "applied": outcome.applied,
+            "outcome": category.rawValue,
+        ]
+        // Omitted rather than null when there is no staged package: a `.pkg`
+        // is the only route that produces one, and `NSNull` in a stream of
+        // otherwise-typed values trips naive readers.
+        if let staged = outcome.stagedPackageURL { payload["stagedPackage"] = staged.path }
+        return payload
     }
 
     /// The `--json` record for an item the pre-install re-check did NOT install
@@ -742,21 +813,33 @@ public enum Install {
     /// than a missing field (#404 review #5). Text-mode printing is the caller's
     /// job: each outcome has its own wording, so this only ever writes the JSON
     /// line.
+    ///
+    /// `outcome` is a required parameter, not defaulted (#436): every call site
+    /// in `apply` already knows which counter it is about to increment (it is
+    /// sitting right next to `skippedCount += 1` / `declinedCount += 1` /
+    /// `failed += 1`), so this asks it to say so once more, in a form a
+    /// `--json` consumer can read back — the same reasoning CLAUDE.md gives
+    /// for `RowActions.live` taking no defaults: a new call site should have to
+    /// say which bucket it is rather than silently landing in a wrong one.
     static func emitSkipped(
-        name: String, route: InstallCoordinator.Route?, reason: String, json: Bool
+        name: String, route: InstallCoordinator.Route?, reason: String,
+        outcome: RowOutcome, json: Bool
     ) {
         guard json else { return }
-        NDJSON.emit(skippedPayload(name: name, route: route, reason: reason))
+        NDJSON.emit(skippedPayload(name: name, route: route, reason: reason, outcome: outcome))
     }
 
-    /// The row `emitSkipped` writes, pulled out as a pure function so the
-    /// route-omission rule (#404 review #5) is testable directly: `route` is
-    /// left out of the payload entirely when the caller has none to give,
-    /// rather than defaulted to something that could contradict `reason`.
+    /// The row `emitSkipped` writes, pulled out as a pure function so both the
+    /// route-omission rule (#404 review #5) and the `outcome` category (#436)
+    /// are testable directly. `route` is left out of the payload entirely when
+    /// the caller has none to give, rather than defaulted to something that
+    /// could contradict `reason`; `outcome` has no default for the same reason.
     static func skippedPayload(
-        name: String, route: InstallCoordinator.Route?, reason: String
+        name: String, route: InstallCoordinator.Route?, reason: String, outcome: RowOutcome
     ) -> [String: Any] {
-        var payload: [String: Any] = ["app": name, "applied": false, "reason": reason]
+        var payload: [String: Any] = [
+            "app": name, "applied": false, "reason": reason, "outcome": outcome.rawValue,
+        ]
         if let route { payload["route"] = route.rawValue }
         return payload
     }

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -64,7 +64,10 @@ install options:
                       override — the route follows from the source, and forcing a
                       different one is how you install a build from the wrong
                       channel.
-  --json              One JSON object per installed app, after a schema line.
+  --json              One JSON object per line, after a schema line — one row
+                      per plan item, whether it installed or not. `outcome` is
+                      installed, openedInstaller, skipped, declined, or failed;
+                      `applied` says whether the bundle on disk actually changed.
 
   App Store updates are refused, not attempted: that route needs the privileged
   helper or the Accessibility API, neither of which a standalone binary has.

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -541,10 +541,11 @@ import DuoUpdaterCore
     }
 }
 
-/// #404 review #5 and #3: the `--json` payload for an item the pre-install
-/// re-check did not install, and the text-mode summary line's counts — both
-/// pulled out as pure functions so their exact shape is testable without
-/// capturing stdout or driving a real `InstallCoordinator`.
+/// #404 review #5 and #3, plus #435/#436: the `--json` payloads for both an
+/// actual install (`installedPayload`) and an item the pre-install re-check
+/// did not install (`skippedPayload`), and the text-mode summary line's
+/// counts — all pulled out as pure functions so their exact shape is testable
+/// without capturing stdout or driving a real `InstallCoordinator`.
 @Suite struct InstallApplySummaryTests {
 
     /// #404 review #5: when `reconsider` had no freshly re-derived route to
@@ -556,7 +557,8 @@ import DuoUpdaterCore
     /// — this test went red (expected no `route` key, found one).
     @Test func skippedPayloadOmitsRouteWhenThereIsNoneToGive() {
         let payload = Install.skippedPayload(
-            name: "Fixture", route: nil, reason: "no readable bundle right now")
+            name: "Fixture", route: nil, reason: "no readable bundle right now",
+            outcome: .skipped)
         #expect(payload["route"] == nil)
         #expect(payload["app"] as? String == "Fixture")
         #expect(payload["applied"] as? Bool == false)
@@ -564,8 +566,66 @@ import DuoUpdaterCore
 
     @Test func skippedPayloadIncludesTheRouteWhenThereIsOne() {
         let payload = Install.skippedPayload(
-            name: "Fixture", route: .vendor, reason: "already at 1.1 on disk — nothing to install")
+            name: "Fixture", route: .vendor, reason: "already at 1.1 on disk — nothing to install",
+            outcome: .skipped)
         #expect(payload["route"] as? String == "vendor")
+    }
+
+    /// #436: before this, `emitSkipped` wrote the identical
+    /// `{applied: false, reason: …}` shape for a real failure and an ordinary
+    /// skip — a `--json` consumer had no way to separate them except by
+    /// pattern-matching the English prose in `reason`, and rewording a
+    /// message would silently reclassify a row. The two payloads below are
+    /// built from the SAME `reason` text on purpose, to isolate the one
+    /// thing that is supposed to tell them apart. Mutation (reverted after
+    /// running): changed `skippedPayload` to ignore its `outcome` parameter
+    /// and always write `"skipped"` — this test went red (the failure
+    /// payload's `outcome` read `"skipped"` instead of `"failed"`, so the
+    /// two payloads matched again).
+    @Test func skippedPayloadDistinguishesFailureFromSkipByOutcomeNotReasonProse() {
+        let sameReason = "already at 1.1 on disk — nothing to install"
+        let skip = Install.skippedPayload(
+            name: "Fixture", route: nil, reason: sameReason, outcome: .skipped)
+        let failure = Install.skippedPayload(
+            name: "Fixture", route: nil, reason: sameReason, outcome: .failed)
+        #expect(skip["outcome"] as? String == "skipped")
+        #expect(failure["outcome"] as? String == "failed")
+        #expect(skip["reason"] as? String == failure["reason"] as? String)
+    }
+
+    @Test func skippedPayloadCarriesTheDeclinedOutcome() {
+        let payload = Install.skippedPayload(
+            name: "Fixture", route: .installer, reason: "administrator access was declined",
+            outcome: .declined)
+        #expect(payload["outcome"] as? String == "declined")
+    }
+
+    /// #435: `installedPayload` is what `emit` writes for an item
+    /// `InstallCoordinator.perform` returned from without throwing. The
+    /// `.installer` route returns `applied == false` (bytes fetched and
+    /// verified, a system installer window open, nothing replaced yet) — the
+    /// category must read `openedInstaller`, not `installed`. Mutation
+    /// (reverted after running): changed the ternary in `installedPayload`
+    /// from `outcome.applied ? .installed : .openedInstaller` to
+    /// unconditionally `.installed` — this test went red (expected
+    /// `"openedInstaller"`, found `"installed"`).
+    @Test func installedPayloadReadsOpenedInstallerWhenNotApplied() {
+        let outcome = InstallCoordinator.Outcome(
+            bytesDownloaded: 12_000_000, finalHost: "example.com",
+            stagedPackageURL: URL(fileURLWithPath: "/tmp/Fixture.pkg"), applied: false)
+        let payload = Install.installedPayload(name: "Fixture", route: .installer, outcome: outcome)
+        #expect(payload["outcome"] as? String == "openedInstaller")
+        #expect(payload["applied"] as? Bool == false)
+        #expect(payload["stagedPackage"] as? String == "/tmp/Fixture.pkg")
+    }
+
+    @Test func installedPayloadReadsInstalledWhenApplied() {
+        let outcome = InstallCoordinator.Outcome(
+            bytesDownloaded: 12_000_000, finalHost: "example.com",
+            stagedPackageURL: nil, applied: true)
+        let payload = Install.installedPayload(name: "Fixture", route: .vendor, outcome: outcome)
+        #expect(payload["outcome"] as? String == "installed")
+        #expect(payload["applied"] as? Bool == true)
     }
 
     /// #404 review #3: a declined install is not a failure, but it must not
@@ -573,13 +633,39 @@ import DuoUpdaterCore
     /// dropped the `declined` clause from `Install.summaryLine` — this test
     /// went red (missing ", 1 declined" from the string).
     @Test func declinedElevationAppearsInTheSummaryLine() {
-        #expect(Install.summaryLine(installed: 2, failed: 0, skipped: 0, declined: 1)
+        #expect(Install.summaryLine(
+            installed: 2, failed: 0, skipped: 0, declined: 1, openedInstaller: 0)
             == "2 installed, 0 failed, 1 declined.")
     }
 
     @Test func summaryLineOmitsZeroCounts() {
-        #expect(Install.summaryLine(installed: 3, failed: 0, skipped: 0, declined: 0)
+        #expect(Install.summaryLine(
+            installed: 3, failed: 0, skipped: 0, declined: 0, openedInstaller: 0)
             == "3 installed, 0 failed.")
+    }
+
+    /// #435: an `.installer` route must not be counted as "installed" — false
+    /// at the exact moment the line prints, since nothing is on disk yet —
+    /// and must not be silently folded into "skipped" either, since real work
+    /// (a verified download) already happened. Mutation (reverted after
+    /// running): dropped the `openedInstaller` clause from `summaryLine`
+    /// entirely — this test went red (missing ", 1 opened in the installer").
+    @Test func summaryLineNamesOpenedInstallerSeparatelyFromInstalledAndSkipped() {
+        #expect(Install.summaryLine(
+            installed: 0, failed: 0, skipped: 0, declined: 0, openedInstaller: 1)
+            == "0 installed, 0 failed, 1 opened in the installer.")
+    }
+
+    /// The "every item in the plan is accounted for" invariant (#404 review
+    /// #3) now spans five buckets, not four (#435). All five distinct and
+    /// nonzero, so a mutation that dropped or mis-ordered any one clause is
+    /// visible in the pinned string. Mutation (reverted after running):
+    /// reordered the `declined` and `openedInstaller` clauses in
+    /// `summaryLine` — this test went red (wrong order in the joined string).
+    @Test func summaryLineAccountsForAllFiveBucketsWhenEachIsNonzero() {
+        #expect(Install.summaryLine(
+            installed: 1, failed: 2, skipped: 3, declined: 4, openedInstaller: 5)
+            == "1 installed, 2 failed, 3 skipped, 4 declined, 5 opened in the installer.")
     }
 }
 


### PR DESCRIPTION
Closes #435, closes #436. Implemented together, as instructed on both issues: they touch the same four functions in `CLI/Sources/DuoKit/Install.swift` (`Install.apply`'s counters, `summaryLine`, `emit`, `emitSkipped`/`skippedPayload`) and interlock — fixing one alone would have reopened the other.

## #435 — an `.installer` route was counted as "installed"

`Install.apply` incremented `installedCount` for every non-throwing `coordinator.perform`, including the `.installer` route, whose `InstallCoordinator.Outcome.applied` is `false` while the system Installer window is still open. `duo install` on a pkg app printed "1 installed, 0 failed" at a moment when nothing was actually on disk yet.

Verified in `InstallCoordinator.swift` (not assumed): `.appStore` throws immediately; `.homebrew`, `.vendor`, and `.sparkle` (via `fetchThenSwap`) all return `applied: true` on their non-throwing path; `.installer` is the only route whose `perform` returns without throwing yet `applied == false`. So the fix keys the distinction off `installOutcome.applied` — the same signal the call site already reads two lines above for `attempted` — not off `route == .installer`, which would have been a second, drift-prone way of asking the same question.

`Install.apply` now tracks a fifth counter, `openedInstallerCount`, incremented instead of `installedCount` exactly when `applied == false`. `summaryLine` gained a fifth, omitted-when-zero clause: "N opened in the installer" — worded to be true at the moment it prints (bytes fetched and verified, installer window open, nothing replaced). `installed + failed + skipped + declined + openedInstaller` still accounts for the whole plan. The exit code is unchanged: an opened installer is still not a failure.

## #436 — a failed install and a skipped one were the same `--json` row

`Install.emitSkipped` wrote the identical `{app, route, applied: false, reason}` shape for a real failure, an ordinary skip, and a declined authorization prompt. Only the English prose in `reason` told a consumer which was which, so rewording a message would silently reclassify a row.

Added `Install.RowOutcome`, a `String`-backed enum with five cases: `installed`, `openedInstaller`, `skipped`, `declined`, `failed`. It is a **required** parameter of `emitSkipped` and `skippedPayload` — not defaulted — so a new call site has to say which bucket it belongs to, the same principle CLAUDE.md gives for `RowActions.live` taking no defaults. Every existing call site in `apply` already knew which counter it was about to increment (`skippedCount += 1`, `declinedCount += 1`, `failed += 1`), so this asks each to say so once more in machine-readable form:

- `.notRequested`, `.skip`, `.unreadable` → `.skipped`
- `.cannotConfirm`, `.answerRegressed`, the generic `catch` → `.failed`
- `AuthorizationDeclinedError` → `.declined`
- a non-throwing `perform` → `.installed` or `.openedInstaller`, from `installedPayload` (pulled out of `emit`, mirroring `skippedPayload`, so it's testable directly)

`applied` is unchanged — same key, same meaning, same values as before — so an existing `--json` reader keeps working. `outcome` is additive.

## Docs / help text (count-the-copies check)

Grepped `README.md`, `docs/` (excluding `app-audits/`), the doc comments on `emit`/`emitSkipped`/`skippedPayload`/`summaryLine`, and `--help` text for other copies of the row shape or summary wording:

- `README.md`: no description of the install `--json` row shape or the summary line text — nothing to update.
- `docs/`: no non-audit doc describes this row shape or wording.
- `duo install --help` (`CLI/Sources/duo/main.swift`): the one other place this is documented. Its description was already stale before this PR ("one JSON object per installed app" — skip/fail rows have been emitted since #434) and is exactly the row shape this PR changes, so updated it to name `outcome` and `applied` together.
- `docs/app-audits/com-readdle-PDFExpert-Mac.md`: records dated real `--json` output from 2026-09-04 (`{"applied":true,"bytesDownloaded":...}`). Left untouched per instruction — these are observations with a date attached, not a schema spec — but flagging here that they are now incomplete relative to current output (missing `outcome`).
- No CHANGELOG entry: this is a `--json`/`--help` schema addition plus internal counting, not something a user perceives without reading a script's output; `applied` (what scripts already depend on) is unchanged.

## Mutations run (each confirmed red, then reverted)

1. `skippedPayload` ignoring its `outcome` parameter, always writing `"skipped"` — red on `skippedPayloadDistinguishesFailureFromSkipByOutcomeNotReasonProse` and `skippedPayloadCarriesTheDeclinedOutcome`.
2. `installedPayload`'s `outcome.applied ? .installed : .openedInstaller` replaced by an unconditional `.installed` — red on `installedPayloadReadsOpenedInstallerWhenNotApplied`.
3. The `openedInstaller` clause dropped from `summaryLine` entirely — red on `summaryLineNamesOpenedInstallerSeparatelyFromInstalledAndSkipped` and `summaryLineAccountsForAllFiveBucketsWhenEachIsNonzero`.
4. The `declined`/`openedInstaller` clauses reordered in `summaryLine` — red on `summaryLineAccountsForAllFiveBucketsWhenEachIsNonzero` (order matters in the pinned string).

Not covered by a unit test — and the honest scope is wider than the first draft of this line said. It is not only the `installedCount` / `openedInstallerCount` split: **none** of `apply()`'s per-item wiring is covered, including which `RowOutcome` each of the seven `emitSkipped` call sites passes — which is the whole subject of #436. `CLI/Tests/DuoKitTests/InstallTests.swift` contains zero calls to `Install.apply`; it exercises `classify`, `reconsider`, `skippedPayload`, `summaryLine` and `installedPayload` only. So changing the generic `catch`'s `outcome: .failed` to `.skipped` — which silently reinstates #436's exact defect, a failure row indistinguishable from a skip while `failed += 1` still fires — leaves every test green, as do the same substitution at `.cannotConfirm`, `.answerRegressed` and the declined catch, swapping the two `applied` branches, and passing `openedInstaller: 0` at the `summaryLine` call site.

The wiring is correct as written: all nine exits from the loop were checked by hand in review and each increments exactly one counter and emits exactly one row. This is regression risk, not a live bug, and it is pre-existing — the other four buckets were never wired-tested either; this PR only made it visible by adding a fifth. `apply()` does real I/O, so closing it properly means extracting the decision as a pure function: tracked in #445.

## Real row shapes (constructed, not imagined)

From a temporary test added, run, and removed before committing (`swift test --filter zzTempDemoRowShapes`, output captured, test deleted):

```
skip:    {"app":"Foo","applied":false,"outcome":"skipped","reason":"already at 2.1 on disk — nothing to install","route":"vendor"}
failure: {"app":"Bar","applied":false,"outcome":"failed","reason":"the update source could not be reached","route":"vendor"}
```

## Verification

```
$ scripts/run-with-hang-report.sh 1800 make test
...
✔ Test run with 2434 tests in 201 suites passed after 19.791 seconds with 1 known issue.   (DuoUpdaterCore)
✔ Test run with 263 tests in 32 suites passed after 0.139 seconds.                          (CLI, includes InstallApplySummaryTests: 10 tests)
✓ App tests — 9 of 9 cases executed
✓ localizable keys agree — 516 in the catalog, all reachable
✓ version comparisons discriminate — 244 files, ...
✓ app audits consistent — 115 docs, all indexed, ...
✓ engine-notes pointers resolve — 481 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, ...
✓ no machine-population claims in code comments — 481 files
EXIT:0
```

## Note on base

Branched from `origin/main` at `047fe9cc`. While this PR was in progress, #442 merged to `main` and also touches `Install.swift` (30 lines, confined to `reconsider` — unrelated region, no overlap with `apply`/`summaryLine`/`emit`/`emitSkipped`). Did not rebase, per this task's explicit instruction not to merge/rebase onto that work. Confirmed clean: `git merge-tree --write-tree HEAD origin/main` produces no conflicts.

