### PR TITLE
Judge the brew actor test by ordering, not a wall-clock bound

### DIFF
--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaReleaseActorTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Darwin
 @testable import DuoUpdaterCore
 
 /// `BrewFormulaReleaseService` runs `brew info` (a ~0.5s subprocess) on the way to
@@ -34,10 +35,49 @@ struct BrewFormulaReleaseActorTests {
         return URLSession(configuration: configuration)
     }
 
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+        func increment() { lock.lock(); count += 1; lock.unlock() }
+        var value: Int { lock.lock(); defer { lock.unlock() }; return count }
+    }
+
     /// A disk-cached formula must stay instantly readable while a prewarm-sized batch
     /// of uncached `release(...)` calls is in flight. Guards the executor hop in
-    /// `brewInfoOffActor`: revert it to a synchronous `Self.brewInfo(name:)` and the
-    /// `cached(...)` below queues behind every subprocess in the batch instead.
+    /// `brewInfoOffActor`: revert it to a synchronous `Self.brewInfo(name:)` and each
+    /// subprocess holds the actor for its whole run, so a `cached(...)` issued beside
+    /// one can only return after it exits.
+    ///
+    /// Ordering, not wall clock. Two bounds were tried and both went red on healthy
+    /// builds on the 3-core runner: a fixed 0.2s (#394), then half of one `brew info`
+    /// timed after the batch. The second failed 3 times in ~113 CI runs, at 0.53-1.44s.
+    /// Instrumented runs of the whole core suite there (2026-09-10, runs 34460475080 and
+    /// 34461525444, 32 samples) showed why a bound can't hold. The suite runs ~2,500
+    /// tests in parallel in this process, so the cooperative pool is saturated:
+    ///   - the old 0.1s settle sleep woke 0.1-6.4s late;
+    ///   - the batch's `brew info` started 1.1-9.4s after its tasks were created and
+    ///     ran 0.6-7.1s, while the post-batch `solo` ran 0.39-0.99s. The bound was
+    ///     measured at a different load from the read it judged, and on a fast
+    ///     runner `solo` fell under the old `solo > 4 * settle` guard;
+    ///   - a healthy read usually ran inline in ~0.2ms. But in 2 of 32 samples (and 3
+    ///     of 6 local full-suite runs) it waited 12-82ms to enter the actor, behind
+    ///     batch members whose own entry jobs were still waiting for a pool thread.
+    ///     No subprocess was involved. The three CI failures were not captured under
+    ///     instrumentation, but that queueing is the only way the instrumented runs
+    ///     show a healthy read waiting at all, and pool waits there reached seconds.
+    ///
+    /// So the read is issued only once every batch member is inside `brew info` at the
+    /// same time. A live subprocess means its member has made its actor entry and hopped
+    /// off, and none has come back yet, so the actor has nothing queued for the read to
+    /// wait behind — nothing except the actor being held, which is the one thing this
+    /// is here to catch. The verdict is then an ordering: at least one of those
+    /// subprocesses must still be running when `cached()` returns. With the hop
+    /// reverted that gate can never be met — each subprocess holds the actor, so at
+    /// most one is ever alive (at most 1 of 4 in all 3 hop-reverted samples, run in
+    /// their own job on a 3-core runner) — and the test fails and says so.
+    ///
+    /// Only this process's own children, under names made up here, are looked at, so
+    /// the answer doesn't depend on what else the host is running.
     @Test func cachedStaysResponsiveWhileUncachedFormulaeAreComputing() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("BrewFormulaReleaseActorTest-\(UUID().uuidString)")
@@ -56,68 +96,117 @@ struct BrewFormulaReleaseActorTests {
         await service.persist(seeded, name: cachedName, version: cachedVersion)
 
         // Guard against a vacuous pass: a `cached` that misses returns nil instantly,
-        // and the timing assertion below would then prove nothing.
+        // and the ordering check below would then prove nothing.
         #expect(await service.cached(for: cachedName, version: cachedVersion) == seeded,
                 "seeded entry must be readable before timing it")
 
         // A prewarm-sized batch of uncached formulae, each paying a full `brew info`.
+        // Up to three batches: the poll below sleeps on the same saturated pool, and one
+        // that oversleeps a whole batch must not decide the verdict. A pass needs the
+        // gate met once; with the hop reverted it is never met, and that costs three
+        // serialized batches before the failure.
         let batch = 4
-        let inFlight = (0..<batch).map { i in
-            Task {
-                _ = await service.release(
-                    for: "duo-uncached-formula-\(i)", version: "9.9.9", token: nil)
+        let rounds = 3
+        var peaks: [Int] = []
+        var stillRunningAfterRead: Set<String>?
+        var elapsed: TimeInterval = 0
+        for round in 0..<rounds {
+            let names = (0..<batch).map { "duo-uncached-formula-r\(round)-\($0)" }
+            let finished = Counter()
+            let inFlight = names.map { name in
+                Task {
+                    _ = await service.release(for: name, version: "9.9.9", token: nil)
+                    finished.increment()
+                }
+            }
+            var peak = 0
+            while finished.value < batch {
+                let running = Self.runningBrewInfo(named: names)
+                peak = max(peak, running.count)
+                if running.count == batch {
+                    // Nothing suspends between the snapshot and the read, so the
+                    // snapshot still describes the actor the read meets.
+                    let start = Date()
+                    let hit = await service.cached(for: cachedName, version: cachedVersion)
+                    elapsed = Date().timeIntervalSince(start)
+                    stillRunningAfterRead = Self.runningBrewInfo(named: names)
+                    #expect(hit == seeded)
+                    break
+                }
+                try await Task.sleep(nanoseconds: 5_000_000)
+            }
+            for task in inFlight { await task.value }
+            peaks.append(peak)
+            if stillRunningAfterRead != nil { break }
+        }
+
+        guard let stillRunningAfterRead else {
+            let most = peaks.max() ?? 0
+            let why = switch most {
+            case 0: """
+                premise gone: no `brew info` was ever seen running, so there is nothing \
+                for `cached()` to be kept waiting behind. Re-tune or delete this test.
+                """
+            case 1: """
+                `brew info` was never seen running more than one at a time, which is what \
+                a held actor looks like: each subprocess holds it for its whole run, so \
+                `cached()` would queue behind every one of them. A batch too short-lived \
+                for this poll to catch two together looks the same, so check how long \
+                `brew info` takes here before blaming the actor.
+                """
+            default: """
+                the batch overlapped (so the actor is not serializing it) but was never \
+                seen all \(batch) at once, so `cached()` was never checked against it.
+                """
+            }
+            Issue.record("\(why) Most seen running at once per round: \(peaks).")
+            return
+        }
+        #expect(!stillRunningAfterRead.isEmpty, """
+            cached() returned only after all \(batch) `brew info` subprocesses it was \
+            issued beside had exited (\(elapsed)s): something held the actor while they ran
+            """)
+    }
+
+    /// Which of `names` are in `brew info` right now, read from this process's own
+    /// children. `brew` execs into Ruby under the same pid and keeps the formula name as
+    /// its last argument, so argv tells the batch apart with no hook in the code under
+    /// test. An exited child that hasn't been reaped yet has no argv and doesn't count.
+    private static func runningBrewInfo(named names: [String]) -> Set<String> {
+        let wanted = Set(names)
+        var pids = [pid_t](repeating: 0, count: 4096)
+        let listed = proc_listchildpids(
+            getpid(), &pids, Int32(pids.count * MemoryLayout<pid_t>.stride))
+        guard listed >= 0 else { return [] }
+        var running: Set<String> = []
+        for pid in pids where pid > 0 {
+            if let name = arguments(of: pid)?.last, wanted.contains(name) {
+                running.insert(name)
             }
         }
-        defer { for task in inFlight { task.cancel() } }
+        return running
+    }
 
-        // Let the batch enter the actor before timing the interactive read.
-        let settle = 0.1
-        try await Task.sleep(nanoseconds: UInt64(settle * 1_000_000_000))
-
-        let start = Date()
-        let hit = await service.cached(for: cachedName, version: cachedVersion)
-        let elapsed = Date().timeIntervalSince(start)
-        #expect(hit == seeded)
-
-        for task in inFlight { await task.value }
-
-        // What one `brew info` costs on THIS host, measured with nothing else on the
-        // actor — which is the whole point of taking it here rather than reusing the
-        // batch's wall clock. A bound derived from the batch would inflate ~4x in
-        // exactly the case this test exists to catch (the batch is serialized when the
-        // bug is present), so `batchElapsed / 2` would be ~2 subprocesses of room — and a
-        // `cached()` admitted after only one `brewInfo` is the bug, per the reasoning
-        // below. Measured 2026-09-07 by reverting the hop: `solo` moved 0.563s -> 0.571s
-        // while `batchElapsed` went to 2.459s. The batch is over when this runs, so
-        // nothing contends and the number does not inflate with the bug.
-        let soloStart = Date()
-        _ = await service.release(for: "duo-uncached-formula-solo", version: "9.9.9", token: nil)
-        let solo = Date().timeIntervalSince(soloStart)
-
-        // Half a subprocess. The floor of the broken case is `solo - settle`: the batch
-        // has been running for `settle` when the read starts, so a `cached()` that has
-        // to wait for the actor waits out at least the remainder of the subprocess
-        // holding it. Half sits under that floor with room at every host speed the
-        // guard below admits, and unlike the old hard-coded 0.2s it means the same
-        // thing on a 14-core laptop and a 3-core runner — where 0.2s is a much thinner
-        // slice of a much slower subprocess, and went red on a healthy build (#394).
-        let bound = solo / 2
-        #expect(elapsed < bound, """
-            cached() waited \(elapsed)s behind the brew info batch, over the \(bound)s \
-            bound derived from a \(solo)s `brew info` on this host
-            """)
-
-        // Vacuity guard on this test's own premise, and it has to be an absolute floor
-        // now: the old ratio guard (`batch * batchElapsed > 3 * bound`) becomes a
-        // tautology once the bound is derived from the same measurement. What actually
-        // has to hold is that a subprocess outlasts `settle` by enough to be visible —
-        // at `solo == 4 * settle` the broken case still floors at 3x `settle` against a
-        // 2x-`settle` bound. Below that the two cases stop being separable and a pass
-        // proves nothing.
-        #expect(solo > 4 * settle, """
-            premise gone: one `brew info` now takes \(solo)s, too close to the \(settle)s \
-            the batch is given to settle, so "actor held" and "actor free" are no longer \
-            distinguishable here. Re-tune or delete this test.
-            """)
+    /// argv of `pid` from `KERN_PROCARGS2`: an `Int32` argc, the exec path, NUL padding,
+    /// then argc NUL-terminated arguments.
+    private static func arguments(of pid: pid_t) -> [String]? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size = 0
+        guard sysctl(&mib, 3, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [UInt8](repeating: 0, count: size)
+        guard sysctl(&mib, 3, &buffer, &size, nil, 0) == 0,
+              size > MemoryLayout<Int32>.size else { return nil }
+        let argc = buffer.withUnsafeBytes { $0.load(as: Int32.self) }
+        var i = MemoryLayout<Int32>.size
+        while i < size, buffer[i] != 0 { i += 1 }
+        while i < size, buffer[i] == 0 { i += 1 }
+        var arguments: [String] = []
+        while arguments.count < argc, i < size {
+            let start = i
+            while i < size, buffer[i] != 0 { i += 1 }
+            arguments.append(String(decoding: buffer[start..<i], as: UTF8.self))
+            i += 1
+        }
+        return arguments
     }
 }


### PR DESCRIPTION
`cachedStaysResponsiveWhileUncachedFormulaeAreComputing` went red on #503 (run 34458536819, head 4580ffa8) on a commit that touches nothing under Brew*: `elapsed 0.843s < bound 0.500s`. Attempt 2 of the same run, same commit, passed. This replaces the wall-clock bound with an ordering the actor can't fake, and says why a bound can't hold on the 3-core runner.

## Pass rate before touching anything

- **CI history since the bound became `solo / 2`** (bafe9f18, #426): 110 passed, 2 failed, 28 attempts never reached the test (cancelled/skipped). With #503's run that makes **3 failures in ~113 runs**, all on the `elapsed` line: 0.53s, 0.84s, 1.44s. Two of the three commits touch no Brew code.
- **Repeat runs of unmodified main on the hosted runner** (run 34460475080, 3 jobs × 4 full core-suite iterations): the `elapsed` assertion passed 12/12. But **2/12 failed the vacuity guard instead** (`solo 0.397 / 0.388 > 0.4`) on a fast runner in iterations without the download gate. So the old test had a second failure mode as well.

So: a flake, ~3% on the `elapsed` line, not a regression from #503.

## Mechanism (measured)

Instrumented copies (diag branch only, never merged) timestamped every actor entry/exit, the per-formula `brew info` start/end and the hop off/back, plus pool/Dispatch probes at the moment of the read. That's 32 samples of the full core suite on the 3-core runner (runs 34460475080, 34461525444), plus 6 local.

The suite runs ~2,550 tests in parallel in one process, so the cooperative pool is saturated when this test runs:

| | measured on the 3-core runner (32 samples) |
|---|---|
| 0.1s `settle` sleep, lateness | 0.1 – 6.4 s |
| batch `brew info` start, after the tasks were created | 1.1 – 9.4 s |
| batch `brew info` duration | 0.6 – 7.1 s |
| post-batch `solo` (the bound's source) | 0.39 – 0.99 s |
| healthy read, usual | ~0.2 ms, inline on the test's thread |
| healthy read, slow cases | 2/32 waited **26 / 41 ms** to *enter* the actor |

- **`solo` was measured at a different load from the read it judged**: the batch's own subprocesses ran up to ~7× longer.
- **The slow healthy reads queued behind the batch's late *entries*, not behind a subprocess.** In both CI traces (and in 3/6 local full-suite runs, 12–82 ms), batch members 2 and 3 only made their actor entry 20–75 ms *after* `read.start`, because their tasks were still waiting for a pool thread. The read went in right behind them, and no `brew info` had even started. So "let the batch settle for 0.1s" does not mean the batch has entered.
- **Not proven:** the three CI failures (0.53–1.44s) weren't captured under instrumentation. That queueing is the only way the instrumented runs show a healthy read waiting at all, and pool admission on that runner reached seconds. I'm inferring it's the same mechanism at a larger scale. The actor itself does **not** hold the read: no healthy sample ever had a subprocess running on it.
- **Hop reverted** (mutation, 3 samples): elapsed 1.9–3.8s, all of it waiting to enter the actor. **At most one `brew info` alive at any instant, in every sample.**

## The fix (test only; the actor is fine)

1. Start the batch and poll this process's own children (`proc_listchildpids` + argv via `KERN_PROCARGS2`; `brew` execs into Ruby under the same pid with the formula name last).
2. Issue the read only when **all four** batch members are inside `brew info` at once. A live subprocess means its member has entered the actor and hopped off, and none has come back, so the actor has nothing queued for the read to wait behind — unless the actor is being held, which is the one thing the test is there to catch.
3. The verdict is an ordering: **at least one of those subprocesses is still running when `cached()` returns.** No bound, no host speed.
4. With the hop reverted, at most one subprocess is ever alive, so the gate can't be met. After three batches the test fails and says so. The three batches exist so that one poll oversleeping a whole batch on the saturated pool doesn't decide the verdict.

The old `solo > 4 * settle` guard is replaced by the failure classification: if no subprocess was ever seen, it reports "premise gone".

## Mutation proof

Each mutation was applied in a scratch copy with the substitution asserted to hit exactly once:

| mutation | where it fails | local | 3-core runner |
|---|---|---|---|
| M1: `brewInfoOffActor` → synchronous `brewInfo` (the one the comment names) | gate: ``brew info` was never seen running more than one at a time … Most seen running at once per round: [1, 1, 1]`` | red, 7.1 s | **red 3/3** (run 34463294528, nmut-1), peaks `[1, 1, 1]` every time, 14.5–25.4 s |
| M2: hop intact, `cached()` for the seeded name holds the actor 15 s | ordering: `cached() returned only after all 4 brew info subprocesses … had exited (15.007s)` | red | **red 2/2** (nhold-1): gate met (4 of 4 running), then 0 still running after a 15.03–15.04 s read |

Each mutation fails at the assertion it's meant to hit, not the other one.

## Verification

- Local, healthy, `swift test --filter BrewFormulaReleaseActorTests` ×5: 5/5 passed (0.64–0.89 s).
- 3-core runner, healthy, new test inside the full core suite (run 34463294528, 4 jobs × 5 iterations, download gate on in iteration 1): **20/20 passed**. The gate was met in the **first** batch every time (peak 4 of 4 running). **All 4** subprocesses were still running when `cached()` returned. The read took **0.15–1.9 ms**.
- `make test` on the final tree, locally: `EXIT=0`, 0 lines with ✘ or `error:`:
  ```
  ✔ Test cachedStaysResponsiveWhileUncachedFormulaeAreComputing() passed after 3.285 seconds.
  ━ Test run with 2552 tests in 211 suites passed after 23.690 seconds with 1 known issue.
  ✔ Test run with 263 tests in 32 suites passed after 0.156 seconds.
  ✓ App tests — 9 of 9 cases executed
  OK
  ```
  The known issue is `ankiZeroPaddedTagComparesEqualToInstalled()` (`GitHubReleaseRuleTests.swift:993`). It is recorded identically in main's CI (#503's run, head 4580ffa8), so it doesn't come from this change.

## Caveats

- The test now depends on `brew` exec'ing into a process whose last argv is the formula name. If Homebrew changes that, the failure is loud: "premise gone", or the `[1, 1, 1]`-style message, which names that possibility. It can't pass silently.
- The instrumentation and repeat-run workflow live on `diag/brew-actor-timing` (never to be merged). The branch can be deleted once this is reviewed.
