### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.2",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -133,29 +133,29 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
     "changelog:com.bytedance.inputmethod.doubaoime:-" : {
-      "consecutiveActionable" : 2,
+      "consecutiveActionable" : 3,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 497,
       "lastCommentedAt" : "2026-09-09T20:30:20Z",
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.9.7",
       "lastSignature" : "newest changelog entry (0.9.7) trails th",
-      "sweepsSinceComment" : 0,
+      "sweepsSinceComment" : 1,
       "triagedSignature" : "newest changelog entry (0.9.7) trails th"
     },
     "changelog:com.carriez.rustdesk:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -164,16 +164,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 7,
-      "lastGoodVersion" : "0.84.0",
+      "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
     },
     "changelog:com.corecode.MacUpdater:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -182,7 +182,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
@@ -191,7 +191,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -200,7 +200,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
@@ -209,7 +209,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
@@ -218,7 +218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -227,7 +227,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -236,7 +236,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -245,7 +245,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -254,7 +254,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -263,7 +263,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -272,7 +272,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -281,7 +281,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
@@ -290,7 +290,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
@@ -299,7 +299,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -308,7 +308,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -317,7 +317,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -326,7 +326,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -335,7 +335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -344,7 +344,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
@@ -353,7 +353,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -362,7 +362,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.137",
       "sweepsSinceComment" : 0
@@ -371,7 +371,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -382,7 +382,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
@@ -392,7 +392,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
@@ -401,7 +401,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -410,7 +410,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -419,7 +419,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "12.27.2",
       "sweepsSinceComment" : 0
@@ -428,7 +428,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.2.1",
       "sweepsSinceComment" : 0
@@ -439,7 +439,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0,
@@ -449,7 +449,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -458,7 +458,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.2",
       "sweepsSinceComment" : 0
@@ -467,7 +467,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
@@ -476,7 +476,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -485,7 +485,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -494,7 +494,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -503,7 +503,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -514,7 +514,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609082",
       "sweepsSinceComment" : 0,
@@ -524,7 +524,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -533,7 +533,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -542,7 +542,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -551,7 +551,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -560,7 +560,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -569,7 +569,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
@@ -578,7 +578,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260909.1",
       "sweepsSinceComment" : 0
@@ -587,7 +587,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -596,7 +596,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -605,7 +605,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -614,7 +614,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -623,7 +623,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -634,7 +634,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -644,7 +644,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.5.4",
       "sweepsSinceComment" : 0
@@ -653,7 +653,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -662,7 +662,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -671,7 +671,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
@@ -680,7 +680,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.02",
       "sweepsSinceComment" : 0
@@ -689,7 +689,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
@@ -698,7 +698,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
@@ -707,7 +707,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -716,7 +716,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -725,7 +725,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
@@ -734,7 +734,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -743,7 +743,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -752,7 +752,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
@@ -761,29 +761,29 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
     "changelog:notion.id:-" : {
-      "consecutiveActionable" : 3,
+      "consecutiveActionable" : 4,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 493,
       "lastCommentedAt" : "2026-09-09T14:25:37Z",
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "lastSignature" : "newest changelog entry (7.32.0) trails t",
-      "sweepsSinceComment" : 1,
+      "sweepsSinceComment" : 2,
       "triagedSignature" : "newest changelog entry (7.32.0) trails t"
     },
     "changelog:now.typeless.desktop:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
@@ -792,7 +792,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -801,7 +801,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -810,7 +810,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
@@ -819,7 +819,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -828,16 +828,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
-      "lastGoodVersion" : "155.0",
+      "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
     "changelog:org.mozilla.thunderbirdbeta:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -846,7 +846,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -855,7 +855,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -864,16 +864,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "5.0.4",
+      "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
     "changelog:pro.betterdisplay.BetterDisplay:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4.3.6",
       "sweepsSinceComment" : 0
@@ -882,16 +882,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "5.0.4",
+      "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
     "changelog:sh.waku:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 13,
       "lastGoodVersion" : "0.1.18",
       "sweepsSinceComment" : 0
@@ -900,7 +900,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 17,
       "lastGoodVersion" : "1.7.1",
       "sweepsSinceComment" : 0
@@ -909,7 +909,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
@@ -918,7 +918,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
@@ -926,7 +926,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -934,7 +934,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -942,7 +942,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -950,7 +950,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -958,7 +958,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -966,7 +966,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -974,7 +974,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -982,7 +982,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -990,7 +990,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.3.9",
       "sweepsSinceComment" : 0
     },
@@ -998,7 +998,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -1006,7 +1006,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1014,7 +1014,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1022,7 +1022,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1030,7 +1030,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.135.06055",
       "sweepsSinceComment" : 0
     },
@@ -1038,7 +1038,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1046,7 +1046,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1054,7 +1054,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1062,7 +1062,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1070,7 +1070,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1078,7 +1078,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1086,7 +1086,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1094,7 +1094,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1102,7 +1102,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
@@ -1110,7 +1110,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1118,7 +1118,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1126,7 +1126,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1134,7 +1134,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1142,7 +1142,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1150,7 +1150,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1158,7 +1158,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1166,7 +1166,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1174,7 +1174,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1182,7 +1182,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1190,7 +1190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1198,7 +1198,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1206,7 +1206,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1214,7 +1214,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1222,7 +1222,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1230,7 +1230,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1238,7 +1238,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1246,7 +1246,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1254,7 +1254,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1262,7 +1262,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.20.2",
       "sweepsSinceComment" : 0
     },
@@ -1270,7 +1270,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1278,7 +1278,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1286,7 +1286,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1294,7 +1294,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1302,15 +1302,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "1.1.16",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "1.1.17",
       "sweepsSinceComment" : 0
     },
     "github:godotengine\/godot:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1318,7 +1318,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1326,7 +1326,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1334,7 +1334,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1342,7 +1342,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1350,7 +1350,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1358,7 +1358,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1366,7 +1366,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1374,7 +1374,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1382,7 +1382,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1390,7 +1390,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1398,7 +1398,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1406,7 +1406,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1414,7 +1414,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1422,7 +1422,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -1430,7 +1430,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1438,7 +1438,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1446,7 +1446,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1454,7 +1454,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.33.3",
       "sweepsSinceComment" : 0
     },
@@ -1462,15 +1462,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "1.22.2",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "1.23.0",
       "sweepsSinceComment" : 0
     },
     "github:pingdotgg\/t3code:alpha" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1478,15 +1478,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "0.0.41-nightly.20260909.1461",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "0.0.41-nightly.20260910.1473",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1494,7 +1494,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1502,7 +1502,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1510,7 +1510,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1518,7 +1518,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1526,7 +1526,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1534,7 +1534,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1542,7 +1542,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1550,7 +1550,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1558,7 +1558,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1566,7 +1566,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1574,7 +1574,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1582,7 +1582,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1590,7 +1590,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1598,7 +1598,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1606,7 +1606,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1614,7 +1614,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1622,7 +1622,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1652,7 +1652,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1660,7 +1660,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1668,7 +1668,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
@@ -1676,7 +1676,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
@@ -1684,7 +1684,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1824,7 +1824,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1832,7 +1832,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1840,7 +1840,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1848,7 +1848,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1856,7 +1856,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1864,7 +1864,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1872,7 +1872,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1880,7 +1880,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1888,7 +1888,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1896,7 +1896,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
     },
@@ -1904,7 +1904,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1912,7 +1912,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.47.0",
       "sweepsSinceComment" : 0
     },
@@ -1920,7 +1920,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1928,23 +1928,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
     "vendor:com.bjango.istatmenus:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
+      "infraSince" : "2026-09-10T02:24:42Z",
       "lastGoodAt" : "2026-09-09T20:25:05Z",
       "lastGoodVersion" : "7.30",
-      "sweepsSinceComment" : 0
+      "sweepsSinceComment" : 1
     },
     "vendor:com.bombich.ccc:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1952,7 +1953,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1960,7 +1961,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1968,7 +1969,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1976,7 +1977,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.96.49.0",
       "sweepsSinceComment" : 0
     },
@@ -1984,15 +1985,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "1.97.18.0",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "1.97.20.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.bytedance.inputmethod.doubaoime:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2000,7 +2001,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.125.0",
       "sweepsSinceComment" : 0
     },
@@ -2008,15 +2009,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "0.84.2",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.corecode.MacUpdater:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2024,7 +2025,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2032,7 +2033,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2040,7 +2041,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.6.793",
       "sweepsSinceComment" : 0
     },
@@ -2048,7 +2049,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.9.19",
       "sweepsSinceComment" : 0
     },
@@ -2056,7 +2057,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2064,7 +2065,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2072,7 +2073,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2080,7 +2081,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "154.0.8037.17",
       "sweepsSinceComment" : 0
     },
@@ -2088,7 +2089,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "155.0.8049.0",
       "sweepsSinceComment" : 0
     },
@@ -2096,7 +2097,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -2104,7 +2105,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2112,7 +2113,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.111.1.839",
       "sweepsSinceComment" : 0
     },
@@ -2120,7 +2121,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2128,7 +2129,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -2136,7 +2137,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2144,7 +2145,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2152,7 +2153,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -2160,7 +2161,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "7.543.3",
       "sweepsSinceComment" : 0
     },
@@ -2168,7 +2169,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2176,7 +2177,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2184,15 +2185,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "0.0.1314",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "0.0.1317",
       "sweepsSinceComment" : 0
     },
     "vendor:com.hnc.DiscordPTB:ptb" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -2200,7 +2201,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -2208,7 +2209,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2216,7 +2217,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2224,7 +2225,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2234,7 +2235,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "9.5.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -2244,7 +2245,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2252,7 +2253,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2260,7 +2261,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
@@ -2268,7 +2269,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2276,7 +2277,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2284,7 +2285,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -2292,7 +2293,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2300,7 +2301,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2308,7 +2309,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.137.0",
       "sweepsSinceComment" : 0
     },
@@ -2316,7 +2317,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.138.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -2324,7 +2325,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2332,23 +2333,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "153.0.4234.19",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "154.0.4258.9",
       "sweepsSinceComment" : 0
     },
     "vendor:com.microsoft.edgemac.Dev:dev" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "154.0.4251.0",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "155.0.4268.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.microsoft.edgemac:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -2356,7 +2357,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2364,7 +2365,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2372,7 +2373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2380,7 +2381,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2388,7 +2389,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2396,7 +2397,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2404,7 +2405,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26.903.61454",
       "sweepsSinceComment" : 0
     },
@@ -2412,7 +2413,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "135.0.5973.92",
       "sweepsSinceComment" : 0
     },
@@ -2420,7 +2421,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2428,7 +2429,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2436,7 +2437,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "12.27.2",
       "sweepsSinceComment" : 0
     },
@@ -2444,7 +2445,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2452,7 +2453,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2460,7 +2461,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.104.28",
       "sweepsSinceComment" : 0
     },
@@ -2468,7 +2469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.2.1.0",
       "sweepsSinceComment" : 0
     },
@@ -2476,7 +2477,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2484,7 +2485,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2492,7 +2493,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2500,7 +2501,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2508,7 +2509,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2516,7 +2517,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2524,7 +2525,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2532,7 +2533,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2542,7 +2543,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "7.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2551,7 +2552,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2561,7 +2562,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2570,7 +2571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.02.2609082",
       "sweepsSinceComment" : 0
     },
@@ -2578,7 +2579,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2586,7 +2587,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2594,7 +2595,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2602,7 +2603,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "10.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2610,7 +2611,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "10.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2618,7 +2619,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2626,7 +2627,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2634,7 +2635,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.19.19",
       "sweepsSinceComment" : 0
     },
@@ -2642,7 +2643,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.21.1",
       "sweepsSinceComment" : 0
     },
@@ -2650,7 +2651,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "8.3.4157.3",
       "sweepsSinceComment" : 0
     },
@@ -2658,7 +2659,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2666,7 +2667,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2674,7 +2675,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2682,7 +2683,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2690,7 +2691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2698,7 +2699,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2706,7 +2707,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2714,7 +2715,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2722,7 +2723,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2730,7 +2731,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2738,7 +2739,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2746,7 +2747,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2754,7 +2755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2762,15 +2763,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "0.2026.09.09.08.26.00",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "0.2026.09.09.22.34.00",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.warp.Warp-Preview:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2778,7 +2779,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2786,7 +2787,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2794,7 +2795,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2026090901",
       "sweepsSinceComment" : 0
     },
@@ -2802,7 +2803,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2810,7 +2811,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2818,7 +2819,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2826,7 +2827,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2834,7 +2835,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.103.201",
       "sweepsSinceComment" : 0
     },
@@ -2842,7 +2843,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2850,7 +2851,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2858,7 +2859,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2866,7 +2867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2874,7 +2875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26.36.18",
       "sweepsSinceComment" : 0
     },
@@ -2882,7 +2883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
@@ -2890,7 +2891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2898,7 +2899,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2906,7 +2907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2914,7 +2915,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2922,24 +2923,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 3,
+      "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "infraSince" : "2026-09-09T08:25:06Z",
-      "lastGoodAt" : "2026-09-09T02:22:27Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 3
+      "sweepsSinceComment" : 0
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2947,7 +2947,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2955,7 +2955,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2963,7 +2963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2971,7 +2971,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2979,7 +2979,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2987,7 +2987,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2995,7 +2995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -3003,15 +3003,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
-      "lastGoodVersion" : "155.0",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
     "vendor:org.mozilla.thunderbirdbeta:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -3019,7 +3019,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3027,7 +3027,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3035,7 +3035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3043,7 +3043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -3051,7 +3051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "8.26.0",
       "sweepsSinceComment" : 0
     },
@@ -3061,7 +3061,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "10.0.2",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -3070,7 +3070,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3078,11 +3078,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-09T20:25:05Z",
+      "lastGoodAt" : "2026-09-10T02:24:42Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-09T20:30:20Z"
+  "updatedAt" : "2026-09-10T02:24:43Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.