### PR TITLE
Pin what happens when a tester installs an older build over the current one

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/WrappedIOSTestFlightTests.swift
@@ -648,4 +648,62 @@ struct WrappedIOSTestFlightTests {
             #expect(inventory.latestIOS(forBundleID: "com.jizhi0v0.claude-usage")?.latestBuild == "1301")
         }
     }
+
+    // MARK: - Installing an older build over the current one
+
+    /// TestFlight lets a tester install any previous build over what they have, so
+    /// "installed" and "newest offered" routinely disagree in the *downgrade*
+    /// direction. Nothing was pinning that: the answer today falls out of three
+    /// separate mechanisms agreeing, and a change to any one of them would go red
+    /// somewhere else — or not at all.
+    ///
+    /// The fixture is the measured shape (2026-09-09, `com.jizhi0v0.claude-usage`
+    /// on this machine): the store is a snapshot holding exactly the installed row
+    /// and the currently offered one, superseded builds having been dropped from it.
+    ///
+    /// ```
+    /// 0.3.384 | 1301 | installed = 1     ← on disk
+    /// 0.3.384 | 1307 | 0                 ← what TestFlight offers
+    /// ```
+    ///
+    /// Run for both platform routes, because they reach `latest` through different
+    /// accessors and only the caller knows which (#476).
+    ///
+    /// Mutations, both run:
+    ///   * filter the newest-offered index to `ZINSTALLSTATUSRAW = 1` (the shape the
+    ///     type's header warns about — "keeping only the installed one would make
+    ///     every app permanently up to date") → no update is offered, this fails.
+    ///   * widen #483's staleness gate from "installed is NEWER than the newest
+    ///     offered" to "installed differs from it" → the row becomes
+    ///     `.testFlightManaged` and the user is told nothing, this fails.
+    @Test(arguments: [Int32(3), Int32(1)])
+    func anOlderInstalledBuildIsStillOfferedTheNewestOne(platform: Int32) async throws {
+        let wrapped = platform == 1
+        let inventory = try Self.withTemporaryRoot { root -> TestFlightInventory in
+            let db = try Self.plantDatabase([
+                (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.384", build: "1301",
+                 platform: platform, installed: 1),
+                (bundleID: "com.jizhi0v0.claude-usage", short: "0.3.384", build: "1307",
+                 platform: platform, installed: 0),
+            ], in: root)
+            return TestFlightInventory(databaseURL: db)
+        }
+        #expect(inventory.accessible, "fixture database was not opened")
+
+        let app = InstalledApp(
+            name: "ClaudeUsageApp", bundleID: "com.jizhi0v0.claude-usage",
+            shortVersion: "0.3.384", buildVersion: "1301",
+            path: URL(fileURLWithPath: "/Applications/ClaudeUsageApp.app"),
+            isMASApp: false, isiOSAppOnMac: wrapped, isTestFlightApp: true,
+            sparkleFeedURL: nil)
+        let result = await UpdateChecker(sources: [], testflight: inventory).check(app)
+
+        #expect(result.remote?.version == "1307")
+        guard case .updateAvailable(let latest) = result.status else {
+            Issue.record("expected an update for the \(wrapped ? "iOS" : "mac") route, got \(result.status)")
+            return
+        }
+        // Marketing frozen across the track, so the build disambiguates.
+        #expect(latest == "0.3.384 (1307)")
+    }
 }


### PR DESCRIPTION
纯测试，没有行为改动。

## 为什么

TestFlight 允许测试者**把任意旧 build 覆盖装回去**，所以"装着的"和"当前提供的"在**降级方向**
上不一致是常态——这台机器整晚就在这个状态（磁盘 1301，厂商侧供 1307）。

而这件事**之前没有任何用例钉着**：今天的正确答案是三个机制**恰好一致**的结果——

1. 库是快照，保留「装着的那行 + 当前提供的那行」（被取代的 build 会被删掉，今天实测过）；
2. `latest` 取的是提供的那条，于是 `isNewer(1307, 1301)` 为真；
3. #483 的自证闸只在「装着的比提供的还新」时才响，降级是反方向。

改动其中任何一个，都可能在别处变红——或者哪儿都不红。

## 用例

fixture 就是实测到的那个形状：

```
0.3.384 | 1301 | installed = 1     ← 磁盘上的
0.3.384 | 1307 | 0                 ← TestFlight 提供的
```

参数化跑**两条平台路线**（mac 与 wrapped iOS），因为它们经由不同的访问器拿到 `latest`，
而只有调用方知道该问哪个（#476）。

## 变异（两个都实测跑过，两条平台参数各自变红）

| 变异 | 后果 |
|---|---|
| 把「最新提供」索引过滤成 `ZINSTALLSTATUSRAW = 1` | 不再有更新可报——正是类型头部注释警告过的那句"只留装着的那条会让每个 app 永远显示已是最新" |
| 把 #483 的闸从「装着的更新」放宽成「不相等」 | 这一行变成 `.testFlightManaged`，用户什么也不会被告知 |

```
$ scripts/run-with-hang-report.sh 1800 make test   →  EXIT=0
━ Test run with 2502 tests in 207 suites passed
✓ App tests — 9 of 9 cases executed
```

## 顺带

想故意降级又不想被反复提醒的用户，用的是 `duo skip <app>`（把当前提供的版本静音到下一个版本
出现为止）——这条用例不改变那个行为，只是把"默认会提醒"钉住。
