### PR TITLE
Let a TestFlight row settle on a rescan

### DIFF
--- a/App/Sources/ScanRowAssembly.swift
+++ b/App/Sources/ScanRowAssembly.swift
@@ -87,10 +87,22 @@ enum ScanRowAssembly {
                 return carrying(remote, UpdateChecker.evaluateToolbox(
                     cached: was.status, installed: app, remote: remote))
             }
-            // TestFlight owns its betas' status (its own cache, not a version
-            // compare) — keep it; don't re-evaluate.
-            guard remote.sourceName != "TestFlight" else {
-                return carrying(remote, was.status)
+            // A TestFlight row settles the way a check would answer it
+            // (`UpdateChecker.testFlightVerdict`), against the build the store named
+            // as the latest. TestFlight installs its betas itself, between our
+            // checks, and the kept verdict used to stand until the next full round:
+            // an update offered that was already installed, or "up to date" beside
+            // a copy TestFlight had moved past what its store knew (#478). A row
+            // the check refused to bound has no remote and kept its status above.
+            // The tester, sign-in and announcement signals are not read here; they
+            // can only take a verdict away, and the next round reads them.
+            if remote.sourceName == "TestFlight" {
+                guard let build = remote.version else { return carrying(remote, was.status) }
+                let verdict = UpdateChecker.testFlightVerdict(
+                    installed: app, latestShortVersion: remote.shortVersion, latestBuild: build)
+                return verdict == .testFlightManaged
+                    ? carrying(nil, .testFlightManaged)
+                    : carrying(remote, verdict)
             }
             return carrying(remote, UpdateChecker.evaluate(installed: app, remote: remote))
         }

--- a/App/Sources/ScanRowAssembly.swift
+++ b/App/Sources/ScanRowAssembly.swift
@@ -118,8 +118,9 @@ enum ScanRowAssembly {
     /// a refresh the user asked for found the TestFlight updates, and the
     /// scheduler's next tick, with nothing else in between, published the same
     /// list minus exactly those rows. So in such a round they are not checked;
-    /// they keep the row already on screen, which `merged` carried forward with
-    /// its status untouched (`keepsTestFlightRows`, from
+    /// they keep the row already on screen: the last check's verdict, which
+    /// `merged` re-derived against the build that check read if the copy on disk
+    /// has moved since (`keepsTestFlightRows`, from
     /// `RefreshIntent.keepsTestFlightVerdicts(fullDiskAccess:)`).
     ///
     /// Not a round without the grant: nothing can read the store then, so a kept

--- a/App/Tests/ScanRowAssemblyTests.swift
+++ b/App/Tests/ScanRowAssemblyTests.swift
@@ -197,31 +197,64 @@ struct ScanRowAssemblyTests {
         #expect(rows[0].effectiveReleaseChannel == .beta)
     }
 
-    /// TestFlight owns its betas' status — it comes from TestFlight's own cache,
-    /// not from a version compare — and the row's label carries the build,
-    /// because TF betas keep one marketing string across builds
-    /// (`UpdateChecker` builds "1.2 (345)" for exactly that reason). Re-deriving
-    /// it here would rewrite that label to a bare "1.2" on every FS-watcher
-    /// rescan.
-    ///
-    /// Mutations: delete the `guard remote.sourceName != "TestFlight"`; or
-    /// rebuild its return with `UpdateResult(app:remote:status:)`.
-    @Test func aTestFlightRowKeepsItsOwnStatusAndItsChannel() {
-        let app = InstalledApp(
+    // MARK: merge — TestFlight rows settle on a rescan
+
+    /// Invented path, like `planApp` below.
+    private func tfBeta(build: String) -> InstalledApp {
+        InstalledApp(
             name: "Beta", bundleID: "com.example.beta",
-            shortVersion: "1.2", buildVersion: "344",
-            path: URL(fileURLWithPath: Self.betaPath),
+            shortVersion: "1.2", buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/ZZFixture-Beta.app"),
             isMASApp: false, isToolboxManaged: false, isTestFlightApp: true,
             sparkleFeedURL: nil)
-        let cached = remote("1.2", channel: nil, source: "TestFlight", build: "345")
+    }
+    /// What the last check read from TestFlight's store: 1.2 (345) on offer.
+    private var tfOffer: RemoteVersion {
+        remote("1.2", channel: nil, source: "TestFlight", build: "345")
+    }
+
+    /// Nothing moved on disk: the offer stands, and so does the row's channel.
+    /// Mutation: rebuild the TestFlight branch's return with
+    /// `UpdateResult(app:remote:status:)` — the channel goes.
+    @Test func anUnmovedTestFlightRowKeepsItsOfferAndItsChannel() {
+        let app = tfBeta(build: "344")
         let prior = [UpdateResult(
-            app: app, remote: cached, status: .updateAvailable(latest: "1.2 (345)"),
+            app: app, remote: tfOffer, status: .updateAvailable(latest: "1.2"),
             provenChannel: .beta)]
 
         let rows = ScanRowAssembly.merged([app], prior: prior, proofs: noProofs)
 
-        #expect(rows[0].status == .updateAvailable(latest: "1.2 (345)"))
+        #expect(rows[0].status == .updateAvailable(latest: "1.2"))
         #expect(rows[0].effectiveReleaseChannel == .beta)
+    }
+
+    /// TestFlight installed the build it was offering, between our checks — it
+    /// does that on its own. The row must stop offering it. Mutation: carry
+    /// `was.status` as before — the row keeps offering 1.2 beside a copy that
+    /// already is 1.2 (345).
+    @Test func aTestFlightRowSettlesOnceTheOfferIsInstalled() {
+        let prior = [UpdateResult(
+            app: tfBeta(build: "344"), remote: tfOffer, status: .updateAvailable(latest: "1.2"))]
+
+        let rows = ScanRowAssembly.merged([tfBeta(build: "345")], prior: prior, proofs: noProofs)
+
+        #expect(rows[0].status == .upToDate)
+    }
+
+    /// TestFlight installed a build newer than the one its store named — the
+    /// #478 shape. The store cannot bound this copy, so neither the carried
+    /// "update available" nor the "up to date" a plain version compare gives a
+    /// copy ahead of its source may stand. Mutations: carry `was.status`; answer
+    /// through `UpdateChecker.evaluate`; keep the remote on the unbounded verdict
+    /// — each fails a line below.
+    @Test func aTestFlightRowAheadOfTheStoreIsNotCalledCurrent() {
+        let prior = [UpdateResult(
+            app: tfBeta(build: "344"), remote: tfOffer, status: .updateAvailable(latest: "1.2"))]
+
+        let rows = ScanRowAssembly.merged([tfBeta(build: "346")], prior: prior, proofs: noProofs)
+
+        #expect(rows[0].status == .testFlightManaged)
+        #expect(rows[0].remote == nil)
     }
 
     /// The ordinary path — a GitHub row whose verdict is re-derived against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **A TestFlight beta Duo Updater can't vouch for no longer looks up to date.** When TestFlight hasn't reported a beta's latest build, its row now shows a question mark instead of the same icon a current beta gets.
 
+**A TestFlight row catches up when TestFlight updates the beta by itself.** It kept offering the update TestFlight had just installed, or kept calling the beta up to date after TestFlight had moved it past what it last reported, until the next full check.
+
 **`duo` stops calling a TestFlight beta up to date when TestFlight has already announced a newer build.** The copy of TestFlight's data your Mac keeps only refreshes while the Mac is idle, so on a machine in use it can sit hours behind — and `duo check` was reading it and answering "up-to-date". Those rows read "testflight" now.
 
 **`duo`, the optional command-line companion, refreshes TestFlight without taking your screen.** `--refresh-testflight` did nothing at all when TestFlight was already open. It now runs a hidden copy of TestFlight and closes it again, whether or not you have one open — and a TestFlight you do have open is left alone.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker+TestFlightVerdict.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker+TestFlightVerdict.swift
@@ -4,9 +4,12 @@ extension UpdateChecker {
     /// A TestFlight row's verdict from the build TestFlight's store names as the
     /// latest, against the copy on disk. One function for the check (`check`'s
     /// TestFlight branch, after the gates that can refuse any verdict) and for a
-    /// rescan (`ScanRowAssembly.merged`), so the two cannot answer one copy
-    /// differently. The rescan used to keep whatever the last check said, and
-    /// TestFlight installs its betas itself between checks (#478).
+    /// rescan (`ScanRowAssembly.merged`), so the two compare the same way. Only
+    /// the check runs those gates: a rescan answers from the build the last check
+    /// read, and until the next round it can call a copy current that the check's
+    /// announcement witness would have refused. The rescan used to keep whatever
+    /// the last check said, and TestFlight installs its betas itself between
+    /// checks (#478).
     ///
     /// - `.testFlightManaged` when the installed build is newer than the store's
     ///   latest: whatever else is true, that latest is not an upper bound for this

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker+TestFlightVerdict.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker+TestFlightVerdict.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension UpdateChecker {
+    /// A TestFlight row's verdict from the build TestFlight's store names as the
+    /// latest, against the copy on disk. One function for the check (`check`'s
+    /// TestFlight branch, after the gates that can refuse any verdict) and for a
+    /// rescan (`ScanRowAssembly.merged`), so the two cannot answer one copy
+    /// differently. The rescan used to keep whatever the last check said, and
+    /// TestFlight installs its betas itself between checks (#478).
+    ///
+    /// - `.testFlightManaged` when the installed build is newer than the store's
+    ///   latest: whatever else is true, that latest is not an upper bound for this
+    ///   copy, so neither an update nor "up to date" may be claimed. The caller
+    ///   drops the remote, so a version called unusable is not the one shown.
+    /// - `.updateAvailable` when the store's latest is newer, labelled with its
+    ///   marketing version alone, even when it did not move: a beta that keeps its
+    ///   version across builds is the common case, and the row shows both builds
+    ///   through `UpdateResult.buildBump`, which only recognizes a build bump when
+    ///   `latest` IS the marketing version. A blank marketing version falls back to
+    ///   the build, so the row never names nothing.
+    /// - `.upToDate` otherwise.
+    ///
+    /// Compares `VersionSide` pairs, not bare build strings: a major version that
+    /// restarts build numbering (TestFlight allows it, since build uniqueness is
+    /// per marketing version) is still an update.
+    public static func testFlightVerdict(
+        installed app: InstalledApp, latestShortVersion: String?, latestBuild: String
+    ) -> UpdateStatus {
+        let marketing = latestShortVersion.flatMap { $0.isEmpty ? nil : $0 }
+        let installedSide = VersionSide(marketing: app.shortVersion, build: app.buildVersion)
+        let latestSide = VersionSide(marketing: marketing, build: latestBuild)
+        if VersionComparator.isNewer(installedSide, than: latestSide) { return .testFlightManaged }
+        return VersionComparator.isNewer(latestSide, than: installedSide)
+            ? .updateAvailable(latest: marketing ?? latestBuild)
+            : .upToDate
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -305,12 +305,13 @@ public struct UpdateChecker: Sendable {
                 // build-only `isNewer("500", "1")` read that as "the database
                 // cannot bound this app" and the row swallowed the update
                 // (`status = testFlightManaged`, remote nil).
-                let installedSide = VersionSide(
-                    marketing: app.shortVersion, build: app.buildVersion)
-                let latestSide = VersionSide(
-                    marketing: latest.latestShortVersion.isEmpty ? nil : latest.latestShortVersion,
-                    build: latest.latestBuild)
-                if VersionComparator.isNewer(installedSide, than: latestSide) {
+                // The comparison itself is `testFlightVerdict`, which a rescan runs
+                // too (`ScanRowAssembly.merged`), so the two cannot answer one copy
+                // differently.
+                let verdict = Self.testFlightVerdict(
+                    installed: app, latestShortVersion: latest.latestShortVersion,
+                    latestBuild: latest.latestBuild)
+                if verdict == .testFlightManaged {
                     Log.check.info("""
                         \(label, privacy: .public): TestFlight database holds \
                         \(latest.latestBuild, privacy: .public) but \
@@ -322,7 +323,7 @@ public struct UpdateChecker: Sendable {
                     // the one the row shows.
                     return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
                 }
-                let hasUpdate = VersionComparator.isNewer(latestSide, than: installedSide)
+                let hasUpdate = verdict != .upToDate
                 // Second witness, and it can only ever take the up-to-date verdict
                 // away. TestFlight announced a build whose id outruns everything this
                 // store holds, so — exactly as above — whatever else is true, the
@@ -343,27 +344,17 @@ public struct UpdateChecker: Sendable {
                     // we have just called unusable must not be the one the row shows.
                     return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
                 }
-                // The marketing version alone, even when it did not move. A beta
-                // that keeps its version across builds is the common case, and the
-                // row shows both builds through `UpdateResult.buildBump` — which
-                // only recognizes a build bump when `latest` IS the marketing
-                // version. Baking the build in here, as this used to, made the row
-                // show the new build and hide the installed one. A blank marketing
-                // version falls back to the build, so the row never names nothing.
-                let display = latest.latestShortVersion.isEmpty
-                    ? latest.latestBuild
-                    : latest.latestShortVersion
+                // The label is `testFlightVerdict`'s: the marketing version alone,
+                // even when it did not move — see there for why baking the build in
+                // hid the installed one.
                 let remote = RemoteVersion(
                     shortVersion: latest.latestShortVersion,
                     version: latest.latestBuild,
                     downloadURL: nil,
                     sourceName: "TestFlight",
                     requiresManualInstaller: true)
-                let status: UpdateStatus = hasUpdate
-                    ? .updateAvailable(latest: display)
-                    : .upToDate
                 Log.check.info("\(label, privacy: .public): TestFlight → \(latest.latestBuild, privacy: .public) (hasUpdate=\(hasUpdate, privacy: .public))")
-                return UpdateResult(app: app, remote: remote, status: status)
+                return UpdateResult(app: app, remote: remote, status: verdict)
             }
             Log.check.debug("\(label, privacy: .public): TestFlight-managed, no cached build")
             return UpdateResult(app: app, remote: nil, status: .testFlightManaged)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -306,8 +306,8 @@ public struct UpdateChecker: Sendable {
                 // cannot bound this app" and the row swallowed the update
                 // (`status = testFlightManaged`, remote nil).
                 // The comparison itself is `testFlightVerdict`, which a rescan runs
-                // too (`ScanRowAssembly.merged`), so the two cannot answer one copy
-                // differently.
+                // too (`ScanRowAssembly.merged`), so the two compare the same way.
+                // The gates above and the witness below are the check's alone.
                 let verdict = Self.testFlightVerdict(
                     installed: app, latestShortVersion: latest.latestShortVersion,
                     latestBuild: latest.latestBuild)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightVerdictTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightVerdictTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+@Suite("UpdateChecker.testFlightVerdict")
+struct TestFlightVerdictTests {
+    /// Invented path: the verdict reads versions only.
+    private func beta(_ short: String?, _ build: String?) -> InstalledApp {
+        InstalledApp(
+            name: "Beta", bundleID: "zz.fixture.beta", shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/ZZFixture-Beta.app"),
+            isMASApp: false, isTestFlightApp: true, sparkleFeedURL: nil)
+    }
+
+    /// A newer build on offer is an update, labelled with the marketing version
+    /// even though it did not move. Mutation: swap the sides of the second compare
+    /// — no update is ever offered.
+    @Test func aNewerBuildIsAnUpdate() {
+        #expect(UpdateChecker.testFlightVerdict(
+            installed: beta("1.2", "344"), latestShortVersion: "1.2", latestBuild: "345")
+            == .updateAvailable(latest: "1.2"))
+    }
+
+    /// Mutation: answer `.updateAvailable` for the last line instead of
+    /// `.upToDate` — a copy at the offered build keeps being offered it.
+    @Test func theBuildOnOfferIsCurrent() {
+        #expect(UpdateChecker.testFlightVerdict(
+            installed: beta("1.2", "345"), latestShortVersion: "1.2", latestBuild: "345")
+            == .upToDate)
+    }
+
+    /// An installed build newer than the store's latest cannot be bounded by it
+    /// (#478). Mutation: drop the first compare — this reads as up to date.
+    @Test func aCopyAheadOfTheStoreCannotBeBounded() {
+        #expect(UpdateChecker.testFlightVerdict(
+            installed: beta("1.2", "346"), latestShortVersion: "1.2", latestBuild: "345")
+            == .testFlightManaged)
+    }
+
+    /// Mutation: label with the marketing string unconditionally — the row names
+    /// an empty version.
+    @Test func aBlankMarketingVersionLabelsWithTheBuild() {
+        #expect(UpdateChecker.testFlightVerdict(
+            installed: beta(nil, "344"), latestShortVersion: "", latestBuild: "345")
+            == .updateAvailable(latest: "345"))
+    }
+
+    /// A major version that restarts build numbering is still an update.
+    /// Mutation: compare the builds alone — 500 beside 1 reads the copy as ahead
+    /// of the store, and the update is swallowed as unbounded.
+    @Test func aRestartedBuildNumberUnderANewVersionIsStillAnUpdate() {
+        #expect(UpdateChecker.testFlightVerdict(
+            installed: beta("1.0", "500"), latestShortVersion: "2.0", latestBuild: "1")
+            == .updateAvailable(latest: "2.0"))
+    }
+}


### PR DESCRIPTION
Part of #478: the rescan half.

## What was wrong

A rescan (the network-free `refreshLocal`, and the merge inside `performRefresh`) kept a TestFlight row's status exactly as the last check left it. TestFlight installs its betas by itself between our checks, so the row could stand wrong until the next full round:

| Last check said | TestFlight then installed | Row showed until the next round |
|---|---|---|
| update to 1.2 (345), 344 installed | 345 | still "update available" beside 345 |
| up to date, 345 installed | 346, which the store has not named | still "up to date" |

## The fix

- `UpdateChecker.testFlightVerdict` (Core) holds the comparison the check's TestFlight branch did inline: installed newer than the store's latest → `.testFlightManaged` (unbounded); latest newer → `.updateAvailable` labelled with the marketing version (the build when that is blank); otherwise `.upToDate`. It compares `VersionSide` pairs. The check calls it after its gates, with no behaviour change.
- `ScanRowAssembly.merged` answers a TestFlight row with the same function, against the build the store named. A copy ahead of it becomes unbounded and drops its remote, as a check does.

## What a rescan still does not do

- Rows the check refused to bound (signed out, not a tester, announcement witness, no Full Disk Access, no cached build) carry no remote, so a rescan keeps their status. The "?" without Full Disk Access stays a "?".
- The tester, sign-in and announcement signals are not re-read on a rescan. They can only take a verdict away, and the next round reads them.
- Cell 2 of #478 (the store is stale but happens to match the installed build) is not addressed. There is no reliable "last synced" signal to tell it apart from a genuinely current beta.

## Tests

- `TestFlightVerdictTests` (Core, 5): a newer build is an update; the offered build is current; a copy ahead is unbounded; a blank marketing version labels with the build; a restarted build number under a new version is still an update.
- `ScanRowAssemblyTests` (App): the old `aTestFlightRowKeepsItsOwnStatusAndItsChannel` asserted the bug. It is replaced by three: an unmoved row keeps its offer and channel; a row settles once the offer is installed; a row ahead of the store is unbounded with no remote.
- Mutations, all red, each on the case named for it: Core — swap the update compare, never up to date, drop the copy-ahead compare, label with the raw marketing string, compare builds alone; App — carry the old status (the pre-fix rule), answer through `evaluate`, keep the remote on the unbounded verdict, rebuild without `carriedForward`.
- `make test`: green through `scripts/run-with-hang-report.sh 1800 make test` (Core 2611 tests, App 265).
