### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.2",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -133,25 +133,29 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
-      "lastGoodVersion" : "8.7.9",
+      "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
     "changelog:com.bytedance.inputmethod.doubaoime:-" : {
-      "consecutiveActionable" : 0,
+      "consecutiveActionable" : 2,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "issueNumber" : 497,
+      "lastCommentedAt" : "2026-09-09T20:30:20Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.9.7",
-      "sweepsSinceComment" : 0
+      "lastSignature" : "newest changelog entry (0.9.7) trails th",
+      "sweepsSinceComment" : 0,
+      "triagedSignature" : "newest changelog entry (0.9.7) trails th"
     },
     "changelog:com.carriez.rustdesk:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -160,7 +164,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.84.0",
       "sweepsSinceComment" : 0
@@ -169,7 +173,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -178,7 +182,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
@@ -187,7 +191,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -196,7 +200,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
@@ -205,7 +209,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
@@ -214,7 +218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -223,7 +227,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -232,7 +236,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -241,7 +245,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -250,7 +254,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -259,7 +263,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -268,7 +272,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -277,7 +281,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
@@ -286,7 +290,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
@@ -295,7 +299,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -304,7 +308,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -313,7 +317,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -322,7 +326,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -331,7 +335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -340,16 +344,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
-      "lastGoodVersion" : "0.19.1",
+      "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
     "changelog:com.microsoft.Headlamp:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -358,16 +362,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
-      "lastGoodVersion" : "1.136",
+      "lastGoodVersion" : "1.137",
       "sweepsSinceComment" : 0
     },
     "changelog:com.mitchellh.ghostty:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -378,7 +382,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
@@ -388,7 +392,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
@@ -397,7 +401,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -406,7 +410,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -415,7 +419,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "12.27.2",
       "sweepsSinceComment" : 0
@@ -424,7 +428,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.2.1",
       "sweepsSinceComment" : 0
@@ -435,7 +439,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0,
@@ -445,7 +449,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -454,7 +458,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -463,16 +467,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "3.13.2",
+      "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
     "changelog:com.shotbase.app:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -481,7 +485,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -490,7 +494,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -499,7 +503,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -510,7 +514,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609082",
       "sweepsSinceComment" : 0,
@@ -520,7 +524,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -529,7 +533,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -538,7 +542,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -547,7 +551,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -556,7 +560,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -565,7 +569,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
@@ -574,16 +578,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "1.7.0-daily.20260906",
+      "lastGoodVersion" : "1.7.0-daily.20260909.1",
       "sweepsSinceComment" : 0
     },
     "changelog:com.utmapp.UTM:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -592,7 +596,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -601,7 +605,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -610,7 +614,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -619,7 +623,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -630,7 +634,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -640,7 +644,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.5.4",
       "sweepsSinceComment" : 0
@@ -649,7 +653,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -658,7 +662,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -667,7 +671,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
@@ -676,7 +680,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.02",
       "sweepsSinceComment" : 0
@@ -685,25 +689,25 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "1.19.1",
+      "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
     "changelog:dev.zed.Zed:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "1.18.1",
+      "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
     "changelog:io.dcloud.HBuilderX:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -712,7 +716,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -721,7 +725,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
@@ -730,7 +734,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -739,7 +743,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -748,7 +752,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
@@ -757,26 +761,29 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
     "changelog:notion.id:-" : {
-      "consecutiveActionable" : 1,
+      "consecutiveActionable" : 3,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "issueNumber" : 493,
+      "lastCommentedAt" : "2026-09-09T14:25:37Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "lastSignature" : "newest changelog entry (7.32.0) trails t",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 1,
+      "triagedSignature" : "newest changelog entry (7.32.0) trails t"
     },
     "changelog:now.typeless.desktop:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
@@ -785,7 +792,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -794,7 +801,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -812,7 +819,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -821,7 +828,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
@@ -830,7 +837,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -839,7 +846,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -848,7 +855,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -857,7 +864,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -866,7 +873,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
@@ -875,7 +882,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -884,7 +891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 13,
       "lastGoodVersion" : "0.1.18",
       "sweepsSinceComment" : 0
@@ -893,7 +900,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 17,
       "lastGoodVersion" : "1.7.1",
       "sweepsSinceComment" : 0
@@ -902,7 +909,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
@@ -911,7 +918,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
@@ -919,7 +926,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -927,7 +934,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -935,7 +942,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -943,7 +950,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -951,7 +958,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -959,7 +966,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -967,7 +974,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -975,7 +982,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -983,7 +990,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.3.9",
       "sweepsSinceComment" : 0
     },
@@ -991,7 +998,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -999,7 +1006,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1007,7 +1014,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1015,7 +1022,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1023,15 +1030,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.126.04524",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.135.06055",
       "sweepsSinceComment" : 0
     },
     "github:XQuartz\/XQuartz:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1039,7 +1046,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1047,7 +1054,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1055,7 +1062,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1063,7 +1070,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1071,7 +1078,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1079,7 +1086,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1087,7 +1094,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1095,7 +1102,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
@@ -1103,7 +1110,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1111,7 +1118,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1119,7 +1126,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1127,7 +1134,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1135,7 +1142,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1143,7 +1150,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1151,7 +1158,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1159,7 +1166,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1167,7 +1174,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1175,7 +1182,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1183,7 +1190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1191,7 +1198,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1199,7 +1206,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1207,7 +1214,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1215,7 +1222,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1223,7 +1230,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1231,7 +1238,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1239,7 +1246,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1247,7 +1254,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1255,7 +1262,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.20.2",
       "sweepsSinceComment" : 0
     },
@@ -1263,7 +1270,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1271,7 +1278,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1279,7 +1286,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1287,7 +1294,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1295,7 +1302,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.1.16",
       "sweepsSinceComment" : 0
     },
@@ -1303,7 +1310,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1311,7 +1318,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1319,7 +1326,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1327,7 +1334,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1335,7 +1342,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1343,7 +1350,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1351,7 +1358,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1359,7 +1366,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1367,7 +1374,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1375,7 +1382,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1383,7 +1390,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1391,7 +1398,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1399,7 +1406,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1407,7 +1414,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1415,7 +1422,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -1423,7 +1430,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1431,7 +1438,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1439,7 +1446,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1447,7 +1454,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -1455,7 +1462,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.22.2",
       "sweepsSinceComment" : 0
     },
@@ -1463,7 +1470,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1471,15 +1478,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "0.0.41-nightly.20260909.1439",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "0.0.41-nightly.20260909.1461",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1487,7 +1494,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1495,7 +1502,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1503,7 +1510,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1511,7 +1518,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1519,7 +1526,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1527,7 +1534,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1535,7 +1542,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1543,7 +1550,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1551,7 +1558,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1559,7 +1566,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1567,7 +1574,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1575,7 +1582,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1583,7 +1590,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1591,7 +1598,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1599,7 +1606,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1607,7 +1614,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1615,7 +1622,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1645,7 +1652,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1653,7 +1660,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1661,23 +1668,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.19.1",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
     "github:zed-industries\/zed:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.18.1",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
     "github:zen-browser\/desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1817,7 +1824,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1825,7 +1832,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1833,7 +1840,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1841,7 +1848,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1849,7 +1856,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1857,7 +1864,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1865,7 +1872,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1873,7 +1880,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1881,15 +1888,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "2.2.1",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "2.2.2",
       "sweepsSinceComment" : 0
     },
     "vendor:com.anthropic.claudefordesktop:stable:ga" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
     },
@@ -1897,7 +1904,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1905,15 +1912,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "0.44.0",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "0.47.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.anythingllm:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1921,15 +1928,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "8.7.9",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
     "vendor:com.bjango.istatmenus:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1937,7 +1944,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1945,7 +1952,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1953,7 +1960,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1961,7 +1968,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1969,31 +1976,31 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.95.96.0",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.96.49.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.brave.Browser.nightly:nightly" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.97.14.0",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.97.18.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.bytedance.inputmethod.doubaoime:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "0.9.7",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.canva.CanvaDesktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.125.0",
       "sweepsSinceComment" : 0
     },
@@ -2001,7 +2008,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.84.2",
       "sweepsSinceComment" : 0
     },
@@ -2009,7 +2016,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2017,7 +2024,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2025,7 +2032,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2033,7 +2040,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.6.793",
       "sweepsSinceComment" : 0
     },
@@ -2041,7 +2048,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.9.19",
       "sweepsSinceComment" : 0
     },
@@ -2049,7 +2056,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2057,7 +2064,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2065,7 +2072,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2073,23 +2080,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "154.0.8037.0",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "154.0.8037.17",
       "sweepsSinceComment" : 0
     },
     "vendor:com.google.Chrome.canary:canary" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "155.0.8048.0",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "155.0.8049.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.google.Chrome.dev:dev" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -2097,7 +2104,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2105,15 +2112,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.107.3.828",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.111.1.839",
       "sweepsSinceComment" : 0
     },
     "vendor:com.google.android.studio:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2121,7 +2128,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -2129,7 +2136,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2137,7 +2144,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2145,7 +2152,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -2153,15 +2160,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "7.543.2",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "7.543.3",
       "sweepsSinceComment" : 0
     },
     "vendor:com.henrikruscon.Alcove:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2169,7 +2176,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2177,15 +2184,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "0.0.1313",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "0.0.1314",
       "sweepsSinceComment" : 0
     },
     "vendor:com.hnc.DiscordPTB:ptb" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -2193,7 +2200,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -2201,7 +2208,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2209,7 +2216,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2217,7 +2224,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2227,8 +2234,8 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "9.5.0-beta2",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "9.5.5-beta1",
       "sweepsSinceComment" : 0
     },
     "vendor:com.lemon.lvoverseas:stable" : {
@@ -2237,7 +2244,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2245,7 +2252,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2253,15 +2260,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "0.19.1",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.macpaw.site.theunarchiver:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2269,7 +2276,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2277,7 +2284,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -2285,7 +2292,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2293,7 +2300,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2301,23 +2308,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.136.2",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.137.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.microsoft.VSCodeInsiders:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "1.137.0-insider",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "1.138.0-insider",
       "sweepsSinceComment" : 0
     },
     "vendor:com.microsoft.Word:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2325,7 +2332,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "153.0.4234.19",
       "sweepsSinceComment" : 0
     },
@@ -2333,7 +2340,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "154.0.4251.0",
       "sweepsSinceComment" : 0
     },
@@ -2341,7 +2348,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -2349,7 +2356,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2357,7 +2364,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2365,7 +2372,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2373,7 +2380,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2381,7 +2388,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2389,7 +2396,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2397,7 +2404,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26.903.61454",
       "sweepsSinceComment" : 0
     },
@@ -2405,7 +2412,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -2413,7 +2420,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2421,7 +2428,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2429,7 +2436,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "12.27.2",
       "sweepsSinceComment" : 0
     },
@@ -2437,7 +2444,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2445,7 +2452,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2453,7 +2460,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.104.28",
       "sweepsSinceComment" : 0
     },
@@ -2461,7 +2468,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.2.1.0",
       "sweepsSinceComment" : 0
     },
@@ -2469,7 +2476,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2477,7 +2484,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2485,7 +2492,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2493,7 +2500,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2501,7 +2508,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2509,7 +2516,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2517,7 +2524,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2525,7 +2532,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2535,7 +2542,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2544,7 +2551,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2554,7 +2561,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2563,7 +2570,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.02.2609082",
       "sweepsSinceComment" : 0
     },
@@ -2571,7 +2578,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2579,7 +2586,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2587,7 +2594,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2595,23 +2602,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "9.44.0",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "10.0.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.termius-dmg.mac:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "9.43.1",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "10.0.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.tigervnc.tigervnc:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2619,7 +2626,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2627,7 +2634,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.19.19",
       "sweepsSinceComment" : 0
     },
@@ -2635,7 +2642,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.21.1",
       "sweepsSinceComment" : 0
     },
@@ -2643,15 +2650,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "8.2.4133.43",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "8.3.4157.3",
       "sweepsSinceComment" : 0
     },
     "vendor:com.windscribe.client:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2659,7 +2666,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2667,7 +2674,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2675,7 +2682,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2683,7 +2690,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2691,7 +2698,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2699,7 +2706,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2707,7 +2714,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2715,7 +2722,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2723,7 +2730,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2731,7 +2738,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2739,7 +2746,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2747,7 +2754,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2755,15 +2762,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "0.2026.09.08.18.11.00",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "0.2026.09.09.08.26.00",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.warp.Warp-Preview:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2771,7 +2778,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2779,7 +2786,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2787,15 +2794,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "2026090701",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "2026090901",
       "sweepsSinceComment" : 0
     },
     "vendor:io.dcloud.HBuilderX:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2803,7 +2810,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2811,7 +2818,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2819,7 +2826,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2827,7 +2834,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.103.201",
       "sweepsSinceComment" : 0
     },
@@ -2835,7 +2842,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2843,7 +2850,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2851,7 +2858,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2859,7 +2866,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2867,7 +2874,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26.36.18",
       "sweepsSinceComment" : 0
     },
@@ -2875,7 +2882,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
@@ -2883,7 +2890,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2891,7 +2898,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2899,7 +2906,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2907,7 +2914,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2915,24 +2922,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 1,
+      "consecutiveInfra" : 3,
       "consecutiveInstallTransient" : 0,
       "infraSince" : "2026-09-09T08:25:06Z",
       "lastGoodAt" : "2026-09-09T02:22:27Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 3
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2940,15 +2947,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "156.0b4",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
     "vendor:org.mozilla.firefox:esr" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2956,7 +2963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2964,15 +2971,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "156.0b4",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
     "vendor:org.mozilla.nightly:nightly" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2980,7 +2987,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2988,7 +2995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2996,7 +3003,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "155.0",
       "sweepsSinceComment" : 0
     },
@@ -3004,15 +3011,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "156.0b2",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
     "vendor:org.pgadmin.pgadmin4:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3020,7 +3027,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3028,7 +3035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3036,7 +3043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -3044,7 +3051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "8.26.0",
       "sweepsSinceComment" : 0
     },
@@ -3054,8 +3061,8 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
-      "lastGoodVersion" : "10.0.1",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodVersion" : "10.0.2",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
     },
@@ -3063,7 +3070,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3071,11 +3078,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T08:25:06Z",
+      "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-09T08:25:08Z"
+  "updatedAt" : "2026-09-09T20:30:20Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.