### PR TITLE
Fix #473: exited-with-subordinates lsappinfo tombstones read as a running build

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -4259,28 +4259,14 @@ final class AppListModel {
             kill.cancel()
             guard let text = String(data: data, encoding: .utf8) else { return [:] }
 
-            var map: [String: String] = [:]
-            var current: String?
-            for line in text.split(separator: "\n") {
-                if let path = quotedValue(after: "bundle path", in: line) {
-                    // Resolve symlinks to line up with how `AppScanner` records
-                    // `InstalledApp.path` (and `computeRestartInfo`'s lookup key).
-                    current = UpdatePolicy.runtimeBundlePath(URL(fileURLWithPath: path))
-                } else if let cur = current, map[cur] == nil,
-                          let version = quotedValue(after: "Version", in: line) {
-                    map[cur] = version
-                }
-            }
-            return map
+            // What the text MEANS — including skipping `(exited-with-subordinates)`
+            // tombstones LaunchServices keeps for an app whose own process quit but
+            // left a spawned helper/daemon running (#473) — is a pure function in
+            // Core (`LSAppInfoParser`), so it can be asserted against fixed text
+            // instead of a live process list. This closure only owns invoking the
+            // tool and its timeout/kill backstop.
+            return LSAppInfoParser.runningBuildVersions(from: text)
         }.value
-    }
-
-    /// Extract the value of a `key="value"` pair from a line.
-    nonisolated private static func quotedValue(after key: String, in line: Substring) -> String? {
-        guard let start = line.range(of: key + "=\"") else { return nil }
-        let rest = line[start.upperBound...]
-        guard let end = rest.firstIndex(of: "\"") else { return nil }
-        return String(rest[..<end])
     }
 
     /// Take down a note one of the restart paths wrote — and only if it is still

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/LSAppInfoParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/LSAppInfoParser.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Parses the text `lsappinfo list` prints, into the one thing
+/// `computeRestartInfo` needs from it: resolved bundle path → the
+/// `CFBundleVersion` the running process actually launched with.
+///
+/// Pure and file-I/O-free on purpose — the app is the one thing that knows how
+/// to invoke `/usr/bin/lsappinfo` (with its timeout/kill backstop for a wedged
+/// process); everything about what the text MEANS belongs here, where it can be
+/// asserted against fixed strings instead of a live process list.
+public enum LSAppInfoParser {
+    /// Build the path → version map, skipping any entry LaunchServices marks
+    /// `(exited-with-subordinates)`.
+    ///
+    /// That marker is a tombstone: the app's own process already exited, but
+    /// LaunchServices keeps the record around because something it spawned (a
+    /// helper, a bundled daemon) — or another member of its process coalition —
+    /// is still alive. The `Version` on that record is frozen at whatever build
+    /// launched, which after an update is the OLD one, so treating the record as
+    /// "running" makes `disk newer than running` true forever and the Relaunch
+    /// badge never clears (issue #473).
+    ///
+    /// Measured 2026-09-09 on macOS 27.0.0 (arm64), two real records:
+    ///   - a UIElement helper whose main process had quit, one coalition member
+    ///     still alive: `pid = 1193 … Version=[ NULL ] … Arch=ARM64
+    ///     (exited-with-subordinates)` — the marker trails every other flag on
+    ///     the `pid = …` line, after a sandboxed-or-not app with `Version=[ NULL ]`
+    ///     (unquoted, so `quotedValue` already skips it regardless of this guard).
+    ///   - the reporter's own case (AndroMeld, a sandboxed app):
+    ///     `pid = 32196 … Version="2608.29.0" … sandboxed (exited-with-subordinates)`
+    ///     — here `Version` IS quoted, so without this guard it would be read as
+    ///     the live running build.
+    /// `strings` on `/usr/bin/lsappinfo` shows `(exited-with-subordinates)` is
+    /// the only literal parenthetical status marker the tool's `list` format
+    /// emits — there is no separate bare `(exited)` to also guard against, and
+    /// nothing else in that binary looks like a second spelling of it.
+    ///
+    /// The marker always trails the same `pid = …` line the (quoted-or-not)
+    /// `Version` appears on, alongside `sandboxed`/`!signalled`/etc — so this
+    /// checks the current line only, not a flag carried across lines.
+    public static func runningBuildVersions(from text: String) -> [String: String] {
+        var map: [String: String] = [:]
+        var current: String?
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            if let path = quotedValue(after: "bundle path", in: line) {
+                current = UpdatePolicy.runtimeBundlePath(URL(fileURLWithPath: path))
+            } else if let cur = current, map[cur] == nil,
+                      !line.contains("(exited-with-subordinates)"),
+                      let version = quotedValue(after: "Version", in: line) {
+                map[cur] = version
+            }
+        }
+        return map
+    }
+
+    /// Extract the value of a `key="value"` pair from a line.
+    static func quotedValue(after key: String, in line: Substring) -> String? {
+        guard let start = line.range(of: key + "=\"") else { return nil }
+        let rest = line[start.upperBound...]
+        guard let end = rest.firstIndex(of: "\"") else { return nil }
+        return String(rest[..<end])
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/LSAppInfoParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/LSAppInfoParser.swift
@@ -9,7 +9,12 @@ import Foundation
 /// process); everything about what the text MEANS belongs here, where it can be
 /// asserted against fixed strings instead of a live process list.
 public enum LSAppInfoParser {
-    /// Build the path → version map, skipping any entry LaunchServices marks
+
+    /// What LaunchServices stamps on a record whose app already exited but whose
+    /// process coalition still has a member alive.
+    static let tombstoneMarker = "(exited-with-subordinates)"
+
+    /// Build the path → version map, discarding any record LaunchServices marks
     /// `(exited-with-subordinates)`.
     ///
     /// That marker is a tombstone: the app's own process already exited, but
@@ -20,40 +25,79 @@ public enum LSAppInfoParser {
     /// "running" makes `disk newer than running` true forever and the Relaunch
     /// badge never clears (issue #473).
     ///
-    /// Measured 2026-09-09 on macOS 27.0.0 (arm64), two real records:
+    /// Measured 2026-09-09 on macOS 27.0.0 (arm64), three real records:
     ///   - a UIElement helper whose main process had quit, one coalition member
     ///     still alive: `pid = 1193 … Version=[ NULL ] … Arch=ARM64
-    ///     (exited-with-subordinates)` — the marker trails every other flag on
-    ///     the `pid = …` line, after a sandboxed-or-not app with `Version=[ NULL ]`
-    ///     (unquoted, so `quotedValue` already skips it regardless of this guard).
+    ///     (exited-with-subordinates)`. `Version` unquoted, so `quotedValue`
+    ///     already skipped it regardless of this guard.
     ///   - the reporter's own case (AndroMeld, a sandboxed app):
     ///     `pid = 32196 … Version="2608.29.0" … sandboxed (exited-with-subordinates)`
-    ///     — here `Version` IS quoted, so without this guard it would be read as
-    ///     the live running build.
-    /// `strings` on `/usr/bin/lsappinfo` shows `(exited-with-subordinates)` is
-    /// the only literal parenthetical status marker the tool's `list` format
-    /// emits — there is no separate bare `(exited)` to also guard against, and
-    /// nothing else in that binary looks like a second spelling of it.
+    ///     — here `Version` IS quoted, so without this guard it reads as the live
+    ///     running build. This is the shape the bug turned on.
+    ///   - one live tombstone in a full `lsappinfo list` sweep (1092 lines, 106
+    ///     records), also with an unquoted `Version`.
+    /// `strings` on `/usr/bin/lsappinfo` shows `(exited-with-subordinates)` is the
+    /// only literal parenthetical status marker the `list` format emits — the six
+    /// other `exited`-bearing literals in that binary are API key names and flag
+    /// spellings, none of them parenthesised. Scanning that same 1092-line sweep for
+    /// parenthesised tokens turned up only app names plus `(PID …)`, `(Renderer)`
+    /// and `(in front)` beside it.
     ///
-    /// The marker always trails the same `pid = …` line the (quoted-or-not)
-    /// `Version` appears on, alongside `sandboxed`/`!signalled`/etc — so this
-    /// checks the current line only, not a flag carried across lines.
+    /// **Why the whole record is discarded rather than just the marked line.** In all
+    /// three observations the marker sat on the same `pid = …` line as `Version`, so
+    /// skipping that one line would have sufficed — but three samples are not a format
+    /// guarantee, and the failure mode of being wrong is silent: a tombstone whose
+    /// `Version` landed on some other line would be read as a live build again, which
+    /// is precisely bug #473 returning with no test to catch it.
+    ///
+    /// Getting that independence requires **holding the version back** rather than
+    /// clearing a cursor: a record is only committed once the next record begins (or
+    /// the text ends), so a marker appearing anywhere inside it — before the `Version`
+    /// line, on it, or after it — still cancels the whole thing. Simply nulling the
+    /// current path on the marker line would leave a marker that trails `Version` too
+    /// late to matter, which is the half of the format we have the least evidence about.
+    ///
+    /// The pre-existing first-wins rule survives as two guards: `held == nil` keeps the
+    /// FIRST `Version` line within a record, and `map[path] == nil` at commit time keeps
+    /// the first record for a path — so a live record already recorded is never
+    /// overwritten by a later tombstone for the same path.
     public static func runningBuildVersions(from text: String) -> [String: String] {
         var map: [String: String] = [:]
         var current: String?
-        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+        /// The version read for `current`, not yet committed: a tombstone marker later
+        /// in the same record still has to be able to cancel it.
+        var held: String?
+
+        func commitCurrentRecord() {
+            guard let path = current, let version = held else { return }
+            if map[path] == nil { map[path] = version }
+        }
+
+        for line in text.split(separator: "\n") {
             if let path = quotedValue(after: "bundle path", in: line) {
+                commitCurrentRecord()
+                // Resolve symlinks to line up with how `AppScanner` records
+                // `InstalledApp.path` (and `computeRestartInfo`'s lookup key).
                 current = UpdatePolicy.runtimeBundlePath(URL(fileURLWithPath: path))
-            } else if let cur = current, map[cur] == nil,
-                      !line.contains("(exited-with-subordinates)"),
+                held = nil
+            } else if line.contains(tombstoneMarker) {
+                current = nil
+                held = nil
+            } else if current != nil, held == nil,
                       let version = quotedValue(after: "Version", in: line) {
-                map[cur] = version
+                held = version
             }
         }
+        commitCurrentRecord()
         return map
     }
 
     /// Extract the value of a `key="value"` pair from a line.
+    ///
+    /// ⚠️ Substring search, so `key` matches as a suffix too: asking for `Version`
+    /// would also accept a `SomethingVersion="…"` pair. No `lsappinfo list` output
+    /// measured so far carries one, and this behaviour predates #473 — noted rather
+    /// than changed, so a future reader does not mistake it for intent.
     static func quotedValue(after key: String, in line: Substring) -> String? {
         guard let start = line.range(of: key + "=\"") else { return nil }
         let rest = line[start.upperBound...]

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// `LSAppInfoParser.runningBuildVersions` turns `lsappinfo list`'s text into
+/// path → running-build-version. Its one job beyond the original path/Version
+/// scrape is excluding `(exited-with-subordinates)` tombstones — records
+/// LaunchServices keeps for an app whose own process already quit because
+/// something it spawned (or another coalition member) is still alive. Reading
+/// one of those as "running" is issue #473: the frozen pre-update `Version` on
+/// the tombstone reads as older than the disk build forever, so Relaunch never
+/// clears even after the app is long gone and the update long applied.
+///
+/// Every fixture below is built from the two real `lsappinfo list` records
+/// measured 2026-09-09 on macOS 27.0.0 (arm64) — not retyped from the issue's
+/// single sample, since that text is one observation, not a spec. Both are
+/// reproduced verbatim except for cosmetic renaming (the running app's own
+/// name/bundle id/pid), confirmed byte-for-byte against `lsappinfo list`
+/// output captured on this machine:
+///   - a sandboxed app, `Version` QUOTED, marker trailing `sandboxed`:
+///     `pid = 32196 … Version="2608.29.0" … sandboxed (exited-with-subordinates)`
+///     (this is also the shape the issue itself reports for AndroMeld).
+///   - a non-sandboxed UIElement helper, `Version` UNQUOTED (`[ NULL ]`),
+///     marker trailing `Arch=ARM64` directly (no `sandboxed`):
+///     `pid = 1193 … Version=[ NULL ]  … Arch=ARM64 (exited-with-subordinates)`
+@Suite struct LSAppInfoParserTests {
+
+    /// One "N) "Name" ASN:…" entry block, shaped like real `lsappinfo list` text.
+    /// `pidLineSuffix` is everything on the `pid = …` line after `Arch=ARM64 `,
+    /// which is where both the quoted-or-not `Version` and the
+    /// `(exited-with-subordinates)` marker (when present) actually live.
+    private func entry(number: Int, name: String, bundleID: String, path: String, pidLineSuffix: String) -> String {
+        """
+         \(number)) "\(name)" ASN:0x0-0x18fb8fa:
+            bundleID="\(bundleID)"
+            bundle path="\(path)"
+            executable path="\(path)/Contents/MacOS/\(name)"
+            pid = 32196 token=[sess=100019 pid=32196 uid:501,501,501 g:20,20 pV:3002] type="UIElement" flavor=3 Version=\(pidLineSuffix)
+            checkin time = 2026/09/09 10:21:52 ( 12 minutes ago )
+        """
+    }
+
+    // MARK: - Baseline: an ordinary running app is unaffected
+
+    /// Mutation this pins: deleting the `(exited-with-subordinates)` guard
+    /// entirely (i.e. reverting to the pre-#473 parser) must NOT make this red
+    /// — an app with no tombstone marker has to keep working exactly as before.
+    @Test func anOrdinaryRunningAppIsCaptured() {
+        let text = entry(
+            number: 1, name: "Xcode", bundleID: "com.apple.dt.Xcode",
+            path: "/Applications/Xcode.app",
+            pidLineSuffix: "\"16.0\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed ")
+        let map = LSAppInfoParser.runningBuildVersions(from: text)
+        #expect(map["/Applications/Xcode.app"] == "16.0")
+    }
+
+    // MARK: - The tombstone itself
+
+    /// The core fix. AndroMeld-shaped: `Version` IS quoted, so without the
+    /// `(exited-with-subordinates)` guard this reads as a live running build —
+    /// exactly the #473 failure (disk build compares newer than this frozen one
+    /// forever). Mutation this pins: delete the
+    /// `!line.contains("(exited-with-subordinates)")` clause in
+    /// `LSAppInfoParser.runningBuildVersions` → this goes from `nil` to
+    /// `"2608.29.0"`, i.e. red. Verified by actually deleting that clause and
+    /// re-running: this test fails, the baseline above does not.
+    @Test func quotedVersionTombstoneIsExcluded() {
+        let text = entry(
+            number: 149, name: "AndroMeld", bundleID: "com.catchingnow.andfiles",
+            path: "/Applications/AndDrive.app",
+            pidLineSuffix: "\"2608.29.0\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed (exited-with-subordinates)")
+        let map = LSAppInfoParser.runningBuildVersions(from: text)
+        #expect(map["/Applications/AndDrive.app"] == nil)
+    }
+
+    /// Fixture guard, not a marker-guard mutation: this is the OTHER real shape
+    /// measured (a non-sandboxed UIElement helper whose tombstone carries
+    /// `Version=[ NULL ]`, unquoted). `quotedValue` already returns `nil` for an
+    /// unquoted value regardless of the marker, so this can't go red by
+    /// deleting the marker guard alone — it grounds the parser against the
+    /// shape actually observed rather than assuming quoting is universal.
+    @Test func unquotedVersionTombstoneIsAlsoExcluded() {
+        let text = entry(
+            number: 35, name: "ClaudeWakeHost", bundleID: "",
+            path: "/Users/bobby/Applications/ClaudeWakeHost.app",
+            pidLineSuffix: "[ NULL ]  fileType=\"APPL\" creator=\"aplt\" Arch=ARM64 (exited-with-subordinates)")
+        let map = LSAppInfoParser.runningBuildVersions(from: text)
+        #expect(map["/Users/bobby/Applications/ClaudeWakeHost.app"] == nil)
+    }
+
+    // MARK: - Interaction with "first entry wins"
+
+    /// `runningBuildVersions` keeps the FIRST version seen per path (so a
+    /// later, unrelated re-listing can't clobber an earlier read). That rule
+    /// predates the tombstone guard and must compose with it correctly: a
+    /// skipped (tombstone) block must NOT count as "already recorded", or the
+    /// live entry that follows it would never get in. This is also the order
+    /// #473 actually hit — a bundle path reported once, with the tombstone's
+    /// own entry the only one LaunchServices had. Mutation this pins: deleting
+    /// the `!line.contains("(exited-with-subordinates)")` clause (the same
+    /// mutation `quotedVersionTombstoneIsExcluded` catches) makes the tombstone
+    /// satisfy `map[cur] == nil` and claim the slot first — verified by
+    /// deleting that clause and re-running: this and
+    /// `quotedVersionTombstoneIsExcluded` are the only two of these six tests
+    /// that go red, this one from `nil` to `"9.9.9"` — locking out the live
+    /// entry that follows, not `"1.2.3"`.
+    @Test func aTombstoneBeforeTheLiveEntryDoesNotBlockIt() {
+        let path = "/Applications/TwoInstances.app"
+        let tombstone = entry(
+            number: 1, name: "TwoInstances", bundleID: "com.example.two",
+            path: path, pidLineSuffix: "\"9.9.9\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed (exited-with-subordinates)")
+        let live = entry(
+            number: 2, name: "TwoInstances", bundleID: "com.example.two",
+            path: path, pidLineSuffix: "\"1.2.3\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed ")
+        let map = LSAppInfoParser.runningBuildVersions(from: tombstone + "\n" + live)
+        #expect(map[path] == "1.2.3")
+    }
+
+    /// The reverse order: once a LIVE version is recorded, a tombstone
+    /// appearing later for the same path must not overwrite it with its own
+    /// (frozen, possibly different) version. ⚠️ No corresponding single-line
+    /// mutation of its own — verified: deleting the marker clause alone (the
+    /// mutation the two tests above pin) leaves this one green, because the
+    /// pre-existing `map[cur] == nil` first-wins check already blocks the
+    /// second write regardless of the marker (`live` claims the slot before
+    /// `tombstone` is ever read). This order was never actually broken by
+    /// #473 — only tombstone-before-live was. Kept as a fixture guard: it
+    /// pins that first-wins composes safely with the new marker check in
+    /// BOTH orders, not just the one #473 hit.
+    @Test func aTombstoneAfterTheLiveEntryDoesNotOverwriteIt() {
+        let path = "/Applications/TwoInstancesReversed.app"
+        let live = entry(
+            number: 1, name: "TwoInstancesReversed", bundleID: "com.example.two",
+            path: path, pidLineSuffix: "\"1.2.3\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed ")
+        let tombstone = entry(
+            number: 2, name: "TwoInstancesReversed", bundleID: "com.example.two",
+            path: path, pidLineSuffix: "\"9.9.9\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed (exited-with-subordinates)")
+        let map = LSAppInfoParser.runningBuildVersions(from: live + "\n" + tombstone)
+        #expect(map[path] == "1.2.3")
+    }
+
+    // MARK: - Path normalization still applies
+
+    /// The map is keyed through `UpdatePolicy.runtimeBundlePath`, the same
+    /// normalizer `computeRestartInfo`'s lookup key goes through — a staged
+    /// component in the reported path must still be stripped for a live entry.
+    /// Not itself a #473 regression guard (pre-existing behavior), included so
+    /// this file is the one place asserting the parser's full contract.
+    @Test func stagedPathComponentIsNormalizedForALiveEntry() {
+        let text = entry(
+            number: 1, name: "Staged", bundleID: "com.example.staged",
+            path: "/Applications/.duoupdater-staged-Staged.app",
+            pidLineSuffix: "\"4.0\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed ")
+        let map = LSAppInfoParser.runningBuildVersions(from: text)
+        #expect(map["/Applications/Staged.app"] == "4.0")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
@@ -25,12 +25,38 @@ import Testing
 ///     `pid = 1193 … Version=[ NULL ]  … Arch=ARM64 (exited-with-subordinates)`
 @Suite struct LSAppInfoParserTests {
 
+    /// Every fixture path below must NOT exist on the machine running these tests.
+    ///
+    /// `runningBuildVersions` keys its map through `UpdatePolicy.runtimeBundlePath`,
+    /// whose first act is `resolvingSymlinksInPath()`. For a path that does not exist
+    /// that is the identity, so the key is exactly the string in the fixture. For one
+    /// that DOES exist and is a symlink, it is not — and the assertion then compares
+    /// against a key the parser never produced.
+    ///
+    /// This is not hypothetical. The first version of this suite used
+    /// "/Applications/Xcode.app": green on the author's machine, which has no
+    /// `Xcode.app` (it runs Xcode-beta), and RED on CI, whose runner image has one and
+    /// resolves it elsewhere. The `== nil` cases are worse than the failing one,
+    /// because they stay green either way: a key that drifts is simply absent from the
+    /// map, so the case keeps passing while no longer exercising the tombstone rule at
+    /// all. Two of them were pointed at real paths on this machine
+    /// ("/Applications/AndDrive.app", the reporter's own app, and a real
+    /// ClaudeWakeHost bundle).
+    ///
+    /// So: made-up names, and this guard so a future fixture cannot quietly
+    /// reintroduce the dependency.
+    private func assertFixturePathIsAbsent(_ path: String) {
+        #expect(!FileManager.default.fileExists(atPath: path),
+                "fixture path \(path) exists on this host — see assertFixturePathIsAbsent")
+    }
+
     /// One "N) "Name" ASN:…" entry block, shaped like real `lsappinfo list` text.
     /// `pidLineSuffix` is everything on the `pid = …` line after `Arch=ARM64 `,
     /// which is where both the quoted-or-not `Version` and the
     /// `(exited-with-subordinates)` marker (when present) actually live.
     private func entry(number: Int, name: String, bundleID: String, path: String, pidLineSuffix: String) -> String {
-        """
+        assertFixturePathIsAbsent(path)
+        return """
          \(number)) "\(name)" ASN:0x0-0x18fb8fa:
             bundleID="\(bundleID)"
             bundle path="\(path)"
@@ -48,10 +74,10 @@ import Testing
     @Test func anOrdinaryRunningAppIsCaptured() {
         let text = entry(
             number: 1, name: "Xcode", bundleID: "com.apple.dt.Xcode",
-            path: "/Applications/Xcode.app",
+            path: "/Applications/ZZFixture-Ordinary.app",
             pidLineSuffix: "\"16.0\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed ")
         let map = LSAppInfoParser.runningBuildVersions(from: text)
-        #expect(map["/Applications/Xcode.app"] == "16.0")
+        #expect(map["/Applications/ZZFixture-Ordinary.app"] == "16.0")
     }
 
     // MARK: - The tombstone itself
@@ -69,10 +95,10 @@ import Testing
     @Test func quotedVersionTombstoneIsExcluded() {
         let text = entry(
             number: 149, name: "AndroMeld", bundleID: "com.catchingnow.andfiles",
-            path: "/Applications/AndDrive.app",
+            path: "/Applications/ZZFixture-QuotedTombstone.app",
             pidLineSuffix: "\"2608.29.0\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed (exited-with-subordinates)")
         let map = LSAppInfoParser.runningBuildVersions(from: text)
-        #expect(map["/Applications/AndDrive.app"] == nil)
+        #expect(map["/Applications/ZZFixture-QuotedTombstone.app"] == nil)
     }
 
     /// Fixture guard, not a marker-guard mutation: this is the OTHER real shape
@@ -85,10 +111,10 @@ import Testing
     @Test func unquotedVersionTombstoneIsAlsoExcluded() {
         let text = entry(
             number: 35, name: "ClaudeWakeHost", bundleID: "",
-            path: "/Users/bobby/Applications/ClaudeWakeHost.app",
+            path: "/Applications/ZZFixture-UnquotedTombstone.app",
             pidLineSuffix: "[ NULL ]  fileType=\"APPL\" creator=\"aplt\" Arch=ARM64 (exited-with-subordinates)")
         let map = LSAppInfoParser.runningBuildVersions(from: text)
-        #expect(map["/Users/bobby/Applications/ClaudeWakeHost.app"] == nil)
+        #expect(map["/Applications/ZZFixture-UnquotedTombstone.app"] == nil)
     }
 
     // MARK: - Interaction with "first entry wins"
@@ -106,7 +132,7 @@ import Testing
     /// longer true when the live entry arrives — measured: this goes to
     /// `"9.9.9"`, locking out the live entry that follows, not `"1.2.3"`.
     @Test func aTombstoneBeforeTheLiveEntryDoesNotBlockIt() {
-        let path = "/Applications/TwoInstances.app"
+        let path = "/Applications/ZZFixture-TwoInstances.app"
         let tombstone = entry(
             number: 1, name: "TwoInstances", bundleID: "com.example.two",
             path: path, pidLineSuffix: "\"9.9.9\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed (exited-with-subordinates)")
@@ -130,7 +156,7 @@ import Testing
     /// first-wins composes safely with the marker check in BOTH orders, not just
     /// the one #473 hit.
     @Test func aTombstoneAfterTheLiveEntryDoesNotOverwriteIt() {
-        let path = "/Applications/TwoInstancesReversed.app"
+        let path = "/Applications/ZZFixture-TwoInstancesReversed.app"
         let live = entry(
             number: 1, name: "TwoInstancesReversed", bundleID: "com.example.two",
             path: path, pidLineSuffix: "\"1.2.3\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed ")
@@ -151,10 +177,10 @@ import Testing
     @Test func stagedPathComponentIsNormalizedForALiveEntry() {
         let text = entry(
             number: 1, name: "Staged", bundleID: "com.example.staged",
-            path: "/Applications/.duoupdater-staged-Staged.app",
+            path: "/Applications/.duoupdater-staged-ZZFixture-Staged.app",
             pidLineSuffix: "\"4.0\"  fileType=\"APPL\" creator=\"????\" Arch=ARM64 sandboxed ")
         let map = LSAppInfoParser.runningBuildVersions(from: text)
-        #expect(map["/Applications/Staged.app"] == "4.0")
+        #expect(map["/Applications/ZZFixture-Staged.app"] == "4.0")
     }
 
     // MARK: - The marker's position within a record
@@ -177,19 +203,22 @@ import Testing
     /// swallow the one that follows it, which is the way a hold-and-commit parser breaks
     /// if the commit boundary is placed wrong.
     @Test func aMarkerOnALaterLineStillCancelsTheRecord() {
+        // Built by hand rather than via `entry`, so it needs the guard explicitly.
+        assertFixturePathIsAbsent("/Applications/ZZFixture-Ghost.app")
+        assertFixturePathIsAbsent("/Applications/ZZFixture-Live.app")
         let text = """
          1) "Ghost" ASN:0x0-0x1:
             bundleID="com.example.ghost"
-            bundle path="/Applications/Ghost.app"
+            bundle path="/Applications/ZZFixture-Ghost.app"
             pid = 999 token=[sess=100019 pid=999] type="UIElement" flavor=3 Version="1.0.0" fileType="APPL" Arch=ARM64 sandboxed
             \(LSAppInfoParser.tombstoneMarker)
          2) "Live" ASN:0x0-0x2:
             bundleID="com.example.live"
-            bundle path="/Applications/Live.app"
+            bundle path="/Applications/ZZFixture-Live.app"
             pid = 1000 token=[sess=100019 pid=1000] type="UIElement" flavor=3 Version="2.0.0" fileType="APPL" Arch=ARM64 sandboxed
         """
         let map = LSAppInfoParser.runningBuildVersions(from: text)
-        #expect(map["/Applications/Ghost.app"] == nil)
-        #expect(map["/Applications/Live.app"] == "2.0.0")
+        #expect(map["/Applications/ZZFixture-Ghost.app"] == nil)
+        #expect(map["/Applications/ZZFixture-Live.app"] == "2.0.0")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
@@ -154,4 +154,37 @@ import Testing
         let map = LSAppInfoParser.runningBuildVersions(from: text)
         #expect(map["/Applications/Staged.app"] == "4.0")
     }
+
+    // MARK: - The marker's position within a record
+
+    /// Mutation this pins: committing the version the moment its line is read
+    /// (`map[cur] = version` inline, i.e. both the pre-review implementation and the
+    /// original pre-#473 one) — then the marker arrives too late and Ghost is recorded
+    /// as a live 1.0.0 build, which is #473 verbatim.
+    ///
+    /// Every record measured so far carries the marker on the SAME line as `Version`,
+    /// where a cursor-clearing guard would also have worked. This case covers the half
+    /// of the format we have no observation of: a marker that trails `Version` on a
+    /// later line. It is deliberately synthetic — `lsappinfo` has not been seen emitting
+    /// this shape, and the point is that the parser must not depend on it not doing so.
+    ///
+    /// The second entry is not decoration: it pins that cancelling a record does not
+    /// swallow the one that follows it, which is the way a hold-and-commit parser breaks
+    /// if the commit boundary is placed wrong.
+    @Test func aMarkerOnALaterLineStillCancelsTheRecord() {
+        let text = """
+         1) "Ghost" ASN:0x0-0x1:
+            bundleID="com.example.ghost"
+            bundle path="/Applications/Ghost.app"
+            pid = 999 token=[sess=100019 pid=999] type="UIElement" flavor=3 Version="1.0.0" fileType="APPL" Arch=ARM64 sandboxed
+            \(LSAppInfoParser.tombstoneMarker)
+         2) "Live" ASN:0x0-0x2:
+            bundleID="com.example.live"
+            bundle path="/Applications/Live.app"
+            pid = 1000 token=[sess=100019 pid=1000] type="UIElement" flavor=3 Version="2.0.0" fileType="APPL" Arch=ARM64 sandboxed
+        """
+        let map = LSAppInfoParser.runningBuildVersions(from: text)
+        #expect(map["/Applications/Ghost.app"] == nil)
+        #expect(map["/Applications/Live.app"] == "2.0.0")
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/LSAppInfoParserTests.swift
@@ -59,11 +59,13 @@ import Testing
     /// The core fix. AndroMeld-shaped: `Version` IS quoted, so without the
     /// `(exited-with-subordinates)` guard this reads as a live running build —
     /// exactly the #473 failure (disk build compares newer than this frozen one
-    /// forever). Mutation this pins: delete the
-    /// `!line.contains("(exited-with-subordinates)")` clause in
+    /// forever). Mutation this pins (**M1**): delete the whole
+    /// `else if line.contains(tombstoneMarker)` branch from
     /// `LSAppInfoParser.runningBuildVersions` → this goes from `nil` to
-    /// `"2608.29.0"`, i.e. red. Verified by actually deleting that clause and
-    /// re-running: this test fails, the baseline above does not.
+    /// `"2608.29.0"`, i.e. red. Measured 2026-09-09 by actually deleting that
+    /// branch and re-running: M1 turns exactly three of this suite's seven cases
+    /// red — this one, `aTombstoneBeforeTheLiveEntryDoesNotBlockIt`, and
+    /// `aMarkerOnALaterLineStillCancelsTheRecord`.
     @Test func quotedVersionTombstoneIsExcluded() {
         let text = entry(
             number: 149, name: "AndroMeld", bundleID: "com.catchingnow.andfiles",
@@ -76,9 +78,10 @@ import Testing
     /// Fixture guard, not a marker-guard mutation: this is the OTHER real shape
     /// measured (a non-sandboxed UIElement helper whose tombstone carries
     /// `Version=[ NULL ]`, unquoted). `quotedValue` already returns `nil` for an
-    /// unquoted value regardless of the marker, so this can't go red by
-    /// deleting the marker guard alone — it grounds the parser against the
-    /// shape actually observed rather than assuming quoting is universal.
+    /// unquoted value regardless of the marker, so this cannot go red under
+    /// either M1 or M2 (measured: green under both) — it grounds the parser
+    /// against the shape actually observed rather than assuming quoting is
+    /// universal.
     @Test func unquotedVersionTombstoneIsAlsoExcluded() {
         let text = entry(
             number: 35, name: "ClaudeWakeHost", bundleID: "",
@@ -96,14 +99,12 @@ import Testing
     /// skipped (tombstone) block must NOT count as "already recorded", or the
     /// live entry that follows it would never get in. This is also the order
     /// #473 actually hit — a bundle path reported once, with the tombstone's
-    /// own entry the only one LaunchServices had. Mutation this pins: deleting
-    /// the `!line.contains("(exited-with-subordinates)")` clause (the same
-    /// mutation `quotedVersionTombstoneIsExcluded` catches) makes the tombstone
-    /// satisfy `map[cur] == nil` and claim the slot first — verified by
-    /// deleting that clause and re-running: this and
-    /// `quotedVersionTombstoneIsExcluded` are the only two of these six tests
-    /// that go red, this one from `nil` to `"9.9.9"` — locking out the live
-    /// entry that follows, not `"1.2.3"`.
+    /// own entry the only one LaunchServices had. Mutation this pins (**M1**,
+    /// the same one `quotedVersionTombstoneIsExcluded` catches): deleting the
+    /// whole `else if line.contains(tombstoneMarker)` branch lets the tombstone
+    /// be held and committed first, so `map[path] == nil` at commit time is no
+    /// longer true when the live entry arrives — measured: this goes to
+    /// `"9.9.9"`, locking out the live entry that follows, not `"1.2.3"`.
     @Test func aTombstoneBeforeTheLiveEntryDoesNotBlockIt() {
         let path = "/Applications/TwoInstances.app"
         let tombstone = entry(
@@ -118,15 +119,16 @@ import Testing
 
     /// The reverse order: once a LIVE version is recorded, a tombstone
     /// appearing later for the same path must not overwrite it with its own
-    /// (frozen, possibly different) version. ⚠️ No corresponding single-line
-    /// mutation of its own — verified: deleting the marker clause alone (the
-    /// mutation the two tests above pin) leaves this one green, because the
-    /// pre-existing `map[cur] == nil` first-wins check already blocks the
-    /// second write regardless of the marker (`live` claims the slot before
-    /// `tombstone` is ever read). This order was never actually broken by
-    /// #473 — only tombstone-before-live was. Kept as a fixture guard: it
-    /// pins that first-wins composes safely with the new marker check in
-    /// BOTH orders, not just the one #473 hit.
+    /// (frozen, possibly different) version. ⚠️ **No mutation of its own** —
+    /// measured: both M1 (deleting the marker branch) and M2 (see
+    /// `aMarkerOnALaterLineStillCancelsTheRecord`) leave this one green, because
+    /// first-wins already blocks the second write regardless of the marker: the
+    /// live record is committed when the tombstone's `bundle path` line opens the
+    /// next record, so `map[path] == nil` is already false by the time the
+    /// tombstone could be held. This order was never actually broken by #473 —
+    /// only tombstone-before-live was. Kept as a fixture guard: it pins that
+    /// first-wins composes safely with the marker check in BOTH orders, not just
+    /// the one #473 hit.
     @Test func aTombstoneAfterTheLiveEntryDoesNotOverwriteIt() {
         let path = "/Applications/TwoInstancesReversed.app"
         let live = entry(
@@ -157,10 +159,13 @@ import Testing
 
     // MARK: - The marker's position within a record
 
-    /// Mutation this pins: committing the version the moment its line is read
+    /// Mutation this pins (**M2**): committing the version the moment its line is read
     /// (`map[cur] = version` inline, i.e. both the pre-review implementation and the
     /// original pre-#473 one) — then the marker arrives too late and Ghost is recorded
-    /// as a live 1.0.0 build, which is #473 verbatim.
+    /// as a live 1.0.0 build, which is #473 verbatim. Measured 2026-09-09: **M2 turns
+    /// this case and only this case red**; the other six stay green, because every
+    /// other fixture has the marker on the same line as `Version`, where committing
+    /// early and clearing a cursor are indistinguishable. It also goes red under M1.
     ///
     /// Every record measured so far carries the marker on the SAME line as `Version`,
     /// where a cursor-clearing guard would also have worked. This case covers the half


### PR DESCRIPTION
Closes #473.

`lsappinfo` keeps a record for an app whose own process already quit if something it spawned — a helper, a bundled daemon like AndroMeld's `adb server nodaemon` — or another coalition member is still alive. LaunchServices marks it `(exited-with-subordinates)` and freezes `Version` at the build that launched, so `disk newer than running` stayed true forever and the Relaunch badge never cleared.

## What changed

The `lsappinfo` text parsing moves out of `AppListModel` into a pure Core function, `LSAppInfoParser.runningBuildVersions`, which discards a whole record carrying that marker. The app keeps only the part that is inherently impure: invoking `/usr/bin/lsappinfo` with its timeout/kill backstop.

**A whole record, not just the marked line.** All three records measured carry the marker on the same `pid = …` line as `Version`, where skipping that one line would have sufficed — but three samples are not a format guarantee, and being wrong there is silent: a tombstone whose `Version` landed elsewhere reads as a live build again, which is this bug returning with no test to catch it. That independence needs the version *held back* and committed when the next record begins; simply nulling the cursor on the marker line leaves a marker that trails `Version` too late to matter. The first version of this change made exactly that mistake, and `aMarkerOnALaterLineStillCancelsTheRecord` is the case that caught it.

## Verification

Two mutations, both actually run:

| | mutation | red |
|---|---|---|
| M1 | delete the whole `else if line.contains(tombstoneMarker)` branch | 3 of 7 |
| M2 | commit the version inline instead of holding it | 1 of 7 |

Each case's doc comment says which of the two it answers to; the two that answer to neither say so and say why.

**Independent recompute:** the rule was ported to Python and run against this machine's real `lsappinfo list` (1092 lines, 106 records) — old and new agree on all 106, zero entries lost, zero versions rewritten. Also verified by killing the live `adb` child: the tombstone record disappears from `lsappinfo` entirely and the Relaunch badge clears, closing the causal chain.

`make test`: exit 0. Core 2464 / 204 suites, CLI 263, app tests 9 of 9, all six python gates green.
