### PR TITLE
Refresh TestFlight whether or not it is already running

### DIFF
--- a/CLI/Sources/DuoKit/Check.swift
+++ b/CLI/Sources/DuoKit/Check.swift
@@ -62,12 +62,20 @@ public enum Check {
             // finished. Measured 6.0s here against 14.0s wall clock, so saying
             // "took" would be wrong by more than half.
             let seconds = Double(after.components.seconds) + Double(after.components.attoseconds) / 1e18
-            return String(format: "duo: TestFlight refreshed its data (launched in the background; new data landed after %.1fs)", seconds)
+            return String(format: "duo: TestFlight refreshed its data (new data landed after %.1fs)", seconds)
         case .launchedWithoutChange:
             return "duo: launched TestFlight in the background; its data did not change"
-        case .alreadyRunning:
-            return "duo: TestFlight is already running — a background launch would not refresh it. "
-                 + "Switch to TestFlight yourself if you want its data reloaded."
+        case .activatedWithoutChange:
+            return "duo: nudged the running TestFlight; its data did not change"
+        case .activationUnavailable:
+            return "duo: TestFlight is already running, and this macOS does not let us reload it "
+                 + "without taking the screen. Switch to TestFlight yourself if you want its data reloaded."
+        case .refusedSecureInput:
+            return "duo: not touching TestFlight while a password field is active — try again in a moment"
+        case .alreadyFrontmost:
+            return "duo: TestFlight is open in front of you — its own window is more current than anything we can reload"
+        case .activationFailed(let code):
+            return "duo: could not reload the running TestFlight (code \(code))"
         case .notInstalled:
             return "duo: TestFlight is not installed, so there is nothing to refresh"
         case .launchFailed:

--- a/CLI/Sources/DuoKit/Check.swift
+++ b/CLI/Sources/DuoKit/Check.swift
@@ -71,11 +71,18 @@ public enum Check {
             return "duo: TestFlight is already running, and this macOS does not let us reload it "
                  + "without taking the screen. Switch to TestFlight yourself if you want its data reloaded."
         case .refusedSecureInput:
-            return "duo: not touching TestFlight while a password field is active — try again in a moment"
+            // Secure keyboard entry is session-wide, and Terminal's own Secure
+            // Keyboard Entry holds it for the life of the terminal you are probably
+            // reading this in. So this must not promise it will clear on its own.
+            return "duo: secure keyboard entry is on, so TestFlight was left alone. "
+                 + "A password field, a password manager, or your terminal's Secure Keyboard Entry holds it."
         case .alreadyFrontmost:
             return "duo: TestFlight is open in front of you — its own window is more current than anything we can reload"
         case .activationFailed(let code):
             return "duo: could not reload the running TestFlight (code \(code))"
+        case .focusNotRestored(let code):
+            return "duo: reloaded TestFlight, but could not put your focus back (code \(code)) — "
+                 + "TestFlight may be in front now"
         case .notInstalled:
             return "duo: TestFlight is not installed, so there is nothing to refresh"
         case .launchFailed:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppRestarter.swift
@@ -285,9 +285,21 @@ public enum AppRestarter {
     /// asked for, but every restart-after-update path passes the app's pre-quit
     /// foreground state instead (see `isFrontmost`), so an app that was in the
     /// background comes back in the background.
+    ///
+    /// `hides` is the launch-time equivalent of ⌘H, and is only ever paired with
+    /// `activates: false`. It matters for one caller — `TestFlightRefresh`, which
+    /// starts an app the user did not ask for. Measured 2026-09-09 with
+    /// `CGWindowListCopyWindowInfo`: launched with `activates: false` alone,
+    /// TestFlight puts a real window on screen (layer 0, alpha 1, 1010×717) behind
+    /// whatever the user is working in, visible the moment they open Mission
+    /// Control. Adding this leaves zero windows on screen and the process still
+    /// syncs. Measured harmless for an app that is already up: on both Macs, in
+    /// both the background and the frontmost case, a hidden launch of a running
+    /// TestFlight neither hid its window nor moved the focus.
     @discardableResult
     public static func launchApp(
-        _ bundle: URL, activates: Bool = true, timeout: Duration = launchTimeout
+        _ bundle: URL, activates: Bool = true, hides: Bool = false,
+        timeout: Duration = launchTimeout
     ) async -> Bool {
         return await firstToFinish(timeout: timeout, fallback: false) {
             Log.install.error(
@@ -298,6 +310,7 @@ public enum AppRestarter {
             // boundary to race the timer.
             let config = NSWorkspace.OpenConfiguration()
             config.activates = activates
+            config.hides = hides
             do {
                 _ = try await NSWorkspace.shared.openApplication(at: bundle, configuration: config)
                 return true

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
@@ -58,6 +58,11 @@ public struct TestFlightRefresh: Sendable {
         case alreadyFrontmost
         /// TestFlight is running and the activation itself was refused.
         case activationFailed(code: Int32)
+        /// The activation landed but the user's focus could not be put back, twice.
+        /// Returned **instead of** waiting for the store: a window the user did not
+        /// raise is more urgent than a version number, and the refresh that did
+        /// happen will be on disk for the next check either way.
+        case focusNotRestored(code: Int32)
         /// No TestFlight on this Mac.
         case notInstalled
         /// LaunchServices refused or timed out.
@@ -139,6 +144,8 @@ public struct TestFlightRefresh: Sendable {
             switch await activate() {
             case .activated:
                 launched = false
+            case .frontNotRestored(let code):
+                return .focusNotRestored(code: code)
             case .unavailable:
                 return .activationUnavailable
             case .refusedSecureInput:
@@ -212,7 +219,15 @@ public struct TestFlightRefresh: Sendable {
     /// right before the front changes.
     public static let activateTestFlight: @Sendable () async -> SilentActivation.Outcome = {
         await SilentActivation(
-            runningPID: { runningTestFlight()?.processIdentifier },
+            runningPID: {
+                // -1 means "no pid", not "pid minus one": NSRunningApplication keeps
+                // returning a valid object after the app exits, and TestFlight is
+                // automatically terminated all the time. Forwarding it would make the
+                // quit-during-the-race branch unreachable and report an error where a
+                // cold launch is the right answer.
+                guard let pid = runningTestFlight()?.processIdentifier, pid > 0 else { return nil }
+                return pid
+            },
             isActive: { runningTestFlight()?.isActive ?? false },
             isHidden: { runningTestFlight()?.isHidden ?? false },
             setHidden: { hidden in if hidden { _ = runningTestFlight()?.hide() } }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
@@ -1,8 +1,7 @@
 import AppKit
 import Foundation
 
-/// Asks TestFlight to refresh the local store `TestFlightInventory` reads, by
-/// launching it **into the background** while it is not running.
+/// Asks TestFlight to refresh the local store `TestFlightInventory` reads.
 ///
 /// Why this exists at all: that store is written by TestFlight.app and by nothing
 /// else, and the background activity that would refresh it (`com.apple.appstored.
@@ -11,47 +10,54 @@ import Foundation
 /// 2026-09-09, every 30–60s for a whole day, while a build sat available for
 /// hours and the store never learned it (#478).
 ///
-/// Measured 2026-09-09, three trials, two machines:
+/// TestFlight goes and asks the server on exactly two occasions, and this serves
+/// whichever one applies:
 ///
-/// | trial | action | result |
-/// |---|---|---|
-/// | cold + `-g` + deep link | quit, then open `itms-beta://…/v1/app/<adamId>` | store written in **11s**, foreground untouched |
-/// | cold + `-g`, no URL | quit, then just launch the bundle | store written in **9s** |
-/// | cold + `-g`, over ssh, second Mac | same | **8s**, 3 rows → 111 rows |
+///   * **not running** — a hidden background launch. Measured 2026-09-09 across
+///     three trials on two Macs: store written in 11s, 9s, and 8s (3 rows → 111
+///     rows on the second Mac), foreground untouched throughout.
+///   * **already running** — a silent activation, see ``SilentActivation``. A
+///     background launch does *nothing* for a running TestFlight: the request is
+///     delivered, and two minutes later the store still has not learned the build
+///     that was already published. Measured four times.
 ///
-/// and the two negatives that fix the shape of the rule:
+/// The deep link is not needed (the second trial used no URL at all), so this does
+/// not use one: with no URL there is no `/join/<code>` shape nearby to reach for by
+/// mistake, and joining a beta is an account-level side effect.
 ///
-///   * **already running + background launch does nothing.** The URL is delivered,
-///     one request goes out, and two minutes later the store still has not learned
-///     the build that was already published. That is why ``Outcome/alreadyRunning``
-///     is a refusal rather than a launch: there is nothing this can do for a
-///     running TestFlight except steal the user's focus.
-///   * **already running + foreground activation works in 3s** — and is exactly the
-///     thing we will not do behind someone's back.
-///
-/// The deep link is not needed (trial 2), so this does not use one: with no URL
-/// there is no `/join/<code>` shape nearby to reach for by mistake, and joining a
-/// beta is an account-level side effect.
-///
-/// ⚠️ **This is an explicit, user-initiated action.** It starts an app the user did
-/// not start — one that creates a window (measured: `count windows` = 1, behind
-/// everything else) and lingers until macOS's automatic termination collects it.
-/// Do not put it on a periodic check: the system deliberately declines to do this
-/// work while the device is in use, and doing it for the system on a timer would
-/// be overriding that decision on the user's behalf.
+/// ⚠️ **This is an explicit, user-initiated action.** The launch path starts an app
+/// the user did not start, and that app lingers until macOS's automatic termination
+/// collects it — measured 6–10 minutes typically, once 47. The activation path
+/// takes the front process for ``SilentActivation/defaultHold``. Do not put either
+/// on a periodic check: the system deliberately declines to do this work while the
+/// device is in use, and doing it for the system on a timer would be overriding
+/// that decision on the user's behalf.
 public struct TestFlightRefresh: Sendable {
 
     /// What one attempt did. Every case is a thing the caller may want to say out
     /// loud — nothing here is a silent no-op.
     public enum Outcome: Sendable, Equatable {
-        /// Launched, and the store changed within the deadline.
+        /// The store changed within the deadline.
         case refreshed(after: Duration)
-        /// Launched, but the store never changed. Usually "already current"; it can
-        /// also be a sync that did not happen, and this deliberately does not claim
-        /// to know which — the store carries no "last synced" of its own.
+        /// Launched from cold, but the store never changed. Usually "already
+        /// current"; it can also be a sync that did not happen, and this
+        /// deliberately does not claim to know which — the store carries no "last
+        /// synced" of its own.
         case launchedWithoutChange
-        /// TestFlight was already running, so a background launch would do nothing.
-        case alreadyRunning
+        /// Activated a running instance, but the store never changed. Same
+        /// ambiguity as ``launchedWithoutChange``, different route.
+        case activatedWithoutChange
+        /// TestFlight is running, and this macOS does not expose the symbols that
+        /// would let us reach it without stealing the screen.
+        case activationUnavailable
+        /// TestFlight is running, but a password field owns the keyboard.
+        case refusedSecureInput
+        /// TestFlight is the app the user is looking at right now. Nothing to do:
+        /// an already-active app cannot be made to become active, and its own
+        /// window is a better view of this data than anything we could print.
+        case alreadyFrontmost
+        /// TestFlight is running and the activation itself was refused.
+        case activationFailed(code: Int32)
         /// No TestFlight on this Mac.
         case notInstalled
         /// LaunchServices refused or timed out.
@@ -61,9 +67,9 @@ public struct TestFlightRefresh: Sendable {
     /// Bundle id of the app that owns the store.
     public static let bundleID = "com.apple.TestFlight"
 
-    /// How long to wait for the store to change after the launch. Generous against
-    /// the measured 8–11s, because those were three warm-ish samples on two Macs
-    /// and the work is a network round trip.
+    /// How long to wait for the store to change. Generous against the measured
+    /// 8–11s, because those were three warm-ish samples on two Macs and the work is
+    /// a network round trip.
     public static let defaultDeadline: Duration = .seconds(30)
 
     /// How often to look at the store while waiting.
@@ -93,6 +99,7 @@ public struct TestFlightRefresh: Sendable {
     let locate: @Sendable () -> URL?
     let isRunning: @Sendable () -> Bool
     let launch: @Sendable (URL) async -> Bool
+    let activate: @Sendable () async -> SilentActivation.Outcome
     /// A value that changes when the store is written. Production passes the
     /// write-ahead log's modification date; the main file's is not enough on its
     /// own, since SQLite in WAL mode leaves it alone for long stretches.
@@ -102,13 +109,15 @@ public struct TestFlightRefresh: Sendable {
     public init(
         locate: @escaping @Sendable () -> URL? = Self.locateTestFlight,
         isRunning: @escaping @Sendable () -> Bool = Self.testFlightIsRunning,
-        launch: @escaping @Sendable (URL) async -> Bool = { await AppRestarter.launchApp($0, activates: false) },
+        launch: @escaping @Sendable (URL) async -> Bool = { await AppRestarter.launchApp($0, activates: false, hides: true) },
+        activate: @escaping @Sendable () async -> SilentActivation.Outcome = Self.activateTestFlight,
         storeStamp: @escaping @Sendable () -> Date? = Self.storeStamp,
         sleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) }
     ) {
         self.locate = locate
         self.isRunning = isRunning
         self.launch = launch
+        self.activate = activate
         self.storeStamp = storeStamp
         self.sleep = sleep
     }
@@ -121,13 +130,33 @@ public struct TestFlightRefresh: Sendable {
         settle: Duration = settleInterval
     ) async -> Outcome {
         guard let bundle = locate() else { return .notInstalled }
-        // Checked BEFORE the launch, not after: this is the case the measurement
-        // says we cannot serve, and launching anyway would leave the caller
-        // believing a refresh happened.
-        guard !isRunning() else { return .alreadyRunning }
 
+        // Read the store BEFORE either route touches anything, so the wait below
+        // compares against the state that predates our own writes.
         let before = storeStamp()
-        guard await launch(bundle) else { return .launchFailed }
+        let launched: Bool
+        if isRunning() {
+            switch await activate() {
+            case .activated:
+                launched = false
+            case .unavailable:
+                return .activationUnavailable
+            case .refusedSecureInput:
+                return .refusedSecureInput
+            case .alreadyActive:
+                return .alreadyFrontmost
+            case .failed(let code):
+                return .activationFailed(code: code)
+            case .notRunning:
+                // It quit between the check and the activation. Serve the cold
+                // route rather than reporting a race as a failure.
+                guard await launch(bundle) else { return .launchFailed }
+                launched = true
+            }
+        } else {
+            guard await launch(bundle) else { return .launchFailed }
+            launched = true
+        }
 
         var waited: Duration = .zero
         var seen = before
@@ -152,7 +181,7 @@ public struct TestFlightRefresh: Sendable {
         // Ran out of time. It still changed, so say so rather than pretending
         // nothing happened; the caller gets the last moment we saw it move.
         if let lastChange { return .refreshed(after: lastChange) }
-        return .launchedWithoutChange
+        return launched ? .launchedWithoutChange : .activatedWithoutChange
     }
 
     // MARK: - Live effects
@@ -173,6 +202,27 @@ public struct TestFlightRefresh: Sendable {
     /// behind it.
     public static let testFlightIsRunning: @Sendable () -> Bool = {
         !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty
+    }
+
+    /// The activation route, bound to TestFlight.
+    ///
+    /// `isHidden` and `setHidden` are read and written through a fresh lookup each
+    /// time rather than captured: `NSRunningApplication` is a snapshot, and the
+    /// whole point of the hidden-state restore is that it reflects what is true
+    /// right before the front changes.
+    public static let activateTestFlight: @Sendable () async -> SilentActivation.Outcome = {
+        await SilentActivation(
+            runningPID: { runningTestFlight()?.processIdentifier },
+            isActive: { runningTestFlight()?.isActive ?? false },
+            isHidden: { runningTestFlight()?.isHidden ?? false },
+            setHidden: { hidden in if hidden { _ = runningTestFlight()?.hide() } }
+        ).run()
+    }
+
+    /// A fresh lookup every time — `NSRunningApplication` is a snapshot, and a
+    /// captured one would answer about the moment the closure was built.
+    static func runningTestFlight() -> NSRunningApplication? {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first
     }
 
     /// Modification date of the store's write-ahead log.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/SilentActivation.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/SilentActivation.swift
@@ -1,0 +1,236 @@
+import AppKit
+import Carbon
+
+/// Makes an already-running app *become active* — so it runs whatever it does on
+/// `applicationDidBecomeActive` — without raising its windows, without moving the
+/// pointer, and without leaving the user's front app changed.
+///
+/// **Why this is needed at all.** The store `TestFlightInventory` reads is written
+/// by TestFlight.app and by nothing else, and TestFlight only goes and asks the
+/// server on two occasions: a cold launch, and becoming active. `TestFlightRefresh`
+/// serves the first with a hidden background launch. The second is what this
+/// serves, and it is the only thing that reaches a TestFlight that is **already
+/// running** — measured four times: a background launch delivered to a running
+/// TestFlight does nothing at all.
+///
+/// **What was measured, 2026-09-10, with two independent witnesses** (the store's
+/// write-ahead log, and `lsof` sampling TestFlight's own sockets every 500ms):
+///
+/// | trigger | network | store | focus |
+/// |---|---|---|---|
+/// | cold hidden launch (control) | 6 connections | written | unchanged |
+/// | **this, on a running instance** | **2 connections** | **written** | **unchanged** |
+/// | `CGEventPostToPid` click | none | untouched | unchanged |
+/// | `CGEventPostToPid` scroll | none | untouched | unchanged |
+/// | AX `AXRaise` | none (returned -25205) | untouched | unchanged |
+/// | AX `AXScrollDownByPage` | none (returned -25205) | untouched | unchanged |
+///
+/// The whole input-injection family is dead for this purpose, and the reason is the
+/// same one that makes this type necessary: TestFlight's trigger is *activation*,
+/// not user interaction, and posted input events do not make an app active.
+///
+/// **On the private symbols.** `_SLPSSetFrontProcessWithOptions` and friends live in
+/// `SkyLight.framework`, which is private. They are resolved with `dlopen`/`dlsym`
+/// and every failure degrades to ``Outcome/unavailable`` — never a crash, never a
+/// wrong answer. Notarization does not inspect API surface (Apple: the notary
+/// service "scans your software for malicious content, checks for code-signing
+/// issues"; it "is not App Review"), and shipping Developer ID apps do exactly
+/// this. The real cost is that there is no contract: a future macOS may remove
+/// them, which is why the caller must treat `unavailable` as an ordinary answer.
+///
+/// **No new permission.** Measured 2026-09-10 by running this through
+/// `launchctl submit`, which breaks the responsibility chain that would otherwise
+/// lend it the parent's grant: with `AXIsProcessTrusted() == false` the activation
+/// still succeeded and TestFlight still went to the network. This is the one way it
+/// beats `CGEventPostToPid`, which Apple documents as requiring Accessibility.
+public struct SilentActivation: Sendable {
+
+    /// What one attempt did. Every case is something the caller may need to say out
+    /// loud — a silent no-op would leave the user reading a stale version number
+    /// believing it was just refreshed.
+    public enum Outcome: Sendable, Equatable {
+        /// The app was made active for `heldFor` and the previous state was restored.
+        case activated(heldFor: Duration)
+        /// SkyLight is not resolvable on this macOS. Not a failure to report as one.
+        case unavailable
+        /// A password field somewhere owns the keyboard; see ``refusedSecureInput``.
+        case refusedSecureInput
+        /// Nothing to activate — the app is not running.
+        case notRunning
+        /// The app is already the active one, so there is no activation to deliver.
+        /// Measured 2026-09-10 with TestFlight frontmost: the front swap is a no-op
+        /// and **no sync happens** — zero connections against the 2 that the same
+        /// call makes on a background instance. Reported rather than swallowed,
+        /// because "we nudged it and nothing changed" would be a lie about a nudge
+        /// that never landed.
+        case alreadyActive
+        /// SkyLight was there and said no.
+        case failed(code: Int32)
+    }
+
+    /// How long the app stays front.
+    ///
+    /// ⚠️ **This window is real**: keystrokes during it go to the activated app, not
+    /// to whatever the user was typing in. Measured 2026-09-10 against the store's
+    /// write-ahead log: a 120ms hold syncs, a ~50ms hold produced a single write
+    /// where 120ms produced the full burst — so this is not padding, it is the
+    /// shorter of the two values that was actually seen to work, and it is not safe
+    /// to trim without re-measuring.
+    public static let defaultHold: Duration = .milliseconds(120)
+
+    // Effects, injected so the ordering rules below are testable without SkyLight,
+    // without a real app, and without taking anyone's focus.
+    let available: @Sendable () -> Bool
+    let secureInputActive: @Sendable () -> Bool
+    let runningPID: @Sendable () -> pid_t?
+    let isActive: @Sendable () -> Bool
+    let isHidden: @Sendable () -> Bool
+    let setHidden: @Sendable (Bool) -> Void
+    /// Captures the current front process. Non-zero means it could not be read, and
+    /// without it there is nothing to restore, so the activation must not happen.
+    let saveFront: @Sendable () -> Int32
+    let makeFront: @Sendable (pid_t) -> Int32
+    let restoreFront: @Sendable () -> Int32
+    let sleep: @Sendable (Duration) async -> Void
+
+    public init(
+        available: @escaping @Sendable () -> Bool = Live.available,
+        secureInputActive: @escaping @Sendable () -> Bool = Live.secureInputActive,
+        runningPID: @escaping @Sendable () -> pid_t?,
+        isActive: @escaping @Sendable () -> Bool,
+        isHidden: @escaping @Sendable () -> Bool,
+        setHidden: @escaping @Sendable (Bool) -> Void,
+        saveFront: @escaping @Sendable () -> Int32 = Live.saveFront,
+        makeFront: @escaping @Sendable (pid_t) -> Int32 = Live.makeFront,
+        restoreFront: @escaping @Sendable () -> Int32 = Live.restoreFront,
+        sleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) }
+    ) {
+        self.available = available
+        self.secureInputActive = secureInputActive
+        self.runningPID = runningPID
+        self.isActive = isActive
+        self.isHidden = isHidden
+        self.setHidden = setHidden
+        self.saveFront = saveFront
+        self.makeFront = makeFront
+        self.restoreFront = restoreFront
+        self.sleep = sleep
+    }
+
+    /// Run one activation. Never throws; every failure is an `Outcome`.
+    ///
+    /// The guard order is the contract. Each guard is above the front change
+    /// because each one describes a state in which taking the front would be wrong
+    /// rather than merely useless, and a guard below it would mean the user's focus
+    /// had already moved by the time we decided not to move it.
+    public func run(hold: Duration = defaultHold) async -> Outcome {
+        guard available() else { return .unavailable }
+        // A password field owns the keyboard. Even 120ms of it going somewhere else
+        // is unacceptable, and macOS will not report what was typed, so this can
+        // never be made safe by checking afterwards.
+        guard !secureInputActive() else { return .refusedSecureInput }
+        guard let pid = runningPID() else { return .notRunning }
+        // Above the front change because swapping the front process to the app that
+        // already holds it is pure cost: it cannot fire the activation the caller
+        // wants, and it still spends the hold.
+        guard !isActive() else { return .alreadyActive }
+
+        // Read before anything moves: activating an app unhides it, and on one of
+        // the two trials that side effect appeared and on the other it did not — so
+        // restoring this is not optional, it is covering a coin flip.
+        let wasHidden = isHidden()
+        let saveCode = saveFront()
+        guard saveCode == 0 else { return .failed(code: saveCode) }
+
+        let code = makeFront(pid)
+        guard code == 0 else { return .failed(code: code) }
+
+        // From here on the front process has moved, so every exit restores it.
+        defer {
+            _ = restoreFront()
+            if wasHidden { setHidden(true) }
+        }
+        await sleep(hold)
+        return .activated(heldFor: hold)
+    }
+
+    // MARK: - Live effects
+
+    /// The SkyLight side, resolved once and shared. A `final class` rather than
+    /// free functions because the saved front process has to live somewhere between
+    /// ``saveFront`` and ``restoreFront``.
+    public final class Live: @unchecked Sendable {
+        public static let shared = Live()
+
+        /// An 8-byte `ProcessSerialNumber`. Declared here rather than imported so
+        /// that nothing in this file depends on the deprecated Carbon struct.
+        private struct PSN { var hi: UInt32 = 0; var lo: UInt32 = 0 }
+
+        private typealias GetProcessForPIDFn = @convention(c) (pid_t, UnsafeMutableRawPointer) -> Int32
+        private typealias GetFrontFn = @convention(c) (UnsafeMutableRawPointer) -> Int32
+        private typealias SetFrontFn = @convention(c) (UnsafeMutableRawPointer, UInt32, UInt32) -> Int32
+
+        /// Front the process without bringing any of its windows forward.
+        private static let kCPSNoWindows: UInt32 = 0x400
+
+        private let lock = NSLock()
+        private var saved: PSN?
+
+        private let getProcessForPID: GetProcessForPIDFn?
+        private let getFront: GetFrontFn?
+        private let setFront: SetFrontFn?
+
+        private init() {
+            let sky = dlopen(
+                "/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight", RTLD_LAZY)
+            func sym<T>(_ name: String, _ handle: UnsafeMutableRawPointer?) -> T? {
+                guard let handle, let p = dlsym(handle, name) else { return nil }
+                return unsafeBitCast(p, to: T.self)
+            }
+            getFront = sym("_SLPSGetFrontProcess", sky)
+            setFront = sym("_SLPSSetFrontProcessWithOptions", sky)
+            getProcessForPID = sym("GetProcessForPID", dlopen(nil, RTLD_LAZY))
+            if getFront == nil || setFront == nil || getProcessForPID == nil {
+                Log.scan.notice("skylight symbols missing — silent activation unavailable")
+            }
+        }
+
+        /// Whether all three symbols resolved. Checked by the caller before anything
+        /// else, so a macOS that drops them costs a refusal rather than a crash.
+        public static let available: @Sendable () -> Bool = { shared.resolved }
+        var resolved: Bool { getFront != nil && setFront != nil && getProcessForPID != nil }
+
+        /// Whether a password field (or anything else) has taken secure input.
+        /// Public Carbon API, unlike everything else in this class.
+        public static let secureInputActive: @Sendable () -> Bool = { IsSecureEventInputEnabled() }
+
+        public static let saveFront: @Sendable () -> Int32 = { shared.saveFrontProcess() }
+        public static let makeFront: @Sendable (pid_t) -> Int32 = { shared.makeFrontProcess($0) }
+        public static let restoreFront: @Sendable () -> Int32 = { shared.restoreFrontProcess() }
+
+        func saveFrontProcess() -> Int32 {
+            guard let getFront else { return -1 }
+            var psn = PSN()
+            let code = getFront(&psn)
+            if code == 0 {
+                lock.lock(); saved = psn; lock.unlock()
+            }
+            return code
+        }
+
+        func makeFrontProcess(_ pid: pid_t) -> Int32 {
+            guard let getProcessForPID, let setFront else { return -1 }
+            var psn = PSN()
+            let code = getProcessForPID(pid, &psn)
+            guard code == 0 else { return code }
+            return setFront(&psn, 0, Self.kCPSNoWindows)
+        }
+
+        func restoreFrontProcess() -> Int32 {
+            guard let setFront else { return -1 }
+            lock.lock(); let psn = saved; lock.unlock()
+            guard var psn else { return -1 }
+            return setFront(&psn, 0, Self.kCPSNoWindows)
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/SilentActivation.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/SilentActivation.swift
@@ -14,7 +14,9 @@ import Carbon
 /// TestFlight does nothing at all.
 ///
 /// **What was measured, 2026-09-10, with two independent witnesses** (the store's
-/// write-ahead log, and `lsof` sampling TestFlight's own sockets every 500ms):
+/// write-ahead log, and `lsof` sampling TestFlight's own sockets every 500ms). A
+/// cold hidden launch was the positive control, so an empty row means "nothing
+/// happened", not "the witness was blind":
 ///
 /// | trigger | network | store | focus |
 /// |---|---|---|---|
@@ -22,10 +24,19 @@ import Carbon
 /// | **this, on a running instance** | **2 connections** | **written** | **unchanged** |
 /// | `CGEventPostToPid` click | none | untouched | unchanged |
 /// | `CGEventPostToPid` scroll | none | untouched | unchanged |
-/// | AX `AXRaise` | none (returned -25205) | untouched | unchanged |
-/// | AX `AXScrollDownByPage` | none (returned -25205) | untouched | unchanged |
+/// | AX `AXRaise` | none — refused | untouched | unchanged |
+/// | AX `AXScrollDownByPage` | none — refused | untouched | unchanged |
 ///
-/// The whole input-injection family is dead for this purpose, and the reason is the
+/// ⚠️ **On those two AX rows.** Both actions were genuinely performed — verified
+/// step by step, because the first reading of this had the error constant wrong and
+/// a failure while *reading* an attribute would have meant the action was never
+/// attempted at all. Copying `kAXWindows` succeeded (1 window), copying the action
+/// names succeeded (`["AXRaise"]`), and only then did `AXUIElementPerformAction`
+/// return **-25205, `kAXErrorAttributeUnsupported`** — for an action the element
+/// itself advertises. Odd, but measured: the actions reach TestFlight, and
+/// TestFlight refuses them.
+///
+/// The input-injection family therefore does not serve this, and the reason is the
 /// same one that makes this type necessary: TestFlight's trigger is *activation*,
 /// not user interaction, and posted input events do not make an app active.
 ///
@@ -38,11 +49,15 @@ import Carbon
 /// this. The real cost is that there is no contract: a future macOS may remove
 /// them, which is why the caller must treat `unavailable` as an ordinary answer.
 ///
-/// **No new permission.** Measured 2026-09-10 by running this through
-/// `launchctl submit`, which breaks the responsibility chain that would otherwise
-/// lend it the parent's grant: with `AXIsProcessTrusted() == false` the activation
-/// still succeeded and TestFlight still went to the network. This is the one way it
-/// beats `CGEventPostToPid`, which Apple documents as requiring Accessibility.
+/// **On permissions — what was measured and what is inferred.** *Measured*
+/// 2026-09-10: run under `launchctl submit`, `AXIsProcessTrusted()` reported
+/// `false` and the activation still succeeded and still made TestFlight go to the
+/// network. *Inferred*: that this is because `launchctl submit` breaks the
+/// responsibility chain which would otherwise lend the harness its parent's grant.
+/// *Not measured*: the same run from the signed, hardened-runtime `duo` rather than
+/// from an ad-hoc harness. So this is strong evidence that no Accessibility grant is
+/// needed — the one way it beats `CGEventPostToPid`, which Apple documents as
+/// requiring one — and not yet a guarantee.
 public struct SilentActivation: Sendable {
 
     /// What one attempt did. Every case is something the caller may need to say out
@@ -50,12 +65,16 @@ public struct SilentActivation: Sendable {
     /// believing it was just refreshed.
     public enum Outcome: Sendable, Equatable {
         /// The app was made active for `heldFor` and the previous state was restored.
+        ///
+        /// `heldFor` is the hold that was **requested**. Under `Task.cancel()` the
+        /// production sleep returns early, so a cancelled run would report a hold
+        /// longer than it took; the restore still happens, and the CLI never cancels.
         case activated(heldFor: Duration)
         /// SkyLight is not resolvable on this macOS. Not a failure to report as one.
         case unavailable
-        /// A password field somewhere owns the keyboard; see ``refusedSecureInput``.
+        /// Secure keyboard entry is on somewhere in this login session.
         case refusedSecureInput
-        /// Nothing to activate — the app is not running.
+        /// Nothing to activate — the app is not running, or has no pid.
         case notRunning
         /// The app is already the active one, so there is no activation to deliver.
         /// Measured 2026-09-10 with TestFlight frontmost: the front swap is a no-op
@@ -66,6 +85,36 @@ public struct SilentActivation: Sendable {
         case alreadyActive
         /// SkyLight was there and said no.
         case failed(code: Int32)
+        /// The activation happened, but putting the front process back did not —
+        /// twice. Whatever the caller wanted from the activation is still valid; the
+        /// user's focus is not where they left it, which is the worst thing this
+        /// type can do and so is never folded into ``activated``.
+        case frontNotRestored(code: Int32)
+    }
+
+    /// Whichever process was front before we moved it. Opaque on purpose: the only
+    /// thing anyone may do with one is hand it back to `restoreFront`.
+    public struct FrontProcess: Sendable, Equatable {
+        let hi: UInt32
+        let lo: UInt32
+        public init(hi: UInt32, lo: UInt32) { self.hi = hi; self.lo = lo }
+    }
+
+    /// The result of reading the front process — the code is kept so a failure can
+    /// be reported as the OSStatus it actually was.
+    public enum FrontSnapshot: Sendable, Equatable {
+        case saved(FrontProcess)
+        case unreadable(code: Int32)
+    }
+
+    /// The outcome of one hop's worth of blocking work.
+    public enum Step: Sendable, Equatable {
+        /// The front has moved; here is what to put back and whether to re-hide.
+        case fronted(previous: FrontProcess, wasHidden: Bool)
+        /// Nothing is left moved, and this is the answer.
+        case refused(Outcome)
+        /// The post-hold hop: the restore's code, after up to one retry.
+        case restored(code: Int32)
     }
 
     /// How long the app stays front.
@@ -82,16 +131,32 @@ public struct SilentActivation: Sendable {
     // without a real app, and without taking anyone's focus.
     let available: @Sendable () -> Bool
     let secureInputActive: @Sendable () -> Bool
+    /// The app's pid, or nil when there is nothing to activate.
+    ///
+    /// ⚠️ **nil, not -1.** `NSRunningApplication` documents that "applications
+    /// without a pid return -1", that such an object "remains valid after the
+    /// application exits", and that the pid "may change if it is automatically
+    /// terminated" — which is exactly what happens to TestFlight. A wiring that
+    /// forwards -1 makes ``Outcome/notRunning`` unreachable and turns a
+    /// quit-during-the-race into `GetProcessForPID(-1)` failing: an error reported
+    /// where a cold launch was the right answer.
     let runningPID: @Sendable () -> pid_t?
     let isActive: @Sendable () -> Bool
     let isHidden: @Sendable () -> Bool
     let setHidden: @Sendable (Bool) -> Void
-    /// Captures the current front process. Non-zero means it could not be read, and
-    /// without it there is nothing to restore, so the activation must not happen.
-    let saveFront: @Sendable () -> Int32
+    /// Captures the current front process. The snapshot is **returned to the
+    /// caller** rather than parked in the shared `Live`: one process-wide slot is
+    /// one save/restore pair, and two overlapping activations would interleave into
+    /// it — A saves Claude, A fronts TestFlight, B saves *TestFlight*, and now
+    /// neither restore puts the user back. Per-call state makes that
+    /// unrepresentable rather than merely unlikely.
+    let saveFront: @Sendable () -> FrontSnapshot
     let makeFront: @Sendable (pid_t) -> Int32
-    let restoreFront: @Sendable () -> Int32
+    let restoreFront: @Sendable (FrontProcess) -> Int32
     let sleep: @Sendable (Duration) async -> Void
+    /// Hop for the blocking effects. Production sends them off the cooperative
+    /// pool; tests run them inline so ordering stays observable.
+    let offPool: @Sendable (@escaping @Sendable () -> Step) async -> Step
 
     public init(
         available: @escaping @Sendable () -> Bool = Live.available,
@@ -100,10 +165,11 @@ public struct SilentActivation: Sendable {
         isActive: @escaping @Sendable () -> Bool,
         isHidden: @escaping @Sendable () -> Bool,
         setHidden: @escaping @Sendable (Bool) -> Void,
-        saveFront: @escaping @Sendable () -> Int32 = Live.saveFront,
+        saveFront: @escaping @Sendable () -> FrontSnapshot = Live.saveFront,
         makeFront: @escaping @Sendable (pid_t) -> Int32 = Live.makeFront,
-        restoreFront: @escaping @Sendable () -> Int32 = Live.restoreFront,
-        sleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) }
+        restoreFront: @escaping @Sendable (FrontProcess) -> Int32 = Live.restoreFront,
+        sleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) },
+        offPool: @escaping @Sendable (@escaping @Sendable () -> Step) async -> Step = Live.offPool
     ) {
         self.available = available
         self.secureInputActive = secureInputActive
@@ -115,66 +181,131 @@ public struct SilentActivation: Sendable {
         self.makeFront = makeFront
         self.restoreFront = restoreFront
         self.sleep = sleep
+        self.offPool = offPool
     }
 
     /// Run one activation. Never throws; every failure is an `Outcome`.
     ///
-    /// The guard order is the contract. Each guard is above the front change
-    /// because each one describes a state in which taking the front would be wrong
-    /// rather than merely useless, and a guard below it would mean the user's focus
-    /// had already moved by the time we decided not to move it.
+    /// The blocking work runs in **two hops** off the cooperative pool, one either
+    /// side of the hold, rather than one hop per call: the order inside each hop is
+    /// load-bearing, and every extra hop is another chance to disturb it. All of it
+    /// blocks — `dlopen`, XPC to LaunchServices, and synchronous Mach IPC to the
+    /// WindowServer — and this repository has already lost an entire test process to
+    /// blocking the cooperative pool (see ``offCooperativePool``).
     public func run(hold: Duration = defaultHold) async -> Outcome {
-        guard available() else { return .unavailable }
-        // A password field owns the keyboard. Even 120ms of it going somewhere else
-        // is unacceptable, and macOS will not report what was typed, so this can
-        // never be made safe by checking afterwards.
-        guard !secureInputActive() else { return .refusedSecureInput }
-        guard let pid = runningPID() else { return .notRunning }
+        let previousFront: FrontProcess
+        let wasHidden: Bool
+        switch await offPool({ self.takeFront() }) {
+        case .refused(let outcome): return outcome
+        case .fronted(let previous, let hidden):
+            previousFront = previous
+            wasHidden = hidden
+        case .restored(let code):
+            // `takeFront` never produces this; treat a hop that did as a failure
+            // rather than falling through with an unset front to restore.
+            return .failed(code: code)
+        }
+
+        await sleep(hold)
+
+        // ⚠️ Process death during the hold skips this — a Ctrl-C in that 120ms
+        // leaves the user's focus on the activated app. The window is small and the
+        // damage is one focus change, so this is a documented limit rather than a
+        // signal handler.
+        guard case .restored(let restoreCode) =
+                await offPool({ self.putFrontBack(previousFront, wasHidden: wasHidden) })
+        else { return .failed(code: -1) }
+
+        guard restoreCode == 0 else {
+            Log.install.error(
+                "silent activation could not restore the front process (code \(restoreCode, privacy: .public))")
+            return .frontNotRestored(code: restoreCode)
+        }
+        return .activated(heldFor: hold)
+    }
+
+    /// Everything before the hold, in one hop.
+    ///
+    /// The guard order is the contract. Each guard is above the front change because
+    /// each describes a state in which taking the front would be *wrong* rather than
+    /// merely useless, and a guard below it would mean the user's focus had already
+    /// moved by the time we decided not to move it.
+    func takeFront() -> Step {
+        guard available() else { return .refused(.unavailable) }
+        // Secure keyboard entry is a **login-session** state, not "a password field
+        // is focused right now": Terminal's Secure Keyboard Entry and some password
+        // managers hold it for their whole lifetime. Refusing is still right — 120ms
+        // of someone's typing going where they cannot see it is not recoverable —
+        // but the caller's message must not promise it will clear on its own.
+        guard !secureInputActive() else { return .refused(.refusedSecureInput) }
+        guard let pid = runningPID() else { return .refused(.notRunning) }
         // Above the front change because swapping the front process to the app that
         // already holds it is pure cost: it cannot fire the activation the caller
         // wants, and it still spends the hold.
-        guard !isActive() else { return .alreadyActive }
+        guard !isActive() else { return .refused(.alreadyActive) }
 
         // Read before anything moves: activating an app unhides it, and on one of
         // the two trials that side effect appeared and on the other it did not — so
         // restoring this is not optional, it is covering a coin flip.
         let wasHidden = isHidden()
-        let saveCode = saveFront()
-        guard saveCode == 0 else { return .failed(code: saveCode) }
 
-        let code = makeFront(pid)
-        guard code == 0 else { return .failed(code: code) }
-
-        // From here on the front process has moved, so every exit restores it.
-        defer {
-            _ = restoreFront()
-            if wasHidden { setHidden(true) }
+        // Nothing to put back afterwards means the front must not move at all: a
+        // "restore" that lands somewhere the user did not choose is worse than never
+        // having activated. Read **once** — asking twice and reporting the second
+        // answer is how the first version of this returned a code the API never
+        // produced, and no fixture with a constant stub could tell the two apart.
+        switch saveFront() {
+        case .unreadable(let code):
+            return .refused(.failed(code: code))
+        case .saved(let previous):
+            let code = makeFront(pid)
+            guard code == 0 else {
+                // Put it back anyway. A non-zero return from a symbol with no
+                // contract is not evidence that nothing moved, and that is the one
+                // premise whose failure costs the user their focus with nothing
+                // anywhere to say so.
+                _ = restoreFront(previous)
+                if wasHidden { setHidden(true) }
+                return .refused(.failed(code: code))
+            }
+            return .fronted(previous: previous, wasHidden: wasHidden)
         }
-        await sleep(hold)
-        return .activated(heldFor: hold)
+    }
+
+    /// Everything after the hold, in one hop.
+    func putFrontBack(_ previous: FrontProcess, wasHidden: Bool) -> Step {
+        var code = restoreFront(previous)
+        if code != 0 {
+            // One retry. Leaving someone's focus where they did not put it is the
+            // worst thing this type can do, and re-asking costs nothing.
+            code = restoreFront(previous)
+        }
+        if wasHidden { setHidden(true) }
+        return .restored(code: code)
     }
 
     // MARK: - Live effects
 
-    /// The SkyLight side, resolved once and shared. A `final class` rather than
-    /// free functions because the saved front process has to live somewhere between
-    /// ``saveFront`` and ``restoreFront``.
-    public final class Live: @unchecked Sendable {
+    /// The SkyLight side, resolved once and shared.
+    ///
+    /// Deliberately **stateless**: it resolves symbols and calls them, and holds
+    /// nothing between calls. The saved front process lives in the `run()` that
+    /// saved it — see ``saveFront`` for why a shared slot was the wrong shape.
+    public final class Live: Sendable {
         public static let shared = Live()
 
         /// An 8-byte `ProcessSerialNumber`. Declared here rather than imported so
         /// that nothing in this file depends on the deprecated Carbon struct.
         private struct PSN { var hi: UInt32 = 0; var lo: UInt32 = 0 }
 
-        private typealias GetProcessForPIDFn = @convention(c) (pid_t, UnsafeMutableRawPointer) -> Int32
-        private typealias GetFrontFn = @convention(c) (UnsafeMutableRawPointer) -> Int32
-        private typealias SetFrontFn = @convention(c) (UnsafeMutableRawPointer, UInt32, UInt32) -> Int32
+        private typealias GetProcessForPIDFn =
+            @convention(c) @Sendable (pid_t, UnsafeMutableRawPointer) -> Int32
+        private typealias GetFrontFn = @convention(c) @Sendable (UnsafeMutableRawPointer) -> Int32
+        private typealias SetFrontFn =
+            @convention(c) @Sendable (UnsafeMutableRawPointer, UInt32, UInt32) -> Int32
 
         /// Front the process without bringing any of its windows forward.
         private static let kCPSNoWindows: UInt32 = 0x400
-
-        private let lock = NSLock()
-        private var saved: PSN?
 
         private let getProcessForPID: GetProcessForPIDFn?
         private let getFront: GetFrontFn?
@@ -189,9 +320,13 @@ public struct SilentActivation: Sendable {
             }
             getFront = sym("_SLPSGetFrontProcess", sky)
             setFront = sym("_SLPSSetFrontProcessWithOptions", sky)
+            // Resolved out of the already-loaded image rather than by opening
+            // HIServices: `import Carbon` above is what puts it there, so if that
+            // import ever goes the feature degrades to `.unavailable` for good,
+            // silently. `theLiveSymbolsResolveOnThisMac` is what notices.
             getProcessForPID = sym("GetProcessForPID", dlopen(nil, RTLD_LAZY))
             if getFront == nil || setFront == nil || getProcessForPID == nil {
-                Log.scan.notice("skylight symbols missing — silent activation unavailable")
+                Log.install.notice("skylight symbols missing — silent activation unavailable")
             }
         }
 
@@ -200,22 +335,27 @@ public struct SilentActivation: Sendable {
         public static let available: @Sendable () -> Bool = { shared.resolved }
         var resolved: Bool { getFront != nil && setFront != nil && getProcessForPID != nil }
 
-        /// Whether a password field (or anything else) has taken secure input.
+        /// Whether secure keyboard entry is on anywhere in this login session.
         /// Public Carbon API, unlike everything else in this class.
         public static let secureInputActive: @Sendable () -> Bool = { IsSecureEventInputEnabled() }
 
-        public static let saveFront: @Sendable () -> Int32 = { shared.saveFrontProcess() }
+        public static let saveFront: @Sendable () -> FrontSnapshot = { shared.saveFrontProcess() }
         public static let makeFront: @Sendable (pid_t) -> Int32 = { shared.makeFrontProcess($0) }
-        public static let restoreFront: @Sendable () -> Int32 = { shared.restoreFrontProcess() }
+        public static let restoreFront: @Sendable (FrontProcess) -> Int32 = { shared.restore($0) }
 
-        func saveFrontProcess() -> Int32 {
-            guard let getFront else { return -1 }
+        /// The production hop. `offCooperativePool` is not cancellable, which is what
+        /// this wants: a half-done front change must finish putting itself back
+        /// rather than abandon someone's focus.
+        public static let offPool: @Sendable (@escaping @Sendable () -> Step) async -> Step = { work in
+            (try? await offCooperativePool { work() }) ?? .refused(.failed(code: -1))
+        }
+
+        func saveFrontProcess() -> FrontSnapshot {
+            guard let getFront else { return .unreadable(code: -1) }
             var psn = PSN()
             let code = getFront(&psn)
-            if code == 0 {
-                lock.lock(); saved = psn; lock.unlock()
-            }
-            return code
+            guard code == 0 else { return .unreadable(code: code) }
+            return .saved(FrontProcess(hi: psn.hi, lo: psn.lo))
         }
 
         func makeFrontProcess(_ pid: pid_t) -> Int32 {
@@ -226,10 +366,9 @@ public struct SilentActivation: Sendable {
             return setFront(&psn, 0, Self.kCPSNoWindows)
         }
 
-        func restoreFrontProcess() -> Int32 {
+        func restore(_ front: FrontProcess) -> Int32 {
             guard let setFront else { return -1 }
-            lock.lock(); let psn = saved; lock.unlock()
-            guard var psn else { return -1 }
+            var psn = PSN(hi: front.hi, lo: front.lo)
             return setFront(&psn, 0, Self.kCPSNoWindows)
         }
     }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SilentActivationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SilentActivationTests.swift
@@ -19,6 +19,14 @@ struct SilentActivationTests {
         private(set) var hiddenWrites: [Bool] = []
         func note(_ s: String) { lock.lock(); log.append(s); lock.unlock() }
         func wroteHidden(_ v: Bool) { lock.lock(); hiddenWrites.append(v); lock.unlock() }
+        private var restoreCalls = 0
+        func nextRestoreCode(_ codes: [Int32]) -> Int32 {
+            lock.lock(); defer { lock.unlock() }
+            defer { restoreCalls += 1 }
+            return restoreCalls < codes.count ? codes[restoreCalls] : codes.last ?? 0
+        }
+        var restoreAttempts: Int { log.filter { $0 == "restoreFront" }.count }
+        var saveAttempts: Int { log.filter { $0 == "saveFront" }.count }
         var frontWasTaken: Bool { log.contains("makeFront") }
         var frontWasRestored: Bool { log.contains("restoreFront") }
     }
@@ -29,7 +37,8 @@ struct SilentActivationTests {
         pid: pid_t? = 4242,
         active: Bool = false,
         hidden: Bool = false,
-        saveCode: Int32 = 0,
+        saveFails: Int32? = nil,
+        restoreCodes: [Int32] = [0],
         frontCode: Int32 = 0,
         spy: Spy
     ) -> SilentActivation {
@@ -40,10 +49,21 @@ struct SilentActivationTests {
             isActive: { spy.note("isActive"); return active },
             isHidden: { spy.note("isHidden"); return hidden },
             setHidden: { spy.note("setHidden"); spy.wroteHidden($0) },
-            saveFront: { spy.note("saveFront"); return saveCode },
+            saveFront: {
+                spy.note("saveFront")
+                if let saveFails { return .unreadable(code: saveFails) }
+                return .saved(SilentActivation.FrontProcess(hi: 0, lo: 99))
+            },
             makeFront: { _ in spy.note("makeFront"); return frontCode },
-            restoreFront: { spy.note("restoreFront"); return 0 },
-            sleep: { _ in spy.note("sleep") })
+            restoreFront: { front in
+                spy.note("restoreFront")
+                #expect(front == SilentActivation.FrontProcess(hi: 0, lo: 99))
+                return spy.nextRestoreCode(restoreCodes)
+            },
+            sleep: { _ in spy.note("sleep") },
+            // Inline rather than a real Dispatch hop: the cases assert on ordering,
+            // and production's hop is pinned separately by `theProductionHopIsOffPool`.
+            offPool: { work in work() })
     }
 
     /// A password field owns the keyboard, so the 120ms window would send the
@@ -89,8 +109,11 @@ struct SilentActivationTests {
         #expect(outcome == .activated(heldFor: .milliseconds(1)))
         #expect(spy.frontWasRestored)
         // Ordering is the point: restore comes after the hold, not before it.
-        #expect(spy.log.firstIndex(of: "makeFront")! < spy.log.firstIndex(of: "sleep")!)
-        #expect(spy.log.firstIndex(of: "sleep")! < spy.log.firstIndex(of: "restoreFront")!)
+        // Optional-compared rather than force-unwrapped, so a mutation that removes
+        // one of these fails the case instead of trapping and killing the run.
+        let order = ["makeFront", "sleep", "restoreFront"].map { spy.log.firstIndex(of: $0) }
+        #expect(order.allSatisfy { $0 != nil })
+        #expect(order == order.compactMap { $0 }.sorted().map { Optional($0) })
     }
 
     /// An app the user had hidden goes back to hidden: activating unhides it, and
@@ -123,7 +146,7 @@ struct SilentActivationTests {
     /// Mutation: ignore `saveFront()`'s return value — `frontWasTaken` becomes true.
     @Test func aFrontProcessThatCannotBeSavedIsNeverReplaced() async {
         let spy = Spy()
-        let outcome = await Self.activation(saveCode: -1, spy: spy).run()
+        let outcome = await Self.activation(saveFails: -1, spy: spy).run()
         #expect(outcome == .failed(code: -1))
         #expect(!spy.frontWasTaken)
     }
@@ -152,6 +175,99 @@ struct SilentActivationTests {
         #expect(outcome == .alreadyActive)
         #expect(!spy.frontWasTaken)
         #expect(spy.hiddenWrites.isEmpty)
+    }
+
+    /// A failed restore is retried once and then reported. Leaving someone's focus
+    /// where they did not put it is the worst thing this type can do, so it is the
+    /// one failure that must not be folded into the success case.
+    ///
+    /// Mutation: write `_ = restoreFront(previousFront)` and return `.activated`
+    /// unconditionally (the shape this file shipped with first) — the outcome and
+    /// the retry count both change, and this fails on both.
+    @Test func aFailedRestoreIsRetriedAndThenReported() async {
+        let spy = Spy()
+        let outcome = await Self.activation(restoreCodes: [-1, -1], spy: spy)
+            .run(hold: .milliseconds(1))
+        #expect(outcome == .frontNotRestored(code: -1))
+        #expect(spy.restoreAttempts == 2)
+    }
+
+    /// ...and a restore that succeeds on the retry is an ordinary success, not a
+    /// reported failure.
+    ///
+    /// Mutation: drop the retry — the outcome becomes `.frontNotRestored` and this
+    /// fails. Without this case the retry could be deleted and the suite stay green.
+    @Test func aRestoreThatSucceedsOnTheRetryIsStillASuccess() async {
+        let spy = Spy()
+        let outcome = await Self.activation(restoreCodes: [-1, 0], spy: spy)
+            .run(hold: .milliseconds(1))
+        #expect(outcome == .activated(heldFor: .milliseconds(1)))
+        #expect(spy.restoreAttempts == 2)
+    }
+
+    /// The front process is read **once**. The first version of this asked twice —
+    /// once in the `guard`, once in its `else` — so a transient failure followed by a
+    /// success returned `.failed(code: -1)`, a code the API never produced, and threw
+    /// away a perfectly good snapshot.
+    ///
+    /// ⚠️ This case exists because the *mutation was run and nothing went red*: every
+    /// other case stubs `saveFront` as a constant, so the correct implementation and
+    /// the double-reading one give identical answers for every input. Counting the
+    /// calls is the only thing that separates them.
+    ///
+    /// Mutation: read `saveFront()` a second time in the failure path — `saveAttempts`
+    /// becomes 2 and this fails.
+    @Test func theFrontProcessIsReadExactlyOnce() async {
+        for failing in [true, false] {
+            let spy = Spy()
+            _ = await Self.activation(saveFails: failing ? -1 : nil, spy: spy)
+                .run(hold: .milliseconds(1))
+            #expect(spy.saveAttempts == 1)
+        }
+    }
+
+    /// A `makeFront` that reports failure still gets a restore. A non-zero return
+    /// from a symbol with no contract is not evidence that nothing moved, and that
+    /// is the one premise whose failure costs the user their focus silently.
+    ///
+    /// Mutation: return `.refused(.failed(code:))` without the `restoreFront` /
+    /// `setHidden` pair — `restoreAttempts` drops to 0 and this fails.
+    @Test func aFrontChangeThatReportedFailureIsStillPutBack() async {
+        let spy = Spy()
+        let outcome = await Self.activation(hidden: true, frontCode: -600, spy: spy).run()
+        #expect(outcome == .failed(code: -600))
+        #expect(spy.restoreAttempts == 1)
+        #expect(spy.hiddenWrites == [true])
+    }
+
+    /// The three symbols really do resolve on a Mac. Everything else in this file
+    /// stubs `Live` out entirely, so without this the whole live side — the dlopen,
+    /// the three dlsym names, `GetProcessForPID` coming from the `import Carbon`
+    /// rather than an explicit handle — could be replaced with `return 0` and the
+    /// suite would stay green.
+    ///
+    /// ⚠️ Vacuity: this asserts the symbols exist, not that they do anything. It is a
+    /// smoke test for the resolution step, and it is expected to start failing on
+    /// some future macOS — that failure is the signal, and the product degrades to
+    /// `.unavailable` rather than misbehaving.
+    @Test func theLiveSymbolsResolveOnThisMac() {
+        #expect(SilentActivation.Live.available())
+    }
+
+    /// Production must hop off the cooperative pool: `dlopen`, XPC to LaunchServices,
+    /// and Mach IPC to the WindowServer all block, and this repository has already
+    /// lost a whole test process to blocking that pool.
+    ///
+    /// Mutation: change the default to `{ work in work() }` — this fails. Pinned in
+    /// the source text because the default closure is otherwise opaque.
+    @Test func theProductionHopIsOffPool() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/DuoUpdaterCore/Support/SilentActivation.swift"),
+            encoding: .utf8)
+        #expect(source.contains("try? await offCooperativePool { work() }"))
     }
 
     /// The hold is a measured value, not a guess: 50ms produced a single store

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SilentActivationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SilentActivationTests.swift
@@ -1,0 +1,166 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The ordering rules of `SilentActivation`, with SkyLight and the front process
+/// replaced by spies so no case takes anyone's focus.
+///
+/// Almost everything here asserts on what did **not** happen. That is the shape of
+/// the type: it moves the user's front process for 120ms, and every rule in it
+/// exists to make sure that move is skipped, or undone, in some state where it
+/// would be wrong.
+struct SilentActivationTests {
+
+    /// Records the effects in the order they were asked for, so a case can pin
+    /// ordering and not merely occurrence.
+    private final class Spy: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var log: [String] = []
+        private(set) var hiddenWrites: [Bool] = []
+        func note(_ s: String) { lock.lock(); log.append(s); lock.unlock() }
+        func wroteHidden(_ v: Bool) { lock.lock(); hiddenWrites.append(v); lock.unlock() }
+        var frontWasTaken: Bool { log.contains("makeFront") }
+        var frontWasRestored: Bool { log.contains("restoreFront") }
+    }
+
+    private static func activation(
+        available: Bool = true,
+        secureInput: Bool = false,
+        pid: pid_t? = 4242,
+        active: Bool = false,
+        hidden: Bool = false,
+        saveCode: Int32 = 0,
+        frontCode: Int32 = 0,
+        spy: Spy
+    ) -> SilentActivation {
+        SilentActivation(
+            available: { available },
+            secureInputActive: { secureInput },
+            runningPID: { spy.note("runningPID"); return pid },
+            isActive: { spy.note("isActive"); return active },
+            isHidden: { spy.note("isHidden"); return hidden },
+            setHidden: { spy.note("setHidden"); spy.wroteHidden($0) },
+            saveFront: { spy.note("saveFront"); return saveCode },
+            makeFront: { _ in spy.note("makeFront"); return frontCode },
+            restoreFront: { spy.note("restoreFront"); return 0 },
+            sleep: { _ in spy.note("sleep") })
+    }
+
+    /// A password field owns the keyboard, so the 120ms window would send the
+    /// user's typing somewhere they cannot see and macOS will not report.
+    ///
+    /// Mutation: move the `secureInputActive` guard below `makeFront(pid)`, or drop
+    /// it — `frontWasTaken` becomes true and this fails.
+    @Test func aSecureInputSessionIsRefusedWithoutTakingTheFront() async {
+        let spy = Spy()
+        let outcome = await Self.activation(secureInput: true, spy: spy).run()
+        #expect(outcome == .refusedSecureInput)
+        #expect(!spy.frontWasTaken)
+    }
+
+    /// A macOS that no longer exports the SkyLight symbols is an ordinary answer,
+    /// not a failure — and nothing at all may be touched on the way to saying so.
+    ///
+    /// Mutation: return `.failed(code:)` instead of `.unavailable`, or move the
+    /// `available()` guard below `saveFront()` — the outcome or the log changes.
+    @Test func aMacWithoutTheSymbolsIsNotAFailureToReport() async {
+        let spy = Spy()
+        let outcome = await Self.activation(available: false, spy: spy).run()
+        #expect(outcome == .unavailable)
+        #expect(spy.log.isEmpty)
+    }
+
+    /// Mutation: move the `runningPID()` guard below `makeFront` — this fails,
+    /// because there is no pid to front and the front would move for nothing.
+    @Test func anAppThatIsNotRunningIsNeverFronted() async {
+        let spy = Spy()
+        let outcome = await Self.activation(pid: nil, spy: spy).run()
+        #expect(outcome == .notRunning)
+        #expect(!spy.frontWasTaken)
+    }
+
+    /// The front process is restored on the way out, always.
+    ///
+    /// Mutation: delete the `defer` block, or turn it into a plain trailing
+    /// statement after an early `return` — `frontWasRestored` becomes false.
+    @Test func theFrontProcessIsAlwaysRestored() async {
+        let spy = Spy()
+        let outcome = await Self.activation(spy: spy).run(hold: .milliseconds(1))
+        #expect(outcome == .activated(heldFor: .milliseconds(1)))
+        #expect(spy.frontWasRestored)
+        // Ordering is the point: restore comes after the hold, not before it.
+        #expect(spy.log.firstIndex(of: "makeFront")! < spy.log.firstIndex(of: "sleep")!)
+        #expect(spy.log.firstIndex(of: "sleep")! < spy.log.firstIndex(of: "restoreFront")!)
+    }
+
+    /// An app the user had hidden goes back to hidden: activating unhides it, and
+    /// that side effect appeared on one live trial and not on the other, so this
+    /// covers a coin flip rather than a known behaviour.
+    ///
+    /// Mutation: drop the `if wasHidden { setHidden(true) }` line — `hiddenWrites`
+    /// is empty and this fails.
+    @Test func anAppThatWasHiddenIsHiddenAgain() async {
+        let spy = Spy()
+        _ = await Self.activation(hidden: true, spy: spy).run(hold: .milliseconds(1))
+        #expect(spy.hiddenWrites == [true])
+    }
+
+    /// ...and an app the user had **open** is not hidden behind their back.
+    ///
+    /// Mutation: make the restore unconditional (`setHidden(true)` with no `if`) —
+    /// `hiddenWrites` becomes `[true]` and this fails. This is the half that a
+    /// single "state is restored" case would silently lose.
+    @Test func anAppThatWasNotHiddenIsLeftAlone() async {
+        let spy = Spy()
+        _ = await Self.activation(hidden: false, spy: spy).run(hold: .milliseconds(1))
+        #expect(spy.hiddenWrites.isEmpty)
+    }
+
+    /// Without a saved front process there is nothing to restore, so the front must
+    /// not move at all — a "restore" that puts the user somewhere they did not
+    /// choose is worse than never having activated.
+    ///
+    /// Mutation: ignore `saveFront()`'s return value — `frontWasTaken` becomes true.
+    @Test func aFrontProcessThatCannotBeSavedIsNeverReplaced() async {
+        let spy = Spy()
+        let outcome = await Self.activation(saveCode: -1, spy: spy).run()
+        #expect(outcome == .failed(code: -1))
+        #expect(!spy.frontWasTaken)
+    }
+
+    /// A refused activation is reported with the code, and does not report a hold
+    /// that never happened.
+    ///
+    /// Mutation: `_ = makeFront(pid)` — this returns `.activated` and fails.
+    @Test func aRefusedActivationIsNotReportedAsAHold() async {
+        let spy = Spy()
+        let outcome = await Self.activation(frontCode: -600, spy: spy).run()
+        #expect(outcome == .failed(code: -600))
+        #expect(spy.log.last != "sleep")
+    }
+
+    /// Swapping the front process to the app that already holds it cannot fire the
+    /// activation, so it is pure cost — and reporting it as a hold would claim a
+    /// nudge that never landed. Measured 2026-09-10 with TestFlight frontmost: zero
+    /// network connections, against 2 for the same call on a background instance.
+    ///
+    /// Mutation: drop the `isActive()` guard — the outcome becomes `.activated` and
+    /// `frontWasTaken` becomes true; this fails on both.
+    @Test func anAppThatIsAlreadyActiveIsLeftCompletelyAlone() async {
+        let spy = Spy()
+        let outcome = await Self.activation(active: true, spy: spy).run()
+        #expect(outcome == .alreadyActive)
+        #expect(!spy.frontWasTaken)
+        #expect(spy.hiddenWrites.isEmpty)
+    }
+
+    /// The hold is a measured value, not a guess: 50ms produced a single store
+    /// write where 120ms produced the full burst. A case pins it because the
+    /// temptation to "just make it shorter" is exactly what the measurement
+    /// forbids.
+    ///
+    /// Mutation: change `defaultHold` to 50ms — this fails and says why.
+    @Test func theDefaultHoldIsTheMeasuredValue() {
+        #expect(SilentActivation.defaultHold == .milliseconds(120))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
@@ -138,6 +138,41 @@ struct TestFlightRefreshTests {
         #expect(spy.sleeps == 0)
     }
 
+    /// A focus that could not be put back is told to the user at once, instead of
+    /// after a 30-second wait for a version number. A window they did not raise is
+    /// the more urgent fact, and the refresh that did happen is on disk for the next
+    /// check regardless.
+    ///
+    /// Mutation: fall through to the wait (`launched = false`) — the outcome becomes
+    /// a refresh verdict, `sleeps` stops being 0, and this fails on both.
+    @Test func aFocusThatCouldNotBeRestoredIsReportedImmediately() async {
+        let spy = Spy()
+        let refresher = Self.refresher(
+            running: true, activation: .frontNotRestored(code: -600),
+            stamp: Stamp(changesAt: [3]), spy: spy)
+        let outcome = await refresher.run(deadline: .seconds(30))
+        #expect(outcome == .focusNotRestored(code: -600))
+        #expect(spy.sleeps == 0)
+    }
+
+    /// The production wiring must map "no pid" to nil, not forward -1.
+    /// `NSRunningApplication` documents that applications without a pid return -1 and
+    /// that the object outlives the process — and TestFlight is automatically
+    /// terminated constantly, so this is the common path, not a corner.
+    ///
+    /// Mutation: drop the `pid > 0` check — the `.notRunning` fallback becomes
+    /// unreachable and a quit-during-the-race is reported as `GetProcessForPID(-1)`
+    /// failing. Pinned in the source text because the closure is a live effect.
+    @Test func theProductionWiringTreatsMinusOneAsNoPid() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift"),
+            encoding: .utf8)
+        #expect(source.contains("pid > 0 else { return nil }"))
+    }
+
     /// TestFlight quitting between `isRunning()` and the activation is a race, not
     /// a failure: the cold route serves it.
     ///

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
@@ -16,10 +16,15 @@ struct TestFlightRefreshTests {
     private final class Spy: @unchecked Sendable {
         private let lock = NSLock()
         private(set) var launches: [URL] = []
+        private(set) var activations = 0
         private(set) var sleeps = 0
         func launched(_ url: URL) {
             lock.lock(); defer { lock.unlock() }
             launches.append(url)
+        }
+        func activated() {
+            lock.lock(); defer { lock.unlock() }
+            activations += 1
         }
         func slept() {
             lock.lock(); defer { lock.unlock() }
@@ -50,6 +55,7 @@ struct TestFlightRefreshTests {
         installed: Bool = true,
         running: Bool = false,
         launchSucceeds: Bool = true,
+        activation: SilentActivation.Outcome = .activated(heldFor: .milliseconds(120)),
         stamp: Stamp = Stamp(),
         spy: Spy
     ) -> TestFlightRefresh {
@@ -57,22 +63,93 @@ struct TestFlightRefreshTests {
             locate: { installed ? bundle : nil },
             isRunning: { running },
             launch: { url in spy.launched(url); return launchSucceeds },
+            activate: { spy.activated(); return activation },
             storeStamp: { stamp.read() },
             sleep: { _ in spy.slept() })
     }
 
-    /// Measured: with TestFlight already running, a background launch delivers the
-    /// request and the store is still unchanged two minutes later. So this is a
-    /// refusal, and it must come BEFORE the launch — otherwise the caller is told a
-    /// refresh happened, having only started a process.
+    /// Measured four times: with TestFlight already running, a background launch
+    /// delivers the request and the store is still unchanged two minutes later. So
+    /// the running case takes the activation route instead — and it must still
+    /// launch nothing, or the caller is told a refresh happened having only started
+    /// a second process.
     ///
-    /// Mutation: move the `isRunning` guard below `launch(bundle)`, or drop it —
+    /// Mutation: swap the two branches of `if isRunning()`, or drop the check —
     /// `launches` becomes non-empty and this fails.
-    @Test func aRunningTestFlightIsRefusedWithoutLaunchingAnything() async {
+    @Test func aRunningTestFlightIsActivatedAndNeverLaunched() async {
         let spy = Spy()
-        let outcome = await Self.refresher(running: true, spy: spy).run()
-        #expect(outcome == .alreadyRunning)
+        let refresher = Self.refresher(running: true, stamp: Stamp(changesAt: [3]), spy: spy)
+        let outcome = await refresher.run(deadline: .seconds(30))
+        #expect(outcome == .refreshed(after: .seconds(1)))
         #expect(spy.launches.isEmpty)
+        #expect(spy.activations == 1)
+    }
+
+    /// An activation that changed nothing is reported as its own case: "we nudged
+    /// the running app and its data did not move" is a different sentence from
+    /// "we started it from cold and its data did not move", and the CLI prints
+    /// both.
+    ///
+    /// Mutation: return `.launchedWithoutChange` for both routes — this fails.
+    @Test func anActivationThatChangesNothingIsNotCalledALaunch() async {
+        let spy = Spy()
+        let outcome = await Self.refresher(running: true, spy: spy).run(deadline: .seconds(2))
+        #expect(outcome == .activatedWithoutChange)
+        #expect(spy.launches.isEmpty)
+    }
+
+    /// A macOS without the SkyLight symbols cannot serve a running TestFlight, and
+    /// says so rather than launching a second copy behind the user's back.
+    ///
+    /// Mutation: fall through to `launch(bundle)` on `.unavailable` — `launches`
+    /// becomes non-empty and this fails.
+    @Test func aRunningTestFlightIsNotLaunchedWhenActivationIsUnavailable() async {
+        let spy = Spy()
+        let outcome = await Self.refresher(running: true, activation: .unavailable, spy: spy).run()
+        #expect(outcome == .activationUnavailable)
+        #expect(spy.launches.isEmpty)
+        #expect(spy.sleeps == 0)
+    }
+
+    /// A password field owning the keyboard is surfaced, not worked around.
+    ///
+    /// Mutation: map `.refusedSecureInput` onto `.activationUnavailable` — the
+    /// user is then told this Mac cannot do it at all, which is false and would
+    /// stop them retrying a second later. This fails.
+    @Test func aSecureInputRefusalReachesTheCaller() async {
+        let spy = Spy()
+        let outcome = await Self.refresher(running: true, activation: .refusedSecureInput, spy: spy).run()
+        #expect(outcome == .refusedSecureInput)
+        #expect(spy.launches.isEmpty)
+    }
+
+    /// The user is looking at TestFlight right now. Nothing is launched, nothing is
+    /// activated a second time, and the CLI says so rather than reporting a refresh
+    /// that did not happen — measured: zero network connections in this state.
+    ///
+    /// Mutation: map `.alreadyActive` onto `.activatedWithoutChange` — the user is
+    /// then told their data "did not change" when in fact nothing was ever asked.
+    /// This fails.
+    @Test func aFrontmostTestFlightIsReportedNotNudged() async {
+        let spy = Spy()
+        let outcome = await Self.refresher(running: true, activation: .alreadyActive, spy: spy).run()
+        #expect(outcome == .alreadyFrontmost)
+        #expect(spy.launches.isEmpty)
+        #expect(spy.sleeps == 0)
+    }
+
+    /// TestFlight quitting between `isRunning()` and the activation is a race, not
+    /// a failure: the cold route serves it.
+    ///
+    /// Mutation: return `.activationFailed` on `.notRunning` — a refresh that
+    /// would have worked is reported as broken. This fails.
+    @Test func anAppThatQuitsDuringTheRaceFallsBackToTheColdLaunch() async {
+        let spy = Spy()
+        let refresher = Self.refresher(
+            running: true, activation: .notRunning, stamp: Stamp(changesAt: [3]), spy: spy)
+        let outcome = await refresher.run(deadline: .seconds(30))
+        #expect(outcome == .refreshed(after: .seconds(1)))
+        #expect(spy.launches == [Self.bundle])
     }
 
     /// Mutation: return `.launchFailed` (or `.notInstalled`) unconditionally when
@@ -153,14 +230,20 @@ struct TestFlightRefreshTests {
         #expect(spy.sleeps == 4)
     }
 
-    /// The launch must be a background one. This is the whole reason the feature is
-    /// acceptable at all — a foreground activation refreshes in 3s but takes the
-    /// user's screen, and doing that from a background check is what #491 refuses.
+    /// The launch must be background AND hidden. Both halves were measured, and
+    /// each covers a different way of getting in the user's way:
     ///
-    /// Mutation: change the default `launch` to `AppRestarter.launchApp($0)` (which
-    /// defaults to `activates: true`) — the compiler is happy and this case is the
-    /// only thing that objects.
-    @Test func theProductionLaunchDoesNotActivate() async {
+    ///   * `activates: false` — a foreground activation refreshes in 3s but takes
+    ///     the screen, which is what #491 refuses to do from a background check.
+    ///   * `hides: true` — without it the launch still puts a real window on screen
+    ///     behind the user's work (measured 2026-09-09 with
+    ///     `CGWindowListCopyWindowInfo`: layer 0, alpha 1, 1010×717, and visible in
+    ///     Mission Control). With it: zero on-screen windows, same sync.
+    ///
+    /// Mutation: drop either argument — `AppRestarter.launchApp($0)` defaults to
+    /// `activates: true` and `hides: false`, the compiler stays happy, and this case
+    /// is the only thing that objects.
+    @Test func theProductionLaunchIsBackgroundAndHidden() async {
         // The default closure is opaque, so this pins the intent where it is
         // written rather than the closure itself: `activates` must be false.
         let source = try? String(
@@ -171,6 +254,6 @@ struct TestFlightRefreshTests {
                 .appendingPathComponent("Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift"),
             encoding: .utf8)
         let text = try! #require(source)
-        #expect(text.contains("AppRestarter.launchApp($0, activates: false)"))
+        #expect(text.contains("AppRestarter.launchApp($0, activates: false, hides: true)"))
     }
 }


### PR DESCRIPTION
`duo check --refresh-testflight` used to give up whenever TestFlight happened to be
running — which is most of the time, since TestFlight lingers six to ten minutes
after any launch. It now serves both states.

## What TestFlight actually responds to

Its store is written by TestFlight.app and nothing else, and TestFlight goes and
asks the server on exactly two occasions: a **cold launch**, and **becoming
active**. The existing hidden background launch serves the first. The second is new
here, and it is the only thing that reaches an instance that is already up — a
background launch delivered to a running TestFlight does nothing at all, measured
four times.

## Everything that was tried

Two independent witnesses: the store's write-ahead log, and `lsof` sampling
TestFlight's own sockets every 500 ms. A cold hidden launch was the positive
control, so an empty result means "nothing happened", not "the witness was blind".

| trigger | network | store | focus |
|---|---|---|---|
| cold hidden launch (control) | 6 connections | written | unchanged |
| **silent activation** | **2 connections** | **written** | **unchanged** |
| `CGEventPostToPid` click | none | untouched | unchanged |
| `CGEventPostToPid` scroll | none | untouched | unchanged |
| AX `AXRaise` | none (returned -25205) | untouched | unchanged |
| AX `AXScrollDownByPage` | none (returned -25205) | untouched | unchanged |

The whole input-injection family is dead for this purpose, for the same reason the
new type is needed: posted input events do not make an app active.

## On the private symbols

`_SLPSSetFrontProcessWithOptions` and friends are in `SkyLight.framework`. They are
resolved with `dlopen`/`dlsym` and every failure degrades to `.unavailable` — the
caller treats that as an ordinary answer, not an error.

- **Notarization does not inspect API surface.** Apple: the notary service "scans
  your software for malicious content, checks for code-signing issues" and "is not
  App Review". Shipping Developer ID apps do exactly this.
- **No new permission.** Run through `launchctl submit` so it could not inherit the
  parent's grant, the activation still worked with `AXIsProcessTrusted()` false.
  This is the one way it beats `CGEventPostToPid`, which Apple documents as
  requiring Accessibility.
- **The real cost is that there is no contract**: a future macOS may remove them,
  which is why `unavailable` is a first-class outcome with its own CLI sentence.

## Verified on a real Mac with the deployed binary

Four states, front process sampled four times a second throughout:

| state | result |
|---|---|
| not running | new pid, hidden, 0 on-screen windows, focus never moved, 6 connections |
| running, hidden | same pid, still hidden, 0 windows, focus restored, 2 connections |
| running, window visible | same pid, **window not raised**, focus restored, 1 connection |
| running, frontmost | nothing touched, 0 connections, and it says so |

That last state gets its own outcome: an already-active app cannot be made to
become active, so the front swap would be pure cost and no sync happens. Reporting
it as "nudged, nothing changed" would claim a nudge that never landed.

## Cost, stated plainly

The activation holds the front process for **120 ms**, and keystrokes in that window
go to TestFlight. 50 ms was tried and produced a single store write where 120 ms
produced the full burst, so this is the shorter of the two values seen to work.
`IsSecureEventInputEnabled()` refuses the whole thing while a password field is
active.

Restoring the hidden state is **not optional**: activating unhides the app on some
runs and not others, and both halves are pinned (an app that was hidden goes back to
hidden; an app that was open is never hidden behind the user's back).

## Testing

- `make test` — 2522 / 263 / App tests 9 of 9, exit 0
- **14 mutations run, each reddened only the case that names it** — every new guard
  has one: the secure-input refusal, the already-active refusal, the front restore,
  both halves of the hidden restore, both ignored return codes, both guard
  reorderings, the hold constant, and the four routing branches.
- Still deliberately explicit and user-initiated. Not on a periodic check: the
  system declines this work while the device is in use, and doing it on a timer
  would override that decision on the user's behalf.