### PR TITLE
Recognize TestFlight iOS-on-Mac apps instead of probing the store for them

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -124,6 +124,45 @@ public struct AppScanner: Sendable {
         return MDItemCopyAttribute(item, "kMDItemAppStoreReceiptType" as CFString) as? String
     }
 
+    /// Whether a wrapped iPhone/iPad bundle was installed by TestFlight, read from
+    /// the store metadata the installer leaves beside the inner bundle.
+    ///
+    /// The receipt signal `readApp` prefers cannot answer for a wrapped bundle, and
+    /// not because of the `!isiOSAppOnMac` guard in front of it: measured
+    /// 2026-09-08 across all three iOS-on-Mac apps on one machine — two installed
+    /// by TestFlight, one bought from the store — `kMDItemAppStoreReceiptType` is
+    /// null on every one and no `_MASReceipt` exists anywhere in any of the three
+    /// bundles. There is nothing there to read. So this plist is the only local
+    /// evidence, and without it a TestFlight-only app falls through to `isMASApp`
+    /// and gets probed against a store listing that does not exist — the home
+    /// storefront plus seven fallbacks, every scan, forever (#456).
+    ///
+    /// ⚠️ **Undocumented private format.** No Apple documentation describes these
+    /// keys (searched 2026-09-08; the Xamarin page of the same filename documents
+    /// the *Ad Hoc* metadata a developer writes into an IPA, which is a different
+    /// file). The shape below is what those three installs actually carried: the
+    /// two TestFlight ones had identical 23-key sets including both keys read here,
+    /// while the store one had neither and instead carried catalog metadata a
+    /// TestFlight build has no way to acquire (`softwareVersionExternalIdentifier`,
+    /// `rating`, `releaseDate`, `genre`). n=3, so treat a future OS reshaping this
+    /// as expected rather than surprising.
+    ///
+    /// **Presence is the test, never a value.** What `betaTesterType`'s `2` means is
+    /// undocumented too, so nothing here compares against it. Either key alone
+    /// suffices, so renaming one does not take the signal with it — and an
+    /// unreadable or reshaped plist returns false, which is exactly today's
+    /// behaviour. The failure direction is the bug this fixes, never a store copy
+    /// mis-tagged as a beta.
+    static func wrappedBundleIsTestFlight(_ bundleURL: URL) -> Bool {
+        let url = bundleURL.appendingPathComponent("Wrapper/iTunesMetadata.plist")
+        guard let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(
+                from: data, options: [], format: nil) as? [String: Any]
+        else { return false }
+        if plist["betaExternalVersionIdentifier"] != nil { return true }
+        return (plist["distributorInfo"] as? [String: Any])?["betaTesterType"] != nil
+    }
+
     /// The App Store track id (`kMDItemAppStoreAdamID`) Spotlight has indexed for
     /// a store-installed bundle, used to deep-link to the product page. Returns
     /// nil when absent or zero (sideloaded copies report 0).
@@ -223,8 +262,15 @@ public struct AppScanner: Sendable {
             // distributed through TestFlight today, so this declines rather than
             // guessing; the raw value is not recoverable from an already-scanned app.
             let matchable = !Self.buildVersionIsOverridden(bundleID: app.bundleID)
-            let isTestFlight = app.isTestFlightApp || (matchable && inventory.isManaged(
-                bundleID: app.bundleID, installedBuild: app.buildVersion))
+            // The iOS half mirrors `readApp`'s: a wrapped bundle's TestFlight rows
+            // are filed under the iOS platform, so the mac-only lookup can never
+            // see them. Both halves are needed here and not just in `readApp`,
+            // because this is the pass that runs once the privacy gate is finally
+            // answered — the first scan deliberately ran with an empty inventory.
+            let isTestFlight = app.isTestFlightApp || (matchable && (
+                inventory.isManaged(bundleID: app.bundleID, installedBuild: app.buildVersion)
+                || (app.isiOSAppOnMac && inventory.hasIOSBuild(
+                    bundleID: app.bundleID, installedBuild: app.buildVersion))))
             guard isTestFlight, !app.isTestFlightApp else { return app }
 
             return InstalledApp(
@@ -455,9 +501,24 @@ public struct AppScanner: Sendable {
         // distinguishes a TestFlight copy from an App Store copy of an app the user
         // merely has TestFlight access to. Fall back to the DB match when the type
         // is unreadable (e.g. Spotlight indexing off).
+        //
+        // The two `isiOSAppOnMac` clauses exist because NEITHER of the other two
+        // can answer for a wrapped bundle: there is no receipt to read (measured —
+        // see `wrappedBundleIsTestFlight`), and a wrapped app's TestFlight rows are
+        // filed under the iOS platform, which `isManaged` deliberately does not
+        // look at. Both are scoped to wrapped bundles rather than asked of
+        // everything, so the native-Mac path — which the receipt signal already
+        // answers correctly, verified on two TestFlight Mac apps making zero
+        // network requests — is left exactly as it was. They are kept as two
+        // clauses, not one, because their failure modes do not overlap: the plist
+        // is local but privately formatted, the DB is documented by its own schema
+        // but sits behind the app-data privacy gate and lags real installs.
         let isTestFlight =
             (hasReceipt && Self.appStoreReceiptType(bundleURL) == "ProductionSandbox")
+            || (isiOSAppOnMac && Self.wrappedBundleIsTestFlight(bundleURL))
             || testflight.isManaged(bundleID: bundleID, installedBuild: buildVersion)
+            || (isiOSAppOnMac && testflight.hasIOSBuild(
+                bundleID: bundleID, installedBuild: buildVersion))
         let isMAS = !isTestFlight && (isiOSAppOnMac || hasReceipt)
 
         var feedURL: URL?

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -269,7 +269,7 @@ public struct AppScanner: Sendable {
             // answered — the first scan deliberately ran with an empty inventory.
             let isTestFlight = app.isTestFlightApp || (matchable && (
                 inventory.isManaged(bundleID: app.bundleID, installedBuild: app.buildVersion)
-                || (app.isiOSAppOnMac && inventory.hasIOSBuild(
+                || (app.isiOSAppOnMac && inventory.hasInstalledIOSBuild(
                     bundleID: app.bundleID, installedBuild: app.buildVersion))))
             guard isTestFlight, !app.isTestFlightApp else { return app }
 
@@ -513,11 +513,16 @@ public struct AppScanner: Sendable {
         // clauses, not one, because their failure modes do not overlap: the plist
         // is local but privately formatted, the DB is documented by its own schema
         // but sits behind the app-data privacy gate and lags real installs.
+        //
+        // The DB clause asks whether TestFlight says this build is installed HERE,
+        // not merely whether the user has access to it — so it cannot promote a
+        // store copy of an app the user also happens to beta-test, even when the
+        // two carry the same build number. See `hasInstalledIOSBuild`.
         let isTestFlight =
             (hasReceipt && Self.appStoreReceiptType(bundleURL) == "ProductionSandbox")
             || (isiOSAppOnMac && Self.wrappedBundleIsTestFlight(bundleURL))
             || testflight.isManaged(bundleID: bundleID, installedBuild: buildVersion)
-            || (isiOSAppOnMac && testflight.hasIOSBuild(
+            || (isiOSAppOnMac && testflight.hasInstalledIOSBuild(
                 bundleID: bundleID, installedBuild: buildVersion))
         let isMAS = !isTestFlight && (isiOSAppOnMac || hasReceipt)
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -14,8 +14,15 @@ import SQLite3
 ///     *offered* for, so they alone feed ``latest(forBundleID:)`` and
 ///     ``isManaged(bundleID:installedBuild:)``. iOS rows are read too but kept
 ///     strictly apart, for one question only — see ``hasIOSBuild(bundleID:installedBuild:)``.
-///   - `ZINSTALLSTATUSRAW` 1 == the build currently installed on this machine
-///     (its `ZBUNDLEVERSION` matches the app's on-disk `CFBundleVersion`).
+///   - `ZINSTALLSTATUSRAW` 1 == the build currently installed on this machine.
+///     Measured 2026-09-08: 6 of 110 rows carry it, no nulls, values only 0/1,
+///     never twice for one (bundle, platform) — and all 6 matched an app on disk
+///     at exactly that build. It is what separates "TestFlight installed this
+///     here" from "the user merely has access to this build", which is the
+///     question ``hasInstalledIOSBuild(bundleID:installedBuild:)`` asks. Mac rows
+///     deliberately do NOT filter on it: ``latest(forBundleID:)`` needs the builds
+///     that are *available*, and keeping only the installed one would make every
+///     app permanently up to date.
 ///   - The newest available build is the highest `ZBUNDLEVERSION` among an app's
 ///     macOS rows.
 public struct TestFlightInventory: Sendable {
@@ -42,8 +49,8 @@ public struct TestFlightInventory: Sendable {
     /// Every (bundleID, build) macOS pair seen — used to confirm a given on-disk
     /// app really is the TestFlight install (its build appears here).
     private let buildsByBundleID: [String: Set<String>]
-    /// The same, for iOS rows, and deliberately a separate map rather than more
-    /// entries in the one above.
+    /// The same, for the iOS rows TestFlight marks as installed here, and
+    /// deliberately a separate map rather than more entries in the one above.
     ///
     /// Merging them would corrupt the answer `latest(forBundleID:)` gives for a
     /// native Mac app that ALSO has iOS betas — both TestFlight Mac apps on the
@@ -128,19 +135,27 @@ public struct TestFlightInventory: Sendable {
         return builds.contains(installedBuild)
     }
 
-    /// Whether the DB holds an **iOS** row for this bundle at this exact build.
+    /// Whether TestFlight says this exact iOS build is installed **on this
+    /// machine** — the rows behind this are already filtered to
+    /// `ZINSTALLSTATUSRAW = 1`.
     ///
-    /// For wrapped iPhone/iPad apps only, and named for what it reads rather than
-    /// for a verdict, because on its own it is not one: a native Mac app can hold
-    /// iOS rows for betas the user tests on a phone, and answering true for those
-    /// would tag a Mac bundle off the strength of a build installed somewhere else
-    /// entirely. `AppScanner` gates the call on `isiOSAppOnMac`; the same build
-    /// match `isManaged` relies on is what makes it specific once it is.
+    /// For wrapped iPhone/iPad bundles, and still named for what it reads rather
+    /// than for a verdict: `AppScanner` gates the call on `isiOSAppOnMac`, because
+    /// a native Mac app can hold iOS rows of its own and a Mac bundle must never
+    /// be tagged off a build installed on a phone.
     ///
-    /// This exists because a wrapped app's rows carry `ZPLATFORMRAW` 1, never 3 —
-    /// measured: `com.ampcode.amp.ios` sits in the DB at build 64, matching the
-    /// installed build exactly, and was still invisible to `isManaged` (#456).
-    public func hasIOSBuild(bundleID: String?, installedBuild: String?) -> Bool {
+    /// It exists because a wrapped app's rows carry `ZPLATFORMRAW` 1, never 3 —
+    /// `com.ampcode.amp.ios` sat in the DB at build 64, matching the installed
+    /// build exactly, and was invisible to `isManaged` (#456).
+    ///
+    /// **The build match stays, on top of the install flag**, and is not
+    /// redundant with it: this database lags real installs (recorded in
+    /// `AppScanner` — Paste on disk at 18771 while the DB still said 18655), so a
+    /// stale `ZINSTALLSTATUSRAW = 1` can point at a build that is no longer the
+    /// one on disk. Requiring both means a lagging DB answers false and the
+    /// caller falls through to its other signal, rather than confirming an
+    /// install on the strength of a number that has moved on.
+    public func hasInstalledIOSBuild(bundleID: String?, installedBuild: String?) -> Bool {
         guard let bundleID, let installedBuild,
               let builds = iosBuildsByBundleID[bundleID] else { return false }
         return builds.contains(installedBuild)
@@ -174,7 +189,7 @@ public struct TestFlightInventory: Sendable {
     static let openTimeout: TimeInterval = 5
 
     /// A slot one thread fills and another reads. Needed because the reader can
-    /// give up before the writer finishes — see `readMacRows(at:)`.
+    /// give up before the writer finishes — see `readRows(at:)`.
     private final class ResultBox: @unchecked Sendable {
         private let lock = NSLock()
         private var value: Reading?
@@ -276,7 +291,7 @@ public struct TestFlightInventory: Sendable {
         // macOS, 1 of platform 4), nothing here knows what they are, and a bucket
         // nobody can name is not one to start filing installs under.
         let sql = """
-        SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION, ZPLATFORMRAW
+        SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION, ZPLATFORMRAW, ZINSTALLSTATUSRAW
         FROM ZTFAPPBUNDLEMODEL
         WHERE ZPLATFORMRAW IN (1, 3) AND ZBUNDLEID IS NOT NULL AND ZBUNDLEVERSION IS NOT NULL;
         """
@@ -295,17 +310,35 @@ public struct TestFlightInventory: Sendable {
             let bundleID = String(cString: bundleC)
             let short = sqlite3_column_text(stmt, 1).map { String(cString: $0) } ?? ""
             let build = String(cString: buildC)
-            if sqlite3_column_int64(stmt, 3) == Self.macOSPlatform {
+            // Each platform is matched POSITIVELY, with anything else dropped.
+            // Written as "macOS or else iOS" this was correct only because the
+            // WHERE clause thirty lines up says `IN (1, 3)` — so widening that
+            // list later (visionOS, tvOS) would have filed rows from a platform
+            // nobody identified straight into the iOS bucket, with no compile
+            // error and nothing red. Platforms 2 and 4 do occur in the real
+            // database; what they are is unknown, and an unknown bucket is not one
+            // to start filing installs under.
+            switch sqlite3_column_int64(stmt, 3) {
+            case Self.macOSPlatform:
+                // Every mac row, installed or not: `latest(forBundleID:)` is
+                // asking which builds are AVAILABLE.
                 rows.append((bundleID, short, build))
-            } else {
+            case Self.iOSPlatform where sqlite3_column_int64(stmt, 4) == Self.installedHere:
+                // Only the one TestFlight says is installed here. These rows
+                // answer a membership question, never an "is there something
+                // newer" one, and an available-but-not-installed iOS build is
+                // exactly the thing that must not tag a bundle.
                 iosRows.append((bundleID, short, build))
+            default:
+                break
             }
         }
         return (rows, iosRows, true)
     }
 
-    /// `ZPLATFORMRAW` for a native macOS build. The iOS value (1) is not named
-    /// because nothing branches on it — the split above is "macOS or not", over a
-    /// result set the query already narrowed to those two.
+    /// `ZPLATFORMRAW` values, both named because both are now matched positively.
     private static let macOSPlatform: Int64 = 3
+    private static let iOSPlatform: Int64 = 1
+    /// `ZINSTALLSTATUSRAW` for "this build is the one installed on this machine".
+    private static let installedHere: Int64 = 1
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -10,7 +10,10 @@ import SQLite3
 ///
 /// The DB lives in TestFlight's sandbox container and stores one row per
 /// (app, build, platform) in `ZTFAPPBUNDLEMODEL`:
-///   - `ZPLATFORMRAW` 3 == macOS (1 == iOS); we only care about Mac builds.
+///   - `ZPLATFORMRAW` 3 == macOS, 1 == iOS. Mac builds are what an update can be
+///     *offered* for, so they alone feed ``latest(forBundleID:)`` and
+///     ``isManaged(bundleID:installedBuild:)``. iOS rows are read too but kept
+///     strictly apart, for one question only — see ``hasIOSBuild(bundleID:installedBuild:)``.
 ///   - `ZINSTALLSTATUSRAW` 1 == the build currently installed on this machine
 ///     (its `ZBUNDLEVERSION` matches the app's on-disk `CFBundleVersion`).
 ///   - The newest available build is the highest `ZBUNDLEVERSION` among an app's
@@ -39,6 +42,15 @@ public struct TestFlightInventory: Sendable {
     /// Every (bundleID, build) macOS pair seen — used to confirm a given on-disk
     /// app really is the TestFlight install (its build appears here).
     private let buildsByBundleID: [String: Set<String>]
+    /// The same, for iOS rows, and deliberately a separate map rather than more
+    /// entries in the one above.
+    ///
+    /// Merging them would corrupt the answer `latest(forBundleID:)` gives for a
+    /// native Mac app that ALSO has iOS betas — both TestFlight Mac apps on the
+    /// machine this was written on are exactly that: Mithka carries mac 1138 and
+    /// iOS 1149, Notability mac 7127 and iOS 7117. A merged table would offer
+    /// Mithka the iOS build as its next Mac update.
+    private let iosBuildsByBundleID: [String: Set<String>]
 
     /// Whether we actually opened the TestFlight database. `false` means the file
     /// was missing or the read was blocked/denied — notably the "access data from
@@ -55,8 +67,9 @@ public struct TestFlightInventory: Sendable {
 
     public init(databaseURL: URL? = nil) {
         let url = databaseURL ?? Self.defaultDatabaseURL
-        let (rows, opened) = Self.readMacRows(at: url)
+        let (rows, iosRows, opened) = Self.readRows(at: url)
         self.accessible = opened
+        self.iosBuildsByBundleID = Self.buildIndex(iosRows)
 
         var latest: [String: App] = [:]
         var builds: [String: Set<String>] = [:]
@@ -82,8 +95,13 @@ public struct TestFlightInventory: Sendable {
     /// the DB read. `accessible` defaults to `true` (the caller supplied data); pass
     /// `false` to build the "couldn't read TestFlight" sentinel used when the TCC
     /// gate blocks the real read.
-    public init(macRows: [(bundleID: String, shortVersion: String, build: String)], accessible: Bool = true) {
+    public init(
+        macRows: [(bundleID: String, shortVersion: String, build: String)],
+        iosRows: [(bundleID: String, shortVersion: String, build: String)] = [],
+        accessible: Bool = true
+    ) {
         self.accessible = accessible
+        self.iosBuildsByBundleID = Self.buildIndex(iosRows)
         var latest: [String: App] = [:]
         var builds: [String: Set<String>] = [:]
         for row in macRows {
@@ -110,6 +128,33 @@ public struct TestFlightInventory: Sendable {
         return builds.contains(installedBuild)
     }
 
+    /// Whether the DB holds an **iOS** row for this bundle at this exact build.
+    ///
+    /// For wrapped iPhone/iPad apps only, and named for what it reads rather than
+    /// for a verdict, because on its own it is not one: a native Mac app can hold
+    /// iOS rows for betas the user tests on a phone, and answering true for those
+    /// would tag a Mac bundle off the strength of a build installed somewhere else
+    /// entirely. `AppScanner` gates the call on `isiOSAppOnMac`; the same build
+    /// match `isManaged` relies on is what makes it specific once it is.
+    ///
+    /// This exists because a wrapped app's rows carry `ZPLATFORMRAW` 1, never 3 —
+    /// measured: `com.ampcode.amp.ios` sits in the DB at build 64, matching the
+    /// installed build exactly, and was still invisible to `isManaged` (#456).
+    public func hasIOSBuild(bundleID: String?, installedBuild: String?) -> Bool {
+        guard let bundleID, let installedBuild,
+              let builds = iosBuildsByBundleID[bundleID] else { return false }
+        return builds.contains(installedBuild)
+    }
+
+    /// bundleID → the set of build numbers seen for it.
+    private static func buildIndex(
+        _ rows: [(bundleID: String, shortVersion: String, build: String)]
+    ) -> [String: Set<String>] {
+        var index: [String: Set<String>] = [:]
+        for row in rows { index[row.bundleID, default: []].insert(row.build) }
+        return index
+    }
+
     /// The newest available macOS build for an app, if any.
     public func latest(forBundleID bundleID: String?) -> App? {
         guard let bundleID else { return nil }
@@ -119,6 +164,9 @@ public struct TestFlightInventory: Sendable {
     // MARK: - SQLite
 
     typealias Row = (bundleID: String, shortVersion: String, build: String)
+    /// What one read of the database yields: the two platform buckets, plus
+    /// whether we got in at all.
+    typealias Reading = (rows: [Row], iosRows: [Row], opened: Bool)
 
     /// How long to wait for the database to open before treating it as
     /// unreachable. Generous: a cold sandboxed sqlite open is milliseconds, so
@@ -129,12 +177,12 @@ public struct TestFlightInventory: Sendable {
     /// give up before the writer finishes — see `readMacRows(at:)`.
     private final class ResultBox: @unchecked Sendable {
         private let lock = NSLock()
-        private var value: (rows: [Row], opened: Bool)?
-        func set(_ v: (rows: [Row], opened: Bool)) {
+        private var value: Reading?
+        func set(_ v: Reading) {
             lock.lock(); defer { lock.unlock() }
             value = v
         }
-        func take() -> (rows: [Row], opened: Bool)? {
+        func take() -> Reading? {
             lock.lock(); defer { lock.unlock() }
             return value
         }
@@ -163,9 +211,14 @@ public struct TestFlightInventory: Sendable {
     }
     private static let probe = ProbeState()
 
-    /// Returns the macOS rows plus whether the DB was actually opened. `opened`
-    /// is `false` for a missing file or a failed/denied open (the TCC gate), so
-    /// the caller can tell "read it, nothing there" from "never got in".
+    /// Returns the macOS rows, the iOS rows, and whether the DB was actually
+    /// opened. `opened` is `false` for a missing file or a failed/denied open (the
+    /// TCC gate), so the caller can tell "read it, nothing there" from "never got
+    /// in".
+    ///
+    /// Both platforms come back from ONE open. Splitting them into two reads would
+    /// double the exposure to the gate described below, which is the expensive and
+    /// hazardous part of this — the extra rows are not.
     ///
     /// **Bounded, because the open can block forever rather than fail.** The
     /// database sits in TestFlight's container behind macOS's app-data privacy
@@ -177,9 +230,9 @@ public struct TestFlightInventory: Sendable {
     ///
     /// Observed 2026-08-15: a nightly sweep sat in `guarded_open_np` for ten
     /// minutes at 0.03s of CPU before it was killed.
-    private static func readMacRows(at url: URL) -> (rows: [Row], opened: Bool) {
-        guard FileManager.default.fileExists(atPath: url.path) else { return ([], false) }
-        guard !probe.isStuck(url.path) else { return ([], false) }
+    private static func readRows(at url: URL) -> Reading {
+        guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], false) }
+        guard !probe.isStuck(url.path) else { return ([], [], false) }
 
         let box = ResultBox()
         let done = DispatchSemaphore(value: 0)
@@ -200,44 +253,59 @@ public struct TestFlightInventory: Sendable {
                 TestFlight DB open did not return within \(openTimeout, privacy: .public)s at \
                 \(url.path, privacy: .public) — treating it as inaccessible (app-data privacy gate)
                 """)
-            return ([], false)
+            return ([], [], false)
         }
-        return box.take() ?? ([], false)
+        return box.take() ?? ([], [], false)
     }
 
-    /// The actual read. Only ever called from `readMacRows(at:)`'s worker thread.
-    private static func openAndRead(at url: URL) -> (rows: [Row], opened: Bool) {
+    /// The actual read. Only ever called from `readRows(at:)`'s worker thread.
+    private static func openAndRead(at url: URL) -> Reading {
         var db: OpaquePointer?
         // Read-only; SQLITE_OPEN_READONLY still applies the -wal on open so we see
         // TestFlight's most recent (uncheckpointed) writes.
         guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
             sqlite3_close(db)
             Log.scan.error("TestFlight DB open failed at \(url.path, privacy: .public)")
-            return ([], false)
+            return ([], [], false)
         }
         defer { sqlite3_close(db) }
 
+        // Both platforms, sorted into two buckets below rather than merged. The
+        // `IN` list is explicit rather than "anything non-null": platforms 2 and 4
+        // also occur (measured on one machine — 86 iOS rows, 5 of platform 2, 18
+        // macOS, 1 of platform 4), nothing here knows what they are, and a bucket
+        // nobody can name is not one to start filing installs under.
         let sql = """
-        SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION
+        SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION, ZPLATFORMRAW
         FROM ZTFAPPBUNDLEMODEL
-        WHERE ZPLATFORMRAW = 3 AND ZBUNDLEID IS NOT NULL AND ZBUNDLEVERSION IS NOT NULL;
+        WHERE ZPLATFORMRAW IN (1, 3) AND ZBUNDLEID IS NOT NULL AND ZBUNDLEVERSION IS NOT NULL;
         """
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             Log.scan.error("TestFlight DB prepare failed")
-            return ([], true)  // we opened it; the schema just didn't match
+            return ([], [], true)  // we opened it; the schema just didn't match
         }
         defer { sqlite3_finalize(stmt) }
 
         var rows: [Row] = []
+        var iosRows: [Row] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
             guard let bundleC = sqlite3_column_text(stmt, 0),
                   let buildC = sqlite3_column_text(stmt, 2) else { continue }
             let bundleID = String(cString: bundleC)
             let short = sqlite3_column_text(stmt, 1).map { String(cString: $0) } ?? ""
             let build = String(cString: buildC)
-            rows.append((bundleID, short, build))
+            if sqlite3_column_int64(stmt, 3) == Self.macOSPlatform {
+                rows.append((bundleID, short, build))
+            } else {
+                iosRows.append((bundleID, short, build))
+            }
         }
-        return (rows, true)
+        return (rows, iosRows, true)
     }
+
+    /// `ZPLATFORMRAW` for a native macOS build. The iOS value (1) is not named
+    /// because nothing branches on it — the split above is "macOS or not", over a
+    /// result set the query already narrowed to those two.
+    private static let macOSPlatform: Int64 = 3
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -339,6 +339,14 @@ public struct TestFlightInventory: Sendable {
 
     /// Runs one of the two queries above. `nil` means it would not prepare, which
     /// is the caller's cue to try the next one.
+    ///
+    /// ⚠️ `hasInstallStatus` cannot change the outcome today — the fallback query
+    /// selects `ZPLATFORMRAW = 3`, so no iOS row ever reaches the branch that reads
+    /// it (measured: inverting the flag leaves the suite green). It stays because
+    /// of what it guards, not what it currently decides: column 4 does not exist in
+    /// the fallback's result set, and `&&` short-circuiting is what keeps
+    /// `sqlite3_column_int64(stmt, 4)` from being an out-of-range read the day
+    /// someone widens that query the way the primary one is widened.
     private static func runRowQuery(
         _ db: OpaquePointer?, sql: String, hasInstallStatus: Bool
     ) -> Reading? {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -102,13 +102,21 @@ public struct TestFlightInventory: Sendable {
     /// the DB read. `accessible` defaults to `true` (the caller supplied data); pass
     /// `false` to build the "couldn't read TestFlight" sentinel used when the TCC
     /// gate blocks the real read.
+    ///
+    /// ⚠️ `installedIOSRows` is **already filtered**, and the label says so because
+    /// the filter lives in the SQL rather than here: the reader keeps only iOS rows
+    /// carrying `ZINSTALLSTATUSRAW = 1`. Passing a build the user merely has access
+    /// to builds an inventory the database can never produce, and a case resting on
+    /// it would assert behaviour that only exists in the fixture. `macRows` has no
+    /// such precondition — every mac row is kept, installed or not, because
+    /// ``latest(forBundleID:)`` is asking what is available.
     public init(
         macRows: [(bundleID: String, shortVersion: String, build: String)],
-        iosRows: [(bundleID: String, shortVersion: String, build: String)] = [],
+        installedIOSRows: [(bundleID: String, shortVersion: String, build: String)] = [],
         accessible: Bool = true
     ) {
         self.accessible = accessible
-        self.iosBuildsByBundleID = Self.buildIndex(iosRows)
+        self.iosBuildsByBundleID = Self.buildIndex(installedIOSRows)
         var latest: [String: App] = [:]
         var builds: [String: Set<String>] = [:]
         for row in macRows {
@@ -285,20 +293,59 @@ public struct TestFlightInventory: Sendable {
         }
         defer { sqlite3_close(db) }
 
-        // Both platforms, sorted into two buckets below rather than merged. The
-        // `IN` list is explicit rather than "anything non-null": platforms 2 and 4
-        // also occur (measured on one machine — 86 iOS rows, 5 of platform 2, 18
-        // macOS, 1 of platform 4), nothing here knows what they are, and a bucket
-        // nobody can name is not one to start filing installs under.
-        let sql = """
+        // Two queries, tried in order, because a prepare failure is total: it
+        // returns an empty inventory that still reports `opened`, so every
+        // TestFlight app silently loses its build and no native-Mac beta is
+        // offered an update again. `ZINSTALLSTATUSRAW` only feeds the wrapped-bundle
+        // signal, so a schema that no longer has that column must cost that signal
+        // and nothing else — not the macOS rows this file has read since before it
+        // existed. Naming a column in a SELECT is what makes its absence fatal, so
+        // the fallback names one fewer.
+        if let reading = runRowQuery(db, sql: Self.rowsWithInstallStatusSQL, hasInstallStatus: true) {
+            return reading
+        }
+        Log.scan.error("""
+            TestFlight DB prepare failed with ZINSTALLSTATUSRAW — retrying without it; \
+            wrapped iOS apps lose their install signal for this read
+            """)
+        if let reading = runRowQuery(db, sql: Self.macRowsOnlySQL, hasInstallStatus: false) {
+            return reading
+        }
+        Log.scan.error("TestFlight DB prepare failed")
+        return ([], [], true)  // we opened it; the schema just didn't match
+    }
+
+    /// Both platforms, sorted into two buckets by the reader rather than merged.
+    /// The `IN` list is explicit rather than "anything non-null": platforms 2 and 4
+    /// also occur (measured on one machine — 86 iOS rows, 5 of platform 2, 18
+    /// macOS, 1 of platform 4), nothing here knows what they are, and a bucket
+    /// nobody can name is not one to start filing installs under.
+    private static let rowsWithInstallStatusSQL = """
         SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION, ZPLATFORMRAW, ZINSTALLSTATUSRAW
         FROM ZTFAPPBUNDLEMODEL
         WHERE ZPLATFORMRAW IN (1, 3) AND ZBUNDLEID IS NOT NULL AND ZBUNDLEVERSION IS NOT NULL;
         """
+
+    /// The fallback: exactly the columns this file named before the install status
+    /// was read, so it prepares on any schema the old query prepared on. iOS rows
+    /// are not selected at all — without the status column there is no way to tell
+    /// an installed build from one the user merely has access to, and guessing is
+    /// the mistake the status column exists to prevent.
+    private static let macRowsOnlySQL = """
+        SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION, ZPLATFORMRAW
+        FROM ZTFAPPBUNDLEMODEL
+        WHERE ZPLATFORMRAW = 3 AND ZBUNDLEID IS NOT NULL AND ZBUNDLEVERSION IS NOT NULL;
+        """
+
+    /// Runs one of the two queries above. `nil` means it would not prepare, which
+    /// is the caller's cue to try the next one.
+    private static func runRowQuery(
+        _ db: OpaquePointer?, sql: String, hasInstallStatus: Bool
+    ) -> Reading? {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
-            Log.scan.error("TestFlight DB prepare failed")
-            return ([], [], true)  // we opened it; the schema just didn't match
+            sqlite3_finalize(stmt)
+            return nil
         }
         defer { sqlite3_finalize(stmt) }
 
@@ -323,7 +370,8 @@ public struct TestFlightInventory: Sendable {
                 // Every mac row, installed or not: `latest(forBundleID:)` is
                 // asking which builds are AVAILABLE.
                 rows.append((bundleID, short, build))
-            case Self.iOSPlatform where sqlite3_column_int64(stmt, 4) == Self.installedHere:
+            case Self.iOSPlatform
+                where hasInstallStatus && sqlite3_column_int64(stmt, 4) == Self.installedHere:
                 // Only the one TestFlight says is installed here. These rows
                 // answer a membership question, never an "is there something
                 // newer" one, and an available-but-not-installed iOS build is

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -1,0 +1,299 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// A TestFlight-installed iPhone/iPad app running on Apple Silicon must be
+/// recognized as a TestFlight install, not as an App Store copy (#456).
+///
+/// Why it needed its own signals: the receipt environment `readApp` prefers is
+/// unavailable for a wrapped bundle. Measured 2026-09-08 on all three iOS-on-Mac
+/// apps on one machine — two from TestFlight, one bought from the store —
+/// `kMDItemAppStoreReceiptType` was null on every one and no `_MASReceipt`
+/// existed anywhere in any of the bundles. And the TestFlight database files a
+/// wrapped app's rows under `ZPLATFORMRAW` 1, which the mac-only query never
+/// selected: `com.ampcode.amp.ios` sat there at build 64 — matching the
+/// installed build exactly — and was invisible.
+///
+/// The consequence was not cosmetic. `isMAS` falls out of `!isTestFlight &&
+/// (isiOSAppOnMac || hasReceipt)`, so a TestFlight-only app read as a store copy
+/// and `MacAppStoreSource` probed it against a listing that does not exist:
+/// measured, seven fallback storefronts per scan, every scan, each answering a
+/// 42-byte `resultCount: 0` — 1248 requests in 15 hours for one app.
+///
+/// Every case names the mutation it catches, and each of those mutations was run
+/// and confirmed to turn this file red on that case alone.
+struct WrappedIOSTestFlightTests {
+
+    // MARK: - Fixtures
+
+    /// Plants a wrapped iPhone/iPad bundle: `WrappedBundle` symlink, inner
+    /// `Wrapper/<name>.app/Info.plist`, and optionally the store metadata that
+    /// sits beside it.
+    ///
+    /// `metadata` is written as the real installs write it — the top-level key,
+    /// the nested one, or both — so a case can name exactly which key it is
+    /// testing rather than relying on a fixture that happens to carry both.
+    private static func plantWrapped(
+        bundleID: String,
+        build: String = "64",
+        metadata: [String: Any]?,
+        in root: URL
+    ) throws -> URL {
+        let fm = FileManager.default
+        let bundle = root.appendingPathComponent("Fixture.app")
+        let inner = bundle.appendingPathComponent("Wrapper/Inner.app")
+        try fm.createDirectory(at: inner, withIntermediateDirectories: true)
+        let plist: [String: Any] = [
+            "CFBundleDisplayName": "Fixture",
+            "CFBundleIdentifier": bundleID,
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleVersion": build,
+        ]
+        try PropertyListSerialization
+            .data(fromPropertyList: plist, format: .xml, options: 0)
+            .write(to: inner.appendingPathComponent("Info.plist"))
+        try fm.createSymbolicLink(
+            atPath: bundle.appendingPathComponent("WrappedBundle").path,
+            withDestinationPath: "Wrapper/Inner.app")
+        if let metadata {
+            try PropertyListSerialization
+                .data(fromPropertyList: metadata, format: .xml, options: 0)
+                .write(to: bundle.appendingPathComponent("Wrapper/iTunesMetadata.plist"))
+        }
+        return bundle
+    }
+
+    /// A normal Mac bundle, for the cases that pin what must NOT change.
+    private static func plantNative(
+        bundleID: String, build: String = "1138", in root: URL
+    ) throws -> URL {
+        let fm = FileManager.default
+        let bundle = root.appendingPathComponent("Native.app")
+        let contents = bundle.appendingPathComponent("Contents")
+        try fm.createDirectory(at: contents, withIntermediateDirectories: true)
+        try PropertyListSerialization.data(
+            fromPropertyList: [
+                "CFBundleDisplayName": "Native",
+                "CFBundleIdentifier": bundleID,
+                "CFBundleShortVersionString": "1.0",
+                "CFBundleVersion": build,
+            ] as [String: Any],
+            format: .xml, options: 0
+        ).write(to: contents.appendingPathComponent("Info.plist"))
+        return bundle
+    }
+
+    /// What the store-bought wrapped app carried: no beta keys at all, and the
+    /// catalog metadata a TestFlight build has no way to acquire. A function
+    /// rather than a stored property because `[String: Any]` is not `Sendable`.
+    private static func storeMetadata() -> [String: Any] {
+        [
+            "softwareVersionBundleId": "com.example.app.ios",
+            "softwareVersionExternalIdentifier": 876543210,
+            "releaseDate": "2026-08-01T00:00:00Z",
+            "rating": ["name": "4+"],
+            "storefrontCountryCode": "us",
+        ]
+    }
+
+    private static func withTemporaryRoot<T>(_ body: (URL) throws -> T) throws -> T {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wrapped-tf-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        return try body(root)
+    }
+
+    // MARK: - The plist signal
+
+    /// Mutation: drop the `betaExternalVersionIdentifier` branch from
+    /// `wrappedBundleIsTestFlight`.
+    ///
+    /// The fixture carries ONLY that key, so a reader that has quietly come to
+    /// depend on the nested one cannot pass. It also asserts `isiOSAppOnMac`
+    /// first: a fixture that stopped reading as wrapped would make the real
+    /// assertion vacuous, since `isMASApp` would then be false for the wrong
+    /// reason (no receipt) rather than the right one.
+    @Test func theTopLevelBetaKeyAloneIsEnough() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios",
+                metadata: ["betaExternalVersionIdentifier": 234431759], in: root)
+            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
+            #expect(app.isTestFlightApp)
+            #expect(!app.isMASApp)
+        }
+    }
+
+    /// Mutation: drop the `distributorInfo` branch.
+    ///
+    /// Only the nested key is present. Both branches exist so that a rename of
+    /// one does not take the signal with it, and neither is load-bearing alone —
+    /// which is only true if each is separately exercised.
+    @Test func theNestedBetaTesterTypeAloneIsEnough() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios",
+                metadata: ["distributorInfo": ["betaTesterType": 2]], in: root)
+            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
+            #expect(app.isTestFlightApp)
+            #expect(!app.isMASApp)
+        }
+    }
+
+    /// Mutation: compare `betaTesterType` against a value (`== 2`) instead of
+    /// testing for presence.
+    ///
+    /// What that `2` means is undocumented, so nothing may branch on it. A tester
+    /// type this code has never seen must still read as a beta.
+    @Test func anUnseenBetaTesterTypeStillReadsAsABeta() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios",
+                metadata: ["distributorInfo": ["betaTesterType": 99]], in: root)
+            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            #expect(app.isTestFlightApp)
+        }
+    }
+
+    /// Mutation: return `true` when the plist is missing or unparseable.
+    ///
+    /// The store-bought wrapped app is the one that must keep going to
+    /// `MacAppStoreSource` — it has a real listing there — so over-tagging is a
+    /// regression in the opposite direction, and it would be silent: the row
+    /// would simply stop checking for updates.
+    @Test func aStoreBoughtWrappedAppIsStillAStoreCopy() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios", metadata: Self.storeMetadata(), in: root)
+            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
+            #expect(!app.isTestFlightApp)
+            #expect(app.isMASApp)
+        }
+    }
+
+    /// Mutation: make an unreadable plist fall back to `true`.
+    ///
+    /// A wrapped bundle with no metadata at all must land on exactly today's
+    /// behaviour — store copy — rather than on a guess. This is the direction the
+    /// fix is allowed to fail in.
+    @Test func aWrappedBundleWithNoMetadataFallsBackToTodaysAnswer() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios", metadata: nil, in: root)
+            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
+            #expect(!app.isTestFlightApp)
+            #expect(app.isMASApp)
+        }
+    }
+
+    // MARK: - The database signal
+
+    /// Mutation: delete the `isiOSAppOnMac && testflight.hasIOSBuild(…)` clause
+    /// from `readApp`.
+    ///
+    /// The plist is absent here, so the DB row is the only thing that can carry
+    /// this — the two signals are asserted separately on purpose, because a
+    /// fixture holding both would let either one rot unnoticed.
+    @Test func aniOSPlatformRowAloneIdentifiesAWrappedTestFlightApp() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios", build: "64", metadata: nil, in: root)
+            let scanner = AppScanner(testflight: TestFlightInventory(
+                macRows: [],
+                iosRows: [(bundleID: "com.example.app.ios", shortVersion: "1.0", build: "64")]))
+            let app = try #require(scanner.scan(bundlesAt: [bundle]).first)
+            #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
+            #expect(app.isTestFlightApp)
+            #expect(!app.isMASApp)
+        }
+    }
+
+    /// Mutation: relax the build match in `hasIOSBuild` to a bundle-id match.
+    ///
+    /// The same reason `isManaged` matches on the build: the user may merely have
+    /// TestFlight *access* to an app whose store copy is what is installed here.
+    @Test func aniOSRowForADifferentBuildDoesNotTagThisCopy() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios", build: "64", metadata: nil, in: root)
+            let scanner = AppScanner(testflight: TestFlightInventory(
+                macRows: [],
+                iosRows: [(bundleID: "com.example.app.ios", shortVersion: "1.1", build: "77")]))
+            let app = try #require(scanner.scan(bundlesAt: [bundle]).first)
+            #expect(!app.isTestFlightApp)
+            #expect(app.isMASApp)
+        }
+    }
+
+    /// Mutation: drop the `app.isiOSAppOnMac &&` guard in front of `hasIOSBuild`
+    /// (in `readApp`, and again in `applyingTestFlightInventory`).
+    ///
+    /// A native Mac app commonly holds iOS rows for betas the user tests on a
+    /// phone — both TestFlight Mac apps on the machine this was written on do.
+    /// Tagging a Mac bundle off one of those would be tagging it on the strength
+    /// of a build installed somewhere else entirely.
+    @Test func aNativeMacAppIsNotTaggedByItsPhoneBetas() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantNative(bundleID: "com.example.mac", build: "1138", in: root)
+            let inventory = TestFlightInventory(
+                macRows: [],
+                iosRows: [(bundleID: "com.example.mac", shortVersion: "1.4.0", build: "1138")])
+            let app = try #require(AppScanner(testflight: inventory).scan(bundlesAt: [bundle]).first)
+            #expect(!app.isiOSAppOnMac, "fixture must be a native bundle for this to mean anything")
+            #expect(!app.isTestFlightApp)
+
+            let retagged = AppScanner.applyingTestFlightInventory(inventory, to: [app])[0]
+            #expect(!retagged.isTestFlightApp)
+        }
+    }
+
+    /// Mutation: merge `iosBuildsByBundleID` into `buildsByBundleID` (or feed iOS
+    /// rows into `appsByBundleID`).
+    ///
+    /// Mithka on the machine this was written on carries mac 1138 and iOS 1149 in
+    /// the same database. A merged table offers it the phone build as its next
+    /// Mac update — a wrong version, not a missing one, and `latest` is what
+    /// `UpdateChecker` turns into the offer.
+    @Test func iOSRowsNeverBecomeTheLatestMacBuild() {
+        let inventory = TestFlightInventory(
+            macRows: [(bundleID: "ad.neko.mithka", shortVersion: "1.4.0", build: "1138")],
+            iosRows: [(bundleID: "ad.neko.mithka", shortVersion: "1.4.0", build: "1149")])
+        #expect(inventory.latest(forBundleID: "ad.neko.mithka")?.latestBuild == "1138")
+        // And the mac-only membership question keeps its old answer, so nothing
+        // that was already right starts depending on the new bucket.
+        #expect(inventory.isManaged(bundleID: "ad.neko.mithka", installedBuild: "1138"))
+        #expect(!inventory.isManaged(bundleID: "ad.neko.mithka", installedBuild: "1149"))
+        #expect(inventory.hasIOSBuild(bundleID: "ad.neko.mithka", installedBuild: "1149"))
+    }
+
+    /// Mutation: apply the new iOS clause in `applyingTestFlightInventory`
+    /// unconditionally, or not at all.
+    ///
+    /// This is the pass that runs once the app-data privacy gate is finally
+    /// answered — the first scan deliberately runs with an empty inventory — so a
+    /// wrapped app whose plist has been reshaped by a future OS is corrected
+    /// here or nowhere.
+    @Test func theLateInventoryPassAlsoCorrectsAWrappedApp() throws {
+        try Self.withTemporaryRoot { root in
+            let bundle = try Self.plantWrapped(
+                bundleID: "com.example.app.ios", build: "64", metadata: nil, in: root)
+            let blind = AppScanner(testflight: TestFlightInventory(macRows: [], accessible: false))
+            let before = try #require(blind.scan(bundlesAt: [bundle]).first)
+            #expect(!before.isTestFlightApp, "fixture must start untagged for this to mean anything")
+            #expect(before.isMASApp)
+
+            let after = AppScanner.applyingTestFlightInventory(
+                TestFlightInventory(
+                    macRows: [],
+                    iosRows: [(bundleID: "com.example.app.ios", shortVersion: "1.0", build: "64")]),
+                to: [before])[0]
+            #expect(after.isTestFlightApp)
+            #expect(!after.isMASApp)
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -399,7 +399,10 @@ struct WrappedIOSTestFlightTests {
             #expect(inventory.isManaged(bundleID: "com.example.mac", installedBuild: "100"))
             // The wrapped-bundle signal is the only casualty, and it fails closed:
             // with no status column there is no way to tell an installed build from
-            // one the user merely has access to, so it claims neither.
+            // one the user merely has access to, so it claims neither. ⚠️ This
+            // assertion is carried by the fallback's `ZPLATFORMRAW = 3`, not by the
+            // `hasInstallStatus` flag — measured, inverting that flag leaves this
+            // green, because no iOS row is selected for it to judge.
             #expect(!inventory.hasInstalledIOSBuild(
                 bundleID: "com.example.app.ios", installedBuild: "64"))
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -234,7 +234,7 @@ struct WrappedIOSTestFlightTests {
                 bundleID: "com.example.app.ios", build: "64", metadata: nil, in: root)
             let scanner = AppScanner(testflight: TestFlightInventory(
                 macRows: [],
-                iosRows: [(bundleID: "com.example.app.ios", shortVersion: "1.0", build: "64")]))
+                installedIOSRows: [(bundleID: "com.example.app.ios", shortVersion: "1.0", build: "64")]))
             let app = try #require(scanner.scan(bundlesAt: [bundle]).first)
             #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
             #expect(app.isTestFlightApp)
@@ -252,7 +252,7 @@ struct WrappedIOSTestFlightTests {
                 bundleID: "com.example.app.ios", build: "64", metadata: nil, in: root)
             let scanner = AppScanner(testflight: TestFlightInventory(
                 macRows: [],
-                iosRows: [(bundleID: "com.example.app.ios", shortVersion: "1.1", build: "77")]))
+                installedIOSRows: [(bundleID: "com.example.app.ios", shortVersion: "1.1", build: "77")]))
             let app = try #require(scanner.scan(bundlesAt: [bundle]).first)
             #expect(!app.isTestFlightApp)
             #expect(app.isMASApp)
@@ -271,7 +271,7 @@ struct WrappedIOSTestFlightTests {
             let bundle = try Self.plantNative(bundleID: "com.example.mac", build: "1138", in: root)
             let inventory = TestFlightInventory(
                 macRows: [],
-                iosRows: [(bundleID: "com.example.mac", shortVersion: "1.4.0", build: "1138")])
+                installedIOSRows: [(bundleID: "com.example.mac", shortVersion: "1.4.0", build: "1138")])
             let app = try #require(AppScanner(testflight: inventory).scan(bundlesAt: [bundle]).first)
             #expect(!app.isiOSAppOnMac, "fixture must be a native bundle for this to mean anything")
             #expect(!app.isTestFlightApp)
@@ -291,7 +291,7 @@ struct WrappedIOSTestFlightTests {
     @Test func iOSRowsNeverBecomeTheLatestMacBuild() {
         let inventory = TestFlightInventory(
             macRows: [(bundleID: "ad.neko.mithka", shortVersion: "1.4.0", build: "1138")],
-            iosRows: [(bundleID: "ad.neko.mithka", shortVersion: "1.4.0", build: "1149")])
+            installedIOSRows: [(bundleID: "ad.neko.mithka", shortVersion: "1.4.0", build: "1149")])
         #expect(inventory.latest(forBundleID: "ad.neko.mithka")?.latestBuild == "1138")
         // And the mac-only membership question keeps its old answer, so nothing
         // that was already right starts depending on the new bucket.
@@ -319,7 +319,7 @@ struct WrappedIOSTestFlightTests {
             let after = AppScanner.applyingTestFlightInventory(
                 TestFlightInventory(
                     macRows: [],
-                    iosRows: [(bundleID: "com.example.app.ios", shortVersion: "1.0", build: "64")]),
+                    installedIOSRows: [(bundleID: "com.example.app.ios", shortVersion: "1.0", build: "64")]),
                 to: [before])[0]
             #expect(after.isTestFlightApp)
             #expect(!after.isMASApp)
@@ -329,7 +329,7 @@ struct WrappedIOSTestFlightTests {
     // MARK: - What the SQL itself decides
 
     /// The two buckets are filled in `openAndRead`, which only runs against a real
-    /// database file — the `macRows:`/`iosRows:` seam takes rows that are already
+    /// database file — the `macRows:`/`installedIOSRows:` seam takes rows that are already
     /// sorted, so nothing reaching it can prove the query is right. These cases
     /// build an actual SQLite file instead.
     private static func plantDatabase(
@@ -353,6 +353,56 @@ struct WrappedIOSTestFlightTests {
             #expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
         }
         return url
+    }
+
+    /// The schema as it was before `ZINSTALLSTATUSRAW` was read: no such column.
+    private static func plantLegacyDatabase(
+        _ rows: [(bundleID: String, short: String, build: String, platform: Int32)],
+        in root: URL
+    ) throws -> URL {
+        let url = root.appendingPathComponent("Legacy.sqlite")
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        #expect(sqlite3_exec(db, """
+            CREATE TABLE ZTFAPPBUNDLEMODEL (
+              ZBUNDLEID TEXT, ZSHORTVERSION TEXT, ZBUNDLEVERSION TEXT, ZPLATFORMRAW INTEGER);
+            """, nil, nil, nil) == SQLITE_OK)
+        for row in rows {
+            #expect(sqlite3_exec(db, """
+                INSERT INTO ZTFAPPBUNDLEMODEL VALUES \
+                ('\(row.bundleID)', '\(row.short)', '\(row.build)', \(row.platform));
+                """, nil, nil, nil) == SQLITE_OK)
+        }
+        return url
+    }
+
+    /// Mutation: delete the `macRowsOnlySQL` retry, leaving one query.
+    ///
+    /// Naming a column in a SELECT is what makes its absence fatal, and a prepare
+    /// failure here is total — it returns an empty inventory that still reports
+    /// `accessible`, so nothing retries and nothing looks broken. Without the
+    /// retry, a TestFlight schema that drops `ZINSTALLSTATUSRAW` would take every
+    /// native Mac beta's update with it, for a column only wrapped bundles use.
+    @Test func aSchemaWithoutTheInstallColumnStillYieldsTheMacRows() throws {
+        try Self.withTemporaryRoot { root in
+            let db = try Self.plantLegacyDatabase([
+                (bundleID: "com.example.mac", short: "1.0", build: "100", platform: 3),
+                (bundleID: "com.example.mac", short: "1.1", build: "200", platform: 3),
+                (bundleID: "com.example.app.ios", short: "1.0", build: "64", platform: 1),
+            ], in: root)
+            let inventory = TestFlightInventory(databaseURL: db)
+            #expect(inventory.accessible)
+            // The macOS half survives untouched — this is the part that must not
+            // pay for a column it never needed.
+            #expect(inventory.latest(forBundleID: "com.example.mac")?.latestBuild == "200")
+            #expect(inventory.isManaged(bundleID: "com.example.mac", installedBuild: "100"))
+            // The wrapped-bundle signal is the only casualty, and it fails closed:
+            // with no status column there is no way to tell an installed build from
+            // one the user merely has access to, so it claims neither.
+            #expect(!inventory.hasInstalledIOSBuild(
+                bundleID: "com.example.app.ios", installedBuild: "64"))
+        }
     }
 
     /// Mutation: drop the `where sqlite3_column_int64(stmt, 4) == Self.installedHere`

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import SQLite3
 @testable import DuoUpdaterCore
 
 /// A TestFlight-installed iPhone/iPad app running on Apple Silicon must be
@@ -106,6 +107,19 @@ struct WrappedIOSTestFlightTests {
         ]
     }
 
+    /// A scanner that cannot reach the real TestFlight database.
+    ///
+    /// `AppScanner()` defaults `testflight:` to `TestFlightInventory()`, which
+    /// opens the developer's own TestFlight container — so a bare `AppScanner()`
+    /// here would make these cases depend on machine state (a real row for the
+    /// fixture's bundle id would flip the store-copy case) and pay the app-data
+    /// privacy gate, which this code's own comments record blocking for ten
+    /// minutes. Every case below asserts the plist signal, so the inventory is
+    /// empty on purpose: whatever they prove, they prove about the plist.
+    private static func plistOnlyScanner() -> AppScanner {
+        AppScanner(testflight: TestFlightInventory(macRows: []))
+    }
+
     private static func withTemporaryRoot<T>(_ body: (URL) throws -> T) throws -> T {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("wrapped-tf-\(UUID().uuidString)")
@@ -129,7 +143,7 @@ struct WrappedIOSTestFlightTests {
             let bundle = try Self.plantWrapped(
                 bundleID: "com.example.app.ios",
                 metadata: ["betaExternalVersionIdentifier": 234431759], in: root)
-            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            let app = try #require(Self.plistOnlyScanner().scan(bundlesAt: [bundle]).first)
             #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
             #expect(app.isTestFlightApp)
             #expect(!app.isMASApp)
@@ -146,7 +160,7 @@ struct WrappedIOSTestFlightTests {
             let bundle = try Self.plantWrapped(
                 bundleID: "com.example.app.ios",
                 metadata: ["distributorInfo": ["betaTesterType": 2]], in: root)
-            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            let app = try #require(Self.plistOnlyScanner().scan(bundlesAt: [bundle]).first)
             #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
             #expect(app.isTestFlightApp)
             #expect(!app.isMASApp)
@@ -163,7 +177,7 @@ struct WrappedIOSTestFlightTests {
             let bundle = try Self.plantWrapped(
                 bundleID: "com.example.app.ios",
                 metadata: ["distributorInfo": ["betaTesterType": 99]], in: root)
-            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            let app = try #require(Self.plistOnlyScanner().scan(bundlesAt: [bundle]).first)
             #expect(app.isTestFlightApp)
         }
     }
@@ -178,7 +192,7 @@ struct WrappedIOSTestFlightTests {
         try Self.withTemporaryRoot { root in
             let bundle = try Self.plantWrapped(
                 bundleID: "com.example.app.ios", metadata: Self.storeMetadata(), in: root)
-            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            let app = try #require(Self.plistOnlyScanner().scan(bundlesAt: [bundle]).first)
             #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
             #expect(!app.isTestFlightApp)
             #expect(app.isMASApp)
@@ -194,7 +208,7 @@ struct WrappedIOSTestFlightTests {
         try Self.withTemporaryRoot { root in
             let bundle = try Self.plantWrapped(
                 bundleID: "com.example.app.ios", metadata: nil, in: root)
-            let app = try #require(AppScanner().scan(bundlesAt: [bundle]).first)
+            let app = try #require(Self.plistOnlyScanner().scan(bundlesAt: [bundle]).first)
             #expect(app.isiOSAppOnMac, "fixture stopped reading as a wrapped bundle")
             #expect(!app.isTestFlightApp)
             #expect(app.isMASApp)
@@ -203,7 +217,7 @@ struct WrappedIOSTestFlightTests {
 
     // MARK: - The database signal
 
-    /// Mutation: delete the `isiOSAppOnMac && testflight.hasIOSBuild(…)` clause
+    /// Mutation: delete the `isiOSAppOnMac && testflight.hasInstalledIOSBuild(…)` clause
     /// from `readApp`.
     ///
     /// The plist is absent here, so the DB row is the only thing that can carry
@@ -223,7 +237,7 @@ struct WrappedIOSTestFlightTests {
         }
     }
 
-    /// Mutation: relax the build match in `hasIOSBuild` to a bundle-id match.
+    /// Mutation: relax the build match in `hasInstalledIOSBuild` to a bundle-id match.
     ///
     /// The same reason `isManaged` matches on the build: the user may merely have
     /// TestFlight *access* to an app whose store copy is what is installed here.
@@ -240,7 +254,7 @@ struct WrappedIOSTestFlightTests {
         }
     }
 
-    /// Mutation: drop the `app.isiOSAppOnMac &&` guard in front of `hasIOSBuild`
+    /// Mutation: drop the `app.isiOSAppOnMac &&` guard in front of `hasInstalledIOSBuild`
     /// (in `readApp`, and again in `applyingTestFlightInventory`).
     ///
     /// A native Mac app commonly holds iOS rows for betas the user tests on a
@@ -278,7 +292,7 @@ struct WrappedIOSTestFlightTests {
         // that was already right starts depending on the new bucket.
         #expect(inventory.isManaged(bundleID: "ad.neko.mithka", installedBuild: "1138"))
         #expect(!inventory.isManaged(bundleID: "ad.neko.mithka", installedBuild: "1149"))
-        #expect(inventory.hasIOSBuild(bundleID: "ad.neko.mithka", installedBuild: "1149"))
+        #expect(inventory.hasInstalledIOSBuild(bundleID: "ad.neko.mithka", installedBuild: "1149"))
     }
 
     /// Mutation: apply the new iOS clause in `applyingTestFlightInventory`
@@ -304,6 +318,102 @@ struct WrappedIOSTestFlightTests {
                 to: [before])[0]
             #expect(after.isTestFlightApp)
             #expect(!after.isMASApp)
+        }
+    }
+
+    // MARK: - What the SQL itself decides
+
+    /// The two buckets are filled in `openAndRead`, which only runs against a real
+    /// database file — the `macRows:`/`iosRows:` seam takes rows that are already
+    /// sorted, so nothing reaching it can prove the query is right. These cases
+    /// build an actual SQLite file instead.
+    private static func plantDatabase(
+        _ rows: [(bundleID: String, short: String, build: String, platform: Int32, installed: Int32)],
+        in root: URL
+    ) throws -> URL {
+        let url = root.appendingPathComponent("TestFlight.sqlite")
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        #expect(sqlite3_exec(db, """
+            CREATE TABLE ZTFAPPBUNDLEMODEL (
+              ZBUNDLEID TEXT, ZSHORTVERSION TEXT, ZBUNDLEVERSION TEXT,
+              ZPLATFORMRAW INTEGER, ZINSTALLSTATUSRAW INTEGER);
+            """, nil, nil, nil) == SQLITE_OK)
+        for row in rows {
+            let sql = """
+                INSERT INTO ZTFAPPBUNDLEMODEL VALUES \
+                ('\(row.bundleID)', '\(row.short)', '\(row.build)', \(row.platform), \(row.installed));
+                """
+            #expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
+        }
+        return url
+    }
+
+    /// Mutation: drop the `where sqlite3_column_int64(stmt, 4) == Self.installedHere`
+    /// guard on the iOS bucket.
+    ///
+    /// This is the whole reason the DB clause cannot promote a store copy of an app
+    /// the user merely beta-tests. Mithka on the machine this was written on is the
+    /// real shape: an iOS row it has ACCESS to (build 1149, not installed here) next
+    /// to the Mac row that IS installed. Only the installed one may answer.
+    @Test func onlyTheIOSBuildTestFlightSaysIsInstalledHereCounts() throws {
+        try Self.withTemporaryRoot { root in
+            let db = try Self.plantDatabase([
+                (bundleID: "com.example.app.ios", short: "1.0", build: "64",
+                 platform: 1, installed: 1),
+                (bundleID: "com.example.app.ios", short: "1.1", build: "77",
+                 platform: 1, installed: 0),
+            ], in: root)
+            let inventory = TestFlightInventory(databaseURL: db)
+            #expect(inventory.accessible, "fixture database was not opened")
+            #expect(inventory.hasInstalledIOSBuild(
+                bundleID: "com.example.app.ios", installedBuild: "64"))
+            #expect(!inventory.hasInstalledIOSBuild(
+                bundleID: "com.example.app.ios", installedBuild: "77"))
+        }
+    }
+
+    /// Mutation: apply the same install filter to the macOS bucket.
+    ///
+    /// It must NOT be applied there. `latest(forBundleID:)` is asking which builds
+    /// are *available*; keeping only the installed one would make every TestFlight
+    /// Mac app permanently up to date — a silent stop to updates, with every row
+    /// still rendering normally.
+    @Test func macRowsKeepTheBuildsThatAreMerelyAvailable() throws {
+        try Self.withTemporaryRoot { root in
+            let db = try Self.plantDatabase([
+                (bundleID: "com.example.mac", short: "1.0", build: "100",
+                 platform: 3, installed: 1),
+                (bundleID: "com.example.mac", short: "1.1", build: "200",
+                 platform: 3, installed: 0),
+            ], in: root)
+            let inventory = TestFlightInventory(databaseURL: db)
+            #expect(inventory.latest(forBundleID: "com.example.mac")?.latestBuild == "200")
+            #expect(inventory.isManaged(bundleID: "com.example.mac", installedBuild: "100"))
+        }
+    }
+
+    /// Mutation: restore the `else { iosRows.append(…) }` bucketing.
+    ///
+    /// A platform the query does not name must reach neither bucket. Written as an
+    /// `else`, a later widening of the `IN` list would file unidentified rows as
+    /// iOS evidence with nothing red; matched positively, it is a no-op.
+    @Test func anUnknownPlatformReachesNeitherBucket() throws {
+        try Self.withTemporaryRoot { root in
+            let db = try Self.plantDatabase([
+                (bundleID: "com.example.other", short: "1.0", build: "300",
+                 platform: 2, installed: 1),
+                (bundleID: "com.example.other", short: "1.0", build: "400",
+                 platform: 4, installed: 1),
+            ], in: root)
+            let inventory = TestFlightInventory(databaseURL: db)
+            #expect(inventory.accessible, "fixture database was not opened")
+            #expect(!inventory.hasInstalledIOSBuild(
+                bundleID: "com.example.other", installedBuild: "300"))
+            #expect(!inventory.hasInstalledIOSBuild(
+                bundleID: "com.example.other", installedBuild: "400"))
+            #expect(inventory.latest(forBundleID: "com.example.other") == nil)
         }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -116,6 +116,11 @@ struct WrappedIOSTestFlightTests {
     /// privacy gate, which this code's own comments record blocking for ten
     /// minutes. Every case below asserts the plist signal, so the inventory is
     /// empty on purpose: whatever they prove, they prove about the plist.
+    ///
+    /// ⚠️ Measured: swapping this back for a bare `AppScanner()` leaves the file
+    /// **green**, because no real TestFlight row happens to name the fixtures'
+    /// bundle id. So this is hygiene that no test can enforce — the hazard is a
+    /// machine where that coincidence holds, and a gate nobody can answer.
     private static func plistOnlyScanner() -> AppScanner {
         AppScanner(testflight: TestFlightInventory(macRows: []))
     }
@@ -394,11 +399,20 @@ struct WrappedIOSTestFlightTests {
         }
     }
 
-    /// Mutation: restore the `else { iosRows.append(…) }` bucketing.
+    /// Mutation: widen the query's `IN` list AND restore the `else { iosRows… }`
+    /// bucketing. Both together — measured, and the pair is the point.
     ///
-    /// A platform the query does not name must reach neither bucket. Written as an
-    /// `else`, a later widening of the `IN` list would file unidentified rows as
-    /// iOS evidence with nothing red; matched positively, it is a no-op.
+    /// Widening the `IN` list alone leaves this **green**, and that is the guard
+    /// working rather than a hole: platforms 2 and 4 then come back from SQL, the
+    /// positive `switch` drops them at `default`, and behaviour is unchanged. Put
+    /// the `else` back as well and this goes red. So what the case pins is the
+    /// combination — that a future widening of the query cannot silently turn rows
+    /// from a platform nobody identified into install evidence.
+    ///
+    /// ⚠️ With today's `IN (1, 3)` no input can reach `default`, so the positive
+    /// matching has no test of its own and cannot have one. It is defence in depth
+    /// against an edit that has not happened, and this comment is the honest
+    /// statement of that rather than a claim of coverage.
     @Test func anUnknownPlatformReachesNeitherBucket() throws {
         try Self.withTemporaryRoot { root in
             let db = try Self.plantDatabase([

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -20,8 +20,18 @@ import Foundation
 /// measured, seven fallback storefronts per scan, every scan, each answering a
 /// 42-byte `resultCount: 0` — 1248 requests in 15 hours for one app.
 ///
-/// Every case names the mutation it catches, and each of those mutations was run
-/// and confirmed to turn this file red on that case alone.
+/// Every case names the mutation it catches. All eleven were run against this
+/// commit's parent-plus-fix and every one turned the file red on the case that
+/// names it — including the two that only a wrong answer in the *other*
+/// direction can trigger (`aStoreBoughtWrappedAppIsStillAStoreCopy` needs
+/// `wrappedBundleIsTestFlight` to return true unconditionally;
+/// `aWrappedBundleWithNoMetadataFallsBackToTodaysAnswer` needs an unreadable
+/// plist to fall back to true).
+///
+/// Some mutations redden more than the one case, because several fixtures are
+/// legitimately wrapped bundles and a broken wrapped-bundle signal fails all of
+/// them. That is collateral, not coverage: what each case is *for* is the
+/// mutation named in its own doc comment.
 struct WrappedIOSTestFlightTests {
 
     // MARK: - Fixtures


### PR DESCRIPTION
Fixes #456.

A wrapped iPhone/iPad app installed by TestFlight read as an App Store copy, so
`MacAppStoreSource` probed it against a listing that does not exist — the home
storefront plus seven fallbacks, every scan, forever. Measured on one machine at
`CheckFrequency = every5Min`: **1248 requests in 15 hours** for `Amp 2` alone,
each answering a 42-byte `resultCount: 0`, and a second app reproduced it within
two minutes of being installed.

## Why the existing signals could not answer

Neither one is reachable for a wrapped bundle, and this was measured rather than
reasoned from the code:

- **No receipt exists.** All three iOS-on-Mac apps on the machine — two from
  TestFlight, one bought from the store — report `kMDItemAppStoreReceiptType`
  null, and `find` turns up no `_MASReceipt` anywhere in any of them. So the
  `!isiOSAppOnMac` guard in front of that read is not the cause; there is
  genuinely nothing behind it.
- **The DB row is filed under the wrong platform.** `com.ampcode.amp.ios` sits in
  TestFlight's database at build 64 — matching the installed build exactly — with
  `ZPLATFORMRAW = 1`, and the query selected `= 3` only.

## What this adds

Two signals, both **scoped to wrapped bundles**, kept as separate clauses because
their failure modes do not overlap (the plist is local but privately formatted;
the DB is schema-documented but sits behind the app-data privacy gate and lags
real installs):

1. `Wrapper/iTunesMetadata.plist` — presence of `betaExternalVersionIdentifier`
   or `distributorInfo.betaTesterType`.
2. iOS-platform rows from the TestFlight DB, read in the **same single open** and
   kept in their own bucket.

The native-Mac path is untouched, and that is load-bearing: Mithka and Notability
are both TestFlight installs, both already classified correctly by the receipt
signal, and both make **zero** network requests across the whole retained event
window. Adding signal there would only widen the false-positive surface.

## Two things deliberately not done

- **iOS rows never feed `latest(forBundleID:)`.** Mithka carries mac 1138 and iOS
  1149 in the same database; a merged table would offer it the phone build as its
  next Mac update — a wrong version, not a missing one. `hasIOSBuild` is named for
  what it reads rather than for a verdict, precisely because on its own it is not
  one; `AppScanner` gates it on `isiOSAppOnMac`.
- **No TestFlight update is offered for wrapped apps.** They now land on
  `.testFlightManaged` with no version, which is honest and already better than
  today. Offering one is a feature, not this fix.

## ⚠️ The plist format is undocumented

No Apple documentation describes these keys (searched — the Xamarin page of the
same filename documents the *Ad Hoc* metadata a developer writes into an IPA,
which is a different file; TheAppleWiki is community reverse-engineering). The
evidence is n=3: the two TestFlight installs carried identical 23-key sets
including both keys read here, while the store-bought one carried neither and
instead had catalog metadata a TestFlight build has no way to acquire
(`softwareVersionExternalIdentifier`, `rating`, `releaseDate`, `genre`).

Two consequences are written into the code: **presence is the test, never a
value** (what `betaTesterType`'s `2` means is undocumented too), and an
unreadable or reshaped plist returns false — landing on exactly today's
behaviour. The failure direction is the bug being fixed, never a store copy
mis-tagged as a beta.

## Verification

```
$ scripts/run-with-hang-report.sh 1800 make test
make test exit code: 0
Test run with 2449 tests in 202 suites passed after 20.065 seconds with 1 known issue.
Test run with 263 tests in 32 suites passed after 0.155 seconds.
✓ App tests — 9 of 9 cases executed
✓ localizable keys agree · version comparisons discriminate · app audits consistent
✓ engine-notes pointers resolve · skill docs consistent · no machine-population claims
```

Eleven mutations were run against the fix; **every one turned the new file red on
the case that names it**, and every one of the ten cases is reddened by at least
one:

| mutation | red case |
|---|---|
| drop the plist clause from `readApp` | the three plist cases |
| drop the iOS-row clause from `readApp` | `aniOSPlatformRowAloneIdentifiesAWrappedTestFlightApp` |
| drop the `betaExternalVersionIdentifier` branch | `theTopLevelBetaKeyAloneIsEnough` |
| drop the `distributorInfo` branch | `theNestedBetaTesterTypeAloneIsEnough` |
| compare `betaTesterType == 2` instead of presence | `anUnseenBetaTesterTypeStillReadsAsABeta` |
| unreadable plist falls back to `true` | `aWrappedBundleWithNoMetadataFallsBackToTodaysAnswer` |
| merge iOS rows into the mac table | `iOSRowsNeverBecomeTheLatestMacBuild` |
| drop the `isiOSAppOnMac` guard (both sites) | `aNativeMacAppIsNotTaggedByItsPhoneBetas` |
| relax `hasIOSBuild` to a bundle-id match | `aniOSRowForADifferentBuildDoesNotTagThisCopy` |
| drop the iOS clause from `applyingTestFlightInventory` | `theLateInventoryPassAlsoCorrectsAWrappedApp` |
| `wrappedBundleIsTestFlight` returns `true` always | `aStoreBoughtWrappedAppIsStillAStoreCopy` |

A live check against the two real apps is running on the machine that reported
this; result to follow as a comment.
