### PR TITLE
Add an explicit TestFlight refresh: background launch, then wait for the store to settle

### DIFF
--- a/CLI/Sources/DuoKit/Check.swift
+++ b/CLI/Sources/DuoKit/Check.swift
@@ -57,8 +57,12 @@ public enum Check {
     static func describe(_ outcome: TestFlightRefresh.Outcome) -> String {
         switch outcome {
         case .refreshed(let after):
+            // The moment the store last changed, NOT how long the command waited:
+            // the wait runs on past it by `settleInterval` to be sure the sync has
+            // finished. Measured 6.0s here against 14.0s wall clock, so saying
+            // "took" would be wrong by more than half.
             let seconds = Double(after.components.seconds) + Double(after.components.attoseconds) / 1e18
-            return String(format: "duo: TestFlight refreshed its data (launched in the background, %.1fs)", seconds)
+            return String(format: "duo: TestFlight refreshed its data (launched in the background; new data landed after %.1fs)", seconds)
         case .launchedWithoutChange:
             return "duo: launched TestFlight in the background; its data did not change"
         case .alreadyRunning:
@@ -87,6 +91,17 @@ public enum Check {
 
     public static func run(_ options: Options) async -> Int32 {
         let settings = Settings.load()
+        // Before the scan, not just before the check. `AppScanner` reads the
+        // TestFlight store too — that is where a bundle gets tagged
+        // `isTestFlightApp`, and for a wrapped iPhone/iPad app the store is the
+        // evidence (#456), the receipt being unavailable. Refreshing after the scan
+        // would leave this run's tagging on the stale store and only fix the
+        // version comparison, so a beta installed since the last sync would still
+        // be read as something else until the next invocation.
+        if options.refreshTestFlight {
+            let outcome = await TestFlightRefresh().run()
+            FileHandle.standardError.write(Data((describe(outcome) + "\n").utf8))
+        }
         let apps = await Inventory.scan(settings)
         let selected: [InstalledApp]
         switch Inventory.select(apps, matching: options.queries) {
@@ -104,14 +119,6 @@ public enum Check {
             ? settings.appsWorthChecking(
                 selected, named: !options.queries.isEmpty, includeHidden: options.includeHidden)
             : selected
-
-        if options.refreshTestFlight {
-            // Before the inventory is read, not after: `Inventory.checker` builds a
-            // `TestFlightInventory` by reading the store, so a refresh that lands
-            // afterwards would not be seen until the next run.
-            let outcome = await TestFlightRefresh().run()
-            FileHandle.standardError.write(Data((describe(outcome) + "\n").utf8))
-        }
 
         let results: [UpdateResult]
         if options.checkForUpdates {

--- a/CLI/Sources/DuoKit/Check.swift
+++ b/CLI/Sources/DuoKit/Check.swift
@@ -19,6 +19,13 @@ public enum Check {
         /// against `RemoteVersion.sourceName` ("Sparkle", "Homebrew", "Vendor",
         /// "GitHub", "App Store", …). Empty means every source.
         public var sources: Set<String> = []
+        /// Ask TestFlight to refresh its local store before checking.
+        ///
+        /// Off by default and never implied: it starts an app the user did not
+        /// start. See `TestFlightRefresh` for why a background launch is the only
+        /// form of this we are willing to offer, and #478 for why the store goes
+        /// stale in the first place.
+        public var refreshTestFlight = false
         public init() {}
     }
 
@@ -42,6 +49,26 @@ public enum Check {
         let hasUpdate: Bool
         let hidden: Bool
         let route: String?
+    }
+
+    /// What to tell the user about a refresh attempt. Written to stderr so `--json`
+    /// stays one object per line, and phrased so that "we launched TestFlight" is
+    /// never left implicit — the user is entitled to know why an app appeared.
+    static func describe(_ outcome: TestFlightRefresh.Outcome) -> String {
+        switch outcome {
+        case .refreshed(let after):
+            let seconds = Double(after.components.seconds) + Double(after.components.attoseconds) / 1e18
+            return String(format: "duo: TestFlight refreshed its data (launched in the background, %.1fs)", seconds)
+        case .launchedWithoutChange:
+            return "duo: launched TestFlight in the background; its data did not change"
+        case .alreadyRunning:
+            return "duo: TestFlight is already running — a background launch would not refresh it. "
+                 + "Switch to TestFlight yourself if you want its data reloaded."
+        case .notInstalled:
+            return "duo: TestFlight is not installed, so there is nothing to refresh"
+        case .launchFailed:
+            return "duo: could not launch TestFlight"
+        }
     }
 
     /// A row worth acting on: an update the user has not hidden.
@@ -77,6 +104,14 @@ public enum Check {
             ? settings.appsWorthChecking(
                 selected, named: !options.queries.isEmpty, includeHidden: options.includeHidden)
             : selected
+
+        if options.refreshTestFlight {
+            // Before the inventory is read, not after: `Inventory.checker` builds a
+            // `TestFlightInventory` by reading the store, so a refresh that lands
+            // afterwards would not be seen until the next run.
+            let outcome = await TestFlightRefresh().run()
+            FileHandle.standardError.write(Data((describe(outcome) + "\n").utf8))
+        }
 
         let results: [UpdateResult]
         if options.checkForUpdates {

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -42,6 +42,12 @@ list / check options:
                       first line names the schema version.
   --all               Include apps that are already up to date (implied by list).
   --include-hidden    Include apps you ignored or whose version you skipped.
+  --refresh-testflight
+                      Ask TestFlight to reload its data first, by launching it in
+                      the background (it does not take the foreground). Its data
+                      only refreshes while the Mac is idle otherwise, so a machine
+                      in use can be hours behind. Does nothing when TestFlight is
+                      already running — switch to it yourself for that.
   --source <names>    Only apps answered by these sources, comma-separated:
                       sparkle, homebrew, vendor, github, "app store", toolbox,
                       testflight. `check` only — `list` asks no source, so it has
@@ -251,6 +257,7 @@ case "list", "check":
     options.queries = args.operands
     options.json = args.has("json")
     options.includeHidden = args.has("include-hidden")
+    options.refreshTestFlight = args.has("refresh-testflight")
     // `list` is the offline inventory, so "everything" is the only sensible
     // default; `check` shows what needs doing unless asked for the rest.
     options.checkForUpdates = (args.subcommand == "check")

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -269,6 +269,12 @@ case "list", "check":
     if !options.sources.isEmpty && !options.checkForUpdates {
         die("--source needs a source to have answered; use `duo check --source …`", code: 2)
     }
+    // Same shape as `--source` above: `list` prints on-disk versions and asks
+    // nothing, so a refresh cannot change a single character of its output — and
+    // this one is not merely useless, it starts an app the user did not start.
+    if options.refreshTestFlight && !options.checkForUpdates {
+        die("--refresh-testflight only changes what a check can see; use `duo check --refresh-testflight`", code: 2)
+    }
     run = { await Check.run(options) }
 
 case "install":

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
@@ -1,0 +1,184 @@
+import AppKit
+import Foundation
+
+/// Asks TestFlight to refresh the local store `TestFlightInventory` reads, by
+/// launching it **into the background** while it is not running.
+///
+/// Why this exists at all: that store is written by TestFlight.app and by nothing
+/// else, and the background activity that would refresh it (`com.apple.appstored.
+/// activities.TestFlightExtensionSyncActivity`) is registered `Require Device
+/// Inactivity`. On a Mac someone is using, Duet answers `MNP` — measured
+/// 2026-09-09, every 30–60s for a whole day, while a build sat available for
+/// hours and the store never learned it (#478).
+///
+/// Measured 2026-09-09, three trials, two machines:
+///
+/// | trial | action | result |
+/// |---|---|---|
+/// | cold + `-g` + deep link | quit, then open `itms-beta://…/v1/app/<adamId>` | store written in **11s**, foreground untouched |
+/// | cold + `-g`, no URL | quit, then just launch the bundle | store written in **9s** |
+/// | cold + `-g`, over ssh, second Mac | same | **8s**, 3 rows → 111 rows |
+///
+/// and the two negatives that fix the shape of the rule:
+///
+///   * **already running + background launch does nothing.** The URL is delivered,
+///     one request goes out, and two minutes later the store still has not learned
+///     the build that was already published. That is why ``Outcome/alreadyRunning``
+///     is a refusal rather than a launch: there is nothing this can do for a
+///     running TestFlight except steal the user's focus.
+///   * **already running + foreground activation works in 3s** — and is exactly the
+///     thing we will not do behind someone's back.
+///
+/// The deep link is not needed (trial 2), so this does not use one: with no URL
+/// there is no `/join/<code>` shape nearby to reach for by mistake, and joining a
+/// beta is an account-level side effect.
+///
+/// ⚠️ **This is an explicit, user-initiated action.** It starts an app the user did
+/// not start — one that creates a window (measured: `count windows` = 1, behind
+/// everything else) and lingers until macOS's automatic termination collects it.
+/// Do not put it on a periodic check: the system deliberately declines to do this
+/// work while the device is in use, and doing it for the system on a timer would
+/// be overriding that decision on the user's behalf.
+public struct TestFlightRefresh: Sendable {
+
+    /// What one attempt did. Every case is a thing the caller may want to say out
+    /// loud — nothing here is a silent no-op.
+    public enum Outcome: Sendable, Equatable {
+        /// Launched, and the store changed within the deadline.
+        case refreshed(after: Duration)
+        /// Launched, but the store never changed. Usually "already current"; it can
+        /// also be a sync that did not happen, and this deliberately does not claim
+        /// to know which — the store carries no "last synced" of its own.
+        case launchedWithoutChange
+        /// TestFlight was already running, so a background launch would do nothing.
+        case alreadyRunning
+        /// No TestFlight on this Mac.
+        case notInstalled
+        /// LaunchServices refused or timed out.
+        case launchFailed
+    }
+
+    /// Bundle id of the app that owns the store.
+    public static let bundleID = "com.apple.TestFlight"
+
+    /// How long to wait for the store to change after the launch. Generous against
+    /// the measured 8–11s, because those were three warm-ish samples on two Macs
+    /// and the work is a network round trip.
+    public static let defaultDeadline: Duration = .seconds(30)
+
+    /// How often to look at the store while waiting.
+    public static let pollInterval: Duration = .milliseconds(500)
+
+    /// How long the store has to hold still before the refresh counts as finished.
+    ///
+    /// ⚠️ **The first write is not the sync.** Measured 2026-09-09, polling every
+    /// 500ms from a cold background launch: the log was written at +0.3s, +1s,
+    /// +2s (twice), and then again at **+7s**, after which it stayed quiet for the
+    /// remaining 13s of the window. Returning on the first change reported success
+    /// in 0.5s — before the network round trip had landed — and a caller that read
+    /// the store on that signal would read it pre-sync. That is the same
+    /// "wrote ≠ learned" trap this whole area is full of (#478), and it shipped in
+    /// the first draft of this file.
+    ///
+    /// Six seconds because the interval has to be **longer than the gap inside the
+    /// burst**: in that trace the launch writes stopped at +2s and the sync write
+    /// landed at +7s, so anything up to five seconds would have declared the
+    /// refresh finished during the pause and reported the +1s write. The first fix
+    /// used three and did exactly that — caught by the unit case, not by hand.
+    /// One trace, so the margin is deliberate rather than fitted.
+    public static let settleInterval: Duration = .seconds(6)
+
+    // Effects, injected so the decision table is testable without launching
+    // anything or waiting on a real clock.
+    let locate: @Sendable () -> URL?
+    let isRunning: @Sendable () -> Bool
+    let launch: @Sendable (URL) async -> Bool
+    /// A value that changes when the store is written. Production passes the
+    /// write-ahead log's modification date; the main file's is not enough on its
+    /// own, since SQLite in WAL mode leaves it alone for long stretches.
+    let storeStamp: @Sendable () -> Date?
+    let sleep: @Sendable (Duration) async -> Void
+
+    public init(
+        locate: @escaping @Sendable () -> URL? = Self.locateTestFlight,
+        isRunning: @escaping @Sendable () -> Bool = Self.testFlightIsRunning,
+        launch: @escaping @Sendable (URL) async -> Bool = { await AppRestarter.launchApp($0, activates: false) },
+        storeStamp: @escaping @Sendable () -> Date? = Self.storeStamp,
+        sleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) }
+    ) {
+        self.locate = locate
+        self.isRunning = isRunning
+        self.launch = launch
+        self.storeStamp = storeStamp
+        self.sleep = sleep
+    }
+
+    /// Run one attempt. Never throws: every failure is an `Outcome` the caller can
+    /// print, because "we tried to refresh and could not" is information the user
+    /// needs before reading a version number.
+    public func run(
+        deadline: Duration = defaultDeadline,
+        settle: Duration = settleInterval
+    ) async -> Outcome {
+        guard let bundle = locate() else { return .notInstalled }
+        // Checked BEFORE the launch, not after: this is the case the measurement
+        // says we cannot serve, and launching anyway would leave the caller
+        // believing a refresh happened.
+        guard !isRunning() else { return .alreadyRunning }
+
+        let before = storeStamp()
+        guard await launch(bundle) else { return .launchFailed }
+
+        var waited: Duration = .zero
+        var seen = before
+        var lastChange: Duration?
+        while waited < deadline {
+            await sleep(Self.pollInterval)
+            waited += Self.pollInterval
+            let now = storeStamp()
+            // `!=` rather than `>`: a checkpoint can shorten or replace the log, and
+            // any change at all means TestFlight wrote, which is the question.
+            if now != seen {
+                seen = now
+                lastChange = waited
+                continue
+            }
+            // Quiet for long enough after a write — see `settleInterval` for why
+            // the first write is not the answer.
+            if let lastChange, waited - lastChange >= settle {
+                return .refreshed(after: lastChange)
+            }
+        }
+        // Ran out of time. It still changed, so say so rather than pretending
+        // nothing happened; the caller gets the last moment we saw it move.
+        if let lastChange { return .refreshed(after: lastChange) }
+        return .launchedWithoutChange
+    }
+
+    // MARK: - Live effects
+
+    /// Where TestFlight is, or nil when it is not installed.
+    public static let locateTestFlight: @Sendable () -> URL? = {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
+    }
+
+    /// Whether a TestFlight **process** exists.
+    ///
+    /// `runningApplications(withBundleIdentifier:)` and not the `NSWorkspace`
+    /// snapshot: that one is a stale cache in a process with no run loop, which is
+    /// exactly what the CLI is. Measured 2026-09-09 that this query agrees with
+    /// `pgrep` in both directions — 1 entry carrying the real pid while TestFlight
+    /// ran, 0 the moment it quit — including after macOS's automatic termination,
+    /// where LaunchServices can still list the app as "open" with no process
+    /// behind it.
+    public static let testFlightIsRunning: @Sendable () -> Bool = {
+        !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty
+    }
+
+    /// Modification date of the store's write-ahead log.
+    public static let storeStamp: @Sendable () -> Date? = {
+        let wal = URL(fileURLWithPath: TestFlightInventory.defaultDatabaseURL.path + "-wal")
+        let attrs = try? FileManager.default.attributesOfItem(atPath: wal.path)
+        return attrs?[.modificationDate] as? Date
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
@@ -1,0 +1,176 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The decision table of `TestFlightRefresh`, with every effect injected so no
+/// case launches anything or waits on a real clock.
+///
+/// What the cases are *for* is the measurement behind each branch (#491): a
+/// background launch refreshes the store only while TestFlight is **not** running,
+/// and the wait has to end on the store actually changing rather than on a guess
+/// about how long a sync takes.
+struct TestFlightRefreshTests {
+
+    /// Records what the effects were asked to do, so a case can assert on the
+    /// things that did NOT happen — which is most of this type's contract.
+    private final class Spy: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var launches: [URL] = []
+        private(set) var sleeps = 0
+        func launched(_ url: URL) {
+            lock.lock(); defer { lock.unlock() }
+            launches.append(url)
+        }
+        func slept() {
+            lock.lock(); defer { lock.unlock() }
+            sleeps += 1
+        }
+    }
+
+    private static let bundle = URL(fileURLWithPath: "/Applications/TestFlight.app")
+
+    /// A stamp source that changes after `changesAfter` reads, standing in for the
+    /// store being rewritten partway through the wait.
+    private final class Stamp: @unchecked Sendable {
+        private let lock = NSLock()
+        private var reads = 0
+        /// Read numbers at which the store is rewritten. Production is not one
+        /// change but a burst then a pause: measured +0.3s, +1s, +2s, +2s, **+7s**.
+        private let changesAt: Set<Int>
+        init(changesAt: Set<Int> = []) { self.changesAt = changesAt }
+        func read() -> Date? {
+            lock.lock(); defer { lock.unlock() }
+            reads += 1
+            let bumps = changesAt.filter { $0 <= reads }.count
+            return Date(timeIntervalSince1970: Double(bumps))
+        }
+    }
+
+    private static func refresher(
+        installed: Bool = true,
+        running: Bool = false,
+        launchSucceeds: Bool = true,
+        stamp: Stamp = Stamp(),
+        spy: Spy
+    ) -> TestFlightRefresh {
+        TestFlightRefresh(
+            locate: { installed ? bundle : nil },
+            isRunning: { running },
+            launch: { url in spy.launched(url); return launchSucceeds },
+            storeStamp: { stamp.read() },
+            sleep: { _ in spy.slept() })
+    }
+
+    /// Measured: with TestFlight already running, a background launch delivers the
+    /// request and the store is still unchanged two minutes later. So this is a
+    /// refusal, and it must come BEFORE the launch — otherwise the caller is told a
+    /// refresh happened, having only started a process.
+    ///
+    /// Mutation: move the `isRunning` guard below `launch(bundle)`, or drop it —
+    /// `launches` becomes non-empty and this fails.
+    @Test func aRunningTestFlightIsRefusedWithoutLaunchingAnything() async {
+        let spy = Spy()
+        let outcome = await Self.refresher(running: true, spy: spy).run()
+        #expect(outcome == .alreadyRunning)
+        #expect(spy.launches.isEmpty)
+    }
+
+    /// Mutation: return `.launchFailed` (or `.notInstalled`) unconditionally when
+    /// the bundle is missing — the point is that a Mac without TestFlight is not a
+    /// failure to report as one, and nothing is launched.
+    @Test func aMacWithoutTestFlightSaysSoAndLaunchesNothing() async {
+        let spy = Spy()
+        let outcome = await Self.refresher(installed: false, spy: spy).run()
+        #expect(outcome == .notInstalled)
+        #expect(spy.launches.isEmpty)
+    }
+
+    /// Mutation: ignore `launch`'s return value (`_ = await launch(bundle)`) — the
+    /// wait then runs to the deadline and this returns `.launchedWithoutChange`,
+    /// reporting a wait we never earned.
+    @Test func aRefusedLaunchIsNotAWait() async {
+        let spy = Spy()
+        let outcome = await Self.refresher(launchSucceeds: false, spy: spy).run()
+        #expect(outcome == .launchFailed)
+        #expect(spy.sleeps == 0)
+    }
+
+    /// **The first write is not the sync.** The fixture is the measured shape: a
+    /// burst of writes right after launch (reads 2 and 3 here) and then the one
+    /// that matters several seconds later (read 15 ≈ +7s), with quiet after it.
+    ///
+    /// Two mutations, both run and both red here:
+    ///   * return on the first change (`if now != seen { return .refreshed(…) }`) —
+    ///     the shape this file shipped with first. The answer becomes 1s, before the
+    ///     network round trip; the live CLI printed "refreshed … 0.5s", which is how
+    ///     it was caught.
+    ///   * shorten `settleInterval` back to 3s — the wait ends inside the pause
+    ///     between the launch burst and the sync write, and reports 1s again.
+    @Test func theWaitOutlastsTheLaunchBurstAndEndsOnTheLastWrite() async {
+        let spy = Spy()
+        let refresher = Self.refresher(stamp: Stamp(changesAt: [2, 3, 15]), spy: spy)
+        let outcome = await refresher.run(deadline: .seconds(30))
+        guard case .refreshed(let after) = outcome else {
+            Issue.record("expected a refresh, got \(outcome)")
+            return
+        }
+        // The pre-launch reading consumes read 1, so read 15 lands on poll 14:
+        // 14 × 500ms = 7s. That is the write reported — not the 1s one that came
+        // first.
+        #expect(after == .seconds(7))
+        #expect(spy.launches == [Self.bundle])
+    }
+
+    /// The settle rule must not swallow the answer when the store keeps moving past
+    /// the deadline: a refresh that did happen is still reported, with the last
+    /// moment it was seen moving.
+    ///
+    /// Mutation: drop the post-loop `if let lastChange { return .refreshed(…) }` —
+    /// this becomes `.launchedWithoutChange` and fails.
+    @Test func aStoreStillMovingAtTheDeadlineIsStillARefresh() async {
+        let spy = Spy()
+        // Changes on every poll, so it never settles.
+        let refresher = Self.refresher(stamp: Stamp(changesAt: Set(1...20)), spy: spy)
+        let outcome = await refresher.run(deadline: .seconds(2), settle: .seconds(3))
+        guard case .refreshed(let after) = outcome else {
+            Issue.record("expected a refresh, got \(outcome)")
+            return
+        }
+        #expect(after == .seconds(2))
+    }
+
+    /// A launch that changes nothing is NOT reported as a refresh. The store has no
+    /// "last synced" of its own, so "already current" and "the sync did not happen"
+    /// are indistinguishable from here, and the honest answer names neither.
+    ///
+    /// Mutation: return `.refreshed` at the end of the loop — this fails.
+    @Test func aLaunchThatChangesNothingIsNotCalledARefresh() async {
+        let spy = Spy()
+        let refresher = Self.refresher(stamp: Stamp(), spy: spy)
+        let outcome = await refresher.run(deadline: .seconds(2))
+        #expect(outcome == .launchedWithoutChange)
+        // 2s deadline at 500ms per poll.
+        #expect(spy.sleeps == 4)
+    }
+
+    /// The launch must be a background one. This is the whole reason the feature is
+    /// acceptable at all — a foreground activation refreshes in 3s but takes the
+    /// user's screen, and doing that from a background check is what #491 refuses.
+    ///
+    /// Mutation: change the default `launch` to `AppRestarter.launchApp($0)` (which
+    /// defaults to `activates: true`) — the compiler is happy and this case is the
+    /// only thing that objects.
+    @Test func theProductionLaunchDoesNotActivate() async {
+        // The default closure is opaque, so this pins the intent where it is
+        // written rather than the closure itself: `activates` must be false.
+        let source = try? String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()          // DuoUpdaterCoreTests
+                .deletingLastPathComponent()          // Tests
+                .deletingLastPathComponent()          // DuoUpdaterCore
+                .appendingPathComponent("Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift"),
+            encoding: .utf8)
+        let text = try! #require(source)
+        #expect(text.contains("AppRestarter.launchApp($0, activates: false)"))
+    }
+}


### PR DESCRIPTION
Refs #491、#478。

## 为什么需要它

TestFlight 的本地库只由 TestFlight.app 写，而负责刷新它的后台活动注册着
`Require Device Inactivity`——**机器在用就一直 MNP**。2026-09-09 实测：一个 build 在厂商侧
可用四个多小时，dasd 每 30~60 秒重评一次、每次都拒，库始终不知道它。

## 做法

TestFlight **没在运行**时把它**后台启动**（`activates: false`），然后等它的库停止变化。

三次实测（两台机器）：11s / 9s / 8s 同步完成，**前台一次都没被抢**；其中一次是经 ssh 在
另一台 Mac 上，那台的库从 3 行变成 111 行。

两个反例定住了规则的形状：

- **已在运行时后台启动什么也不做**（实测两分钟不写库，只发了一次请求）→ 这个分支**拒绝**而不是
  硬来，因为对一个正在运行的 TestFlight，唯一有效的动作是抢用户的焦点。
- **已在运行 + 前台激活 3 秒就好**——而这正是我们不愿意在背后做的事。

深链不需要（第二次实测证明），所以代码里没有 URL：既省掉一个参数，也让 `/join/<code>`
那种有账号侧作用的形状不会出现在手边。

## 一个自己踩进去又爬出来的坑

第一版**在库第一次变化时就返回**，真机上打出 `refreshed … 0.5s`。逐 500ms 采样看，
启动会先写一串（+0.3s、+1s、+2s、+2s），**真正的同步写在 +7s**。3 秒的静默期会在那段停顿里
提前收工、报出 +1s 那次写——正是这一带反复出现的 **"写了 ≠ 学到了"**。

现在等的是"变化后静默 6 秒"，6 秒的理由写在常量注释里（实测停顿是 5 秒，一条 trace，
所以留了余量而不是贴着拟合）。

## 验收：真机端到端

刷新前库里是 `1301, 1305`，TestFlight 没在跑，1306 刚上架：

```
$ duo check --refresh-testflight --json --all /Applications/ClaudeUsageApp.app
duo: TestFlight refreshed its data (launched in the background, 6.0s)
{"installedBuild":"1301","latestBuild":"1306","status":"update 0.3.384 (1306)","hasUpdate":true}
  → 全程 14.0s，前台仍是 Claude
```

已在运行时：

```
$ duo check --refresh-testflight …
duo: TestFlight is already running — a background launch would not refresh it.
     Switch to TestFlight yourself if you want its data reloaded.
```

未知 flag 仍被拒（说明新 flag 真的登记进了 `ArgParser` 的 `seen`）：

```
unknown flag '--refresh-testflightt'; accepted: --all --include-hidden --json --refresh-testflight --source
```

## 测试与变异

7 条用例，三个变异各自实测点名：

| 变异 | 变红的 |
|---|---|
| 首次变化就返回（第一版的形状） | `theWaitOutlastsTheLaunchBurstAndEndsOnTheLastWrite` + `aStoreStillMovingAtTheDeadlineIsStillARefresh` |
| `settleInterval` 退回 3 秒 | `theWaitOutlastsTheLaunchBurstAndEndsOnTheLastWrite` |
| 生产 launch 改成会抢前台（`activates` 默认 true） | `theProductionLaunchDoesNotActivate` |

```
$ scripts/run-with-hang-report.sh 1800 make test   →  EXIT=0
━ Test run with 2501 tests in 207 suites passed
✓ App tests — 9 of 9 cases executed
```

## 不在这个 PR 里

- **菜单栏 app 的按钮。** 那要动两个界面（popover / 工作台）、走 `RowActions.live`、进
  `RowStateGalleryCases`、并且新增用户可见文案要过整套本地化流程。CLI 先落地，UI 单开。
- **绝不挂在周期检查上**，理由写在类型的文档注释里：系统刻意不在设备活跃时做这件事，
  替它做等于替用户否决了那个决定。
