### PR TITLE
TestFlight: let a wrapped iPhone/iPad app be offered its own iOS builds

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -220,6 +220,14 @@ public struct UpdateChecker: Sendable {
             // with an iOS track at 29814462, and Claudo — a wrapped bundle —
             // had 0.3.384 (1300) installed with 1301 offered, both iOS rows, which
             // the mac-only lookup could not see at all (#476).
+            //
+            // ⚠️ This also lets a wrapped bundle reach `.upToDate`, which it could
+            // not before: with no mac rows it always landed on `.testFlightManaged`
+            // and claimed nothing. That immunity was an accident of the bug, not a
+            // safeguard — but it did mean these rows could never inherit the
+            // staleness this database has (measured six weeks old on one machine
+            // while pushes kept arriving). What closes that is the freshness gate
+            // in #478, for every TestFlight row at once, not a special case here.
             let known = app.isiOSAppOnMac
                 ? testflight?.latestIOS(forBundleID: app.bundleID)
                 : testflight?.latest(forBundleID: app.bundleID)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -211,7 +211,19 @@ public struct UpdateChecker: Sendable {
         // track); read TestFlight's cached latest build instead. The action stays
         // "open TestFlight".
         if app.isTestFlightApp {
-            if let latest = testflight?.latest(forBundleID: app.bundleID) {
+            // Which platform's rows may answer for this bundle is decided HERE, not
+            // inside the inventory, and the two are mutually exclusive on purpose.
+            // A wrapped iPhone/iPad bundle's builds are filed under the iOS
+            // platform and it can never install a mac build; a native Mac app can
+            // hold iOS rows of its own and must never be offered one. Measured
+            // 2026-09-09 on one machine: Paste is on the mac track at 29808607
+            // with an iOS track at 29814462, and Claudo — a wrapped bundle —
+            // had 0.3.384 (1300) installed with 1301 offered, both iOS rows, which
+            // the mac-only lookup could not see at all (#476).
+            let known = app.isiOSAppOnMac
+                ? testflight?.latestIOS(forBundleID: app.bundleID)
+                : testflight?.latest(forBundleID: app.bundleID)
+            if let latest = known {
                 let installedBuild = app.buildVersion ?? ""
                 // An installed build NEWER than anything the database holds says
                 // something about the DATABASE, not about the app: whatever else is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -10,10 +10,13 @@ import SQLite3
 ///
 /// The DB lives in TestFlight's sandbox container and stores one row per
 /// (app, build, platform) in `ZTFAPPBUNDLEMODEL`:
-///   - `ZPLATFORMRAW` 3 == macOS, 1 == iOS. Mac builds are what an update can be
-///     *offered* for, so they alone feed ``latest(forBundleID:)`` and
-///     ``isManaged(bundleID:installedBuild:)``. iOS rows are read too but kept
-///     strictly apart, for one question only — see ``hasIOSBuild(bundleID:installedBuild:)``.
+///   - `ZPLATFORMRAW` 3 == macOS, 1 == iOS. The two are read into strictly
+///     separate tables and never merged: mac rows feed ``latest(forBundleID:)``
+///     and ``isManaged(bundleID:installedBuild:)``, iOS rows feed
+///     ``latestIOS(forBundleID:)`` and ``hasInstalledIOSBuild(bundleID:installedBuild:)``,
+///     and it is the CALLER that picks a side, from `isiOSAppOnMac`. A native Mac
+///     app can hold iOS rows of its own, so a merged table would offer it an
+///     iPhone build as its next Mac update.
 ///   - `ZINSTALLSTATUSRAW` 1 == the build currently installed on this machine.
 ///     Measured 2026-09-08: 6 of 110 rows carry it, no nulls, values only 0/1,
 ///     never twice for one (bundle, platform) — and all 6 matched an app on disk
@@ -59,6 +62,20 @@ public struct TestFlightInventory: Sendable {
     /// Mithka the iOS build as its next Mac update.
     private let iosBuildsByBundleID: [String: Set<String>]
 
+    /// The newest iOS build TestFlight OFFERS for each bundle — every iOS row,
+    /// installed or not, exactly as `appsByBundleID` is built from every mac row.
+    ///
+    /// Separate from `iosBuildsByBundleID` above because the two answer opposite
+    /// questions and the SQL treats them differently: that one is filtered to
+    /// `ZINSTALLSTATUSRAW = 1` and asks "did TestFlight put this copy here", this
+    /// one must keep the rows the user has NOT installed or it could never offer
+    /// an update. Merging them would either make membership answer yes for a build
+    /// the user merely has access to, or make this one permanently say "current".
+    ///
+    /// Only ``latestIOS(forBundleID:)`` reads it, and only for a wrapped bundle —
+    /// see there for why a native Mac app must never be routed through it.
+    private let iosLatestByBundleID: [String: App]
+
     /// Whether we actually opened the TestFlight database. `false` means the file
     /// was missing or the read was blocked/denied — notably the "access data from
     /// other apps" TCC gate. The UI uses this to tell "we read it and there was
@@ -74,9 +91,10 @@ public struct TestFlightInventory: Sendable {
 
     public init(databaseURL: URL? = nil) {
         let url = databaseURL ?? Self.defaultDatabaseURL
-        let (rows, iosRows, opened) = Self.readRows(at: url)
+        let (rows, iosRows, iosAvailableRows, opened) = Self.readRows(at: url)
         self.accessible = opened
         self.iosBuildsByBundleID = Self.buildIndex(iosRows)
+        self.iosLatestByBundleID = Self.newestByBundleID(iosAvailableRows)
 
         var latest: [String: App] = [:]
         var builds: [String: Set<String>] = [:]
@@ -110,13 +128,25 @@ public struct TestFlightInventory: Sendable {
     /// it would assert behaviour that only exists in the fixture. `macRows` has no
     /// such precondition — every mac row is kept, installed or not, because
     /// ``latest(forBundleID:)`` is asking what is available.
+    ///
+    /// `availableIOSRows` is the other iOS bucket and carries the opposite
+    /// precondition: it is NOT filtered by install status, because
+    /// ``latestIOS(forBundleID:)`` is asking what TestFlight offers. Passing only
+    /// `installedIOSRows` therefore describes a machine where the user is already
+    /// on the newest beta — a legitimate fixture, and the default, but not the one
+    /// to use for a case about an update being available.
     public init(
         macRows: [(bundleID: String, shortVersion: String, build: String)],
         installedIOSRows: [(bundleID: String, shortVersion: String, build: String)] = [],
+        availableIOSRows: [(bundleID: String, shortVersion: String, build: String)]? = nil,
         accessible: Bool = true
     ) {
         self.accessible = accessible
         self.iosBuildsByBundleID = Self.buildIndex(installedIOSRows)
+        // The database always yields the installed rows as a subset of the
+        // available ones, so a fixture that names only the installed rows gets the
+        // same shape rather than an inventory that says "installed but not offered".
+        self.iosLatestByBundleID = Self.newestByBundleID(availableIOSRows ?? installedIOSRows)
         var latest: [String: App] = [:]
         var builds: [String: Set<String>] = [:]
         for row in macRows {
@@ -184,12 +214,54 @@ public struct TestFlightInventory: Sendable {
         return appsByBundleID[bundleID]
     }
 
+    /// The newest iOS build TestFlight offers for a wrapped iPhone/iPad bundle.
+    ///
+    /// ⚠️ **Only for `isiOSAppOnMac` bundles**, and the caller owns that gate — the
+    /// same split `AppScanner` already applies to `hasInstalledIOSBuild`. A native
+    /// Mac app can hold iOS rows of its own, and handing it this answer is the
+    /// exact corruption `iosBuildsByBundleID` was kept separate to prevent:
+    /// measured 2026-09-09, Paste is on the mac track at 29808607 while its iOS
+    /// track sits at 29814462, so a Mac app routed here would be offered an iPhone
+    /// build as its next Mac update.
+    ///
+    /// ⚠️ **Compatibility is not in this database.** Whether a given build runs on
+    /// this Mac lives in TestFlight's API response (`compatible`), not in any
+    /// column here, so a build offered from these rows can turn out to be
+    /// iPhone-only. The cost is bounded — the row's action is "open TestFlight",
+    /// which is where the real answer is, and nothing is downloaded on our side —
+    /// but it is a real gap, not one this can close.
+    public func latestIOS(forBundleID bundleID: String?) -> App? {
+        guard let bundleID else { return nil }
+        return iosLatestByBundleID[bundleID]
+    }
+
+    /// bundleID → the row with the highest build. Shared by both platform buckets
+    /// so they cannot drift apart in how "newest" is decided.
+    private static func newestByBundleID(
+        _ rows: [(bundleID: String, shortVersion: String, build: String)]
+    ) -> [String: App] {
+        var newest: [String: App] = [:]
+        for row in rows {
+            let candidate = App(
+                bundleID: row.bundleID,
+                latestShortVersion: row.shortVersion, latestBuild: row.build)
+            guard let cur = newest[row.bundleID] else {
+                newest[row.bundleID] = candidate
+                continue
+            }
+            if VersionComparator.isNewer(row.build, than: cur.latestBuild) {
+                newest[row.bundleID] = candidate
+            }
+        }
+        return newest
+    }
+
     // MARK: - SQLite
 
     typealias Row = (bundleID: String, shortVersion: String, build: String)
     /// What one read of the database yields: the two platform buckets, plus
     /// whether we got in at all.
-    typealias Reading = (rows: [Row], iosRows: [Row], opened: Bool)
+    typealias Reading = (rows: [Row], iosRows: [Row], iosAvailableRows: [Row], opened: Bool)
 
     /// How long to wait for the database to open before treating it as
     /// unreachable. Generous: a cold sandboxed sqlite open is milliseconds, so
@@ -224,14 +296,14 @@ public struct TestFlightInventory: Sendable {
     /// Observed 2026-08-15: a nightly sweep sat in `guarded_open_np` for ten
     /// minutes at 0.03s of CPU before it was killed.
     private static func readRows(at url: URL) -> Reading {
-        guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], false) }
+        guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], [], false) }
         // nil covers both give-up modes — this open timed out, or an earlier one
         // for this path is still stranded — and both mean the same thing to the
         // caller: we never got in, so `opened` is false rather than "read it,
         // nothing inside".
         return bounded.run(key: url.path, timeout: openTimeout) {
             openAndRead(at: url)
-        } ?? ([], [], false)
+        } ?? ([], [], [], false)
     }
 
     /// The actual read. Only ever called from `readRows(at:)`'s worker thread.
@@ -242,7 +314,7 @@ public struct TestFlightInventory: Sendable {
         guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
             sqlite3_close(db)
             Log.scan.error("TestFlight DB open failed at \(url.path, privacy: .public)")
-            return ([], [], false)
+            return ([], [], [], false)
         }
         defer { sqlite3_close(db) }
 
@@ -265,7 +337,7 @@ public struct TestFlightInventory: Sendable {
             return reading
         }
         Log.scan.error("TestFlight DB prepare failed")
-        return ([], [], true)  // we opened it; the schema just didn't match
+        return ([], [], [], true)  // we opened it; the schema just didn't match
     }
 
     /// Both platforms, sorted into two buckets by the reader rather than merged.
@@ -312,6 +384,7 @@ public struct TestFlightInventory: Sendable {
 
         var rows: [Row] = []
         var iosRows: [Row] = []
+        var iosAvailableRows: [Row] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
             guard let bundleC = sqlite3_column_text(stmt, 0),
                   let buildC = sqlite3_column_text(stmt, 2) else { continue }
@@ -331,18 +404,22 @@ public struct TestFlightInventory: Sendable {
                 // Every mac row, installed or not: `latest(forBundleID:)` is
                 // asking which builds are AVAILABLE.
                 rows.append((bundleID, short, build))
-            case Self.iOSPlatform
-                where hasInstallStatus && sqlite3_column_int64(stmt, 4) == Self.installedHere:
-                // Only the one TestFlight says is installed here. These rows
-                // answer a membership question, never an "is there something
-                // newer" one, and an available-but-not-installed iOS build is
-                // exactly the thing that must not tag a bundle.
-                iosRows.append((bundleID, short, build))
+            case Self.iOSPlatform:
+                // Every iOS row is what TestFlight OFFERS for this bundle, which is
+                // the only bucket an update can come out of.
+                iosAvailableRows.append((bundleID, short, build))
+                // …and, separately, the one TestFlight says is installed here.
+                // These rows answer a membership question, never an "is there
+                // something newer" one, and an available-but-not-installed iOS
+                // build is exactly the thing that must not tag a bundle.
+                if hasInstallStatus && sqlite3_column_int64(stmt, 4) == Self.installedHere {
+                    iosRows.append((bundleID, short, build))
+                }
             default:
                 break
             }
         }
-        return (rows, iosRows, true)
+        return (rows, iosRows, iosAvailableRows, true)
     }
 
     /// `ZPLATFORMRAW` values, both named because both are now matched positively.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -319,9 +319,12 @@ public struct TestFlightInventory: Sendable {
         // for this path is still stranded — and both mean the same thing to the
         // caller: we never got in, so `opened` is false rather than "read it,
         // nothing inside".
+        // Labelled rather than `([], [], [], false)`: with four elements the bare
+        // literal leaves `bounded.run`'s generic parameter ambiguous between the
+        // tuple type and `Reading`, and the compiler rejects it.
         return bounded.run(key: url.path, timeout: openTimeout) {
             openAndRead(at: url)
-        } ?? ([], [], [], false)
+        } ?? (rows: [], iosRows: [], iosAvailableRows: [], opened: false)
     }
 
     /// The actual read. Only ever called from `readRows(at:)`'s worker thread.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -27,10 +27,18 @@ import SQLite3
 ///     that are *available*, and keeping only the installed one would make every
 ///     app permanently up to date.
 ///   - The newest available build is the highest `ZBUNDLEVERSION` among an app's
-///     macOS rows.
+///     rows **on the platform being asked about** — the two platforms are ranked
+///     separately and never against each other.
+///     ⚠️ Highest by BUILD only, which is wrong when one app carries the same
+///     build number under two marketing versions; the database's own unique index
+///     allows exactly that, and it was measured (see #485). Both buckets share the
+///     defect because they share the ranking.
 public struct TestFlightInventory: Sendable {
 
-    /// The macOS TestFlight builds known for one app, newest first by build.
+    /// The newest TestFlight build known for one app on ONE platform. Both buckets
+    /// use this type — `latest(forBundleID:)` returns the mac answer,
+    /// `latestIOS(forBundleID:)` the iOS one — so nothing here names a platform and
+    /// the caller is the only thing that knows which it asked for.
     public struct App: Sendable, Hashable {
         public let bundleID: String
         /// Marketing version of the newest available build (`ZSHORTVERSION`).
@@ -237,6 +245,16 @@ public struct TestFlightInventory: Sendable {
 
     /// bundleID → the row with the highest build. Shared by both platform buckets
     /// so they cannot drift apart in how "newest" is decided.
+    ///
+    /// ⚠️ **Build only, and that is a known defect (#485), not a simplification.**
+    /// The same build number can appear under two marketing versions — the
+    /// database's unique index is `(bundleID, shortVersion, bundleVersion,
+    /// platformRaw)`, and it was measured on 2026-09-09: `com.jizhi0v0.claude-usage`
+    /// held (0.3.370, 1300) and (0.3.384, 1300) at once. `isNewer` is then false in
+    /// both directions and the row SQLite happened to return first wins, which is
+    /// arbitrary. Fixing it means deciding the tie on the marketing version, in
+    /// #485, for both buckets at once — doing it here alone would leave the two
+    /// ranking differently, which is the thing this function exists to prevent.
     private static func newestByBundleID(
         _ rows: [(bundleID: String, shortVersion: String, build: String)]
     ) -> [String: App] {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -483,4 +483,102 @@ struct WrappedIOSTestFlightTests {
             #expect(inventory.latest(forBundleID: "com.example.other") == nil)
         }
     }
+
+    // MARK: - Which platform's rows may answer (#476)
+
+    /// A wrapped bundle's builds are filed under the iOS platform, so the mac-only
+    /// lookup returned nil for it and the row went to `.testFlightManaged` — never
+    /// an update, however many newer builds TestFlight was offering.
+    ///
+    /// The fixture is the measured one: Claudo on 2026-09-09 had 0.3.384 (1300)
+    /// installed on this Mac with 1301 offered, both iOS rows, both in the local
+    /// database at the moment `duo` reported nothing.
+    ///
+    /// Mutation: put `testflight?.latest(` back in place of the `isiOSAppOnMac`
+    /// branch in `UpdateChecker` — this becomes `.testFlightManaged` and fails.
+    @Test func aWrappedBundleIsOfferedItsNewerIOSBuild() async throws {
+        // The inventory reads the database eagerly, so it outlives the fixture
+        // directory — which is what lets the async check run outside the
+        // (non-async) temporary-root helper.
+        let inventory = try Self.withTemporaryRoot { root -> TestFlightInventory in
+            let db = try Self.plantDatabase([
+                (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.384", build: "1300",
+                 platform: 1, installed: 1),
+                (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.384", build: "1301",
+                 platform: 1, installed: 0),
+            ], in: root)
+            return TestFlightInventory(databaseURL: db)
+        }
+        #expect(inventory.accessible, "fixture database was not opened")
+
+        let app = InstalledApp(
+            name: "ClaudeUsageApp", bundleID: "com.jizhi0v0.claude-usage",
+            shortVersion: "0.3.384", buildVersion: "1300",
+            path: URL(fileURLWithPath: "/Applications/ClaudeUsageApp.app"),
+            isMASApp: false, isiOSAppOnMac: true, isTestFlightApp: true,
+            sparkleFeedURL: nil)
+        let result = await UpdateChecker(sources: [], testflight: inventory).check(app)
+
+        #expect(result.remote?.sourceName == "TestFlight")
+        #expect(result.remote?.version == "1301")
+        guard case .updateAvailable(let latest) = result.status else {
+            Issue.record("expected an update, got \(result.status)")
+            return
+        }
+        // Marketing did not move, so the build disambiguates it.
+        #expect(latest == "0.3.384 (1301)")
+    }
+
+    /// The other half of the same split, and the reason it is a split rather than a
+    /// merge: a native Mac app that ALSO has an iOS track must keep answering from
+    /// the mac rows. Paste's measured shape on 2026-09-09 — mac 6.6.11 (29808607)
+    /// installed, iOS 7.0.0 (29814462) offered.
+    ///
+    /// Mutation: drop the `app.isiOSAppOnMac ?` condition and always ask
+    /// `latestIOS` — this row becomes `updateAvailable("7.0.0")`, an iPhone build
+    /// offered as a Mac update, and the case fails.
+    @Test func aNativeMacAppIsNeverOfferedItsIOSTrack() async throws {
+        let inventory = try Self.withTemporaryRoot { root -> TestFlightInventory in
+            let db = try Self.plantDatabase([
+                (bundleID: "com.wiheads.paste", short: "6.6.11", build: "29808607",
+                 platform: 3, installed: 1),
+                (bundleID: "com.wiheads.paste", short: "7.0.0", build: "29814462",
+                 platform: 1, installed: 0),
+            ], in: root)
+            return TestFlightInventory(databaseURL: db)
+        }
+        #expect(inventory.accessible, "fixture database was not opened")
+
+        let app = InstalledApp(
+            name: "Paste", bundleID: "com.wiheads.paste",
+            shortVersion: "6.6.11", buildVersion: "29808607",
+            path: URL(fileURLWithPath: "/Applications/Paste.app"),
+            isMASApp: false, isiOSAppOnMac: false, isTestFlightApp: true,
+            sparkleFeedURL: nil)
+        let result = await UpdateChecker(sources: [], testflight: inventory).check(app)
+
+        #expect(result.status == .upToDate)
+        #expect(result.remote?.version == "29808607")
+    }
+
+    /// The new availability bucket must not leak into the membership one. An iOS
+    /// build the user merely has access to is offerable — and is still not evidence
+    /// that TestFlight put a copy on this machine, which is the question
+    /// `AppScanner` asks before tagging a bundle at all.
+    ///
+    /// Mutation: build `iosBuildsByBundleID` from the available rows instead of the
+    /// installed ones — the first expectation flips to true and this fails.
+    @Test func anOfferedIOSBuildIsNotEvidenceOfAnInstall() throws {
+        try Self.withTemporaryRoot { root in
+            let db = try Self.plantDatabase([
+                (bundleID: "com.example.app.ios", short: "1.1", build: "77",
+                 platform: 1, installed: 0),
+            ], in: root)
+            let inventory = TestFlightInventory(databaseURL: db)
+            #expect(inventory.accessible, "fixture database was not opened")
+            #expect(!inventory.hasInstalledIOSBuild(
+                bundleID: "com.example.app.ios", installedBuild: "77"))
+            #expect(inventory.latestIOS(forBundleID: "com.example.app.ios")?.latestBuild == "77")
+        }
+    }
 }


### PR DESCRIPTION
关闭条件见 #476。**基于 #483 那条分支**（两者都改 `UpdateChecker` 的 TestFlight 分支，叠着开免得互相冲突）；#483 合并后这条会自动改指 `main`。

## 改了什么

`latest(forBundleID:)` 只索引 `ZPLATFORMRAW = 3`（mac）行，而 wrapped iPhone/iPad bundle 的
build 全部记在 `ZPLATFORMRAW = 1` 下——于是它永远拿到 nil，整行落在 `.testFlightManaged`，
**不管 TestFlight 提供了多少个更新的 build，都不会有更新**。

- `TestFlightInventory` 新增 `latestIOS(forBundleID:)`，由**所有** iOS 行建的索引回答；
- `UpdateChecker` 按 `app.isiOSAppOnMac` **二选一**，不是合并、不是回退。

两张表继续分开，且**由调用方选边**：原生 mac app 可能自己也有 iOS 轨，合表就会把 iPhone 的
build 当成它的下一个 mac 更新。Paste 今天就是这个形状（mac 29808607 装着，iOS 29814462 在供）。

"有没有"和"装没装"也继续分开：新的 latest 索引保留每一条 iOS 行，而
`hasInstalledIOSBuild` 仍然只认 `ZINSTALLSTATUSRAW = 1`。一张表答不了这两个问题——
要么永远给不出更新，要么拿用户"只是有权限"的 build 去给 bundle 打标。

## 验证：在真机上红→绿

为此专门推了一个 TestFlight build（同 marketing、build +1）。**改之前**：

```
$ duo check --json --all /Applications/ClaudeUsageApp.app
{"installedVersion":"0.3.384","installedBuild":"1300","status":"testflight","hasUpdate":false}
```

而同一时刻本机库里两条都在：

```
0.3.384|1300|platform=1|installed=1     ← 磁盘上装着的
0.3.384|1301|platform=1|0               ← TestFlight 在供的
```

**改之后**（`make cli` 装了新二进制，同一台机器同一份数据）：

```
$ duo check --json --all /Applications/ClaudeUsageApp.app
{"installedVersion":"0.3.384","installedBuild":"1300","latestVersion":"0.3.384","latestBuild":"1301",
 "source":"TestFlight","route":"manual","status":"update 0.3.384 (1301)","hasUpdate":true}

$ duo check --json --all /Applications/Paste.app        ← 负对照，必须不受影响
{"installedVersion":"6.6.11","installedBuild":"29808607","latestVersion":"6.6.11",
 "latestBuild":"29808607","source":"TestFlight","status":"up-to-date","hasUpdate":false}
```

## 测试与变异

三条新用例，各自点名它挡的那个变异，三个都实测跑过：

| 变异 | 变红的用例 |
|---|---|
| 退回 `testflight?.latest(`（只看 mac 行） | `aWrappedBundleIsOfferedItsNewerIOSBuild`（3 个断言） |
| 去掉 `isiOSAppOnMac ?`，所有 app 都问 `latestIOS` | `aNativeMacAppIsNeverOfferedItsIOSTrack`（Paste 变成 `updateAvailable("7.0.0")`） |
| 用 available 行去建 membership 表 | `anOfferedIOSBuildIsNotEvidenceOfAnInstall` + 既有的 `onlyTheIOSBuildTestFlightSaysIsInstalledHereCounts` |

第三个连带弄红了一条既有用例，那是这个文件头部就写明的 collateral，不是覆盖面。

```
$ scripts/run-with-hang-report.sh 1800 make test   →  EXIT=0
━ Test run with 2460 tests in 203 suites passed
✔ Test run with 263 tests in 32 suites passed
✓ App tests — 9 of 9 cases executed
```

## 已知缺口，写下来而不是绕过

**这个库里没有"这个 build 在这台 Mac 上跑不跑得起来"这一列**——`compatible` 只存在于
TestFlight 的 API 响应里。所以从 iOS 行提供的更新，理论上可能是一个 iPhone-only 的 build。
代价有界：这一行的动作本来就是"打开 TestFlight"，真正的答案在那里，我们这边不下载任何东西。
注释里写明了，没有假装它不存在。
