### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.2",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.52386.0",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -133,7 +133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
@@ -144,7 +144,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 497,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0,
@@ -154,7 +154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -163,7 +163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
@@ -172,7 +172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -181,7 +181,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-rc",
       "sweepsSinceComment" : 0
@@ -190,7 +190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -199,7 +199,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
@@ -210,7 +210,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 507,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0,
@@ -220,7 +220,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -229,7 +229,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -238,7 +238,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -247,7 +247,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -256,7 +256,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -265,7 +265,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -274,7 +274,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -283,7 +283,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
@@ -292,7 +292,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
@@ -301,7 +301,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -310,7 +310,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -319,7 +319,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -328,7 +328,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -337,7 +337,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -346,7 +346,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
@@ -355,7 +355,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -364,7 +364,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.137",
       "sweepsSinceComment" : 0
@@ -373,7 +373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -384,7 +384,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
@@ -394,7 +394,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "135.0.5973.123",
       "sweepsSinceComment" : 0
@@ -403,7 +403,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -412,7 +412,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -421,16 +421,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 30,
-      "lastGoodVersion" : "12.27.5",
+      "lastGoodVersion" : "12.27.6",
       "sweepsSinceComment" : 0
     },
     "changelog:com.qoder.app:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
@@ -441,7 +441,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0,
@@ -451,7 +451,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -460,7 +460,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -469,7 +469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
@@ -478,7 +478,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -487,7 +487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -496,7 +496,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -505,7 +505,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -516,7 +516,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0,
@@ -526,7 +526,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -535,7 +535,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -544,7 +544,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -553,7 +553,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -562,7 +562,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -571,7 +571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 10, 2026",
       "sweepsSinceComment" : 0
@@ -580,7 +580,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260909.1",
       "sweepsSinceComment" : 0
@@ -589,7 +589,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -598,7 +598,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -607,7 +607,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -616,7 +616,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -625,7 +625,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -636,7 +636,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -646,16 +646,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
-      "lastGoodVersion" : "5.5.4",
+      "lastGoodVersion" : "5.5.6",
       "sweepsSinceComment" : 0
     },
     "changelog:com.zarifpour.superconductor:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "8545a7d8",
       "sweepsSinceComment" : 0
@@ -664,7 +664,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -673,7 +673,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -682,7 +682,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
@@ -691,7 +691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
@@ -700,7 +700,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
@@ -709,7 +709,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
@@ -718,7 +718,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -727,7 +727,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -736,7 +736,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
@@ -745,7 +745,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -754,7 +754,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -763,7 +763,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
@@ -772,7 +772,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
@@ -783,7 +783,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 493,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0,
@@ -793,7 +793,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.7.0",
       "sweepsSinceComment" : 0
@@ -802,7 +802,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -811,7 +811,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -829,7 +829,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -838,7 +838,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
@@ -847,7 +847,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -856,7 +856,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -865,7 +865,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -874,7 +874,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -883,7 +883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -892,7 +892,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -901,7 +901,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 14,
       "lastGoodVersion" : "0.1.19",
       "sweepsSinceComment" : 0
@@ -910,7 +910,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "2.0.0",
       "sweepsSinceComment" : 0
@@ -919,7 +919,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
@@ -928,7 +928,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
@@ -936,7 +936,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -944,7 +944,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -952,7 +952,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -960,7 +960,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -968,7 +968,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -976,15 +976,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
-      "lastGoodVersion" : "11.16",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
+      "lastGoodVersion" : "11.17",
       "sweepsSinceComment" : 0
     },
     "github:IntelliScape\/caffeine:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -992,7 +992,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1000,7 +1000,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.3.10",
       "sweepsSinceComment" : 0
     },
@@ -1008,7 +1008,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -1016,7 +1016,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1024,7 +1024,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1032,7 +1032,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1040,7 +1040,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.135.06055",
       "sweepsSinceComment" : 0
     },
@@ -1048,7 +1048,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1056,7 +1056,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1064,7 +1064,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1072,7 +1072,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1080,7 +1080,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1088,7 +1088,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1096,7 +1096,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1104,7 +1104,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1112,7 +1112,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
@@ -1120,7 +1120,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1128,7 +1128,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1136,7 +1136,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1144,7 +1144,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1152,7 +1152,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1160,7 +1160,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1168,7 +1168,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1176,7 +1176,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1184,7 +1184,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1192,7 +1192,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1200,7 +1200,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1208,7 +1208,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1216,7 +1216,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1224,7 +1224,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1232,7 +1232,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1240,7 +1240,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1248,7 +1248,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1256,7 +1256,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1264,7 +1264,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1272,7 +1272,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.20.2",
       "sweepsSinceComment" : 0
     },
@@ -1280,7 +1280,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1288,7 +1288,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1296,7 +1296,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1304,7 +1304,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1312,15 +1312,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
-      "lastGoodVersion" : "1.1.18",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
+      "lastGoodVersion" : "1.1.19",
       "sweepsSinceComment" : 0
     },
     "github:godotengine\/godot:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1328,7 +1328,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1336,7 +1336,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1344,7 +1344,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1352,7 +1352,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1360,7 +1360,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1368,7 +1368,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1376,7 +1376,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1384,7 +1384,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1392,7 +1392,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1400,7 +1400,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1408,7 +1408,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1416,7 +1416,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1424,7 +1424,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1432,7 +1432,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -1440,7 +1440,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1448,7 +1448,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1456,7 +1456,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1464,7 +1464,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0
     },
@@ -1472,7 +1472,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.23.0",
       "sweepsSinceComment" : 0
     },
@@ -1480,7 +1480,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1488,15 +1488,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
-      "lastGoodVersion" : "0.0.41-nightly.20260911.1520",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
+      "lastGoodVersion" : "0.0.41-nightly.20260911.1533",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1504,7 +1504,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1512,7 +1512,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1520,7 +1520,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1528,7 +1528,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1536,7 +1536,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1544,7 +1544,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1552,7 +1552,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1560,7 +1560,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1568,7 +1568,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1576,7 +1576,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1584,7 +1584,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1592,7 +1592,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1600,7 +1600,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1608,7 +1608,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1616,7 +1616,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1624,7 +1624,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1632,7 +1632,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1662,7 +1662,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1670,7 +1670,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1678,7 +1678,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
@@ -1686,7 +1686,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
@@ -1694,7 +1694,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1834,7 +1834,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.9.9",
       "sweepsSinceComment" : 0
     },
@@ -1842,7 +1842,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1850,7 +1850,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1858,7 +1858,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1866,7 +1866,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1874,7 +1874,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1882,7 +1882,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1890,7 +1890,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1898,7 +1898,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1906,7 +1906,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.52386.0",
       "sweepsSinceComment" : 0
     },
@@ -1914,7 +1914,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1922,7 +1922,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.47.0",
       "sweepsSinceComment" : 0
     },
@@ -1930,7 +1930,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1938,7 +1938,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
@@ -1946,7 +1946,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1954,7 +1954,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1962,7 +1962,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1970,7 +1970,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1978,7 +1978,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1986,7 +1986,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.96.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1994,7 +1994,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.97.22.0",
       "sweepsSinceComment" : 0
     },
@@ -2002,7 +2002,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2010,7 +2010,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.125.1",
       "sweepsSinceComment" : 0
     },
@@ -2018,7 +2018,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
     },
@@ -2026,7 +2026,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2034,7 +2034,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2042,7 +2042,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2050,7 +2050,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.6.827",
       "sweepsSinceComment" : 0
     },
@@ -2058,7 +2058,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.9.19",
       "sweepsSinceComment" : 0
     },
@@ -2066,7 +2066,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2074,7 +2074,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2082,7 +2082,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2090,7 +2090,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "154.0.8037.17",
       "sweepsSinceComment" : 0
     },
@@ -2098,15 +2098,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
-      "lastGoodVersion" : "155.0.8051.0",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
+      "lastGoodVersion" : "155.0.8052.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.google.Chrome.dev:dev" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "155.0.8048.0",
       "sweepsSinceComment" : 0
     },
@@ -2114,7 +2114,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2122,7 +2122,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.111.1.839",
       "sweepsSinceComment" : 0
     },
@@ -2130,7 +2130,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2138,7 +2138,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.2.1 Canary 5",
       "sweepsSinceComment" : 0
     },
@@ -2146,7 +2146,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2154,7 +2154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2162,7 +2162,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.12.2",
       "sweepsSinceComment" : 0
     },
@@ -2170,7 +2170,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.559.2",
       "sweepsSinceComment" : 0
     },
@@ -2178,7 +2178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2186,7 +2186,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2194,7 +2194,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.0.1319",
       "sweepsSinceComment" : 0
     },
@@ -2202,7 +2202,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.0.260",
       "sweepsSinceComment" : 0
     },
@@ -2210,7 +2210,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "263.3889.65",
       "sweepsSinceComment" : 0
     },
@@ -2218,7 +2218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2226,7 +2226,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2234,7 +2234,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2244,7 +2244,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "9.5.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -2254,7 +2254,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2262,7 +2262,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2270,7 +2270,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
@@ -2278,7 +2278,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2286,7 +2286,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2294,7 +2294,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -2302,7 +2302,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2310,7 +2310,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2318,7 +2318,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.137.0",
       "sweepsSinceComment" : 0
     },
@@ -2326,7 +2326,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.138.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -2334,7 +2334,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2342,7 +2342,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "154.0.4258.9",
       "sweepsSinceComment" : 0
     },
@@ -2350,7 +2350,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "155.0.4268.0",
       "sweepsSinceComment" : 0
     },
@@ -2358,7 +2358,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "153.0.4234.32",
       "sweepsSinceComment" : 0
     },
@@ -2366,7 +2366,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2374,7 +2374,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2382,7 +2382,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2390,7 +2390,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2398,7 +2398,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.39.1",
       "sweepsSinceComment" : 0
     },
@@ -2406,7 +2406,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2414,7 +2414,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26.903.71938",
       "sweepsSinceComment" : 0
     },
@@ -2422,7 +2422,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "135.0.5973.123",
       "sweepsSinceComment" : 0
     },
@@ -2430,7 +2430,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2438,7 +2438,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2446,15 +2446,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
-      "lastGoodVersion" : "12.27.5",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
+      "lastGoodVersion" : "12.27.6",
       "sweepsSinceComment" : 0
     },
     "vendor:com.qoder.app:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2462,7 +2462,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2470,7 +2470,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.104.29",
       "sweepsSinceComment" : 0
     },
@@ -2478,7 +2478,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.3.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2486,7 +2486,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2494,7 +2494,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2502,7 +2502,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2510,7 +2510,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2518,7 +2518,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2526,7 +2526,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2534,7 +2534,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2542,7 +2542,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2552,7 +2552,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.2.8",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2561,7 +2561,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2571,7 +2571,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2580,7 +2580,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0
     },
@@ -2588,7 +2588,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2596,7 +2596,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2604,7 +2604,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2612,7 +2612,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2620,7 +2620,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2628,7 +2628,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2636,7 +2636,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2644,7 +2644,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.20.10",
       "sweepsSinceComment" : 0
     },
@@ -2652,7 +2652,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.21.2",
       "sweepsSinceComment" : 0
     },
@@ -2660,7 +2660,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "8.3.4157.3",
       "sweepsSinceComment" : 0
     },
@@ -2668,7 +2668,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2676,7 +2676,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2684,7 +2684,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2692,7 +2692,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2700,7 +2700,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2708,7 +2708,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2716,7 +2716,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2724,7 +2724,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.0.2.0",
       "sweepsSinceComment" : 0
     },
@@ -2732,7 +2732,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "8545a7d8",
       "sweepsSinceComment" : 0
     },
@@ -2740,7 +2740,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2748,7 +2748,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2756,7 +2756,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2764,7 +2764,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2772,7 +2772,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2780,7 +2780,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.2026.09.10.22.18.00",
       "sweepsSinceComment" : 0
     },
@@ -2788,7 +2788,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2796,7 +2796,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2804,7 +2804,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2812,7 +2812,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2026091001",
       "sweepsSinceComment" : 0
     },
@@ -2820,7 +2820,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2828,7 +2828,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2836,7 +2836,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2844,7 +2844,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2852,7 +2852,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.103.219",
       "sweepsSinceComment" : 0
     },
@@ -2860,7 +2860,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2868,7 +2868,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2876,7 +2876,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2884,7 +2884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2892,7 +2892,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26.36.21",
       "sweepsSinceComment" : 0
     },
@@ -2900,7 +2900,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
@@ -2908,7 +2908,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2916,7 +2916,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.2.6",
       "sweepsSinceComment" : 0
     },
@@ -2924,7 +2924,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2932,7 +2932,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2940,23 +2940,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
+      "infraSince" : "2026-09-11T08:20:44Z",
       "lastGoodAt" : "2026-09-11T02:23:53Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 0
+      "sweepsSinceComment" : 1
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2964,7 +2965,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2972,7 +2973,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2980,7 +2981,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2988,7 +2989,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2996,7 +2997,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "158.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3004,7 +3005,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "157.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3012,7 +3013,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -3020,7 +3021,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -3028,7 +3029,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -3036,7 +3037,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3044,7 +3045,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3052,7 +3053,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3060,7 +3061,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "8.28.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -3068,7 +3069,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "8.27.0",
       "sweepsSinceComment" : 0
     },
@@ -3078,7 +3079,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "10.0.2",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -3087,7 +3088,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3095,11 +3096,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T02:23:53Z",
+      "lastGoodAt" : "2026-09-11T08:20:44Z",
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-11T02:23:54Z"
+  "updatedAt" : "2026-09-11T08:20:45Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.