### PR TITLE
Stop calling an unfinished TestFlight sync a refresh

### DIFF
--- a/CLI/Sources/DuoKit/Check.swift
+++ b/CLI/Sources/DuoKit/Check.swift
@@ -63,6 +63,16 @@ public enum Check {
             // "took" would be wrong by more than half.
             let seconds = Double(after.components.seconds) + Double(after.components.attoseconds) / 1e18
             return String(format: "duo: TestFlight refreshed its data (new data landed after %.1fs)", seconds)
+        case .changedWithoutSettling(let lastChange):
+            // Says "may not have finished", never "refreshed". The row printed
+            // immediately below this line can be the pre-sync one, and a user who
+            // was told the refresh succeeded has no reason to look twice.
+            let seconds = Double(lastChange.components.seconds)
+                + Double(lastChange.components.attoseconds) / 1e18
+            return String(
+                format: "duo: TestFlight was still writing when we stopped waiting "
+                      + "(last seen moving after %.1fs); the versions below may predate the sync",
+                seconds)
         case .launchedWithoutChange:
             return "duo: launched TestFlight in the background; its data did not change"
         case .activatedWithoutChange:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
@@ -91,10 +91,12 @@ public struct TestFlightRefresh: Sendable {
     ///
     /// 90s is not fitted to that 40 — it is roughly twice it, because five samples
     /// establish that the work is a network round trip whose tail is long, not
-    /// where the tail ends. The cost of the larger number is bounded: the loop
-    /// returns as soon as the store settles, so a healthy refresh still comes back
-    /// in the 15–25s the same trials measured, and only a store that keeps moving
-    /// waits longer.
+    /// where the tail ends. For a store that settles the larger number costs
+    /// nothing: the loop returns as soon as it does, so a healthy refresh still
+    /// comes back in the 15–25s the same trials measured. Two cases wait all 90s:
+    /// a store that keeps moving, and one that never changes at all
+    /// (`launchedWithoutChange` / `activatedWithoutChange`), which has no write to
+    /// settle after. All five trials above wrote, so that second case is unmeasured.
     public static let defaultDeadline: Duration = .seconds(90)
 
     /// How often to look at the store while waiting.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
@@ -37,8 +37,16 @@ public struct TestFlightRefresh: Sendable {
     /// What one attempt did. Every case is a thing the caller may want to say out
     /// loud — nothing here is a silent no-op.
     public enum Outcome: Sendable, Equatable {
-        /// The store changed within the deadline.
+        /// The store changed and then held still for ``settleInterval`` — the
+        /// sync finished, and the caller may read the store.
         case refreshed(after: Duration)
+        /// The store changed but the deadline arrived before it ever went quiet,
+        /// so whether the sync finished is **unknown**. Deliberately not
+        /// ``refreshed``: a caller that reads the store on this signal can read it
+        /// mid-sync, which is exactly what happened on 2026-09-10 — the refresh
+        /// announced success at +10s, the data landed at +40s, and the check in the
+        /// same process printed the *previous* build as up to date.
+        case changedWithoutSettling(lastChange: Duration)
         /// Launched from cold, but the store never changed. Usually "already
         /// current"; it can also be a sync that did not happen, and this
         /// deliberately does not claim to know which — the store carries no "last
@@ -72,10 +80,22 @@ public struct TestFlightRefresh: Sendable {
     /// Bundle id of the app that owns the store.
     public static let bundleID = "com.apple.TestFlight"
 
-    /// How long to wait for the store to change. Generous against the measured
-    /// 8–11s, because those were three warm-ish samples on two Macs and the work is
-    /// a network round trip.
-    public static let defaultDeadline: Duration = .seconds(30)
+    /// How long to wait for the store to change.
+    ///
+    /// ⚠️ **This was 30s, and 30s is inside the measured spread.** Time from the
+    /// trigger to the data actually landing, measured 2026-09-10 across five valid
+    /// trials on two Macs (three cold launches, two activations): **2s, 4s, 6s,
+    /// 10s, and 40s**. The 40s trial is the one that broke: the loop ran its full
+    /// 30 seconds, never saw the store settle, and returned `.refreshed` anyway on
+    /// the strength of a write at +4s that turned out to be preliminary.
+    ///
+    /// 90s is not fitted to that 40 — it is roughly twice it, because five samples
+    /// establish that the work is a network round trip whose tail is long, not
+    /// where the tail ends. The cost of the larger number is bounded: the loop
+    /// returns as soon as the store settles, so a healthy refresh still comes back
+    /// in the 15–25s the same trials measured, and only a store that keeps moving
+    /// waits longer.
+    public static let defaultDeadline: Duration = .seconds(90)
 
     /// How often to look at the store while waiting.
     public static let pollInterval: Duration = .milliseconds(500)
@@ -186,8 +206,10 @@ public struct TestFlightRefresh: Sendable {
             }
         }
         // Ran out of time. It still changed, so say so rather than pretending
-        // nothing happened; the caller gets the last moment we saw it move.
-        if let lastChange { return .refreshed(after: lastChange) }
+        // nothing happened — but do NOT call it a refresh: the store never held
+        // still, so the sync may well be in flight, and the caller is about to
+        // read it.
+        if let lastChange { return .changedWithoutSettling(lastChange: lastChange) }
         return launched ? .launchedWithoutChange : .activatedWithoutChange
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightRefreshTests.swift
@@ -233,22 +233,51 @@ struct TestFlightRefreshTests {
         #expect(spy.launches == [Self.bundle])
     }
 
-    /// The settle rule must not swallow the answer when the store keeps moving past
-    /// the deadline: a refresh that did happen is still reported, with the last
-    /// moment it was seen moving.
+    /// A store still moving at the deadline is reported — something did happen and
+    /// saying nothing would be worse — but it is NOT called a refresh. The sync may
+    /// still be in flight, and the caller reads the store on the next line.
     ///
-    /// Mutation: drop the post-loop `if let lastChange { return .refreshed(…) }` —
-    /// this becomes `.launchedWithoutChange` and fails.
-    @Test func aStoreStillMovingAtTheDeadlineIsStillARefresh() async {
+    /// Mutation: drop the post-loop `if let lastChange { … }` — this becomes
+    /// `.launchedWithoutChange` and fails. Change it back to `.refreshed(after:)` —
+    /// the `guard case` fails and names what came back.
+    @Test func aStoreStillMovingAtTheDeadlineIsNotCalledARefresh() async {
         let spy = Spy()
         // Changes on every poll, so it never settles.
         let refresher = Self.refresher(stamp: Stamp(changesAt: Set(1...20)), spy: spy)
         let outcome = await refresher.run(deadline: .seconds(2), settle: .seconds(3))
-        guard case .refreshed(let after) = outcome else {
-            Issue.record("expected a refresh, got \(outcome)")
+        guard case .changedWithoutSettling(let lastChange) = outcome else {
+            Issue.record("expected an unsettled change, got \(outcome)")
             return
         }
-        #expect(after == .seconds(2))
+        #expect(lastChange == .seconds(2))
+    }
+
+    /// Replay of the failure this case exists for, 2026-09-10. A cold launch wrote
+    /// the store early, went quiet for far longer than `settle`, and the real sync
+    /// landed **after** the deadline. The old code returned `.refreshed(after: 4s)`
+    /// on the strength of that early write, and the check in the same process then
+    /// printed build 1311 as up to date while 1312 was on its way to disk.
+    ///
+    /// The shape is what matters: an early write, a long silence, and a deadline
+    /// that arrives first. Reporting a refresh here is reporting a version number
+    /// the user has not got yet.
+    ///
+    /// Mutation: return `.refreshed(after: lastChange)` from the post-loop branch —
+    /// this fails, because a store that never settled cannot be called refreshed no
+    /// matter how early the first write was.
+    @Test func anEarlyWriteFollowedBySilenceIsNotASync() async {
+        let spy = Spy()
+        // One write on the 8th poll, then nothing: with a deadline shorter than
+        // settle, the loop can never satisfy the settle rule.
+        let refresher = Self.refresher(stamp: Stamp(changesAt: [8]), spy: spy)
+        let outcome = await refresher.run(deadline: .seconds(5), settle: .seconds(6))
+        guard case .changedWithoutSettling(let lastChange) = outcome else {
+            Issue.record("expected an unsettled change, got \(outcome)")
+            return
+        }
+        // Read 8 lands on the 7th poll: `run` reads the stamp once *before* the
+        // loop, so loop iteration k is read k+1. 7 × 500ms.
+        #expect(lastChange == .milliseconds(3500))
     }
 
     /// A launch that changes nothing is NOT reported as a refresh. The store has no


### PR DESCRIPTION
`--refresh-testflight` could announce success while the sync was still in flight, and the check running in the same process then printed the previous build as up to date.

## What happened

Measured 2026-09-10, cold launch, TestFlight started at 10:49:35:

| | |
|---|---|
| +4s | store written (preliminary) |
| +10s | quiet for `settleInterval`, refresh returns **`.refreshed(after: 4.0s)`** |
| — | the check in the same process reads the store: build **1311** |
| +40s | the real sync lands: build **1312** |

A plain `duo check` run straight afterwards reported `update 0.3.384 (1312)`, so nothing was wrong with the store or the reader — only with the moment the refresh said it was safe to read.

## Why 30s was the wrong number

Time from trigger to data actually landing, five valid trials on two Macs (three cold launches, two activations):

**2s, 4s, 6s, 10s, 40s**

The old `defaultDeadline` of 30s sits *inside* that spread. On the 40s trial the loop ran its full 30 seconds, never saw the store settle, and fell into the post-loop branch — which returned `.refreshed` on the strength of the +4s write.

## The change

- **`.changedWithoutSettling(lastChange:)`** — the timeout path no longer borrows `.refreshed`. Something happened and it is still reported (saying nothing would be worse), but the caller is not told the sync finished.
- **`defaultDeadline` 30s → 90s.** Not fitted to the 40: five samples establish that the tail is long, not where it ends, so this is roughly twice the longest one seen. The cost is bounded — the loop returns the moment the store settles, so a healthy refresh still comes back in the 15–25s these same trials measured. A store that never changes has no write to settle after, so it waits the full 90s (was 30s); all five trials wrote, so how often that happens is unmeasured.
- CLI wording for the new outcome says the rows below may predate the sync.

## Tests

`aStoreStillMovingAtTheDeadlineIsStillARefresh` had encoded the defect as the specification — its reasoning ("a refresh that did happen is still reported") was right about *reporting* and wrong about *what to call it*. Renamed, re-asserted, and joined by `anEarlyWriteFollowedBySilenceIsNotASync`, which replays the shape above: an early write, a long silence, and a deadline that arrives first.

Mutation-verified: putting `.refreshed(after: lastChange)` back in the post-loop branch turns both cases red and each names what came back; reverting is green.

```
make test → 2553 tests in 211 suites passed, 263 tests in 32 suites passed
            ALL GATES PASSED
```

## Not in this PR

The shorter activation hold and the documentation corrections (the menu bar is occupied for `hold + ~10ms`; `kCPSNoWindows` does **not** suppress the window raise on macOS 26; a refresh queues TestFlight's own auto-updates) are a separate change — different risk, and mixing them would bury this one.

