### PR TITLE
Read Rockxy's recent release history from GitHub, not the one entry its appcast holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.90
 
-**Rockxy now shows its full release history.** The feed Rockxy publishes is rewritten in place and only ever holds the newest release, so the window had a single entry to show no matter how many builds you had skipped.
+**Rockxy's release notes now go back through its recent releases.** The feed Rockxy publishes is rewritten in place and only ever holds the newest one, so the window had a single entry to show no matter how many builds you had skipped.
 
 ## 0.3.89
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.90
+
+**Rockxy now shows its full release history.** The feed Rockxy publishes is rewritten in place and only ever holds the newest release, so the window had a single entry to show no matter how many builds you had skipped.
+
 ## 0.3.89
 
 **Telegram Desktop gets update checks again.** Telegram changed the name of the file it publishes, and the row could no longer read a version out of it — so it showed a check failure instead of the update waiting behind it.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1630,6 +1630,18 @@ public enum ChangelogRecipeRegistry {
         // it is not a top-level `-`/`*`/`+` bullet. Verified against all 40 bodies:
         // the phrase appears in zero extracted items. Naming it in `skipSections`
         // would be a no-op anyway, since it sits under no heading of its own.
+        //
+        // ⚠️ What this costs on the FAILURE path, which is unique to this recipe.
+        // `ChangelogPane.fallback` reaches for `changelogURL` BEFORE
+        // `releaseNotesHTML`, so a fetch that fails (`api.github.com` is
+        // unauthenticated at 60/hour/IP and ~70 repos here share that budget) now
+        // web-views the tag page where the pane used to render this appcast's
+        // inline notes natively. Unlike Waku (appcast notes are unparseable raw
+        // markdown) and Shotbase (appcast carries none), Rockxy's appcast has real
+        // inline notes to lose. Accepted rather than reordered: for THIS app the
+        // fallback URL is a single tag page, so the inline notes would be strictly
+        // better — but for a recipe whose `changelogURL` is a full changelog page
+        // the current order is the right one, so the fix is not a local swap.
         ChangelogRecipe(
             bundleID: "com.amunx.rockxy.community",
             source: URL(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1608,6 +1608,36 @@ public enum ChangelogRecipeRegistry {
             maxEntries: 20,
             structuredFormat: .gitHubReleases),
 
+        // Rockxy — GitHub releases, because the appcast holds exactly ONE item.
+        //
+        // `raw.githubusercontent.com/RockxyApp/Rockxy/main/appcast.xml` is the
+        // address the bundle itself declares in `SUFeedURL`, so
+        // `SparkleAppcastSource` already answers for detection and needs no recipe.
+        // What it cannot do is history: the vendor rewrites that file in place, so
+        // it carries the newest release and nothing else (fetched 2026-09-09: 1
+        // `<item>`, 2225 bytes). Its `<description>` is real inline HTML, which the
+        // pane WOULD render — but as a single entry, and the version rail then has
+        // one rung no matter how many builds the user skipped.
+        //
+        // github.com/RockxyApp/Rockxy carries the same notes plus the history, and
+        // the tag is the marketing version verbatim (`v0.38.2` → `0.38.2` via
+        // `stripLeadingV`), which is what `CFBundleShortVersionString` reports.
+        // Measured over the live 40-release page 2026-09-09: 40/40 parse, 0
+        // prereleases, 0 drafts, 0 empty bodies.
+        //
+        // No `skipSections`. Every body opens with a `> **Distribution notice:**`
+        // blockquote about the binary EULA, and the strict pass already drops it —
+        // it is not a top-level `-`/`*`/`+` bullet. Verified against all 40 bodies:
+        // the phrase appears in zero extracted items. Naming it in `skipSections`
+        // would be a no-op anyway, since it sits under no heading of its own.
+        ChangelogRecipe(
+            bundleID: "com.amunx.rockxy.community",
+            source: URL(
+                string: "https://api.github.com/repos/RockxyApp/Rockxy/releases?per_page=40")!,
+            mode: .json,
+            maxEntries: 20,
+            structuredFormat: .gitHubReleases),
+
         // BetterDisplay — the same GitHub release bodies the vendor's own page was
         // already showing, rendered natively instead of in a web view.
         //

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RockxyChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RockxyChangelogRecipeTests.swift
@@ -70,13 +70,4 @@ private let rockxyReleasesFixture = #"""
         #expect(!latest.items.contains { $0 == "Added" || $0 == "Changed" || $0 == "Fixed" })
         #expect(log.entries.last?.items.count == 4)
     }
-
-    /// The bullets keep their Markdown inline syntax (`**Choose & Open Developer
-    /// App**`), so the changelog has to declare it or the renderer prints the
-    /// asterisks verbatim.
-    @Test func itemsAreMarkedAsMarkdown() throws {
-        let log = try #require(
-            StructuredChangelogDecoder.decodeGitHubReleases(rockxyReleasesFixture, maxEntries: 20))
-        #expect(log.itemSyntax == .markdown)
-    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RockxyChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RockxyChangelogRecipeTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import DuoUpdaterCore
+
+/// Two releases from `api.github.com/repos/RockxyApp/Rockxy/releases` (fetched
+/// 2026-09-09), bodies verbatim, trimmed to the fields the decoder reads. Both
+/// carry the `> **Distribution notice:**` blockquote every Rockxy release opens
+/// with — that is the shape this fixture exists for.
+private let rockxyReleasesFixture = #"""
+[{"tag_name":"v0.38.2","prerelease":false,"draft":false,"published_at":"2026-09-08T02:21:24Z",
+  "body":"> **Distribution notice:** The attached DMG is the official Rockxy binary distribution under the Rockxy Binary EULA. It runs in Community mode without a purchase and can unlock Pro. The public tag identifies the separate AGPL Community source edition for this product version; it is not represented as the complete build source for the DMG.\n\n# Rockxy 0.38.2 (build 57)\n\n## Added\n\n- Added **Choose & Open Developer App** to Automatic Setup, so Rockxy can launch a fully quit macOS developer tool with scoped proxy and certificate settings without changing shell profiles.\n\n## Changed\n\n- Compatible helpers now refresh safely after app updates while preserving macOS approval; explicit action is required only for genuinely incompatible helpers.\n\n## Fixed\n\n- Restored recognized application proxy settings after prepared apps exit or Rockxy relaunches, while preserving newer user choices and unrelated settings.\n- Prevented interrupted recovery from overwriting newer capture sessions or manually changed system proxy settings.\n- Preserved each macOS network service's own proxy configuration during stop and recovery.\n- Improved helper, certificate, and TLS fallback behavior to reduce stuck capture states and restore application traffic more reliably.\n\n"},
+ {"tag_name":"v0.38.1","prerelease":false,"draft":false,"published_at":"2026-09-05T09:39:28Z",
+  "body":"> **Distribution notice:** The attached DMG is the official Rockxy binary distribution under the Rockxy Binary EULA. It runs in Community mode without a purchase and can unlock Pro. The public tag identifies the separate AGPL Community source edition for this product version; it is not represented as the complete build source for the DMG.\n\n# Rockxy 0.38.1 (build 56)\n\n## Fixed\n\n- Preserved the same Rockxy root certificate across app relaunches, preventing unexpected certificate replacement and repeated HTTPS inspection setup.\n- Made certificate installation, trust checks, and removal safer by targeting exact certificates, preserving unrelated roots, and preventing overlapping privileged changes.\n- Improved recovery for outdated helpers and unreadable certificate states with clearer recheck, reinstall, and trust guidance.\n- Clarified JetBrains IDE proxy setup and surfaced failed HTTPS CONNECT tunnels for easier diagnosis.\n\n"}]
+"""#
+
+@Suite struct RockxyChangelogRecipeTests {
+
+    /// Rockxy's update source is the Sparkle appcast its own `SUFeedURL` names, so
+    /// detection needs no recipe. Its NOTES come from GitHub because that appcast
+    /// is rewritten in place and holds exactly one `<item>` — inline notes for the
+    /// newest build and no history at all.
+    @Test func readsGitHubReleases() throws {
+        let recipe = try #require(
+            ChangelogRecipeRegistry.recipe(forBundleID: "com.amunx.rockxy.community"))
+        #expect(recipe.structuredFormat == .gitHubReleases)
+        #expect(recipe.mode == .json)
+        #expect(recipe.source.host == "api.github.com")
+        #expect(recipe.source.path == "/repos/RockxyApp/Rockxy/releases")
+        // Without `skipSections` the recipe leans entirely on the strict bullet
+        // pass to drop the distribution notice. Stating it here means adding one
+        // later is a deliberate edit rather than a silent behaviour change.
+        #expect(recipe.skipSections.isEmpty)
+    }
+
+    /// Newest first, `v` stripped so the rail version matches
+    /// `CFBundleShortVersionString` (`v0.38.2` → `0.38.2`, which is what the real
+    /// bundle reports), dates as ISO days.
+    @Test func versionsAndDatesMatchTheInstalledVersionScheme() throws {
+        let log = try #require(
+            StructuredChangelogDecoder.decodeGitHubReleases(rockxyReleasesFixture, maxEntries: 20))
+        #expect(log.entries.map(\.version) == ["0.38.2", "0.38.1"])
+        #expect(log.entries.map(\.date) == ["2026-09-08", "2026-09-05"])
+    }
+
+    /// Every Rockxy release body opens with a `> **Distribution notice:**`
+    /// blockquote about the binary EULA. It is not a change, and it is identical
+    /// in all 40 releases on the live page — surfaced as an item it would be the
+    /// first and longest line of every entry in the rail. The strict bullet pass
+    /// drops it because it is not a top-level `-`/`*`/`+` bullet, which is why the
+    /// recipe carries no `skipSections`; this is the assertion that keeps that
+    /// argument honest.
+    @Test func dropsTheDistributionNoticeBlockquote() throws {
+        let log = try #require(
+            StructuredChangelogDecoder.decodeGitHubReleases(rockxyReleasesFixture, maxEntries: 20))
+        #expect(!log.entries.contains { $0.items.contains { $0.contains("Distribution notice") } })
+        #expect(!log.entries.contains { $0.items.contains { $0.contains("Binary EULA") } })
+    }
+
+    /// The bullets under `## Added` / `## Changed` / `## Fixed` are the changes,
+    /// flattened in document order — the headings themselves are not items, and
+    /// none of the three is a section this app skips.
+    @Test func keepsEveryBulletAcrossTheThreeSections() throws {
+        let log = try #require(
+            StructuredChangelogDecoder.decodeGitHubReleases(rockxyReleasesFixture, maxEntries: 20))
+        let latest = try #require(log.entries.first)
+        #expect(latest.items.count == 6)
+        #expect(latest.items.first == "Added **Choose & Open Developer App** to Automatic Setup, so Rockxy can launch a fully quit macOS developer tool with scoped proxy and certificate settings without changing shell profiles.")
+        #expect(latest.items.last == "Improved helper, certificate, and TLS fallback behavior to reduce stuck capture states and restore application traffic more reliably.")
+        #expect(!latest.items.contains { $0 == "Added" || $0 == "Changed" || $0 == "Fixed" })
+        #expect(log.entries.last?.items.count == 4)
+    }
+
+    /// The bullets keep their Markdown inline syntax (`**Choose & Open Developer
+    /// App**`), so the changelog has to declare it or the renderer prints the
+    /// asterisks verbatim.
+    @Test func itemsAreMarkedAsMarkdown() throws {
+        let log = try #require(
+            StructuredChangelogDecoder.decodeGitHubReleases(rockxyReleasesFixture, maxEntries: 20))
+        #expect(log.itemSyntax == .markdown)
+    }
+}

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -153,6 +153,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**Blender**](org-blenderfoundation-blender.md) · `org.blenderfoundation.blender` — C (version-pinned) + Homebrew
 - [x] [**JetBrains Air**](com-jetbrains-air.md) · `com.jetbrains.air` — C + Toolbox/Sparkle
 - [x] [**欧路词典 (Eudic)**](com-eusoft-eudic.md) · `com.eusoft.eudic` — C + Sparkle **1**.27.3 · recipe 的 `source` 就是 appcast 本身：整部历史（1 个 `<h2>` + 34 个 `<h3>`、0 个 `<li>`）塞在最新一条 item 的 `<description>` 里，原本十六年记录全挂在「26.9.0」标题下；34 个标题里 7 个是标签「更新内容」，故按"含点分数字的标题"切而非按标签 · live feed + fixture 双证 29 条 ✓ · 另记两个已修的坑：`CFBundleDisplayName` 是**空串**（行里没名字）、未登录时的登录 sheet 挡住退出（Relaunch 静默失败）· 2026-09-01
+- [x] [**Rockxy**](com-amunx-rockxy-community.md) · `com.amunx.rockxy.community` — C + Sparkle verified · appcast 是原地重写的单条文件（1 个 `<item>`），inline notes 只够一格版本轨，故 changelog 走 GitHub releases（40/40 解析，0 prerelease）· 只有一条轨：prod 与 staging 两个 xcconfig 指向同一个 feed、同一个 bundle id · 2026-09-09
 
 ## Sparkle-covered (auto-detected, no custom recipe)
 

--- a/docs/app-audits/com-amunx-rockxy-community.md
+++ b/docs/app-audits/com-amunx-rockxy-community.md
@@ -76,6 +76,17 @@ GitHub releases 有同一份正文加上完整历史，tag 就是 marketing 版�
 （`v0.38.2` → `stripLeadingV` → `0.38.2`，与 `CFBundleShortVersionString` 一致）。
 recipe 在渲染优先级上高于 `releaseNotesHTML`，所以加了它就是用 20 条历史换 1 条内联。
 
+⚠️ **代价记在这里，而且这条 recipe 是唯一有这个代价的。** `ChangelogPane` 的
+`fallback`（recipe 加载**失败**时走的那条）先看 `changelogURL`、后看
+`releaseNotesHTML`。Rockxy 的 appcast 两样都给了，于是一次抓取失败
+（`api.github.com` 未带 token、60 次/小时/IP，仓库里约 70 个 repo 共用这个额度）
+会把面板从「原生渲染的内联 notes」变成「嵌一个 GitHub tag 页」。
+Waku 的 appcast notes 是解析不出来的裸 markdown、Shotbase 的 appcast 根本没有 notes，
+所以那两条 recipe 没有东西可失去，只有这条有。
+**没有顺手把顺序调过来**：对这个 app 而言 `changelogURL` 只是一个 tag 页、内联稳赢，
+但对一条 `changelogURL` 指向完整变更日志页的 recipe 而言现在的顺序才是对的 ——
+所以那不是一处局部交换能修的事，要修得单独立项。
+
 **不需要 `skipSections`。** 每条 release 正文都以
 `> **Distribution notice:** …`（二进制 EULA 声明）开头，但它是引用块、不是顶层
 `-`/`*`/`+` 列表项，`GitHubMarkdownParser` 的 strict pass 直接略过。2026-09-09 对

--- a/docs/app-audits/com-amunx-rockxy-community.md
+++ b/docs/app-audits/com-amunx-rockxy-community.md
@@ -1,0 +1,128 @@
+# Rockxy
+
+开源的原生 macOS HTTP/HTTPS 抓包调试器（AGPL-3.0 源码版 + 官方二进制发行）。
+
+## 基本信息
+- Bundle ID: `com.amunx.rockxy.community`
+- Team ID: `9YNS969KZE`（`Developer ID Application: Loc Nguyen`，`spctl` 判定
+  `Notarized Developer ID`；对下载的 DMG 挂载只读取证，2026-09-09）
+- 观测版本: 0.38.2（`CFBundleVersion` 57）
+- 架构: universal（`x86_64 arm64`）
+- 自更新机制: **Sparkle 2.9.1**（`SUFeedURL` + `SUPublicEDKey` 都在 Info.plist 里，
+  `SUEnableAutomaticChecks` / `SUAllowsAutomaticUpdates` 均为 true）
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|              | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|--------------|---------|----------|-----|--------|-------------|
+| **stable**   | ✓       | ✗        | —   | ○      | —           |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **Sparkle**。
+Homebrew cask `rockxy` 存在但是 `auto_updates: true`，`HomebrewCaskSource` 因此返回 nil、
+落到下一级；GitHub Releases 也带完整的 macOS 资产，但排在 Sparkle 之后、不会被问到，
+所以标 ○ 而不是 ✓ —— 它是「能用但用不上」，不是「已接入」。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `com.amunx.rockxy.community` | — | `SUFeedURL` | Sparkle appcast（无 channel 标签） | ✓ |
+
+**只有一条轨道，这一点是从构建配置读出来的、不是从 feed 推的。**
+仓库里 `Configuration/CommunityProduction.xcconfig`（`community-prod`）和
+`CommunityStaging.xcconfig`（`community-stag`）都把 `ROCKXY_SPARKLE_FEED_URL` 指向
+**同一个** `ROCKXY_PUBLIC_APPCAST_FEED_URL`，bundle id 也同为
+`$(ROCKXY_FAMILY_NAMESPACE).community`；`community-stag` 的注释自己写着
+"promotes the same build without rebuilding"。所以 staging 是构建阶段的标签，
+不是用户可见的第二条发布轨。GitHub 上 40 个 release **全部** `prerelease=false`
+（2026-09-09 实测），appcast 里也没有任何 `<sparkle:channel>` 标签。
+
+## 更新检测
+- 源: `SparkleAppcastSource`（零改动，无需 recipe）
+- 端点: `https://raw.githubusercontent.com/RockxyApp/Rockxy/main/appcast.xml`
+  —— 就是 bundle 自己 `SUFeedURL` 声明的地址，`feed-discover` 判 `declared`。
+- 版本方案: **无错位**。appcast 的 `sparkle:shortVersionString="0.38.2"` /
+  `sparkle:version="57"` 与真实 bundle 的 `CFBundleShortVersionString` / `CFBundleVersion`
+  逐字相同，marketing 和 build 都不需要 `versionIsBuild` 这类补丁。
+- OS 分轨: feed 带 `<sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>`，
+  **没有** `maximumSystemVersion`；真实 bundle 的 `LSMinimumSystemVersion` 也是 `14.0`，
+  与 `Configuration/Base.xcconfig` 的 `MACOSX_DEPLOYMENT_TARGET = 14.0` 一致。
+  `SparkleAppcastSource` 走的是自己的 `usableItems` 过滤，这个下限由它处理。
+- 注意事项: feed 是**原地重写**的单条文件 —— 2026-09-09 抓下来 2225 字节、只有 1 个
+  `<item>`。这不影响检测（要的就是最新那条），但决定了 changelog 那一节的做法。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 有（Sparkle 自带） | **无** | 能，但今天没东西可消费 |
+| 证据 | bundle 内 `Contents/Frameworks/Sparkle.framework` 版本 2.9.1，`BinaryDelta` 随框架发行 | 2026-09-09 的 appcast 只有一个 `<enclosure>`，**没有** `<sparkle:deltas>`；GitHub release 资产只有 `.dmg` / `.dmg.sha256` / `manifest.json` / `THIRD_PARTY_NOTICES.txt`，没有 `.delta` | `DeltaApplier` + `VendorAppcastDeltas` 是现成的，厂商一旦开始发 `<sparkle:deltas>` 就自动生效 |
+
+- 格式: 若将来有，会是 Sparkle binary delta（厂商没有自研更新器）。
+- 阻塞项: 无 —— 是厂商不发，不是我们读不了。
+
+## Changelog
+- 来源: `ChangelogRecipe`（`.gitHubReleases`），
+  `https://api.github.com/repos/RockxyApp/Rockxy/releases?per_page=40`
+- 跟随 channel: 否（只有一条轨）
+- Recipe 状态: 已有
+
+**为什么明明有 inline notes 还要 recipe。** appcast 那一条 `<item>` 的
+`<description>` 是真的内联 HTML（1005 字符），面板本来就能渲染 —— 但只有**一条**。
+那个文件是原地重写的，历史不在里面，于是版本轨无论用户跳过了多少个构建都只有一格。
+GitHub releases 有同一份正文加上完整历史，tag 就是 marketing 版本本身
+（`v0.38.2` → `stripLeadingV` → `0.38.2`，与 `CFBundleShortVersionString` 一致）。
+recipe 在渲染优先级上高于 `releaseNotesHTML`，所以加了它就是用 20 条历史换 1 条内联。
+
+**不需要 `skipSections`。** 每条 release 正文都以
+`> **Distribution notice:** …`（二进制 EULA 声明）开头，但它是引用块、不是顶层
+`-`/`*`/`+` 列表项，`GitHubMarkdownParser` 的 strict pass 直接略过。2026-09-09 对
+live 页面 40 条全量实测：40/40 有条目、0 prerelease、0 draft、0 空正文，
+提取出的条目里「Distribution notice」出现 **0 次**。
+
+## 一键安装
+- 状态: 由 Sparkle installer path 决定；无 custom install recipe
+- 格式: Sparkle enclosure（`.dmg`）
+- **读的是**: 轨道最新 —— 但这里不构成 Phase 3⅞ 说的那种风险：appcast 只有一条
+  item，它既是「轨道最新」也是「人人可从厂商 GitHub Release 页手动下载的 GA」，
+  厂商没有做灰度分配（无 device id、无 rollout 参数，feed 是一个静态文件）。
+- 阻塞: 无。
+
+## 已知问题
+- 无。
+
+## 如何复验
+
+```sh
+swift run --package-path application-test feed-discover  <Rockxy-<版本>.dmg>
+swift run --package-path application-test channel-verify <Rockxy-<版本>.dmg> --expect stable
+```
+
+2026-09-09 对 `Rockxy-0.38.2-57.dmg` 跑出来的证据（DMG 只读挂载、未安装）：
+
+| 项 | 值 |
+|---|---|
+| `feed-discover` | `declared` → `raw.githubusercontent.com/RockxyApp/Rockxy/main/appcast.xml` |
+| 真实 bundle id | `com.amunx.rockxy.community` |
+| 真实 `CFBundleShortVersionString` / `CFBundleVersion` | `0.38.2` / `57` |
+| channel 标记 | `KSChannelID` 无、`RemotingName` 无、`package.json` 无、`ChannelBinding` 无 |
+| detected channel | `stable`（`--expect stable` 通过，退出码 0） |
+| winning source | `Sparkle` |
+| latest / download | `0.38.2` / `.../releases/download/v0.38.2/Rockxy-0.38.2-57.dmg` |
+| release notes | 1005 字符 inline，changelogURL 指向 `releases/tag/v0.38.2` |
+| status | `up to date` |
+| 签名 | `Developer ID Application: Loc Nguyen (9YNS969KZE)`，`spctl` = `Notarized Developer ID` |
+| DMG SHA256 | `95c38a821d161a6f747970ea0f16d645757b3c48428a8872920c8655f18818b9`，与厂商同发的 `.dmg.sha256` 及 `releases/latest.json` 的 `checksumSha256` 三方吻合 |
+
+changelog 那半边的回归证据在 `RockxyChangelogRecipeTests`（fixture 是 2026-09-09
+的两条真实 release 正文，含那段 Distribution notice 引用块）。
+
+## 建议下一步
+1. 检测: 无需改动，`SparkleAppcastSource` 已覆盖。
+2. Changelog: 已加 recipe，见上。
+3. 顺带记一笔厂商还发了 `releases/latest.json` 和 `releases/catalog.json`
+   （schema 化的全量发布目录，带 sha256、EdDSA 签名、`minimum_system_version`）。
+   今天用不到 —— Sparkle 已经答了检测、GitHub API 已经答了 changelog ——
+   但如果哪天 appcast 挪走了，那两个文件是最省事的替代端点。


### PR DESCRIPTION
Rockxy (open-source native macOS HTTP/HTTPS debugger) needs **no detection work**: its bundle declares its own `SUFeedURL`, so `SparkleAppcastSource` already resolves it. Verified end to end against a real `Rockxy-0.38.2-57.dmg` (mounted read-only, never installed):

```
feed-discover   declared  raw.githubusercontent.com/RockxyApp/Rockxy/main/appcast.xml
channel-verify  com.amunx.rockxy.community  0.38.2 (57)
                detected channel → stable   (--expect stable, exit 0)
                winning source Sparkle · latest 0.38.2 · status up to date
```

The gap is **history**. The vendor rewrites that appcast in place, so it holds exactly one `<item>` (2225 bytes, fetched 2026-09-09). Its inline `<description>` renders fine — but as a single entry, and the version rail then has one rung no matter how many builds the user skipped. A recipe outranks `releaseNotesHTML` in `ChangelogPane`, so registering one trades that single inline entry for 20 of history (`maxEntries: 20` — the vendor has published more than that, so this is *recent* history, not the complete archive).

⚠️ **What it costs on the failure path**, found by `/code-review` and recorded in the recipe comment rather than papered over: `ChangelogPane.fallback` reaches for `changelogURL` before `releaseNotesHTML`, so a fetch that fails (`api.github.com` unauthenticated, 60/hour/IP, ~70 repos sharing that budget) web-views the tag page where the appcast's inline notes used to render natively. Rockxy is the only `.gitHubReleases` recipe with inline notes to lose — Waku's are unparseable raw markdown, Shotbase's appcast carries none. Not reordered here: for a recipe whose `changelogURL` is a full changelog page the current order is the right one, so the fix is not a local swap.

`api.github.com/repos/RockxyApp/Rockxy/releases?per_page=40` via the existing `.gitHubReleases` decoder — the same route Waku and Shotbase take, both also Sparkle-covered apps whose appcast cannot carry notes. The tag is the marketing version verbatim (`v0.38.2` → `0.38.2` via `stripLeadingV`), which is what `CFBundleShortVersionString` reports.

**No `skipSections`.** Every release body opens with a `> **Distribution notice:**` blockquote about the binary EULA. It is not a top-level `-`/`*`/`+` bullet, so `GitHubMarkdownParser`'s strict pass already drops it; naming it would be a no-op anyway, since it sits under no heading of its own.

### Measured on the live 40-release page, 2026-09-09
40/40 parse · 0 prereleases · 0 drafts · 0 empty bodies · the phrase "Distribution notice" appears in **0** extracted items.

### One track, read from the build config rather than inferred from the feed
`CommunityProduction.xcconfig` (`community-prod`) and `CommunityStaging.xcconfig` (`community-stag`) point `ROCKXY_SPARKLE_FEED_URL` at the **same** feed and share the bundle id; staging's own comment says it "promotes the same build without rebuilding". So it is a build-stage label, not a second user-visible track. No `<sparkle:channel>` tags in the feed either.

### Verification
- `make test` — green (2458 + 263 tests, 9/9 app cases, all Python gates)
- `duo verify --only rockxy` — `changelog ✓ 1 ⚠ 0 ✗ 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
