### PR TITLE
Keep TestFlight betas' answers through Check Again and Refresh

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2140,16 +2140,6 @@ final class AppListModel {
         Log.app.info("refresh: start (scan + network check, intent=\(String(describing: intent), privacy: .public), testflight=\(allowTestFlight, privacy: .public), mayReadTestFlight=\(mayReadTestFlight, privacy: .public))")
         isRefreshing = true
         defer { isRefreshing = false }
-        // The refresh button, and only the button, also asks TestFlight to sync —
-        // in a hidden instance of our own; see `TestFlightRefresh`. Started first
-        // and awaited only after the network check, because its wait is long and
-        // unrelated to everything else here: a store that never moves holds it for
-        // the whole `TestFlightRefresh.defaultDeadline`. Awaited up front, that is
-        // how long the button would spin before the scan even began.
-        let testFlightSync: Task<TestFlightRefresh.Outcome, Never>? =
-            intent.refreshesTestFlight && mayReadTestFlight
-            ? Task.detached(priority: .utility) { await TestFlightRefresh().run() }
-            : nil
         // Once per session, before the scan: recover any app left at
         // `<App>.app.duoupdater-old` by a privileged swap that died mid-rename (a
         // power loss / force-quit on the non-admin install path). Restoring it here
@@ -2214,6 +2204,30 @@ final class AppListModel {
         let tfLoader: Task<TestFlightInventory, Never>? =
             allowTestFlight ? Task.detached(priority: .utility) { TestFlightInventory() } : nil
         if allowTestFlight { testFlightReadThisSession = true }
+
+        // The refresh button, and only the button, also asks TestFlight to sync —
+        // in a hidden instance of our own; see `TestFlightRefresh`. Started here,
+        // before the scan, and awaited only after the network check, because its
+        // wait is long and unrelated to everything else here: a store that never
+        // moves holds it for the whole `TestFlightRefresh.defaultDeadline`. Awaited
+        // up front, that is how long the button would spin before the scan began.
+        //
+        // But it does not start TestFlight until the read above has returned.
+        // Starting TestFlight rebuilds that store, and for a few seconds it names no
+        // beta as being tested — measured 2026-09-11 by sampling the tester query
+        // through a refresh: all of them, then none from about +1.2s, then all again
+        // by about +6.9s. This round's read used to race that window, and when it
+        // lost, every beta read "not testing" and showed "can't tell" until the
+        // re-check after the sync, some fourteen seconds later. Bounded like the
+        // round's own wait on that read, so a read that never returns cannot hold
+        // the sync, and with it the round, hostage.
+        let testFlightSync: Task<TestFlightRefresh.Outcome, Never>? =
+            intent.refreshesTestFlight && mayReadTestFlight
+            ? Task.detached(priority: .utility) { [tfLoader] in
+                if let tfLoader { _ = await Self.firstResult(of: tfLoader, within: .seconds(2)) }
+                return await TestFlightRefresh().run()
+            }
+            : nil
 
         // First scan with no TestFlight data → the list appears instantly, with no
         // wait on the prompt.

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2352,8 +2352,9 @@ final class AppListModel {
         // one — and only them, since nothing else reads that store. Tagging is
         // re-applied first because a wrapped iPhone/iPad app is recognized from the
         // store itself (#456), so a beta the sync just told us about is not yet a
-        // TestFlight row in `checkable`. Not `recheckMany`: that path is
-        // TestFlight-free on purpose, and would strip exactly those tags. The
+        // TestFlight row in `checkable`. Not `recheckMany`: it decides whether to
+        // read the store from the rows' tags and a scan taken without it, and
+        // exactly those betas carry neither yet. The
         // re-read is bounded like the first one, for the same reason — a read that
         // has not returned is a prompt that is still up.
         if let testFlightSync {
@@ -6419,20 +6420,20 @@ final class AppListModel {
     private func recheckMany(_ targets: [UpdateResult]) async -> [UpdateResult] {
         let ids = Set(targets.map(\.id))
         guard !ids.isEmpty else { return [] }
-        // Off-main and TestFlight-free: the post-install recheck must never block the
-        // UI on the TestFlight container's TCC gate. The next full refresh re-applies
-        // TestFlight tagging, so a single-app recheck just scans without it.
-        let testflight = TestFlightInventory(macRows: [], accessible: false)
         let toolbox = await Task.detached(priority: .userInitiated) { Self.toolboxInventory() }.value
         let githubToken = await githubTokenForRecheck()
         let bundles = targets.map(\.app.path)
-        let apps = await Task.detached(priority: .userInitiated) {
-            AppScanner(toolbox: toolbox, testflight: testflight).scan(bundlesAt: bundles)
+        // Scanned without TestFlight's store, which `ScanRowAssembly.recheck` reads
+        // afterwards and only for a TestFlight row — so a post-install recheck
+        // still never waits on that container's gate.
+        let scanned = await Task.detached(priority: .userInitiated) {
+            AppScanner(toolbox: toolbox, testflight: TestFlightInventory(macRows: [], accessible: false))
+                .scan(bundlesAt: bundles)
         }.value
         // Identity is the resolved path, which is what a row already carries, so
         // this normally admits everything. Kept as the guard it always was: a bundle
         // that now resolves elsewhere reads as gone, not as a row under another id.
-        let fresh = apps.filter { ids.contains($0.id) }
+        let fresh = scanned.filter { ids.contains($0.id) }
         guard !fresh.isEmpty else { return [] }
         // A recheck is the user insisting, so it must not be answered out of the
         // App Store page cache — for an iOS-on-Mac listing that page is the only
@@ -6444,19 +6445,48 @@ final class AppListModel {
         // must not force a live re-scrape of every OTHER App Store app too —
         // see `AppStorePageCache.invalidateAll`'s doc comment for the incident
         // this replaced. The checker drops the memo for exactly the array it
-        // is about to check — `fresh`, passed once — so the invalidated set and
-        // the checked set can no longer drift apart.
-        // No `announcements:` here on purpose, for the same reason `testflight` is
-        // the empty sentinel three lines up: this path is deliberately TestFlight-free
-        // so a post-install recheck never waits on that container's gate. The next
-        // full refresh re-applies both.
-        let checker = UpdateChecker(
-            sources: makeSources(token: githubToken),
-            maxConcurrency: prefs.maxConcurrency,
-            toolbox: ToolboxSource(inventory: toolbox),
-            testflight: testflight,
-            channelStore: ResolvedChannelStore.shared)
-        return await checker.check(fresh, freshening: true)
+        // is about to check — the apps `ScanRowAssembly.recheck` hands `check`,
+        // passed once — so the invalidated set and the checked set can no longer
+        // drift apart.
+        let sources = makeSources(token: githubToken)
+        let maxConcurrency = prefs.maxConcurrency
+        let (rows, kept) = await ScanRowAssembly.recheck(
+            targets, scanned: fresh,
+            mayRead: mayReadTestFlightStore,
+            read: {
+                await Self.firstResult(
+                    of: Task.detached(priority: .userInitiated) { TestFlightInventory() },
+                    within: .seconds(2))
+            },
+            proofs: ResolvedChannelStore.Snapshot(),
+            check: { apps, testflight in
+                // What qualifies that store's answer, read as
+                // `recheckTestFlightRowsOnce` reads it, so a recheck cannot call a
+                // beta current that a round would call unbounded. Neither is read
+                // unless the store was.
+                let announcements: TestFlightAnnouncements? = testflight.accessible
+                    ? await Self.firstResult(
+                        of: Task.detached(priority: .userInitiated) { TestFlightAnnouncements() },
+                        within: .seconds(2))
+                    : nil
+                let signedIn: Bool? = testflight.accessible ? await AppStoreSignIn.current() : nil
+                let checker = UpdateChecker(
+                    sources: sources,
+                    maxConcurrency: maxConcurrency,
+                    toolbox: ToolboxSource(inventory: toolbox),
+                    testflight: testflight,
+                    announcements: announcements,
+                    appStoreSignedIn: signedIn,
+                    channelStore: ResolvedChannelStore.shared)
+                return await checker.check(apps, freshening: true)
+            })
+        // Said out loud, because nothing else will: the caller logs a kept row's
+        // status next as if it were an answer, and on screen a kept row looks
+        // exactly like a checked one.
+        if !kept.isEmpty {
+            Log.app.notice("recheck: TestFlight's store did not open — kept \(kept.count, privacy: .public) TestFlight row(s) as they were: \(kept.map(\.app.name).joined(separator: ", "), privacy: .public)")
+        }
+        return rows
     }
 
     // MARK: - Failed checks

--- a/App/Sources/ScanRowAssembly.swift
+++ b/App/Sources/ScanRowAssembly.swift
@@ -150,4 +150,63 @@ enum ScanRowAssembly {
         }
         return (check, carried)
     }
+
+    /// A per-row recheck, from the rows it was handed and a fresh scan of their
+    /// bundles: the rows to put back, and which of them are TestFlight rows kept as
+    /// they were rather than checked.
+    ///
+    /// A TestFlight row is answered from TestFlight's store and nothing else
+    /// (`UpdateChecker`'s TestFlight branch), so checking one without reading the
+    /// store answers it from an empty one: "no cached build", on a row that had a
+    /// verdict. The recheck used to skip the read for every row, so Check Again on
+    /// a beta took its verdict away — measured 2026-09-11, `retry done: Amp →
+    /// testFlightManaged` 59 ms after the click, while the round 28s later read
+    /// its build from the same store, unchanged in between.
+    ///
+    /// So this does what a round does, in the round's order. The scan is taken
+    /// without the store. The store is read if any row is a TestFlight row — by its
+    /// old tag or by the scan's, since a copy can become one between checks — and
+    /// the grant allows it; `mayRead` is asked only then, because it probes the
+    /// disk and an install's recheck never has such a row. The scan is retagged
+    /// from what was read (`AppScanner.applyingTestFlightInventory`), since a
+    /// wrapped iPhone/iPad beta can be recognized from the store alone (#456), and
+    /// `check` is handed that store.
+    ///
+    /// When the read is allowed but does not come back open, the TestFlight rows
+    /// are kept rather than answered from the empty store — the answer this exists
+    /// to stop — as in a round that skips the store (`roundPlan`), and kept the way
+    /// that round keeps them: re-derived against the scan (`merged`), so a build
+    /// TestFlight has installed since is not still offered. Without the grant
+    /// nothing is kept, since nothing will ever read the store to refresh a kept
+    /// verdict; those rows are checked and say they cannot tell, as in a round
+    /// without it.
+    ///
+    /// On the main actor so `read` and `check` run where their caller formed them:
+    /// the app's are main-actor closures, and handing them to a nonisolated async
+    /// function does not compile under Swift 6. The slow work still happens off the
+    /// main thread, inside them.
+    @MainActor static func recheck(
+        _ rows: [UpdateResult], scanned: [InstalledApp],
+        mayRead: @autoclosure () -> Bool,
+        read: () async -> TestFlightInventory?,
+        proofs: some ChannelProofSource,
+        check: ([InstalledApp], TestFlightInventory) async -> [UpdateResult]
+    ) async -> (rows: [UpdateResult], kept: [UpdateResult]) {
+        let unread = TestFlightInventory(macRows: [], accessible: false)
+        let hasTestFlightRow = rows.contains(where: \.app.isTestFlightApp)
+            || scanned.contains(where: \.isTestFlightApp)
+        let reads = hasTestFlightRow && mayRead()
+        let opened = reads ? await read() : nil
+        let store = opened.flatMap { $0.accessible ? $0 : nil } ?? unread
+        let apps = store.accessible
+            ? AppScanner.applyingTestFlightInventory(store, to: scanned) : scanned
+        // Only a row that was a TestFlight row has a TestFlight verdict to keep. One
+        // whose copy became a beta since carries another source's verdict, which
+        // must not stand for a beta, so it is checked and says it cannot tell.
+        let wereTestFlight = Set(rows.filter(\.app.isTestFlightApp).map(\.id))
+        let plan = roundPlan(
+            apps, keepsTestFlightRows: reads && !store.accessible,
+            onScreen: merged(apps, prior: rows, proofs: proofs).filter { wereTestFlight.contains($0.id) })
+        return (await check(plan.check, store) + plan.carried, plan.carried)
+    }
 }

--- a/App/Tests/ScanRowAssemblyTests.swift
+++ b/App/Tests/ScanRowAssemblyTests.swift
@@ -356,3 +356,171 @@ extension ScanRowAssemblyTests {
         #expect(plan.carried.isEmpty)
     }
 }
+
+// MARK: - recheck: what a per-row recheck answers a TestFlight row from
+
+@MainActor
+extension ScanRowAssemblyTests {
+    /// A store that opened, offering 1.2 (345) for the beta — `tfOffer`'s build.
+    private var openStore: TestFlightInventory {
+        TestFlightInventory(macRows: [(bundleID: "com.example.beta", shortVersion: "1.2", build: "345")])
+    }
+
+    /// Records what `recheck` asked for, and answers each app from the store it
+    /// was handed: a build there is an offer, none is "no cached build". That is
+    /// the one respect in which `UpdateChecker`'s TestFlight branch matters here.
+    private final class Probe {
+        var grantAsked = 0
+        var reads = 0
+        var checked: [String] = []
+        var checkedApps: [InstalledApp] = []
+        func grant(_ granted: Bool) -> Bool {
+            grantAsked += 1
+            return granted
+        }
+        func check(_ apps: [InstalledApp], _ store: TestFlightInventory) -> [UpdateResult] {
+            checked += apps.map(\.id)
+            checkedApps += apps
+            return apps.map { app in
+                guard let build = store.latest(forBundleID: app.bundleID)?.latestBuild else {
+                    return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
+                }
+                return UpdateResult(app: app, remote: nil, status: .updateAvailable(latest: build))
+            }
+        }
+    }
+
+    private var offered: UpdateResult {
+        UpdateResult(app: tfBeta(build: "344"), remote: tfOffer, status: .updateAvailable(latest: "1.2"))
+    }
+
+    /// A wrapped iPhone/iPad beta that only the store recognizes (#456): there is
+    /// no receipt to read, so the scan taken without the store does not call it
+    /// one, while its row — from the last round that read the store — does.
+    /// Mutation: skip the retag (`? scanned : scanned`) — `check` is handed a copy
+    /// that is not a TestFlight app, which a real checker answers from the App
+    /// Store instead.
+    @Test func aWrappedBetaIsRetaggedFromTheStoreItRead() async {
+        let probe = Probe()
+        func wrapped(testFlight: Bool) -> InstalledApp {
+            InstalledApp(
+                name: "Wrapped", bundleID: "com.example.wrapped",
+                shortVersion: "2.0", buildVersion: "7",
+                path: URL(fileURLWithPath: "/Applications/ZZFixture-Wrapped.app"),
+                isMASApp: !testFlight, isiOSAppOnMac: true, isTestFlightApp: testFlight,
+                sparkleFeedURL: nil)
+        }
+        let store = TestFlightInventory(
+            macRows: [], installedIOSRows: [(bundleID: "com.example.wrapped", shortVersion: "2.0", build: "7")])
+        _ = await ScanRowAssembly.recheck(
+            [UpdateResult(app: wrapped(testFlight: true), remote: nil, status: .upToDate)],
+            scanned: [wrapped(testFlight: false)], mayRead: probe.grant(true),
+            read: { store }, proofs: noProofs, check: { probe.check($0, $1) })
+        #expect(probe.checkedApps.map(\.isTestFlightApp) == [true])
+    }
+
+    /// Check Again on a beta answers it from the store it read. Mutations: skip
+    /// the read — what the recheck did until 2026-09-11 — or hand `check` the
+    /// empty store; either way the beta is "no cached build".
+    @Test func checkAgainAnswersABetaFromTheStore() async {
+        let probe = Probe()
+        let (rows, kept) = await ScanRowAssembly.recheck(
+            [offered], scanned: [tfBeta(build: "344")], mayRead: probe.grant(true),
+            read: { probe.reads += 1; return self.openStore },
+            proofs: noProofs, check: { probe.check($0, $1) })
+        #expect(probe.reads == 1)
+        #expect(rows.map(\.status) == [.updateAvailable(latest: "345")])
+        #expect(kept.isEmpty)
+    }
+
+    /// Granted, but the store did not open — no answer in time, or one that never
+    /// got in: the beta is kept, not answered from nothing. Mutations: keep only
+    /// when the read returned nothing (`opened == nil`); check every scanned app
+    /// instead of `plan.check`; drop `+ plan.carried` — each fails a line below.
+    @Test func aRecheckWhoseReadFailedKeepsTheBeta() async {
+        for failed in [nil, TestFlightInventory(macRows: [], accessible: false)] {
+            let probe = Probe()
+            let (rows, kept) = await ScanRowAssembly.recheck(
+                [offered], scanned: [tfBeta(build: "344")], mayRead: probe.grant(true),
+                read: { failed }, proofs: noProofs, check: { probe.check($0, $1) })
+            #expect(probe.checked.isEmpty)
+            #expect(rows.map(\.status) == [.updateAvailable(latest: "1.2")])
+            #expect(kept.map(\.id) == [offered.id])
+        }
+    }
+
+    /// TestFlight installed the offered build since the last check, and the read
+    /// failed: the kept row settles against the copy on disk instead of still
+    /// offering it. Mutation: `onScreen: rows` — the row as it was, not re-derived
+    /// — and it offers 1.2 (345) beside a copy that is 1.2 (345).
+    @Test func aKeptBetaSettlesAgainstTheCopyOnDisk() async {
+        let probe = Probe()
+        let (rows, _) = await ScanRowAssembly.recheck(
+            [offered], scanned: [tfBeta(build: "345")], mayRead: probe.grant(true),
+            read: { nil }, proofs: noProofs, check: { probe.check($0, $1) })
+        #expect(rows.map(\.status) == [.upToDate])
+    }
+
+    /// An install's recheck never has a beta, and neither probes the grant nor
+    /// reads the store. Mutations: ask `mayRead` before the TestFlight-row test;
+    /// drop that test — each fails a line below.
+    @Test func aRecheckWithoutABetaAsksNothing() async {
+        let probe = Probe()
+        let plain = planApp("Plain", testFlight: false)
+        _ = await ScanRowAssembly.recheck(
+            [UpdateResult(app: plain, remote: nil, status: .upToDate)], scanned: [plain],
+            mayRead: probe.grant(true),
+            read: { probe.reads += 1; return self.openStore },
+            proofs: noProofs, check: { probe.check($0, $1) })
+        #expect(probe.grantAsked == 0)
+        #expect(probe.reads == 0)
+        #expect(probe.checked == [plain.id])
+    }
+
+    /// Without the grant the store is not read and the beta not kept: it is
+    /// checked, and says it cannot tell, as in a round without the grant.
+    /// Mutations: drop `mayRead` — the read runs where it cannot succeed
+    /// (`TCCPreflight.admitsOtherAppsData`); keep the beta anyway — a kept verdict
+    /// nothing will ever refresh.
+    @Test func withoutTheGrantABetaIsCheckedNotKept() async {
+        let probe = Probe()
+        let (rows, kept) = await ScanRowAssembly.recheck(
+            [offered], scanned: [tfBeta(build: "344")], mayRead: probe.grant(false),
+            read: { probe.reads += 1; return self.openStore },
+            proofs: noProofs, check: { probe.check($0, $1) })
+        #expect(probe.reads == 0)
+        #expect(rows.map(\.status) == [.testFlightManaged])
+        #expect(kept.isEmpty)
+    }
+
+    /// The row was not a beta at the last check; the copy on disk now is one,
+    /// because TestFlight replaced it. The store is still read. Mutation: decide
+    /// on the rows' old tags alone — the new beta is answered from an empty store,
+    /// the bug this path fixes, reached by another door.
+    @Test func aCopyThatBecameABetaReadsTheStore() async {
+        let probe = Probe()
+        let before = planApp("Beta", testFlight: false)
+        let (rows, _) = await ScanRowAssembly.recheck(
+            [UpdateResult(app: before, remote: nil, status: .upToDate)],
+            scanned: [tfBeta(build: "344")], mayRead: probe.grant(true),
+            read: { probe.reads += 1; return self.openStore },
+            proofs: noProofs, check: { probe.check($0, $1) })
+        #expect(probe.reads == 1)
+        #expect(rows.map(\.status) == [.updateAvailable(latest: "345")])
+    }
+
+    /// The same new beta when the read fails: its row carries another source's
+    /// verdict, which a kept row would pass off as the beta's. It is checked
+    /// instead, and says it cannot tell. Mutation: drop the `wereTestFlight`
+    /// filter — the row is kept, still "up to date" on the old source's word.
+    @Test func aCopyThatBecameABetaIsNotKeptOnAFailedRead() async {
+        let probe = Probe()
+        let before = planApp("Beta", testFlight: false)
+        let (rows, kept) = await ScanRowAssembly.recheck(
+            [UpdateResult(app: before, remote: nil, status: .upToDate)],
+            scanned: [tfBeta(build: "344")], mayRead: probe.grant(true),
+            read: { nil }, proofs: noProofs, check: { probe.check($0, $1) })
+        #expect(kept.isEmpty)
+        #expect(rows.map(\.status) == [.testFlightManaged])
+    }
+}

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -450,7 +450,7 @@ public enum Install {
     /// source re-query, which is the entire point of the re-check and must not be
     /// hoisted alongside the shared plumbing.
     ///
-    /// TestFlight-free for the same reason `recheckMany` is: this must never block
+    /// TestFlight-free: this must never block
     /// on TestFlight's local database, which lives behind the Sequoia app-data TCC
     /// gate — with nobody at a prompt mid-install that would hang the batch. The
     /// next full `duo check`/`duo install` re-applies TestFlight tagging from


### PR DESCRIPTION
Two ways a TestFlight beta's row turned into a question mark ("TestFlight hasn't told Duo Updater this beta's latest build yet") while TestFlight's store knew its build.

## 1. Check Again

Every per-row recheck (Check Again, un-ignore, channel switch, the install rechecks) handed the checker an empty TestFlight store on purpose, so a beta always came back "no cached build". The row stayed a question mark until the next full refresh.

`ScanRowAssembly.recheck` now does what a round does, in the round's order:
- The scan is taken without the store.
- The store is read when a row is a TestFlight row (by its old tag or the scan's) and Full Disk Access allows it. `mayRead` is an autoclosure, so install rechecks, which never have a beta, don't even probe the grant.
- The scan is retagged from what was read, since wrapped iPhone/iPad betas can be recognized from the store alone (#456).
- The rows are checked against that store, with the announcement and sign-in signals a round reads.

A read that doesn't come back open keeps the rows that were already TestFlight rows, re-derived against the copy on disk (`merged`), and logs it. `recheckMany` keeps only the wiring.

## 2. Refresh

The refresh button starts a hidden TestFlight so its store syncs. Launching TestFlight rebuilds the store, and for a few seconds the store names no beta as tested. Sampled through a refresh, the tester query went from all of them, to none from about +1.2 s, to all again by about +6.9 s. The round's own read of the store raced that window. When it lost, every beta read "not testing" until the post-sync re-check, about 14 s later.

The sync now waits for the round's read to return (bounded at 2 s) before it launches TestFlight. `duo check --refresh-testflight` already awaited the sync before reading, so the CLI is unaffected.

## Verification

- `make test`: exit 0. 2611 core tests, 265 CLI tests, `App tests — 23 of 23 cases executed`, `localizable keys agree`.
- Mutations: 13 one-line mutations of `ScanRowAssembly.recheck` were run. Each turned red exactly the case(s) whose comment names it, and the restored file passes.
- Real app: the installed binary was checked with `cmp` against this branch's Release build.
  - Check Again before the fix: `retry done: Amp → testFlightManaged`, 59 ms after the click. The sampler showed the store unchanged, and the next round read `Amp … TestFlight → 75`.
  - Check Again after the fix: `Amp … TestFlight → 75 (hasUpdate=true)`, then `retry done: Amp → updateAvailable(latest: "1.0")`.
  - Final build (16:10:51): `Amp … TestFlight → 75 (hasUpdate=false)` → `retry done: Amp → upToDate`. That's correct: TestFlight had installed Amp 1.0 (75) itself at 15:48:18, and the store marks that build installed.
  - Refresh before the fix (15:26): the first pass logged "not testing this beta" for all 7 betas; the post-sync re-check fixed them. The sampler at 15:43 showed a TestFlight pid appearing 0.2 s after the refresh started, and the tester rows hitting 0 at +1.2 s.
  - Refresh on the final build (16:10:55): the first pass got a real build for all 8 betas, with no "not testing" lines. The first answer was logged at 16:10:56.101, and TestFlight's pid appeared at 16:10:56.455, after the read. The tester rows then went to 0 at 16:10:56.799 and were back by 16:11:02.

## Not covered

- The wiring in `AppListModel` (`recheckMany` → `recheck`, and the order of the sync relative to the read) has no automated test. It was checked on the real app only.
- Check Again within a few seconds after clicking Refresh can still read a store mid-rebuild and show a question mark. This isn't a regression, since Check Again always gave that answer, and it was left as is on purpose.
- A wrapped iPhone/iPad beta that only the store recognizes, rechecked when the store read fails, is checked as an App Store copy. This predates the change; the scheduler's tick does the same.

## Release notes (draft for the next version)

**Check Again on a TestFlight beta now gives its real answer.** It used to turn the row into a question mark until the next refresh.

**Refresh no longer briefly shows every TestFlight beta as a question mark.**
