### PR TITLE
Stop mas's ADAM-ID lookup failure from pasting its raw text at the user (#474)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/MASInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/MASInstaller.swift
@@ -86,6 +86,16 @@ public actor MASInstaller {
                 if Self.isReceiptImportFailure(output) {
                     return "The App Store blocked mas from finishing this update. \(MASError.appStoreUpdatesHint)"
                 }
+                // mas's own lookup by ADAM ID came up empty. The most common cause is
+                // a wrapped iPhone/iPad app: mas only knows the Mac App Store catalog,
+                // and those live in the iOS one — but the same message also covers an
+                // app that's genuinely been pulled from sale. Either way "this app
+                // isn't in the App Store" would be false (the iOS-on-Mac case is very
+                // much still there), so this only asserts what actually happened: mas's
+                // lookup found nothing, and the App Store app itself is the fallback.
+                if Self.isAdamIDNotFound(output) {
+                    return "mas can’t look up this app by its App Store ID, so it can’t install the update. \(MASError.appStoreUpdatesHint)"
+                }
                 let tail = Self.tail(of: output)
                 return tail.isEmpty ? "mas failed (\(code))." : "mas failed (\(code)): \(tail)"
             }
@@ -162,6 +172,21 @@ public actor MASInstaller {
             // exactly what this classification offers the user.
             return lower.contains("the upgrade failed")
                 || lower.contains("moving files to the final destination")
+        }
+
+        /// True when mas's own store lookup found nothing for the ADAM ID
+        /// ("Error: No apps found in the App Store for ADAM ID …", from both
+        /// `mas info` and `mas install`). This is mas's Mac App Store namespace
+        /// coming up empty — it does not by itself mean the app is unavailable
+        /// everywhere: a wrapped iPhone/iPad app lives in the iOS catalog instead
+        /// and is never in mas's namespace, so this fires for every one of them
+        /// (100% of the time, not intermittently). It also fires for an app that
+        /// really has been removed from sale — this string alone can't tell the
+        /// two apart, so the message built from it (`errorDescription`) only
+        /// claims what's true of both: mas couldn't find it, not that it isn't in
+        /// the App Store.
+        static func isAdamIDNotFound(_ output: String) -> Bool {
+            output.lowercased().contains("no apps found")
         }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/MASInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/MASInstaller.swift
@@ -86,13 +86,15 @@ public actor MASInstaller {
                 if Self.isReceiptImportFailure(output) {
                     return "The App Store blocked mas from finishing this update. \(MASError.appStoreUpdatesHint)"
                 }
-                // mas's own lookup by ADAM ID came up empty. The most common cause is
-                // a wrapped iPhone/iPad app: mas only knows the Mac App Store catalog,
-                // and those live in the iOS one — but the same message also covers an
-                // app that's genuinely been pulled from sale. Either way "this app
-                // isn't in the App Store" would be false (the iOS-on-Mac case is very
-                // much still there), so this only asserts what actually happened: mas's
-                // lookup found nothing, and the App Store app itself is the fallback.
+                // mas's own lookup by ADAM ID came up empty. In production that means
+                // the app has been pulled from sale: the other thing mas cannot find —
+                // a wrapped iPhone/iPad app, which lives in the iOS catalog and never in
+                // mas's Mac-only one — cannot reach this installer at all (see
+                // `isAdamIDNotFound` for where it is turned away). The message must
+                // therefore not say "this app isn't in the App Store" either: for a
+                // delisted app that is a guess about why the lookup failed, and if a
+                // wrapped app ever did reach here it would be flatly false. It asserts
+                // only what happened — mas found nothing — and points at the App Store.
                 if Self.isAdamIDNotFound(output) {
                     return "mas can’t look up this app by its App Store ID, so it can’t install the update. \(MASError.appStoreUpdatesHint)"
                 }
@@ -176,15 +178,24 @@ public actor MASInstaller {
 
         /// True when mas's own store lookup found nothing for the ADAM ID
         /// ("Error: No apps found in the App Store for ADAM ID …", from both
-        /// `mas info` and `mas install`). This is mas's Mac App Store namespace
-        /// coming up empty — it does not by itself mean the app is unavailable
-        /// everywhere: a wrapped iPhone/iPad app lives in the iOS catalog instead
-        /// and is never in mas's namespace, so this fires for every one of them
-        /// (100% of the time, not intermittently). It also fires for an app that
-        /// really has been removed from sale — this string alone can't tell the
-        /// two apart, so the message built from it (`errorDescription`) only
-        /// claims what's true of both: mas couldn't find it, not that it isn't in
-        /// the App Store.
+        /// `mas info` and `mas install`). That is mas's Mac App Store namespace
+        /// coming up empty, which is not the same as the app being unavailable —
+        /// hence the deliberately narrow message in `errorDescription`.
+        ///
+        /// ⚠️ **What actually reaches this in production is a delisted app.** The
+        /// other candidate — a wrapped iPhone/iPad app, which lives in the iOS
+        /// catalog and is never in mas's namespace — cannot get here: measured
+        /// 2026-09-09, `masInstaller.install` has exactly two call sites
+        /// (`AppListModel` ~3206 / ~3241) and three gates stand in front of them —
+        /// `UpdatePolicy.canAutoInstall` excludes `isiOSAppOnMac` on the `.full`
+        /// route, `AppListModel` redirects those rows to the App Store deep link
+        /// before any install runs, and the `.incremental` route excludes them from
+        /// the mas fallback too. The CLI cannot reach it either (`DuoKit/Install`
+        /// refuses the whole `.appStore` route). Routing them here would be the
+        /// change to make deliberately, not something to infer from this comment.
+        ///
+        /// The string alone still cannot tell the two apart, which is why the
+        /// message claims only that mas could not find it.
         static func isAdamIDNotFound(_ output: String) -> Bool {
             output.lowercased().contains("no apps found")
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MASInstallerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MASInstallerTests.swift
@@ -212,15 +212,19 @@ private let receiptImportLog =
     #expect(msg.contains(MASInstaller.MASError.appStoreUpdatesHint))
 }
 
-// The exact shape from #474's field report (Aqara Home, ADAM ID 1248669703 —
-// a wrapped iPhone/iPad app, which mas's Mac App Store lookup can never find).
+// The exact shape from #474's field report, captured by running `mas install
+// 1248669703` by hand (Aqara Home). ⚠️ That app is a wrapped iPhone/iPad one, and
+// three upstream gates keep those away from this installer entirely — the sample
+// is the string's shape, not the case that reaches this code. What reaches it is
+// an app pulled from sale (see `isAdamIDNotFound`).
 private let adamIDNotFoundLog = "Error: No apps found in the App Store for ADAM ID 1248669703"
 
 /// mas's own lookup came up empty for the ADAM ID. Before this, the surfaced
 /// message was mas's raw text verbatim ("mas failed (1): Error: No apps found in
 /// the App Store for ADAM ID …") — which reads as "this app isn't in the App
-/// Store", and for the #474 sample that's false (it's an iOS-on-Mac app; mas's
-/// Mac-only namespace just doesn't carry it). Mutation this catches: deleting the
+/// Store", a claim the string does not support: for a delisted app it guesses at
+/// why the lookup failed, and for a wrapped app it would be flatly wrong.
+/// Mutation this catches: deleting the
 /// `isAdamIDNotFound` branch in `errorDescription` (falls through to the raw
 /// `tail`, which both re-leaks "ADAM ID" and drops the "Open App Store" hint) —
 /// confirmed red by commenting the branch out and rerunning.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MASInstallerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MASInstallerTests.swift
@@ -212,6 +212,58 @@ private let receiptImportLog =
     #expect(msg.contains(MASInstaller.MASError.appStoreUpdatesHint))
 }
 
+// The exact shape from #474's field report (Aqara Home, ADAM ID 1248669703 —
+// a wrapped iPhone/iPad app, which mas's Mac App Store lookup can never find).
+private let adamIDNotFoundLog = "Error: No apps found in the App Store for ADAM ID 1248669703"
+
+/// mas's own lookup came up empty for the ADAM ID. Before this, the surfaced
+/// message was mas's raw text verbatim ("mas failed (1): Error: No apps found in
+/// the App Store for ADAM ID …") — which reads as "this app isn't in the App
+/// Store", and for the #474 sample that's false (it's an iOS-on-Mac app; mas's
+/// Mac-only namespace just doesn't carry it). Mutation this catches: deleting the
+/// `isAdamIDNotFound` branch in `errorDescription` (falls through to the raw
+/// `tail`, which both re-leaks "ADAM ID" and drops the "Open App Store" hint) —
+/// confirmed red by commenting the branch out and rerunning.
+@Test func classifiesAdamIDNotFound() {
+    #expect(MASInstaller.MASError.isAdamIDNotFound(adamIDNotFoundLog))
+    // Case-insensitive, and matches both `mas info` and `mas install`'s wording
+    // (identical string per the issue's repro).
+    #expect(MASInstaller.MASError.isAdamIDNotFound("ERROR: NO APPS FOUND IN THE APP STORE FOR ADAM ID 1"))
+    // Doesn't fire on unrelated definitive answers — over-broad matching would
+    // also swallow "Not purchased" into the wrong message.
+    #expect(!MASInstaller.MASError.isAdamIDNotFound("Error: Not purchased"))
+    #expect(!MASInstaller.MASError.isAdamIDNotFound(transientLog))
+    #expect(!MASInstaller.MASError.isAdamIDNotFound(receiptImportLog))
+
+    let msg = MASInstaller.MASError.failed(code: 1, output: adamIDNotFoundLog).errorDescription ?? ""
+    // Actionable guidance is present (the UI keys its "Open App Store" button off
+    // this sentinel — same contract as the receipt-import message).
+    #expect(msg.contains(MASInstaller.MASError.appStoreUpdatesHint))
+    // The raw mas line — and the specific false claim "isn't in the App Store" —
+    // must not appear. The message may only say mas's lookup failed, not why.
+    #expect(!msg.contains("No apps found"))
+    #expect(!msg.contains("ADAM ID"))
+    #expect(!msg.lowercased().contains("isn’t in the app store"))
+    #expect(!msg.lowercased().contains("isn't in the app store"))
+}
+
+/// "No apps found" is one of the definitive store answers ("Not purchased" is the
+/// other one already covered by `doesNotRetryDefinitiveMasFailure") — retrying just
+/// re-runs the same doomed lookup. Mutation this catches: adding
+/// `isAdamIDNotFound` output to `isTransientNetworkFailure`'s or
+/// `isReceiptImportFailure`'s matched set (either would make `install` retry it) —
+/// confirmed red by temporarily making `isTransientNetworkFailure` return `true`
+/// for this log and rerunning (calls goes from 1 to 4, the retry ceiling).
+@Test func doesNotRetryAdamIDNotFound() async {
+    let runner = ScriptedMASRunner([(1, adamIDNotFoundLog)])
+    let installer = MASInstaller(runner: runner, retryBackoffNanos: 0)
+    await #expect(throws: MASInstaller.MASError.self) {
+        try await installer.install(adamID: 900000006) { _ in }
+    }
+    let calls = await runner.calls
+    #expect(calls == 1)  // no retry on a definitive failure
+}
+
 @Test func masFailureTailStaysShortAndDropsProgressNoise() {
     // mas draws progress with carriage returns, so splitting on "\n" alone left the
     // whole blob as one "line" — the popover rendered ~40 lines of red text.


### PR DESCRIPTION
Addresses #474 — but read the correction on that issue first: **its central claim was wrong.**

## What the issue got wrong

#474 asserted that the `.full` (mas) route fails for every iOS-on-Mac app and shows the user a false error. Measured since: such an app **cannot reach `MASInstaller.install` at all**. Three gates stand in front of its two call sites — `UpdatePolicy.canAutoInstall` excludes `isiOSAppOnMac` on `.full`, `AppListModel` redirects those rows to the App Store deep link before any install runs, and the `.incremental` route excludes them from the mas fallback too. The CLI refuses the whole `.appStore` route before getting near it. All of that landed in `9b6b57d5` (2026-08-29), whose own comment records the same `"No apps found for ADAM ID"` behaviour this issue rediscovered.

The issue was written after grepping `MASInstaller.swift` for `isiOSAppOnMac` (0 hits) without grepping one layer up.

## What is left, and why it is still worth doing

`mas` answers `"Error: No apps found in the App Store for ADAM ID …"` with exit code 1 for an app that has been **pulled from sale**, and that path is live. `MASError.failed` only translates the receipt-import case; everything else gets mas's raw text pasted into the row:

> mas failed (1): Error: No apps found in the App Store for ADAM ID 1248669703

This change gives that case a message that says only what happened, and reuses the existing `appStoreUpdatesHint` sentinel so the UI's "Open App Store" button appears with no UI changes:

> mas can't look up this app by its App Store ID, so it can't install the update. Update it from the App Store's Updates page.

Deliberately **not** "this app isn't in the App Store": the string cannot distinguish a delisted app from a wrapped one, so for a delisted app that would be a guess at *why* the lookup failed, and for a wrapped app it would be flatly false.

Scope is the honest-failure half only. Routing iOS-on-Mac installs through the AX route is the other option #474 lists; it depends on #471/#472 and on whether `.incremental` is ever opened up, so it is not attempted here.

## Verification

Two cases, each with the mutation it pins, both run and confirmed red:

- `classifiesAdamIDNotFound` — deleting the branch drops back to the raw tail, re-leaking `"ADAM ID"` and losing the hint. Also asserts the built message contains none of `"No apps found"`, `"ADAM ID"`, or `"isn't in the App Store"`.
- `doesNotRetryAdamIDNotFound` — making `isTransientNetworkFailure` match this log takes the call count from 1 to 4 (the retry ceiling), so the case genuinely pins that this is treated as definitive.

The comments were corrected after review: the first version presented a wrapped iPhone/iPad app as the branch's main cause — one of them as "100% of the time" — which, per the gates above, is the case that never gets here. They now name the three gates so the next reader can check rather than infer.

No localization entry: every other `MASError` string is English-only, verified absent from `Localizable.xcstrings`, so this follows the file's own convention rather than the repo-wide default.

`make test`: exit 0. Core 2459 / 203 suites (1 pre-existing known issue), CLI 263, app tests 9 of 9, all six python gates green.
