### PR TITLE
TestFlight: rank builds by marketing version first, and rank every bucket the same way

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -253,7 +253,21 @@ public struct UpdateChecker: Sendable {
                 // call stale. This does not try to tell the two apart: the answer we
                 // are entitled to give is the same either way, and a guess about
                 // which one it is would be a claim we cannot support.
-                if VersionComparator.isNewer(installedBuild, than: latest.latestBuild) {
+                // Both verdicts compare `VersionSide` pairs, not bare build strings,
+                // because that is the scale the inventory now RANKS on. Mixing the
+                // two is not academic: probed on this branch with mac rows
+                // (1.0, 500) and (2.0, 1) — a major version that restarts build
+                // numbering, which TestFlight allows since build uniqueness is per
+                // marketing version — the ranking correctly picked 2.0, then a
+                // build-only `isNewer("500", "1")` read that as "the database
+                // cannot bound this app" and the row swallowed the update
+                // (`status = testFlightManaged`, remote nil).
+                let installedSide = VersionSide(
+                    marketing: app.shortVersion, build: app.buildVersion)
+                let latestSide = VersionSide(
+                    marketing: latest.latestShortVersion.isEmpty ? nil : latest.latestShortVersion,
+                    build: latest.latestBuild)
+                if VersionComparator.isNewer(installedSide, than: latestSide) {
                     Log.check.info("""
                         \(label, privacy: .public): TestFlight database holds \
                         \(latest.latestBuild, privacy: .public) but \
@@ -265,7 +279,7 @@ public struct UpdateChecker: Sendable {
                     // the one the row shows.
                     return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
                 }
-                let hasUpdate = VersionComparator.isNewer(latest.latestBuild, than: installedBuild)
+                let hasUpdate = VersionComparator.isNewer(latestSide, than: installedSide)
                 // Beta builds often keep the same marketing version across builds,
                 // so disambiguate with the build number when the short string matches.
                 let display = (latest.latestShortVersion == app.shortVersion)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -17,22 +17,31 @@ import SQLite3
 ///     and it is the CALLER that picks a side, from `isiOSAppOnMac`. A native Mac
 ///     app can hold iOS rows of its own, so a merged table would offer it an
 ///     iPhone build as its next Mac update.
-///   - `ZINSTALLSTATUSRAW` 1 == the build currently installed on this machine.
-///     Measured 2026-09-08: 6 of 110 rows carry it, no nulls, values only 0/1,
-///     never twice for one (bundle, platform) — and all 6 matched an app on disk
-///     at exactly that build. It is what separates "TestFlight installed this
-///     here" from "the user merely has access to this build", which is the
-///     question ``hasInstalledIOSBuild(bundleID:installedBuild:)`` asks. Mac rows
+///   - `ZINSTALLSTATUSRAW` 1 == a build TestFlight installed on this machine.
+///     Measured 2026-09-08: 6 of 110 rows carry it, no nulls, values only 0/1, and
+///     all 6 matched an app on disk at exactly that build. It is what separates
+///     "TestFlight installed this here" from "the user merely has access to this
+///     build", which is the question ``hasInstalledIOSBuild(bundleID:installedBuild:)``
+///     asks.
+///     ⚠️ **It is NOT unique per (bundle, platform)**, and an earlier version of
+///     this note said it was, on that one sample. Falsified 2026-09-09, watching
+///     TestFlight auto-install a build we had just pushed: both rows stayed marked
+///     installed —
+///     ```
+///     com.jizhi0v0.claude-usage | 0.3.384 | 1300 | platform 1 | installed 1
+///     com.jizhi0v0.claude-usage | 0.3.384 | 1301 | platform 1 | installed 1
+///     ```
+///     while only 1301 was on disk. Membership is the only safe question to ask of
+///     this column: "is this on-disk build one TestFlight put here" survives the
+///     stale row, "which build is installed" does not. Mac rows
 ///     deliberately do NOT filter on it: ``latest(forBundleID:)`` needs the builds
 ///     that are *available*, and keeping only the installed one would make every
 ///     app permanently up to date.
-///   - The newest available build is the highest `ZBUNDLEVERSION` among an app's
-///     rows **on the platform being asked about** — the two platforms are ranked
-///     separately and never against each other.
-///     ⚠️ Highest by BUILD only, which is wrong when one app carries the same
-///     build number under two marketing versions; the database's own unique index
-///     allows exactly that, and it was measured (see #485). Both buckets share the
-///     defect because they share the ranking.
+///   - The newest available build is the newest row **on the platform being asked
+///     about** — the two platforms are ranked separately and never against each
+///     other. Newest means `VersionSide`: `ZSHORTVERSION` first, `ZBUNDLEVERSION`
+///     only to break a marketing tie. Both halves are load-bearing, and the
+///     reasoning (with the rows that measured each) is on ``newestByBundleID``.
 public struct TestFlightInventory: Sendable {
 
     /// The newest TestFlight build known for one app on ONE platform. Both buckets

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -104,23 +104,9 @@ public struct TestFlightInventory: Sendable {
         self.iosBuildsByBundleID = Self.buildIndex(iosRows)
         self.iosLatestByBundleID = Self.newestByBundleID(iosAvailableRows)
 
-        var latest: [String: App] = [:]
         var builds: [String: Set<String>] = [:]
-        for row in rows {
-            builds[row.bundleID, default: []].insert(row.build)
-            if let cur = latest[row.bundleID] {
-                if VersionComparator.isNewer(row.build, than: cur.latestBuild) {
-                    latest[row.bundleID] = App(
-                        bundleID: row.bundleID,
-                        latestShortVersion: row.shortVersion, latestBuild: row.build)
-                }
-            } else {
-                latest[row.bundleID] = App(
-                    bundleID: row.bundleID,
-                    latestShortVersion: row.shortVersion, latestBuild: row.build)
-            }
-        }
-        self.appsByBundleID = latest
+        for row in rows { builds[row.bundleID, default: []].insert(row.build) }
+        self.appsByBundleID = Self.newestByBundleID(rows)
         self.buildsByBundleID = builds
     }
 
@@ -155,19 +141,9 @@ public struct TestFlightInventory: Sendable {
         // available ones, so a fixture that names only the installed rows gets the
         // same shape rather than an inventory that says "installed but not offered".
         self.iosLatestByBundleID = Self.newestByBundleID(availableIOSRows ?? installedIOSRows)
-        var latest: [String: App] = [:]
         var builds: [String: Set<String>] = [:]
-        for row in macRows {
-            builds[row.bundleID, default: []].insert(row.build)
-            if let cur = latest[row.bundleID] {
-                if VersionComparator.isNewer(row.build, than: cur.latestBuild) {
-                    latest[row.bundleID] = App(bundleID: row.bundleID, latestShortVersion: row.shortVersion, latestBuild: row.build)
-                }
-            } else {
-                latest[row.bundleID] = App(bundleID: row.bundleID, latestShortVersion: row.shortVersion, latestBuild: row.build)
-            }
-        }
-        self.appsByBundleID = latest
+        for row in macRows { builds[row.bundleID, default: []].insert(row.build) }
+        self.appsByBundleID = Self.newestByBundleID(macRows)
         self.buildsByBundleID = builds
     }
 
@@ -243,21 +219,44 @@ public struct TestFlightInventory: Sendable {
         return iosLatestByBundleID[bundleID]
     }
 
-    /// bundleID → the row with the highest build. Shared by both platform buckets
-    /// so they cannot drift apart in how "newest" is decided.
+    /// bundleID → the newest row. **Every** bucket ranks through here — mac and
+    /// iOS, real database and test seam — so they cannot drift apart in how
+    /// "newest" is decided.
     ///
-    /// ⚠️ **Build only, and that is a known defect (#485), not a simplification.**
-    /// The same build number can appear under two marketing versions — the
-    /// database's unique index is `(bundleID, shortVersion, bundleVersion,
-    /// platformRaw)`, and it was measured on 2026-09-09: `com.jizhi0v0.claude-usage`
-    /// held (0.3.370, 1300) and (0.3.384, 1300) at once. `isNewer` is then false in
-    /// both directions and the row SQLite happened to return first wins, which is
-    /// arbitrary. Fixing it means deciding the tie on the marketing version, in
-    /// #485, for both buckets at once — doing it here alone would leave the two
-    /// ranking differently, which is the thing this function exists to prevent.
+    /// Newest means `VersionSide`: marketing version first, build only to break a
+    /// marketing tie. Both halves are load-bearing here, and each is the whole
+    /// answer for some app in this database:
+    ///
+    ///   * **Build alone is not enough.** The same build number can appear under
+    ///     two marketing versions — the database's unique index is `(bundleID,
+    ///     shortVersion, bundleVersion, platformRaw)`, and ASC's build-number
+    ///     uniqueness is per marketing version, so this is a shape it is designed
+    ///     to hold. Measured 2026-09-09: `com.jizhi0v0.claude-usage` held
+    ///     (0.3.370, 1300) and (0.3.384, 1300) at once. Comparing builds alone made
+    ///     `isNewer` false in both directions, so whichever row SQLite happened to
+    ///     return first won — and the query has no `ORDER BY`, so "newest" was
+    ///     arbitrary and could name an expired version older than the installed one
+    ///     (#485).
+    ///   * **Marketing alone is not enough.** Beta tracks routinely freeze it:
+    ///     APTV's rows are all `1.0` with builds 300/301/304, and Claudo shipped
+    ///     0.3.384 twice (1300, then 1301). For those apps the build is the whole
+    ///     comparison.
+    ///
+    /// A blank `ZSHORTVERSION` is folded to nil rather than passed through: the
+    /// comparator's tokenizer reads a string with no digits the same as `"0"`, so
+    /// an empty marketing string would lose every comparison it entered instead of
+    /// standing aside and letting the build decide.
+    ///
+    /// ⚠️ Marketing-first means a row whose build is higher but whose marketing
+    /// version is LOWER does not win — a hotfix cut from an older line, say. That
+    /// is `VersionComparator`'s rule everywhere in this codebase rather than a
+    /// choice made here, and the alternative (build-first) is what #485 was.
     private static func newestByBundleID(
         _ rows: [(bundleID: String, shortVersion: String, build: String)]
     ) -> [String: App] {
+        func side(marketing: String, build: String) -> VersionSide {
+            VersionSide(marketing: marketing.isEmpty ? nil : marketing, build: build)
+        }
         var newest: [String: App] = [:]
         for row in rows {
             let candidate = App(
@@ -267,7 +266,10 @@ public struct TestFlightInventory: Sendable {
                 newest[row.bundleID] = candidate
                 continue
             }
-            if VersionComparator.isNewer(row.build, than: cur.latestBuild) {
+            if VersionComparator.isNewer(
+                side(marketing: row.shortVersion, build: row.build),
+                than: side(marketing: cur.latestShortVersion, build: cur.latestBuild)
+            ) {
                 newest[row.bundleID] = candidate
             }
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
@@ -176,6 +176,40 @@ final class TestFlightInventoryTests: XCTestCase {
         XCTAssertNil(result.remote)
     }
 
+    /// The verdicts have to be on the same scale the inventory RANKS on. A major
+    /// version that restarts build numbering is legal here — TestFlight's build
+    /// uniqueness is per marketing version — and it puts the two scales in direct
+    /// conflict: 2.0 (1) is the newest row, while its build is far below the
+    /// installed 1.0 (500).
+    ///
+    /// Probed on the branch before this was fixed: the ranking picked 2.0
+    /// correctly, then the build-only `isNewer("500", "1")` read that as "the
+    /// database cannot bound this app" and the row swallowed the update entirely
+    /// (`status = testFlightManaged`, `remote = nil`) — the user never learns 2.0
+    /// exists.
+    ///
+    /// Mutation: put either verdict back on bare build strings
+    /// (`isNewer(installedBuild, than: latest.latestBuild)` or its mirror) — this
+    /// becomes `.testFlightManaged` / `.upToDate` and fails.
+    func testCheckerOffersAMarketingBumpThatRestartsBuildNumbering() async {
+        let tf = TestFlightInventory(macRows: [
+            (bundleID: "com.example.reset", shortVersion: "1.0", build: "500"),
+            (bundleID: "com.example.reset", shortVersion: "2.0", build: "1"),
+        ])
+        let checker = UpdateChecker(sources: [], testflight: tf)
+        let app = InstalledApp(
+            name: "Reset", bundleID: "com.example.reset",
+            shortVersion: "1.0", buildVersion: "500",
+            path: URL(fileURLWithPath: "/Applications/Reset.app"),
+            isMASApp: false, isTestFlightApp: true, sparkleFeedURL: nil)
+        let result = await checker.check(app)
+        guard case .updateAvailable(let latest) = result.status else {
+            return XCTFail("expected an update, got \(result.status)")
+        }
+        XCTAssertEqual(latest, "2.0")
+        XCTAssertEqual(result.remote?.version, "1")
+    }
+
     func testCheckerManagedWhenNoCache() async {
         // TestFlight app but the inventory has nothing for it → managed label.
         let checker = UpdateChecker(sources: [], testflight: TestFlightInventory(macRows: []))

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -581,4 +581,71 @@ struct WrappedIOSTestFlightTests {
             #expect(inventory.latestIOS(forBundleID: "com.example.app.ios")?.latestBuild == "77")
         }
     }
+
+    // MARK: - Ranking (#485)
+
+    /// The same build number under two marketing versions is a shape this database
+    /// is designed to hold — ASC's build-number uniqueness is per marketing
+    /// version — and it was measured on 2026-09-09: `com.jizhi0v0.claude-usage`
+    /// held (0.3.370, 1300) and (0.3.384, 1300) at once, with 0.3.370 long expired.
+    ///
+    /// Ranking on the build alone made `isNewer` false in both directions, so the
+    /// winner was whichever row SQLite returned first — and the query has no
+    /// `ORDER BY`. **Both insertion orders are asserted** because one of them
+    /// passes under the broken rule by luck, and a case that only tried that one
+    /// would have been green on the bug.
+    ///
+    /// Mutation: rank on `row.build` alone again — the second order fails.
+    @Test(arguments: [false, true])
+    func aMarketingBumpWinsATiedBuildInEitherOrder(reversed: Bool) throws {
+        var rows: [(bundleID: String, short: String, build: String, platform: Int32, installed: Int32)] = [
+            (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.370", build: "1300",
+             platform: 1, installed: 0),
+            (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.384", build: "1300",
+             platform: 1, installed: 1),
+        ]
+        if reversed { rows.reverse() }
+        try Self.withTemporaryRoot { root in
+            let inventory = TestFlightInventory(databaseURL: try Self.plantDatabase(rows, in: root))
+            #expect(inventory.accessible, "fixture database was not opened")
+            let latest = inventory.latestIOS(forBundleID: "com.jizhi0v0.claude-usage")
+            #expect(latest?.latestShortVersion == "0.3.384")
+            #expect(latest?.latestBuild == "1300")
+        }
+    }
+
+    /// The mac bucket ranks through the same function, so the fix has to hold there
+    /// too — and it is the bucket every native TestFlight app uses.
+    ///
+    /// Mutation: give `appsByBundleID` its own build-only loop back (the shape both
+    /// initialisers carried before) — the second order fails here instead.
+    @Test(arguments: [false, true])
+    func theMacBucketRanksByTheSameRule(reversed: Bool) throws {
+        var rows: [(bundleID: String, short: String, build: String, platform: Int32, installed: Int32)] = [
+            (bundleID: "com.example.mac", short: "2.0", build: "500", platform: 3, installed: 0),
+            (bundleID: "com.example.mac", short: "2.1", build: "500", platform: 3, installed: 0),
+        ]
+        if reversed { rows.reverse() }
+        try Self.withTemporaryRoot { root in
+            let inventory = TestFlightInventory(databaseURL: try Self.plantDatabase(rows, in: root))
+            #expect(inventory.latest(forBundleID: "com.example.mac")?.latestShortVersion == "2.1")
+        }
+    }
+
+    /// The other half of the rule, and the one a marketing-only fix would break: a
+    /// frozen marketing version is the norm on a beta track (APTV's rows are all
+    /// `1.0`; Claudo shipped 0.3.384 twice), so the build has to decide the tie.
+    ///
+    /// Mutation: rank on marketing alone — this returns 1300 and fails.
+    @Test func afrozenMarketingVersionStillLetsTheBuildDecide() throws {
+        try Self.withTemporaryRoot { root in
+            let inventory = TestFlightInventory(databaseURL: try Self.plantDatabase([
+                (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.384", build: "1300",
+                 platform: 1, installed: 1),
+                (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.384", build: "1301",
+                 platform: 1, installed: 0),
+            ], in: root))
+            #expect(inventory.latestIOS(forBundleID: "com.jizhi0v0.claude-usage")?.latestBuild == "1301")
+        }
+    }
 }


### PR DESCRIPTION
Closes #485。

## 缺陷

`TestFlightInventory` 选"最新"只比 build 号，而**同一个 build 号可以出现在两个 marketing 版本下**
——ASC 的 build 唯一性按 marketing 版本算，库自己的唯一索引就是
`(ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION, ZPLATFORMRAW)`。两条并列时 `isNewer` 两个方向都假，
于是留下 **SQLite 先返回的那条**，而查询没有 `ORDER BY`。

2026-09-09 实测，`com.jizhi0v0.claude-usage` 库里正好是这两行：

```
0.3.370|1300|platform=1      ← 5 月的，早就过期
0.3.384|1300|platform=1
```

挑中前者，"最新可用"就报成一个**比装着的还老的过期版本**，而且 #483 那道自证闸也抓不到——build 相等。

## 改法

排序换成 `VersionSide`：**marketing 优先，marketing 打平时才由 build 裁决**——
就是这个仓库其它地方一直在用的那条规则。两半都承重，各自都有本库里的实例：

- **只比 build 不够**：上面那两行。
- **只比 marketing 不够**：beta 轨常年冻结 marketing——APTV 的行全是 `1.0`（build 300/301/304），
  Claudo 的 `0.3.384` 发了两次（1300、1301）。这些 app 的比较全靠 build。

顺带把**三份排序合成一份**：mac 索引在两个 initializer 里各有一段内联循环，所以那个
helper 注释里"两个 bucket 不会漂"其实只对 iOS 那半成立。现在真的成立了。

空的 `ZSHORTVERSION` 折成 nil 而不是原样传：比较器的分词把"没有数字的串"当 `"0"`，
空 marketing 会输掉它参与的每一次比较，而不是让位给 build。

## 测试与变异

三条用例，两条是参数化的（**两种插入顺序都断言**——其中一种在旧规则下会**碰巧通过**，
只测那一种的用例会在 bug 上绿着）：

| 变异 | 变红的 |
|---|---|
| 退回只比 `row.build` | `aMarketingBumpWinsATiedBuildInEitherOrder`（**只有 `reversed → false` 那一格**，正是"碰巧通过"的证据）+ `theMacBucketRanksByTheSameRule` |
| 只比 marketing（能编译的写法） | `afrozenMarketingVersionStillLetsTheBuildDecide` + `aWrappedBundleIsOfferedItsNewerIOSBuild` |

⚠️ 第一版的"只比 marketing"变异我写成了 `build: nil` 传给一个 `build: String` 的局部函数，
**编译不过**——那不算变异验证，重写成能编译的形式才拿到上面这个结果。

```
$ scripts/run-with-hang-report.sh 1800 make test   →  EXIT=0
━ Test run with 2494 tests in 206 suites passed
✔ Test run with 263 tests in 32 suites passed
✓ App tests — 9 of 9 cases executed
✓ version comparisons discriminate — 246 files, 8 marketing-first pick(s), all display-only
```

## 真机

`make cli` 之后，本机五个 TestFlight 行全部自洽：

```
ClaudeUsageApp  0.3.384 (1300) → update 0.3.384 (1301)
Mithka          1.4.0 (1138)   up-to-date
Notability      16.12 (7127)   up-to-date
Nowledge Mem    0.10.79        up-to-date
Paste           6.6.11         up-to-date
ScreenCam       1.3.1          up-to-date
```

## 已知取舍

marketing 优先意味着**build 更高但 marketing 更低的行不会赢**（比如从旧线切出来的 hotfix）。
那是 `VersionComparator` 在这个仓库里的既定语义，不是这里新做的选择；反过来的那种（build 优先）
正是 #485 本身。写在函数注释里了。
