### PR TITLE
Refuse an up-to-date verdict TestFlight's own notifications contradict

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2082,11 +2082,22 @@ final class AppListModel {
         // again (see `resolvedGitHubToken`).
         let token = await githubToken
         resolvedGitHubToken = ResolvedGitHubToken(explicit: explicitToken, token: token)
+        // Second witness for TestFlight rows, read off-main and bounded. It lives in
+        // Notification Center's container — a different store behind a different
+        // permission from TestFlight's own — so it is a separate way to be denied,
+        // and nil here simply turns the witness off and leaves every verdict as it
+        // was. Bounded for the same reason the TestFlight read above is: a read that
+        // has not returned is a prompt that is still up, and the refresh must not
+        // wait on it.
+        let announcements = await Self.firstResult(
+            of: Task.detached(priority: .userInitiated) { TestFlightAnnouncements() },
+            within: .seconds(2))
         let checker = UpdateChecker(
             sources: makeSources(token: token),
             maxConcurrency: prefs.maxConcurrency,
             toolbox: ToolboxSource(inventory: toolbox),
             testflight: testflight,
+            announcements: announcements,
             channelStore: ResolvedChannelStore.shared)
         // Ignored apps are not asked after. Nothing would be said about the answer,
         // so the request is pure cost — and against an unauthenticated GitHub hour
@@ -6053,6 +6064,10 @@ final class AppListModel {
         // this replaced. The checker drops the memo for exactly the array it
         // is about to check — `fresh`, passed once — so the invalidated set and
         // the checked set can no longer drift apart.
+        // No `announcements:` here on purpose, for the same reason `testflight` is
+        // the empty sentinel three lines up: this path is deliberately TestFlight-free
+        // so a post-install recheck never waits on that container's gate. The next
+        // full refresh re-applies both.
         let checker = UpdateChecker(
             sources: makeSources(token: githubToken),
             maxConcurrency: prefs.maxConcurrency,

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -515,9 +515,17 @@ public enum Install {
         // still happen per item, inside `recheckOne`; only the shared plumbing
         // around them is hoisted here (#404 review #8).
         let recheckTestflight = TestFlightInventory(macRows: [], accessible: false)
+        // The same sentinel for the second witness, and for a sharper reason than
+        // symmetry: `Inventory.checker`'s default argument would otherwise read the
+        // notification store here, and with a TestFlight inventory carrying no
+        // frontiers the answer can only ever be "not behind" — a database read whose
+        // result is unusable by construction, on the one path that exists to avoid
+        // paying for reads.
+        let recheckAnnouncements = TestFlightAnnouncements(announcements: [], accessible: false)
         let recheckToolbox = ToolboxInventory()
         let recheckChecker = Inventory.checker(
-            settings, testflight: recheckTestflight, toolbox: recheckToolbox)
+            settings, testflight: recheckTestflight,
+            announcements: recheckAnnouncements, toolbox: recheckToolbox)
         var failed = 0
         var installedCount = 0
         var skippedCount = 0

--- a/CLI/Sources/DuoKit/Inventory.swift
+++ b/CLI/Sources/DuoKit/Inventory.swift
@@ -43,6 +43,7 @@ public enum Inventory {
     public static func checker(
         _ settings: Settings,
         testflight: TestFlightInventory = TestFlightInventory(),
+        announcements: TestFlightAnnouncements = TestFlightAnnouncements(),
         toolbox: ToolboxInventory = ToolboxInventory()
     ) -> UpdateChecker {
         UpdateChecker(
@@ -52,6 +53,7 @@ public enum Inventory {
             maxConcurrency: settings.maxConcurrency,
             toolbox: ToolboxSource(inventory: toolbox),
             testflight: testflight,
+            announcements: announcements,
             channelStore: ResolvedChannelStore.shared)
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -18,6 +18,12 @@ public struct UpdateChecker: Sendable {
     /// labelled `.testFlightManaged` without a version.
     public let testflight: TestFlightInventory?
 
+    /// What TestFlight has *told the user about*, as a second witness to the store
+    /// above. Only ever used to **refuse** an up-to-date verdict — see
+    /// ``TestFlightAnnouncements``, whose absence proves nothing. nil turns the
+    /// witness off and leaves every verdict exactly as it was.
+    public let announcements: TestFlightAnnouncements?
+
     /// The same store the GitHub source writes its channel proofs to. Held here
     /// so a check that FAILED can still label the row with what an earlier one
     /// proved; nil simply means no such memory (the default, and every app whose
@@ -29,12 +35,14 @@ public struct UpdateChecker: Sendable {
         maxConcurrency: Int = 12,
         toolbox: ToolboxSource? = nil,
         testflight: TestFlightInventory? = nil,
+        announcements: TestFlightAnnouncements? = nil,
         channelStore: ResolvedChannelStore? = nil
     ) {
         self.sources = sources
         self.maxConcurrency = max(1, maxConcurrency)
         self.toolbox = toolbox
         self.testflight = testflight
+        self.announcements = announcements
         self.channelStore = channelStore
     }
 
@@ -280,6 +288,26 @@ public struct UpdateChecker: Sendable {
                     return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
                 }
                 let hasUpdate = VersionComparator.isNewer(latestSide, than: installedSide)
+                // Second witness, and it can only ever take the up-to-date verdict
+                // away. TestFlight announced a build whose id outruns everything this
+                // store holds, so — exactly as above — whatever else is true, the
+                // store's "latest" is not an upper bound for this bundle.
+                //
+                // Only on the `!hasUpdate` side: when the store already knows about
+                // an update there is nothing to refuse, and replacing a concrete
+                // version with "TestFlight manages this" would throw information away
+                // in order to say something weaker.
+                if !hasUpdate,
+                   announcements?.isBehind(testflight?.frontier(forBundleID: app.bundleID)) == true {
+                    Log.check.info("""
+                        \(label, privacy: .public): TestFlight announced a build newer \
+                        than anything its database holds — it cannot bound this app, \
+                        so no up-to-date verdict
+                        """)
+                    // `remote: nil` for the same reason as the branch above: a version
+                    // we have just called unusable must not be the one the row shows.
+                    return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
+                }
                 // Beta builds often keep the same marketing version across builds,
                 // so disambiguate with the build number when the short string matches.
                 let display = (latest.latestShortVersion == app.shortVersion)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
@@ -88,6 +88,24 @@ public struct TestFlightAnnouncements: Sendable {
     /// `TestFlightRefresh.bundleID`.
     static let notifyingApp = "com.apple.testflight"
 
+    /// How long to wait for the notification store before treating it as
+    /// unreachable. Same value and same reason as `TestFlightInventory.openTimeout`:
+    /// a local sqlite open is milliseconds, so anything near this is a gate, not
+    /// slow disk.
+    static let openTimeout: TimeInterval = 5
+
+    /// The bound, shared with nothing. This store is a **different container behind
+    /// a different permission** from TestFlight's own, so it is a separate way to be
+    /// denied and gets its own key space; one unreadable store must never suppress
+    /// reads of the other.
+    ///
+    /// ⚠️ Without this the read was unbounded, and `Task.detached` is not a
+    /// substitute — a detached task still runs on the cooperative pool, so a read
+    /// that never returns parks one of very few threads forever. A timeout on the
+    /// *caller's wait* does not help: it stops us waiting, not the thread being
+    /// held.
+    private static let bounded = BoundedBlockingWork(label: "notification store open")
+
     public init(databaseURL: URL? = nil) {
         let (rows, opened) = Self.read(at: databaseURL ?? Self.defaultDatabaseURL)
         self.announcements = rows
@@ -133,6 +151,16 @@ public struct TestFlightAnnouncements: Sendable {
 
     private static func read(at url: URL) -> ([Announcement], Bool) {
         guard FileManager.default.fileExists(atPath: url.path) else { return ([], false) }
+        // nil covers both give-up modes — this open timed out, or an earlier one for
+        // this path is still stranded — and both mean the same to the caller: we
+        // never got in, so `accessible` is false rather than "read it, nothing there".
+        return bounded.run(key: url.path, timeout: openTimeout) {
+            openAndRead(at: url)
+        } ?? ([], false)
+    }
+
+    /// The actual read. Only ever called from `read(at:)`'s worker thread.
+    private static func openAndRead(at url: URL) -> ([Announcement], Bool) {
         var db: OpaquePointer?
         guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
             sqlite3_close(db)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
@@ -1,0 +1,209 @@
+import Foundation
+import SQLite3
+
+/// What TestFlight has *told the user about* — read out of the notification
+/// store, as a second witness to what `TestFlightInventory` holds.
+///
+/// The point is one comparison: a build TestFlight announced whose id is **greater
+/// than anything the store holds** for that app proves the store is behind. No
+/// timestamp, no threshold, no prose — the same self-evident shape as the gate in
+/// `UpdateChecker` that refuses an up-to-date verdict when the installed build
+/// outruns the store.
+///
+/// ⚠️ **"Not in the store" is the wrong test, and it was the first one written
+/// here.** Measured 2026-09-10 against the live stores: of 5 announcements, **3
+/// named a build the store did not hold** — and in all three the store was *ahead*
+/// (announced 234414114 vs held 234615396; 234696688 vs 234839053; 234026569 vs
+/// 234783351). The store keeps one row per platform for the *current* build and no
+/// history, so every announcement older than the current build fails a membership
+/// test. That rule would have fired on 3 of 5 live rows, all wrong. Comparing
+/// against the store's maximum fires on **none** of them, which is the right answer
+/// for a machine whose store is current.
+///
+/// ⚠️ **That comparison assumes build ids increase over time, and the sample is
+/// small.** Sorted by the notification store's own `delivered_date`, the five
+/// announcements are strictly increasing (233627973, 234026569, 234414114,
+/// 234696688, 234839053 across 09-07 to 09-09), and the ids look like one global
+/// TestFlight sequence rather than a per-app counter. **n=5** — enough to prefer
+/// this rule over membership, not enough to call it a documented property. If it is
+/// wrong, the cost is a refusal we should not have made: the row says "TestFlight
+/// manages this" instead of "up to date". It can never invent an update.
+///
+/// **Why a second witness is needed at all.** The store is refreshed by a Duet
+/// activity registered `Require Device Inactivity`, so on a Mac in use it does not
+/// run: measured 2026-09-09, a published build sat unseen for four hours while
+/// `dasd` answered `MNP` every 30–60 seconds (#478). Notifications arrive on a
+/// different path and are not gated that way — the machine that was six weeks
+/// stale still received them.
+///
+/// **The payload is structured; nothing here parses the sentence.** Each record
+/// carries `durl` (`https://testflight.apple.com/v1/app/<appAdamId>`) and, inside
+/// `usda`, an archived dictionary with the numeric build id under `b`. Measured
+/// 2026-09-09 against the store's `ZBUILDID` column: 7 announcements, 6 exact
+/// matches, and the seventh's store row had no build id at all — so the two live
+/// in one id space and can be compared as integers.
+///
+/// ⚠️ **One-directional.** The absence of an announcement proves nothing: on one of
+/// the two Macs measured that day every TestFlight notification was a
+/// *post-install* "is Now Up to Date", and the two builds actually waiting to be
+/// installed were never announced at all. Use this to refuse a claim, never to
+/// make one.
+///
+/// ⚠️ **It is a rolling window, not a log.** Records are pruned: the mini held 13
+/// spanning three days while the same database kept 652 records for other apps
+/// going back nine months.
+public struct TestFlightAnnouncements: Sendable {
+
+    /// One "there is a build" notice: which app, and which build id.
+    public struct Announcement: Sendable, Hashable {
+        /// The App Store id, taken from the notification's default-action URL.
+        public let appAdamID: Int64
+        /// TestFlight's own build id — the same space as `ZTFAPPBUNDLEMODEL.ZBUILDID`,
+        /// and NOT `CFBundleVersion`.
+        public let buildID: Int64
+
+        public init(appAdamID: Int64, buildID: Int64) {
+            self.appAdamID = appAdamID
+            self.buildID = buildID
+        }
+    }
+
+    public let announcements: [Announcement]
+
+    /// Whether the notification store was opened at all. `false` means missing or
+    /// blocked — and because this witness only ever refuses claims, a false here
+    /// must leave every verdict exactly as it was.
+    public let accessible: Bool
+
+    /// Notification Center's per-user store. A different container from
+    /// TestFlight's own, so it is a separate read and a separate way to be denied.
+    public static var defaultDatabaseURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
+            "Library/Group Containers/group.com.apple.usernoted/db2/db")
+    }
+
+    /// Bundle id of the app whose notifications these are. Lowercase in this
+    /// database, unlike the bundle id TestFlight.app itself carries — measured, and
+    /// the reason this is a constant rather than something derived from
+    /// `TestFlightRefresh.bundleID`.
+    static let notifyingApp = "com.apple.testflight"
+
+    public init(databaseURL: URL? = nil) {
+        let (rows, opened) = Self.read(at: databaseURL ?? Self.defaultDatabaseURL)
+        self.announcements = rows
+        self.accessible = opened
+    }
+
+    /// Test seam: inject the parsed announcements directly.
+    public init(announcements: [Announcement], accessible: Bool = true) {
+        self.announcements = announcements
+        self.accessible = accessible
+    }
+
+    /// Build ids announced for one app.
+    public func buildIDs(forAppAdamID id: Int64?) -> Set<Int64> {
+        guard let id else { return [] }
+        return Set(announcements.filter { $0.appAdamID == id }.map(\.buildID))
+    }
+
+    /// The newest build id announced for one app, or nil when none was.
+    ///
+    /// Nil is not "up to date": see the type's note — the absence of an
+    /// announcement proves nothing at all, so a caller may only ever use this to
+    /// refuse a claim.
+    public func latestAnnouncedBuild(forAppAdamID id: Int64?) -> Int64? {
+        buildIDs(forAppAdamID: id).max()
+    }
+
+    /// Whether TestFlight has announced a build newer than anything this store
+    /// holds — the one question this type exists to answer.
+    ///
+    /// Deliberately takes the frontier rather than reading the store itself: the
+    /// two databases live behind different permissions and are read by different
+    /// code, and folding them together here would make one failure look like the
+    /// other's answer.
+    public func isBehind(_ frontier: TestFlightInventory.Frontier?) -> Bool {
+        guard let frontier,
+              let announced = latestAnnouncedBuild(forAppAdamID: frontier.adamID)
+        else { return false }
+        return announced > frontier.maxBuildID
+    }
+
+    // MARK: - Reading
+
+    private static func read(at url: URL) -> ([Announcement], Bool) {
+        guard FileManager.default.fileExists(atPath: url.path) else { return ([], false) }
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            sqlite3_close(db)
+            Log.scan.error("notification store open failed at \(url.path, privacy: .public)")
+            return ([], false)
+        }
+        defer { sqlite3_close(db) }
+
+        let sql = """
+            SELECT record.data FROM record
+            JOIN app ON app.app_id = record.app_id
+            WHERE app.identifier = ?;
+            """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            Log.scan.error("notification store prepare failed — schema changed")
+            return ([], true)  // we opened it; the schema just didn't match
+        }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, notifyingApp, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+
+        var out: [Announcement] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let bytes = sqlite3_column_blob(stmt, 0) else { continue }
+            let count = Int(sqlite3_column_bytes(stmt, 0))
+            let data = Data(bytes: bytes, count: count)
+            if let announcement = parse(record: data) { out.append(announcement) }
+        }
+        return (out, true)
+    }
+
+    /// One notification record — a binary plist — into an announcement, or nil when
+    /// it is not one (a record with no build id, a shape we do not recognise).
+    ///
+    /// Deliberately total: every failure is a `nil`, never a throw and never a
+    /// partial answer, because this witness's whole job is to refuse claims and a
+    /// half-parsed record must not be able to refuse one.
+    static func parse(record data: Data) -> Announcement? {
+        guard let root = (try? PropertyListSerialization.propertyList(
+            from: data, options: [], format: nil)) as? [String: Any],
+            let request = root["req"] as? [String: Any],
+            let adamID = appAdamID(fromDefaultActionURL: request["durl"] as? String),
+            let payload = request["usda"] as? Data,
+            let buildID = self.buildID(fromArchivedPayload: payload)
+        else { return nil }
+        return Announcement(appAdamID: adamID, buildID: buildID)
+    }
+
+    /// `https://testflight.apple.com/v1/app/6760637748` → 6760637748.
+    ///
+    /// The last path component, not a pattern match on the host: the id is what we
+    /// need, and a URL shaped differently enough to break this yields nil, which
+    /// costs a refusal we would otherwise have made — never a wrong one.
+    static func appAdamID(fromDefaultActionURL raw: String?) -> Int64? {
+        guard let raw, let url = URL(string: raw) else { return nil }
+        return Int64(url.lastPathComponent)
+    }
+
+    /// The `b` value out of the archived APNs payload.
+    ///
+    /// `NSKeyedUnarchiver` rather than walking `$objects` by hand: the payload is a
+    /// plain dictionary of strings and numbers, and reading the key by name is the
+    /// difference between "the build id" and "some big integer that happened to be
+    /// in the archive" — the app id is in there too, and is also a big integer.
+    static func buildID(fromArchivedPayload payload: Data) -> Int64? {
+        let allowed: [AnyClass] = [
+            NSDictionary.self, NSArray.self, NSString.self, NSNumber.self, NSNull.self,
+        ]
+        guard let unarchived = try? NSKeyedUnarchiver.unarchivedObject(
+            ofClasses: allowed, from: payload) as? [String: Any] else { return nil }
+        return (unarchived["b"] as? NSNumber)?.int64Value
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
@@ -23,11 +23,31 @@ import SQLite3
 /// ⚠️ **That comparison assumes build ids increase over time, and the sample is
 /// small.** Sorted by the notification store's own `delivered_date`, the five
 /// announcements are strictly increasing (233627973, 234026569, 234414114,
-/// 234696688, 234839053 across 09-07 to 09-09), and the ids look like one global
-/// TestFlight sequence rather than a per-app counter. **n=5** — enough to prefer
-/// this rule over membership, not enough to call it a documented property. If it is
-/// wrong, the cost is a refusal we should not have made: the row says "TestFlight
-/// manages this" instead of "up to date". It can never invent an update.
+/// 234696688, 234839053 across 09-07 to 09-09). **n=5** — enough to prefer this
+/// rule over membership, not enough to call it a documented property.
+///
+/// ⚠️ **Do not reach for `CFBundleVersion` ordering as extra support for it.** It
+/// looks like it should corroborate and it does not: measured 2026-09-10 over the
+/// 14 comparable same-app pairs in this store, **2 disagree** — one app has
+/// `CFBundleVersion` 12 at build id 227551062 and `CFBundleVersion` 2 at
+/// 227941721. That is the two-build-namespaces problem this repository already
+/// documents (mac and iOS number independently), not a counter-example to the
+/// sequence itself, but it means the proxy is unusable.
+///
+/// If the monotonicity assumption is wrong, the cost is a refusal we should not
+/// have made: the row says "TestFlight manages this" instead of "up to date". It
+/// can never invent an update.
+///
+/// ⚠️ **A refusal is not free, and one shape of it can stick.** `.testFlightManaged`
+/// is not in `UpdatePolicy.settledRowIDs`, so a refused row never settles and any
+/// in-flight install note pinned to it is never retracted. The way to get stuck
+/// there is a build that is expired or rolled back: the store's maximum *drops*
+/// back to the earlier build while the announcement for the withdrawn one stays in
+/// the notification window — measured at 5 records spanning three days — so the
+/// comparison stays true for as long as that record lives. The neighbouring gate
+/// argues expiry needs no special case because its discriminator is the disk; that
+/// argument does **not** carry over here, where the discriminator is a notification
+/// that outlives what it announced.
 ///
 /// **Why a second witness is needed at all.** The store is refreshed by a Duet
 /// activity registered `Require Device Inactivity`, so on a Mac in use it does not
@@ -38,10 +58,17 @@ import SQLite3
 ///
 /// **The payload is structured; nothing here parses the sentence.** Each record
 /// carries `durl` (`https://testflight.apple.com/v1/app/<appAdamId>`) and, inside
-/// `usda`, an archived dictionary with the numeric build id under `b`. Measured
-/// 2026-09-09 against the store's `ZBUILDID` column: 7 announcements, 6 exact
-/// matches, and the seventh's store row had no build id at all — so the two live
-/// in one id space and can be compared as integers.
+/// `usda`, an archived dictionary with the numeric build id under `b`.
+///
+/// That the two live in one id space is *measured*, on two machines and two ways.
+/// **On the second Mac, 2026-09-09**: 7 announcements, 6 exact matches against
+/// `ZBUILDID`, and the seventh's store row had no build id at all. That count does
+/// **not** reproduce on this machine — 5 records here, 2 exact — because the
+/// notification store is a rolling window and the rest have aged out, so it is
+/// evidence from that machine on that day, not a standing property.
+/// **Reproducible here, 2026-09-10**: 111 store rows carry 97 distinct `ZBUILDID`s
+/// and **not one is reused across two different apps**, which is what a global
+/// sequence looks like and what a per-app counter does not.
 ///
 /// ⚠️ **One-directional.** The absence of an announcement proves nothing: on one of
 /// the two Macs measured that day every TestFlight notification was a

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -408,7 +408,12 @@ public struct TestFlightInventory: Sendable {
             return reading
         }
         Log.scan.error("TestFlight DB prepare failed")
-        return ([], [], [], [:], true)  // we opened it; the schema just didn't match
+        // Still ask for the frontier. Its two columns live in different tables from
+        // the ones above, so a schema that breaks the row queries does not imply this
+        // one cannot prepare — and the whole reason the frontier got its own query is
+        // that each signal fails on its own. Returning here without trying made the
+        // implication run backwards.
+        return ([], [], [], readFrontiers(db), true)  // we opened it; the schema just didn't match
     }
 
     /// Both platforms, sorted into two buckets by the reader rather than merged.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -251,16 +251,25 @@ public struct TestFlightInventory: Sendable {
     /// iPhone-only. The cost is bounded — the row's action is "open TestFlight",
     /// which is where the real answer is, and nothing is downloaded on our side —
     /// but it is a real gap, not one this can close.
-    /// What the store knows about this app in TestFlight's own id space, or nil
-    /// when the store has no app row for it (or the frontier query did not run).
-    public func frontier(forBundleID bundleID: String?) -> Frontier? {
-        guard let bundleID else { return nil }
-        return frontierByBundleID[bundleID]
-    }
-
     public func latestIOS(forBundleID bundleID: String?) -> App? {
         guard let bundleID else { return nil }
         return iosLatestByBundleID[bundleID]
+    }
+
+    /// What the store knows about this app in TestFlight's own id space, or nil
+    /// when the store has no app row for it (or the frontier query did not run).
+    ///
+    /// ⚠️ **This one is deliberately NOT split by platform, and that is not the
+    /// merge the warning above forbids.** That warning is about *offering* a build:
+    /// hand a native Mac app its iOS track and it gets an iPhone build as its next
+    /// Mac update. This offers nothing. It answers "how recently has this store
+    /// synced anything at all for this app", and the store syncs every platform in
+    /// one pass, so the newest row of any platform is the better answer to that
+    /// question — a mac-only frontier would call a store stale on the strength of a
+    /// track that simply has no new builds.
+    public func frontier(forBundleID bundleID: String?) -> Frontier? {
+        guard let bundleID else { return nil }
+        return frontierByBundleID[bundleID]
     }
 
     /// bundleID → the newest row. **Every** bucket ranks through here — mac and

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -93,6 +93,31 @@ public struct TestFlightInventory: Sendable {
     /// see there for why a native Mac app must never be routed through it.
     private let iosLatestByBundleID: [String: App]
 
+    /// What the store knows about one app, in TestFlight's **own** id space —
+    /// nothing here is a `CFBundleVersion`.
+    ///
+    /// `maxBuildID` is a frontier, not a version: the store keeps one row per
+    /// platform for the *current* build and no history, so the only question it can
+    /// answer is "has this store seen anything at least this new".
+    public struct Frontier: Sendable, Equatable {
+        /// The App Store id, from `ZTFAPPMODEL.ZAPPID` — the same id TestFlight's
+        /// notifications carry in their default-action URL.
+        public let adamID: Int64
+        /// The largest `ZTFAPPBUNDLEMODEL.ZBUILDID` this store holds for the app,
+        /// across platforms.
+        public let maxBuildID: Int64
+
+        public init(adamID: Int64, maxBuildID: Int64) {
+            self.adamID = adamID
+            self.maxBuildID = maxBuildID
+        }
+    }
+
+    /// Per bundle id: which app the store thinks it is, and the newest build id it
+    /// has ever recorded for it. Empty when the frontier query did not prepare,
+    /// which costs this signal and nothing else.
+    private let frontierByBundleID: [String: Frontier]
+
     /// Whether we actually opened the TestFlight database. `false` means the file
     /// was missing or the read was blocked/denied — notably the "access data from
     /// other apps" TCC gate. The UI uses this to tell "we read it and there was
@@ -108,8 +133,9 @@ public struct TestFlightInventory: Sendable {
 
     public init(databaseURL: URL? = nil) {
         let url = databaseURL ?? Self.defaultDatabaseURL
-        let (rows, iosRows, iosAvailableRows, opened) = Self.readRows(at: url)
+        let (rows, iosRows, iosAvailableRows, frontiers, opened) = Self.readRows(at: url)
         self.accessible = opened
+        self.frontierByBundleID = frontiers
         self.iosBuildsByBundleID = Self.buildIndex(iosRows)
         self.iosLatestByBundleID = Self.newestByBundleID(iosAvailableRows)
 
@@ -142,9 +168,11 @@ public struct TestFlightInventory: Sendable {
         macRows: [(bundleID: String, shortVersion: String, build: String)],
         installedIOSRows: [(bundleID: String, shortVersion: String, build: String)] = [],
         availableIOSRows: [(bundleID: String, shortVersion: String, build: String)]? = nil,
+        frontiers: [String: Frontier] = [:],
         accessible: Bool = true
     ) {
         self.accessible = accessible
+        self.frontierByBundleID = frontiers
         self.iosBuildsByBundleID = Self.buildIndex(installedIOSRows)
         // The database always yields the installed rows as a subset of the
         // available ones, so a fixture that names only the installed rows gets the
@@ -223,6 +251,13 @@ public struct TestFlightInventory: Sendable {
     /// iPhone-only. The cost is bounded — the row's action is "open TestFlight",
     /// which is where the real answer is, and nothing is downloaded on our side —
     /// but it is a real gap, not one this can close.
+    /// What the store knows about this app in TestFlight's own id space, or nil
+    /// when the store has no app row for it (or the frontier query did not run).
+    public func frontier(forBundleID bundleID: String?) -> Frontier? {
+        guard let bundleID else { return nil }
+        return frontierByBundleID[bundleID]
+    }
+
     public func latestIOS(forBundleID bundleID: String?) -> App? {
         guard let bundleID else { return nil }
         return iosLatestByBundleID[bundleID]
@@ -290,7 +325,9 @@ public struct TestFlightInventory: Sendable {
     typealias Row = (bundleID: String, shortVersion: String, build: String)
     /// What one read of the database yields: the two platform buckets, plus
     /// whether we got in at all.
-    typealias Reading = (rows: [Row], iosRows: [Row], iosAvailableRows: [Row], opened: Bool)
+    typealias Reading = (
+        rows: [Row], iosRows: [Row], iosAvailableRows: [Row],
+        frontiers: [String: Frontier], opened: Bool)
 
     /// How long to wait for the database to open before treating it as
     /// unreachable. Generous: a cold sandboxed sqlite open is milliseconds, so
@@ -325,7 +362,7 @@ public struct TestFlightInventory: Sendable {
     /// Observed 2026-08-15: a nightly sweep sat in `guarded_open_np` for ten
     /// minutes at 0.03s of CPU before it was killed.
     private static func readRows(at url: URL) -> Reading {
-        guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], [], false) }
+        guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], [], [:], false) }
         // nil covers both give-up modes — this open timed out, or an earlier one
         // for this path is still stranded — and both mean the same thing to the
         // caller: we never got in, so `opened` is false rather than "read it,
@@ -335,7 +372,7 @@ public struct TestFlightInventory: Sendable {
         // tuple type and `Reading`, and the compiler rejects it.
         return bounded.run(key: url.path, timeout: openTimeout) {
             openAndRead(at: url)
-        } ?? (rows: [], iosRows: [], iosAvailableRows: [], opened: false)
+        } ?? (rows: [], iosRows: [], iosAvailableRows: [], frontiers: [:], opened: false)
     }
 
     /// The actual read. Only ever called from `readRows(at:)`'s worker thread.
@@ -346,7 +383,7 @@ public struct TestFlightInventory: Sendable {
         guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
             sqlite3_close(db)
             Log.scan.error("TestFlight DB open failed at \(url.path, privacy: .public)")
-            return ([], [], [], false)
+            return ([], [], [], [:], false)
         }
         defer { sqlite3_close(db) }
 
@@ -358,18 +395,20 @@ public struct TestFlightInventory: Sendable {
         // and nothing else — not the macOS rows this file has read since before it
         // existed. Naming a column in a SELECT is what makes its absence fatal, so
         // the fallback names one fewer.
-        if let reading = runRowQuery(db, sql: Self.rowsWithInstallStatusSQL, hasInstallStatus: true) {
+        if var reading = runRowQuery(db, sql: Self.rowsWithInstallStatusSQL, hasInstallStatus: true) {
+            reading.frontiers = readFrontiers(db)
             return reading
         }
         Log.scan.error("""
             TestFlight DB prepare failed with ZINSTALLSTATUSRAW — retrying without it; \
             wrapped iOS apps lose their install signal for this read
             """)
-        if let reading = runRowQuery(db, sql: Self.macRowsOnlySQL, hasInstallStatus: false) {
+        if var reading = runRowQuery(db, sql: Self.macRowsOnlySQL, hasInstallStatus: false) {
+            reading.frontiers = readFrontiers(db)
             return reading
         }
         Log.scan.error("TestFlight DB prepare failed")
-        return ([], [], [], true)  // we opened it; the schema just didn't match
+        return ([], [], [], [:], true)  // we opened it; the schema just didn't match
     }
 
     /// Both platforms, sorted into two buckets by the reader rather than merged.
@@ -392,6 +431,46 @@ public struct TestFlightInventory: Sendable {
         SELECT ZBUNDLEID, ZSHORTVERSION, ZBUNDLEVERSION, ZPLATFORMRAW
         FROM ZTFAPPBUNDLEMODEL
         WHERE ZPLATFORMRAW = 3 AND ZBUNDLEID IS NOT NULL AND ZBUNDLEVERSION IS NOT NULL;
+        """
+
+    /// The store's build-id frontier per bundle, joined to the app row that carries
+    /// the App Store id.
+    ///
+    /// **Its own query, and its own failure.** This file's rule is that naming a
+    /// column in a SELECT makes its absence fatal, so `ZBUILDID` and `ZAPPID` are
+    /// not added to the row queries above: a schema without them must cost this
+    /// signal alone, not the macOS rows the inventory has read since before either
+    /// existed. An empty map here is a working inventory with one witness missing.
+    private static func readFrontiers(_ db: OpaquePointer?) -> [String: Frontier] {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, Self.frontierSQL, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            Log.scan.error("TestFlight DB frontier query did not prepare — announcement witness is off")
+            return [:]
+        }
+        defer { sqlite3_finalize(stmt) }
+        var out: [String: Frontier] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let raw = sqlite3_column_text(stmt, 0) else { continue }
+            let bundleID = String(cString: raw)
+            let frontier = Frontier(
+                adamID: sqlite3_column_int64(stmt, 1), maxBuildID: sqlite3_column_int64(stmt, 2))
+            // One app row per bundle in practice; keep the larger frontier if the
+            // store ever carries two, since this is an "at least this new" bound.
+            if let existing = out[bundleID], existing.maxBuildID >= frontier.maxBuildID { continue }
+            out[bundleID] = frontier
+        }
+        return out
+    }
+
+    /// Both platforms deliberately: the frontier answers "has this store seen
+    /// anything at least this new for this app", and a Mac beta and its iOS twin
+    /// are announced through the same notification stream.
+    private static let frontierSQL = """
+        SELECT a.ZBUNDLEID, a.ZAPPID, MAX(b.ZBUILDID)
+        FROM ZTFAPPMODEL a JOIN ZTFAPPBUNDLEMODEL b ON b.ZAPP = a.Z_PK
+        WHERE a.ZBUNDLEID IS NOT NULL AND a.ZAPPID IS NOT NULL AND b.ZBUILDID IS NOT NULL
+        GROUP BY a.Z_PK;
         """
 
     /// Runs one of the two queries above. `nil` means it would not prepare, which
@@ -451,7 +530,8 @@ public struct TestFlightInventory: Sendable {
                 break
             }
         }
-        return (rows, iosRows, iosAvailableRows, true)
+        // Frontiers are filled in by `openAndRead`, from its own query.
+        return (rows, iosRows, iosAvailableRows, [:], true)
     }
 
     /// `ZPLATFORMRAW` values, both named because both are now matched positively.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
@@ -191,6 +191,82 @@ struct TestFlightAnnouncementWitnessTests {
 
     // MARK: - Reading the frontier out of a real schema
 
+    /// The frontier survives a schema that breaks the row queries. Its two columns
+    /// live in different tables from theirs, so "the row queries did not prepare"
+    /// does not imply "this one cannot" — and the whole reason it got its own query
+    /// is that each signal fails on its own.
+    ///
+    /// The fixture drops `ZSHORTVERSION`, which both row queries name and neither
+    /// can do without, while leaving everything the frontier needs.
+    ///
+    /// Mutation: return `([], [], [], [:], true)` from the both-queries-failed path
+    /// instead of calling `readFrontiers` — the frontier comes back nil and this
+    /// fails.
+    @Test func theFrontierIsStillReadWhenTheRowQueriesCannotPrepare() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ZZFixture-noshort-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("TestFlight.sqlite")
+
+        var db: OpaquePointer?
+        #expect(sqlite3_open(dbURL.path, &db) == SQLITE_OK)
+        let schema = """
+            CREATE TABLE ZTFAPPMODEL (Z_PK INTEGER PRIMARY KEY, ZAPPID INTEGER, ZBUNDLEID VARCHAR);
+            CREATE TABLE ZTFAPPBUNDLEMODEL (
+                Z_PK INTEGER PRIMARY KEY, ZAPP INTEGER, ZBUILDID INTEGER,
+                ZBUNDLEID VARCHAR, ZBUNDLEVERSION VARCHAR, ZPLATFORMRAW INTEGER);
+            INSERT INTO ZTFAPPMODEL VALUES (1, 6761822408, 'zz.fixture.beta');
+            INSERT INTO ZTFAPPBUNDLEMODEL VALUES (1, 1, 234839053, 'zz.fixture.beta', '200', 3);
+            """
+        #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+
+        let inventory = TestFlightInventory(databaseURL: dbURL)
+        #expect(inventory.accessible, "fixture database was not opened")
+        #expect(inventory.latest(forBundleID: "zz.fixture.beta") == nil,
+                "fixture guard: the row queries must actually have failed here")
+        let frontier = try #require(
+            inventory.frontier(forBundleID: "zz.fixture.beta"),
+            "the frontier query does not name ZSHORTVERSION, so it must still have run")
+        #expect(frontier.maxBuildID == 234_839_053)
+    }
+
+    /// The notification store read is bounded and abandons its thread, like the
+    /// TestFlight store read beside it. `Task.detached` is not a substitute — a
+    /// detached task still runs on the cooperative pool — and a timeout on the
+    /// caller's wait stops us waiting, not the thread being held.
+    ///
+    /// Mutation: drop the `bounded.run` wrapper and open inline — this fails.
+    /// Pinned in the source text because a hang is not a thing a unit case can wait
+    /// for.
+    @Test func theNotificationStoreReadIsBounded() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift"),
+            encoding: .utf8)
+        #expect(source.contains("bounded.run(key: url.path, timeout: openTimeout)"))
+    }
+
+    /// The install recheck must not pay for a read whose answer it cannot use: it
+    /// deliberately carries a TestFlight inventory with no frontiers, so the witness
+    /// can only ever say "not behind".
+    ///
+    /// Mutation: delete the `announcements:` argument at that call site and let the
+    /// default fire — this fails.
+    @Test func theInstallRecheckPassesTheEmptyWitness() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .appendingPathComponent("CLI/Sources/DuoKit/Install.swift"),
+            encoding: .utf8)
+        #expect(source.contains("TestFlightAnnouncements(announcements: [], accessible: false)"))
+        #expect(source.contains("announcements: recheckAnnouncements"))
+    }
+
     /// The frontier query has to run against TestFlight's actual two-table shape,
     /// not just against the injected seam — the join, the `MAX`, and both column
     /// names are only exercised here.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
@@ -96,6 +96,27 @@ struct TestFlightAnnouncementWitnessTests {
         #expect(!Self.announced([(42, 234_900_000)]).isBehind(nil))
     }
 
+    /// A withdrawn build keeps refusing until its notification ages out, and this
+    /// pins that rather than hiding it. The store's maximum *drops* back when a
+    /// build is expired or rolled back, while the announcement for the withdrawn one
+    /// stays in the window — measured at 5 records spanning three days.
+    ///
+    /// This is an accepted cost, not a bug being asserted: the alternative needs a
+    /// timestamp comparison the announcement does not carry, and the failure is a
+    /// refusal rather than a wrong update. It is a case so that changing it is a
+    /// decision someone makes on purpose — and because the refusal sticks:
+    /// `.testFlightManaged` is not in `UpdatePolicy.settledRowIDs`, so the row does
+    /// not settle for as long as this holds.
+    ///
+    /// Mutation: none — this asserts current behaviour. If a future change starts
+    /// ignoring aged-out announcements, this case is the one that must be updated,
+    /// and its failure is the reminder to update the doc comment with it.
+    @Test func aWithdrawnBuildKeepsRefusingUntilItsNotificationAgesOut() {
+        // Announced 234900000, then pulled; the store falls back to 234839053.
+        let witness = Self.announced([(42, 234_900_000)])
+        #expect(witness.isBehind(Self.frontier(adam: 42, max: 234_839_053)))
+    }
+
     // MARK: - What the checker does with it
 
     private static func app(build: String) -> InstalledApp {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
@@ -1,0 +1,232 @@
+import Testing
+import Foundation
+import SQLite3
+@testable import DuoUpdaterCore
+
+/// The second witness: TestFlight's own notifications, used only ever to **refuse**
+/// an up-to-date verdict the local store is not entitled to give.
+///
+/// ⚠️ **The first rule written here was wrong, and live data is what said so.**
+/// "An announced build the store does not hold proves the store is behind" sounds
+/// self-evident and is false: the store keeps one row per platform for the *current*
+/// build and no history, so every announcement older than the current build fails a
+/// membership test. Measured 2026-09-10 across the two live stores — of 5
+/// announcements, **3 named a build the store did not hold, and in all three the
+/// store was ahead**. Those three numbers are the fixtures below, because a rule
+/// this plausible needs the counter-example written down next to it.
+struct TestFlightAnnouncementWitnessTests {
+
+    private static func frontier(adam: Int64, max: Int64) -> TestFlightInventory.Frontier {
+        TestFlightInventory.Frontier(adamID: adam, maxBuildID: max)
+    }
+    private static func announced(_ pairs: [(Int64, Int64)]) -> TestFlightAnnouncements {
+        TestFlightAnnouncements(
+            announcements: pairs.map {
+                TestFlightAnnouncements.Announcement(appAdamID: $0.0, buildID: $0.1)
+            })
+    }
+
+    // MARK: - The comparison
+
+    /// The three live rows that killed the membership rule. Each announced a build
+    /// the store does not hold, and in each the store is **ahead** — so the honest
+    /// answer is "not behind", and a membership test would have said the opposite
+    /// on every one.
+    ///
+    /// Mutation: change `announced > frontier.maxBuildID` to
+    /// `!buildIDs(forAppAdamID:).contains(frontier.maxBuildID)` — all three fail.
+    @Test(arguments: [
+        (announced: Int64(234414114), held: Int64(234615396)),  // co.nowledge.mem.mobile
+        (announced: Int64(234696688), held: Int64(234839053)),  // com.jizhi0v0.claude-usage
+        (announced: Int64(234026569), held: Int64(234783351)),  // com.ampcode.amp.ios
+    ])
+    func aStoreAheadOfAStaleAnnouncementIsNotBehind(c: (announced: Int64, held: Int64)) {
+        let witness = Self.announced([(42, c.announced)])
+        #expect(!witness.isBehind(Self.frontier(adam: 42, max: c.held)))
+    }
+
+    /// The case the witness exists for.
+    ///
+    /// Mutation: use `>=`, or drop the comparison and return true whenever an
+    /// announcement exists — the equality case below fails instead.
+    @Test func anAnnouncementBeyondTheStoreMeansTheStoreIsBehind() {
+        let witness = Self.announced([(42, 234_900_000)])
+        #expect(witness.isBehind(Self.frontier(adam: 42, max: 234_839_053)))
+    }
+
+    /// Measured live: the store held exactly the newest announced build. That is a
+    /// store which is current, not one that is behind by zero.
+    ///
+    /// Mutation: `>=` instead of `>` — this fails, and every machine whose store is
+    /// perfectly current starts refusing its own up-to-date verdicts.
+    @Test func aStoreHoldingExactlyTheAnnouncedBuildIsNotBehind() {
+        let witness = Self.announced([(42, 234_839_053)])
+        #expect(!witness.isBehind(Self.frontier(adam: 42, max: 234_839_053)))
+    }
+
+    /// Announcements are scoped to their app. A neighbour's newer build says
+    /// nothing, and TestFlight build ids look like one global sequence, so without
+    /// the scoping every app on the machine would be refused whenever any app got a
+    /// build.
+    ///
+    /// Mutation: drop the `$0.appAdamID == id` filter in `buildIDs(forAppAdamID:)`
+    /// — this fails.
+    @Test func aNeighboursAnnouncementDoesNotAccuseThisApp() {
+        let witness = Self.announced([(999, 234_900_000)])
+        #expect(!witness.isBehind(Self.frontier(adam: 42, max: 234_839_053)))
+    }
+
+    /// The absence of an announcement proves nothing, so it can never produce a
+    /// refusal. Measured on one of the two Macs: every TestFlight notification there
+    /// was a *post-install* "is Now Up to Date", and the two builds actually waiting
+    /// were never announced at all.
+    ///
+    /// Mutation: return `true` when `latestAnnouncedBuild` is nil — this fails, and
+    /// every app with no notification loses its up-to-date verdict.
+    @Test func silenceIsNotEvidence() {
+        #expect(!Self.announced([]).isBehind(Self.frontier(adam: 42, max: 1)))
+    }
+
+    /// No frontier means the store had no app row, or the frontier query did not
+    /// prepare. Either way there is nothing to compare against.
+    ///
+    /// Mutation: treat a nil frontier as behind — this fails, and a schema change
+    /// would take every TestFlight verdict on the machine with it.
+    @Test func noFrontierIsNoAccusation() {
+        #expect(!Self.announced([(42, 234_900_000)]).isBehind(nil))
+    }
+
+    // MARK: - What the checker does with it
+
+    private static func app(build: String) -> InstalledApp {
+        InstalledApp(
+            name: "ZZFixture", bundleID: "zz.fixture.beta",
+            shortVersion: "1.0", buildVersion: build,
+            path: URL(fileURLWithPath: "/ZZFixture-does-not-exist/ZZFixture.app"),
+            isMASApp: false, isiOSAppOnMac: false, isTestFlightApp: true,
+            sparkleFeedURL: nil)
+    }
+
+    private static func inventory(storeBuild: String, frontierMax: Int64) -> TestFlightInventory {
+        TestFlightInventory(
+            macRows: [(bundleID: "zz.fixture.beta", shortVersion: "1.0", build: storeBuild)],
+            frontiers: ["zz.fixture.beta": frontier(adam: 42, max: frontierMax)])
+    }
+
+    /// Fixture guard: the invented path must not exist, or this suite starts
+    /// measuring the host's filesystem instead of the rule.
+    @Test func theFixturePathIsNotReal() {
+        #expect(!FileManager.default.fileExists(
+            atPath: "/ZZFixture-does-not-exist/ZZFixture.app"))
+    }
+
+    /// The store says "you are current"; the notification says a newer build exists.
+    /// The store's "latest" is therefore not an upper bound for this app, which is
+    /// exactly the verdict `.upToDate` claims it is — so the verdict goes, and no
+    /// version is shown in its place.
+    ///
+    /// Mutation: delete the `announcements?.isBehind(...)` branch — the status
+    /// becomes `.upToDate` and this fails.
+    @Test func anAnnouncedBuildBeyondTheStoreTakesAwayTheUpToDateVerdict() async {
+        let result = await UpdateChecker(
+            sources: [],
+            testflight: Self.inventory(storeBuild: "100", frontierMax: 234_839_053),
+            announcements: Self.announced([(42, 234_900_000)])
+        ).check(Self.app(build: "100"))
+
+        #expect(result.status == .testFlightManaged)
+        #expect(result.remote == nil, "a version we just called unusable must not be shown")
+    }
+
+    /// ...and it only ever takes that verdict away. When the store already knows
+    /// about a newer build, the concrete version survives: replacing it with
+    /// "TestFlight manages this" would throw information away in order to say
+    /// something weaker.
+    ///
+    /// Mutation: drop the `!hasUpdate` condition — the status collapses to
+    /// `.testFlightManaged` and this fails.
+    @Test func anAnnouncementNeverReplacesAnUpdateTheStoreAlreadyFound() async {
+        let result = await UpdateChecker(
+            sources: [],
+            testflight: Self.inventory(storeBuild: "200", frontierMax: 234_839_053),
+            announcements: Self.announced([(42, 234_900_000)])
+        ).check(Self.app(build: "100"))
+
+        guard case .updateAvailable(let latest) = result.status else {
+            Issue.record("expected the store's update to survive, got \(result.status)")
+            return
+        }
+        #expect(latest == "1.0 (200)")
+        #expect(result.remote?.version == "200")
+    }
+
+    /// A stale announcement leaves a current store alone — the live shape from the
+    /// top of this file, now end to end through the checker.
+    ///
+    /// Mutation: any of the comparison mutations above — this becomes
+    /// `.testFlightManaged` and fails.
+    @Test func aStaleAnnouncementLeavesTheVerdictAlone() async {
+        let result = await UpdateChecker(
+            sources: [],
+            testflight: Self.inventory(storeBuild: "100", frontierMax: 234_839_053),
+            announcements: Self.announced([(42, 234_696_688)])
+        ).check(Self.app(build: "100"))
+
+        #expect(result.status == .upToDate)
+    }
+
+    /// No witness at all must leave every verdict exactly as it was — this is what
+    /// makes the whole thing safe to fail open when the notification store cannot be
+    /// read.
+    ///
+    /// Mutation: make `announcements == nil` behave like "behind" — this fails.
+    @Test func noWitnessChangesNothing() async {
+        let result = await UpdateChecker(
+            sources: [],
+            testflight: Self.inventory(storeBuild: "100", frontierMax: 1)
+        ).check(Self.app(build: "100"))
+
+        #expect(result.status == .upToDate)
+    }
+
+    // MARK: - Reading the frontier out of a real schema
+
+    /// The frontier query has to run against TestFlight's actual two-table shape,
+    /// not just against the injected seam — the join, the `MAX`, and both column
+    /// names are only exercised here.
+    ///
+    /// Mutation: rename any column in `frontierSQL`, or drop the `GROUP BY` — the
+    /// frontier comes back empty or wrong and this fails.
+    @Test func theFrontierIsReadFromTheStoresOwnTwoTables() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ZZFixture-frontier-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("TestFlight.sqlite")
+
+        var db: OpaquePointer?
+        #expect(sqlite3_open(dbURL.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        let schema = """
+            CREATE TABLE ZTFAPPMODEL (Z_PK INTEGER PRIMARY KEY, ZAPPID INTEGER, ZBUNDLEID VARCHAR);
+            CREATE TABLE ZTFAPPBUNDLEMODEL (
+                Z_PK INTEGER PRIMARY KEY, ZAPP INTEGER, ZBUILDID INTEGER,
+                ZBUNDLEID VARCHAR, ZSHORTVERSION VARCHAR, ZBUNDLEVERSION VARCHAR,
+                ZPLATFORMRAW INTEGER, ZINSTALLSTATUSRAW INTEGER);
+            INSERT INTO ZTFAPPMODEL VALUES (1, 6761822408, 'zz.fixture.beta');
+            -- Two platforms, deliberately out of order, so MAX has something to do.
+            INSERT INTO ZTFAPPBUNDLEMODEL VALUES (1, 1, 234839053, 'zz.fixture.beta', '1.0', '200', 3, 1);
+            INSERT INTO ZTFAPPBUNDLEMODEL VALUES (2, 1, 234696688, 'zz.fixture.beta', '1.0', '100', 1, 0);
+            """
+        #expect(sqlite3_exec(db, schema, nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+        db = nil
+
+        let inventory = TestFlightInventory(databaseURL: dbURL)
+        #expect(inventory.accessible, "fixture database was not opened")
+        let frontier = try #require(inventory.frontier(forBundleID: "zz.fixture.beta"))
+        #expect(frontier.adamID == 6_761_822_408)
+        #expect(frontier.maxBuildID == 234_839_053, "MAX across platforms, not the first row")
+        #expect(inventory.frontier(forBundleID: "zz.fixture.absent") == nil)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementsTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementsTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// Reading TestFlight's notifications as a second witness to what its local store
+/// holds (#478).
+///
+/// The fixture is a **real record**, lifted byte for byte out of
+/// `group.com.apple.usernoted` on 2026-09-09 — the "Ready to Test" notice for a
+/// build pushed from this repo's owner's own TestFlight app, at the moment the
+/// local store did not have it. A synthesised one would test the parser against my
+/// idea of the shape rather than the shape, which is the failure this whole area
+/// keeps producing.
+struct TestFlightAnnouncementsTests {
+
+    /// `“Claudo” Ready to Test — Version 0.3.384 (1307)`, app 6761822408.
+    /// Carries no account identifier: the record holds the app id, two notification
+    /// UUIDs, a date, the visible strings, and the archived payload.
+    static let realRecord = Data(base64Encoded:
+        "YnBsaXN0MDDYAQIDBAUGBwgJCgsMDQ4PHlRzdHlsVGludGxTYXBwVHV1aWRUZGF0ZVRzcmNlU3JlcVRvcmlnEAEJXxAU" +
+        "Y29tLmFwcGxlLlRlc3RGbGlnaHRPEBDUKU+TqFpA7LpYoFy6w/iKI0HIKNNc6TpYTxAQFs3lKjTJS96lvUZkYbIVqNcQ" +
+        "ERITFBUWFxgZGhscHVRkdXJsVGRlc3RUc291blR1c2RhVGJvZHlUdGl0bFRpZGVuXxAuaHR0cHM6Ly90ZXN0ZmxpZ2h0" +
+        "LmFwcGxlLmNvbS92MS9hcHAvNjc2MTgyMjQwOBAP0E8RAaJicGxpc3QwMNQBAgMEBQYHClgkdmVyc2lvblkkYXJjaGl2" +
+        "ZXJUJHRvcFgkb2JqZWN0cxIAAYagXxAPTlNLZXllZEFyY2hpdmVy0QgJVHJvb3SAAasLDBkaGxwiIyQqK1UkbnVsbNMN" +
+        "Dg8QFBhXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6MREhOAAoADgASjFRYXgAWACYAKgAhTYXBzUWFRYtMNDg8dHxih" +
+        "HoAGoSCAB4AIVWFsZXJ0bxAWIBwAQwBsAGEAdQBkAG8gHQAgAFIAZQBhAGQAeQAgAHQAbwAgAFQAZQBzAHTSJSYnKFok" +
+        "Y2xhc3NuYW1lWCRjbGFzc2VzXE5TRGljdGlvbmFyeaInKVhOU09iamVjdBMAAAABkwk4yBIN/xiOAAgAEQAaACQAKQAy" +
+        "ADcASQBMAFEAUwBfAGUAbAB0AH8AhgCKAIwAjgCQAJQAlgCYAJoAnACgAKIApACrAK0ArwCxALMAtQC7AOoA7wD6AQMB" +
+        "EAETARwBJQAAAAAAAAIBAAAAAAAAACwAAAAAAAAAAAAAAAAAAAEqXxA7VmVyc2lvbiAwLjMuMzg0ICgxMzA3KSBjYW4g" +
+        "bm93IGJlIGluc3RhbGxlZCBvbiB5b3VyIGRldmljZS5vEBYgHABDAGwAYQB1AGQAbyAdACAAUgBlAGEAZAB5ACAAdABv" +
+        "ACAAVABlAHMAdF8QJERCOTJBN0NCLTgyNEItNDJFMS1BMUI0LTNDMDY2Nzc1OUJERBACAAgAGQAeACMAJwAsADEANgA6" +
+        "AD8AQQBCAFkAbAB1AIgAlwCcAKEApgCrALAAtQC6AOsA7QDuApQC0gMBAygAAAAAAAACAQAAAAAAAAAfAAAAAAAAAAAA" +
+        "AAAAAAADKg=="
+    )!
+
+    /// Mutation: read the build id by scanning `$objects` for a large integer
+    /// (the shape the shell probe used while investigating) — the app id
+    /// 6761822408 is also in there and is larger, so the answer silently becomes
+    /// the app id and this fails.
+    @Test func aRealRecordYieldsItsAppAndBuildIDs() throws {
+        let parsed = try #require(TestFlightAnnouncements.parse(record: Self.realRecord))
+        #expect(parsed.appAdamID == 6761822408)
+        // Not the CFBundleVersion (1307) — TestFlight's own build id. Checked
+        // against the live store the same minute this fixture was taken:
+        // `select ZBUNDLEVERSION, ZBUILDID … → 1307 | 234821774`. That equality is
+        // the entire premise of using these notices as a witness, and it is pinned
+        // here rather than asserted in prose.
+        #expect(parsed.buildID == 234821774)
+    }
+
+    /// A record we cannot fully read must produce nothing at all. This witness only
+    /// ever refuses claims, so a half-parsed record could refuse one on the strength
+    /// of a field we did not actually understand.
+    ///
+    /// Mutation: default the app id to 0 when `durl` is absent instead of returning
+    /// nil — the announcement survives with a nonsense app and this fails.
+    @Test func aRecordWithoutADefaultActionURLIsNotAnAnnouncement() throws {
+        var root = try #require(PropertyListSerialization.propertyList(
+            from: Self.realRecord, options: [], format: nil) as? [String: Any])
+        var request = try #require(root["req"] as? [String: Any])
+        request.removeValue(forKey: "durl")
+        root["req"] = request
+        let stripped = try PropertyListSerialization.data(
+            fromPropertyList: root, format: .binary, options: 0)
+        #expect(TestFlightAnnouncements.parse(record: stripped) == nil)
+    }
+
+    /// Same again for the payload that carries the build id — the half this one
+    /// cannot do without.
+    @Test func aRecordWithoutThePayloadIsNotAnAnnouncement() throws {
+        var root = try #require(PropertyListSerialization.propertyList(
+            from: Self.realRecord, options: [], format: nil) as? [String: Any])
+        var request = try #require(root["req"] as? [String: Any])
+        request.removeValue(forKey: "usda")
+        root["req"] = request
+        let stripped = try PropertyListSerialization.data(
+            fromPropertyList: root, format: .binary, options: 0)
+        #expect(TestFlightAnnouncements.parse(record: stripped) == nil)
+    }
+
+    /// The lookup is per app: one app's announcements must never answer for another,
+    /// or the gate they feed would refuse a verdict for the wrong row.
+    ///
+    /// Mutation: drop the `appAdamID` filter in `buildIDs(forAppAdamID:)` — every
+    /// app gets every build id and this fails.
+    @Test func buildIDsAreScopedToTheirApp() {
+        let witness = TestFlightAnnouncements(announcements: [
+            .init(appAdamID: 1, buildID: 100),
+            .init(appAdamID: 1, buildID: 101),
+            .init(appAdamID: 2, buildID: 200),
+        ])
+        #expect(witness.buildIDs(forAppAdamID: 1) == [100, 101])
+        #expect(witness.buildIDs(forAppAdamID: 2) == [200])
+        #expect(witness.buildIDs(forAppAdamID: 3).isEmpty)
+        #expect(witness.buildIDs(forAppAdamID: nil).isEmpty)
+    }
+
+    /// A store we could not open must look like "nothing to say", never like
+    /// "nothing was announced" — the two are the same value here, so the flag is the
+    /// only thing that keeps a caller from reading a denied read as evidence.
+    @Test func anUnreadableStoreIsMarkedInaccessible() {
+        let witness = TestFlightAnnouncements(
+            databaseURL: URL(fileURLWithPath: "/nonexistent/usernoted.db"))
+        #expect(!witness.accessible)
+        #expect(witness.announcements.isEmpty)
+    }
+}


### PR DESCRIPTION
TestFlight's local store only advances when TestFlight.app runs, and the background
activity that would refresh it is registered `Require Device Inactivity` — so on a
Mac in use it does not run. #496 gave the user a way to force a refresh. This adds
the thing that works when nobody forces anything: TestFlight's **own
notifications**, which arrive on a different path and are not gated that way.

It is a second witness, and it can only ever **take an up-to-date verdict away**.
Same shape as the gate it sits next to — a store that cannot bound this app does not
get to say the app is current. That one triggers on an installed build that outruns
the store; this one on a build TestFlight announced that outruns it.

## The obvious rule is wrong, and live data is what said so

"An announced build the store does not hold proves the store is behind" sounds
self-evident. The store keeps one row per platform for the *current* build and no
history, so **every announcement older than the current build fails a membership
test**. Measured across the two live stores — of 5 announcements, **3 named a build
the store did not hold, and in all three the store was ahead**:

| app | announced | store holds |
|---|---|---|
| co.nowledge.mem.mobile | 234414114 | 234615396 |
| com.jizhi0v0.claude-usage | 234696688 | 234839053 |
| com.ampcode.amp.ios | 234026569 | 234783351 |

That rule would have fired on 3 of 5 live rows, all wrong. Comparing against the
store's **maximum** fires on none of them. Those three numbers are now the
parametrised fixtures, because a rule that plausible needs its counter-example
written down beside it.

⚠️ The comparison assumes build ids increase over time. Sorted by the notification
store's own `delivered_date` the five are strictly increasing (233627973 →
234839053, 09-07 to 09-09) and they look like one global TestFlight sequence.
**n=5** — enough to prefer this over membership, not enough to call it a documented
property. If it is wrong the cost is a refusal we should not have made: the row says
"TestFlight manages this" instead of "up to date". **It can never invent an update.**

## Verified live, and shown not to be vacuous

The risk with a witness that mostly answers "no" is that it is answering "no"
because it is not wired up. Recomputed independently in Python against both stores,
for the 8 TestFlight rows installed here:

```
app              status            frontier   announced   isBehind
ClaudeUsageApp   up-to-date       234839053   234839053     False   ← equality
Paste            up-to-date       234497457   233627973     False   ← stale announcement
Amp              update 1.0 (67)  234783351   234026569     False
Nowledge Mem     update 0.10.80   234615396   234414114     False
Lettera/Mithka/Notability/ScreenCam  up-to-date  —  (no announcement)  False
```

Two `up-to-date` rows really did compare live data on both sides — and each is a
live counter-example to one of the two wrong rules: `>=` would have wrongly refused
**ClaudeUsageApp**, and membership would have wrongly refused **Paste**. Zero rows
fell to `testFlightManaged`, which is the right answer for a current store.

## Shape

- `TestFlightInventory.Frontier` — the App Store id plus the largest `ZBUILDID` per
  app, read by **its own query**: this file's rule is that naming a column makes its
  absence fatal, so a schema without `ZBUILDID`/`ZAPPID` must cost this signal alone
  and not the macOS rows the inventory has read since before either existed.
- `TestFlightAnnouncements.isBehind(_:)` — takes the frontier rather than reading the
  store itself, so one database's failure can never look like the other's answer.
- The refusal fires only when the store has **not** already found an update:
  replacing a concrete version with "TestFlight manages this" would throw
  information away in order to say something weaker.
- Read bounded and off-main in the app, and not wired into the post-install recheck
  at all — that path is deliberately TestFlight-free so it never waits on a TCC gate.

## Testing

- `make test` — 2542 / 263 / App tests 9 of 9, exit 0
- **10 mutations run, each reddening only the case that names it**, including both
  wrong rules and both halves of the "only ever refuses" contract.
- Live `duo check --json --all --source testflight` after deploying: no verdict
  changed, and the two rows above prove the comparison actually ran.