### PR TITLE
Bound every channel resolver so a pending consent prompt cannot wedge the pool

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -257,16 +257,75 @@ public enum ChannelBinding {
     }
 
     /// The user-chosen channel (and feed, for feed-swap apps) for `bundleID`, or
-    /// nil when no bespoke resolver exists.
+    /// nil when no bespoke resolver exists **or when the resolver did not answer
+    /// in time** — see `resolveTimeout` and `BoundedBlockingWork`.
+    ///
+    /// nil is the honest answer for a timed-out resolver, not a shrug. It is the
+    /// same answer an app with no binding at all gets, which leaves
+    /// `ReleaseChannel.detect()` and the bundle's own signed `SUFeedURL` in
+    /// charge — i.e. it declines to be AUTHORITATIVE about a preference we did not
+    /// manage to read. Synthesising `.stable` instead would be worse in exactly
+    /// the direction `CotEditorChannel`'s own comment warns about: an
+    /// authoritative `.stable` silences `detect()`, so a `7.1.0-beta.6` copy whose
+    /// container we could not open would be pinned to the stable line and offered
+    /// a downgrade. With nil, `detect()` still reads `-beta.6` off the version and
+    /// keeps that copy on beta.
+    ///
+    /// The chokepoint could not do better even if it wanted to: each app's
+    /// shipped default lives in its own resolver, and reaching it means running
+    /// the resolver that just hung.
     ///
     /// Matched case-insensitively: a `CFBundleIdentifier` is case-insensitive
     /// (TablePlus ships `com.tinyapp.TablePlus` but its prefs live under the
     /// lower-cased domain), so a case-sensitive `switch` silently failed to bind
     /// — same convention `ChangelogRecipe.recipe(forBundleID:)` already uses.
     public static func resolve(bundleID: String?) -> ResolvedChannel? {
-        guard let id = bundleID?.lowercased(), let resolver = resolver(for: id) else { return nil }
-        return resolver()
+        resolve(bundleID: bundleID, bounded: bounded)
     }
+
+    /// The body of the above, with the bound injected.
+    ///
+    /// Tests need a resolver to be treated as stuck without marking the shared
+    /// instance, which is process-wide: another test asserting that Ghostty
+    /// resolves would start failing depending on which test ran first, and
+    /// `swift-testing` runs them in parallel. A fresh instance per test has no
+    /// such reach.
+    ///
+    /// The one thing this seam does NOT pin is that the public entry point hands
+    /// over the *shared* instance rather than a throwaway — a one-line delegation
+    /// `ChannelBindingBoundTests` would not notice being changed, because every
+    /// case there brings its own instance. Said out loud rather than left to be
+    /// discovered: the memo is what keeps a gated file to one stranded thread for
+    /// the life of the process, so a throwaway here would strand one per scan
+    /// with the whole suite still green.
+    static func resolve(bundleID: String?, bounded: BoundedBlockingWork) -> ResolvedChannel? {
+        guard let id = bundleID?.lowercased(), let resolver = resolver(for: id) else { return nil }
+        return bounded.run(key: id, timeout: resolveTimeout, resolver) ?? nil
+    }
+
+    /// How long a resolver gets before it is abandoned.
+    ///
+    /// Every resolver here is one plist read or one `CFPreferences` lookup —
+    /// sub-millisecond warm, single-digit milliseconds cold — so this is three
+    /// orders of magnitude of headroom and nothing near it is a slow disk. What it
+    /// is instead is the gate: see `BoundedBlockingWork`.
+    ///
+    /// Shorter than `TestFlightInventory.openTimeout` (5s) on purpose. That one is
+    /// paid once per scan; this one is paid once per BOUND APP per scan, so on a
+    /// machine where the gate covers several of them the wait multiplies.
+    static let resolveTimeout: TimeInterval = 2
+
+    /// The bound applies at this chokepoint rather than inside each resolver, so
+    /// a resolver added tomorrow is covered by having a `case` in the switch and
+    /// nothing else. That matters more here than the tidiness of it: the
+    /// resolvers are a growing list written one app at a time, and the hazard is
+    /// invisible in the source — `Data(contentsOf:)` against a file that exists
+    /// looks exactly like `Data(contentsOf:)` against a file behind a consent
+    /// prompt. `CFPreferences` resolvers go through it too, not because a
+    /// `cfprefsd` round trip is known to hang, but because exempting them would
+    /// make this a list somebody has to keep correct, which is the thing being
+    /// removed.
+    static let bounded = BoundedBlockingWork(label: "channel binding")
 
     /// Whether this id has a case in the switch at all — asked without running the
     /// resolver, so the answer does not depend on the machine asking.
@@ -290,7 +349,7 @@ public enum ChannelBinding {
 
     /// The one switch both of the above go through. Returns the resolver itself,
     /// unevaluated, so asking "is there one" costs no preference read.
-    private static func resolver(for id: String) -> (() -> ResolvedChannel?)? {
+    private static func resolver(for id: String) -> (@Sendable () -> ResolvedChannel?)? {
         switch id {
         case DuoPasteChannel.bundleID.lowercased(): return DuoPasteChannel.resolveCurrent
         case ForkChannel.bundleID.lowercased():     return ForkChannel.resolveCurrent

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -196,43 +196,13 @@ public struct TestFlightInventory: Sendable {
     /// anything near this is the gate, not slow disk.
     static let openTimeout: TimeInterval = 5
 
-    /// A slot one thread fills and another reads. Needed because the reader can
-    /// give up before the writer finishes — see `readRows(at:)`.
-    private final class ResultBox: @unchecked Sendable {
-        private let lock = NSLock()
-        private var value: Reading?
-        func set(_ v: Reading) {
-            lock.lock(); defer { lock.unlock() }
-            value = v
-        }
-        func take() -> Reading? {
-            lock.lock(); defer { lock.unlock() }
-            return value
-        }
-    }
-
-    /// Paths whose open is *still* stuck behind the gate. Once one is, we stop
-    /// starting new opens for it: in a long-running process (the menu-bar app) a
-    /// scan happens periodically, and without this each one would strand another
-    /// thread. Bounded at one stranded thread per path, and cleared the moment
-    /// that open finally returns — so granting access mid-session recovers on
-    /// the next scan without a restart.
-    ///
-    /// Keyed by path rather than a single flag so one unreadable database can
-    /// never suppress reads of a different one.
-    private final class ProbeState: @unchecked Sendable {
-        private let lock = NSLock()
-        private var stuck: Set<String> = []
-        func isStuck(_ path: String) -> Bool {
-            lock.lock(); defer { lock.unlock() }
-            return stuck.contains(path)
-        }
-        func mark(_ path: String, stuck isStuck: Bool) {
-            lock.lock(); defer { lock.unlock() }
-            if isStuck { stuck.insert(path) } else { stuck.remove(path) }
-        }
-    }
-    private static let probe = ProbeState()
+    /// The bound itself, plus the memo of paths whose open never came back. Both
+    /// live in `BoundedBlockingWork`, which is this code generalised — see its
+    /// doc comment for why the thread is abandoned rather than pooled, and why
+    /// one stranded thread per path is the ceiling. Keyed by path rather than a
+    /// single flag so one unreadable database can never suppress reads of a
+    /// different one.
+    private static let bounded = BoundedBlockingWork(label: "TestFlight DB open")
 
     /// Returns the macOS rows, the iOS rows, and whether the DB was actually
     /// opened. `opened` is `false` for a missing file or a failed/denied open (the
@@ -255,30 +225,13 @@ public struct TestFlightInventory: Sendable {
     /// minutes at 0.03s of CPU before it was killed.
     private static func readRows(at url: URL) -> Reading {
         guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], false) }
-        guard !probe.isStuck(url.path) else { return ([], [], false) }
-
-        let box = ResultBox()
-        let done = DispatchSemaphore(value: 0)
-        // A Thread, not a Task: a blocked syscall on a cooperative-pool thread
-        // starves the pool, and a structured child would pin its parent until it
-        // returned — which is the bug this replaces.
-        let worker = Thread {
-            box.set(openAndRead(at: url))
-            probe.mark(url.path, stuck: false)
-            done.signal()
-        }
-        worker.stackSize = 512 * 1024
-        worker.start()
-
-        if done.wait(timeout: .now() + openTimeout) == .timedOut {
-            probe.mark(url.path, stuck: true)
-            Log.scan.error("""
-                TestFlight DB open did not return within \(openTimeout, privacy: .public)s at \
-                \(url.path, privacy: .public) — treating it as inaccessible (app-data privacy gate)
-                """)
-            return ([], [], false)
-        }
-        return box.take() ?? ([], [], false)
+        // nil covers both give-up modes — this open timed out, or an earlier one
+        // for this path is still stranded — and both mean the same thing to the
+        // caller: we never got in, so `opened` is false rather than "read it,
+        // nothing inside".
+        return bounded.run(key: url.path, timeout: openTimeout) {
+            openAndRead(at: url)
+        } ?? ([], [], false)
     }
 
     /// The actual read. Only ever called from `readRows(at:)`'s worker thread.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/BoundedBlockingWork.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/BoundedBlockingWork.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Run synchronous work that can block **forever** on a thread we are willing to
+/// abandon, and stop waiting for it after a deadline.
+///
+/// ## Why this exists next to `offCooperativePool`
+///
+/// `offCooperativePool` is the right tool when the caller is `async`: it hops the
+/// blocking call onto Dispatch, which overcommits when a thread parks, and awaits
+/// the result. It cannot help a caller that is not `async`, and it never gives
+/// up — a call that never returns still never returns, it just strands a Dispatch
+/// worker instead of one of the very few cooperative threads.
+///
+/// Both of those matter on the app-scan path. `AppScanner.scan()` is synchronous
+/// all the way down (`scan` → `admit` → `readApp` → `ChannelBinding.resolve`), and
+/// it is reached from `async` contexts on both hosts, so the blocking work it does
+/// lands on whatever thread the caller happened to be on — a cooperative one in
+/// the test suite and in `Task.detached` (a detached task still runs on the
+/// cooperative pool). And the specific way these reads fail is not "slow": macOS
+/// gates another app's data behind a consent prompt, and while that prompt sits
+/// unanswered `open(2)` does not fail, it does not time out, and it is not a
+/// cancellation point. It simply never returns.
+///
+/// Measured 2026-09-09: a `make test` run was killed at
+/// `scripts/run-with-hang-report.sh`'s 1800s timeout with two CPU samples 60s
+/// apart showing 0.00s burned in between, and `sample(1)` put a
+/// `com.apple.root.default-qos.cooperative` thread inside `__open` on
+/// `~/Library/Containers/com.coteditor.CotEditor/Data/Library/Preferences/com.coteditor.CotEditor.plist`,
+/// reached from `AppScanner.scan()` via `ChannelBinding.resolve`. Once the pending
+/// consent dialog was answered the identical suite finished in 15.5s.
+/// `TestFlightInventory` hit the same wall from the other direction on 2026-08-15
+/// (ten minutes in `guarded_open_np` at 0.03s of CPU) and grew the first copy of
+/// this pattern; this type is that copy, extracted so there is one of it.
+///
+/// ## What it buys, and what it does not
+///
+/// It bounds the *caller*. The abandoned thread is still stuck — nothing can
+/// un-stick a syscall that is not a cancellation point — so the guarantee is
+/// "this call returns", not "that read completed". A `Thread`, not a Dispatch
+/// item, precisely because it is abandoned: a stranded Dispatch worker is drawn
+/// from a pool with a per-QoS ceiling, and stranding those is how you convert one
+/// gated file into a process-wide outage a second time.
+///
+/// ## One stranded thread per key, not one per call
+///
+/// A long-running host scans on a timer, so without the memo every pass would
+/// strand another thread and pay the deadline again. Once a key is known stuck we
+/// stop starting work for it and answer immediately; the worker clears the mark if
+/// it ever does return, so granting the permission mid-session recovers on the
+/// next pass without a restart. Keyed, so one gated file cannot silence an
+/// unrelated one.
+final class BoundedBlockingWork: @unchecked Sendable {
+    /// Names this instance in the log line a give-up emits. One instance per
+    /// subsystem, so the key namespaces cannot collide across callers.
+    private let label: String
+    private let lock = NSLock()
+    private var stuck: Set<String> = []
+
+    init(label: String) {
+        self.label = label
+    }
+
+    /// Whether `key` is currently being waited on by a thread that never came
+    /// back. Callers that want to distinguish "gave up" from "answered nothing"
+    /// can ask; `run` consults it itself.
+    func isStuck(_ key: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return stuck.contains(key)
+    }
+
+    /// Force the mark. Exists for tests, which need a key to be stuck without
+    /// having to hang a real syscall to get it there.
+    func mark(_ key: String, stuck isStuck: Bool) {
+        lock.lock(); defer { lock.unlock() }
+        if isStuck { stuck.insert(key) } else { stuck.remove(key) }
+    }
+
+    /// Run `work`, giving up after `timeout`.
+    ///
+    /// Returns nil for both failure modes — the deadline passed, or `key` was
+    /// already known stuck from an earlier call. Callers must treat nil as "no
+    /// answer", never as an answer: what makes these reads dangerous is exactly
+    /// that a missing answer and a denied one are indistinguishable from here.
+    func run<T: Sendable>(
+        key: String,
+        timeout: TimeInterval,
+        _ work: @escaping @Sendable () -> T
+    ) -> T? {
+        guard !isStuck(key) else { return nil }
+
+        let box = Box<T>()
+        let done = DispatchSemaphore(value: 0)
+        let worker = Thread { [self] in
+            box.value = work()
+            mark(key, stuck: false)
+            done.signal()
+        }
+        // Small on purpose: these are file reads, not deep recursion, and a
+        // stranded thread's stack is memory we never get back.
+        worker.stackSize = 512 * 1024
+        worker.start()
+
+        if done.wait(timeout: .now() + timeout) == .timedOut {
+            mark(key, stuck: true)
+            Log.scan.error("""
+                \(self.label, privacy: .public): \(key, privacy: .public) did not return within \
+                \(timeout, privacy: .public)s — abandoning it (app-data privacy gate?)
+                """)
+            return nil
+        }
+        return box.value
+    }
+
+    /// A slot one thread fills and another reads. Needed rather than a captured
+    /// `var` because the reader can give up before the writer stores anything.
+    private final class Box<T>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: T?
+        var value: T? {
+            get { lock.lock(); defer { lock.unlock() }; return stored }
+            set { lock.lock(); defer { lock.unlock() }; stored = newValue }
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/BoundedBlockingWork.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/BoundedBlockingWork.swift
@@ -86,12 +86,32 @@ final class BoundedBlockingWork: @unchecked Sendable {
         timeout: TimeInterval,
         _ work: @escaping @Sendable () -> T
     ) -> T? {
+        run(key: key, timeout: timeout, onDeadline: { _ in }, work)
+    }
+
+    /// The above, with a hook that runs after the deadline passes and before the
+    /// give-up is claimed.
+    ///
+    /// Only a test passes one, and it is not a convenience: the race the claim
+    /// exists to settle lives in the handful of instructions between `wait`
+    /// returning `.timedOut` and `abandon()`, which is not a window anything can
+    /// aim at from outside. The hook is that window, held open. Without it the one
+    /// line that fixes the bug would be pinned by review alone.
+    func run<T: Sendable>(
+        key: String,
+        timeout: TimeInterval,
+        onDeadline: (Slot<T>) -> Void,
+        _ work: @escaping @Sendable () -> T
+    ) -> T? {
         guard !isStuck(key) else { return nil }
 
-        let box = Box<T>()
+        let slot = Slot<T>()
         let done = DispatchSemaphore(value: 0)
         let worker = Thread { [self] in
-            box.value = work()
+            _ = slot.complete(work())
+            // Unconditionally, including when the caller already gave up: the
+            // mark says "a thread is stranded on this key", and this thread is
+            // not, whoever is still listening.
             mark(key, stuck: false)
             done.signal()
         }
@@ -101,6 +121,20 @@ final class BoundedBlockingWork: @unchecked Sendable {
         worker.start()
 
         if done.wait(timeout: .now() + timeout) == .timedOut {
+            // ⚠️ `.timedOut` does NOT mean the work is still running. The worker
+            // can finish in the gap between the deadline passing and this line,
+            // and the first version of this — and of `TestFlightInventory`, where
+            // it was extracted from — then wrote `stuck = true` on top of the
+            // worker's `stuck = false`. Nothing clears that mark afterwards,
+            // because no thread is stranded to clear it: the key would answer nil
+            // for the rest of the process. On the channel path that is a bound app
+            // silently losing its authoritative channel until the app is
+            // relaunched.
+            //
+            // So the give-up is CLAIMED rather than assumed. Losing the claim means
+            // the answer landed in the gap, and it is a perfectly good answer.
+            onDeadline(slot)
+            guard slot.abandon() else { return slot.value }
             mark(key, stuck: true)
             Log.scan.error("""
                 \(self.label, privacy: .public): \(key, privacy: .public) did not return within \
@@ -108,17 +142,43 @@ final class BoundedBlockingWork: @unchecked Sendable {
                 """)
             return nil
         }
-        return box.value
+        return slot.value
     }
 
-    /// A slot one thread fills and another reads. Needed rather than a captured
-    /// `var` because the reader can give up before the writer stores anything.
-    private final class Box<T>: @unchecked Sendable {
+    /// A slot one thread fills and another reads, plus the race between them.
+    /// Needed rather than a captured `var` because the reader can give up before
+    /// the writer stores anything — and, less obviously, because the two can
+    /// arrive at the same instant and exactly one of them has to win.
+    /// Not private: this is the race, and `BoundedBlockingWorkTests` pins both
+    /// orderings on it directly. Driving them through `run` would mean timing the
+    /// gap between a deadline and the line after it, which is not something a
+    /// test can arrange on purpose.
+    final class Slot<T>: @unchecked Sendable {
         private let lock = NSLock()
         private var stored: T?
+        private var abandoned = false
+
+        /// Store the result. False means the caller had already given up, so the
+        /// value is too late to be returned to it.
+        func complete(_ value: T) -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            guard !abandoned else { return false }
+            stored = value
+            return true
+        }
+
+        /// Claim the give-up. False means the work finished first and `value`
+        /// holds a real answer.
+        func abandon() -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            guard stored == nil else { return false }
+            abandoned = true
+            return true
+        }
+
         var value: T? {
-            get { lock.lock(); defer { lock.unlock() }; return stored }
-            set { lock.lock(); defer { lock.unlock() }; stored = newValue }
+            lock.lock(); defer { lock.unlock() }
+            return stored
         }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BoundedBlockingWorkTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BoundedBlockingWorkTests.swift
@@ -128,6 +128,65 @@ struct BoundedBlockingWorkTests {
                 "a worker that finally came back must let its key be tried again")
     }
 
+    /// The two orderings of the give-up race, pinned on `Slot` itself because
+    /// `run` cannot be made to hit them on purpose: the window is between
+    /// `done.wait` reporting `.timedOut` and the very next line.
+    ///
+    /// Mutation: drop the `guard !abandoned` from `complete` and the
+    /// `guard stored == nil` from `abandon` (i.e. let both always succeed) — the
+    /// return values below stop discriminating and both cases fail.
+    @Test func exactlyOneOfTheWorkerAndTheDeadlineWinsTheSlot() {
+        let workFirst = BoundedBlockingWork.Slot<Int>()
+        #expect(workFirst.complete(7))
+        #expect(workFirst.abandon() == false,
+                "the deadline must not claim a give-up over work that already landed")
+        #expect(workFirst.value == 7, "and the answer must survive to be returned")
+
+        let deadlineFirst = BoundedBlockingWork.Slot<Int>()
+        #expect(deadlineFirst.abandon())
+        #expect(deadlineFirst.complete(7) == false,
+                "work that finishes after the caller gave up must not resurrect an answer")
+        #expect(deadlineFirst.value == nil)
+    }
+
+    /// The `run`-level half of the case above: when the worker lands its answer
+    /// inside the give-up window, `run` must return that answer rather than nil.
+    ///
+    /// Held open with `onDeadline`, which is why that hook exists — the real
+    /// window is the few instructions between `wait` reporting `.timedOut` and
+    /// `abandon()`, and nothing outside `run` can aim at it. The hook releases the
+    /// worker and waits until its result is in the slot, so the ordering is
+    /// arranged rather than hoped for.
+    ///
+    /// What it buys beyond a dropped answer: the first version of this code, and
+    /// of `TestFlightInventory` where it was extracted from, wrote `stuck = true`
+    /// on top of the worker's `stuck = false` here. Nothing clears that mark
+    /// afterwards — no thread is stranded to clear it — so on the channel path a
+    /// bound app would answer nil for the rest of the process, silently losing its
+    /// authoritative channel.
+    ///
+    /// Mutation: delete `guard slot.abandon() else { return slot.value }` (the
+    /// unconditional give-up this replaced) — `run` answers nil and this fails.
+    @Test func anAnswerThatLandsInsideTheGiveUpWindowIsReturned() {
+        let bounded = BoundedBlockingWork(label: "test")
+        let release = DispatchSemaphore(value: 0)
+
+        let answer = bounded.run(
+            key: "raced",
+            timeout: 0.05,
+            onDeadline: { slot in
+                release.signal()
+                while slot.value == nil { usleep(200) }
+            }
+        ) { () -> Int in
+            release.wait()
+            return 7
+        }
+
+        #expect(answer == 7,
+                "the deadline must not discard an answer that arrived before it claimed the give-up")
+    }
+
     /// Mutation: replace the `Set<String>` memo with a single `Bool` — the second
     /// expectation fails. One gated file must not silence an unrelated resolver,
     /// which on this path means one app's pending prompt deciding another app's

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BoundedBlockingWorkTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BoundedBlockingWorkTests.swift
@@ -1,0 +1,224 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `BoundedBlockingWork` is what stands between one file behind macOS's app-data
+/// privacy gate and a wedged process. Every case below names the mutation it
+/// exists to catch, and each mutation was applied and watched go red.
+///
+/// The blocking stand-in is a FIFO, the same one `TestFlightInventoryTests` uses:
+/// the file exists, so every "is it there" check passes, and then `open(2)` blocks
+/// for a writer that never arrives. That is the shape of the real failure — a
+/// consent prompt nobody answers is not a slow read, it is a read with no end —
+/// and it is not a cancellation point, so nothing but abandoning it works.
+///
+/// ⚠️ The stand-in calls `open(2)` directly rather than `Data(contentsOf:)`.
+/// Measured 2026-09-09: `Data(contentsOf:)` against a FIFO does **not** block, it
+/// throws immediately, so the first version of this file passed in 0.0002s while
+/// asserting it had waited half a second. `open(2)` is also the frame the
+/// `sample(1)` stack was actually wedged in.
+///
+/// Timeouts here are deliberately far below the production ones: what is being
+/// measured is that a deadline is enforced at all, not what it is set to.
+struct BoundedBlockingWorkTests {
+
+    /// The blocking read itself: `open(2)` on a FIFO with no writer parks the
+    /// thread indefinitely, which is what a pending consent prompt does to a real
+    /// container plist.
+    private static func openAndClose(_ url: URL) -> Bool {
+        let fd = open(url.path, O_RDONLY)
+        guard fd >= 0 else { return false }
+        close(fd)
+        return true
+    }
+
+    /// A FIFO at a fresh path, plus its directory, cleaned up by the caller.
+    private static func blockingFile() throws -> (url: URL, cleanup: () -> Void) {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bounded-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let fifo = dir.appendingPathComponent("blocked.plist")
+        #expect(mkfifo(fifo.path, 0o600) == 0, "could not create the blocking stand-in")
+        return (fifo, {
+            // Let the stranded reader's open(2) complete so the thread unwinds
+            // instead of outliving the suite.
+            let writeEnd = open(fifo.path, O_WRONLY | O_NONBLOCK)
+            if writeEnd >= 0 { close(writeEnd) }
+            try? FileManager.default.removeItem(at: dir)
+        })
+    }
+
+    /// Mutation: widen the wait to `.now() + timeout * 10` (2.5s past the ceiling
+    /// below, not a hair over it) — the elapsed ceiling fails. Remove the deadline entirely (`done.wait()`) and this case
+    /// never returns, which is the failure the whole type exists to prevent and
+    /// which `scripts/run-with-hang-report.sh` turns into a report rather than a
+    /// mystery.
+    @Test func aReadThatNeverReturnsIsAbandonedAtTheDeadline() throws {
+        let (fifo, cleanup) = try Self.blockingFile()
+        defer { cleanup() }
+
+        let bounded = BoundedBlockingWork(label: "test")
+        let started = Date()
+        let answer = bounded.run(key: fifo.path, timeout: 0.5) {
+            Self.openAndClose(fifo)
+        }
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(answer == nil, "an abandoned read must not report an answer")
+        #expect(elapsed >= 0.4, "returned too early to have actually waited on the open")
+        #expect(elapsed < 2, "did not give up — this is the hang the bound exists to prevent")
+        #expect(bounded.isStuck(fifo.path), "giving up must record that the key is stranded")
+    }
+
+    /// Mutation: delete the `guard !isStuck(key)` in `run` — the second call pays
+    /// the deadline again and the elapsed ceiling fails. Without this the
+    /// menu-bar app, which scans on a timer, strands one more thread every pass.
+    @Test func aKeyKnownStuckIsAnsweredWithoutStartingMoreWork() throws {
+        let (fifo, cleanup) = try Self.blockingFile()
+        defer { cleanup() }
+
+        let bounded = BoundedBlockingWork(label: "test")
+        _ = bounded.run(key: fifo.path, timeout: 0.5) { Self.openAndClose(fifo) }
+
+        let started = Date()
+        let second = bounded.run(key: fifo.path, timeout: 0.5) { Self.openAndClose(fifo) }
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(second == nil)
+        #expect(elapsed < 0.2,
+                "a key already known stuck must short-circuit, not wait again")
+    }
+
+    /// Mutation: mark the key stuck unconditionally rather than only on the
+    /// timeout path — `isStuck` below fails, and in production the first scan
+    /// would silence every later one.
+    ///
+    /// Also the fixture guard for the two cases above: it is what says a
+    /// `nil` from `run` means "gave up", because work that finishes does answer.
+    @Test func workThatFinishesInTimeAnswersAndLeavesNoMark() {
+        let bounded = BoundedBlockingWork(label: "test")
+        let answer = bounded.run(key: "quick", timeout: 5) { 41 + 1 }
+        #expect(answer == 42)
+        #expect(!bounded.isStuck("quick"))
+    }
+
+    /// Mutation: delete `mark(key, stuck: false)` from the worker body — the poll
+    /// below never sees the mark clear and the case fails. That is the difference
+    /// between "granting the permission recovers on the next scan" and "recovers
+    /// on the next launch", which for the menu-bar app can be weeks.
+    @Test func aStrandedWorkerThatEventuallyReturnsClearsItsMark() {
+        let bounded = BoundedBlockingWork(label: "test")
+        let release = DispatchSemaphore(value: 0)
+
+        let answer = bounded.run(key: "gated", timeout: 0.3) {
+            release.wait()
+            return 7
+        }
+        #expect(answer == nil)
+        #expect(bounded.isStuck("gated"))
+
+        release.signal()
+        // The worker clears the mark on its own thread; wait for it rather than
+        // assuming the signal has been observed.
+        let deadline = Date().addingTimeInterval(5)
+        while bounded.isStuck("gated") && Date() < deadline {
+            usleep(10_000)
+        }
+        #expect(!bounded.isStuck("gated"),
+                "a worker that finally came back must let its key be tried again")
+    }
+
+    /// Mutation: replace the `Set<String>` memo with a single `Bool` — the second
+    /// expectation fails. One gated file must not silence an unrelated resolver,
+    /// which on this path means one app's pending prompt deciding another app's
+    /// channel.
+    @Test func oneStuckKeyDoesNotSilenceAnother() {
+        let bounded = BoundedBlockingWork(label: "test")
+        bounded.mark("gated", stuck: true)
+
+        #expect(bounded.run(key: "gated", timeout: 5) { 1 } == nil)
+        #expect(bounded.run(key: "other", timeout: 5) { 2 } == 2,
+                "an unrelated key must still be tried")
+    }
+}
+
+/// The chokepoint half: `ChannelBinding.resolve` runs its resolver under the
+/// bound, and answers nil — not a fabricated channel — when it gives up.
+///
+/// A fresh `BoundedBlockingWork` per case, never the shared one: the shared
+/// instance is process-wide, `swift-testing` runs cases in parallel, and
+/// `ChannelGuardTests` asserts that Ghostty resolves. Marking the shared memo
+/// would make that case pass or fail on ordering.
+struct ChannelBindingBoundTests {
+
+    /// Ghostty is the witness the two cases below need, and this is the fixture
+    /// guard that says so: its resolver reads nothing and returns a constant, so
+    /// it answers the same on CI, on a machine with Ghostty installed, and on one
+    /// without. Every other binding's live answer depends on this Mac's
+    /// preferences, and several of them legitimately answer nil — against those,
+    /// "stuck ⇒ nil" is `f(X) == f(X)` and measures nothing.
+    @Test func ghosttyResolvesToSomethingWhenTheBoundIsNotInTheWay() {
+        let resolved = ChannelBinding.resolve(bundleID: GhosttyChannel.bundleID)
+        #expect(resolved != nil)
+        #expect(resolved?.channel == .stable)
+    }
+
+    /// Mutation: in `resolve(bundleID:bounded:)`, call `resolver()` directly
+    /// instead of `bounded.run(...)` — Ghostty answers its constant and this
+    /// fails. That is the mutation that matters: it is the whole hazard, and it
+    /// compiles.
+    @Test func aBoundResolverThatIsStuckIsNotRunAndAnswersNil() {
+        let bounded = BoundedBlockingWork(label: "test")
+        bounded.mark(GhosttyChannel.bundleID.lowercased(), stuck: true)
+
+        let resolved = ChannelBinding.resolve(
+            bundleID: GhosttyChannel.bundleID, bounded: bounded)
+
+        #expect(resolved == nil)
+    }
+
+    /// The safety half, and the reason nil is the answer rather than `.stable`.
+    ///
+    /// An authoritative `.stable` from a resolver we could not read would SILENCE
+    /// `ReleaseChannel.detect()` — see `CotEditorChannel`'s own comment — pinning
+    /// a `7.1.0-beta.6` copy whose container is behind a consent prompt to the
+    /// stable line and offering it a downgrade. nil leaves `detect()` reading
+    /// `-beta.6` off the version string, which is what an app with no binding at
+    /// all already gets.
+    ///
+    /// Mutation: change `resolve`'s `?? nil` to
+    /// `?? ResolvedChannel(channel: .stable)` — the shape somebody reaching for a
+    /// "safe default" would write. The case above goes red on it too; this one is
+    /// what says which of the two possible nils is being demanded and why.
+    @Test func aResolverWeCouldNotReadIsNeverReportedAsStable() {
+        let bounded = BoundedBlockingWork(label: "test")
+        bounded.mark(GhosttyChannel.bundleID.lowercased(), stuck: true)
+
+        let resolved = ChannelBinding.resolve(
+            bundleID: GhosttyChannel.bundleID, bounded: bounded)
+
+        #expect(resolved?.channel != .stable,
+                "a channel we failed to read must not be asserted as stable")
+    }
+
+    /// Derived from the registry rather than from a hand-written list, the way
+    /// `ChannelResolverTests.everyBoundIDHasAResolverBehindIt` is: a binding added
+    /// tomorrow is covered by being in `boundBundleIDs`, with nothing to remember.
+    ///
+    /// Honest about its own strength: for an id whose live resolution is already
+    /// nil on this machine, "stuck ⇒ nil" measures nothing. It is a sweep for the
+    /// shape — no id may bypass the chokepoint — and
+    /// `aBoundResolverThatIsStuckIsNotRunAndAnswersNil` is the case with the real
+    /// signal in it.
+    ///
+    /// Mutation: same as that case (call `resolver()` directly); on a machine with
+    /// any bound app installed this goes red too.
+    @Test func noBoundIDBypassesTheChokepoint() {
+        for id in ChannelBinding.boundBundleIDs {
+            let bounded = BoundedBlockingWork(label: "test")
+            bounded.mark(id, stuck: true)
+            #expect(ChannelBinding.resolve(bundleID: id, bounded: bounded) == nil,
+                    "\(id) answered while its resolver was marked stuck")
+        }
+    }
+}


### PR DESCRIPTION
## The hang

`AppScanner.scan()` is synchronous all the way down to `ChannelBinding.resolve`, and several resolvers read another app's data directly — CotEditor's sandbox container, Surge's and Alfred's Application Support plists, CapCut's file under `~/Movies`, Windscribe's plist. macOS gates those behind the app-data privacy prompt, and while the prompt sits unanswered `open(2)` does not fail, does not time out, and is not a cancellation point. It never returns.

Measured 2026-09-09: `make test` was killed by `scripts/run-with-hang-report.sh` at its 1800s timeout (EXIT=124), two CPU samples 60s apart showing 0.00s burned in between, and `sample(1)` on a `com.apple.root.default-qos.cooperative` thread:

```
installPipelineDryRun() → AppScanner.scan() → admit → readApp
  → ChannelBinding.resolve → CotEditorChannel.resolveCurrent
    → decodeChecksUpdatesForBeta → Data.init(contentsOf:) → __open
```

Once the pending consent dialog was answered, the identical suite finished in 15.5s. Not test-only: `scan()` is on the shipping app's path, and `InstallPermits(applies: 2)` means there is real concurrency to starve.

Reproduced again in this branch, by accident: applying the "call `resolver()` directly" mutation made the test run block until the machine owner clicked the prompt that appeared.

## The fix

`TestFlightInventory` already hit this wall from the other direction (2026-08-15, ten minutes in `guarded_open_np` at 0.03s of CPU) and grew a fix. This extracts it as `BoundedBlockingWork`: an abandoned `Thread` (not a Dispatch item — a stranded pool worker is how you convert one gated file into a second outage), a deadline, and a per-key memo so one gated file strands one thread rather than one per scan, cleared if the worker ever does return. `TestFlightInventory` now uses that same copy instead of its own.

`offCooperativePool` is the wrong tool here on both counts: it needs an `async` caller, and it never gives up.

The bound sits at `ChannelBinding`'s single dispatch point, not in each resolver — so a binding added tomorrow is covered by having a `case` in the switch and nothing else. `CFPreferences` resolvers go through it too, not because a `cfprefsd` round trip is known to hang, but because exempting them would make this a list somebody has to keep correct.

## What a timed-out resolver answers

nil — the same answer an app with no binding gets, leaving `ReleaseChannel.detect()` and the bundle's own signed `SUFeedURL` in charge. Synthesising `.stable` would be *authoritative* and would therefore silence `detect()`, pinning a `7.1.0-beta.6` copy whose container we could not open to the stable line and offering it a downgrade — the direction `CotEditorChannel`'s own comment warns about. With nil, `detect()` still reads `-beta.6` off the version string. The chokepoint could not do better anyway: each app's shipped default lives in its own resolver, and reaching it means running the resolver that just hung.

## Tests

Nine cases, each naming its mutation; all seven mutations applied and watched go red:

| mutation | red |
|---|---|
| widen the wait to `timeout * 10` | `aReadThatNeverReturnsIsAbandonedAtTheDeadline` |
| drop the `guard !isStuck(key)` | `aKeyKnownStuckIsAnsweredWithoutStartingMoreWork` (+4) |
| mark stuck unconditionally | `workThatFinishesInTimeAnswersAndLeavesNoMark`, `aStrandedWorker…` |
| never clear the mark | `aStrandedWorkerThatEventuallyReturnsClearsItsMark` |
| memo collapses to one flag | `oneStuckKeyDoesNotSilenceAnother` |
| `resolve` calls `resolver()` directly | `aBoundResolverThatIsStuckIsNotRunAndAnswersNil` (+2) |
| `?? ResolvedChannel(channel: .stable)` | `aResolverWeCouldNotReadIsNeverReportedAsStable` (+2) |

⚠️ The FIFO stand-in calls `open(2)` directly: measured, `Data(contentsOf:)` against a FIFO throws immediately rather than blocking, so the first version of the file passed in 0.0002s while asserting it had waited half a second.

## Verification

`scripts/run-with-hang-report.sh 1800 make test` → EXIT=0, all gates green, App tests 9/9 executed.

## Known gap

The public `resolve(bundleID:)` handing over the *shared* `BoundedBlockingWork` rather than a throwaway is a one-line delegation no test here would notice being changed — a throwaway would strand one thread per scan with the suite still green. Stated in the source rather than left to be discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)