### PR TITLE
TestFlight: refuse an up-to-date verdict the database cannot support

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -213,6 +213,38 @@ public struct UpdateChecker: Sendable {
         if app.isTestFlightApp {
             if let latest = testflight?.latest(forBundleID: app.bundleID) {
                 let installedBuild = app.buildVersion ?? ""
+                // An installed build NEWER than anything the database holds says
+                // something about the DATABASE, not about the app: whatever else is
+                // true, its "latest" is not an upper bound for this bundle. That
+                // rules out `.upToDate`, which is precisely the answer that claims it
+                // is one — and it rules it out without anyone having to pick a
+                // staleness threshold.
+                //
+                // It happens because the database is written by TestFlight.app and by
+                // nothing else — not by the push that announces a build, not by the
+                // background install that lands one. Measured 2026-09-09 on a Mac
+                // whose TestFlight had not been opened since July: TestFlight itself
+                // had installed APTV 319 the day before and said so in a notification,
+                // while the store still held only 300/301/304, and this branch called
+                // that up to date. ScreenCam on the same machine was the second case.
+                //
+                // A build can also expire out of the store while staying on disk,
+                // which produces the same comparison with a database nobody would
+                // call stale. This does not try to tell the two apart: the answer we
+                // are entitled to give is the same either way, and a guess about
+                // which one it is would be a claim we cannot support.
+                if VersionComparator.isNewer(installedBuild, than: latest.latestBuild) {
+                    Log.check.info("""
+                        \(label, privacy: .public): TestFlight database holds \
+                        \(latest.latestBuild, privacy: .public) but \
+                        \(installedBuild, privacy: .public) is installed — it cannot \
+                        bound this app, so no up-to-date verdict
+                        """)
+                    // `remote: nil` for the same reason the no-cache branch below
+                    // passes nil: a version we have just called unusable must not be
+                    // the one the row shows.
+                    return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
+                }
                 let hasUpdate = VersionComparator.isNewer(latest.latestBuild, than: installedBuild)
                 // Beta builds often keep the same marketing version across builds,
                 // so disambiguate with the build number when the short string matches.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -501,7 +501,15 @@ public enum UpdatePolicy {
     /// `.toolboxManaged` and `.testFlightManaged` from the *same* "no source could
     /// answer" branch that produces `.unknown` for everything else, so treating
     /// them as settlements would delete a live error on nothing more than a
-    /// transient lookup miss. That is not hypothetical for App Store rows, where
+    /// transient lookup miss.
+    ///
+    /// ⚠️ `.testFlightManaged` now has a SECOND producer where a source did answer:
+    /// the checker refuses an up-to-date verdict when the installed build outruns
+    /// everything TestFlight's database holds. Not settling is still right there —
+    /// that row's whole point is that we could not establish it is current — but
+    /// "nobody answered" is no longer what the status means, so do not build a rule
+    /// (a retry, a settlement once a source is known to have replied) on that
+    /// reading. That is not hypothetical for App Store rows, where
     /// the error text is also what gates the row's recovery buttons
     /// (`showsHelperApprovalFallback` and friends read `installErrors`): one
     /// unanswered check would take away the message *and* the only route to the

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
@@ -151,6 +151,31 @@ final class TestFlightInventoryTests: XCTestCase {
         XCTAssertEqual(result.status, .upToDate)
     }
 
+    /// The database is written by TestFlight.app and by nothing else, so a build it
+    /// installed in the background can sit on disk while the store still names an
+    /// older one as newest. Measured 2026-09-09: APTV on disk at 319 against a store
+    /// holding 300/301/304, reported up to date; ScreenCam on the same machine was
+    /// the second case. A store whose "latest" is below what is installed cannot
+    /// bound this app, so no up-to-date verdict may rest on it.
+    ///
+    /// Mutation: delete the `isNewer(installedBuild, than: latest.latestBuild)`
+    /// early return in `UpdateChecker` — this becomes `.upToDate` and fails, while
+    /// `testCheckerUpToDateOnNewestBuild` (equal builds) stays green, so the two
+    /// together pin the boundary rather than just the direction.
+    func testCheckerRefusesUpToDateWhenInstalledBuildOutrunsTheDatabase() async {
+        let tf = inventory()
+        let checker = UpdateChecker(sources: [], testflight: tf)
+        let app = InstalledApp(
+            name: "Paste", bundleID: "com.wiheads.paste",
+            shortVersion: "6.6.2", buildVersion: "18999",  // > the store's newest, 18706
+            path: URL(fileURLWithPath: "/Applications/Paste.app"),
+            isMASApp: false, isTestFlightApp: true, sparkleFeedURL: nil)
+        let result = await checker.check(app)
+        XCTAssertEqual(result.status, .testFlightManaged)
+        // The version we just called unusable must not reach the row either.
+        XCTAssertNil(result.remote)
+    }
+
     func testCheckerManagedWhenNoCache() async {
         // TestFlight app but the inventory has nothing for it → managed label.
         let checker = UpdateChecker(sources: [], testflight: TestFlightInventory(macRows: []))


### PR DESCRIPTION
关闭条件见 #478。

## 改了什么

`UpdateChecker` 的 TestFlight 分支，在比较之前加一道自证判据：**磁盘上的 build 比 TestFlight 本地库里所有 build 都新**时，那个库的 `latest` 就不能作为这个 bundle 的上界——于是 `.upToDate`（唯一声称它是上界的答案）被排除，降级为 `.testFlightManaged`，`remote: nil`。不需要挑任何新鲜度阈值。

状态复用已有的 `.testFlightManaged`（→ `.managedElsewhere(.testFlight)`，gallery 29 号），没有新增状态：那一格的语义本来就是「TestFlight 的事，我们不报版本」。所以 `make gallery` 的图无变化。

## 为什么

TestFlight 的库只由 TestFlight.app 写——push 不写，后台安装也不写。2026-09-09 在一台自 7 月起没打开过 TestFlight 的 Mac 上实测：

```
$ duo check --json --all --source testflight
APTV       installedBuild=319             latestBuild=304             status=up-to-date
ScreenCam  installedBuild=20260903024310  latestBuild=20260610033200  status=up-to-date
```

两行报告自带矛盾还照样判 up-to-date。APTV 那个 319 正是 TestFlight 自己前一天后台装的（还弹了通知）。

同一个比较还有第二种成因：**build 过期**后被清出库、却仍在磁盘上（`buildRemovalType: BUILD_EXPIRED`,本仓库外一个真实例）。代码**刻意不区分**这两者——我们有资格给的答案两种情况下相同,猜是哪一种就是一句撑不住的话。

## 验证

```
$ scripts/run-with-hang-report.sh 1800 make test   →  EXIT=0
━ Test run with 2457 tests in 203 suites passed after 20.291 seconds with 1 known issue.
✔ Test run with 263 tests in 32 suites passed
✓ App tests — 9 of 9 cases executed
```

变异实测（删掉新加的早返回）：

```
testCheckerRefusesUpToDateWhenInstalledBuildOutrunsTheDatabase  FAILED ("upToDate" != "testFlightManaged")
testCheckerUpToDateOnNewestBuild                                passed
```

两条一起钉住的是**边界**（build 相等仍然 up-to-date，只有严格更大才降级），不只是方向。

## 不在这个 PR 里

- #476（iOS-on-Mac 的 beta 更新看不见）——独立问题，且这道闸对 iOS-on-Mac 走不到（`latest(forBundleID:)` 只看 mac 行，那类 app 拿到 nil，本来就已经是 `.testFlightManaged`）。
- #477（changelog 拿不到）——已查明无可用来源。
- 「版本对得上但库很旧」那一格需要时间阈值，样本只有两个，先不做。
- **rescan 路径不在这道闸里**（`ScanRowAssembly` 对 TestFlight 行原样带回上一次的 status），
  所以后台装完到下一轮 check 之间，App 里那一行仍可能显示旧的 `.upToDate`。自愈的窗口，
  但本 PR 的说法只覆盖 check 路径。

## ⚠️ 验收命令改了

**不要**用 `duo check --all --source testflight` 复核：`--source` 匹配的是 `remote.sourceName`，
而这道闸返回 `remote: nil`，于是被它抓到的行会从那个视图里**整行消失**而不是换个状态——
看起来像通过。用不带 `--source` 的：

```sh
duo check --json --all | grep -E 'aptv|thescreen'   # status 应该是 testflight，不再是 up-to-date
```
