### PR TITLE
Network window: one header origin for both tabs

### DIFF
--- a/App/Sources/NetworkWindowView.swift
+++ b/App/Sources/NetworkWindowView.swift
@@ -103,3 +103,19 @@ struct NetworkWindowView: View {
         }
     }
 }
+
+/// The insets the two tabs' headers share.
+///
+/// One window, one header origin: the panes are swapped in place under a fixed
+/// title bar, so any difference here is a jump the reader sees on every switch
+/// rather than a spacing choice they could ever compare side by side. Measured
+/// on the live window before this existed, the ledger sat 2pt lower than the
+/// request log and its bar 4pt lower — small enough to read as the window
+/// twitching rather than as two layouts.
+enum NetworkHeaderMetrics {
+    static let horizontal: CGFloat = 20
+    static let top: CGFloat = 14
+    static let bottom: CGFloat = 12
+    /// Between the headline block and the stacked bar under it.
+    static let rowSpacing: CGFloat = 12
+}

--- a/App/Sources/NetworkWindowView.swift
+++ b/App/Sources/NetworkWindowView.swift
@@ -104,18 +104,23 @@ struct NetworkWindowView: View {
     }
 }
 
-/// The insets the two tabs' headers share.
+/// The insets the Network window's two panes share.
 ///
-/// One window, one header origin: the panes are swapped in place under a fixed
-/// title bar, so any difference here is a jump the reader sees on every switch
-/// rather than a spacing choice they could ever compare side by side. Measured
-/// on the live window before this existed, the ledger sat 2pt lower than the
-/// request log and its bar 4pt lower — small enough to read as the window
-/// twitching rather than as two layouts.
-enum NetworkHeaderMetrics {
-    static let horizontal: CGFloat = 20
-    static let top: CGFloat = 14
-    static let bottom: CGFloat = 12
-    /// Between the headline block and the stacked bar under it.
-    static let rowSpacing: CGFloat = 12
+/// One window, one left edge and one header origin: the panes are swapped in
+/// place under a fixed title bar, so a difference here is a jump the reader
+/// sees on every switch rather than a spacing choice they could ever compare
+/// side by side. Measured 2026-09-08 on the live window, before this existed:
+/// the ledger's headline sat 2pt lower than the request log's, and its stacked
+/// bar 4pt lower — small enough to read as the window twitching rather than as
+/// two layouts.
+enum NetworkPaneMetrics {
+    /// The left and right gutter, held by everything from the headline down to
+    /// the last row — not the header alone. A header that widened on its own
+    /// would split the pane's left edge down the middle of one screen.
+    static let gutter: CGFloat = 20
+    static let headerTop: CGFloat = 14
+    static let headerBottom: CGFloat = 12
+    /// Between the header's rows: headline block, stacked bar, and — in the
+    /// ledger, which has one — the caveat under that.
+    static let headerRowSpacing: CGFloat = 12
 }

--- a/App/Sources/RequestLogPane.swift
+++ b/App/Sources/RequestLogPane.swift
@@ -210,10 +210,18 @@ struct RequestLogPane: View {
     /// pointer between keystrokes. The figures inside it change; the shape does
     /// not — which is also what keeps this tab from jumping when you switch to
     /// it from the ledger.
-    private static let stripHeight: CGFloat = 122
+    ///
+    /// The 84 is the content — headline block plus purpose bar, measured. The
+    /// insets around it are read from ``NetworkPaneMetrics`` rather than folded
+    /// into the total, because this frame is pinned: raise the header's top
+    /// inset with the total left behind and the purpose bar rides into the
+    /// divider below it, with nothing to fail.
+    private static let stripHeight: CGFloat =
+        NetworkPaneMetrics.headerTop + NetworkPaneMetrics.headerRowSpacing
+        + NetworkPaneMetrics.headerBottom + 84
 
     private var statStrip: some View {
-        VStack(alignment: .leading, spacing: NetworkHeaderMetrics.rowSpacing) {
+        VStack(alignment: .leading, spacing: NetworkPaneMetrics.headerRowSpacing) {
             HStack(alignment: .bottom, spacing: 12) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(ByteFormat.stringOrDash(summary.bytesReceived))
@@ -233,9 +241,9 @@ struct RequestLogPane: View {
             }
             purposeBar
         }
-        .padding(.horizontal, NetworkHeaderMetrics.horizontal)
-        .padding(.top, NetworkHeaderMetrics.top)
-        .padding(.bottom, NetworkHeaderMetrics.bottom)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
+        .padding(.top, NetworkPaneMetrics.headerTop)
+        .padding(.bottom, NetworkPaneMetrics.headerBottom)
         .frame(height: Self.stripHeight, alignment: .topLeading)
     }
 
@@ -399,7 +407,7 @@ struct RequestLogPane: View {
             .labelsHidden()
             .fixedSize()
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
         .padding(.top, 10)
     }
 
@@ -444,7 +452,7 @@ struct RequestLogPane: View {
                     .foregroundStyle(.orange)
             }
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
         .padding(.top, 9)
         .padding(.bottom, 10)
     }
@@ -525,7 +533,7 @@ struct RequestLogPane: View {
         .foregroundStyle(.secondary)
         .lineLimit(1)
         .minimumScaleFactor(0.75)
-        .padding(.horizontal, 20)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
         .padding(.vertical, 5)
     }
 
@@ -634,7 +642,7 @@ struct RequestLogPane: View {
                 .foregroundStyle(.tertiary)
                 .frame(width: Column.duration, alignment: .trailing)
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
         .padding(.vertical, 4)
         .background(rowBackground(id))
         .contentShape(Rectangle())
@@ -708,7 +716,7 @@ struct RequestLogPane: View {
             }
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
         .padding(.vertical, 8)
         .background(Color(nsColor: .underPageBackgroundColor).opacity(0.5))
     }
@@ -779,7 +787,7 @@ struct RequestLogPane: View {
         }
         .font(.caption)
         .foregroundStyle(.secondary)
-        .padding(.horizontal, 20)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
         .padding(.vertical, 7)
         .confirmationDialog(
             "Discard the recorded network history?",

--- a/App/Sources/RequestLogPane.swift
+++ b/App/Sources/RequestLogPane.swift
@@ -213,7 +213,7 @@ struct RequestLogPane: View {
     private static let stripHeight: CGFloat = 122
 
     private var statStrip: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: NetworkHeaderMetrics.rowSpacing) {
             HStack(alignment: .bottom, spacing: 12) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(ByteFormat.stringOrDash(summary.bytesReceived))
@@ -233,9 +233,9 @@ struct RequestLogPane: View {
             }
             purposeBar
         }
-        .padding(.horizontal, 20)
-        .padding(.top, 14)
-        .padding(.bottom, 12)
+        .padding(.horizontal, NetworkHeaderMetrics.horizontal)
+        .padding(.top, NetworkHeaderMetrics.top)
+        .padding(.bottom, NetworkHeaderMetrics.bottom)
         .frame(height: Self.stripHeight, alignment: .topLeading)
     }
 

--- a/App/Sources/TrafficLedgerPane.swift
+++ b/App/Sources/TrafficLedgerPane.swift
@@ -61,14 +61,14 @@ struct TrafficLedgerPane: View {
     private var summary: TrafficSummary { model.trafficSummary }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: NetworkHeaderMetrics.rowSpacing) {
+        VStack(alignment: .leading, spacing: NetworkPaneMetrics.headerRowSpacing) {
             statStrip
             sourceBar
             caveat
         }
-        .padding(.horizontal, NetworkHeaderMetrics.horizontal)
-        .padding(.top, NetworkHeaderMetrics.top)
-        .padding(.bottom, NetworkHeaderMetrics.bottom)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
+        .padding(.top, NetworkPaneMetrics.headerTop)
+        .padding(.bottom, NetworkPaneMetrics.headerBottom)
     }
 
     /// Grand total and the trailing months, laid out as equal columns. Equal widths
@@ -237,7 +237,7 @@ struct TrafficLedgerPane: View {
             Text("\(model.trafficPresent.count) apps · \(ByteFormat.string(presentBytes))")
                 .font(.caption).foregroundStyle(.secondary).monospacedDigit()
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, NetworkPaneMetrics.gutter)
         .padding(.vertical, 7)
     }
 
@@ -321,7 +321,7 @@ struct TrafficLedgerPane: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary).monospacedDigit()
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, NetworkPaneMetrics.gutter)
             .padding(.vertical, 8)
             .contentShape(Rectangle())
         }
@@ -427,7 +427,7 @@ private struct TrafficRow: View {
                         .font(.caption).foregroundStyle(.secondary).monospacedDigit()
                         .frame(width: 58, alignment: .trailing)
                 }
-                .padding(.horizontal, 20)
+                .padding(.horizontal, NetworkPaneMetrics.gutter)
                 .padding(.vertical, 6)
                 .contentShape(Rectangle())
             }

--- a/App/Sources/TrafficLedgerPane.swift
+++ b/App/Sources/TrafficLedgerPane.swift
@@ -61,14 +61,14 @@ struct TrafficLedgerPane: View {
     private var summary: TrafficSummary { model.trafficSummary }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: NetworkHeaderMetrics.rowSpacing) {
             statStrip
             sourceBar
             caveat
         }
-        .padding(.horizontal, 20)
-        .padding(.top, 16)
-        .padding(.bottom, 14)
+        .padding(.horizontal, NetworkHeaderMetrics.horizontal)
+        .padding(.top, NetworkHeaderMetrics.top)
+        .padding(.bottom, NetworkHeaderMetrics.bottom)
     }
 
     /// Grand total and the trailing months, laid out as equal columns. Equal widths


### PR DESCRIPTION
Switching between the Network window's two tabs moved the header. The panes are
swapped in place under a fixed title bar, so the difference reads as the window
twitching rather than as two layouts anyone could compare side by side.

## Measured, before

On the live window, relative to its top-left corner (2x capture, pixel-scanned):

|                    | Requests | Downloads |
|--------------------|----------|-----------|
| headline first ink | 73.5 pt  | **75.5 pt** |
| stacked bar top    | 132.0 pt | **136.0 pt** |
| stacked bar left   | 20.0 pt  | 20.0 pt |

Three insets had drifted apart between `RequestLogPane.statStrip` and
`TrafficLedgerPane.header`:

| | Requests | Downloads |
|---|---|---|
| `.padding(.top,)` | 14 | 16 |
| VStack `spacing:` | 12 | 14 |
| `.padding(.bottom,)` | 12 | 14 |
| `.padding(.horizontal,)` | 20 | 20 |

2pt on the headline, 4pt by the time it reaches the bar. The horizontal inset
was already identical; the extra 2pt the headline *appears* to shift sideways
is the leading glyph's side bearing — `1` sits further into its monospaced
advance than `2` — not padding, and not fixable with padding.

## Change

Both panes now read one shared `NetworkHeaderMetrics`, so the next edit cannot
move one header without the other. Requests supplies the values (14 / 12 / 12):
its strip is pinned to `stripHeight = 122` and would have had to grow to take
the ledger's.

## Verified

`make install`, then both tabs on the rebuilt app, same pixel scan:

```
Requests  (141.6 MB)   headline row 147   bar row 264 (132.0 pt)
Downloads (120.23 GB)  headline row 147   bar row 264 (132.0 pt)
```

`scripts/run-with-hang-report.sh 1800 make test` → exit 0 (2437 + 263 cases,
App tests 9/9, all seven python gates green).

No test covers this: `DuoUpdaterAppTests` deliberately excludes anything that
pulls in SwiftUI, and `make gallery` renders row states, not these two panes.
The shared constant is the guard.
