### PR TITLE
Fix #471 and #472: offer-button TOCTOU, and a close-to-update sheet read as a purchase confirmation

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -255,7 +255,7 @@ public actor AppStoreAXInstaller {
 
         let names = AppNames(bundle: appName, store: storeName,
                              localized: AppNames.localizedName(at: appPath))
-        let runningAtStart = bundleID.map { isRunning($0) } ?? false
+        let runningAtStart = bundleID.map { Self.isRunning($0) } ?? false
         Log.install.notice("appstore-ax: start \(appName, privacy: .public) [\(bundleID ?? "?", privacy: .public)] trackID=\(trackID) storeName=\(storeName ?? "-", privacy: .public) needles=\(names.needles.joined(separator: " | "), privacy: .public) viaUpdatesList=\(viaUpdatesList) running=\(runningAtStart)")
 
         onStage(.checking)
@@ -477,7 +477,10 @@ public actor AppStoreAXInstaller {
         return nil
     }
 
-    private func isRunning(_ bundleID: String) -> Bool {
+    // Static: touches no actor state, and `classifyOwnSheet` (also static, so it is
+    // directly testable) needs to call it to decide `bundleID`'s disposition itself
+    // rather than being handed a pre-computed bool.
+    private static func isRunning(_ bundleID: String) -> Bool {
         !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty
     }
 
@@ -621,6 +624,22 @@ public actor AppStoreAXInstaller {
     /// means we caught the page exactly mid-rebuild, which is the state that used to fail
     /// closed at press time; a button still there a poll later has survived past whatever
     /// window that rebuild needed.
+    ///
+    /// This costs latency on every install, not just the ones that would have raced the
+    /// rebuild: `waitForOfferButton` cannot return on the poll that first finds the button,
+    /// it has to wait one more ~150ms poll to confirm it, and the press-time re-find (which
+    /// starts from `foundLastPoll: false`) needs two full polls of its own before it can
+    /// press — so this rule alone adds ~150-450ms to every update, not only the ones that
+    /// were actually churning.
+    ///
+    /// It also trades one failure mode for another. If the page happens to re-render on
+    /// close to a 150ms cadence, "found" and "not found" can keep alternating forever —
+    /// `justFound && foundLastPoll` never holds two polls in a row — and the wait runs out
+    /// its deadline never trusting a button that a plain "found it, use it" would have
+    /// returned on the very first sighting. This is new: the one-shot rule this replaced
+    /// could never fail this way, only the opposite one (#471). Low-probability — it needs
+    /// the rebuild period to land near the poll period — but worth knowing about, since the
+    /// old code had no such window at all.
     static func offerButtonIsStable(justFound: Bool, foundLastPoll: Bool) -> Bool {
         justFound && foundLastPoll
     }
@@ -746,7 +765,7 @@ public actor AppStoreAXInstaller {
                 // The app being open is why the number is allowed to stand still, so
                 // the watchdog is told rather than left to read a frozen wait as a
                 // dead swap (see `swapWatchdog`).
-                let stillOpen = bundleID.map { isRunning($0) } ?? false
+                let stillOpen = bundleID.map { Self.isRunning($0) } ?? false
                 let watch = Self.swapWatchdog(
                     progress: reading, last: lastInstallProgress, stalledPolls: stalledTicks,
                     appRunning: stillOpen)
@@ -773,12 +792,12 @@ public actor AppStoreAXInstaller {
                     // terminate() won't force past) — flag it once so a stuck install is
                     // diagnosable.
                     if postContinueTicks == 10 {  // ~4s after we quit + foregrounded
-                        Log.install.error("appstore-ax: \(appName, privacy: .public) sheet still present ~4s after quit+foreground (app still running=\(bundleID.map { isRunning($0) } ?? false))")
+                        Log.install.error("appstore-ax: \(appName, privacy: .public) sheet still present ~4s after quit+foreground (app still running=\(bundleID.map { Self.isRunning($0) } ?? false))")
                     }
                 } else {
-                    let stillOpen = bundleID.map { isRunning($0) } ?? false
-                    switch Self.classifyOwnSheet(sawProgress: sawProgress, appRunning: stillOpen) {
-                    case .downloadFinishedAppStillOpen:
+                    let stillOpen = bundleID.map { Self.isRunning($0) } ?? false
+                    switch Self.classifyOwnSheet(sawProgress: sawProgress, bundleID: bundleID) {
+                    case .downloadFinishedAppStillOpen(let bundleID):
                         // Download finished, app still open → App Store's "Close this app to
                         // update" sheet. Gate it behind the user's Relaunch tap, then finish.
                         //
@@ -798,11 +817,10 @@ public actor AppStoreAXInstaller {
                         // download ran in the background; the user just tapped Relaunch and expects
                         // the app to cycle.
                         //
-                        // `classifyOwnSheet` only returns this case when `stillOpen` is true, which
-                        // in turn only happens when `bundleID` is non-nil (`stillOpen` comes from
-                        // `bundleID.map { isRunning($0) } ?? false`) — so the force-unwrap below is
-                        // safe.
-                        let bundleID = bundleID!
+                        // `bundleID` here is the associated value `classifyOwnSheet` binds when
+                        // (and only when) it has already confirmed the app is running under it —
+                        // the compiler enforces that, not a cross-function comment (see
+                        // `classifyOwnSheet`'s own `guard let`).
                         if !askedToQuit {
                             Log.install.notice("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown — asking for Relaunch/Cancel")
                             requestQuit(appName)
@@ -818,7 +836,7 @@ public actor AppStoreAXInstaller {
                             answer: await quitAnswer(),
                             sheetPresent: true,
                             versionChanged: Self.versionChanged(from: baseline, appPath: appPath),
-                            appRunning: isRunning(bundleID)
+                            appRunning: Self.isRunning(bundleID)
                         ) {
                         case .keepWaiting:
                             break
@@ -850,8 +868,21 @@ public actor AppStoreAXInstaller {
                         // `versionChanged` check is what catches completion. Log once so a
                         // stalled swap here is still diagnosable, without spamming a line
                         // every ~400ms for however long the swap takes.
+                        //
+                        // Foregrounding App Store here is NOT optional polish: this file's own
+                        // measurement (`activateAppStore`'s doc comment, Spark 2026-06-08) found
+                        // a *backgrounded* App Store parks the close-to-update sheet and never
+                        // completes the swap even after the app has quit — 94s with no swap
+                        // backgrounded, vs. swapped once foregrounded. Skipping this call would
+                        // leave this branch relying only on the 900-poll (~6 min) hard cap, since
+                        // with the app already gone `askedToQuit` never becomes true (no prompt is
+                        // shown to gate `polls`' increment) and `sheetTicks` never advances either
+                        // (that counter only moves in `.possiblePurchaseConfirmation`) — so neither
+                        // of the faster gates applies here. Only asked once, same as the log line,
+                        // so a lingering sheet doesn't repeatedly steal focus.
                         if !loggedAppAlreadyQuitDuringOwnSheet {
                             Log.install.notice("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown with the app already quit — nothing to press, waiting for the swap to land")
+                            activateAppStore()
                             loggedAppAlreadyQuitDuringOwnSheet = true
                         }
                     case .possiblePurchaseConfirmation:
@@ -898,7 +929,7 @@ public actor AppStoreAXInstaller {
                         answer: await quitAnswer(),
                         sheetPresent: false,
                         versionChanged: Self.versionChanged(from: baseline, appPath: appPath),
-                        appRunning: bundleID.map { isRunning($0) } ?? false
+                        appRunning: bundleID.map { Self.isRunning($0) } ?? false
                     ) {
                     case .settledElsewhere:
                         Log.install.notice("appstore-ax: \(appName, privacy: .public) quit confirmed in App Store — withdrawing our prompt")
@@ -1014,7 +1045,7 @@ public actor AppStoreAXInstaller {
         }
         // What a spent budget means depends on what is still true — see
         // `exhaustedBudgetError`.
-        let stillOpen = bundleID.map { isRunning($0) } ?? false
+        let stillOpen = bundleID.map { Self.isRunning($0) } ?? false
         Log.install.error("appstore-ax: \(appName, privacy: .public) timed out — 6-min poll cap reached (continued=\(continued) sawProgress=\(sawProgress) appStillOpen=\(stillOpen))")
         throw Self.exhaustedBudgetError(appName: appName, continued: continued, appRunning: stillOpen)
     }
@@ -1091,7 +1122,7 @@ public actor AppStoreAXInstaller {
             app.terminate()
         }
         for _ in 0..<60 {  // ~12s at 200ms
-            if !isRunning(bundleID) {
+            if !Self.isRunning(bundleID) {
                 Log.install.notice("appstore-ax: \(appName, privacy: .public) quit — App Store can now swap in the update")
                 return
             }
@@ -1131,7 +1162,8 @@ public actor AppStoreAXInstaller {
 
     /// What a not-yet-`continued` sheet that IS ours (`classifySheet` already said so)
     /// actually means, given the two facts on hand: whether this update's own download
-    /// has started (`sawProgress`), and whether the app being updated is still running.
+    /// has started (`sawProgress`), and whether the app being updated is still running
+    /// (decided here from `bundleID`, not handed in as a separate bool — see below).
     ///
     /// #472: the old branch condition was `sawProgress, let bundleID, isRunning(bundleID)`
     /// — `appRunning` gated whether a sheet counted as ours **at all**, so a sheet that
@@ -1146,8 +1178,10 @@ public actor AppStoreAXInstaller {
     /// Store a quit".
     enum OwnSheetDisposition: Equatable {
         /// A download for this update has started and the app is still open. Ask the
-        /// user for Relaunch/Cancel — nothing has quit yet.
-        case downloadFinishedAppStillOpen
+        /// user for Relaunch/Cancel — nothing has quit yet. Carries the bundle id
+        /// `classifyOwnSheet` already confirmed is running, so the caller has a
+        /// non-optional id to quit later without re-deriving (or force-unwrapping) it.
+        case downloadFinishedAppStillOpen(bundleID: String)
         /// A download for this update has started and the app has already quit on its
         /// own (App Store can ask for the close mid-download; a responsive app can be
         /// gone before we ever sample the sheet). Nothing to press: the swap proceeds on
@@ -1158,9 +1192,18 @@ public actor AppStoreAXInstaller {
         case possiblePurchaseConfirmation
     }
 
-    static func classifyOwnSheet(sawProgress: Bool, appRunning: Bool) -> OwnSheetDisposition {
+    /// Takes `bundleID` rather than a pre-computed `appRunning: Bool` so the "app is
+    /// running" fact and the id needed to act on it can never separate: the caller used
+    /// to compute `stillOpen` itself and hand over only the bool, which is how
+    /// `.downloadFinishedAppStillOpen`'s call site ended up re-deriving "the id must be
+    /// non-nil here" from that bool via a force-unwrap, backed only by a comment
+    /// explaining why it couldn't fail. `guard let bundleID` here makes the same fact a
+    /// compiler-checked binding instead — the disposition simply cannot be constructed
+    /// without one.
+    static func classifyOwnSheet(sawProgress: Bool, bundleID: String?) -> OwnSheetDisposition {
         guard sawProgress else { return .possiblePurchaseConfirmation }
-        return appRunning ? .downloadFinishedAppStillOpen : .appAlreadyQuitNothingToPress
+        guard let bundleID, isRunning(bundleID) else { return .appAlreadyQuitNothingToPress }
+        return .downloadFinishedAppStillOpen(bundleID: bundleID)
     }
 
     /// One poll of the swap watchdog, as a pure step so the rules that matter are

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -873,17 +873,36 @@ public actor AppStoreAXInstaller {
                         // stalled swap here is still diagnosable, without spamming a line
                         // every ~400ms for however long the swap takes.
                         //
-                        // Foregrounding App Store here is NOT optional polish: this file's own
-                        // measurement (`activateAppStore`'s doc comment, Spark 2026-06-08) found
-                        // a *backgrounded* App Store parks the close-to-update sheet and never
-                        // completes the swap even after the app has quit — 94s with no swap
-                        // backgrounded, vs. swapped once foregrounded. Skipping this call would
-                        // leave this branch relying only on the 900-poll (~6 min) hard cap, since
-                        // with the app already gone `askedToQuit` never becomes true (no prompt is
-                        // shown to gate `polls`' increment) and `sheetTicks` never advances either
-                        // (that counter only moves in `.possiblePurchaseConfirmation`) — so neither
-                        // of the faster gates applies here. Only asked once, same as the log line,
-                        // so a lingering sheet doesn't repeatedly steal focus.
+                        // Foregrounding here is cheap insurance, and be precise about how
+                        // well it is evidenced — the two halves are not equally solid.
+                        //
+                        // MEASURED, by reading this loop: skipping it would leave this branch
+                        // with nothing faster than the 900-poll (~6 min) hard cap behind it.
+                        // With the app already gone `askedToQuit` never becomes true (no prompt
+                        // is shown), so `polls` keeps incrementing; `sheetTicks` never advances
+                        // either (that counter only moves in `.possiblePurchaseConfirmation`);
+                        // and `continued` stays false, so the `swapHasStalled` watchdog never
+                        // runs. Neither of the faster gates applies here.
+                        //
+                        // ⚠️ CARRIED OVER, NOT RE-MEASURED: that a *backgrounded* App Store
+                        // parks this sheet and never swaps even after the app has quit (94s
+                        // backgrounded vs. swapped once foregrounded) comes from
+                        // `activateAppStore`'s doc comment, Spark 2026-06-08. It was NOT
+                        // reproduced when this branch was written (2026-09-09): the one real
+                        // observation that reached here — AndroMeld — had App Store in the
+                        // FOREGROUND the whole time and swapped fine, so it neither confirms
+                        // nor refutes the backgrounded case. So this call may well be
+                        // unnecessary; it is kept because foregrounding once costs a single
+                        // focus steal at a moment the user just updated an app, while being
+                        // wrong the other way costs a silent 6-minute stall.
+                        //
+                        // It also only fires ONCE (same gate as the log line, so a lingering
+                        // sheet doesn't repeatedly steal focus), which means it buys the swap
+                        // one chance to start, not a guarantee: if the user clicks back to
+                        // their own window, nothing brings App Store forward again. Closing
+                        // that would need a periodic retry here, or a timeout diagnostic that
+                        // can name this state — neither is justified until someone actually
+                        // reproduces the backgrounded case above.
                         if !loggedAppAlreadyQuitDuringOwnSheet {
                             Log.install.notice("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown with the app already quit — nothing to press, waiting for the swap to land")
                             activateAppStore()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -795,8 +795,12 @@ public actor AppStoreAXInstaller {
                         Log.install.error("appstore-ax: \(appName, privacy: .public) sheet still present ~4s after quit+foreground (app still running=\(bundleID.map { Self.isRunning($0) } ?? false))")
                     }
                 } else {
-                    let stillOpen = bundleID.map { Self.isRunning($0) } ?? false
-                    switch Self.classifyOwnSheet(sawProgress: sawProgress, bundleID: bundleID) {
+                    // One LaunchServices lookup, and the id travels with the answer: the
+                    // disposition below and the log line in its last arm are then talking
+                    // about the same instant. Two separate `isRunning` reads could disagree
+                    // — the app quitting mid-poll is the normal case this branch exists for.
+                    let runningBundleID = bundleID.flatMap { Self.isRunning($0) ? $0 : nil }
+                    switch Self.classifyOwnSheet(sawProgress: sawProgress, runningBundleID: runningBundleID) {
                     case .downloadFinishedAppStillOpen(let bundleID):
                         // Download finished, app still open → App Store's "Close this app to
                         // update" sheet. Gate it behind the user's Relaunch tap, then finish.
@@ -897,7 +901,7 @@ public actor AppStoreAXInstaller {
                         // grace and still bails.
                         sheetTicks += 1
                         if sheetTicks == 1 {
-                            Log.install.notice("appstore-ax: \(appName, privacy: .public) sheet before any download (sawProgress=\(sawProgress), running=\(stillOpen)) — waiting to see if a fast delta's progress lands")
+                            Log.install.notice("appstore-ax: \(appName, privacy: .public) sheet before any download (sawProgress=\(sawProgress), running=\(runningBundleID != nil)) — waiting to see if a fast delta's progress lands")
                         }
                         if sheetTicks >= 8 {  // ~3.2s — well past the ~0.5s a real download takes to report progress
                             Log.install.error("appstore-ax: \(appName, privacy: .public) needs manual confirmation — no download after ~3s, bailing without pressing")
@@ -1192,18 +1196,25 @@ public actor AppStoreAXInstaller {
         case possiblePurchaseConfirmation
     }
 
-    /// Takes `bundleID` rather than a pre-computed `appRunning: Bool` so the "app is
-    /// running" fact and the id needed to act on it can never separate: the caller used
-    /// to compute `stillOpen` itself and hand over only the bool, which is how
-    /// `.downloadFinishedAppStillOpen`'s call site ended up re-deriving "the id must be
-    /// non-nil here" from that bool via a force-unwrap, backed only by a comment
-    /// explaining why it couldn't fail. `guard let bundleID` here makes the same fact a
-    /// compiler-checked binding instead — the disposition simply cannot be constructed
-    /// without one.
-    static func classifyOwnSheet(sawProgress: Bool, bundleID: String?) -> OwnSheetDisposition {
+    /// Takes the id **only when the caller has already confirmed it is running** —
+    /// `nil` means "no id, or not running", the two cases that need the same answer
+    /// here. That keeps the "app is running" fact and the id needed to act on it from
+    /// ever separating: the caller used to compute a `stillOpen` bool and hand over only
+    /// that, which is how `.downloadFinishedAppStillOpen`'s call site ended up
+    /// re-deriving "the id must be non-nil here" via a force-unwrap backed by a comment.
+    /// Carrying the id makes it a compiler-checked binding instead — the disposition
+    /// cannot be constructed without one.
+    ///
+    /// Deliberately **pure**, like `classifySheet`, `swapWatchdog` and
+    /// `exhaustedBudgetError` beside it: an earlier revision took `bundleID: String?`
+    /// and called `isRunning` itself, which bought the same compiler guarantee but made
+    /// this the one decision function in the file that reads global process state — and
+    /// left its unit tests asserting against whatever happened to be running on the test
+    /// host (Finder), a dependency that is invisible until some runner disagrees.
+    static func classifyOwnSheet(sawProgress: Bool, runningBundleID: String?) -> OwnSheetDisposition {
         guard sawProgress else { return .possiblePurchaseConfirmation }
-        guard let bundleID, isRunning(bundleID) else { return .appAlreadyQuitNothingToPress }
-        return .downloadFinishedAppStillOpen(bundleID: bundleID)
+        guard let runningBundleID else { return .appAlreadyQuitNothingToPress }
+        return .downloadFinishedAppStillOpen(bundleID: runningBundleID)
     }
 
     /// One poll of the swap watchdog, as a pure step so the rules that matter are

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -35,19 +35,24 @@ import ApplicationServices
 ///      stealing focus. The delta then downloads in the background while the user keeps
 ///      working; the button's title reports live progress as "`N% loaded`", parsed into
 ///      `InstallStage.downloading`.
-///   4. Only once the download finishes does App Store raise an `AXSheet` ("Close
-///      This App to Update" / Continue · Cancel) — and only because the app is open.
-///      We gate that sheet behind the UI's Relaunch tap (`confirmQuit`), then finish the
-///      update by **quitting the app ourselves while foregrounding App Store** — we do
-///      *not* press the sheet's Continue, because App Store custom-draws this sheet with
-///      no accessible affirmative button (`AXDefaultButton` is nil and Continue isn't in
-///      the AX tree at all — only Cancel is reachable; verified 2026-06-08). Quitting the
-///      app IS the consent the sheet asks for (graceful `terminate()`; see
-///      `terminateAndWait`), and foregrounding App Store is required for it to complete
-///      the swap — backgrounded, it parks the sheet and never swaps even after the app
-///      exits. A sheet that appears *without* a download behind it is a subscription /
-///      purchase / terms confirmation, which we never touch — we surface it for manual
-///      handling.
+///   4. App Store raises an `AXSheet` ("Close This App to Update" / Continue · Cancel)
+///      once the app needs to quit for the swap to land. **Not always after the
+///      download finishes, and not always with the app still open** — #472 measured it
+///      appearing mid-download (~80% in) with the app already gone (a responsive app can
+///      honor App Store's close request before we ever sample the sheet). If the app is
+///      still open we gate the sheet behind the UI's Relaunch tap (`confirmQuit`), then
+///      finish the update by **quitting the app ourselves while foregrounding App
+///      Store** — we do *not* press the sheet's Continue, because App Store custom-draws
+///      this sheet with no accessible affirmative button (`AXDefaultButton` is nil and
+///      Continue isn't in the AX tree at all — only Cancel is reachable; verified
+///      2026-06-08). Quitting the app IS the consent the sheet asks for (graceful
+///      `terminate()`; see `terminateAndWait`), and foregrounding App Store is required
+///      for it to complete the swap — backgrounded, it parks the sheet and never swaps
+///      even after the app exits. If the app has already quit there is nothing to press
+///      at all — the swap proceeds on its own and the on-disk version change catches
+///      completion. A sheet that appears *before any download has started* is a
+///      subscription / purchase / terms confirmation, which we never touch — we surface
+///      it for manual handling. See `classifyOwnSheet` for how these are told apart.
 public actor AppStoreAXInstaller {
 
     public init() {}
@@ -303,15 +308,27 @@ public actor AppStoreAXInstaller {
         let baseline = Self.installedVersions(at: appPath, fallbackShort: currentShortVersion)
 
         // Press Update *with the app still running*. App Store downloads the delta in
-        // the background while the user keeps working — it only raises the "Close this
-        // app to update" sheet once the download has finished (verified). We do NOT
-        // quit the app up front (that closed it for the whole download); instead we let
-        // the download run and gate that end-of-download sheet behind the user's
-        // Relaunch tap, pressing Continue ourselves only then (see driveToCompletion).
+        // the background while the user keeps working. It can raise the "Close this app
+        // to update" sheet mid-download rather than only once the download has finished
+        // (#472: measured ~80% in) — and the app may have already quit on its own by
+        // then, in which case there is nothing left to press (see `classifyOwnSheet`).
+        // We do NOT quit the app up front (that closed it for the whole download);
+        // instead we let the download run and, if the app is still open when the sheet
+        // shows, gate it behind the user's Relaunch tap, pressing Continue ourselves
+        // only then (see driveToCompletion).
         // We already know (from detection) an update is due, so press regardless of the
         // localized title — pressing an up-to-date button no-ops. Re-find the button right
         // before pressing: the ref from the wait can go stale if the page re-rendered.
-        guard let offer = offerButton(in: axApp, names: names, viaUpdatesList: viaUpdatesList) else {
+        //
+        // #471: this used to be a one-shot `guard` with no retry budget at all, while the
+        // wait above got ~12s — so a page that happened to churn in the ~0ms gap between
+        // the two failed the whole update. Give it a short window (same stability rule as
+        // the wait, over ~1.5s) rather than a single attempt; no re-navigation here, the
+        // page is already up.
+        guard let offer = try await waitForOfferButton(
+            in: axApp, names: names, viaUpdatesList: viaUpdatesList,
+            renavigateTrackID: nil, deadlinePolls: 10, allowNudge: false
+        ) else {
             Log.install.error("appstore-ax: \(appName, privacy: .public) offer button vanished before press")
             throw viaUpdatesList ? AXError.notInUpdatesList : AXError.offerButtonNotFound
         }
@@ -359,6 +376,30 @@ public actor AppStoreAXInstaller {
             let pid = store.processIdentifier
             Task { await self.refreshUpdatesBadge(pid: pid) }
         }
+    }
+
+    /// Test-only: locate a real product page's offer button end-to-end (App Store
+    /// launch/navigate, then the same `waitForOfferButton` call `update` makes at step
+    /// 2) and report whether it carries the expected `AppStore.offerButton` identifier —
+    /// WITHOUT ever pressing it.
+    ///
+    /// Exists because `AXUIElement` is not `Sendable`: a live #471 harness driving this
+    /// actor from a plain (non-actor-isolated) test function cannot return the element
+    /// itself across that boundary under strict concurrency checking, so this stays
+    /// fully inside the actor and hands back only a `Bool`. See the harness
+    /// (`AppStoreAXLiveHarnessTests.swift`) for why an already-current app (an "Open"
+    /// button) is a safe, valid target: `bind` never reads the button's title.
+    func locateOfferButtonForTesting(trackID: Int, names: AppNames) async throws -> Bool {
+        let (store, didLaunch) = try await ensureAppStoreRunning()
+        if didLaunch { try await Task.sleep(for: .seconds(1)) }
+        try navigateToProductPage(trackID: trackID)
+        let axApp = AXUIElementCreateApplication(store.processIdentifier)
+        guard let offer = try await waitForOfferButton(
+            in: axApp, names: names, viaUpdatesList: false, renavigateTrackID: trackID
+        ) else { return false }
+        var idRef: CFTypeRef?
+        _ = AXUIElementCopyAttributeValue(offer, "AXIdentifier" as CFString, &idRef)
+        return (idRef as? String) == "AppStore.offerButton"
     }
 
     /// Force App Store to recompute its "available updates" count (and thus the Dock
@@ -529,12 +570,35 @@ public actor AppStoreAXInstaller {
     ///     once the app is fully up lands it on the product page.
     /// The refresh is skipped entirely once the target is present (we return above), so a
     /// cache that already carries the row takes the fast path with no reload.
-    private func waitForOfferButton(in axApp: AXUIElement, names: AppNames, viaUpdatesList: Bool, renavigateTrackID: Int? = nil) async throws -> AXUIElement? {
-        let deadline = viaUpdatesList ? 150 : 80   // ~22s (server re-fetch) vs ~12s at 150ms/poll
+    ///
+    /// #471: a poll used to return the INSTANT it found a button, which races an AppKit
+    /// subtree rebuild that can follow right on the heels of `navigateToProductPage` (or,
+    /// while running, a page re-evaluating whether to show "Open" vs "Update"). Measured
+    /// twice (AndroMeld, Aqara Home): the button vanished entirely ~57-59ms after being
+    /// located, so the one-shot re-find right before pressing came up empty and the whole
+    /// update failed closed on a page that plainly had the button. `offerButtonIsStable`
+    /// requires the button to still be findable one MORE poll later before we trust it —
+    /// not the identical element (a rebuild hands back a structurally different one
+    /// anyway), just that the page has stopped churning.
+    ///
+    /// `deadlinePolls` / `allowNudge` let the press-time re-find (see `update`) reuse this
+    /// same stability rule over a much shorter budget, without re-issuing the page's
+    /// refresh — that nudge is for "the page hasn't loaded yet", and at press time it
+    /// already has.
+    private func waitForOfferButton(
+        in axApp: AXUIElement, names: AppNames, viaUpdatesList: Bool,
+        renavigateTrackID: Int? = nil, deadlinePolls: Int? = nil, allowNudge: Bool = true
+    ) async throws -> AXUIElement? {
+        let deadline = deadlinePolls ?? (viaUpdatesList ? 150 : 80)   // ~22s (server re-fetch) vs ~12s at 150ms/poll
+        var foundLastPoll = false
         for i in 0..<deadline {
-            if let offer = offerButton(in: axApp, names: names, viaUpdatesList: viaUpdatesList) { return offer }
+            let offer = offerButton(in: axApp, names: names, viaUpdatesList: viaUpdatesList)
+            if Self.offerButtonIsStable(justFound: offer != nil, foundLastPoll: foundLastPoll) {
+                return offer
+            }
+            foundLastPoll = offer != nil
             // An early nudge once the page has settled (~0.6s), then every ~2.4s.
-            if i == 4 || (i > 0 && i % 16 == 0) {
+            if allowNudge, i == 4 || (i > 0 && i % 16 == 0) {
                 if viaUpdatesList {
                     // A product page opened while we were waiting would hide the list,
                     // and ⌘R would then just reload *it*. Uncover the list first.
@@ -549,20 +613,34 @@ public actor AppStoreAXInstaller {
         return nil
     }
 
+    /// Whether a poll that just found the offer button should be trusted immediately, or
+    /// should wait for a second consecutive poll to also find one first.
+    ///
+    /// #471: pinned separately from the loop so the rule — two consecutive finds, not one
+    /// — is directly assertable. A button gone on the very next poll after being seen once
+    /// means we caught the page exactly mid-rebuild, which is the state that used to fail
+    /// closed at press time; a button still there a poll later has survived past whatever
+    /// window that rebuild needed.
+    static func offerButtonIsStable(justFound: Bool, foundLastPoll: Bool) -> Bool {
+        justFound && foundLastPoll
+    }
+
     // MARK: - Progress / completion
 
     /// After pressing Update (with the app still running), poll until the install
     /// lands — detected by the on-disk bundle version changing from `baseline`, the
     /// authoritative, language-independent signal.
     ///
-    /// Sheet handling is the delicate part. App Store raises the "Close this app to
-    /// update" sheet only *after* the download finishes and only because the app is
-    /// open; a subscription / purchase / terms sheet, by contrast, appears *before*
-    /// any download (you can't download a paid update without confirming the charge
-    /// first). We use that ordering to tell them apart: a sheet that appears once we've
-    /// seen download progress, with the app still running, is the close-to-update one —
-    /// we gate it behind the user's Relaunch tap (`confirmQuit`), then press its
-    /// Continue. Any other sheet (no download behind it, or the app already gone) is a
+    /// Sheet handling is the delicate part. App Store can raise the "Close this app to
+    /// update" sheet mid-download, not only after it finishes, and the app may or may not
+    /// still be open when it does (#472); a subscription / purchase / terms sheet, by
+    /// contrast, appears *before* any download (you can't download a paid update without
+    /// confirming the charge first). We use THAT ordering to tell them apart, via
+    /// `classifyOwnSheet`: a sheet that appears once we've seen download progress is the
+    /// close-to-update one regardless of whether the app is still running — if it is, we
+    /// gate the sheet behind the user's Relaunch tap (`confirmQuit`) and press its
+    /// Continue; if it already quit on its own there is nothing to press, and the swap is
+    /// simply watched for. Any other sheet (no download behind it at all) is a
     /// confirmation we must never auto-press, surfaced as `.needsManualConfirmation`.
     private func driveToCompletion(
         axApp: AXUIElement,
@@ -592,6 +670,7 @@ public actor AppStoreAXInstaller {
         var stalledTicks = 0            // consecutive polls with the swap not moving
         var lastInstallProgress: Double? // last "Installing: N% Complete" we read
         var lastOfferDump: String?      // shape of the last probe we logged (dedupe)
+        var loggedAppAlreadyQuitDuringOwnSheet = false  // #472: log that state only once
 
         // A sheet already on screen before we press is left over from an earlier
         // install: App Store can leave its "Close This App to Update" sheet up for
@@ -696,81 +775,103 @@ public actor AppStoreAXInstaller {
                     if postContinueTicks == 10 {  // ~4s after we quit + foregrounded
                         Log.install.error("appstore-ax: \(appName, privacy: .public) sheet still present ~4s after quit+foreground (app still running=\(bundleID.map { isRunning($0) } ?? false))")
                     }
-                } else if sawProgress, let bundleID, isRunning(bundleID) {
-                    // Download finished, app still open → App Store's "Close this app to
-                    // update" sheet. Gate it behind the user's Relaunch tap, then finish.
-                    //
-                    // We do NOT press the sheet's affirmative ("Continue" / "Quit & Update")
-                    // button: App Store custom-draws this sheet with NO accessible default
-                    // button — `AXDefaultButton` is nil and the affirmative button isn't in
-                    // the AX tree at all (only "Cancel" is reachable; verified for Spark
-                    // 2026-06-08). Every prior "pressed Continue" was a silent no-op. What the
-                    // sheet actually asks for is the app to quit, so we deliver that ourselves
-                    // (graceful terminate — quitting the app IS the consent the user just gave
-                    // via Relaunch; we never force-kill unsaved work).
-                    //
-                    // Crucially we foreground App Store first: a *backgrounded* App Store parks
-                    // this sheet and never completes the swap even after the app exits (Spark,
-                    // backgrounded + clean quit: no swap for 94s; same app foregrounded:
-                    // swapped — 2026-06-08). This is the only point we steal focus — the whole
-                    // download ran in the background; the user just tapped Relaunch and expects
-                    // the app to cycle.
-                    if !askedToQuit {
-                        Log.install.notice("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown — asking for Relaunch/Cancel")
-                        requestQuit(appName)
-                        askedToQuit = true
-                    }
-                    sheetlessPromptTicks = 0
-                    // The sheet has two affirmative buttons within the user's reach:
-                    // ours and App Store's own Continue. `QuitPrompt` weighs both, plus
-                    // the disk — so an answer given in the store's window settles this
-                    // too, and a late tap on ours can never quit an app whose update
-                    // has already landed. See there for what going without cost.
-                    switch QuitPrompt.decide(
-                        answer: await quitAnswer(),
-                        sheetPresent: true,
-                        versionChanged: Self.versionChanged(from: baseline, appPath: appPath),
-                        appRunning: isRunning(bundleID)
-                    ) {
-                    case .keepWaiting:
-                        break
-                    case .cancelled:
-                        Log.install.notice("appstore-ax: \(appName, privacy: .public) user declined — pressing Cancel")
-                        withdrawQuit()
-                        pressCancel(in: axApp, appName: appName)
-                        throw AXError.cancelled
-                    case .settledElsewhere:
-                        Log.install.notice("appstore-ax: \(appName, privacy: .public) quit confirmed in App Store — withdrawing our prompt")
-                        withdrawQuit()
-                        askedToQuit = false
-                        onStage(.installing)
-                        continued = true
-                        sheetTicks = 0
-                    case .quitTheApp:
-                        withdrawQuit()
-                        askedToQuit = false
-                        onStage(.installing)  // "Relaunching" — quit the app, App Store swaps
-                        activateAppStore()
-                        await terminateAndWait(bundleID: bundleID, appName: appName)
-                        continued = true
-                        sheetTicks = 0
-                    }
                 } else {
-                    // A sheet with no download behind it (or the app already gone) is a
-                    // subscription / purchase / terms confirmation. But a *fast* delta can
-                    // raise the close-to-update sheet within ~60ms of the press — before the
-                    // offer button's title flips to a loading/progress state — so `sawProgress`
-                    // is still false for the first poll or two even on a normal update (Spark:
-                    // sheet at +60ms, progress at +420ms). Give sawProgress time to win the
-                    // race before concluding "subscription": a genuine purchase sheet never has
-                    // a download behind it, so it stays past this grace and still bails.
-                    sheetTicks += 1
-                    if sheetTicks == 1 {
-                        Log.install.notice("appstore-ax: \(appName, privacy: .public) sheet before any download (sawProgress=\(sawProgress), running=\(bundleID.map { isRunning($0) } ?? false)) — waiting to see if a fast delta's progress lands")
-                    }
-                    if sheetTicks >= 8 {  // ~3.2s — well past the ~0.5s a real download takes to report progress
-                        Log.install.error("appstore-ax: \(appName, privacy: .public) needs manual confirmation — no download after ~3s, bailing without pressing")
-                        throw AXError.needsManualConfirmation
+                    let stillOpen = bundleID.map { isRunning($0) } ?? false
+                    switch Self.classifyOwnSheet(sawProgress: sawProgress, appRunning: stillOpen) {
+                    case .downloadFinishedAppStillOpen:
+                        // Download finished, app still open → App Store's "Close this app to
+                        // update" sheet. Gate it behind the user's Relaunch tap, then finish.
+                        //
+                        // We do NOT press the sheet's affirmative ("Continue" / "Quit & Update")
+                        // button: App Store custom-draws this sheet with NO accessible default
+                        // button — `AXDefaultButton` is nil and the affirmative button isn't in
+                        // the AX tree at all (only "Cancel" is reachable; verified for Spark
+                        // 2026-06-08). Every prior "pressed Continue" was a silent no-op. What the
+                        // sheet actually asks for is the app to quit, so we deliver that ourselves
+                        // (graceful terminate — quitting the app IS the consent the user just gave
+                        // via Relaunch; we never force-kill unsaved work).
+                        //
+                        // Crucially we foreground App Store first: a *backgrounded* App Store parks
+                        // this sheet and never completes the swap even after the app exits (Spark,
+                        // backgrounded + clean quit: no swap for 94s; same app foregrounded:
+                        // swapped — 2026-06-08). This is the only point we steal focus — the whole
+                        // download ran in the background; the user just tapped Relaunch and expects
+                        // the app to cycle.
+                        //
+                        // `classifyOwnSheet` only returns this case when `stillOpen` is true, which
+                        // in turn only happens when `bundleID` is non-nil (`stillOpen` comes from
+                        // `bundleID.map { isRunning($0) } ?? false`) — so the force-unwrap below is
+                        // safe.
+                        let bundleID = bundleID!
+                        if !askedToQuit {
+                            Log.install.notice("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown — asking for Relaunch/Cancel")
+                            requestQuit(appName)
+                            askedToQuit = true
+                        }
+                        sheetlessPromptTicks = 0
+                        // The sheet has two affirmative buttons within the user's reach:
+                        // ours and App Store's own Continue. `QuitPrompt` weighs both, plus
+                        // the disk — so an answer given in the store's window settles this
+                        // too, and a late tap on ours can never quit an app whose update
+                        // has already landed. See there for what going without cost.
+                        switch QuitPrompt.decide(
+                            answer: await quitAnswer(),
+                            sheetPresent: true,
+                            versionChanged: Self.versionChanged(from: baseline, appPath: appPath),
+                            appRunning: isRunning(bundleID)
+                        ) {
+                        case .keepWaiting:
+                            break
+                        case .cancelled:
+                            Log.install.notice("appstore-ax: \(appName, privacy: .public) user declined — pressing Cancel")
+                            withdrawQuit()
+                            pressCancel(in: axApp, appName: appName)
+                            throw AXError.cancelled
+                        case .settledElsewhere:
+                            Log.install.notice("appstore-ax: \(appName, privacy: .public) quit confirmed in App Store — withdrawing our prompt")
+                            withdrawQuit()
+                            askedToQuit = false
+                            onStage(.installing)
+                            continued = true
+                            sheetTicks = 0
+                        case .quitTheApp:
+                            withdrawQuit()
+                            askedToQuit = false
+                            onStage(.installing)  // "Relaunching" — quit the app, App Store swaps
+                            activateAppStore()
+                            await terminateAndWait(bundleID: bundleID, appName: appName)
+                            continued = true
+                            sheetTicks = 0
+                        }
+                    case .appAlreadyQuitNothingToPress:
+                        // #472: the app already quit on its own (App Store asked for the
+                        // close mid-download, and this app was responsive) — there is nothing
+                        // to press. The swap proceeds on its own; step 1's on-disk
+                        // `versionChanged` check is what catches completion. Log once so a
+                        // stalled swap here is still diagnosable, without spamming a line
+                        // every ~400ms for however long the swap takes.
+                        if !loggedAppAlreadyQuitDuringOwnSheet {
+                            Log.install.notice("appstore-ax: \(appName, privacy: .public) close-to-update sheet shown with the app already quit — nothing to press, waiting for the swap to land")
+                            loggedAppAlreadyQuitDuringOwnSheet = true
+                        }
+                    case .possiblePurchaseConfirmation:
+                        // A sheet with no download behind it (or the app already gone, before
+                        // #472) is a subscription / purchase / terms confirmation. But a *fast*
+                        // delta can raise the close-to-update sheet within ~60ms of the press —
+                        // before the offer button's title flips to a loading/progress state — so
+                        // `sawProgress` is still false for the first poll or two even on a normal
+                        // update (Spark: sheet at +60ms, progress at +420ms). Give sawProgress
+                        // time to win the race before concluding "subscription": a genuine
+                        // purchase sheet never has a download behind it, so it stays past this
+                        // grace and still bails.
+                        sheetTicks += 1
+                        if sheetTicks == 1 {
+                            Log.install.notice("appstore-ax: \(appName, privacy: .public) sheet before any download (sawProgress=\(sawProgress), running=\(stillOpen)) — waiting to see if a fast delta's progress lands")
+                        }
+                        if sheetTicks >= 8 {  // ~3.2s — well past the ~0.5s a real download takes to report progress
+                            Log.install.error("appstore-ax: \(appName, privacy: .public) needs manual confirmation — no download after ~3s, bailing without pressing")
+                            throw AXError.needsManualConfirmation
+                        }
                     }
                 }
             } else {
@@ -1026,6 +1127,40 @@ public actor AppStoreAXInstaller {
     static func classifySheet(onScreen: Bool, ignoringLeftover: Bool) -> (isOurs: Bool, ignoringLeftover: Bool) {
         let stillIgnoring = onScreen && ignoringLeftover
         return (onScreen && !stillIgnoring, stillIgnoring)
+    }
+
+    /// What a not-yet-`continued` sheet that IS ours (`classifySheet` already said so)
+    /// actually means, given the two facts on hand: whether this update's own download
+    /// has started (`sawProgress`), and whether the app being updated is still running.
+    ///
+    /// #472: the old branch condition was `sawProgress, let bundleID, isRunning(bundleID)`
+    /// — `appRunning` gated whether a sheet counted as ours **at all**, so a sheet that
+    /// appeared once a download had started but with the app already gone fell through to
+    /// the subscription/purchase branch and was bailed as `.possiblePurchaseConfirmation`
+    /// after ~3.2s, even though the swap was already under way and landed 18s later
+    /// completely untouched (AndroMeld, 2026-09-09 — App Store raises this sheet mid-
+    /// download, ~80% in, and a responsive app can already be gone by the time we sample
+    /// it: measured 207ms). The comment on the old branch already had the right rule — "a
+    /// genuine purchase sheet never has a download behind it" — `sawProgress` alone
+    /// answers "is this ours"; `appRunning` only answers "does the user still owe App
+    /// Store a quit".
+    enum OwnSheetDisposition: Equatable {
+        /// A download for this update has started and the app is still open. Ask the
+        /// user for Relaunch/Cancel — nothing has quit yet.
+        case downloadFinishedAppStillOpen
+        /// A download for this update has started and the app has already quit on its
+        /// own (App Store can ask for the close mid-download; a responsive app can be
+        /// gone before we ever sample the sheet). Nothing to press: the swap proceeds on
+        /// its own, and step 1's on-disk `versionChanged` check catches completion.
+        case appAlreadyQuitNothingToPress
+        /// No download behind this sheet at all — a subscription / purchase / terms
+        /// confirmation. Never auto-pressed.
+        case possiblePurchaseConfirmation
+    }
+
+    static func classifyOwnSheet(sawProgress: Bool, appRunning: Bool) -> OwnSheetDisposition {
+        guard sawProgress else { return .possiblePurchaseConfirmation }
+        return appRunning ? .downloadFinishedAppStillOpen : .appAlreadyQuitNothingToPress
     }
 
     /// One poll of the swap watchdog, as a pure step so the rules that matter are

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreAXLiveHarnessTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreAXLiveHarnessTests.swift
@@ -1,0 +1,72 @@
+#if os(macOS)
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Drives the AX offer-button lookup (#471) against a REAL App Store product page —
+/// but only reads it, never presses anything. Gated behind an env var and off by
+/// default, same shape as `DUO_DOWNLOAD_GATE` (`VendorInstallTests.swift`): it needs a
+/// real GUI session with Accessibility trust and a real App Store, none of which a
+/// hosted CI runner has, and it is slow (waits real seconds for a real page to render).
+///
+/// Why TestFlight (trackID 899247664): it's Apple's own app, so on any dev Mac it is
+/// either already installed (as here) or installable with no purchase involved either
+/// way, and its trackID is already a known-good fixture elsewhere in this suite
+/// (`MASInstallerTests.swift`). `bind` locates the button purely by `AXIdentifier` and
+/// never reads its title — an "Open" button on an already-current TestFlight locates
+/// exactly the same way an "Update" one would, which is what makes it safe to use here:
+/// `locateOfferButtonForTesting` never performs `AXPress` on anything, so it is safe to
+/// run against an app whatever its update state is.
+///
+/// What this proves, and what it doesn't: it proves `bind`/`waitForOfferButton` still
+/// locate a real product page's offer button end-to-end with the #471 stability gate in
+/// place (`offerButtonIsStable` requiring two consecutive polls doesn't regress the
+/// ordinary, stable case). It does NOT reproduce the ~57-59ms rebuild race itself — that
+/// depends on App Store's own timing right after a real navigation, which isn't
+/// controllable from outside a test. The race's exact rule (found once vs. found twice
+/// in a row) is pinned instead by the unit tests in `AppStoreOfferButtonTests.swift`
+/// (`offerButtonIsStable`), which are deterministic and run on every `make test`.
+@Test func liveAppStoreOfferButtonIsLocatedWithoutBeingPressed() async throws {
+    let stderr = FileHandle.standardError
+    func log(_ s: String) { stderr.write((s + "\n").data(using: .utf8)!) }
+
+    guard ProcessInfo.processInfo.environment["DUO_LIVE_APPSTORE_AX_GATE"] == "1" else {
+        log("""
+            ⚠️ live App Store AX harness SKIPPED — it launches the real App Store app and \
+               reads its AX tree (never presses). Run it with \
+               `DUO_LIVE_APPSTORE_AX_GATE=1 swift test --filter \
+               liveAppStoreOfferButtonIsLocatedWithoutBeingPressed`. It does not run on CI.
+            """)
+        return
+    }
+    guard AppStoreAXInstaller.isTrusted else {
+        Issue.record(Comment(rawValue: """
+            DUO_LIVE_APPSTORE_AX_GATE=1 was set, but this process is not Accessibility- \
+            trusted (AXIsProcessTrusted() == false). Grant Accessibility to whatever \
+            runs `swift test` and re-run.
+            """))
+        return
+    }
+    guard FileManager.default.fileExists(atPath: "/Applications/TestFlight.app") else {
+        log("· TestFlight.app not installed here — SKIPPED (nothing to navigate to)")
+        return
+    }
+
+    let trackID = 899_247_664  // TestFlight — see the type doc comment above for why.
+    let names = AppStoreAXInstaller.AppNames(bundle: "TestFlight", store: "TestFlight", localized: "TestFlight")
+    let installer = AppStoreAXInstaller()
+
+    let located = try await installer.locateOfferButtonForTesting(trackID: trackID, names: names)
+    if located {
+        log("· located AppStore.offerButton on TestFlight's product page — not pressed")
+    } else {
+        Issue.record(Comment(rawValue: """
+            Offer button not located within the wait budget. This can be an environment \
+            gap rather than a code bug — sign in to the App Store, or a slow-rendering \
+            page — not necessarily a regression; see the type doc comment above for what \
+            this harness can and can't prove. Re-run with more patience, or by hand, \
+            before treating this as red.
+            """))
+    }
+}
+#endif

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
@@ -456,5 +456,103 @@ struct AppStoreOfferButtonTests {
         #expect(stalled == 10)
         #expect(last == 0.4)
     }
+
+    // MARK: - #471: a button must be stable, not merely seen, before it's trusted
+
+    /// A button found on only ONE poll must not be trusted yet — that single reading is
+    /// exactly what used to race the AppKit rebuild that follows `navigateToProductPage`
+    /// (or, while running, a page re-deciding "Open" vs "Update"): measured twice
+    /// (AndroMeld, Aqara Home) as the button vanishing ~57-59ms after being located.
+    ///
+    /// Mutation: `justFound || foundLastPoll` — red here (a lone first sighting would be
+    /// trusted immediately, which is the exact bug).
+    @Test func aButtonSeenOnOnlyOnePollIsNotYetTrusted() {
+        #expect(!AppStoreAXInstaller.offerButtonIsStable(justFound: true, foundLastPoll: false))
+    }
+
+    /// Found on two consecutive polls — the page has stopped churning long enough to
+    /// trust the reading.
+    @Test func aButtonSeenOnTwoConsecutivePollsIsTrusted() {
+        #expect(AppStoreAXInstaller.offerButtonIsStable(justFound: true, foundLastPoll: true))
+    }
+
+    /// A button that WAS there last poll but is gone on this one must not be trusted —
+    /// that is catching the page exactly mid-rebuild, the state #471 exists for.
+    ///
+    /// Mutation: return `foundLastPoll` alone (ignoring `justFound`) — red here, because
+    /// it would trust a button that just vanished.
+    @Test func aButtonThatJustVanishedIsNotTrusted() {
+        #expect(!AppStoreAXInstaller.offerButtonIsStable(justFound: false, foundLastPoll: true))
+    }
+
+    /// Neither poll found anything — obviously not stable.
+    @Test func noSightingAtAllIsNotStable() {
+        #expect(!AppStoreAXInstaller.offerButtonIsStable(justFound: false, foundLastPoll: false))
+    }
+
+    /// Exhaustive sweep, same shape as `bothConditionsAreRequired` above: only "found
+    /// twice in a row" is stable, and a future "simplify to a single flag" fails here.
+    @Test func stabilityRequiresBothPollsToHaveFoundIt() {
+        for justFound in [true, false] {
+            for foundLastPoll in [true, false] {
+                let expected = justFound && foundLastPoll
+                #expect(
+                    AppStoreAXInstaller.offerButtonIsStable(justFound: justFound, foundLastPoll: foundLastPoll) == expected,
+                    "justFound=\(justFound) foundLastPoll=\(foundLastPoll) must be \(expected)")
+            }
+        }
+    }
+
+    // MARK: - #472: a close-to-update sheet's meaning doesn't depend on the app still running
+
+    /// The ordinary case this whole branch exists for: a download started and the app is
+    /// still open. Ask the user for Relaunch/Cancel.
+    @Test func aDownloadedSheetWithTheAppStillOpenAsksToQuit() {
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, appRunning: true)
+                == .downloadFinishedAppStillOpen)
+    }
+
+    /// The regression. AndroMeld (2026-09-09): the download started, the app quit on its
+    /// own 207ms before the sheet was sampled, and the old condition
+    /// (`sawProgress, let bundleID, isRunning(bundleID)`) required `isRunning` to even
+    /// recognise the sheet as ours — so this exact input fell through to
+    /// `.possiblePurchaseConfirmation` and bailed with `.needsManualConfirmation` after
+    /// ~3.2s, while the swap that was already running landed untouched 18s later.
+    ///
+    /// Mutation: swap the guard to `guard sawProgress, appRunning else { return
+    /// .possiblePurchaseConfirmation }` — red here (the old bug, verbatim).
+    @Test func aDownloadedSheetWithTheAppAlreadyQuitNeedsNothingPressed() {
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, appRunning: false)
+                == .appAlreadyQuitNothingToPress)
+    }
+
+    /// No download behind the sheet at all is a purchase/subscription confirmation,
+    /// whether or not the app happens to be running — the comment this code was written
+    /// against says why: "a genuine purchase sheet never has a download behind it".
+    ///
+    /// Mutation: swap the guard to key off `appRunning` instead of `sawProgress` — red on
+    /// at least one of these two expectations.
+    @Test func noDownloadAtAllIsAlwaysAPossiblePurchaseConfirmation() {
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, appRunning: true)
+                == .possiblePurchaseConfirmation)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, appRunning: false)
+                == .possiblePurchaseConfirmation)
+    }
+
+    /// Exhaustive sweep: `sawProgress` alone decides "is this ours"; `appRunning` only
+    /// decides which of the two "ours" outcomes applies. A future "simplify the
+    /// condition" that reintroduces `appRunning` as a gate on "ours" fails here.
+    @Test func sawProgressAloneGatesWhetherTheSheetIsOurs() {
+        for sawProgress in [true, false] {
+            for appRunning in [true, false] {
+                let expected: AppStoreAXInstaller.OwnSheetDisposition =
+                    !sawProgress ? .possiblePurchaseConfirmation
+                    : (appRunning ? .downloadFinishedAppStillOpen : .appAlreadyQuitNothingToPress)
+                #expect(
+                    AppStoreAXInstaller.classifyOwnSheet(sawProgress: sawProgress, appRunning: appRunning) == expected,
+                    "sawProgress=\(sawProgress) appRunning=\(appRunning) must be \(expected)")
+            }
+        }
+    }
 }
 #endif

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
@@ -505,21 +505,24 @@ struct AppStoreOfferButtonTests {
 
     // MARK: - #472: a close-to-update sheet's meaning doesn't depend on the app still running
 
-    // `classifyOwnSheet` now decides "is the app running" itself from a `bundleID:
-    // String?`, rather than being handed a pre-computed bool — so these tests need real
-    // bundle ids to check against `NSRunningApplication`. "com.apple.finder" is a stable
-    // choice for "definitely running": Finder cannot be quit on a normal macOS host (and
-    // certainly not from inside a test process), so it is running on every machine and
-    // every CI runner this suite executes on.
+    // `classifyOwnSheet` takes `runningBundleID: String?` — the id the CALLER has
+    // already confirmed is running, or nil for "no id, or not running". So these inputs
+    // are just values: no bundle id here needs to correspond to anything real, and
+    // nothing about these assertions depends on what happens to be running on the host.
+    //
+    // A revision of this code did make the function call `NSRunningApplication` itself
+    // and pinned these tests to "com.apple.finder" as a stand-in for "definitely
+    // running". That is the dependency this shape exists to avoid: it is invisible until
+    // a runner without a full GUI session disagrees, and it would fail looking exactly
+    // like a #472 regression.
 
-    private static let aRunningBundleID = "com.apple.finder"
-    private static let aNotRunningBundleID = "com.duoupdater.tests.definitely-not-a-running-bundle-id"
+    private static let anID = "com.example.someapp"
 
     /// The ordinary case this whole branch exists for: a download started and the app is
     /// still open. Ask the user for Relaunch/Cancel, carrying the bundle id forward.
     @Test func aDownloadedSheetWithTheAppStillOpenAsksToQuit() {
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, bundleID: Self.aRunningBundleID)
-                == .downloadFinishedAppStillOpen(bundleID: Self.aRunningBundleID))
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, runningBundleID: Self.anID)
+                == .downloadFinishedAppStillOpen(bundleID: Self.anID))
     }
 
     /// The regression. AndroMeld (2026-09-09): the download started, the app quit on its
@@ -529,17 +532,21 @@ struct AppStoreOfferButtonTests {
     /// `.possiblePurchaseConfirmation` and bailed with `.needsManualConfirmation` after
     /// ~3.2s, while the swap that was already running landed untouched 18s later.
     ///
-    /// Mutation: swap the guard to `guard sawProgress, let bundleID, isRunning(bundleID)
-    /// else { return .possiblePurchaseConfirmation }` — red here (the old bug, verbatim).
+    /// Mutation: swap the guard to `guard sawProgress, let runningBundleID else {
+    /// return .possiblePurchaseConfirmation }` — red here (the old bug, verbatim).
     @Test func aDownloadedSheetWithTheAppAlreadyQuitNeedsNothingPressed() {
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, bundleID: Self.aNotRunningBundleID)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, runningBundleID: nil)
                 == .appAlreadyQuitNothingToPress)
     }
 
-    /// A `nil` bundle id (no bundle id was known at all) behaves the same as a known,
-    /// not-running one: nothing to press, wait for the on-disk version to change.
+    /// ⚠️ **No mutation of its own**, and deliberately kept anyway. "No bundle id was
+    /// known" and "the app is not running" collapse into the same `nil` at this
+    /// boundary, so this asserts the same input as the case above. It is a fixture
+    /// guard: it records that the collapse is intended, so a future signature that
+    /// splits them apart again has to decide what the missing-id case means rather than
+    /// inheriting an answer.
     @Test func aDownloadedSheetWithNoBundleIDNeedsNothingPressed() {
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, bundleID: nil)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, runningBundleID: nil)
                 == .appAlreadyQuitNothingToPress)
     }
 
@@ -547,37 +554,29 @@ struct AppStoreOfferButtonTests {
     /// whether or not the app happens to be running — the comment this code was written
     /// against says why: "a genuine purchase sheet never has a download behind it".
     ///
-    /// Mutation: swap the guard to key off the running check instead of `sawProgress` —
-    /// red on at least one of these two expectations.
+    /// Mutation: swap the guard to key off `runningBundleID` instead of `sawProgress` —
+    /// red on the first of these two expectations.
     @Test func noDownloadAtAllIsAlwaysAPossiblePurchaseConfirmation() {
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, bundleID: Self.aRunningBundleID)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, runningBundleID: Self.anID)
                 == .possiblePurchaseConfirmation)
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, bundleID: Self.aNotRunningBundleID)
-                == .possiblePurchaseConfirmation)
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, bundleID: nil)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, runningBundleID: nil)
                 == .possiblePurchaseConfirmation)
     }
 
-    /// Exhaustive sweep: `sawProgress` alone decides "is this ours"; whether the app is
-    /// running (derived from `bundleID`) only decides which of the two "ours" outcomes
-    /// applies. A future "simplify the condition" that reintroduces the running check as
-    /// a gate on "ours" fails here.
+    /// Exhaustive sweep over the function's whole input space: `sawProgress` alone
+    /// decides "is this ours"; `runningBundleID` only decides which of the two "ours"
+    /// outcomes applies. A future "simplify the condition" that reintroduces the running
+    /// check as a gate on "ours" fails here.
     @Test func sawProgressAloneGatesWhetherTheSheetIsOurs() {
-        let candidates: [(bundleID: String?, isRunning: Bool)] = [
-            (Self.aRunningBundleID, true),
-            (Self.aNotRunningBundleID, false),
-            (nil, false),
-        ]
         for sawProgress in [true, false] {
-            for candidate in candidates {
+            for runningBundleID in [Self.anID, nil] {
                 let expected: AppStoreAXInstaller.OwnSheetDisposition =
                     !sawProgress ? .possiblePurchaseConfirmation
-                    : (candidate.isRunning
-                       ? .downloadFinishedAppStillOpen(bundleID: candidate.bundleID!)
-                       : .appAlreadyQuitNothingToPress)
+                    : (runningBundleID.map { .downloadFinishedAppStillOpen(bundleID: $0) }
+                       ?? .appAlreadyQuitNothingToPress)
                 #expect(
-                    AppStoreAXInstaller.classifyOwnSheet(sawProgress: sawProgress, bundleID: candidate.bundleID) == expected,
-                    "sawProgress=\(sawProgress) bundleID=\(candidate.bundleID ?? "nil") must be \(expected)")
+                    AppStoreAXInstaller.classifyOwnSheet(sawProgress: sawProgress, runningBundleID: runningBundleID) == expected,
+                    "sawProgress=\(sawProgress) runningBundleID=\(runningBundleID ?? "nil") must be \(expected)")
             }
         }
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
@@ -505,11 +505,21 @@ struct AppStoreOfferButtonTests {
 
     // MARK: - #472: a close-to-update sheet's meaning doesn't depend on the app still running
 
+    // `classifyOwnSheet` now decides "is the app running" itself from a `bundleID:
+    // String?`, rather than being handed a pre-computed bool — so these tests need real
+    // bundle ids to check against `NSRunningApplication`. "com.apple.finder" is a stable
+    // choice for "definitely running": Finder cannot be quit on a normal macOS host (and
+    // certainly not from inside a test process), so it is running on every machine and
+    // every CI runner this suite executes on.
+
+    private static let aRunningBundleID = "com.apple.finder"
+    private static let aNotRunningBundleID = "com.duoupdater.tests.definitely-not-a-running-bundle-id"
+
     /// The ordinary case this whole branch exists for: a download started and the app is
-    /// still open. Ask the user for Relaunch/Cancel.
+    /// still open. Ask the user for Relaunch/Cancel, carrying the bundle id forward.
     @Test func aDownloadedSheetWithTheAppStillOpenAsksToQuit() {
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, appRunning: true)
-                == .downloadFinishedAppStillOpen)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, bundleID: Self.aRunningBundleID)
+                == .downloadFinishedAppStillOpen(bundleID: Self.aRunningBundleID))
     }
 
     /// The regression. AndroMeld (2026-09-09): the download started, the app quit on its
@@ -519,10 +529,17 @@ struct AppStoreOfferButtonTests {
     /// `.possiblePurchaseConfirmation` and bailed with `.needsManualConfirmation` after
     /// ~3.2s, while the swap that was already running landed untouched 18s later.
     ///
-    /// Mutation: swap the guard to `guard sawProgress, appRunning else { return
-    /// .possiblePurchaseConfirmation }` — red here (the old bug, verbatim).
+    /// Mutation: swap the guard to `guard sawProgress, let bundleID, isRunning(bundleID)
+    /// else { return .possiblePurchaseConfirmation }` — red here (the old bug, verbatim).
     @Test func aDownloadedSheetWithTheAppAlreadyQuitNeedsNothingPressed() {
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, appRunning: false)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, bundleID: Self.aNotRunningBundleID)
+                == .appAlreadyQuitNothingToPress)
+    }
+
+    /// A `nil` bundle id (no bundle id was known at all) behaves the same as a known,
+    /// not-running one: nothing to press, wait for the on-disk version to change.
+    @Test func aDownloadedSheetWithNoBundleIDNeedsNothingPressed() {
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: true, bundleID: nil)
                 == .appAlreadyQuitNothingToPress)
     }
 
@@ -530,27 +547,37 @@ struct AppStoreOfferButtonTests {
     /// whether or not the app happens to be running — the comment this code was written
     /// against says why: "a genuine purchase sheet never has a download behind it".
     ///
-    /// Mutation: swap the guard to key off `appRunning` instead of `sawProgress` — red on
-    /// at least one of these two expectations.
+    /// Mutation: swap the guard to key off the running check instead of `sawProgress` —
+    /// red on at least one of these two expectations.
     @Test func noDownloadAtAllIsAlwaysAPossiblePurchaseConfirmation() {
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, appRunning: true)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, bundleID: Self.aRunningBundleID)
                 == .possiblePurchaseConfirmation)
-        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, appRunning: false)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, bundleID: Self.aNotRunningBundleID)
+                == .possiblePurchaseConfirmation)
+        #expect(AppStoreAXInstaller.classifyOwnSheet(sawProgress: false, bundleID: nil)
                 == .possiblePurchaseConfirmation)
     }
 
-    /// Exhaustive sweep: `sawProgress` alone decides "is this ours"; `appRunning` only
-    /// decides which of the two "ours" outcomes applies. A future "simplify the
-    /// condition" that reintroduces `appRunning` as a gate on "ours" fails here.
+    /// Exhaustive sweep: `sawProgress` alone decides "is this ours"; whether the app is
+    /// running (derived from `bundleID`) only decides which of the two "ours" outcomes
+    /// applies. A future "simplify the condition" that reintroduces the running check as
+    /// a gate on "ours" fails here.
     @Test func sawProgressAloneGatesWhetherTheSheetIsOurs() {
+        let candidates: [(bundleID: String?, isRunning: Bool)] = [
+            (Self.aRunningBundleID, true),
+            (Self.aNotRunningBundleID, false),
+            (nil, false),
+        ]
         for sawProgress in [true, false] {
-            for appRunning in [true, false] {
+            for candidate in candidates {
                 let expected: AppStoreAXInstaller.OwnSheetDisposition =
                     !sawProgress ? .possiblePurchaseConfirmation
-                    : (appRunning ? .downloadFinishedAppStillOpen : .appAlreadyQuitNothingToPress)
+                    : (candidate.isRunning
+                       ? .downloadFinishedAppStillOpen(bundleID: candidate.bundleID!)
+                       : .appAlreadyQuitNothingToPress)
                 #expect(
-                    AppStoreAXInstaller.classifyOwnSheet(sawProgress: sawProgress, appRunning: appRunning) == expected,
-                    "sawProgress=\(sawProgress) appRunning=\(appRunning) must be \(expected)")
+                    AppStoreAXInstaller.classifyOwnSheet(sawProgress: sawProgress, bundleID: candidate.bundleID) == expected,
+                    "sawProgress=\(sawProgress) bundleID=\(candidate.bundleID ?? "nil") must be \(expected)")
             }
         }
     }


### PR DESCRIPTION
Closes #471. Closes #472. Follow-up in #479.

Two defects on the App Store AX install route, both found by running real updates on this machine and both surfacing to the user as red text.

## #471 — the offer button vanishes between locating and pressing

`waitForOfferButton` returned the instant it found the button, racing an AppKit subtree rebuild that follows `navigateToProductPage`. The press-time re-find right after it was a one-shot `guard` with **no retry budget at all**, while the wait above had ~12s — so a page that churned in the gap failed the whole update on a page that plainly had the button.

Measured twice (AndroMeld, Aqara Home): the button vanished 57ms and 59ms after being located. Six samples in total are tabulated in the issue.

`offerButtonIsStable` now requires the button on two consecutive polls before it is trusted, and the press-time re-find reuses the same rule over a short (~1.5s) budget instead of a single attempt. Both costs are written down in the doc comment: **every install now pays ~150–450ms**, and a page re-rendering near the 150ms poll cadence could in principle never satisfy "two consecutive" — a failure mode the one-shot rule could not have.

⚠️ The `located→press` interval is **not** a discriminator and should not be used to tune a timeout: successes measured 43–77ms, failures 57 and 59ms — fully overlapping.

## #472 — a close-to-update sheet read as a purchase confirmation

The branch required `isRunning(bundleID)` to recognise a sheet as ours at all. App Store raises that sheet **mid-download** (measured ~80% in) and a responsive app can already be gone when we sample it — 207ms later, per `loginwindow`'s own record. So a normal update fell through to the purchase-confirmation path and bailed after ~3.2s with *"This app needs confirmation in the App Store (e.g. a subscription or purchase)"*, while the swap it had given up on landed untouched 18 seconds later.

The correct rule was already written in the comment beside the bug: *a genuine purchase sheet never has a download behind it*. `sawProgress` alone now decides whether the sheet is ours; whether the app is still running only decides whether anyone owes App Store a quit. When it has already quit there is nothing to press — the on-disk version check catches completion.

Three now-false doc comments were corrected, including the claim that the sheet appears only after the download finishes and only with the app open.

## Review fixes included

- `OwnSheetDisposition.downloadFinishedAppStillOpen` carries the bundle id, replacing a force-unwrap whose safety rested on a cross-function comment.
- `classifyOwnSheet` stays **pure**, taking `runningBundleID: String?` — an intermediate revision had it call `NSRunningApplication` itself, which pinned its tests to Finder being alive on the host. It is now consistent with `classifySheet`, `swapWatchdog` and `exhaustedBudgetError` beside it.
- One `isRunning` lookup per poll instead of two non-atomic ones, so the log line and the branch describe the same instant.

## Verification

Mutations run for real, each hitting only its documented cases: `&&`→`||` and `foundLastPoll` alone on the stability rule; the #472 bug verbatim (3 red); keying "is this ours" off the running check (4 red). Reverting the associated-value fix fails to compile.

A gated live harness (`DUO_LIVE_APPSTORE_AX_GATE=1`, off by default like `DUO_DOWNLOAD_GATE`) drives the real App Store and locates a real `AppStore.offerButton` in 2.27s **without ever pressing it** — safe because `bind` matches on the AX identifier, never the button's title, so an already-current app works as a target.

`make test`: exit 0. Core 2468 / 203 suites (1 pre-existing known issue, the unrelated Anki case), CLI 263, app tests 9 of 9, all six python gates green.

## Known gap

`activateAppStore()` in the already-quit branch fires once. That branch sets neither `continued` nor `sheetTicks`, so if the user clicks back to their own window the sheet can park again with only the ~6 minute poll cap behind it. Written up as #479 rather than widened here.
