### PR TITLE
docs: trim cache and pre-install comments to current contracts (#409)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
@@ -1,23 +1,9 @@
 import Foundation
 
-/// What the defensive re-check right before an install concluded.
-///
-/// Approving an install does NOT mean the disk still needs it: the offer being
-/// acted on may be minutes or hours old — the vendor may have published again,
-/// the app may have updated itself, or a package may have been installed by
-/// hand. So every caller re-reads the bundle off disk and re-queries the source
-/// first, and decides from THAT, through `decision(for:offered:confirmed:)`
-/// below. Two callers do this today: `AppListModel.performInstall` (the
-/// menu-bar click) and the CLI's `Install.reconsider` (#404, added after this
-/// gate already existed).
-///
-/// Every non-`.updateAvailable` outcome used to collapse into one branch and
-/// one log line, "already current on disk" — including a source that had been
-/// tried and failed, which is not a verdict about the disk at all. See
-/// `docs/engine-notes/pre-install-gate.md` §1 for the three endings that used
-/// to share that sentence. `UpdateStatus` already draws the line this enum
-/// reads (`.unknown` = nothing covers this app, `.error` = tried and failed,
-/// retryable).
+/// Shared classification after callers re-read the bundle and re-query its source.
+/// `AppListModel.performInstall` and CLI `Install.reconsider` use this gate.
+/// See `docs/engine-notes/pre-install-gate.md` §1 for history and
+/// `PreInstallGateTests` / CLI `InstallTests` for coverage.
 public enum PreInstallDecision: Sendable, Equatable {
     /// A newer version was confirmed just now. Install it.
     case proceed
@@ -25,64 +11,26 @@ public enum PreInstallDecision: Sendable, Equatable {
     case alreadyCurrent
     /// Something else owns this app's updates. Nothing to do, and not a failure.
     case managedElsewhere
-    /// We could not establish whether an update exists. Carries the source's own
-    /// message when there was one; `nil` when no source covers the app at all.
-    ///
-    /// Deliberately NOT folded into `alreadyCurrent`: "we didn't find out" and
-    /// "there is nothing to find" are different answers, and only one of them is
-    /// worth retrying.
+    /// The source failed (its message) or no source covers the app (nil).
+    /// Failure to confirm is not evidence that the disk is current.
     case cannotConfirm(String?)
-    /// The re-check answered with a version OLDER than what was being offered
-    /// when the install was approved, and called the app current on the
-    /// strength of it. Nothing was installed and nothing is known to be wrong
-    /// with the bundle — the source contradicted itself, one query apart.
-    ///
-    /// Its own case rather than `alreadyCurrent` because the sentence
-    /// `alreadyCurrent` produces ("already current on disk") is a claim about
-    /// the disk, and here it is false: the disk still carries the older build
-    /// that was being offered.
-    ///
-    /// The incident that motivated this case — two live queries seconds apart
-    /// answering different versions for the same app — is not something this
-    /// gate can see the cause of, and the point of this case is that it does
-    /// not have to: an answer that walks backwards is not evidence something
-    /// was already installed, whatever made it walk backwards. See
-    /// `docs/engine-notes/pre-install-gate.md` §2.
-    ///
-    /// Carries no message: the two version strings live in the `UpdateResult`s
-    /// the caller already holds, and the wording belongs where the rest of the
-    /// user-facing copy is.
+    /// The source claims up-to-date with a version older than the approved offer.
+    /// This contradicts the offer, not the disk state. Callers own the wording
+    /// and retain both results for reporting the versions.
+    /// See `docs/engine-notes/pre-install-gate.md` §2 for the motivating incident.
     case answerRegressed
-    /// The re-check found no readable bundle at the row's own path at all.
-    ///
-    /// This can mean three different things, and it cannot say which:
-    /// the bundle was uninstalled, its `Info.plist` no longer parses, or the
-    /// path now resolves to a bundle with a different identity.
-    /// `AppScanner.readApp` returns `nil` for the first two alike and cannot
-    /// distinguish them; the third is caught upstream by the id filter in
-    /// `AppListModel.recheckMany` / `Install.recheckOne`, which also answers
-    /// with nothing rather than with the other app's row.
-    ///
-    /// Carries no message, unlike `.cannotConfirm`: the CLI's sentence names
-    /// the path in plain text, and the App's has to go through
-    /// `String(localized:)`, so the wording belongs to each host. What is
-    /// shared here is only the classification.
+    /// No readable bundle with the expected identity at the row's path.
+    /// Absence, unreadable Info.plist, and identity mismatch are indistinguishable
+    /// here; callers filter identity before this gate and own the user-facing copy.
     case unreadable
 }
 
 public enum PreInstallGate {
 
-    /// Classify the re-check's outcome.
-    ///
-    /// `offered` is what was being offered when the install was approved;
-    /// `confirmed` is what the re-check just answered. Both are ``VersionSide``
-    /// pairs and are compared with
-    /// ``VersionComparator/isNewer(_:than:)-(VersionSide,VersionSide)``, so a
-    /// vendor that freezes its marketing string is decided on its build and
-    /// nothing is ever compared across namespaces. Neither is optional: a caller
-    /// that does not have one passes an empty ``VersionSide``, which is
-    /// incomparable and therefore never regressed — the comparator fails closed —
-    /// and the answer is the one this gate always gave.
+    /// Compare the approved offer with the re-check using `VersionSide` pairs:
+    /// build-only changes remain comparable without crossing version namespaces.
+    /// Pass an empty side for a missing remote; incomparable sides do not regress.
+    /// Only `.upToDate` can produce `.answerRegressed`.
     public static func decision(
         for status: UpdateStatus,
         offered: VersionSide,
@@ -90,21 +38,9 @@ public enum PreInstallGate {
     ) -> PreInstallDecision {
         switch status {
         case .updateAvailable:
-            // NOT second-guessed, deliberately. A re-check can legitimately come
-            // back with a LOWER version than what was offered — e.g. the user
-            // moved the app off a beta channel in its own settings between the
-            // check and the approval, so the stable release it now resolves is
-            // older than the beta that was offered and still newer than what is
-            // installed. Refusing that would block the install just approved.
-            // The `.upToDate` arm below is different: there the source is
-            // claiming there is nothing to install at all.
+            // A channel change can lower the offer while still updating the disk.
             return .proceed
         case .upToDate:
-            // The only reading of `.upToDate` this gate refuses. Every other way
-            // to reach it — a manual pkg install, the app's own updater, a build
-            // that landed between the check and the approval — leaves `confirmed`
-            // at or above what was offered, so this comparison is false and the
-            // answer is unchanged.
             return VersionComparator.isNewer(offered, than: confirmed)
                 ? .answerRegressed
                 : .alreadyCurrent
@@ -117,23 +53,9 @@ public enum PreInstallGate {
         }
     }
 
-    /// Classify the re-check's outcome when the re-check itself may have come
-    /// back with nothing.
-    ///
-    /// This overload exists because "the re-check came back with nothing" is
-    /// part of the same decision as everything `decision(for:offered:confirmed:)`
-    /// already classifies, and each host used to make that call for itself —
-    /// which let the two drift. The CLI grew a `.unreadable` case for it in
-    /// #434; the menu bar's `recheck` kept `?? result`, silently falling back to
-    /// the stale offer, which cancelled out exactly the identity guard
-    /// `recheckMany` stands behind it for (#440). Both hosts now call this
-    /// overload instead of branching on their own optional first, so the arm
-    /// cannot be handled on one side and forgotten on the other.
-    ///
-    /// `nil` confirmed classifies as `.unreadable`; otherwise this delegates to
-    /// `decision(for:offered:confirmed:)` with both sides' `versionSide`s (or an
-    /// empty one when a result carries no remote), exactly as each host already
-    /// did at its own call site.
+    /// A missing re-check result is `.unreadable`; never fall back to the stale
+    /// offer. Otherwise classify its status and the two remote version sides.
+    /// See `docs/engine-notes/pre-install-gate.md` §3 for the shared nil handling.
     public static func decision(
         offered: UpdateResult,
         confirmed: UpdateResult?

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift
@@ -1,61 +1,17 @@
 import Foundation
 
-/// TTL-memoized cache for the two things `MacAppStoreSource` scrapes off an App
-/// Store product page: the Mac-track version (+ "What's New" notes) and the
-/// `isIOSBinaryMacOSCompatible` flag.
-///
-/// **All of the value is across scans, none of it within one.** `resolve()` is
-/// a three-way dispatch with early returns, so exactly one of
-/// `nativeMacVersion` / `remoteVersion(checkMacCompat:)` / `iosOnMacVersion`
-/// runs per app per check — and the version and compatibility pages use
-/// different URLs *and* different dictionaries, so neither can serve the
-/// other. What this class removes is the second scan's fetch, and the
-/// third's, up to the TTL — so the benefit is `1 − interval/ttl`, and at the
-/// six-hour default interval (`Preferences`) an interval longer than the TTL
-/// means every scheduled round is a cold miss and this class saves nothing
-/// there. (How many installs leave that default alone is not something this
-/// repo can see, so the claim stops at the default itself.) What it still buys is the
-/// second scan inside one app launch: the scheduler ticks immediately on a
-/// cold start and opening the workbench forces another refresh, so that pair
-/// costs one round of pages instead of two. See
-/// `docs/engine-notes/app-store-page-cache.md` §1 for the measurements this
-/// is based on and the wrong assumption an earlier version of this comment
-/// made.
-///
-/// Deliberately caches a *parse failure* (2xx response, no version/flag found)
-/// the same as a *parse success* — an unparseable page costs full price again
-/// only once per TTL window, not once per check, which is the failure mode this
-/// exists to fix (skipping the scrape entirely would instead make the two
-/// call sites for a Mac version disagree with each other and with the lookup
-/// API, since only one of them would ever get a fresh page). A *transport
-/// failure or non-2xx response* is NOT cached: a network blip or a server
-/// hiccup must not freeze a bad answer in place for an hour. Callers keep those
-/// two outcomes apart before they ever reach this cache — see
-/// `MacAppStoreSource.fetchMacVersion`/`fetchMacCompatibility`, whose
-/// `PageFetchOutcome.unavailable` case is exactly "don't cache this".
-///
-/// The outer optional in `cachedVersion`/`cachedCompatibility` distinguishes "no
-/// entry, or a stale one" (nil — go fetch) from "cached, and the cached value is
-/// itself nil" (`.some(nil)` — a real answer, use it). Collapsing those two
-/// would re-fetch a legitimately-nil cached parse failure on every single call,
-/// defeating the point of caching it at all.
+/// Cross-scan TTL cache for App Store Mac versions/notes and Mac-compatibility
+/// flags, stored separately by (trackId, region).
+/// Caches nil parses from successful responses; callers must exclude transport
+/// failures, non-2xx responses, and undecodable bodies
+/// (`MacAppStoreSource.PageFetchOutcome`).
+/// See `docs/engine-notes/app-store-page-cache.md` §1 for scope and history,
+/// and `MacAppStorePageCacheTests` for cache and source-integration coverage.
 public actor AppStorePageCache {
 
-    /// The process-wide cache, and the one production actually uses.
-    ///
-    /// **Has to outlive the source that reads it.** `AppListModel.makeSources`
-    /// rebuilds the whole source stack on every check — deliberately, so a
-    /// token change and the signed-in storefront region are re-read — so a
-    /// `MacAppStoreSource` lives about seven seconds. A per-instance cache
-    /// would be born and destroyed inside a single scan and never survive to
-    /// answer the next one. See `docs/engine-notes/app-store-page-cache.md`
-    /// §2 for the incident where this was a per-instance cache instead, the
-    /// production traffic that didn't move, and why the unit tests didn't
-    /// catch it.
-    ///
-    /// Same shape as `ChangelogCache.shared`, `ResolvedChannelStore.shared`
-    /// and `EventStore.shared` for the same reason. Tests inject their own
-    /// instance (with a fake clock) through `MacAppStoreSource.init`.
+    /// Must outlive the source stack, which `AppListModel.makeSources` rebuilds
+    /// each check. Tests inject isolated instances with a controllable clock.
+    /// See `docs/engine-notes/app-store-page-cache.md` §2 for the lifetime regression.
     public static let shared = AppStorePageCache()
 
     private struct Key: Hashable {
@@ -68,37 +24,19 @@ public actor AppStorePageCache {
         let fetchedAt: Date
     }
 
-    /// How long a scraped page stays valid.
-    ///
-    /// This is a staleness bound, not a tuning knob: the default check
-    /// interval is six hours (`Preferences`), longer than this TTL, so in
-    /// normal operation the TTL never spans two scheduled scans (see the
-    /// class doc's cost model). An iOS-on-Mac listing has no source but this
-    /// page, so an hour is how long a user can be told yesterday's answer —
-    /// bounded now by `invalidateAll`, which any user-present refresh calls.
-    ///
-    /// The claim that App Store listings don't change more often than an hour
-    /// is UNVERIFIED; nobody has measured it. See
-    /// `docs/engine-notes/app-store-page-cache.md` §3 for how this number was
-    /// originally chosen and why that reasoning doesn't hold today.
+    /// Maximum entry age (default: one hour); explicit refreshes invalidate sooner.
+    /// This bounds staleness, not vendor publication frequency.
+    /// See `docs/engine-notes/app-store-page-cache.md` §3 for the original choice.
     let ttl: TimeInterval
     private let now: @Sendable () -> Date
 
     private var versionStore: [Key: Entry<MacAppStoreSource.MacVersionInfo?>] = [:]
     private var compatStore: [Key: Entry<Bool?>] = [:]
 
-    /// Reverse index from an installed app's bundle id to every `(trackId,
-    /// region)` key its scrapes have been filed under, so `invalidate(bundleIDs:)`
-    /// can drop just that app's entries instead of everyone's. Populated by
-    /// `MacAppStoreSource.resolve`, the one call site that has both the
-    /// authoritative `app.bundleID` and `result.trackId` in hand — see its doc
-    /// comment for why registration lives there and not in the three branches
-    /// it dispatches to.
-    ///
-    /// A bundleID can accumulate more than one key: the home-store and a
-    /// fallback-store probe file under different regions, and a Universal
-    /// Purchase app can carry two bundleIDs over one trackId (see
-    /// `invalidate(bundleIDs:)`).
+    /// `MacAppStoreSource.resolve` registers each bundle's (trackId, region) keys.
+    /// A bundle can span storefronts; multiple bundle IDs can share a track ID.
+    /// Retained across invalidations for all bundles resolved since process launch,
+    /// including subsequently uninstalled apps.
     private var keysByBundleID: [String: Set<Key>] = [:]
 
     /// `now` is injectable so tests can advance the clock past `ttl` without a
@@ -108,80 +46,27 @@ public actor AppStorePageCache {
         self.now = now
     }
 
-    /// Record that `bundleID`'s scrape was filed under `(trackId, region)`, so
-    /// a later `invalidate(bundleIDs:)` for this bundleID can find and drop it.
-    /// Called once per `resolve()`, regardless of which branch ends up
-    /// scraping (or not) — see `MacAppStoreSource.resolve`.
+    /// Associate a bundle with its cache key for later targeted invalidation.
+    /// Called by `resolve` regardless of which branch scrapes a page.
     func note(bundleID: String, trackId: Int, region: String) {
         keysByBundleID[bundleID, default: []].insert(Key(trackId: trackId, region: region))
     }
 
-    /// Drop everything, so the next scrape is live.
-    ///
-    /// The TTL alone is not enough, and the gap is user-visible. For a
-    /// `kind == "software"` listing the scraped page is the ONLY version source
-    /// — `iosOnMacVersion` returns nil without it, and unlike `nativeMacVersion`
-    /// there is no lookup answer sitting behind it to make a stale page
-    /// harmless. So a user who reads a release announcement and presses Check
-    /// Now would have been told the same old version for up to an hour, with no
-    /// way to insist. Before this cache existed every check re-fetched. Which
-    /// installed apps take the `kind == "software"` route specifically is not
-    /// something the event log can answer — it does not record which branch of
-    /// `resolve` ran.
-    ///
-    /// Called from the one remaining full-wipe path: a refresh the user asked
-    /// for (`RefreshIntent.restartsChangelogs`), which is about to re-check
-    /// every app anyway. A periodic sweep must NOT call it — that would put
-    /// the cache back to fetching a page per app per round, which is the cost
-    /// it exists to remove.
-    ///
-    /// `recheckMany` used to call this too, and that was a real bug: a single
-    /// row's channel-flip recheck wiped every OTHER App Store app's entry, and
-    /// the next scheduled sweep paid full price for all of them. See
-    /// `docs/engine-notes/app-store-page-cache.md` §4.2 for the measured
-    /// incident. `recheckMany` now calls `invalidate(bundleIDs:)` with just
-    /// the rows it re-checked instead.
+    /// Clear both stores for a user-present full refresh. Scheduled sweeps retain
+    /// entries; per-row rechecks use `invalidate(bundleIDs:)` instead.
+    /// Retains the reverse index and does not cancel in-flight fetches.
+    /// See `docs/engine-notes/app-store-page-cache.md` §4 for invalidation history.
     public func invalidateAll() {
         versionStore.removeAll()
         compatStore.removeAll()
     }
 
-    /// Drop the cached entries for exactly these bundleIDs, so an explicit
-    /// per-row recheck (`AppListModel.recheckMany`) scrapes live for the rows
-    /// it actually re-checked without paying for every other App Store app's
-    /// page too — see `invalidateAll`'s doc comment for the incident this
-    /// replaced.
-    ///
-    /// ⚠️ "Forces a live scrape" only absent an overlapping sweep. A scheduled
-    /// check that missed the cache for app X and is still awaiting X's page
-    /// when this runs will `storeVersion` a fresh entry afterwards, and the
-    /// recheck's own fan-out then reads it — so a recheck racing a sweep can
-    /// still be answered from a memo. The window is one page fetch. This is
-    /// not new (`invalidateAll` lost the same race) and closing it needs a
-    /// per-key generation counter checked in `storeVersion`, which nobody has
-    /// written; the guarantee is stated here so the next reader doesn't take
-    /// the absolute wording at face value.
-    ///
-    /// `keysByBundleID`'s own entries are left in place (only the store
-    /// entries they point at are cleared), so this doesn't depend on `note`
-    /// having run again since the last invalidation. Nothing prunes that index
-    /// — not this, not `invalidateAll` — so its real bound is "every MAS
-    /// bundleID resolved since launch, times the storefronts probed for it"
-    /// (up to 9: the home store plus `MacAppStoreSource.fallbackRegions`,
-    /// which is a fixed list of 8 minus the home store if it is one of them —
-    /// so 8 keys for a us/cn/hk/tw/jp/sg/kr/gb storefront and 9 for any
-    /// other), and an uninstalled app
-    /// stays in it for the life of the process. That is memory only, and
-    /// trivial at this scale, but it is not the "bounded by the number of
-    /// installed MAS apps" this comment used to claim.
-    ///
-    /// A bundleID with no noted keys (never scraped, or not a MAS app at all)
-    /// is a harmless no-op. A Universal Purchase app can have two bundleIDs
-    /// sharing one trackId — the iOS and Mac copies of the same purchase — so
-    /// invalidating one of them can also drop the other's entry. That is
-    /// bounded over-invalidation (costs the other copy one extra fetch on its
-    /// next check, nothing more) and is deliberately accepted rather than
-    /// tracked per-bundleID, which the store isn't keyed for.
+    /// Clear both stores for the bundles' registered keys; unknown IDs are a no-op.
+    /// Shared track IDs may also evict another bundle's entry. The reverse index
+    /// survives so repeated invalidation does not require another `note` call.
+    /// An in-flight fetch can repopulate either store after invalidation; this is
+    /// not a guarantee of a separate live fetch for a recheck racing a sweep.
+    /// See `docs/engine-notes/app-store-page-cache.md` §5 for that race window.
     public func invalidate(bundleIDs: [String]) {
         for id in bundleIDs {
             for key in keysByBundleID[id] ?? [] {

--- a/docs/engine-notes/app-store-page-cache.md
+++ b/docs/engine-notes/app-store-page-cache.md
@@ -26,8 +26,9 @@ to the TTL.
 
 An earlier version of the class doc argued for this cache on a different
 ground: that the pages are "read from more than one call site per app per
-check." That was never true — the paragraph above is the correction. The real
-benefit model is `1 − interval/ttl`:
+check." That was never true — the paragraph above is the correction. The old
+`1 − interval/ttl` benefit model is only an approximation for regular scans
+without invalidation or overlapping fetches; it is not a measured hit rate:
 
 - At a five-minute check interval, eleven rounds in twelve are free (as
   originally measured and quoted in the class doc: 23.6 → 3.0 product-page
@@ -38,24 +39,27 @@ benefit model is `1 − interval/ttl`:
   ttl`: **this class saves nothing between scheduled sweeps** for a user who
   hasn't changed that setting, every round is a cold miss. (How many users
   have changed it is not something this repo can see — no telemetry — so
-  that is as far as this claim goes.) What it still buys is the *second*
-  scan inside one app launch: the scheduler ticks immediately on a cold
-  start, and opening the workbench forces another refresh, so that pair
-  costs one round of page fetches instead of two.
+  that is as far as this claim goes.) The earlier claim that a startup scan
+  and a workbench refresh necessarily
+  share one page fetch is incorrect for a user-present refresh: that path
+  invalidates the page cache before checking. Reuse requires a fresh entry
+  that has not been explicitly invalidated.
 
 ## §2 `shared`: the per-instance cache that measurably did nothing
 
 `AppListModel.makeSources` rebuilds the whole source stack on every check —
 deliberately, so a token change and the signed-in storefront region get
-re-read — so a `MacAppStoreSource` lives about seven seconds. A per-instance
-`AppStorePageCache` with a one-hour TTL is therefore born and destroyed
+re-read. Its lifetime is one check, not a fixed duration; the prior comment's
+"about seven seconds" was an unverified local timing, not a lifecycle guarantee.
+A per-instance `AppStorePageCache` with a one-hour TTL is therefore born and destroyed
 inside a single scan and never survives to answer the next one.
 
 This was a real bug, not a hypothetical: **measured 2026-09-04**, the
 product-page fetches per scan round did not fall at all after the cache
-shipped (20.6 → 23.6 requests, 623 → 786 KB) — traffic went up, if anything —
-while every other change landed in the same batch worked exactly as
-predicted. The unit tests at the time missed it because they exercised one
+shipped (20.6 → 23.6 requests, 623 → 786 KB).
+These figures are quoted from the prior account, not re-measured in this pass;
+no claim about other changes in that batch is needed to establish the lifetime
+bug. The unit tests at the time missed it because they exercised one
 `MacAppStoreSource` instance twice, which is exactly the case that was
 already working; nothing in the suite constructed a *second* stack the way
 production does on every check.
@@ -144,7 +148,22 @@ fetch. The window is one page fetch wide. This isn't new: `invalidateAll`
 had the identical race before it was narrowed to `invalidate(bundleIDs:)`.
 Closing it needs a per-key generation counter checked inside `storeVersion`,
 which nobody has written — this is written down so the next reader doesn't
-take the "forces a live scrape" wording in the source comment at face value.
+mistake invalidation for a barrier against in-flight fetches.
+
+## §6 Verification of the comment follow-up (2026-09-08)
+
+Checked the current implementation: `Preferences` defaults to six hours;
+`AppStorePageCache.init` defaults to 3600 seconds; `MacAppStoreSource` defaults
+to `.shared` and stores successful parses (including nil) while excluding
+unavailable responses. `AppListModel` invalidates all pages for
+`RefreshIntent.restartsChangelogs`, which is true for `.userPresent` and false
+for `.scheduled`. These code checks support the corrections in §1–§3;
+historical traffic measurements remain quoted observations, not new measurements.
+
+The reverse index is retained by both invalidation methods. Its keys can grow
+with all bundle IDs and storefronts resolved during the process lifetime;
+it is not bounded by the currently installed population. Shared track IDs
+allow deliberate over-invalidation between Universal Purchase bundles.
 
 ---
 


### PR DESCRIPTION
Follow-up to #409 and the documentation migrations in #431 / #438. The two small core files still repeated the history already preserved in engine notes. This trims those comments to current contracts and links, with no executable Swift changes.

- Keep negative-cache semantics, source-stack lifetime, invalidation races, shared-key over-invalidation, and reverse-index lifetime next to `AppStorePageCache`.
- Keep all six pre-install outcomes, version-comparison boundaries, and shared nil-result handling next to `PreInstallGate`.
- Correct the existing cache note: user-present refreshes invalidate pages, so a startup scan plus a workbench refresh does not guarantee cache reuse. Qualify the cost model and the unverified seven-second source lifetime; retain historical measurements as quoted observations.

Scope remains the two small files. The broader `AppListModel` cleanup in #409 remains open.

Duplicate review: the cache traffic figures have one remaining test-comment copy (`MacAppStorePageCacheTests`) plus the engine note. The old “already current on disk” classification has one test-comment copy (`PreInstallGateTests`) and one AppListModel comment block, plus its engine note; the actual log message is runtime behavior. Test comments explain their regression fixtures and are retained; AppListModel is outside this slice. No matching copies were found in `.agents` or `.claude`.

Validation: `make test`; `git diff --check`; direct comparison against HEAD confirms both Swift files are identical after removing full-line comments and blank lines. Self-review checked the retained contracts against cache callers, refresh intent, and gate branches. No wording-only tests added.
