### PR TITLE
Move BrewFormulaService's blocking brew reads off the actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.92
+
+Under the hood: the Homebrew list in the menu fills in faster.
+
 ## 0.3.91
 
 **Check Again on a TestFlight beta now gives its real answer.** It used to turn the row into a question mark until the next refresh.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaService.swift
@@ -159,12 +159,12 @@ public actor BrewFormulaService {
         // whole Process spawn/read/wait ran synchronously on this actor — so the
         // second `async let` could not even begin until the first one returned.
         // This comment used to claim the two reads ran concurrently; they did not.
-        // Measured on this machine under load (one sample, not a proof — just the
-        // shape of the effect): calling `outdated()` then `outdatedCasks()` in
-        // sequence on this actor and calling them as an `async let` pair on the
-        // un-hopped actor both landed around the same latency, while running the
-        // identical two `brew` commands on separate Dispatch threads was
-        // meaningfully faster.
+        // Measured 2026-09-11, during review of this fix, against the real
+        // (pre-fix) BrewFormulaService on a 14-core M3 Max under heavy load
+        // (1-minute load average 10-20): two reads on the un-hopped actor took
+        // 1357-1439 ms whether called in sequence or as an `async let` pair — i.e.
+        // the pair bought nothing — while the identical two `brew` commands run on
+        // two separate Dispatch threads took 760-783 ms.
         async let leafNames = runReading(["leaves"])
         async let versionList = runReading(["list", "--formula", "--versions"])
 
@@ -267,7 +267,16 @@ public actor BrewFormulaService {
         process.environment = env
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()  // swallow stderr noise
+        // nullDevice, not Pipe(): an undrained stderr pipe deadlocks once its
+        // 64KB buffer fills — brew blocks writing (a long run of deprecation
+        // warnings or a Ruby backtrace is enough), we block forever in the
+        // `readDataToEndOfFile()` below waiting on stdout, which brew never
+        // reaches. Same failure shape as `AppListModel.runningBuildVersions`'s
+        // `lsappinfo` call, which documents it at the call site. `offCooperativePool`
+        // is not cancellable, so this would leak a Dispatch thread and a wedged
+        // `brew` process — and since this is what the Brew tree loads on, the
+        // menu's Brew list would simply never finish loading.
+        process.standardError = FileHandle.nullDevice
         try process.run()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaService.swift
@@ -61,7 +61,35 @@ public struct BrewInstalledFormula: Sendable, Identifiable, Equatable {
 /// real latest even if the pre-count was conservative.
 public actor BrewFormulaService {
 
-    public init() {}
+    /// A read-only `brew` invocation, factored out so tests can control timing and
+    /// outcomes without spawning a real subprocess or asking the host whether
+    /// Homebrew is installed. `nil` means "no brew" (never throws for that case), a
+    /// thrown error means the process itself couldn't start (mirrors
+    /// `Process.run()` throwing), and a returned tuple is the definite outcome —
+    /// the *caller* decides what a nonzero `status` means (an error for
+    /// `outdated()`, an empty read for `runReading`).
+    ///
+    /// `HomebrewInstaller.brewPath()` lives INSIDE `realExecutor` below, not in
+    /// `outdated()` / `installedLeaves()` / `outdatedCasks()` themselves — those
+    /// three used to each ask it directly before running the subprocess, which
+    /// would leave a fake executor unable to answer "no brew" on its own and would
+    /// leave a test for "did the two reads overlap" quietly asking the real host
+    /// underneath its own fixture. See CLAUDE.md "测试不能问宿主".
+    typealias Executor = @Sendable ([String]) throws -> (status: Int32, stdout: Data)?
+
+    private let executor: Executor
+
+    public init() {
+        self.executor = Self.realExecutor
+    }
+
+    /// Test seam — not public, this is a harness detail. `BrewFormulaServiceTests`
+    /// injects a fake executor to control timing and outcomes deterministically,
+    /// instead of depending on Homebrew being installed and on real wall-clock
+    /// subprocess latency.
+    init(executor: @escaping Executor) {
+        self.executor = executor
+    }
 
     public enum BrewError: LocalizedError {
         case brewNotFound
@@ -86,33 +114,26 @@ public actor BrewFormulaService {
     /// Returns an empty list (never throws) when brew is absent or nothing is
     /// outdated, so a missing/clean machine simply shows no row.
     public func outdated() async throws -> [BrewOutdatedFormula] {
-        guard let brew = HomebrewInstaller.brewPath() else { return [] }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: brew)
         // --formula: casks are HomebrewCaskSource's job. --json=v2: stable schema.
-        process.arguments = ["outdated", "--formula", "--json=v2"]
-        // Never let a check trigger an implicit `brew update` (slow, writes the
-        // user's tap). Keep it a pure read of the local state.
-        var env = ProcessInfo.processInfo.environmentWithSystemProxy
-        env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
-        env["HOMEBREW_NO_ENV_HINTS"] = "1"
-        process.environment = env
+        // `HOMEBREW_NO_AUTO_UPDATE=1` (set inside `realExecutor`) keeps this a pure
+        // read of local state — never an implicit `brew update`.
+        //
+        // The spawn/read/wait happens inside `executor`, off this actor via
+        // `offCooperativePool` — doing that sequence directly here would occupy one
+        // of the cooperative pool's few threads for the whole subprocess. See
+        // `offCooperativePool`'s doc comment for why that matters.
+        let exec = executor
+        let outcome = try await offCooperativePool({
+            try exec(["outdated", "--formula", "--json=v2"])
+        })
+        guard let outcome else { return [] }
 
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()  // swallow stderr noise
-
-        try process.run()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard process.terminationStatus == 0 else {
-            let text = String(data: data, encoding: .utf8) ?? ""
-            throw BrewError.failed(code: process.terminationStatus, output: text)
+        guard outcome.status == 0 else {
+            let text = String(data: outcome.stdout, encoding: .utf8) ?? ""
+            throw BrewError.failed(code: outcome.status, output: text)
         }
 
-        return Self.parse(data)
+        return Self.parse(outcome.stdout)
     }
 
     /// Fast local inventory: top-level installed formulae (`brew leaves`) with their
@@ -128,10 +149,22 @@ public actor BrewFormulaService {
     /// transitive packages brew installs to satisfy others would bury the list, and
     /// the user only cares about what they asked for (the analog of "apps you have").
     public func installedLeaves() async throws -> [BrewInstalledFormula] {
-        guard HomebrewInstaller.brewPath() != nil else { return [] }
-
-        // The two reads are independent and each spawns a brew subprocess, so run
-        // them concurrently rather than serializing the latency.
+        // The two reads are independent and each spawns a brew subprocess, and they
+        // genuinely overlap now that `runReading` hops off the actor for the
+        // blocking part (see `offCooperativePool`): the `await` inside it is a real
+        // suspension point, so this actor is free to start the second `async let`
+        // while the first's subprocess is still running.
+        //
+        // Before that hop, `runReading`'s body had no suspension point at all — the
+        // whole Process spawn/read/wait ran synchronously on this actor — so the
+        // second `async let` could not even begin until the first one returned.
+        // This comment used to claim the two reads ran concurrently; they did not.
+        // Measured on this machine under load (one sample, not a proof — just the
+        // shape of the effect): calling `outdated()` then `outdatedCasks()` in
+        // sequence on this actor and calling them as an `async let` pair on the
+        // un-hopped actor both landed around the same latency, while running the
+        // identical two `brew` commands on separate Dispatch threads was
+        // meaningfully faster.
         async let leafNames = runReading(["leaves"])
         async let versionList = runReading(["list", "--formula", "--versions"])
 
@@ -191,10 +224,40 @@ public actor BrewFormulaService {
     }
 
     /// Run a read-only `brew` subcommand and return stdout, never triggering an
-    /// implicit `brew update`. Returns "" on any failure — the callers treat a
-    /// missing read as "nothing to show" rather than surfacing an error.
+    /// implicit `brew update`. Returns "" on any failure — no brew, the process
+    /// failing to start, or a nonzero exit — the callers treat a missing read as
+    /// "nothing to show" rather than surfacing an error.
+    ///
+    /// The spawn/read/wait happens inside `executor`, off this actor via
+    /// `offCooperativePool`. That suspension point is also what lets two
+    /// `runReading` calls (the `async let` pair in `installedLeaves()`) genuinely
+    /// overlap instead of serializing behind this actor — see the comment there.
     private func runReading(_ arguments: [String]) async -> String {
-        guard let brew = HomebrewInstaller.brewPath() else { return "" }
+        let exec = executor
+        let outcome: (status: Int32, stdout: Data)?
+        do {
+            outcome = try await offCooperativePool({ try exec(arguments) })
+        } catch {
+            return ""
+        }
+        guard let outcome, outcome.status == 0 else { return "" }
+        return String(data: outcome.stdout, encoding: .utf8) ?? ""
+    }
+
+    /// The real `Executor`: locate `brew`, spawn it read-only (never an implicit
+    /// `brew update`), and block until it exits.
+    ///
+    /// This is the ONLY place that calls `HomebrewInstaller.brewPath()` for the
+    /// three read paths in this actor — keeping that check out of `outdated()` /
+    /// `installedLeaves()` / `outdatedCasks()` themselves is what lets a fake
+    /// `Executor` answer "no brew" on its own, without a test asking the actual
+    /// host underneath its own fixture.
+    ///
+    /// Always runs off the actor: called only from inside `offCooperativePool` (in
+    /// `outdated()` and `runReading`), never directly from actor-isolated code —
+    /// this function itself blocks synchronously.
+    private static func realExecutor(_ arguments: [String]) throws -> (status: Int32, stdout: Data)? {
+        guard let brew = HomebrewInstaller.brewPath() else { return nil }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: brew)
         process.arguments = arguments
@@ -204,16 +267,11 @@ public actor BrewFormulaService {
         process.environment = env
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
-        do {
-            try process.run()
-        } catch {
-            return ""
-        }
+        process.standardError = Pipe()  // swallow stderr noise
+        try process.run()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        guard process.terminationStatus == 0 else { return "" }
-        return String(data: data, encoding: .utf8) ?? ""
+        return (process.terminationStatus, data)
     }
 
     /// Outdated casks that install **no app** — the ones nothing else covers. See
@@ -222,8 +280,11 @@ public actor BrewFormulaService {
     ///
     /// Non-greedy on purpose: `--greedy` would pull in `auto_updates` casks, whose
     /// update channel is the app's own updater, not brew.
+    ///
+    /// No direct `HomebrewInstaller.brewPath()` check here — `runReading` asks the
+    /// executor, the one seam a test can control (see `Executor`); an absent brew
+    /// reaches this the same way any other empty read does, via `output == ""`.
     public func outdatedCasks() async throws -> [BrewOutdatedFormula] {
-        guard HomebrewInstaller.brewPath() != nil else { return [] }
         let output = await runReading(["outdated", "--cask", "--json=v2"])
         guard let data = output.data(using: .utf8) else { return [] }
         return Self.parseCasks(data).filter { !Self.installsAnApp(caskToken: $0.name) }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaServiceTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaServiceTests.swift
@@ -35,16 +35,27 @@ import Foundation
     /// overlap of the two `brew` calls, not cooperative scheduling.
     ///
     /// Per CLAUDE.md "并行套件里墙钟上界不成立": this asserts overlap happened
-    /// (`observedMaxInFlight`), not how fast it happened. The `timeout` only
-    /// bounds how long a broken (serialized) run waits before giving up — it is
-    /// not a performance assertion.
+    /// (`observedMaxInFlight`), not how fast it happened. `timeout` only bounds
+    /// how long a broken (serialized) run waits before giving up — it is not a
+    /// performance assertion, so it is set generously (60s), not tightly.
+    ///
+    /// On the healthy path the second caller arrives almost immediately (both
+    /// `async let` child tasks start right away, and `arrive()` returns the
+    /// moment the second one calls in), so this test does not normally pay
+    /// anywhere near the full timeout. But a passing run CAN legitimately take
+    /// seconds to get there: the second child task still needs a cooperative-pool
+    /// thread before it can even reach its own call into the gate, and this repo
+    /// has measured 0.5-6.4s of pool-admission / Dispatch wait on a 3-core CI
+    /// runner when ~2550 tests are running concurrently in one process (see
+    /// CLAUDE.md "并行套件里墙钟上界不成立"). A short timeout would read that
+    /// scheduling delay as "never overlapped" and fail a correct implementation.
     final class TwoWayGate: @unchecked Sendable {
         private let condition = NSCondition()
         private var arrivedCount = 0
         private var inFlight = 0
         private var maxInFlight = 0
 
-        func arrive(timeout: TimeInterval = 5) {
+        func arrive(timeout: TimeInterval = 60) {
             condition.lock()
             inFlight += 1
             maxInFlight = max(maxInFlight, inFlight)
@@ -192,7 +203,21 @@ import Foundation
     /// result out. `zzfixture-cli` has no staged `.app`/`.pkg` anywhere real (it
     /// doesn't exist), so it passes the filter; the parser/filter behavior itself
     /// is covered in depth by `BrewOutdatedCaskTests`.
+    ///
+    /// The fake `Executor` above only replaces the `brew` subprocess half of
+    /// `outdatedCasks()` — the filter half, `installsAnApp(caskToken:)`, reads the
+    /// REAL Caskroom via `BrewLocalInventory.defaultCaskroomPaths` directly off
+    /// disk, with no executor seam. So an invented-sounding fixture name is not
+    /// enough by itself (CLAUDE.md "测试不能问宿主": a name that merely LOOKS
+    /// fictitious but happens to collide with something real on some machine is
+    /// exactly the "implicitly asking the host" shape). Assert up front, as a gate
+    /// that fails loudly rather than a comment that can rot, that this name is not
+    /// staged in any real Caskroom this test would actually read.
     @Test func outdatedCasksParsesAndFiltersASuccessfulResponse() async throws {
+        for root in BrewLocalInventory.defaultCaskroomPaths {
+            #expect(!FileManager.default.fileExists(atPath: root + "/zzfixture-cli"))
+        }
+
         let payload = Data("""
         {"formulae":[],"casks":[
           {"name":"zzfixture-cli","installed_versions":["0.1.0"],

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaServiceTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaServiceTests.swift
@@ -1,0 +1,211 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `BrewFormulaService`'s three read paths (`outdated()`, `installedLeaves()` via
+/// `runReading`, `outdatedCasks()` via `runReading`) used to run the blocking
+/// `Process.run()` → `readDataToEndOfFile()` → `waitUntilExit()` sequence directly
+/// on the actor. That has two consequences pinned here:
+///
+/// 1. It violates CLAUDE.md "别在协作池上做阻塞调用" — a synchronous call on the
+///    actor occupies one of the cooperative pool's few threads for the whole
+///    subprocess.
+/// 2. It defeated `installedLeaves()`'s `async let` pair: with no suspension point
+///    inside `runReading`, the actor could not even start the second read until the
+///    first one's subprocess had exited, so the two `brew` calls always ran
+///    serially despite the "run them concurrently" comment.
+///
+/// All tests here go through the internal `init(executor:)` seam instead of a real
+/// `brew` subprocess, per CLAUDE.md "测试不能问宿主" — a fake executor answers "no
+/// brew" / "throws" / "nonzero exit" on cue, deterministically, without depending
+/// on whether Homebrew happens to be installed on whatever machine runs this.
+///
+/// Fixture formula/cask names are fictitious (`zzfixture-*`) — never a name that
+/// might really be installed — for the same reason.
+@Suite struct BrewFormulaServiceTests {
+
+    // MARK: - Overlap (the core regression)
+
+    /// A synchronization gate a fake `Executor` calls into. `arrive()` blocks the
+    /// calling thread until a second caller has also arrived (or `timeout`
+    /// elapses), and records the highest number of callers that were ever inside
+    /// the gate at once. This is deliberately built on locks, not Swift
+    /// concurrency: the `Executor` closure is a plain synchronous function (it
+    /// can't `await`), and the whole point is to observe REAL thread-level
+    /// overlap of the two `brew` calls, not cooperative scheduling.
+    ///
+    /// Per CLAUDE.md "并行套件里墙钟上界不成立": this asserts overlap happened
+    /// (`observedMaxInFlight`), not how fast it happened. The `timeout` only
+    /// bounds how long a broken (serialized) run waits before giving up — it is
+    /// not a performance assertion.
+    final class TwoWayGate: @unchecked Sendable {
+        private let condition = NSCondition()
+        private var arrivedCount = 0
+        private var inFlight = 0
+        private var maxInFlight = 0
+
+        func arrive(timeout: TimeInterval = 5) {
+            condition.lock()
+            inFlight += 1
+            maxInFlight = max(maxInFlight, inFlight)
+            arrivedCount += 1
+            condition.broadcast()
+            let deadline = Date().addingTimeInterval(timeout)
+            while arrivedCount < 2 {
+                if !condition.wait(until: deadline) { break }
+            }
+            inFlight -= 1
+            condition.unlock()
+        }
+
+        var observedMaxInFlight: Int {
+            condition.lock()
+            defer { condition.unlock() }
+            return maxInFlight
+        }
+    }
+
+    /// Canned stdout for the two `installedLeaves()` subcommands.
+    private static func leavesOutput() -> Data { Data("zzfixture-alpha\nzzfixture-beta\n".utf8) }
+    private static func versionsOutput() -> Data {
+        Data("zzfixture-alpha 1.0.0\nzzfixture-beta 2.0.0\n".utf8)
+    }
+
+    @Test func installedLeavesReadsGenuinelyOverlap() async throws {
+        let gate = TwoWayGate()
+        let service = BrewFormulaService(executor: { arguments in
+            gate.arrive()
+            if arguments == ["leaves"] {
+                return (0, Self.leavesOutput())
+            } else if arguments == ["list", "--formula", "--versions"] {
+                return (0, Self.versionsOutput())
+            }
+            Issue.record("unexpected arguments: \(arguments)")
+            return (1, Data())
+        })
+
+        let result = try await service.installedLeaves()
+
+        // The two subprocess calls were both in flight at the same time — the
+        // thing that was NOT true before the actor hop, when the second could not
+        // start until the first's `Process` had already exited.
+        #expect(gate.observedMaxInFlight == 2)
+
+        #expect(result.map(\.name) == ["zzfixture-alpha", "zzfixture-beta"])
+        #expect(result.first { $0.name == "zzfixture-alpha" }?.installedVersion == "1.0.0")
+        #expect(result.first { $0.name == "zzfixture-beta" }?.installedVersion == "2.0.0")
+        #expect(result.allSatisfy { $0.availableVersion == nil })
+    }
+
+    // MARK: - Behavior preserved: outdated()
+
+    @Test func outdatedReturnsEmptyWhenBrewIsAbsent() async throws {
+        let service = BrewFormulaService(executor: { _ in nil })
+        let result = try await service.outdated()
+        #expect(result.isEmpty)
+    }
+
+    private struct FakeSpawnFailure: Error {}
+
+    /// "process.run() 抛错 → 现在是向上抛(别吞掉)" — `outdated()` must propagate,
+    /// not swallow, an executor throw.
+    @Test func outdatedPropagatesASpawnFailure() async throws {
+        let service = BrewFormulaService(executor: { _ in throw FakeSpawnFailure() })
+        await #expect(throws: FakeSpawnFailure.self) {
+            _ = try await service.outdated()
+        }
+    }
+
+    @Test func outdatedThrowsFailedOnNonzeroExit() async throws {
+        let service = BrewFormulaService(executor: { _ in
+            (7, Data("Error: zzfixture-broken: no such tap".utf8))
+        })
+        do {
+            _ = try await service.outdated()
+            Issue.record("expected outdated() to throw BrewError.failed")
+        } catch BrewFormulaService.BrewError.failed(let code, let output) {
+            #expect(code == 7)
+            #expect(output.contains("zzfixture-broken"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func outdatedParsesASuccessfulResponse() async throws {
+        let payload = Data("""
+        {"formulae":[{"name":"zzfixture-alpha","installed_versions":["1.0.0"],
+         "current_version":"1.1.0","pinned":false}],"casks":[]}
+        """.utf8)
+        let service = BrewFormulaService(executor: { arguments in
+            #expect(arguments == ["outdated", "--formula", "--json=v2"])
+            return (0, payload)
+        })
+        let result = try await service.outdated()
+        #expect(result.count == 1)
+        #expect(result.first?.name == "zzfixture-alpha")
+        #expect(result.first?.installedVersion == "1.0.0")
+        #expect(result.first?.currentVersion == "1.1.0")
+    }
+
+    // MARK: - Behavior preserved: runReading (via installedLeaves / outdatedCasks)
+
+    @Test func installedLeavesReturnsEmptyWhenBrewIsAbsent() async throws {
+        let service = BrewFormulaService(executor: { _ in nil })
+        let result = try await service.installedLeaves()
+        #expect(result.isEmpty)
+    }
+
+    /// `runReading` swallows an executor throw into `""` — unlike `outdated()`,
+    /// which must propagate it. A thrown spawn failure on either subcommand must
+    /// not surface as a thrown error from `installedLeaves()`.
+    @Test func installedLeavesSwallowsASpawnFailure() async throws {
+        let service = BrewFormulaService(executor: { _ in throw FakeSpawnFailure() })
+        let result = try await service.installedLeaves()
+        #expect(result.isEmpty)
+    }
+
+    @Test func installedLeavesTreatsNonzeroExitAsEmpty() async throws {
+        let service = BrewFormulaService(executor: { _ in (1, Data("boom".utf8)) })
+        let result = try await service.installedLeaves()
+        #expect(result.isEmpty)
+    }
+
+    @Test func outdatedCasksReturnsEmptyWhenBrewIsAbsent() async throws {
+        let service = BrewFormulaService(executor: { _ in nil })
+        let result = try await service.outdatedCasks()
+        #expect(result.isEmpty)
+    }
+
+    @Test func outdatedCasksSwallowsASpawnFailure() async throws {
+        let service = BrewFormulaService(executor: { _ in throw FakeSpawnFailure() })
+        let result = try await service.outdatedCasks()
+        #expect(result.isEmpty)
+    }
+
+    @Test func outdatedCasksTreatsNonzeroExitAsEmpty() async throws {
+        let service = BrewFormulaService(executor: { _ in (1, Data("boom".utf8)) })
+        let result = try await service.outdatedCasks()
+        #expect(result.isEmpty)
+    }
+
+    /// End-to-end wiring for the cask path: JSON in, filtered-by-`installsAnApp`
+    /// result out. `zzfixture-cli` has no staged `.app`/`.pkg` anywhere real (it
+    /// doesn't exist), so it passes the filter; the parser/filter behavior itself
+    /// is covered in depth by `BrewOutdatedCaskTests`.
+    @Test func outdatedCasksParsesAndFiltersASuccessfulResponse() async throws {
+        let payload = Data("""
+        {"formulae":[],"casks":[
+          {"name":"zzfixture-cli","installed_versions":["0.1.0"],
+           "current_version":"0.2.0","pinned":false,"pinned_version":null}
+        ]}
+        """.utf8)
+        let service = BrewFormulaService(executor: { arguments in
+            #expect(arguments == ["outdated", "--cask", "--json=v2"])
+            return (0, payload)
+        })
+        let result = try await service.outdatedCasks()
+        #expect(result.count == 1)
+        #expect(result.first?.name == "zzfixture-cli")
+        #expect(result.first?.kind == .cask)
+    }
+}


### PR DESCRIPTION
## Problem

`BrewFormulaService`'s three read paths — `outdated()`, and `runReading` (used by
`installedLeaves()` and `outdatedCasks()`) — ran the blocking
`Process.run()` -> `readDataToEndOfFile()` -> `waitUntilExit()` sequence
synchronously **on the actor**. Two consequences:

1. Violates the repo's "don't block on the cooperative pool" rule
   (`Support/OffPool.swift`): a synchronous call on the actor occupies one of
   the cooperative pool's few threads for the whole `brew` subprocess.
2. Defeats the `async let` pair in `installedLeaves()` (lines ~135-136 before
   this change): with no suspension point inside `runReading`'s body, the
   actor could not even start the second read until the first `brew` process
   had already exited. The comment next to it claimed the two reads "run
   concurrently rather than serializing the latency" — that was false.

## Fix

Move the blocking spawn/read/wait into `offCooperativePool` (already used
elsewhere in this repo for the same reason, e.g. `SparkleInstaller`,
`ArchiveExtractor`), and `await` it from the actor. The actor is now free
during the `await`, so the two `async let` reads in `installedLeaves()`
genuinely overlap.

Added an internal (not public) `init(executor:)` seam:

```swift
typealias Executor = @Sendable ([String]) throws -> (status: Int32, stdout: Data)?
```

`nil` means "no brew", a thrown error means the process couldn't start, and a
tuple is the definite (exit status, stdout) outcome — the caller decides what
a nonzero status means. `HomebrewInstaller.brewPath()` was moved out of
`outdated()` / `installedLeaves()` / `outdatedCasks()` and into the default
executor (`realExecutor`) — those three functions used to each ask it
directly, which would leave a fake executor unable to fully replace the real
one and would leave a test for "did the two reads overlap" quietly asking the
real host underneath its own fixture (see this repo's "测试不能问宿主"
guidance). `public init()` is unchanged and still wires up the real brew
subprocess.

Not changed: `run(_:onOutput:)` (the `brew upgrade` streaming path used by
`upgradeAll`/`upgrade(casks:)`/`upgrade(formula:)`). It uses
`readabilityHandler` (async, driven by a dispatch source, not a blocking
read) plus `await withCheckedContinuation` resumed from `terminationHandler`
— no synchronous blocking call runs on the actor there, so it does not need
the same fix.

## Behavior preserved

| Path | No brew | executor throws | nonzero exit | success |
|---|---|---|---|---|
| `outdated()` | `[]` | propagates (not swallowed) | throws `BrewError.failed(code:output:)` | `parse(...)` |
| `runReading` (→ `installedLeaves`/`outdatedCasks`) | `""` | `""` | `""` | decoded stdout |
| `installedLeaves()` | `[]` (empty leaves) | same, via `runReading` | same | merged + sorted |
| `outdatedCasks()` | `[]` | same, via `runReading` | same | parsed + filtered by `installsAnApp` |

All of these are pinned by new tests in `BrewFormulaServiceTests.swift`.

## Tests

New `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BrewFormulaServiceTests.swift`,
12 cases:

- **`installedLeavesReadsGenuinelyOverlap`** (the core regression test): a fake
  executor registers itself in a lock-based two-way gate before returning, and
  the test asserts the observed max-in-flight count was 2 — i.e. both `brew`
  calls were actually in flight at once, not that they were fast. Per this
  repo's "并行套件里墙钟上界不成立" guidance, there's no wall-clock assertion;
  the gate has a 5s timeout only to bound how long a broken (serialized) run
  waits before giving up.
- One test per cell of the behavior table above.
- Fixture formula/cask names are fictitious (`zzfixture-*`), never a name
  that might really be installed, per "测试不能问宿主".

### Mutation verification (manual, not committed)

**Mutation 1** — removed the `offCooperativePool` hop in `runReading`,
calling `exec` synchronously on the actor instead:

```
✘ Test installedLeavesReadsGenuinelyOverlap() recorded an issue at BrewFormulaServiceTests.swift:92:9: Expectation failed: gate.observedMaxInFlight == 2
↳ gate.observedMaxInFlight == 2 → false
↳   gate.observedMaxInFlight → 1
✘ Test installedLeavesReadsGenuinelyOverlap() failed after 5.007 seconds with 1 issue.
```
Only that test failed; the other 11 stayed green. Reverted, confirmed green again.

**Mutation 2** — made `outdated()` swallow a spawn failure instead of
propagating it (`(try? await offCooperativePool { ... }) ?? nil`):

```
✘ Test outdatedPropagatesASpawnFailure() recorded an issue at BrewFormulaServiceTests.swift:114:15: Expectation failed: an error was expected but none was thrown
↳ FakeSpawnFailure.self → <not evaluated>
✘ Test outdatedPropagatesASpawnFailure() failed after 0.001 seconds with 1 issue.
```
Only that test failed. Reverted, confirmed green again.

### `make test`

Ran via `scripts/run-with-hang-report.sh 1800 make test`, output redirected
to a file. Tail of the run:

```
✔ Test run with 2623 tests in 221 suites passed after 24.751 seconds with 1 known issue.
swift test --package-path CLI
✔ Test run with 265 tests in 32 suites passed after 0.195 seconds.
✓ App tests — 23 of 23 cases executed
✓ localizable keys agree — 532 in the catalog, all reachable
✓ version comparisons discriminate — 254 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
Ran 7 tests in 0.000s
OK
✓ app audits consistent — 117 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 510 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 24) match the initializers
✓ no machine-population claims in code comments — 510 files
```

The "1 known issue" is a pre-existing `withKnownIssue` case
(`ankiZeroPaddedTagComparesEqualToInstalled`), unrelated to this change.
`BrewFormulaServiceTests` (12/12) is in the 2623-test DuoUpdaterCore run.

## Non-goals (per review brief)

No TTL/cache added, no change to App-layer call ordering, no change to
`BrewFormulaReleaseService`, no `CHANGELOG.md` entry, no `make install` /
`make cli` / `duo verify` run (they touch the shared `/Applications` and
`~/.local`).
