### PR TITLE
Add super.engineering: nightly updates, release notes, one-click install

### DIFF
--- a/.agents/skills/fragile-recipe/references/vendor-probe-recipe.md
+++ b/.agents/skills/fragile-recipe/references/vendor-probe-recipe.md
@@ -27,7 +27,7 @@ stable endpoint you want.
 ## The recipe fields
 
 > ⚠️ **The initializer is the reference; this page is a tour of the common half.**
-> `VendorProbeRecipe.init` currently takes **24** parameters. Read it before you
+> `VendorProbeRecipe.init` currently takes **25** parameters. Read it before you
 > conclude a situation is unsupported — a recipe that "can't express this" is far
 > more often a field nobody has read than a real limit.
 > `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift`
@@ -64,6 +64,7 @@ The rest, by the problem they solve — go to the source for the exact semantics
 | WAF needs a Referer, or rejects the default UA | `requestHeaders` |
 | Endpoint sometimes returns a "nothing new" / closed-track body | `transientBodyPattern`, `trackClosedPattern` |
 | The body also states the version the caller already has | `installedVersionPattern` |
+| Versions are commit hashes (no order of their own); the vendor publishes its release history | `buildLineage` — see `BuildLineage` |
 
 - **`.redirectFilename`** — `url` is a stable link that 302s to the real package;
   HEAD it, follow redirects, parse the version out of the final filename. Preferred

--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -556,6 +556,7 @@ An audit that does not know a field exists will report the situation it covers a
 | `channel` | this endpoint serves a non-stable track (source refuses cross-channel) |
 | `variant` | one channel legitimately has more than one endpoint worth asking |
 | `hostRequirement` | the build only runs on some Macs (arch / OS floor) — **detection half**. A STATIC per-generation floor only; a bound that moves release to release must be read from the feed instead, never frozen here |
+| `buildLineage` | the version is a commit hash (no order of its own) and the vendor publishes its release history: the engine orders by position there instead of `VersionComparator`, which on hashes is a coin flip. See `BuildLineage` |
 | `identities` (`ProbeIdentity`) | the endpoint only answers for a machine id the app already wrote to disk |
 | `track` (`RolloutTrack`) | one URL, several vendor-assigned tracks, picked by a request-borne value |
 | `requestBody` | the service answers nothing to a GET (Omaha-style) |

--- a/.claude/skills/fragile-recipe/references/vendor-probe-recipe.md
+++ b/.claude/skills/fragile-recipe/references/vendor-probe-recipe.md
@@ -27,7 +27,7 @@ stable endpoint you want.
 ## The recipe fields
 
 > ⚠️ **The initializer is the reference; this page is a tour of the common half.**
-> `VendorProbeRecipe.init` currently takes **24** parameters. Read it before you
+> `VendorProbeRecipe.init` currently takes **25** parameters. Read it before you
 > conclude a situation is unsupported — a recipe that "can't express this" is far
 > more often a field nobody has read than a real limit.
 > `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift`
@@ -64,6 +64,7 @@ The rest, by the problem they solve — go to the source for the exact semantics
 | WAF needs a Referer, or rejects the default UA | `requestHeaders` |
 | Endpoint sometimes returns a "nothing new" / closed-track body | `transientBodyPattern`, `trackClosedPattern` |
 | The body also states the version the caller already has | `installedVersionPattern` |
+| Versions are commit hashes (no order of their own); the vendor publishes its release history | `buildLineage` — see `BuildLineage` |
 
 - **`.redirectFilename`** — `url` is a stable link that 302s to the real package;
   HEAD it, follow redirects, parse the version out of the final filename. Preferred

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.90
 
+**super.engineering is now supported: update checks, release notes and one-click install.** A new nightly shows up in the list with what changed in it, and Update installs it for you.
+
 **Rockxy's release notes now go back through its recent releases.** The feed Rockxy publishes is rewritten in place and only ever holds the newest one, so the window had a single entry to show no matter how many builds you had skipped.
 
 ## 0.3.89

--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -120,6 +120,16 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
 - 同 bundle id 还有一份 **MAS 副本（adamId 1500855883，版本 19.2.0）**，版本方案完全不同；
   两边不串全靠 `_MASReceipt`（`VendorProbeSource` 拒 MAS、`MacAppStoreSource` 拒非 MAS）。
 
+### Pattern B/C 续 — super.engineering（2026-09-11 接，nightly 是唯一轨）
+
+- **super.engineering** `com.zarifpour.superconductor` — 设置页 "Update channel" 选择器，选择写在
+  `~/.superconductor/settings.json` 顶层 `update_channel`（实测 `"nightly"`）。厂商 2026-04-05 关了
+  stable（它 changelog 里的 #711），现在只有 nightly。`SuperconductorChannel`：`nightly` / 无记录 →
+  `.nightly`，其他值 → 无配方的渠道（绝不推 nightly）。门控 = channel-gated VendorProbe（`latest.json`，
+  pattern 全部锚在 `"nightly"` 对象里），一键 dmg，`ChannelProofRegistry` 登记
+  `.artifact(/nightly/Superconductor-nightly-<sha8>-arm64.dmg)`。版本是 commit hash，排序靠
+  `BuildLineage`（`changelog.json`）。stable 重开时的待办见审计文档。
+
 ### 版本后缀分流 续 — Yaak（2026-09-06 接）
 
 共享 `app.yaak.desktop`，两轨都是 GitHub。beta 包的 `CFBundleShortVersionString` 原样

--- a/CLI/Sources/DuoKit/Baseline.swift
+++ b/CLI/Sources/DuoKit/Baseline.swift
@@ -271,7 +271,11 @@ public struct Baseline: Codable, Sendable {
         var complaints: [String] = []
 
         if let version = finding.version, finding.status != .infra {
+            // A recipe whose builds are hashes has no order a version string can
+            // show (see `BuildLineage`); asking `VersionComparator` here would
+            // report every other release as a regression.
             if let previous = entry.lastGoodVersion, previous != version,
+               !VendorProbeRegistry.ordersByLineage(recipeID: finding.recipeID),
                VersionComparator.isNewer(previous, than: version) {
                 complaints.append("version went BACKWARDS since the last sweep "
                     + "(\(previous) → \(version)) — the pattern may have started "

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -849,7 +849,8 @@ public enum Verify {
             if let version, recipe.covers(appVersion: version),
                let complaint = changelogLagComplaint(
                    entry: top, detected: version,
-                   acknowledged: recipe.acknowledgedStaleEntry) {
+                   acknowledged: recipe.acknowledgedStaleEntry,
+                   ordersByLineage: VendorProbeRegistry.ordersByLineage(bundleID: recipe.bundleID)) {
                 warnings.append(complaint)
             }
             return Finding(
@@ -957,8 +958,15 @@ public enum Verify {
     /// major.minor — see the call site for why the full-string comparison had to
     /// go.
     static func changelogLagComplaint(
-        entry: String, detected: String, acknowledged: String? = nil
+        entry: String, detected: String, acknowledged: String? = nil,
+        ordersByLineage: Bool = false
     ) -> String? {
+        // Commit-hash versions have no order a string comparison can see (see
+        // `BuildLineage`): "trails" between two hashes is a coin flip, and a
+        // changelog whose newest release had no notes to show legitimately tops
+        // out one build behind the version. Same reasoning as `Baseline`'s
+        // "went BACKWARDS", which is scoped out for these recipes too.
+        if ordersByLineage { return nil }
         // The vendor is the stale one and somebody has already read the live page
         // and said so — see `ChangelogRecipe.acknowledgedStaleEntry` for why this
         // is a version rather than an off switch. Scoped to the exact entry the

--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -44,6 +44,39 @@ import DuoUpdaterCore
         #expect(!baseline.isReportable("vendor:com.example.app:stable"))
     }
 
+    /// A recipe whose builds are commit hashes has no order a version string can
+    /// show (`BuildLineage`), so "went BACKWARDS" must not fire for it — on hashes
+    /// it would fire for every other release. Pinned with a real FORWARD step from
+    /// super.engineering's history (2026-09-03 → 2026-09-07) that digit runs read
+    /// as a regression, and checked against an ordinary recipe too, so the check is
+    /// shown to be scoped rather than switched off.
+    @Test func aLineageOrderedRecipeIsNeverReportedAsGoingBackwards() {
+        let id = "vendor:com.zarifpour.superconductor:nightly"
+        #expect(VendorProbeRegistry.ordersByLineage(recipeID: id))
+        #expect(VersionComparator.isNewer("1f68f34a", than: "c437b979"))
+
+        var lineageOrdered = Baseline()
+        _ = lineageOrdered.reconcile(finding(id, status: .ok, version: "1f68f34a"))
+        #expect(!lineageOrdered.reconcile(finding(id, status: .ok, version: "c437b979"))
+            .contains { $0.contains("BACKWARDS") })
+
+        var ordinary = Baseline()
+        _ = ordinary.reconcile(finding(status: .ok, version: "1f68f34a"))
+        #expect(ordinary.reconcile(finding(status: .ok, version: "c437b979"))
+            .contains { $0.contains("BACKWARDS") })
+    }
+
+    /// The changelog cross-check has the same blind spot: between two hashes,
+    /// "the changelog trails the detected version" is a coin flip. A real pair from
+    /// super.engineering's history with the changelog one build AHEAD of the probe
+    /// — which digit runs read as a whole release behind.
+    @Test func aLineageOrderedChangelogIsNotCrossCheckedByDigitRuns() {
+        #expect(VendorProbeRegistry.ordersByLineage(bundleID: "com.zarifpour.superconductor"))
+        #expect(Verify.changelogLagComplaint(entry: "1f68f34a", detected: "5b73c7f4") != nil)
+        #expect(Verify.changelogLagComplaint(
+            entry: "1f68f34a", detected: "5b73c7f4", ordersByLineage: true) == nil)
+    }
+
     /// Infrastructure trouble must be inert against the *actionable* streak in
     /// both directions: it can't push a recipe over the threshold, and it can't
     /// reset a real failure streak that is still running. Getting the second half

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift
@@ -133,12 +133,28 @@ public enum PreInstallGate {
     /// `nil` confirmed classifies as `.unreadable`; otherwise this delegates to
     /// `decision(for:offered:confirmed:)` with both sides' `versionSide`s (or an
     /// empty one when a result carries no remote), exactly as each host already
-    /// did at its own call site.
+    /// did at its own call site — except for a lineage-ordered remote, see below.
     public static func decision(
         offered: UpdateResult,
         confirmed: UpdateResult?
     ) -> PreInstallDecision {
         guard let confirmed else { return .unreadable }
+        // Hash-shaped builds (see `BuildLineage`): whether the re-check walked
+        // BACKWARDS is a question only the lineage can answer. Asked of
+        // `VersionComparator`, a copy that updated itself PAST the offer between
+        // the click and the re-check — the vendor's own updater runs hourly — reads
+        // as the source contradicting itself on half of all pairs. Only the
+        // `.upToDate` arm asks, exactly as in `decision(for:offered:confirmed:)`;
+        // the re-check's lineage is the fresher one and decides. A pair it cannot
+        // place falls to "already current", which is what a lineage-ordered
+        // `.upToDate` has already established about the disk.
+        if case .upToDate = confirmed.status,
+           let lineage = confirmed.remote?.buildLineage ?? offered.remote?.buildLineage,
+           let offeredBuild = offered.remote?.version ?? offered.remote?.shortVersion,
+           let confirmedBuild = confirmed.remote?.version ?? confirmed.remote?.shortVersion {
+            return lineage.isNewer(offeredBuild, than: confirmedBuild) == true
+                ? .answerRegressed : .alreadyCurrent
+        }
         return decision(
             for: confirmed.status,
             offered: offered.remote?.versionSide ?? VersionSide(),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -470,6 +470,33 @@ public struct UpdateChecker: Sendable {
     /// against an already-fetched remote (no network) — e.g. to notice an app
     /// updated itself in the background.
     public static func evaluate(installed: InstalledApp, remote: RemoteVersion) -> UpdateStatus {
+        // Build ids with no order of their own (commit hashes) are ordered by the
+        // vendor's published lineage and by nothing else: every branch below ends
+        // in `VersionComparator`, which on two hashes is a coin flip (see
+        // `BuildLineage`).
+        //
+        // A pair the lineage cannot place is a check that FAILED, not an app nothing
+        // covers: "up to date" would be a guess, "update available" would offer a
+        // build whose direction nobody knows, and `.unknown` renders as "no source
+        // covers this app" (`RowActionState`) — false for an app whose source just
+        // answered. The live cause is a copy that updated itself to a build newer
+        // than the lineage this remote carries; the next check reads a lineage that
+        // lists it, which is what the failed check's Retry is for.
+        if let lineage = remote.buildLineage {
+            guard let pair = remote.lineageComparands(
+                installedMarketing: installed.shortVersion,
+                installedBuild: installed.buildVersion(in: remote.buildNamespace))
+            else { return .unknown }
+            switch lineage.isNewer(pair.remote, than: pair.installed) {
+            case .some(true): return .updateAvailable(latest: remote.displayVersion ?? pair.remote)
+            case .some(false): return .upToDate
+            case .none:
+                return .error("The vendor's release history does not place \(pair.installed) "
+                    + "against \(pair.remote), so whether this copy is current cannot be told "
+                    + "— check again.")
+            }
+        }
+
         // A remote build stated in the VENDOR's namespace can only be compared
         // against the vendor's own value. Falling back to the marketing branch
         // here would be the failure this namespace exists to prevent: for a

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -445,6 +445,18 @@ public enum UpdatePolicy {
            installedBuild == remoteBuild {
             return nil
         }
+        // Hash-shaped builds are ordered by the vendor's lineage and by nothing
+        // else (see `BuildLineage`): "the installed copy is ahead" is claimed only
+        // where the lineage places it there. `VersionComparator` below would call
+        // the installed copy ahead on half of all pairs.
+        if let remote = result.remote, let lineage = remote.buildLineage {
+            guard let pair = remote.lineageComparands(
+                      installedMarketing: result.app.shortVersion,
+                      installedBuild: result.app.buildVersion(in: remote.buildNamespace)),
+                  lineage.isNewer(pair.installed, than: pair.remote) == true
+            else { return nil }
+            return remote.displayVersion ?? pair.remote
+        }
         guard let installed = result.app.shortVersion,
               let remoteShort = result.remote?.shortVersion,
               VersionComparator.isNewer(installed, than: remoteShort) else { return nil }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -289,6 +289,14 @@ public struct RemoteVersion: Sendable, Hashable {
     /// anyone can go and look.)
     public let deltas: [DeltaPatch]
 
+    /// The vendor's own order for builds whose ids carry none — set only by a
+    /// recipe that declares `VendorProbeRecipe.buildLineage`. When present it is
+    /// the whole answer to "is this newer": `UpdateChecker.evaluate` and the other
+    /// direction checks ask it instead of `VersionComparator`, and a pair it cannot
+    /// place is "cannot tell", never a coin flip. nil for every other source. See
+    /// `BuildLineage`.
+    public let buildLineage: BuildLineage?
+
     public init(
         shortVersion: String?,
         version: String?,
@@ -316,7 +324,8 @@ public struct RemoteVersion: Sendable, Hashable {
         vendorDay: Date? = nil,
         releaseHistory: [ReleaseHistoryEntry] = [],
         deltas: [DeltaPatch] = [],
-        releaseChannel: ReleaseChannel? = nil
+        releaseChannel: ReleaseChannel? = nil,
+        buildLineage: BuildLineage? = nil
     ) {
         self.shortVersion = shortVersion
         self.version = version
@@ -345,6 +354,7 @@ public struct RemoteVersion: Sendable, Hashable {
         self.releaseHistory = releaseHistory
         self.deltas = deltas
         self.releaseChannel = releaseChannel
+        self.buildLineage = buildLineage
     }
 
     /// Best version string to show the user.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -395,6 +395,15 @@ public struct ChangelogRecipe: Codable, Sendable {
         /// first fragment, so a quarter of the notes would be silently truncated
         /// mid-sentence ("When streaming " — the rest lives past a `codeVoice`).
         case appleDeveloperReleaseNotes
+        /// super.engineering's `releases.superconductor.so/changelog.json` — a
+        /// `releases[]` array, newest first, of `{version, date, groups[{title,
+        /// commits[{message, pr}]}]}`. `version` is a commit hash (40 hex digits
+        /// for most releases, 8 for the oldest ones); the decoder shortens it to
+        /// the eight the installed bundle reports, so an entry's heading is the
+        /// same string the row shows. Group titles ("Features", "Bug Fixes", …)
+        /// become lines of their own ahead of their commits, as
+        /// `alcoveChangelog`'s do.
+        case superconductorChangelog
     }
 
     /// Non-nil → this recipe is parsed by a structured decoder, not the regex
@@ -797,6 +806,18 @@ public enum ChangelogRecipeRegistry {
             mode: .json,
             maxEntries: 20,
             structuredFormat: .chatwiseReleases),
+
+        // super.engineering — the same `changelog.json` the app's own "What's New
+        // in Nightly" reads (that URL sits next to the string in the binary), and
+        // the same document the vendor probe reads its release ORDER from. Every
+        // release lists its commits under the vendor's section titles; see
+        // `StructuredFormat.superconductorChangelog`.
+        ChangelogRecipe(
+            bundleID: "com.zarifpour.superconductor",
+            source: URL(string: "https://releases.superconductor.so/changelog.json")!,
+            mode: .json,
+            maxEntries: 20,
+            structuredFormat: .superconductorChangelog),
 
         // VS Code — the official `/updates` page redirects to the latest stable
         // release page (e.g. /updates/v1_123). The top summary is:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -170,6 +170,12 @@ public enum ChannelProofRegistry {
         // own token rather than a filename convention we inferred.
         ChannelProofKey("com.lemon.lvoverseas", .beta): .artifact(#"_capcutpc_beta_"#),
 
+        // super.engineering: the dmg lives under `/nightly/` and is named
+        // `Superconductor-nightly-<sha8>-arm64.dmg` — the vendor's own track name,
+        // twice, in the URL `latest.json`'s `"nightly"` entry gives (2026-09-10).
+        ChannelProofKey("com.zarifpour.superconductor", .nightly):
+            .artifact(#"/nightly/Superconductor-nightly-[0-9a-f]{8}-arm64\.dmg$"#),
+
         // MARK: Chat / messaging
         ChannelProofKey("org.whispersystems.signal-desktop-beta", .beta): .artifact(#"signal-desktop-beta-mac-"#),
         ChannelProofKey("im.riot.nightly", .nightly): .artifact(#"/nightly/"#),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -168,6 +168,7 @@ public enum ChannelBinding {
         CapCutChannel.bundleID.lowercased(),
         CotEditorChannel.bundleID.lowercased(),
         WindscribeChannel.bundleID.lowercased(),
+        SuperconductorChannel.bundleID.lowercased(),
     ]
 
     /// The directories holding every preference a resolver above reads, for a
@@ -243,6 +244,14 @@ public enum ChannelBinding {
         // `~/Library/Preferences/com.windscribe.Windscribe2.plist`, already
         // inside the first root. Said out loud because the file name is NOT the
         // bundle id, which is the shape that makes a reader check.
+        //
+        // super.engineering deliberately adds nothing either, for the opposite
+        // reason: its choice IS outside every root above
+        // (`~/.superconductor/settings.json`), but that directory is also where the
+        // app writes its logs, and FSEvents streams are recursive — a root there
+        // would fire continuously while the app runs, for a picker that currently
+        // has one possible value. Its key is re-read on every scan and on the app's
+        // own launch and quit instead. See `SuperconductorChannel`.
         return roots
     }
 
@@ -367,6 +376,8 @@ public enum ChannelBinding {
         case CotEditorChannel.bundleID.lowercased(): return CotEditorChannel.resolveCurrent
         case WindscribeChannel.bundleID.lowercased():
             return WindscribeChannel.resolveCurrent
+        case SuperconductorChannel.bundleID.lowercased():
+            return SuperconductorChannel.resolveCurrent
         default:                       return nil
         }
     }
@@ -460,18 +471,18 @@ public enum ChannelBinding {
     // Its channel is `.stable` either way: the key selects an ENTITLEMENT, not a
     // train, so there is no other channel for it to cross into.
 
-    /// The four bindings `allResolutions` deliberately does NOT cover, lower-cased.
+    /// The bindings `allResolutions` deliberately does NOT cover, lower-cased.
     ///
-    /// OrbStack, Alfred, Tailscale and CapCut have bindings, but the binding only
-    /// picks which `VendorProbeRecipe` runs; the install comes from that recipe,
-    /// so their cross-channel question is already answered by
-    /// `ChannelProofRegistry.proofs` and enumerating them here would double-count
-    /// them into a second registry.
+    /// OrbStack, Alfred, Tailscale, CapCut, Windscribe and super.engineering have
+    /// bindings, but the binding only picks which `VendorProbeRecipe` runs; the
+    /// install comes from that recipe, so their cross-channel question is already
+    /// answered by `ChannelProofRegistry.proofs` and enumerating them here would
+    /// double-count them into a second registry.
     ///
     /// Used two ways, and honest about the weaker one: it is what
     /// `everyBindingIsEnumerated` subtracts to compute what SHOULD be enumerated,
     /// and it is a term in `channelBindingsNeedingProof`'s predicate where it is
-    /// currently INERT — none of these four appears in `allResolutions`, so the
+    /// currently INERT — none of them appears in `allResolutions`, so the
     /// term never excludes anything. `vendorProbeBackedBindingsAreNotEnumerated`
     /// measures that inertness rather than leaving it assumed, so the day one of
     /// them does get enumerated (a binding that both overrides the feed and
@@ -482,5 +493,6 @@ public enum ChannelBinding {
         TailscaleChannel.bundleID.lowercased(),
         CapCutChannel.bundleID.lowercased(),
         WindscribeChannel.bundleID.lowercased(),
+        SuperconductorChannel.bundleID.lowercased(),
     ]
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RecipeSanity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RecipeSanity.swift
@@ -23,7 +23,9 @@ public enum RecipeSanity {
     public static func complaints(version: String, recipe: VendorProbeRecipe) -> [String] {
         var complaints: [String] = []
 
-        if !version.contains(where: \.isNumber) {
+        // Except where the version is a commit hash (`buildLineage`): `deadbeef` is
+        // a perfectly good build id with no digit in it.
+        if recipe.buildLineage == nil, !version.contains(where: \.isNumber) {
             complaints.append("version contains no digits: '\(version)'")
         }
         if let first = version.first, !first.isLetter, !first.isNumber {
@@ -98,9 +100,14 @@ public enum RecipeSanity {
         } else {
             return nil
         }
-        guard remoteValue != installedValue,
-              VersionComparator.isNewer(installedValue, than: remoteValue)
-        else { return nil }
+        // Hash-shaped builds have no order but the vendor's lineage (see
+        // `BuildLineage`). Comparing them here would report a healthy recipe as
+        // BEHIND on half of all release pairs, so a lineage decides — and one that
+        // cannot place the pair raises nothing.
+        let installedIsAhead = remote.buildLineage.map {
+            $0.isNewer(installedValue, than: remoteValue) == true
+        } ?? VersionComparator.isNewer(installedValue, than: remoteValue)
+        guard remoteValue != installedValue, installedIsAhead else { return nil }
         return "remote is BEHIND the installed copy (\(remoteValue) < \(installedValue)) — "
             + "the recipe may be reading a different version scheme than the app reports"
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -61,6 +61,8 @@ public enum StructuredChangelogDecoder {
             return decodeNotionPageChunk(body, maxEntries: maxEntries)
         case .appleDeveloperReleaseNotes:
             return decodeAppleDeveloperReleaseNotes(body, maxEntries: maxEntries)
+        case .superconductorChangelog:
+            return decodeSuperconductor(body, maxEntries: maxEntries)
         }
     }
 
@@ -330,6 +332,62 @@ public enum StructuredChangelogDecoder {
                 version: version,
                 date: isoDay(release.date),
                 items: items))
+            if let cap = maxEntries, entries.count >= cap { break }
+        }
+        return entries.isEmpty ? nil : Changelog(entries: entries)
+    }
+
+    // MARK: - super.engineering (releases.superconductor.so/changelog.json)
+
+    private struct SuperconductorFeed: Decodable {
+        let releases: [SuperconductorRelease]?
+    }
+    private struct SuperconductorRelease: Decodable {
+        let version: String?
+        let date: String?
+        let groups: [SuperconductorGroup]?
+    }
+    private struct SuperconductorGroup: Decodable {
+        let title: String?
+        let commits: [SuperconductorCommit]?
+    }
+    /// `pr` is a number on most commits and `null` on some, and nothing here
+    /// shows it, so it is not decoded at all.
+    private struct SuperconductorCommit: Decodable {
+        let message: String?
+    }
+
+    /// Newest-first, kept in document order. Each entry's heading is the first
+    /// eight hex digits of its commit — what the installed bundle and the vendor
+    /// probe both report — and each group's title leads its own commits. A group
+    /// with no non-empty commit is dropped with its title (the vendor ships both: a
+    /// `Features` group with `commits: []`, and a commit whose message is `""`), and
+    /// a release left with nothing is skipped and does not count toward the cap.
+    static func decodeSuperconductor(_ body: String, maxEntries: Int?) -> Changelog? {
+        guard let data = body.data(using: .utf8),
+              let feed = try? JSONDecoder().decode(SuperconductorFeed.self, from: data)
+        else { return nil }
+
+        var entries: [Changelog.Entry] = []
+        for release in feed.releases ?? [] {
+            guard let commit = release.version?
+                    .trimmingCharacters(in: .whitespaces).lowercased(),
+                  commit.count >= 8
+            else { continue }
+            var items: [String] = []
+            for group in release.groups ?? [] {
+                let lines = (group.commits ?? [])
+                    .compactMap { $0.message?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                guard !lines.isEmpty else { continue }
+                if let title = group.title?.trimmingCharacters(in: .whitespaces), !title.isEmpty {
+                    items.append(title)
+                }
+                items.append(contentsOf: lines)
+            }
+            guard !items.isEmpty else { continue }
+            entries.append(.init(
+                version: String(commit.prefix(8)), date: isoDay(release.date), items: items))
             if let cap = maxEntries, entries.count >= cap { break }
         }
         return entries.isEmpty ? nil : Changelog(entries: entries)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SuperconductorChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SuperconductorChannel.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// super.engineering (`com.zarifpour.superconductor`) — one bundle id, and an
+/// "Update channel" picker in the app's own Settings.
+///
+/// Today the picker has one entry. The vendor retired its stable track (#711 in its
+/// own changelog, 2026-04-05, "Disable stable channel and enforce nightly-only
+/// updates") and the Settings row says "Nightly is currently the only release track
+/// available". The picker survived, though, and so did the setting behind it: a
+/// top-level `update_channel` in `~/.superconductor/settings.json`, read as
+/// `"nightly"` off a real install on 2026-09-11.
+///
+/// That key is the only on-disk channel signal there is. The bundle carries none —
+/// its version is a bare commit hash, its name and bundle id are the same for every
+/// build — so `ReleaseChannel.detect()` reads every copy as `.stable`, and without
+/// this resolver the `.nightly` recipe would never apply to anything. `ChannelBinding`
+/// is authoritative, so what this answers replaces `detect()` outright.
+///
+/// Safety, in the one direction that matters: a copy whose recorded choice is
+/// anything but nightly resolves to a channel with no recipe, and is not offered the
+/// nightly build. A recognised channel word maps to that channel; anything else maps
+/// to `.stable`, the conservative end, which has no recipe either. No record at all
+/// — file, key, or a readable value missing — resolves to `.nightly`: that is the
+/// app's own default, and the only track the vendor publishes, not an escalation.
+/// The file serialises the whole settings struct, defaults included (4 `null`s and
+/// 15 `false`s among its 92 top-level keys on that install), so a copy that has run
+/// once almost certainly carries the key; that it always does is inferred, not
+/// measured.
+///
+/// Not watched for changes (`ChannelBinding.preferenceWatchCandidates`): FSEvents
+/// streams are recursive and the app writes its logs inside `~/.superconductor`, so
+/// a watch root there would fire continuously while it runs, for a choice that
+/// currently has one possible value. The key is re-read on every scan, and on the
+/// app's own launch and quit.
+enum SuperconductorChannel {
+    static let bundleID = "com.zarifpour.superconductor"
+
+    /// The value the app writes for its nightly track, and the only one it offers.
+    static let nightlyValue = "nightly"
+
+    /// Map the recorded `update_channel` to a resolution. Pure and tested.
+    ///
+    /// nil — and an empty value — mean "no recorded choice", which is the app's own
+    /// default. No feed override and no Sparkle channel tag: the app has no appcast,
+    /// and the channel here only selects which `VendorProbeRecipe` answers.
+    static func resolve(updateChannel: String?) -> ResolvedChannel {
+        let value = updateChannel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let value, !value.isEmpty, value != nightlyValue else {
+            return ResolvedChannel(channel: .nightly)
+        }
+        return ResolvedChannel(channel: ReleaseChannel(rawValue: value) ?? .stable)
+    }
+
+    static func resolveCurrent() -> ResolvedChannel {
+        resolve(updateChannel: readUpdateChannel())
+    }
+
+    /// The file the app keeps its settings in.
+    static var settingsFileURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".superconductor/settings.json", isDirectory: false)
+    }
+
+    /// `update_channel` from the settings file, or nil when the file, the key, or a
+    /// non-null value is missing. The file is ~9 KB; the cap keeps a path that turns
+    /// out to be something else from being read into memory wholesale.
+    static func readUpdateChannel() -> String? {
+        guard let data = try? Data(contentsOf: settingsFileURL), data.count <= 1024 * 1024
+        else { return nil }
+        return updateChannel(inSettings: data)
+    }
+
+    /// The parsing half, split out so it is testable without a file on disk.
+    ///
+    /// Top level only: a nested object that happens to carry a key of the same name
+    /// is some other setting. A present value that is not a string is still a
+    /// choice, and it is reported as its text rather than dropped — dropping it
+    /// would read as "no record", which resolves to nightly.
+    static func updateChannel(inSettings data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let value = object["update_channel"], !(value is NSNull)
+        else { return nil }
+        return (value as? String) ?? String(describing: value)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -74,6 +74,28 @@ public enum ProbeFailure: Error, Sendable, Equatable {
     /// always — see the note at the throw site in `VendorProbeSource`.
     case vendorErrorEnvelope(sampleBytes: Int)
 
+    /// The recipe's `buildLineage` document answered, but its entry pattern found
+    /// no build in it — the vendor changed that document's shape. A recipe problem,
+    /// like `versionPatternNoMatch`.
+    case buildLineagePatternNoMatch(sampleBytes: Int)
+
+    /// The lineage parsed but does not list the build the version endpoint just
+    /// named. They are two documents published separately — Superconductor's
+    /// `latest.json` and `changelog.json` carried Last-Modified stamps three
+    /// seconds apart on 2026-09-10 — so a check landing between the two sees this.
+    /// The window is the vendor's publish gap, not an edge cache's lifetime: both
+    /// documents were served uncached that day (`CF-Cache-Status: DYNAMIC`).
+    /// Infra, so `duo verify` reports it only once it persists. The probe fails
+    /// rather than answering: without the build's place in the lineage there is
+    /// nothing to compare it by.
+    case buildLineageMissesVersion(String)
+
+    /// The recipe's `buildLineage` document could not be fetched at all. Wraps what
+    /// went wrong so a report names WHICH of the recipe's two documents failed — a
+    /// bare `httpStatus(404)` reads as the version endpoint's. Classified exactly
+    /// as the wrapped failure is.
+    indirect case buildLineageUnavailable(ProbeFailure)
+
     /// What a sweep should *do* about this failure.
     public enum Classification: String, Sendable {
         /// A human needs to look at the recipe.
@@ -88,7 +110,9 @@ public enum ProbeFailure: Error, Sendable, Equatable {
         switch self {
         case .notApplicable:
             return .notApplicable
-        case .transport, .nonHTTPResponse, .vendorErrorEnvelope:
+        case .buildLineageUnavailable(let inner):
+            return inner.classification
+        case .transport, .nonHTTPResponse, .vendorErrorEnvelope, .buildLineageMissesVersion:
             return .infra
         case .httpStatus(let code):
             // 5xx and 429 are the vendor having a bad day; 4xx means the URL we
@@ -96,7 +120,7 @@ public enum ProbeFailure: Error, Sendable, Equatable {
             return (code >= 500 || code == 429) ? .infra : .recipe
         case .redirectMissingLocation, .malformedResolvedURL,
              .archiveExtractionFailed, .plistKeyMissing, .versionPatternNoMatch,
-             .versionSegmentCountChanged, .channelDiscoveryBroken:
+             .versionSegmentCountChanged, .channelDiscoveryBroken, .buildLineagePatternNoMatch:
             return .recipe
         }
     }
@@ -115,6 +139,9 @@ public enum ProbeFailure: Error, Sendable, Equatable {
         case .versionPatternNoMatch: return "versionPatternNoMatch"
         case .versionSegmentCountChanged: return "versionSegmentCountChanged"
         case .vendorErrorEnvelope: return "vendorErrorEnvelope"
+        case .buildLineagePatternNoMatch: return "buildLineagePatternNoMatch"
+        case .buildLineageMissesVersion: return "buildLineageMissesVersion"
+        case .buildLineageUnavailable(let inner): return "buildLineageUnavailable.\(inner.kind)"
         case .channelDiscoveryBroken: return "channelDiscoveryBroken"
         }
     }
@@ -135,6 +162,14 @@ public enum ProbeFailure: Error, Sendable, Equatable {
             return "no match in \(bytes)-byte body, but the same pattern with a "
                 + "variable segment count matches \(would) — the vendor changed "
                 + "how many numbers are in the version"
+        case .buildLineagePatternNoMatch(let bytes):
+            return "the release-order document answered (\(bytes) bytes) but its entry "
+                + "pattern matched no build — the vendor changed that document's shape"
+        case .buildLineageUnavailable(let inner):
+            return "the release-order document could not be read: \(inner.detail)"
+        case .buildLineageMissesVersion(let version):
+            return "the release-order document does not list \(version) yet — the vendor "
+                + "publishes it separately from the version manifest"
         case .vendorErrorEnvelope(let bytes):
             // Says whose fault it is, because this text is what the user reads in
             // the failed-check banner and what `duo verify` puts in a report.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -272,6 +272,33 @@ public struct VendorProbeRecipe: Sendable {
     /// it — see `matchesInstalled(version:)`.
     public let installedVersionPattern: String?
 
+    /// Where to read the vendor's release ORDER, for a vendor whose build ids have
+    /// none of their own — commit hashes. nil (every recipe but one) changes
+    /// nothing. See `BuildLineage` for why `VersionComparator` cannot stand in.
+    ///
+    /// When set, the probe fetches the lineage after reading the version, and the
+    /// remote it produces always carries it — the engine then asks the lineage
+    /// instead of `VersionComparator` wherever it decides "is this newer". A
+    /// lineage that cannot be fetched, matches nothing, or does not list the
+    /// version just read FAILS the probe: a remote without one would silently fall
+    /// back to the coin flip this field exists to replace.
+    public let buildLineage: BuildLineageSpec?
+
+    /// A document listing every release newest first, and how to read one
+    /// release's build id out of it.
+    public struct BuildLineageSpec: Sendable {
+        public let url: URL
+        /// Capture group 1 is one release's build id, written to yield EXACTLY the
+        /// form the installed bundle reports: the lineage is compared by equality,
+        /// never by prefix.
+        public let entryPattern: String
+
+        public init(url: URL, entryPattern: String) {
+            self.url = url
+            self.entryPattern = entryPattern
+        }
+    }
+
     /// The endpoint to probe (a stable "latest" redirect, or a version API).
     ///
     /// When `identity` is set this carries its placeholder token and is NOT a
@@ -701,7 +728,8 @@ public struct VendorProbeRecipe: Sendable {
         track: RolloutTrack? = nil,
         variant: String? = nil,
         hostRequirement: VendorHostRequirement? = nil,
-        installedVersionPattern: String? = nil
+        installedVersionPattern: String? = nil,
+        buildLineage: BuildLineageSpec? = nil
     ) {
         self.bundleID = bundleID
         self.channel = channel
@@ -711,6 +739,7 @@ public struct VendorProbeRecipe: Sendable {
         self.variant = variant
         self.hostRequirement = hostRequirement
         self.installedVersionPattern = installedVersionPattern
+        self.buildLineage = buildLineage
         self.mode = mode
         self.versionPattern = versionPattern
         self.transientBodyPattern = transientBodyPattern
@@ -1066,6 +1095,20 @@ public enum VendorProbeRegistry {
     static let cometStableGateway = URL(
         string: "https://www.perplexity.ai/rest/browser/download"
             + "?channel=stable&platform=mac_arm64")!
+
+    /// Whether the recipe with this id orders its builds by a `BuildLineage` — the
+    /// one fact `duo verify` needs about a finding's version before comparing it
+    /// with an earlier sweep's, since on such a recipe the version is a hash
+    /// `VersionComparator` cannot order.
+    public static func ordersByLineage(recipeID: String) -> Bool {
+        recipes.contains { $0.recipeID == recipeID && $0.buildLineage != nil }
+    }
+
+    /// The same question asked by app rather than by recipe — for a check keyed on
+    /// the bundle (the changelog sweep) that has no probe recipe id to hand.
+    public static func ordersByLineage(bundleID: String) -> Bool {
+        recipes.contains { $0.bundleID == bundleID && $0.buildLineage != nil }
+    }
 
     public static let recipes: [VendorProbeRecipe] = [
         // WhatsApp — the downloads page's link 302s to a versioned dmg on fbcdn:

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -2959,6 +2959,63 @@ public enum VendorProbeRegistry {
             hostRequirement: VendorHostRequirement(
                 minimumSystemVersion: "26.0", architectures: [.arm64])),
 
+        // super.engineering (Superconductor) — `latest.json` is the manifest the
+        // app's own updater reads (the URL, the `superconductor-updater` UA and
+        // "nightly entry missing valid sha" all sit in its binary). Shape,
+        // 2026-09-10:
+        //   {"nightly": {"sha": "<40 hex>", "url": "https://releases.superconductor.so/
+        //     nightly/Superconductor-nightly-<sha8>-arm64.dmg", "sha256": "<hex>",
+        //     "date": "2026-09-10"}}
+        //
+        // The version IS a commit hash. The bundle reports its first eight hex
+        // digits as both `CFBundleShortVersionString` and `CFBundleVersion`
+        // ("8545a7d8"), so the pattern captures exactly those eight: all forty would
+        // never equal the bundle's string and would read as newer forever. Hashes
+        // have no order, so `buildLineage` reads it from `changelog.json` — every
+        // published build, newest first, and the same document the release notes
+        // come from. See `BuildLineage` for what `VersionComparator` does instead.
+        //
+        // Channel: `.nightly`, the app's own name for it. The vendor retired its
+        // stable track (#711 in its own changelog, 2026-04-05) and the app's Settings
+        // say "Nightly is currently the only release track available" — but the
+        // picker is still there, and its choice is `update_channel` in
+        // `~/.superconductor/settings.json`. `SuperconductorChannel` reads it, so a
+        // copy set to anything but nightly resolves to a channel with no recipe and
+        // is never offered this build. Every pattern below is anchored inside the
+        // manifest's `"nightly"` object for the same reason: the updater looks its
+        // entry up by channel name ("nightly entry missing from release manifest"),
+        // so a second track would arrive as a sibling key, and first-match would
+        // take whichever the vendor happened to list first.
+        //
+        // One-click: the dmg `url` names, Developer ID Team MR38E36N26, notarized
+        // (the 2026-09-10 build, mounted and checked). `sha256` is a hex SHA-256,
+        // which `checksumPattern` (base64 SHA-512) cannot consume, so the Team gate
+        // stands in. arm64-only (the filename says so and `lipo` agrees);
+        // `LSMinimumSystemVersion` 14.0.
+        //
+        // Reads the newest build on the only track — the dmg the site's own
+        // Download button (`super.engineering/api/download`, a 302 to the same URL
+        // on 2026-09-10) and the app's updater hand every user.
+        VendorProbeRecipe(
+            bundleID: "com.zarifpour.superconductor",
+            url: URL(string: "https://releases.superconductor.so/latest.json")!,
+            mode: .responseBody,
+            versionPattern:
+                #""nightly"\s*:\s*\{[^{}]*?"sha"\s*:\s*"([0-9a-f]{8})[0-9a-f]{32}""#,
+            downloadURL: URL(string: "https://super.engineering/"),
+            publishedAtPattern:
+                #""nightly"\s*:\s*\{[^{}]*?"date"\s*:\s*"([0-9]{4}-[0-9]{2}-[0-9]{2})""#,
+            install: VendorInstallSpec(
+                urlSource: .bodyPattern(
+                    #""nightly"\s*:\s*\{[^{}]*?"url"\s*:\s*"(https://releases\.superconductor\.so/[^"]+-arm64\.dmg)""#),
+                kind: .dmg),
+            channel: .nightly,
+            hostRequirement: VendorHostRequirement(
+                minimumSystemVersion: "14.0", architectures: [.arm64]),
+            buildLineage: .init(
+                url: URL(string: "https://releases.superconductor.so/changelog.json")!,
+                entryPattern: #""version"\s*:\s*"([0-9a-f]{8})[0-9a-f]*""#)),
+
         // Docker Desktop — Sparkle appcast. Titles read "<ver> (<build>)" (and
         // "Version <ver> (<build>)"); take the highest since the feed isn't
         // strictly ordered. The channel title "Docker for Mac" carries no

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -675,6 +675,49 @@ public struct VendorProbeSource: UpdateSource {
                   publishedFields.publishedAt == nil, publishedFields.vendorDay == nil {
             warnings.append(.publishedAtUnreadable(publishedAtValue))
         }
+        // A recipe whose build ids carry no order of their own reads that order
+        // from a second document. Fetched only after the version read succeeded, so
+        // a dead version endpoint still reports as itself. Failing here fails the
+        // probe: a remote without its lineage would be compared by
+        // `VersionComparator`, which on hashes is a coin flip — no answer is better
+        // than that one. See `BuildLineage`.
+        //
+        // A lineage failure carries the LINEAGE document as its sample, not the
+        // version body: that is the text a human (or `duo triage`) needs to see.
+        var lineage: BuildLineage?
+        if let spec = recipe.buildLineage {
+            let text: String
+            switch await fetchLineage(spec, recipe: recipe) {
+            case .failure(let failure):
+                Log.source.notice(
+                    "vendor probe \(recipe.bundleID, privacy: .public): release-order document failed: \(failure.detail, privacy: .public)")
+                if case .buildLineageUnavailable(.httpStatus(let code)) = failure {
+                    return fail(failure, status: code)
+                }
+                return fail(failure)
+            case .success(let fetched):
+                text = fetched
+            }
+            // Sampled on the failure paths only: the document is a whole release
+            // history, and condensing it on every successful check would be work
+            // nobody reads.
+            guard let fetched = BuildLineage.extract(from: text, pattern: spec.entryPattern) else {
+                Log.source.error(
+                    "vendor probe \(recipe.bundleID, privacy: .public): \(text.utf8.count) bytes of release order, none matched /\(spec.entryPattern, privacy: .public)/")
+                return fail(
+                    .buildLineagePatternNoMatch(sampleBytes: text.utf8.count),
+                    sample: ProbeOutcome.sample(text))
+            }
+            guard fetched.position(of: version) != nil else {
+                Log.source.notice(
+                    "vendor probe \(recipe.bundleID, privacy: .public): release order does not list \(version, privacy: .public) yet")
+                return fail(
+                    .buildLineageMissesVersion(version), status: body.status,
+                    sample: ProbeOutcome.sample(text))
+            }
+            lineage = fetched
+        }
+
         var remote: RemoteVersion
 
         // If this recipe knows how to install in place, resolve the installer URL
@@ -714,7 +757,8 @@ public struct VendorProbeSource: UpdateSource {
                     // (measured 2026-08-30) — but it holds for the reason stated
                     // above, not because nothing here could parse.
                     deltas: VendorAppcastDeltas.patches(
-                        inBody: body.text, forVersion: version, feedURL: recipe.url))
+                        inBody: body.text, forVersion: version, feedURL: recipe.url),
+                    lineage: lineage)
                 // A recipe that names a checksum pattern but no longer matches one
                 // still installs — unverified. Silent today; flag it.
                 if spec.checksumPattern != nil, plan.checksum == nil {
@@ -755,13 +799,15 @@ public struct VendorProbeSource: UpdateSource {
                 remote = Self.makeRemoteVersion(
                     recipe: recipe, version: version, install: nil, plan: nil,
                     resolvedDownload: body.resolvedDownload, display: display,
-                    publishedAt: publishedFields.publishedAt, vendorDay: publishedFields.vendorDay)
+                    publishedAt: publishedFields.publishedAt, vendorDay: publishedFields.vendorDay,
+                    lineage: lineage)
             }
         } else {
             remote = Self.makeRemoteVersion(
                 recipe: recipe, version: version, install: nil, plan: nil,
                 resolvedDownload: body.resolvedDownload, display: display,
-                publishedAt: publishedFields.publishedAt, vendorDay: publishedFields.vendorDay)
+                publishedAt: publishedFields.publishedAt, vendorDay: publishedFields.vendorDay,
+                lineage: lineage)
         }
 
         return ProbeOutcome(
@@ -1115,7 +1161,8 @@ public struct VendorProbeSource: UpdateSource {
         display: String? = nil,
         publishedAt: Date? = nil,
         vendorDay: Date? = nil,
-        deltas: [DeltaPatch] = []
+        deltas: [DeltaPatch] = [],
+        lineage: BuildLineage? = nil
     ) -> RemoteVersion {
         // A build-number recipe routes the value into `version` (compared against
         // the installed `CFBundleVersion`); `shortVersion` stays nil so a build
@@ -1158,7 +1205,10 @@ public struct VendorProbeSource: UpdateSource {
                 // Only on the installable branch: a patch is an alternative route
                 // to an artifact we are going to fetch, so it is meaningless on a
                 // detection-only result that has no artifact to begin with.
-                deltas: deltas
+                deltas: deltas,
+                // On BOTH branches: a lineage recipe's remote without its lineage
+                // would be ordered by `VersionComparator` — see `BuildLineage`.
+                buildLineage: lineage
             )
         }
 
@@ -1176,8 +1226,42 @@ public struct VendorProbeSource: UpdateSource {
             requiresManualInstaller: true,
             changelogURL: recipe.changelogURL,
             publishedAt: publishedAt,
-            vendorDay: vendorDay
+            vendorDay: vendorDay,
+            buildLineage: lineage
         )
+    }
+
+    /// Fetch a recipe's `buildLineage` document. Same request shape as a
+    /// `.responseBody` probe — the recipe's headers, the version-feed cache
+    /// policy, the one gateway retry — so the lineage is asked exactly the way the
+    /// version was. The cache policy matters more here than anywhere: the lineage
+    /// is a whole release history (Superconductor's is ~850 KB), and the vendor
+    /// answers a revalidation with 304 (measured 2026-09-10), so a copy still in
+    /// the memory cache costs a few hundred bytes. Whether it is still there at the
+    /// next check was not measured.
+    ///
+    /// Every failure is wrapped in `.buildLineageUnavailable`, so nothing
+    /// downstream can mistake it for the version endpoint's.
+    private func fetchLineage(
+        _ spec: VendorProbeRecipe.BuildLineageSpec, recipe: VendorProbeRecipe
+    ) async -> Result<String, ProbeFailure> {
+        var request = URLRequest(url: spec.url)
+        request.timeoutInterval = 15
+        request.cachePolicy = URLRequest.versionFeedCachePolicy
+        request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+        Self.apply(recipe.requestHeaders, to: &request)
+        let data: Data
+        let response: URLResponse
+        do { (data, response) = try await session.versionFeedData(
+            for: request, label: "VendorProbe lineage \(recipe.bundleID)") }
+        catch { return .failure(.buildLineageUnavailable(Self.transportFailure(error))) }
+        guard let http = response as? HTTPURLResponse else {
+            return .failure(.buildLineageUnavailable(.nonHTTPResponse))
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            return .failure(.buildLineageUnavailable(.httpStatus(http.statusCode)))
+        }
+        return .success(String(decoding: data, as: UTF8.self))
     }
 
     /// Resolve an install spec into a concrete (url, checksum) pair. The body is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/BuildLineage.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Version/BuildLineage.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// The order of a vendor's builds, for a vendor whose build ids have none of their
+/// own.
+///
+/// **Why this exists.** Some apps version by commit hash. super.engineering
+/// (`com.zarifpour.superconductor`) reports the first eight hex digits of its
+/// commit as both `CFBundleShortVersionString` and `CFBundleVersion` ("8545a7d8"),
+/// and its update manifest names the same commit. `VersionComparator` has no way to
+/// order two such strings — it splits them into digit and letter runs and compares
+/// whichever leading run it finds, so "8545a7d8" outranks "19d32d9a" because 8545 >
+/// 19. Replayed over every consecutive pair in the vendor's own release history
+/// (626 pairs, `changelog.json` fetched 2026-09-10), it called the newer build newer
+/// 313 times and older 313 times. That is a coin flip on every "is this newer?"
+/// the engine asks: half of all updates never offered, and some older builds
+/// offered as updates.
+///
+/// The vendor does publish an order — its release history, newest first — so a
+/// recipe that declares `VendorProbeRecipe.buildLineage` reads it, and the
+/// resulting `RemoteVersion.buildLineage` becomes the whole answer to "is this
+/// newer" wherever the engine asks it. Anything the lineage cannot place (a build
+/// it does not list) is "cannot tell", never a guess in either direction.
+///
+/// Compared by exact equality, never by prefix: the recipe's entry pattern is
+/// written to yield exactly the form the installed bundle reports, the same way
+/// its `versionPattern` is.
+public struct BuildLineage: Sendable, Hashable {
+
+    /// Build ids, newest first. Empty ids and repeats are dropped (first
+    /// occurrence kept), so a position is unambiguous.
+    public let newestFirst: [String]
+
+    public init(newestFirst builds: [String]) {
+        var seen = Set<String>()
+        newestFirst = builds.filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    /// Where `build` sits — 0 is the newest — or nil when the lineage does not
+    /// list it.
+    public func position(of build: String) -> Int? {
+        newestFirst.firstIndex(of: build)
+    }
+
+    /// Whether `candidate` is a newer build than `current`: true or false when the
+    /// lineage places both, nil when it cannot place one of them. The same build is
+    /// never newer than itself, whether or not the lineage lists it.
+    public func isNewer(_ candidate: String, than current: String) -> Bool? {
+        if candidate == current { return false }
+        guard let c = position(of: candidate), let i = position(of: current) else {
+            return nil
+        }
+        return c < i
+    }
+
+    /// Every capture-group-1 match of `pattern` in `body`, in document order (the
+    /// whole match when the pattern has no group). Nil when the pattern is invalid
+    /// or matches nothing — a lineage with no builds in it can place nothing, and
+    /// the caller has to be able to tell that from one that simply lacks a build.
+    public static func extract(from body: String, pattern: String) -> BuildLineage? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let ns = body as NSString
+        let builds = regex.matches(in: body, range: NSRange(location: 0, length: ns.length))
+            .compactMap { match -> String? in
+                let range = match.numberOfRanges > 1 ? match.range(at: 1) : match.range
+                guard range.location != NSNotFound else { return nil }
+                return ns.substring(with: range)
+            }
+        let lineage = BuildLineage(newestFirst: builds)
+        return lineage.newestFirst.isEmpty ? nil : lineage
+    }
+}
+
+extension RemoteVersion {
+    /// The two strings `buildLineage` compares for this remote against an installed
+    /// copy: the builds when both sides carry one (`installedBuild` already read in
+    /// this remote's `buildNamespace`), otherwise the marketing versions — the same
+    /// choice `UpdateChecker.evaluate` makes. Nil when neither pair is complete.
+    func lineageComparands(
+        installedMarketing: String?, installedBuild: String?
+    ) -> (remote: String, installed: String)? {
+        if let rv = version, let iv = installedBuild { return (rv, iv) }
+        if let rs = shortVersion, let isv = installedMarketing { return (rs, isv) }
+        return nil
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RaycastReleasesTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RaycastReleasesTests.swift
@@ -145,6 +145,13 @@ private let raycastChangelogFixture = #"""
             "vendor:com.bombich.ccc:beta",
             "vendor:com.bombich.ccc:stable:ccc6",
             "vendor:com.bombich.ccc:stable:ccc5",
+            // super.engineering: `latest.json` names exactly one dmg and it is
+            // arm64-only (the filename says so and `lipo -archs` on the 2026-09-10
+            // build agrees), with `LSMinimumSystemVersion` 14.0 in the bundle. The
+            // manifest carries no OS bounds of its own, and like CapCut there is no
+            // other train to land an Intel or pre-Sonoma Mac on — so those read
+            // "unknown" rather than being offered a build that cannot run.
+            "vendor:com.zarifpour.superconductor:nightly",
         ])
         let unrestricted = VendorProbeRegistry.recipes.filter { $0.hostRequirement == nil }
         #expect(unrestricted.count == VendorProbeRegistry.recipes.count - restricted.count)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SuperconductorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SuperconductorProbeTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The half of `BuildLineage` that `SuperconductorTests` cannot reach without the
+/// network: what the probe does when the second document is missing, stale, or
+/// unreadable. Every case but the first must FAIL the probe — a remote that
+/// arrives without its lineage would be ordered by `VersionComparator`, which on
+/// commit hashes is a coin flip.
+///
+/// Driven through the real `probeOutcome`, against a local stub, with the
+/// registry's own patterns. Each test serves its documents on its own host, so the
+/// tests can run in parallel without reading each other's bodies.
+struct SuperconductorProbeTests {
+
+    private final class DocumentServer: URLProtocol, @unchecked Sendable {
+        private static let lock = NSLock()
+        nonisolated(unsafe) private static var documents: [String: (status: Int, body: String)] = [:]
+
+        static func serve(_ url: URL, status: Int = 200, _ body: String) {
+            lock.lock(); defer { lock.unlock() }
+            documents[url.absoluteString] = (status, body)
+        }
+
+        private static func document(_ url: URL) -> (status: Int, body: String)? {
+            lock.lock(); defer { lock.unlock() }
+            return documents[url.absoluteString]
+        }
+
+        static func session() -> URLSession {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [DocumentServer.self]
+            return URLSession(configuration: configuration)
+        }
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            guard let url = request.url, let document = Self.document(url) else {
+                client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+                return
+            }
+            let response = HTTPURLResponse(
+                url: url, statusCode: document.status, httpVersion: "HTTP/1.1", headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(document.body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    /// The registered recipe's patterns and install spec, pointed at `host`.
+    private static func recipe(host: String) throws -> (VendorProbeRecipe, latest: URL, lineage: URL) {
+        let registered = try SuperconductorTests.recipe()
+        let spec = try #require(registered.buildLineage)
+        let latest = URL(string: "https://\(host)/latest.json")!
+        let lineage = URL(string: "https://\(host)/changelog.json")!
+        let recipe = VendorProbeRecipe(
+            bundleID: registered.bundleID, url: latest, mode: registered.mode,
+            versionPattern: registered.versionPattern,
+            publishedAtPattern: registered.publishedAtPattern,
+            install: registered.install,
+            buildLineage: .init(url: lineage, entryPattern: spec.entryPattern))
+        return (recipe, latest, lineage)
+    }
+
+    private static func probe(_ recipe: VendorProbeRecipe) async -> ProbeOutcome {
+        await VendorProbeSource(recipes: [], session: DocumentServer.session())
+            .probeOutcome(recipe)
+    }
+
+    @Test func whenBothDocumentsAgreeTheRemoteCarriesTheLineage() async throws {
+        let (recipe, latest, lineage) = try Self.recipe(host: "agree.example.invalid")
+        DocumentServer.serve(latest, SuperconductorTests.latestBody)
+        DocumentServer.serve(lineage, SuperconductorTests.changelogBody)
+
+        let outcome = await Self.probe(recipe)
+        #expect(outcome.failure == nil)
+        let remote = try #require(outcome.remote)
+        #expect(remote.displayVersion == SuperconductorTests.installedBuild)
+        #expect(remote.buildLineage?.newestFirst == SuperconductorTests.historyHead)
+        #expect(remote.vendorInstallerKind == .dmg)
+    }
+
+    /// The two documents are published separately; a check between them must not
+    /// answer with a version it cannot place.
+    @Test func aLineageThatDoesNotListTheVersionFailsTheProbe() async throws {
+        let (recipe, latest, lineage) = try Self.recipe(host: "stale.example.invalid")
+        DocumentServer.serve(latest, SuperconductorTests.latestBody)
+        DocumentServer.serve(lineage, #"{"releases": [{"version": "19d32d9a7d16fc3ccaaa7cfe606b45b90a257b13"}]}"#)
+
+        let outcome = await Self.probe(recipe)
+        #expect(outcome.remote == nil)
+        #expect(outcome.failure == .buildLineageMissesVersion(SuperconductorTests.installedBuild))
+        #expect(outcome.failure?.classification == .infra)
+    }
+
+    @Test func aLineageWhosePatternMatchesNothingFailsTheProbe() async throws {
+        let (recipe, latest, lineage) = try Self.recipe(host: "reshaped.example.invalid")
+        DocumentServer.serve(latest, SuperconductorTests.latestBody)
+        DocumentServer.serve(lineage, #"{"builds": [{"id": "8545a7d8"}]}"#)
+
+        let outcome = await Self.probe(recipe)
+        #expect(outcome.remote == nil)
+        guard case .buildLineagePatternNoMatch? = outcome.failure else {
+            Issue.record("expected buildLineagePatternNoMatch, got \(String(describing: outcome.failure))")
+            return
+        }
+        #expect(outcome.failure?.classification == .recipe)
+        // The sample is the document that stopped matching, not the version body.
+        #expect(outcome.bodySample?.contains("builds") == true)
+    }
+
+    @Test func anUnreachableLineageFailsTheProbe() async throws {
+        let (recipe, latest, lineage) = try Self.recipe(host: "gone.example.invalid")
+        DocumentServer.serve(latest, SuperconductorTests.latestBody)
+        DocumentServer.serve(lineage, status: 404, "not found")
+
+        let outcome = await Self.probe(recipe)
+        #expect(outcome.remote == nil)
+        // Named as the release-order document's failure, not the version endpoint's.
+        #expect(outcome.failure == .buildLineageUnavailable(.httpStatus(404)))
+        #expect(outcome.failure?.classification == .recipe)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SuperconductorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SuperconductorTests.swift
@@ -1,0 +1,687 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// super.engineering (`com.zarifpour.superconductor`): versions that are commit
+/// hashes, ordered by the vendor's own release history (`BuildLineage`).
+///
+/// Both bodies are the vendor's, verbatim: `latest.json` whole, and the first six
+/// releases of `changelog.json` (which ran to 627), both fetched 2026-09-10. What
+/// the installed bundle reports was read off that day's real build, mounted from
+/// the dmg `latest.json` names: `CFBundleShortVersionString` and `CFBundleVersion`
+/// are both `8545a7d8`.
+///
+/// The pairs the evaluation tests use were picked because `VersionComparator` gets
+/// them WRONG — each test first asserts that, so it cannot pass against an engine
+/// that ignores the lineage. `c437b979` was `latest.json`'s build on 2026-09-07.
+struct SuperconductorTests {
+
+    static let bundleID = "com.zarifpour.superconductor"
+
+    static let latestBody = #"""
+        {
+          "nightly": {
+            "sha": "8545a7d83ced2ee07202688ebbb95bda8b3958a4",
+            "url": "https://releases.superconductor.so/nightly/Superconductor-nightly-8545a7d8-arm64.dmg",
+            "sha256": "8b8b408598e343e4e94da170d24ccd90fa45a7008485f114eee7c60cc1489ed7",
+            "date": "2026-09-10"
+          }
+        }
+        """#
+
+    static let changelogBody = #"""
+        {
+          "releases": [
+            {
+              "version": "8545a7d83ced2ee07202688ebbb95bda8b3958a4",
+              "date": "2026-09-10",
+              "groups": [
+                {
+                  "title": "Features",
+                  "commits": [
+                    {
+                      "message": "Allow Claude profiles to use settings API keys",
+                      "pr": 2214
+                    },
+                    {
+                      "message": "The app now supports a consistent interactive approval and question experience for more chat providers, including async prompt responses.",
+                      "pr": 2217
+                    },
+                    {
+                      "message": "Routing settings now let you choose providers, profiles, models, and thinking levels for session defaults and individual actions, with Global, Workspace, and Project overrides.",
+                      "pr": 2216
+                    }
+                  ]
+                },
+                {
+                  "title": "Bug Fixes",
+                  "commits": [
+                    {
+                      "message": "Sidebar sections now expand and collapse reliably when activity updates are pending and the pointer remains over the sidebar.",
+                      "pr": 2205
+                    },
+                    {
+                      "message": "Video files like MP4, MKV, and MOV now open in your system media player instead of taking over workspace preview tabs.",
+                      "pr": 2213
+                    },
+                    {
+                      "message": "You can open pull request review comments from previous diffs even when their file context is no longer in the current view.",
+                      "pr": 2215
+                    },
+                    {
+                      "message": "Structured tool questions now keep multi-select choices and custom text isolated at the provider boundary for more reliable responses.",
+                      "pr": 2217
+                    },
+                    {
+                      "message": "Opening Select models in Agents settings without changing a selection no longer marks the setting as modified.",
+                      "pr": 2216
+                    },
+                    {
+                      "message": "`sc chat list` now clearly marks parked chat sessions so you can distinguish them from other inactive rows.",
+                      "pr": 2219
+                    },
+                    {
+                      "message": "Settings search navigation now redraws the destination section at its scrolled position.",
+                      "pr": 2218
+                    }
+                  ]
+                },
+                {
+                  "title": "Performance",
+                  "commits": [
+                    {
+                      "message": "Settings pages avoid repeated layout work when scrolling long lists.",
+                      "pr": 2216
+                    },
+                    {
+                      "message": "Numeric inputs avoid unnecessary redraws when their values and configuration are unchanged.",
+                      "pr": 2218
+                    }
+                  ]
+                },
+                {
+                  "title": "Improvements",
+                  "commits": [
+                    {
+                      "message": "Interactive provider-specific question flows now use dedicated handling paths instead of generic chat-only fallback behavior.",
+                      "pr": 2217
+                    },
+                    {
+                      "message": "Routing settings offer searchable pickers, keyboard navigation, inheritance guidance, Undo, and compact click-behavior controls in a responsive layout.",
+                      "pr": 2216
+                    },
+                    {
+                      "message": "Agents settings focus on provider availability, model visibility, and advanced setup; branch naming rules now live in Prompts, and Profiles shows where each profile is used.",
+                      "pr": 2216
+                    },
+                    {
+                      "message": "You can now scope chat listings to a specific worktree with `sc chat list --worktree PATH` without triggering chat restoration.",
+                      "pr": 2219
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "version": "19d32d9a7d16fc3ccaaa7cfe606b45b90a257b13",
+              "date": "2026-09-09",
+              "groups": [
+                {
+                  "title": "Improvements",
+                  "commits": [
+                    {
+                      "message": "Sidebar projects now expand and collapse immediately when clicked during activity updates.",
+                      "pr": 2211
+                    },
+                    {
+                      "message": "Sidebar project expand/collapse animations transition smoothly and reverse smoothly when clicked again.",
+                      "pr": 2211
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "version": "fc41dde9c614f5b47b8309b8c900390f93f7c050",
+              "date": "2026-09-09",
+              "groups": [
+                {
+                  "title": "Features",
+                  "commits": [
+                    {
+                      "message": "You can now exclude paths from worktree indexing and raise the indexing limits with a worktree_scan block in the settings file (exclusions, max_files, max_directories).",
+                      "pr": 2182
+                    },
+                    {
+                      "message": "Keep parked chats addressable after parking",
+                      "pr": 2194
+                    }
+                  ]
+                },
+                {
+                  "title": "Bug Fixes",
+                  "commits": [
+                    {
+                      "message": "Markdown previews now update their text color when switching between dark and light mode.",
+                      "pr": 2195
+                    },
+                    {
+                      "message": "Scrolling up while a response streams no longer snaps the chat back to the bottom.",
+                      "pr": 2196
+                    },
+                    {
+                      "message": "Opening a workspace or chat rooted at a very large folder, such as your home directory, no longer causes memory to climb into the multi-gigabyte range or the app to become unresponsive.",
+                      "pr": 2182
+                    },
+                    {
+                      "message": "Command palette file search now finds files in projects whose stored path differs from the on-disk path in letter case or through a symlink, instead of reporting no matching files.",
+                      "pr": 2182
+                    },
+                    {
+                      "message": "Directories you expand in the Files tab stay expanded after the worktree rescans.",
+                      "pr": 2182
+                    },
+                    {
+                      "message": "The right panel rerun action now reruns the script shown in the active tab, including shared-group run tabs.",
+                      "pr": 2197
+                    },
+                    {
+                      "message": "Working spinners remain visible when switching back to a workspace, including repeated switches through other workspaces.",
+                      "pr": 2202
+                    },
+                    {
+                      "message": "Run-output previews no longer show main-pane content through them.",
+                      "pr": 2203
+                    }
+                  ]
+                },
+                {
+                  "title": "Performance",
+                  "commits": [
+                    {
+                      "message": "File-system activity inside ignored or unindexed folders, such as build output and caches, no longer triggers repeated full worktree rescans.",
+                      "pr": 2182
+                    },
+                    {
+                      "message": "Sending a chat message while at the bottom now scrolls the new message into view.",
+                      "pr": 2196
+                    },
+                    {
+                      "message": "The managed sc watch command respects Git ignore rules, reducing work from ignored dependency and build folders while preserving tracked-file updates. Worktrees with incomplete native coverage use periodic reconciliation.",
+                      "pr": 2198
+                    },
+                    {
+                      "message": "Long chat-history refreshes run more efficiently and skip unnecessary work during live turns, reducing pauses in terminal output and app interaction.",
+                      "pr": 2199
+                    },
+                    {
+                      "message": "Workspace swipes are smoother and use less CPU by reusing sidebar content and avoiding unnecessary repository refreshes when returning to a workspace.",
+                      "pr": 2141
+                    },
+                    {
+                      "message": "Reduced UI stalls during startup and auto-hiding sidebar collapse while Git repositories refresh in the background.",
+                      "pr": 2141
+                    },
+                    {
+                      "message": "Terminal chat repaints now adapt to each terminal's rendering cost, with a 16 ms minimum interval to reduce excessive redraws during streaming.",
+                      "pr": 2178
+                    },
+                    {
+                      "message": "Inactive workspaces release persisted terminal preview grids from memory after 15 minutes and reload them when reopened, while retaining workspace state and recent chat content.",
+                      "pr": 2178
+                    },
+                    {
+                      "message": "Completing or cancelling long chat turns now avoids reprocessing unchanged transcript rows, reducing terminal display synchronization latency.",
+                      "pr": 2159
+                    },
+                    {
+                      "message": "Completed terminal tabs now release unused scrollback storage while preserving their visible output and history.",
+                      "pr": 2206
+                    }
+                  ]
+                },
+                {
+                  "title": "Improvements",
+                  "commits": [
+                    {
+                      "message": "Commit titles in the change list now reveal the full message in a tooltip when hovered.",
+                      "pr": 2193
+                    },
+                    {
+                      "message": "Sidebar text and icons keep their proportions while resizing the window.",
+                      "pr": 2201
+                    },
+                    {
+                      "message": "Shared context previews preserve header height and consistent add-button spacing.",
+                      "pr": 2200
+                    },
+                    {
+                      "message": "Worktrees transition smoothly between sidebar sections when pinned, unpinned, or moved by run-state changes, including moves to and from collapsed project rows.",
+                      "pr": 2204
+                    },
+                    {
+                      "message": "Cost and usage counters continue their animations through rapid workspace switches, and animated diff counts preserve their current positions when values change mid-animation.",
+                      "pr": 2210
+                    },
+                    {
+                      "message": "Command palette file search now says the index is incomplete for folders that exceed the file scan limit, instead of reporting no matching files.",
+                      "pr": 2182
+                    },
+                    {
+                      "message": "Sidebar rows appear together at startup instead of animating into view one by one.",
+                      "pr": 2141
+                    },
+                    {
+                      "message": "The Run/Stop button animates smoothly between running and inactive states when switching workspaces.",
+                      "pr": 2141
+                    },
+                    {
+                      "message": "Enhance Prompt notifications identify completed or failed enhancements, with a compact queue label that preserves the chat title and worktree context.",
+                      "pr": 2208
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "version": "c437b97920667df95c1f1d4ba5775a8412d04824",
+              "date": "2026-09-07",
+              "groups": [
+                {
+                  "title": "Improvements",
+                  "commits": [
+                    {
+                      "message": "Add heartbeat timing context to hang diagnostics",
+                      "pr": 2192
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "version": "1f68f34a9fbcd4179b802d4cf23b63d45b7f1ca8",
+              "date": "2026-09-03",
+              "groups": [
+                {
+                  "title": "Bug Fixes",
+                  "commits": [
+                    {
+                      "message": "Oh My Pi models such as Claude Fable 5.1 now show their advertised reasoning-effort options across supported thinking modes.",
+                      "pr": 2190
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "version": "5b73c7f492d42b3e97e4f25c19686d545c037826",
+              "date": "2026-09-03",
+              "groups": [
+                {
+                  "title": "Features",
+                  "commits": [
+                    {
+                      "message": "GPT-6 Astra is now available in Codex model selection and AI routing, including Max reasoning and Fast mode support.",
+                      "pr": 2189
+                    }
+                  ]
+                },
+                {
+                  "title": "Improvements",
+                  "commits": [
+                    {
+                      "message": "Chat mid-turn steered messages can now be selected and copied, and their indicator remains readable on short message bubbles.",
+                      "pr": 2188
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """#
+
+    static let installedBuild = "8545a7d8"
+    static let historyHead = ["8545a7d8", "19d32d9a", "fc41dde9", "c437b979", "1f68f34a", "5b73c7f4"]
+
+    static func recipe() throws -> VendorProbeRecipe {
+        try #require(VendorProbeRegistry.recipes.first { $0.bundleID == bundleID })
+    }
+
+    static func lineage() throws -> BuildLineage {
+        let spec = try #require(try recipe().buildLineage)
+        return try #require(BuildLineage.extract(from: changelogBody, pattern: spec.entryPattern))
+    }
+
+    /// An installed copy on `build`, at a path that does not exist.
+    static func app(_ build: String) -> InstalledApp {
+        let path = "/Applications/ZZFixture-super.engineering.app"
+        #expect(!FileManager.default.fileExists(atPath: path))
+        return InstalledApp(
+            name: "super.engineering", bundleID: bundleID,
+            shortVersion: build, buildVersion: build,
+            path: URL(fileURLWithPath: path), isMASApp: false, sparkleFeedURL: nil)
+    }
+
+    /// Built the way the probe builds it, so a remote here carries exactly what a
+    /// production one would.
+    static func remote(_ build: String, lineage: BuildLineage?) throws -> RemoteVersion {
+        VendorProbeSource.makeRemoteVersion(
+            recipe: try recipe(), version: build, install: nil, plan: nil,
+            resolvedDownload: nil, lineage: lineage)
+    }
+
+    // MARK: - What the recipe reads
+
+    @Test func theVersionIsExactlyWhatTheBundleReports() throws {
+        // Eight digits, not forty: the full hash never equals the bundle's string
+        // and would read as an update forever.
+        #expect(VendorProbeRecipe.extractVersion(
+            from: Self.latestBody, pattern: try Self.recipe().versionPattern) == Self.installedBuild)
+    }
+
+    @Test func theInstallIsTheManifestsArm64DMG() throws {
+        let install = try #require(try Self.recipe().install)
+        guard case .bodyPattern(let pattern) = install.urlSource else {
+            Issue.record("expected a .bodyPattern install URL")
+            return
+        }
+        #expect(VendorProbeRecipe.extractVersion(from: Self.latestBody, pattern: pattern)
+            == "https://releases.superconductor.so/nightly/Superconductor-nightly-8545a7d8-arm64.dmg")
+        #expect(install.kind == .dmg)
+    }
+
+    @Test func thePublishDayIsTheManifestsDate() throws {
+        let pattern = try #require(try Self.recipe().publishedAtPattern)
+        #expect(VendorProbeRecipe.extractVersion(from: Self.latestBody, pattern: pattern) == "2026-09-10")
+    }
+
+    /// Every pattern reads inside the manifest's `"nightly"` object. The updater
+    /// looks its entry up by channel name, so a second track would arrive as a
+    /// sibling key — listed FIRST here, which is where first-match would take it.
+    /// The stable entry is invented (the manifest has carried only `nightly` since
+    /// the vendor retired stable); this pins the anchoring, not what a stable entry
+    /// would look like.
+    @Test func everyPatternReadsTheNightlyEntryOnly() throws {
+        let recipe = try Self.recipe()
+        let twoTracks = #"""
+            {
+              "stable": {
+                "sha": "0123456789abcdef0123456789abcdef01234567",
+                "url": "https://releases.superconductor.so/stable/Superconductor-stable-01234567-arm64.dmg",
+                "sha256": "00",
+                "date": "2026-01-01"
+              },
+              "nightly": {
+                "sha": "8545a7d83ced2ee07202688ebbb95bda8b3958a4",
+                "url": "https://releases.superconductor.so/nightly/Superconductor-nightly-8545a7d8-arm64.dmg",
+                "sha256": "8b8b408598e343e4e94da170d24ccd90fa45a7008485f114eee7c60cc1489ed7",
+                "date": "2026-09-10"
+              }
+            }
+            """#
+        #expect(VendorProbeRecipe.extractVersion(from: twoTracks, pattern: recipe.versionPattern)
+            == "8545a7d8")
+        #expect(VendorProbeRecipe.extractVersion(
+            from: twoTracks, pattern: try #require(recipe.publishedAtPattern)) == "2026-09-10")
+        guard case .bodyPattern(let pattern) = try #require(recipe.install).urlSource else {
+            Issue.record("expected a .bodyPattern install URL")
+            return
+        }
+        #expect(VendorProbeRecipe.extractVersion(from: twoTracks, pattern: pattern)
+            == "https://releases.superconductor.so/nightly/Superconductor-nightly-8545a7d8-arm64.dmg")
+    }
+
+    @Test func theLineageIsTheHistoryNewestFirstInTheBundlesForm() throws {
+        let lineage = try Self.lineage()
+        #expect(lineage.newestFirst == Self.historyHead)
+        // The manifest's build is the history's head — the probe refuses to answer
+        // otherwise (`buildLineageMissesVersion`).
+        #expect(lineage.position(of: Self.installedBuild) == 0)
+    }
+
+    /// The bundle itself carries no channel signal — `detect()` reads it as
+    /// `.stable` — so it is the Settings choice that has to land on the recipe's
+    /// channel, or the probe never applies at all. The binding is authoritative
+    /// (`AppScanner` replaces `detect()` with it), which is what makes that work.
+    @Test func theSettingsChoiceIsWhatSelectsTheRecipe() throws {
+        let detected = ReleaseChannel.detect(
+            name: "super.engineering", bundleID: Self.bundleID, keystoneChannel: nil,
+            version: Self.installedBuild, bundleFileName: "super.engineering.app")
+        #expect(detected == .stable)
+        let recipe = try Self.recipe()
+        #expect(recipe.channel == .nightly)
+        #expect(SuperconductorChannel.resolve(updateChannel: "nightly").channel == recipe.channel)
+        #expect(ChannelBinding.hasResolver(bundleID: Self.bundleID))
+        #expect(ChannelBinding.boundBundleIDs.contains(Self.bundleID))
+        #expect(ChannelBinding.vendorProbeBackedBindings.contains(Self.bundleID))
+    }
+
+    /// The one direction this must never get wrong: a copy set to anything but
+    /// nightly is not offered the nightly build — and nothing but nightly has a
+    /// recipe, so it is offered nothing.
+    @Test func aCopyOnAnyOtherTrackIsNeverOfferedNightly() throws {
+        let served = Set(VendorProbeRegistry.recipes
+            .filter { $0.bundleID == Self.bundleID }.map(\.channel))
+        #expect(served == [.nightly])
+        for value in ["stable", "Stable", "beta", "release", "preview"] {
+            let channel = SuperconductorChannel.resolve(updateChannel: value).channel
+            #expect(channel != .nightly, "\(value)")
+            #expect(!served.contains(channel), "\(value) would be served a recipe")
+        }
+        // No recorded choice is the app's own default — the only track there is.
+        for absent in [nil, "", "  "] as [String?] {
+            #expect(SuperconductorChannel.resolve(updateChannel: absent).channel == .nightly)
+        }
+        #expect(SuperconductorChannel.resolve(updateChannel: " Nightly ").channel == .nightly)
+    }
+
+    /// The file the app actually writes: a flat JSON object with the choice at the
+    /// top level, among ninety-odd other settings.
+    @Test func theResolverReadsTheSettingFromTheFileTheAppWrites() {
+        #expect(SuperconductorChannel.settingsFileURL.path
+            .hasSuffix("/.superconductor/settings.json"))
+        func read(_ json: String) -> String? {
+            SuperconductorChannel.updateChannel(inSettings: Data(json.utf8))
+        }
+        #expect(read(#"{"ai_routing": {"version": 2}, "update_channel": "nightly", "provider_update_checks": true}"#)
+            == "nightly")
+        #expect(read(#"{"provider_update_checks": true}"#) == nil)
+        #expect(read(#"{"update_channel": null}"#) == nil)
+        #expect(read("not json") == nil)
+        // A nested key of the same name is some other setting.
+        #expect(read(#"{"ai_routing": {"update_channel": "stable"}}"#) == nil)
+        // A present value we cannot read as a word is still a choice, and not nightly.
+        let odd = read(#"{"update_channel": 2}"#)
+        #expect(odd != nil)
+        #expect(SuperconductorChannel.resolve(updateChannel: odd).channel != .nightly)
+    }
+
+    // MARK: - Ordering
+
+    /// Pins the equality path, which the lineage branch and the comparator both
+    /// answer the same way — no lineage mutation turns this red, and none should.
+    @Test func theSameBuildIsUpToDate() throws {
+        let status = UpdateChecker.evaluate(
+            installed: Self.app("8545a7d8"),
+            remote: try Self.remote("8545a7d8", lineage: try Self.lineage()))
+        #expect(status == .upToDate)
+    }
+
+    @Test func anOlderCopyIsOfferedTheUpdateTheComparatorWouldMiss() throws {
+        let installed = Self.app("1f68f34a"), older = "1f68f34a", newer = "c437b979"
+        // The trap: by digit runs, "c437…" (text) sorts below "1f68…" (number).
+        #expect(!VersionComparator.isNewer(newer, than: older))
+        #expect(UpdateChecker.evaluate(
+            installed: installed, remote: try Self.remote(newer, lineage: nil)) == .upToDate)
+
+        #expect(UpdateChecker.evaluate(
+            installed: installed, remote: try Self.remote(newer, lineage: try Self.lineage()))
+            == .updateAvailable(latest: newer))
+    }
+
+    @Test func aNewerCopyIsNeverOfferedAnOlderBuild() throws {
+        let installed = Self.app("c437b979"), older = "1f68f34a"
+        #expect(VersionComparator.isNewer(older, than: "c437b979"))
+        #expect(UpdateChecker.evaluate(
+            installed: installed, remote: try Self.remote(older, lineage: nil))
+            == .updateAvailable(latest: older))
+
+        #expect(UpdateChecker.evaluate(
+            installed: installed, remote: try Self.remote(older, lineage: try Self.lineage()))
+            == .upToDate)
+    }
+
+    /// A failed check, not `.unknown`: `.unknown` renders as "no source covers
+    /// this app", which is false for an app whose source just answered.
+    @Test func aBuildTheLineageCannotPlaceIsAFailedCheck() throws {
+        let lineage = try Self.lineage()
+        func failed(_ status: UpdateStatus) -> Bool {
+            if case .error = status { return true }
+            return false
+        }
+        // An installed build the history does not list (a copy that updated itself
+        // past this lineage, or one trimmed from it) …
+        #expect(failed(UpdateChecker.evaluate(
+            installed: Self.app("0badc0de"), remote: try Self.remote("8545a7d8", lineage: lineage))))
+        // … and a remote it does not list.
+        #expect(failed(UpdateChecker.evaluate(
+            installed: Self.app("8545a7d8"), remote: try Self.remote("0badc0de", lineage: lineage))))
+    }
+
+    @Test func theDowngradeNoteTrustsOnlyTheLineage() throws {
+        let lineage = try Self.lineage()
+        func note(installed: String, remote: String, lineage: BuildLineage?) throws -> String? {
+            UpdatePolicy.laggingRemoteVersion(UpdateResult(
+                app: Self.app(installed), remote: try Self.remote(remote, lineage: lineage),
+                status: .upToDate))
+        }
+        // "5b73…" is OLDER than "1f68…", but 5 > 1 by digit runs.
+        #expect(VersionComparator.isNewer("5b73c7f4", than: "1f68f34a"))
+        #expect(try note(installed: "5b73c7f4", remote: "1f68f34a", lineage: nil) == "1f68f34a")
+        #expect(try note(installed: "5b73c7f4", remote: "1f68f34a", lineage: lineage) == nil)
+        // A copy really ahead of a stale answer still gets its note.
+        #expect(try note(installed: "8545a7d8", remote: "c437b979", lineage: lineage) == "c437b979")
+    }
+
+    @Test func verifyReportsBehindOnlyWhereTheLineageSaysSo() throws {
+        let lineage = try Self.lineage()
+        func complaint(installed: String, remote: String, lineage: BuildLineage?) throws -> String? {
+            RecipeSanity.remoteBehindInstalled(
+                remote: try Self.remote(remote, lineage: lineage),
+                installedMarketing: installed, installedBuild: installed)
+        }
+        #expect(try complaint(installed: "5b73c7f4", remote: "1f68f34a", lineage: nil) != nil)
+        #expect(try complaint(installed: "5b73c7f4", remote: "1f68f34a", lineage: lineage) == nil)
+        #expect(try complaint(installed: "8545a7d8", remote: "c437b979", lineage: lineage) != nil)
+    }
+
+    /// The pre-install re-check on a copy that updated itself PAST the offer
+    /// between the click and the re-check. Digit runs read that as the source
+    /// walking backwards; the lineage reads it as what it is.
+    @Test func aCopyThatOvertookTheOfferIsAlreadyCurrentNotARegression() throws {
+        let lineage = try Self.lineage()
+        // Offered "5b73…"; the copy is now on the newer "1f68…", which the re-check
+        // names too. By digit runs 5 > 1, so the offer looks like the newer one.
+        #expect(VersionComparator.isNewer("5b73c7f4", than: "1f68f34a"))
+        func decision(
+            offered: String, confirmed: String, lineage: BuildLineage?
+        ) throws -> PreInstallDecision {
+            // The gate reads only the two remotes and the re-check's status; the
+            // apps are the copy as it was at the click and as it is now.
+            PreInstallGate.decision(
+                offered: UpdateResult(
+                    app: Self.app("0badc0de"), remote: try Self.remote(offered, lineage: lineage),
+                    status: .updateAvailable(latest: offered)),
+                confirmed: UpdateResult(
+                    app: Self.app(confirmed), remote: try Self.remote(confirmed, lineage: lineage),
+                    status: .upToDate))
+        }
+        #expect(try decision(offered: "5b73c7f4", confirmed: "1f68f34a", lineage: nil)
+            == .answerRegressed)
+        #expect(try decision(offered: "5b73c7f4", confirmed: "1f68f34a", lineage: lineage)
+            == .alreadyCurrent)
+        // A re-check that really did walk backwards still says so.
+        #expect(try decision(offered: "1f68f34a", confirmed: "5b73c7f4", lineage: lineage)
+            == .answerRegressed)
+    }
+
+    /// A hash can legitimately contain no digit at all (`deadbeef`); for a lineage
+    /// recipe that is not a broken pattern.
+    @Test func aDigitlessHashIsNotReportedAsABrokenVersion() throws {
+        func saysNoDigits(_ recipe: VendorProbeRecipe) -> Bool {
+            RecipeSanity.complaints(version: "deadbeef", recipe: recipe)
+                .contains { $0.contains("no digits") }
+        }
+        #expect(!saysNoDigits(try Self.recipe()))
+        let ordinary = try #require(VendorProbeRegistry.recipes.first { $0.buildLineage == nil })
+        #expect(saysNoDigits(ordinary))
+    }
+
+    // MARK: - Derived from the registry
+
+    /// A lineage recipe's remote must carry the lineage on EVERY branch the probe
+    /// builds, or that branch silently falls back to the comparator.
+    @Test func everyLineageRecipeCarriesItsLineageOnEveryBranch() throws {
+        let lineageRecipes = VendorProbeRegistry.recipes.filter { $0.buildLineage != nil }
+        #expect(!lineageRecipes.isEmpty)
+        let lineage = BuildLineage(newestFirst: ["b", "a"])
+        for recipe in lineageRecipes {
+            #expect(recipe.buildLineage?.url.scheme == "https", "\(recipe.recipeID)")
+            let detection = VendorProbeSource.makeRemoteVersion(
+                recipe: recipe, version: "a", install: nil, plan: nil,
+                resolvedDownload: nil, lineage: lineage)
+            #expect(detection.buildLineage == lineage, "\(recipe.recipeID) detection-only")
+            if let spec = recipe.install {
+                let installable = VendorProbeSource.makeRemoteVersion(
+                    recipe: recipe, version: "a", install: spec,
+                    plan: (url: URL(string: "https://example.invalid/a.dmg")!, checksum: nil),
+                    resolvedDownload: nil, lineage: lineage)
+                #expect(installable.buildLineage == lineage, "\(recipe.recipeID) installable")
+            }
+            #expect(VendorProbeRegistry.ordersByLineage(recipeID: recipe.recipeID))
+            #expect(VendorProbeRegistry.ordersByLineage(bundleID: recipe.bundleID))
+        }
+        let ordinary = try #require(VendorProbeRegistry.recipes.first { $0.buildLineage == nil })
+        #expect(!VendorProbeRegistry.ordersByLineage(recipeID: ordinary.recipeID))
+        #expect(!VendorProbeRegistry.ordersByLineage(bundleID: ordinary.bundleID))
+    }
+
+    // MARK: - Release notes
+
+    @Test func theChangelogKeepsTheVendorsSectionsUnderTheBundlesVersion() throws {
+        let changelog = try #require(StructuredChangelogDecoder.decode(
+            Self.changelogBody, format: .superconductorChangelog, channel: nil, maxEntries: 20))
+        #expect(changelog.entries.map(\.version) == Self.historyHead)
+        #expect(changelog.entries[0].date == "2026-09-10")
+        #expect(Array(changelog.entries[0].items.prefix(2))
+            == ["Features", "Allow Claude profiles to use settings API keys"])
+        #expect(changelog.entries[3].items
+            == ["Improvements", "Add heartbeat timing context to hang diagnostics"])
+    }
+
+    @Test func emptyGroupsAndBlankCommitsAreDropped() throws {
+        // The two shapes the history really carries: `d08315a7`'s `Features` group
+        // has `commits: []`, and one of `880d2417`'s commits has `"message": ""`.
+        let body = #"""
+            {"releases": [{"version": "d08315a7de8a0a2bf8b5f6e2d6c6f2d0f6d6c6d6", "date": "2026-07-15",
+              "groups": [{"title": "Features", "commits": []},
+                         {"title": "Bug Fixes", "commits": [{"message": "", "pr": 1202},
+                                                             {"message": "load session history for qwen", "pr": 1610}]}]},
+                         {"version": "880d2417", "date": "2026-05-30",
+              "groups": [{"title": "Bug Fixes", "commits": [{"message": "  ", "pr": null}]}]}]}
+            """#
+        let changelog = try #require(StructuredChangelogDecoder.decode(
+            body, format: .superconductorChangelog, channel: nil, maxEntries: 20))
+        #expect(changelog.entries.count == 1)
+        #expect(changelog.entries[0].version == "d08315a7")
+        #expect(changelog.entries[0].items == ["Bug Fixes", "load session history for qwen"])
+    }
+
+    @Test func theChangelogIsTheSameDocumentTheLineageReads() throws {
+        let changelogRecipe = try #require(
+            ChangelogRecipeRegistry.recipes.first { $0.bundleID == Self.bundleID })
+        #expect(changelogRecipe.structuredFormat == .superconductorChangelog)
+        #expect(changelogRecipe.source == (try Self.recipe().buildLineage?.url))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorInstallTests.swift
@@ -266,6 +266,10 @@ import CryptoKit
 @Test func channelAnchorSurfaceCoversEveryRecipeField() {
     let recipe = VendorProbeRegistry.recipes[0]
     let labels = Mirror(reflecting: recipe).children.compactMap(\.label)
+    // 25 since `buildLineage` (2026-09-11). It stays IN: it names a document and a
+    // pattern the recipe READS, which is what this surface is, and neither carries
+    // a channel token for an anchor to be tautological about.
+    //
     // 24 since `trackClosedPattern` (2026-09-04). It stays IN, and unlike its
     // sibling `transientBodyPattern` it is not channel-neutral: only the beta
     // recipe carries one, and the string it holds names a beta-specific key
@@ -284,7 +288,7 @@ import CryptoKit
     // is a bad proof, not a tautological one, and a proof must name the fields it
     // relies on anyway (#110). Useless as an anchor, harmless in the surface,
     // same as every other Bool here.
-    #expect(labels.count == 24,
+    #expect(labels.count == 25,
             "VendorProbeRecipe gained or lost a field (now \(labels.count): \(labels.sorted())) — decide whether it belongs in the .recipeAnchor surface or in nonAnchorFields, then update this count")
     // A renamed field would turn its exclusion into a silent no-op, quietly
     // widening the surface instead of narrowing it. Same class of bug, other

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -54,6 +54,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 - [x] **VS Code** · `com.microsoft.VSCode` — P C (one-click) · ✓ src=Vendor
 - [x] **Claude Desktop** · `com.anthropic.claudefordesktop` — P (one-click) · ✓ src=Vendor
+- [x] [**super.engineering**](com-zarifpour-superconductor.md) · `com.zarifpour.superconductor` — P C B (one-click) · ✓ src=Vendor · 版本是 commit hash，按 `changelog.json` 的发布顺序比较 · 审计 2026-09-11
 - [x] **Codex → ChatGPT** · `com.openai.codex` — P C (one-click) · ✓ src=Vendor · 独立 Codex 桌面端 2026-07 并入 ChatGPT app（cask `codex-app` 已 `deprecate! … replacement_cask: "chatgpt"`），**bundle id 未变**——真包核实 ChatGPT.app 仍登记 `com.openai.codex` / `26.825.51511`，既有 recipe 全链 ✓（2026-08-30 复验）
 - [x] **Cursor** · `com.todesktop.230313mzl4w4u92` — P · ✓ src=Vendor
 - [x] [**Notion**](notion-id.md) · `notion.id` — P C · ✓ src=Vendor · **三个产物版本互不同步**（官网 307 universal / `latest-mac.yml` 纯 x64 / `arm64-mac.yml` 是独立轨）· `arm64-mac.yml` 不是另一个架构而是 `channel: arm64` 的另一条轨，故 ElectronManifestSource 不应接管 · 2026-09-01

--- a/docs/app-audits/com-zarifpour-superconductor.md
+++ b/docs/app-audits/com-zarifpour-superconductor.md
@@ -1,0 +1,137 @@
+# super.engineering（Superconductor）
+
+## 基本信息
+- Bundle ID: `com.zarifpour.superconductor`
+- Team ID: `MR38E36N26`（Developer ID Application: David Daniel，已公证，`spctl -a` accepted）
+- 观测版本: `8545a7d8`（2026-09-10 的构建；`CFBundleShortVersionString` 与 `CFBundleVersion` 都是它）
+- 自更新机制: 自研 —— 每小时查 `releases.superconductor.so/latest.json`，下载 dmg、校验 sha256、暂存，重启时原子交换 bundle（设置页原文 "Downloads stay staged until you restart"）
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|              | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|--------------|---------|----------|-----|--------|-------------|
+| **nightly（当前唯一轨道）** | — | — | — | — | ✓ 一键 |
+| **stable（厂商 2026-04 关闭）** | — | — | — | — | — |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **VendorProbe**
+
+- `feed-discover`（对 2026-09-10 的 dmg）: `no Sparkle and no electron-builder update config`
+- Homebrew 无 cask（`brew info --cask superconductor` → 不存在）；不上 MAS；无公开 GitHub Releases
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| nightly | `com.zarifpour.superconductor` | 共享 | `~/.superconductor/settings.json` → `update_channel` = `nightly`；没有记录时按 app 默认 nightly | channel-gated VendorProbe（`SuperconductorChannel` 选配方）| ✓ |
+| stable | 同上 | 共享 | `update_channel` 为 nightly 以外的任何值 | 无配方 → 不提示，绝不推 nightly | — 厂商已关闭 |
+
+厂商在 2026-04-05 关掉了 stable 轨道（它自己 changelog 里的 #711 "Disable stable channel and
+enforce nightly-only updates"），app 设置页写着 "Nightly is currently the only release track
+available"。但设置页的选择器还在，选择写在 `~/.superconductor/settings.json` 顶层的
+`update_channel`（2026-09-11 在真实安装上读到 `"nightly"`）。这个文件把整份设置连同默认值一起
+序列化（92 个顶层键里有 4 个 `null`、15 个 `false`），所以启动过的安装基本都带这个键 —— 这是推断，
+没有重置设置去验证。
+
+bundle 本身不带渠道信号（`detect()` 读作 `.stable`），所以由 `SuperconductorChannel` 读这个键：
+`nightly` 或没有记录 → `.nightly`（app 自己的默认，也是唯一轨道）；其他任何值 → 一个没有配方的渠道，
+不提示，**绝不把 nightly 推给选了别的轨道的人**。binding 是 authoritative 的，会顶掉 `detect()`。
+`ChannelProofRegistry` 登记了 `.artifact(/nightly/Superconductor-nightly-<sha8>-arm64.dmg)`。
+
+**若厂商重开 stable**：`latest.json` 大概率会多出一个同级的 `"stable"` 条目 —— 更新器按渠道名取条目
+（报错字符串 "nightly entry missing from release manifest"）；这是推断，归档里找不到 #711 之前的清单。
+所有 pattern 已锚在 `"nightly"` 对象里，不会误读另一轨；届时加一条锚 `"stable"` 的 `.stable` recipe，
+并核对 lineage（`changelog.json`）是否分轨。`identity.json` 的 `build_channel`（实测 `prod`）是构建
+风味，不是更新渠道，别读错。
+
+**不监听 `~/.superconductor`**：FSEvents 是递归的，而 app 的日志就写在这个目录下，会持续触发重查；
+现在只有一条轨道、切换不可能发生。渠道在每次扫描、以及 app 启动 / 退出时重读。
+
+## 更新检测
+- 源: VendorProbe，`https://releases.superconductor.so/latest.json` —— app 自己的更新器读的就是它
+  （URL、UA `superconductor-updater`、报错字符串 "nightly entry missing valid sha" 都在二进制里）。
+  浏览器 UA 同样 200。
+- 形状（2026-09-10）: `{"nightly": {"sha": "<40 位 hex>", "url": ".../nightly/Superconductor-nightly-<sha8>-arm64.dmg", "sha256": "<hex>", "date": "2026-09-10"}}`
+- **版本是 commit hash**。bundle 两个版本字段都是 sha 的前 8 位，所以 `versionPattern` 只取这 8 位；
+  取全 40 位会永远不等于 bundle，恒判「有更新」。
+- **hash 没有顺序**。用真实的 `VersionComparator.swift` 重放 `changelog.json` 里全部 626 对相邻发布
+  （2026-09-10 取的 627 条）：新的读作更新 313 次、读作更旧 313 次。直接比较等于抛硬币 —— 一半的
+  更新永远不提示，还会把旧构建当成更新推出去。
+- **所以排序读厂商自己的发布史**：recipe 声明 `buildLineage` → `changelog.json`（按日期倒序，一个已发布
+  构建一条；lineage pattern 同样只取前 8 位，627 条的 8 位前缀互不相同）。引擎在
+  `UpdateChecker.evaluate`、降级提示（`UpdatePolicy.laggingRemoteVersion`）、`duo verify` 的
+  `RecipeSanity.remoteBehindInstalled` 和 baseline 的「version went BACKWARDS」里都按 lineage 位置判断；
+  预装前复查（`PreInstallGate`）判断「复查是否倒退」时同样按 lineage。lineage 放不下的组合记为一次
+  **失败的检查**（带 Retry），不猜 —— 不用 `.unknown`，因为它在 UI 上显示成「没有来源覆盖这个 app」。
+  拿不到 / 解析不出 lineage 时 probe 直接失败（`buildLineageUnavailable` / `buildLineagePatternNoMatch`，
+  附带的样本是 `changelog.json` 本身），绝不退回比较器。
+- 两份文档分开发布：2026-09-10 `latest.json` 与 `changelog.json` 的 Last-Modified 相差 3 秒。
+  落在这个窗口里的检查会报 `buildLineageMissesVersion`（归为 infra，持续才上报）。两份当天都是
+  `CF-Cache-Status: DYNAMIC`（CDN 不缓存），所以窗口就是厂商的发布间隔，不是边缘缓存的寿命。
+- 流量：`changelog.json` 约 850 KB，但两个端点都对 `If-None-Match` 回 304（2026-09-10 实测），更新会话的
+  内存 URLCache（64 MB）容得下这个体积，缓存里还在时一次检查只是一次 304。**未测**：两次检查之间它会不会
+  被挤出缓存。
+- OS 边界: `latest.json` 只有 sha/url/sha256/date 四个字段，**不带** min/max 系统版本。静态下限取自
+  bundle 的 `LSMinimumSystemVersion` = 14.0，连同 arm64（dmg 文件名与 `lipo -archs` 一致）写进
+  `hostRequirement`。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 无 | 不适用 |
+| 证据 | 只看了更新器相关字符串：整包 dmg 下载、sha256 校验、`hdiutil attach`、原子交换；没专门搜 delta/patch | `latest.json`（2026-09-10）全部字段就是 sha/url/sha256/date，没有 patch URL | — |
+
+- 格式: 无
+- 阻塞项: 无
+
+## Changelog
+- 来源: `ChangelogRecipe`（structured `.superconductorChangelog`），与 lineage 同一份 `changelog.json` ——
+  app 内 "What's New in Nightly" 读的也是它（二进制里这个 URL 挨着该字符串）。
+- 条目标题是 sha 前 8 位（与行上显示的版本同一个字符串），厂商的分组标题（Features / Bug Fixes / …）
+  作为独立一行排在各自的 commit 前面；空分组（`commits: []`）和空 message 丢弃。
+- 厂商数据里同一天的多个构建常重复列出同一批 commit（累计式），原样展示。
+- 跟随 channel: 只有一条轨道。
+- Recipe 状态: 已有。站点没有人读的 changelog 页（`/changelog`、`/releases` 均 404），所以不设 `changelogURL`。
+
+## 一键安装
+- 状态: 支持
+- 格式: dmg。镜像里 `Superconductor.app` 是指向 `super.engineering.app` 的符号链接；扫描器先解析符号链接、
+  按真实路径去重，只出一行。
+- 校验: `sha256` 是 hex SHA-256，`checksumPattern` 只吃 base64 SHA-512，未武装；Team `MR38E36N26` 闸兜底。
+- **读的是**: 轨道最新 —— 也是唯一的轨道。它就是官网 Download 按钮（`super.engineering/api/download`
+  在 2026-09-10 302 到同一个 dmg）和 app 自己的更新器发给任何用户的那个构建，不存在「厂商还没分配给
+  这台机器」的情况。
+- 阻塞: 无。**未验证**：app 自带更新器已经暂存了新版、我们又一键装了同一构建时，它下次重启的行为。
+
+## 如何复验
+- `swift run --package-path application-test feed-discover <dmg>` → `no Sparkle and no electron-builder update config`
+- `swift run --package-path application-test channel-verify <dmg>`（2026-09-11，对 2026-09-10 的 dmg，读的是
+  线上两份文档；运行的机器上没有 `settings.json`，走的是「没有记录 → nightly」）: bundle 自身推断
+  `stable`，被 ChannelBinding 覆盖为 `nightly`；VendorProbe 对 `nightly` 应答 `8545a7d8`，下载 URL 就是
+  `latest.json` 里的 nightly dmg；`UpdateChecker.check()` 全链 winning source = Vendor，status = up to date
+- 挂载 `latest.json` 指向的 dmg（sha256 与 `latest.json` 的 `sha256` 一致）:
+  `Info.plist` → `CFBundleIdentifier` `com.zarifpour.superconductor`、两个版本字段 `8545a7d8`、
+  `LSMinimumSystemVersion` 14.0；`lipo -archs` → `arm64`；`codesign -dvvv` → TeamIdentifier `MR38E36N26`
+- 真实安装的布局: `/Applications/super.engineering.app` 目录 + `/Applications/Superconductor.app` 符号链接；
+  `~/.superconductor/settings.json` 的 `last_installed_version` / `last_seen_version` 是 40 位 sha；
+  没有任何本地文件记录发布日期或序号 —— 这就是排序只能来自 `changelog.json` 的原因。
+- 单元测试: `SuperconductorTests`（真实响应体逐字截取；每条排序用例先断言比较器在该组合上是错的）
+- 实时: `duo verify --only com.zarifpour.superconductor`
+
+## 已知问题
+- 厂商若把 plist 里的版本改成别的长度（About 窗口显示的是 7 位 `8545a7d`），`versionPattern` 和 lineage
+  pattern 要一起改；测试钉的是 8 位。
+- App 层「运行中的版本落后于磁盘」的 Restart 徽标（`AppListModel`）仍用 `VersionComparator` 比较 hash，
+  装完新版时约一半情况不会提示重启。未在这次改动里处理。
+- `RelaunchProgress.hasLanded` 仍用比较器，但当前走不到：它只在 `SelfUpdaterStaging` 识别出暂存更新时
+  调用，而它不识别这个 app 的更新器。
+- `duo verify` 的两道历史检查（baseline 的「version went BACKWARDS」、changelog 落后于检测版本）对这个
+  recipe 是**关掉**而不是换成 lineage 版：hash 之间比不出先后。`latest.json` 只有一条，`versionPattern`
+  滑到旧条目的风险低；但同样的字段用在多条目 feed 上时会继承这个缺口。
+- `RecipeSanity` 的「version contains no digits」对 lineage recipe 不适用（`deadbeef` 是合法的 hash），已跳过。
+
+## 建议下一步
+1. 厂商重开 stable 时：加锚 `"stable"` 的 recipe，核对 lineage 是否分轨（见 Channel 详情）。
+2. 让 App 层的 Restart 徽标也认 lineage（单独的 PR）。


### PR DESCRIPTION
## What

Adds super.engineering (`com.zarifpour.superconductor`): nightly update checks, structured release notes and one-click install.

## Why it needs engine work

The app versions by commit hash (`CFBundleShortVersionString` = `CFBundleVersion` = the first 8 hex digits of the commit). `VersionComparator` cannot order hashes: replayed over the vendor's 626 consecutive release pairs it reads the newer build as newer exactly half the time. So a recipe can now declare `buildLineage`, a document listing every release newest first (here `changelog.json`), and every "is this newer" decision for that recipe orders by position in it:

- `UpdateChecker.evaluate`, `UpdatePolicy.laggingRemoteVersion`, `PreInstallGate`, `RecipeSanity`
- `duo verify`: Baseline's "went BACKWARDS" and the changelog lag check are skipped for lineage recipes
- a pair the lineage cannot place is a failed check with Retry, never `.unknown`; a lineage that cannot be fetched or does not list the version fails the probe

Every path without a lineage is unchanged.

## Channel

The app's only track today is Nightly, but its Settings still has the picker (`update_channel` in `~/.superconductor/settings.json`). `SuperconductorChannel` reads it: `nightly` or no record means nightly; anything else resolves to a channel with no recipe, so nightly is never offered to a copy on another track. All patterns are anchored inside the manifest's `"nightly"` object.

## Verification

- `make test`: all green
- 19 mutations, each compiled and turned the targeted tests red
- `channel-verify` on the real dmg with the live documents: binding → nightly, VendorProbe → `8545a7d8`, full chain Vendor / up to date
- `duo verify --only com.zarifpour.superconductor`
- adversarial review: findings fixed (see commits)
