### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,16 +43,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
-      "lastGoodVersion" : "1.18.29",
+      "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
     "changelog:app.chatwise:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.2",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -133,7 +133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
@@ -142,7 +142,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
@@ -151,7 +151,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -160,7 +160,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.84.0",
       "sweepsSinceComment" : 0
@@ -169,7 +169,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -178,7 +178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
@@ -187,7 +187,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -196,7 +196,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
@@ -205,7 +205,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
@@ -214,7 +214,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -223,7 +223,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -232,7 +232,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -241,7 +241,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -250,7 +250,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -259,7 +259,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -268,7 +268,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -277,7 +277,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
@@ -286,7 +286,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
@@ -295,7 +295,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -304,7 +304,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -313,7 +313,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -322,7 +322,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -331,7 +331,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -340,7 +340,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
@@ -349,7 +349,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -358,7 +358,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.136",
       "sweepsSinceComment" : 0
@@ -367,7 +367,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -378,7 +378,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
@@ -388,7 +388,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
@@ -397,7 +397,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -406,7 +406,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -415,38 +415,37 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 30,
-      "lastGoodVersion" : "12.27.1",
+      "lastGoodVersion" : "12.27.2",
       "sweepsSinceComment" : 0
     },
     "changelog:com.qoder.app:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.2.1",
       "sweepsSinceComment" : 0
     },
     "changelog:com.qoder.ide:-" : {
-      "consecutiveActionable" : 3,
+      "closedAt" : "2026-09-09T08:25:08Z",
+      "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastCommentedAt" : "2026-09-08T20:27:23Z",
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
-      "lastGoodVersion" : "1.28.0",
-      "lastSignature" : "newest changelog entry (1.28.0) trails t",
-      "sweepsSinceComment" : 1,
+      "lastGoodVersion" : "1.29.0",
+      "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (1.28.0) trails t"
     },
     "changelog:com.raycast.macos:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -455,7 +454,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -464,7 +463,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.2",
       "sweepsSinceComment" : 0
@@ -473,7 +472,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -482,7 +481,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -491,7 +490,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -500,7 +499,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -511,7 +510,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609082",
       "sweepsSinceComment" : 0,
@@ -521,7 +520,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -530,7 +529,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -539,7 +538,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -548,7 +547,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -557,7 +556,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -566,7 +565,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
@@ -575,7 +574,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260906",
       "sweepsSinceComment" : 0
@@ -584,7 +583,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -593,7 +592,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -602,7 +601,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -611,7 +610,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -620,7 +619,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -631,7 +630,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -641,16 +640,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
-      "lastGoodVersion" : "5.5.3",
+      "lastGoodVersion" : "5.5.4",
       "sweepsSinceComment" : 0
     },
     "changelog:dev.kdrag0n.MacVirt:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -659,7 +658,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -668,7 +667,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
@@ -677,7 +676,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.02",
       "sweepsSinceComment" : 0
@@ -686,7 +685,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
@@ -695,7 +694,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
@@ -704,7 +703,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -713,7 +712,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -722,7 +721,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
@@ -731,7 +730,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -740,7 +739,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -749,34 +748,35 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "0.16.5.1",
+      "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
     "changelog:net.kovidgoyal.calibre:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
     "changelog:notion.id:-" : {
-      "consecutiveActionable" : 0,
+      "consecutiveActionable" : 1,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
-      "sweepsSinceComment" : 0
+      "lastSignature" : "newest changelog entry (7.32.0) trails t",
+      "sweepsSinceComment" : 1
     },
     "changelog:now.typeless.desktop:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
@@ -785,7 +785,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -794,7 +794,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -812,7 +812,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -821,7 +821,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
@@ -830,7 +830,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -839,7 +839,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -848,7 +848,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -857,7 +857,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -866,7 +866,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
@@ -875,7 +875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -884,7 +884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 13,
       "lastGoodVersion" : "0.1.18",
       "sweepsSinceComment" : 0
@@ -893,7 +893,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 17,
       "lastGoodVersion" : "1.7.1",
       "sweepsSinceComment" : 0
@@ -902,7 +902,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
@@ -911,23 +911,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "3.13.2",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
     "feed:net.imput.helium" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "0.16.5.1",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
     "github:AprilNEA\/OpenLogi:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -935,7 +935,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -943,7 +943,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -951,7 +951,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -959,7 +959,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -967,7 +967,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -975,7 +975,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -983,7 +983,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.3.9",
       "sweepsSinceComment" : 0
     },
@@ -991,7 +991,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -999,7 +999,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1007,7 +1007,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1015,7 +1015,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1023,7 +1023,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.126.04524",
       "sweepsSinceComment" : 0
     },
@@ -1031,7 +1031,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1039,7 +1039,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1047,7 +1047,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1055,7 +1055,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1063,7 +1063,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1071,7 +1071,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1079,7 +1079,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1087,7 +1087,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1095,15 +1095,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "1.18.29",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
     "github:anywhere-labs\/dsh-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1111,7 +1111,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1119,7 +1119,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1127,7 +1127,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1135,7 +1135,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1143,7 +1143,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1151,7 +1151,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1159,7 +1159,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1167,7 +1167,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1175,7 +1175,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1183,7 +1183,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1191,7 +1191,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1199,7 +1199,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1207,7 +1207,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1215,7 +1215,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1223,7 +1223,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1231,7 +1231,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1239,7 +1239,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1247,7 +1247,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1255,7 +1255,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.20.2",
       "sweepsSinceComment" : 0
     },
@@ -1263,7 +1263,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1271,7 +1271,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1279,7 +1279,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1287,7 +1287,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1295,7 +1295,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.1.16",
       "sweepsSinceComment" : 0
     },
@@ -1303,7 +1303,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1311,15 +1311,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "0.16.5.1",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
     "github:janhq\/jan:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1327,7 +1327,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1335,7 +1335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1343,7 +1343,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1351,7 +1351,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1359,7 +1359,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1367,7 +1367,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1375,7 +1375,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1383,7 +1383,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1391,7 +1391,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1399,7 +1399,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1407,7 +1407,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1415,7 +1415,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -1423,7 +1423,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1431,7 +1431,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1439,7 +1439,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1447,7 +1447,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -1455,7 +1455,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.22.2",
       "sweepsSinceComment" : 0
     },
@@ -1463,7 +1463,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1471,15 +1471,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "0.0.41-nightly.20260909.1426",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "0.0.41-nightly.20260909.1439",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1487,7 +1487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1495,7 +1495,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1503,7 +1503,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1511,7 +1511,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1519,7 +1519,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1527,7 +1527,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1535,7 +1535,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1543,7 +1543,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1551,7 +1551,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1559,7 +1559,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1567,7 +1567,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1575,7 +1575,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1583,7 +1583,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1591,7 +1591,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1599,7 +1599,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1607,7 +1607,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1615,7 +1615,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1645,7 +1645,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1653,7 +1653,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1661,7 +1661,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1669,7 +1669,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.18.1",
       "sweepsSinceComment" : 0
     },
@@ -1677,7 +1677,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1817,7 +1817,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1825,7 +1825,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1833,7 +1833,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1841,7 +1841,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1849,7 +1849,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1857,7 +1857,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1865,7 +1865,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1873,7 +1873,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1881,7 +1881,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.2.1",
       "sweepsSinceComment" : 0
     },
@@ -1889,7 +1889,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
     },
@@ -1897,7 +1897,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1905,7 +1905,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.44.0",
       "sweepsSinceComment" : 0
     },
@@ -1913,7 +1913,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1921,7 +1921,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "8.7.9",
       "sweepsSinceComment" : 0
     },
@@ -1929,7 +1929,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1937,7 +1937,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1945,7 +1945,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1953,7 +1953,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1961,7 +1961,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1969,7 +1969,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.95.96.0",
       "sweepsSinceComment" : 0
     },
@@ -1977,7 +1977,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.97.14.0",
       "sweepsSinceComment" : 0
     },
@@ -1985,7 +1985,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.9.7",
       "sweepsSinceComment" : 0
     },
@@ -1993,7 +1993,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.125.0",
       "sweepsSinceComment" : 0
     },
@@ -2001,7 +2001,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.84.2",
       "sweepsSinceComment" : 0
     },
@@ -2009,7 +2009,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2017,7 +2017,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2025,7 +2025,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2033,7 +2033,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.6.793",
       "sweepsSinceComment" : 0
     },
@@ -2041,7 +2041,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.9.19",
       "sweepsSinceComment" : 0
     },
@@ -2049,7 +2049,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2057,7 +2057,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2065,7 +2065,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2073,7 +2073,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "154.0.8037.0",
       "sweepsSinceComment" : 0
     },
@@ -2081,15 +2081,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "155.0.8046.0",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "155.0.8048.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.google.Chrome.dev:dev" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -2097,7 +2097,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2105,7 +2105,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.107.3.828",
       "sweepsSinceComment" : 0
     },
@@ -2113,7 +2113,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2121,7 +2121,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -2129,7 +2129,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2137,7 +2137,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2145,7 +2145,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -2153,7 +2153,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "7.543.2",
       "sweepsSinceComment" : 0
     },
@@ -2161,7 +2161,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2169,7 +2169,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2177,7 +2177,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.0.1313",
       "sweepsSinceComment" : 0
     },
@@ -2185,7 +2185,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -2193,7 +2193,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -2201,7 +2201,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2209,7 +2209,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2217,7 +2217,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2227,7 +2227,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "9.5.0-beta2",
       "sweepsSinceComment" : 0
     },
@@ -2237,7 +2237,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2245,7 +2245,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2253,7 +2253,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -2261,7 +2261,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2269,7 +2269,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2277,7 +2277,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -2285,7 +2285,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2293,7 +2293,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2301,7 +2301,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.136.2",
       "sweepsSinceComment" : 0
     },
@@ -2309,7 +2309,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.137.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -2317,7 +2317,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2325,7 +2325,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "153.0.4234.19",
       "sweepsSinceComment" : 0
     },
@@ -2333,7 +2333,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "154.0.4251.0",
       "sweepsSinceComment" : 0
     },
@@ -2341,7 +2341,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -2349,7 +2349,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2357,7 +2357,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2365,7 +2365,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2373,7 +2373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2381,7 +2381,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2389,7 +2389,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2397,15 +2397,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "26.901.51231",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "26.903.61454",
       "sweepsSinceComment" : 0
     },
     "vendor:com.operasoftware.Opera:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -2413,7 +2413,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2421,7 +2421,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2429,23 +2429,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "12.27.1",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "12.27.2",
       "sweepsSinceComment" : 0
     },
     "vendor:com.qoder.app:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "0.2.1",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "0.2.2",
       "sweepsSinceComment" : 0
     },
     "vendor:com.qoder.ide:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2453,7 +2453,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.104.28",
       "sweepsSinceComment" : 0
     },
@@ -2461,7 +2461,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.2.1.0",
       "sweepsSinceComment" : 0
     },
@@ -2469,7 +2469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2477,7 +2477,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2485,7 +2485,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2493,7 +2493,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2501,7 +2501,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2509,7 +2509,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2517,7 +2517,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2525,7 +2525,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2535,7 +2535,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "7.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2544,7 +2544,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2554,7 +2554,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2563,7 +2563,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.02.2609082",
       "sweepsSinceComment" : 0
     },
@@ -2571,7 +2571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2579,7 +2579,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2587,7 +2587,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2595,7 +2595,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "9.44.0",
       "sweepsSinceComment" : 0
     },
@@ -2603,7 +2603,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "9.43.1",
       "sweepsSinceComment" : 0
     },
@@ -2611,7 +2611,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2619,7 +2619,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2627,7 +2627,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.19.19",
       "sweepsSinceComment" : 0
     },
@@ -2635,7 +2635,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.21.1",
       "sweepsSinceComment" : 0
     },
@@ -2643,7 +2643,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "8.2.4133.43",
       "sweepsSinceComment" : 0
     },
@@ -2651,7 +2651,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2659,7 +2659,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2667,7 +2667,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2675,7 +2675,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2683,7 +2683,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2691,7 +2691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2699,7 +2699,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2707,7 +2707,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2715,7 +2715,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2723,7 +2723,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2731,7 +2731,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2739,7 +2739,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2747,7 +2747,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2755,7 +2755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.2026.09.08.18.11.00",
       "sweepsSinceComment" : 0
     },
@@ -2763,7 +2763,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2771,7 +2771,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2779,7 +2779,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2787,7 +2787,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2026090701",
       "sweepsSinceComment" : 0
     },
@@ -2795,7 +2795,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2803,7 +2803,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2811,7 +2811,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2819,7 +2819,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2827,7 +2827,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.103.201",
       "sweepsSinceComment" : 0
     },
@@ -2835,7 +2835,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2843,7 +2843,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2851,7 +2851,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2859,7 +2859,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2867,7 +2867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "26.36.18",
       "sweepsSinceComment" : 0
     },
@@ -2875,15 +2875,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
-      "lastGoodVersion" : "7.32.1",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
     "vendor:now.typeless.desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2891,7 +2891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2899,7 +2899,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2907,7 +2907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2915,23 +2915,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
+      "infraSince" : "2026-09-09T08:25:06Z",
       "lastGoodAt" : "2026-09-09T02:22:27Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 0
+      "sweepsSinceComment" : 1
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2939,7 +2940,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "156.0b4",
       "sweepsSinceComment" : 0
     },
@@ -2947,7 +2948,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2955,7 +2956,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2963,7 +2964,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "156.0b4",
       "sweepsSinceComment" : 0
     },
@@ -2971,7 +2972,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2979,7 +2980,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2987,7 +2988,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2995,7 +2996,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -3003,7 +3004,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "156.0b2",
       "sweepsSinceComment" : 0
     },
@@ -3011,7 +3012,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3019,7 +3020,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3027,7 +3028,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3035,7 +3036,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -3043,7 +3044,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "8.26.0",
       "sweepsSinceComment" : 0
     },
@@ -3053,7 +3054,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "10.0.1",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -3062,7 +3063,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3070,11 +3071,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-09T08:25:06Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-09T02:22:28Z"
+  "updatedAt" : "2026-09-09T08:25:08Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.