### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.2",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -133,29 +133,28 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
     "changelog:com.bytedance.inputmethod.doubaoime:-" : {
-      "consecutiveActionable" : 4,
+      "closedAt" : "2026-09-10T14:22:43Z",
+      "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 497,
-      "lastCommentedAt" : "2026-09-09T20:30:20Z",
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
-      "lastGoodVersion" : "0.9.7",
-      "lastSignature" : "newest changelog entry (0.9.7) trails th",
-      "sweepsSinceComment" : 2,
+      "lastGoodVersion" : "1.0.0",
+      "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (0.9.7) trails th"
     },
     "changelog:com.carriez.rustdesk:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -164,7 +163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
@@ -173,7 +172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -182,7 +181,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
@@ -191,7 +190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -200,26 +199,29 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
     "changelog:com.electron.ollama:-" : {
-      "consecutiveActionable" : 1,
+      "consecutiveActionable" : 2,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "issueNumber" : 507,
+      "lastCommentedAt" : "2026-09-10T14:22:47Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "0.33.3",
       "lastSignature" : "newest changelog entry (0.33.3) trails t",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 0,
+      "triagedSignature" : "newest changelog entry (0.33.3) trails t"
     },
     "changelog:com.eusoft.eudic:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -228,7 +230,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -237,7 +239,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -246,7 +248,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -255,7 +257,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -264,7 +266,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -273,7 +275,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -282,7 +284,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
@@ -291,7 +293,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
@@ -300,7 +302,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -309,7 +311,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -318,7 +320,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -327,7 +329,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -336,7 +338,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -345,7 +347,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
@@ -354,7 +356,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -363,7 +365,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.137",
       "sweepsSinceComment" : 0
@@ -372,7 +374,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -383,7 +385,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
@@ -393,7 +395,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "135.0.5973.123",
       "sweepsSinceComment" : 0
@@ -402,7 +404,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -411,7 +413,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -420,16 +422,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 30,
-      "lastGoodVersion" : "12.27.3",
+      "lastGoodVersion" : "12.27.5",
       "sweepsSinceComment" : 0
     },
     "changelog:com.qoder.app:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
@@ -440,7 +442,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0,
@@ -450,25 +452,25 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
-      "lastGoodVersion" : "2.2",
+      "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
     },
     "changelog:com.raycast.macos:-:1-2" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
-      "lastGoodVersion" : "2.2",
+      "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
     },
     "changelog:com.readdle.pdfexpert-mac:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
@@ -477,7 +479,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -486,7 +488,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -495,7 +497,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -504,7 +506,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -515,7 +517,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0,
@@ -525,7 +527,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -534,7 +536,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -543,7 +545,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -552,7 +554,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -561,7 +563,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -570,7 +572,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 2, 2026",
       "sweepsSinceComment" : 0
@@ -579,7 +581,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260909.1",
       "sweepsSinceComment" : 0
@@ -588,7 +590,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -597,7 +599,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -606,7 +608,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -615,7 +617,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -624,7 +626,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -635,7 +637,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -645,7 +647,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.5.4",
       "sweepsSinceComment" : 0
@@ -654,7 +656,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -663,7 +665,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -672,7 +674,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
@@ -681,7 +683,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.02.08.27.02",
       "sweepsSinceComment" : 0
@@ -690,7 +692,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
@@ -699,7 +701,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
@@ -708,7 +710,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -717,7 +719,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -726,7 +728,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
@@ -735,7 +737,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -744,7 +746,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -753,7 +755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
@@ -762,38 +764,38 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
     },
     "changelog:notion.id:-" : {
-      "consecutiveActionable" : 5,
+      "consecutiveActionable" : 6,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 493,
       "lastCommentedAt" : "2026-09-09T14:25:37Z",
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "lastSignature" : "newest changelog entry (7.32.0) trails t",
-      "sweepsSinceComment" : 3,
+      "sweepsSinceComment" : 4,
       "triagedSignature" : "newest changelog entry (7.32.0) trails t"
     },
     "changelog:now.typeless.desktop:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 12,
-      "lastGoodVersion" : "2.6.0",
+      "lastGoodVersion" : "2.7.0",
       "sweepsSinceComment" : 0
     },
     "changelog:org.audacityteam.audacity:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -802,7 +804,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -811,7 +813,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
@@ -820,7 +822,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -829,7 +831,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
@@ -838,7 +840,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -847,7 +849,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -856,7 +858,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -865,34 +867,34 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "5.0.5",
+      "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
     "changelog:pro.betterdisplay.BetterDisplay:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "4.3.6",
+      "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
     "changelog:pro.betterdisplay.BetterDisplay:unstable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "5.0.5",
+      "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
     },
     "changelog:sh.waku:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 13,
       "lastGoodVersion" : "0.1.18",
       "sweepsSinceComment" : 0
@@ -901,7 +903,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 17,
       "lastGoodVersion" : "1.7.1",
       "sweepsSinceComment" : 0
@@ -910,7 +912,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
@@ -919,7 +921,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
@@ -927,7 +929,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -935,7 +937,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -943,7 +945,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -951,7 +953,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -959,7 +961,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -967,7 +969,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "11.16",
       "sweepsSinceComment" : 0
     },
@@ -975,7 +977,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -983,7 +985,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -991,7 +993,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.3.9",
       "sweepsSinceComment" : 0
     },
@@ -999,7 +1001,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -1007,7 +1009,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1015,7 +1017,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1023,7 +1025,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1031,7 +1033,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.135.06055",
       "sweepsSinceComment" : 0
     },
@@ -1039,7 +1041,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1047,7 +1049,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1055,7 +1057,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1063,7 +1065,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1071,7 +1073,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1079,7 +1081,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1087,7 +1089,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1095,7 +1097,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1103,7 +1105,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
@@ -1111,15 +1113,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "2.0.5",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "2.0.7",
       "sweepsSinceComment" : 0
     },
     "github:artginzburg\/MiddleClick:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1127,7 +1129,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1135,7 +1137,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1143,7 +1145,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1151,7 +1153,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1159,7 +1161,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1167,7 +1169,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1175,7 +1177,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1183,7 +1185,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1191,7 +1193,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1199,7 +1201,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1207,7 +1209,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1215,7 +1217,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1223,7 +1225,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1231,7 +1233,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1239,7 +1241,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1247,7 +1249,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1255,7 +1257,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1263,7 +1265,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.20.2",
       "sweepsSinceComment" : 0
     },
@@ -1271,7 +1273,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1279,7 +1281,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1287,7 +1289,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1295,15 +1297,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "0.7.2",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "0.8.0",
       "sweepsSinceComment" : 0
     },
     "github:github\/app:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.1.17",
       "sweepsSinceComment" : 0
     },
@@ -1311,7 +1313,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1319,7 +1321,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1327,7 +1329,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1335,7 +1337,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1343,7 +1345,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1351,7 +1353,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1359,7 +1361,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1367,7 +1369,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1375,7 +1377,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1383,7 +1385,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1391,7 +1393,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1399,7 +1401,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1407,7 +1409,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1415,7 +1417,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1423,7 +1425,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.8.0-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -1431,7 +1433,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1439,7 +1441,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1447,7 +1449,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1455,7 +1457,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0
     },
@@ -1463,7 +1465,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.23.0",
       "sweepsSinceComment" : 0
     },
@@ -1471,7 +1473,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1479,7 +1481,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.0.41-nightly.20260910.1486",
       "sweepsSinceComment" : 0
     },
@@ -1487,7 +1489,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1495,7 +1497,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1503,7 +1505,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1511,7 +1513,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1519,7 +1521,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1527,7 +1529,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1535,7 +1537,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1543,7 +1545,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1551,7 +1553,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1559,7 +1561,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1567,7 +1569,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1575,7 +1577,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1583,7 +1585,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1591,7 +1593,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1599,7 +1601,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1607,7 +1609,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1615,7 +1617,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1623,7 +1625,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1653,7 +1655,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1661,7 +1663,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1669,7 +1671,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
@@ -1677,7 +1679,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
@@ -1685,7 +1687,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1825,7 +1827,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1833,7 +1835,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1841,7 +1843,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1849,7 +1851,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1857,7 +1859,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1865,7 +1867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1873,7 +1875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1881,7 +1883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1889,7 +1891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1897,7 +1899,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.49585.0",
       "sweepsSinceComment" : 0
     },
@@ -1905,7 +1907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1913,7 +1915,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.47.0",
       "sweepsSinceComment" : 0
     },
@@ -1921,7 +1923,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1929,7 +1931,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
@@ -1937,7 +1939,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1945,7 +1947,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1953,7 +1955,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1961,7 +1963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1969,7 +1971,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1977,15 +1979,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "1.96.49.0",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "1.96.50.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.brave.Browser.nightly:nightly" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.97.20.0",
       "sweepsSinceComment" : 0
     },
@@ -1993,7 +1995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2001,7 +2003,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.125.1",
       "sweepsSinceComment" : 0
     },
@@ -2009,7 +2011,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
     },
@@ -2017,7 +2019,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2025,7 +2027,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2033,7 +2035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2041,7 +2043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.6.793",
       "sweepsSinceComment" : 0
     },
@@ -2049,7 +2051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.9.19",
       "sweepsSinceComment" : 0
     },
@@ -2057,7 +2059,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2065,7 +2067,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2073,7 +2075,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2081,7 +2083,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "154.0.8037.17",
       "sweepsSinceComment" : 0
     },
@@ -2089,7 +2091,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "155.0.8050.0",
       "sweepsSinceComment" : 0
     },
@@ -2097,7 +2099,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "155.0.8040.2",
       "sweepsSinceComment" : 0
     },
@@ -2105,7 +2107,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2113,7 +2115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.111.1.839",
       "sweepsSinceComment" : 0
     },
@@ -2121,7 +2123,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2129,7 +2131,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.2.1 Canary 4",
       "sweepsSinceComment" : 0
     },
@@ -2137,7 +2139,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2145,7 +2147,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2153,7 +2155,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -2161,7 +2163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.543.3",
       "sweepsSinceComment" : 0
     },
@@ -2169,7 +2171,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2177,7 +2179,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2185,7 +2187,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.0.1317",
       "sweepsSinceComment" : 0
     },
@@ -2193,7 +2195,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.0.259",
       "sweepsSinceComment" : 0
     },
@@ -2201,7 +2203,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -2209,7 +2211,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2217,7 +2219,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2225,7 +2227,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2235,7 +2237,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "9.5.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -2245,7 +2247,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2253,7 +2255,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2261,7 +2263,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
@@ -2269,7 +2271,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2277,7 +2279,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2285,7 +2287,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -2293,7 +2295,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2301,7 +2303,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2309,7 +2311,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.137.0",
       "sweepsSinceComment" : 0
     },
@@ -2317,15 +2319,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "1.137.0-insider",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "1.138.0-insider",
       "sweepsSinceComment" : 0
     },
     "vendor:com.microsoft.Word:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "16.112.26083020",
       "sweepsSinceComment" : 0
     },
@@ -2333,7 +2335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "154.0.4258.9",
       "sweepsSinceComment" : 0
     },
@@ -2341,7 +2343,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "155.0.4268.0",
       "sweepsSinceComment" : 0
     },
@@ -2349,7 +2351,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "152.0.4191.66",
       "sweepsSinceComment" : 0
     },
@@ -2357,7 +2359,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2365,7 +2367,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2373,7 +2375,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2381,7 +2383,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2389,7 +2391,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2397,7 +2399,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2405,7 +2407,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "26.903.71938",
       "sweepsSinceComment" : 0
     },
@@ -2413,7 +2415,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "135.0.5973.123",
       "sweepsSinceComment" : 0
     },
@@ -2421,7 +2423,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2429,7 +2431,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2437,15 +2439,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "12.27.3",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "12.27.5",
       "sweepsSinceComment" : 0
     },
     "vendor:com.qoder.app:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2453,7 +2455,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2461,23 +2463,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "1.104.28",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "1.104.29",
       "sweepsSinceComment" : 0
     },
     "vendor:com.raycast.macos:stable:v2" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "2.2.1.0",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "2.3.0.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.runningwithcrayons.Alfred:beta" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2485,7 +2487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2493,7 +2495,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2501,7 +2503,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2509,7 +2511,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2517,7 +2519,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2525,16 +2527,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
     "vendor:com.tclementdev.timemachineeditor.application:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
-      "consecutiveInstallTransient" : 1,
-      "installTransientSince" : "2026-09-10T08:21:32Z",
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2544,7 +2545,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.2.7",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2553,7 +2554,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2563,7 +2564,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2572,7 +2573,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0
     },
@@ -2580,7 +2581,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2588,7 +2589,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2596,7 +2597,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2604,23 +2605,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "10.0.1",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
     "vendor:com.termius-dmg.mac:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "10.0.0",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
     "vendor:com.tigervnc.tigervnc:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2628,7 +2629,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2636,7 +2637,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.20.7",
       "sweepsSinceComment" : 0
     },
@@ -2644,15 +2645,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "3.21.1",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "3.21.2",
       "sweepsSinceComment" : 0
     },
     "vendor:com.vivaldi.Vivaldi.snapshot:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "8.3.4157.3",
       "sweepsSinceComment" : 0
     },
@@ -2660,7 +2661,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2668,7 +2669,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2676,7 +2677,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2684,7 +2685,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2692,7 +2693,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2700,7 +2701,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2708,7 +2709,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2716,7 +2717,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2724,7 +2725,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2732,7 +2733,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2740,7 +2741,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2748,7 +2749,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2756,7 +2757,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2764,15 +2765,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "0.2026.09.09.22.34.00",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "0.2026.09.10.08.27.00",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.warp.Warp-Preview:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2780,7 +2781,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "0.2026.09.02.08.27.01",
       "sweepsSinceComment" : 0
     },
@@ -2788,7 +2789,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2796,15 +2797,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "2026090901",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "2026091001",
       "sweepsSinceComment" : 0
     },
     "vendor:io.dcloud.HBuilderX:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2812,7 +2813,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2820,7 +2821,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2828,7 +2829,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.102.3",
       "sweepsSinceComment" : 0
     },
@@ -2836,7 +2837,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.103.201",
       "sweepsSinceComment" : 0
     },
@@ -2844,7 +2845,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2852,7 +2853,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2860,7 +2861,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2868,7 +2869,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2876,15 +2877,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "26.36.18",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "26.36.21",
       "sweepsSinceComment" : 0
     },
     "vendor:notion.id:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
@@ -2892,7 +2893,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2900,7 +2901,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.2.4",
       "sweepsSinceComment" : 0
     },
@@ -2908,7 +2909,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2916,7 +2917,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2924,24 +2925,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 1,
+      "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "infraSince" : "2026-09-10T08:21:32Z",
-      "lastGoodAt" : "2026-09-10T02:24:42Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 0
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2949,7 +2949,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2957,7 +2957,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2965,7 +2965,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2973,7 +2973,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2981,7 +2981,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2989,7 +2989,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -2997,7 +2997,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -3005,7 +3005,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -3013,7 +3013,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -3021,7 +3021,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3029,7 +3029,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3037,7 +3037,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3045,7 +3045,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "8.27.0-beta.3",
       "sweepsSinceComment" : 0
     },
@@ -3053,8 +3053,8 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
-      "lastGoodVersion" : "8.26.0",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
+      "lastGoodVersion" : "8.27.0",
       "sweepsSinceComment" : 0
     },
     "vendor:org.zotero.zotero:stable" : {
@@ -3063,7 +3063,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "10.0.2",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -3072,7 +3072,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3080,11 +3080,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-10T08:21:32Z",
+      "lastGoodAt" : "2026-09-10T14:20:48Z",
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-10T08:21:33Z"
+  "updatedAt" : "2026-09-10T14:22:47Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.