### PR TITLE
Fix the Ollama and Notion changelog sweep issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Rockxy's release notes now go back through its recent releases.** The feed Rockxy publishes is rewritten in place and only ever holds the newest one, so the window had a single entry to show no matter how many builds you had skipped.
 
+**Ollama's newest release notes show up again.** A release written as paragraphs rather than a bullet list was left out, so the window started one release behind.
+
 ## 0.3.89
 
 **Telegram Desktop gets update checks again.** Telegram changed the name of the file it publishes, and the row could no longer read a version out of it — so it showed a check failure instead of the update waiting behind it.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
@@ -61,7 +61,10 @@ public struct Changelog: Codable, Sendable, Hashable {
     ///   commit already carrying the `GitHubMarkdownParser.isImageOnly` HTML `<img>`
     ///   arm (`9963e3e`) and `ChangelogRecipe.skipSections` (`a6ac16b`), so those are
     ///   folded into generation 1 rather than triggering a bump on their own.
-    public static let parserGeneration = 1
+    /// - 2: Ollama's recipe gained a paragraph item pattern, so a release written as
+    ///   prose (no bullet list) parses to an entry instead of being dropped. Notes
+    ///   already cached for 0.34.0 were stored without 0.34.0's own entry.
+    public static let parserGeneration = 2
 
     public let entries: [Entry]
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1580,6 +1580,15 @@ public enum ChangelogRecipeRegistry {
         // probe's `.redirectFilename` reports) and the release order runs
         // v7.31.0 → v7.29.0 → v7.28.0 → … — newest first, real desktop builds, not
         // the product-announcement post titles the old recipe surfaced.
+        //
+        // `acknowledgedStaleEntry` (#493): read live 2026-09-11, the page's newest
+        // header is still v7.32.0 ("Released" 2026-08-31; the page block was last
+        // edited 2026-09-01 01:22 UTC), while `www.notion.so/desktop/mac/download` already
+        // 307s to `Notion-7.33.0-universal.dmg`. The decoder reads the page
+        // correctly — Notion has not written the 7.33.0 notes — so the sweep's
+        // "a whole release behind" is the vendor's lag, not ours. Named rather than
+        // switched off: once the page moves, to 7.33.0 or anywhere else, the check
+        // runs again.
         ChangelogRecipe(
             bundleID: "notion.id",
             source: URL(string: "https://notion.notion.site/api/v3/loadPageChunk")!,
@@ -1589,7 +1598,8 @@ public enum ChangelogRecipeRegistry {
             requestBody: Data(
                 (#"{"pageId":"5936dabc-8dd6-4978-9578-6c91b9d6f12a","limit":50,"#
                     + #""cursor":{"stack":[]},"chunkNumber":0,"verticalColumns":false}"#
-                ).utf8)),
+                ).utf8),
+            acknowledgedStaleEntry: "7.32.0"),
 
         // Waku — GitHub releases, not the appcast's own notes link.
         //

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -1252,6 +1252,16 @@ public enum ChangelogRecipeRegistry {
         // (ISO datetime), and a <div class="markdown-body …"> with the release
         // body. The version group strips the leading "v" by not capturing it.
         // Only <h2> values matching v+digits are captured so nav sections skip.
+        //
+        // Most releases are a bullet list, but some are written as prose with no
+        // <li> at all — v0.34.0 and v0.32.12 on the live page, 2026-09-11. An entry
+        // that yields no items is dropped, so the newest release vanished from the
+        // pane and `duo verify` read the changelog as a whole release behind
+        // (#507). Item patterns are tried in order and the first that yields
+        // anything wins, so the paragraph fallback only ever speaks for a release
+        // with no bullets. It skips the "Full Changelog: vA...vB" compare-link line
+        // (all ten releases on the page that day end with it), which would
+        // otherwise be a prose release's last item.
         ChangelogRecipe(
             bundleID: "com.electron.ollama",
             source: URL(string: "https://github.com/ollama/ollama/releases")!,
@@ -1260,7 +1270,10 @@ public enum ChangelogRecipeRegistry {
                 + #"<h2 class="sr-only"[^>]*>v(?<version>[\d.]+)</h2>.*?"#
                 + #"<relative-time[^>]*datetime="(?<date>[^T]+)T[^"]*"[^>]*>.*?"#
                 + #"<div[^>]*class="markdown-body[^"]*"[^>]*>(?<body>.*?)</div>\s*</div>"#,
-            itemPatterns: [#"<li>(?<item>.*?)</li>"#]),
+            itemPatterns: [
+                #"<li>(?<item>.*?)</li>"#,
+                #"<p>(?!<strong>Full Changelog</strong>)(?<item>.*?)</p>"#,
+            ]),
 
         // RustDesk — GitHub releases page, same shape as Ollama but the sr-only
         // <h2> carries a bare version ("1.4.7", no leading "v"), so the version

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -912,6 +912,49 @@ private let ollamaFixture = """
 </section>
 """
 
+// Trimmed real markup from github.com/ollama/ollama/releases, read 2026-09-11.
+// v0.34.0 is written as prose — paragraphs and no <li> at all — and v0.33.0 puts
+// a prose paragraph ahead of its bullet lists. Section ids and timestamps are the
+// live ones; the frame between them is abbreviated as in `ollamaFixture`. Bodies
+// are verbatim except that v0.34.0's signed image URL is replaced, v0.33.0's image
+// is dropped, and v0.33.0 keeps 3 of its 7 bullets.
+private let ollamaProseFixture = """
+<section id="release-v0.34.0" aria-labelledby="hd-ddc17a0b" data-release-anchor="release-v0.34.0" style="scroll-margin-top: 24px;">
+        <h2 class="sr-only" id="hd-ddc17a0b">v0.34.0</h2>
+        <div class="tmp-my-5">
+          <relative-time class="no-wrap" prefix="" datetime="2026-09-05T23:49:00Z">
+        05 Sep 23:49
+      </relative-time>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body tmp-my-3"><h2>Use Ollama models in ChatGPT Desktop</h2>
+<p>Ollama models can now be used directly in ChatGPT Desktop, so you can keep your existing workflow while running open models. Setup is available from the Ollama app on MacOS.</p>
+<a target="_blank" rel="noopener noreferrer" href="https://example.invalid/image.png"><img width="1374" height="1300" alt="CleanShot 2026-09-08 at 11 04 07 AM@2x" src="https://example.invalid/image.png" style="max-width: 100%; height: auto; max-height: 1300px;"></a>
+<p>This release also improves structured output performance on Apple Silicon, adds support for OpenAI-compatible client tool search and response compaction.</p>
+<p><strong>Full Changelog</strong>: <a class="commit-link" href="https://github.com/ollama/ollama/compare/v0.33.3...v0.34.0"><tt>v0.33.3...v0.34.0</tt></a></p></div>
+</div>
+</section>
+<section id="release-v0.33.0" aria-labelledby="hd-9722df32" data-release-anchor="release-v0.33.0" style="scroll-margin-top: 24px;">
+        <h2 class="sr-only" id="hd-9722df32">v0.33.0</h2>
+        <div class="tmp-my-5">
+          <relative-time class="no-wrap" prefix="" datetime="2026-08-21T22:52:46Z">
+        21 Aug 22:52
+      </relative-time>
+        <div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body tmp-my-3"><h2>What's Changed</h2>
+<h3>Claude Desktop</h3>
+<p>Developers can now easily configure Claude Desktop to seamlessly work with Ollama as a third-party gateway provider.</p>
+<h3>Improved caching</h3>
+<ul>
+<li>Fixed a hang where agent clients that cancel long prefills</li>
+<li>Disabled Claude Code's "tokens left" token-countdown system message, which Ollama moved to the front of the prompt and broke the KV cache on every request</li>
+</ul>
+<h3>Other improvements</h3>
+<ul>
+<li>Fixed broken default packaging caused by macOS-specific assumptions affecting Linux/Windows builds</li>
+</ul>
+<p><strong>Full Changelog</strong>: <a class="commit-link" href="https://github.com/ollama/ollama/compare/v0.32.15...v0.33.0"><tt>v0.32.15...v0.33.0</tt></a></p></div>
+</div>
+</section>
+"""
+
 // Trimmed real markup from github.com/rustdesk/rustdesk/releases. Same GitHub
 // release-section shape as Ollama, but the sr-only <h2> carries a bare version
 // ("1.4.7", no leading "v"). Body opens with a screenshot link before the
@@ -1004,6 +1047,28 @@ private let orbStackFixture = """
     #expect(changelog.entries[1].date == "2026-05-13")
     #expect(changelog.entries[1].items.count == 2)
     #expect(changelog.entries[1].items[1] == "Bug fixes & stability improvements")
+}
+
+// A release written as prose used to yield no items and be dropped — and it was
+// the newest one, so the pane started a release behind and `duo verify` said so
+// (#507). Each assertion is one way to get the fallback wrong: without it the
+// entry disappears; without its compare-link exclusion that line becomes the last
+// item; tried before the bullets, v0.33.0's intro paragraph replaces its list.
+@Test func extractsOllamaProseReleases() throws {
+    let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.electron.ollama"))
+    let changelog = try #require(ChangelogExtractor.extract(from: ollamaProseFixture, using: recipe))
+
+    #expect(changelog.entries.map(\.version) == ["0.34.0", "0.33.0"])
+    #expect(changelog.entries[0].date == "2026-09-05")
+    #expect(changelog.entries[0].items == [
+        "Ollama models can now be used directly in ChatGPT Desktop, so you can keep your existing workflow while running open models. Setup is available from the Ollama app on MacOS.",
+        "This release also improves structured output performance on Apple Silicon, adds support for OpenAI-compatible client tool search and response compaction.",
+    ])
+    #expect(changelog.entries[1].items == [
+        "Fixed a hang where agent clients that cancel long prefills",
+        #"Disabled Claude Code's "tokens left" token-countdown system message, which Ollama moved to the front of the prompt and broke the KV cache on every request"#,
+        "Fixed broken default packaging caused by macOS-specific assumptions affecting Linux/Windows builds",
+    ])
 }
 
 @Test func extractsOrbStackEntriesInOrder() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
@@ -51,8 +51,12 @@ import Foundation
     /// changes NEITHER fixture's output (a bump "just in case") is caught here for
     /// the opposite reason — it's a signal the bump might be unnecessary, worth a
     /// second look rather than a silent no-op.
+    ///
+    /// 2 moves neither fixture: it is Ollama's paragraph fallback, which changes
+    /// what a release written as prose parses to — pinned by
+    /// `extractsOllamaProseReleases`, not here.
     @Test func pinnedGeneration() {
-        #expect(Changelog.parserGeneration == 1)
+        #expect(Changelog.parserGeneration == 2)
     }
 
     /// Stable (v4.3.6, bulleted): exercises `skipSections` — the `### Included

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotionChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotionChangelogRecipeTests.swift
@@ -74,6 +74,14 @@ private let notionPageChunkFixture = #"""
 {"recordMap": {"block": {"3bfefdee-ad05-8039-a5e6-d8cb747ee142": {"value": {"value": {"type": "header","properties": {"title": [["v7.31.0"]]}}}},"3bfefdee-ad05-8057-9623-dff8b34b7bf0": {"value": {"value": {"type": "text","properties": {"title": [[" 📅 Released "],["‣",[["d",{"type": "datetime","start_date": "2026-08-17","start_time": "16:26","time_zone": "America/Los_Angeles","date_format": "relative"}]]],["  (macOS & Windows)"]]}}}},"3bfefdee-ad05-8067-8fa6-d6b559cfff1f": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Allow additional SSO provider (Entra) login popups from in the app"]]}}}},"3b8efdee-ad05-807b-ba1a-fea9e1c1fac3": {"value": {"value": {"type": "header","properties": {"title": [["v7.29.0"]]}}}},"3b8efdee-ad05-8014-be1f-c9be494eeacd": {"value": {"value": {"type": "text","properties": {"title": [[" 📅 Released "],["‣",[["d",{"type": "date","start_date": "2026-08-03","date_format": "relative"}]]],["  (macOS & Windows)"]]}}}},"3b8efdee-ad05-80bd-99bf-d926b25f2d54": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Resolved an issue where the quick search hotkey wouldn't work properly for certain users"]]}}}},"3b8efdee-ad05-807a-98ec-fd8db89d1895": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Windows 10 users (20H2 and above) can now use the MSIX Installer"]]}}}},"3acefdee-ad05-80a8-8fa8-fde99932d47d": {"value": {"value": {"type": "header","properties": {"title": [["v7.28.0"]]}}}},"3acefdee-ad05-8056-811e-f20f1e5ea0e3": {"value": {"value": {"type": "text","properties": {"title": [[" 📅 Released "],["‣",[["d",{"date_format": "relative","type": "date","start_date": "2026-07-27"}]]],[" (macOS & Windows)"]]}}}},"3acefdee-ad05-80f7-9bfc-dcb3d570930b": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Tabs recover automatically if your system unloads them under memory pressure"]]}}}},"3acefdee-ad05-80a9-919b-f6f7591f741f": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Opening a Notion link in Desktop no longer closes the originating browser tab on macOS"]]}}}},"3acefdee-ad05-8075-80ef-d191c6bfc432": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["As always, security and performance improvements, and small bug fixes"]]}}}},"5936dabc-8dd6-4978-9578-6c91b9d6f12a": {"value": {"value": {"type": "page","content": ["3bfefdee-ad05-8039-a5e6-d8cb747ee142","3bfefdee-ad05-8057-9623-dff8b34b7bf0","3bfefdee-ad05-8067-8fa6-d6b559cfff1f","3b8efdee-ad05-807b-ba1a-fea9e1c1fac3","3b8efdee-ad05-8014-be1f-c9be494eeacd","3b8efdee-ad05-80bd-99bf-d926b25f2d54","3b8efdee-ad05-807a-98ec-fd8db89d1895","3acefdee-ad05-80a8-8fa8-fde99932d47d","3acefdee-ad05-8056-811e-f20f1e5ea0e3","3acefdee-ad05-80f7-9bfc-dcb3d570930b","3acefdee-ad05-80a9-919b-f6f7591f741f","3acefdee-ad05-8075-80ef-d191c6bfc432"]}}}}}}
 """#
 
+/// The same endpoint read live 2026-09-11, trimmed the same way to its newest
+/// release: 4 of the page's 101 returned blocks, titles verbatim. The page stops at
+/// v7.32.0 while Notion's download already serves 7.33.0 — the vendor lag the
+/// registry's `acknowledgedStaleEntry` names.
+private let notionStalePageFixture = #"""
+{"recordMap": {"block": {"3ceefdee-ad05-802f-b91f-dbaa333ae68b": {"value": {"value": {"type": "header","properties": {"title": [["v7.32.0"]]}}}},"3ceefdee-ad05-8076-8e04-dc0ab9143aeb": {"value": {"value": {"type": "text","properties": {"title": [[" 📅 Released "],["‣",[["d",{"date_format": "relative","type": "date","start_date": "2026-08-31"}]]],["   (macOS & Windows)"]]}}}},"3ceefdee-ad05-80c7-864c-d2fe60282df0": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Updated framework dependencies for improved stability and performance"]]}}}},"3ceefdee-ad05-8059-8b3a-e6dcc3077fec": {"value": {"value": {"type": "bulleted_list","properties": {"title": [["Allowed federated Identity Provider (IdP) authentication hops in authorization popups"]]}}}},"5936dabc-8dd6-4978-9578-6c91b9d6f12a": {"value": {"value": {"type": "page","content": ["3ceefdee-ad05-802f-b91f-dbaa333ae68b","3ceefdee-ad05-8076-8e04-dc0ab9143aeb","3ceefdee-ad05-80c7-864c-d2fe60282df0","3ceefdee-ad05-8059-8b3a-e6dcc3077fec"]}}}}}}
+"""#
+
 @Suite struct NotionPageChunkTests {
     @Test func registryPointsAtTheStructuredPostRecipe() throws {
         let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "notion.id"))
@@ -121,6 +129,19 @@ private let notionPageChunkFixture = #"""
         // silently drop a trailing bullet when a release has several.
         #expect(log.entries[2].items.last
             == "As always, security and performance improvements, and small bug fixes")
+    }
+
+    /// The acknowledgement has to name what the decoder reads off the page, not
+    /// what a person typed: `duo verify` compares it to the newest entry by exact
+    /// string, so "v7.32.0" or "7.32" would silence nothing and the sweep would
+    /// keep re-filing the same issue.
+    @Test func theAcknowledgedStaleEntryIsWhatThePageDecodesTo() throws {
+        let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "notion.id"))
+        let log = try #require(StructuredChangelogDecoder.decode(
+            notionStalePageFixture, format: .notionPageChunk, channel: nil, maxEntries: 20))
+        #expect(log.entries.first?.version == "7.32.0")
+        #expect(log.entries.first?.date == "2026-08-31")
+        #expect(recipe.acknowledgedStaleEntry == log.entries.first?.version)
     }
 
     @Test func maxEntriesCapsWithoutTruncatingTheLastKeptEntrysItems() throws {

--- a/docs/app-audits/com-electron-ollama.md
+++ b/docs/app-audits/com-electron-ollama.md
@@ -33,6 +33,9 @@
 - 来源: `ChangelogRecipe` + `ChangelogCatalog`
 - 跟随 channel: 否
 - Recipe 状态: 已有，GitHub releases page（`https://github.com/ollama/ollama/releases`）
+- 条目取 `<li>`；有的发布整篇是散文、一个 `<li>` 都没有（2026-09-11 实测 v0.34.0、v0.32.12），
+  这时走第二条 `<p>` pattern，跳过 "Full Changelog: vA...vB" 对比链接行（当天第一页 10 条发布都以它收尾）。
+  没有这条兜底时，没条目的发布会被丢掉，最新一条恰好是散文时整个面板就落后一个版本（#507）。
 
 ## 一键安装
 - 状态: 仅 notes

--- a/docs/app-audits/notion-id.md
+++ b/docs/app-audits/notion-id.md
@@ -64,6 +64,11 @@ arm64-mac.yml    version: 7.32.0   path: Notion-arm64-7.32.0.zip   releaseDate 2
 - 来源: What's New (Mac & Windows) 页，`ChangelogRecipe(notion.id)` 渲染原生条目
 - `VendorProbe.changelogURL` 指同页作 WebView 兜底
 - 注意: **不要**指向 `www.notion.com/releases` —— 那是产品公告 feed，「版本」是文章标题、不带 build 号，与安装版对不上
+- 页面会比构建慢：2026-09-11 实测页上最新是 v7.32.0（Released 2026-08-31；页面块最后编辑于
+  2026-09-01 01:22 UTC，即太平洋时间 08-31 当天），
+  而官网 307 已经是 `Notion-7.33.0-universal.dmg`。解码没错，是 Notion 还没写 7.33.0 的说明，
+  所以 recipe 带 `acknowledgedStaleEntry: "7.32.0"`（#493）。它只认这一个版本：页面一动
+  （出 7.33.0，或 pattern 滑到更旧的条目），`duo verify` 的落后检查就恢复。
 
 ## 一键安装
 - 状态: 支持


### PR DESCRIPTION
Two sweep issues, two different causes: one was ours, the other is the vendor's.

## #507 — Ollama: a release written as prose was dropped

Read live 2026-09-11: v0.34.0 (the newest release) and v0.32.12 are paragraphs
under a heading, with no `<li>` at all. The recipe only read `<li>`, an entry
with no items is dropped, so the pane started at 0.33.3 and `duo verify` filed
"newest changelog entry trails the detected version".

Fix: a second item pattern reads `<p>` and skips the `Full Changelog: vA...vB`
compare-link paragraph (all ten releases on page 1 end with it). Item patterns
are tried in order and the first that yields anything wins, so bulleted releases
parse exactly as before.

Replayed against the live page in Python before writing the Swift: 10 of 10
releases parse, 0.34.0 and 0.32.12 via `<p>` (2 items each), the other eight via
`<li>` with unchanged counts.

`Changelog.parserGeneration` 1 → 2, per its own doc comment: notes already
cached for 0.34.0 were stored without 0.34.0's own entry. The guard test's pin
moves with it; neither of its fixtures changes.

## #493 — Notion: the vendor's page is behind, not the recipe

Read live 2026-09-11: the What's New page's newest header is v7.32.0
(released 2026-08-31, page last edited 2026-09-01 01:22 UTC), while
`www.notion.so/desktop/mac/download` already 307s to
`Notion-7.33.0-universal.dmg`. The decoder reads the page correctly.

Fix: `acknowledgedStaleEntry: "7.32.0"`, the mechanism built for exactly this
(WorkBuddy intl, #88). It names the version rather than turning the check off,
so the complaint comes back the moment the page moves in either direction.
A test pins the acknowledged string to what the decoder reads off a live
capture, because the comparison is by exact string.

## Tests

- `extractsOllamaProseReleases`: real 2026-09-11 markup. v0.34.0 is prose-only;
  v0.33.0 has a prose paragraph before its bullets.
- `theAcknowledgedStaleEntryIsWhatThePageDecodesTo`: a trimmed live capture,
  with the titles verbatim, including the date line's non-breaking spaces.

**Mutations**: each one was run against the committed tree.

| Mutation | Test that went red |
| --- | --- |
| drop the paragraph fallback | `extractsOllamaProseReleases` |
| fallback keeps the compare-link line | `extractsOllamaProseReleases` |
| paragraphs tried before bullets | `extractsOllamaProseReleases` |
| Notion acknowledgement removed | `theAcknowledgedStaleEntryIsWhatThePageDecodesTo` |
| acknowledgement typed as `v7.32.0` | `theAcknowledgedStaleEntryIsWhatThePageDecodesTo` |
| generation left at 1 | `pinnedGeneration` |

## Validation

A full `make test` passed on the final tree:
- Core: 2578 tests, with 1 known issue.
- CLI: 265 tests.
- App: 9 of 9 cases executed.
- Every gate passed: localization, version-use, audits, engine notes, skill docs and prose claims.

Live `duo verify --only <id> --report`, run with a rebuilt `duo` (`make cli`) after the rebase:
- **Ollama:** changelog `0.34.0`, detected `0.34.0` (GitHub). Both ok, no warnings.
- **Notion:** changelog `7.32.0`, detected `7.33.0` (vendor). Both ok, no warnings, because the acknowledgement covers the gap.
