### PR TITLE
Release 0.3.89

### DIFF
--- a/App/project.yml
+++ b/App/project.yml
@@ -162,8 +162,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.app
-        MARKETING_VERSION: "0.3.88"
-        CURRENT_PROJECT_VERSION: "97"
+        MARKETING_VERSION: "0.3.89"
+        CURRENT_PROJECT_VERSION: "98"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Info.plist
         # Menu-bar-only app: no Dock icon, no main window.
@@ -275,8 +275,8 @@ targets:
         # plist's BundleProgram points at Contents/MacOS/DuoUpdaterHelper. The bundle
         # *identifier* (for signing / XPC pinning) is com.duoupdater.helper.
         PRODUCT_BUNDLE_IDENTIFIER: com.duoupdater.helper
-        MARKETING_VERSION: "0.3.88"
-        CURRENT_PROJECT_VERSION: "97"
+        MARKETING_VERSION: "0.3.89"
+        CURRENT_PROJECT_VERSION: "98"
         SWIFT_VERSION: "6.0"
         # Embed a generated Info.plist into the binary's __TEXT,__info_plist so the
         # helper has a bundle id/version (Bundle.main reads it) without a wrapper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Telegram Desktop gets update checks again.** Telegram changed the name of the file it publishes, and the row could no longer read a version out of it — so it showed a check failure instead of the update waiting behind it.
 
+**A TestFlight build of an iPhone or iPad app is recognized as one.** Duo Updater read it as an App Store purchase instead, so the row named the wrong keeper while the store was asked about a listing that does not exist — on every check, for as long as the app stayed installed.
+
 **A TestFlight beta is marked with TestFlight's own icon.** Rows the App Store looks after already carried the store's icon; the ones TestFlight looks after spelled the name out instead, so the same kind of row was marked two different ways.
+
+**The Network window's header stays put when you switch tabs.** Its two tabs sat their headlines at slightly different heights, so moving between them made the window look like it twitched.
 
 ## 0.3.88
 


### PR DESCRIPTION
Version bump and release-note rollup for 0.3.89. No behaviour change in this
commit — the shipping code all merged earlier.

`MARKETING_VERSION` 0.3.88 → 0.3.89 and `CURRENT_PROJECT_VERSION` 97 → 98, in
both targets. Bumping only the marketing string would leave the previous
release's users never offered this one.

## Notes rolled up

Everything between `v0.3.88` and here, ordered by how much a reader cares:

| merged | note |
|---|---|
| #457 | A TestFlight build of an iPhone or iPad app is recognized as one — it read as an App Store purchase, so the store was asked about a listing that does not exist on every check |
| #454 | Telegram Desktop gets update checks again |
| #453 | A TestFlight beta is marked with TestFlight's own icon |
| #452 | The Network window's header stays put when you switch tabs |

Two commits in the range get no note, deliberately:

- The CapCut half of #454 is evidence for a vendor-side rollback, not a recipe
  change — nothing shipped for a user to notice.
- #455 and the baseline commits are the nightly sweep's own bookkeeping.
