### PR TITLE
Skip the App Store drive when the bundle is already at the target

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3425,6 +3425,40 @@ final class AppListModel {
                     installing[id] = nil
                     return false
                 }
+                // Pre-flight before we drive the store: the row may have gone current
+                // since the install-time re-check ran — the App Store's own background
+                // updater can land the update while this row waits its turn at the
+                // single-slot store gate. It gates BOTH routes below. On the
+                // region-locked one it is not just an optimization: that route matches
+                // the app's row in the Updates list by name and presses its button, and
+                // a row whose update has already landed has moved to "Updated Recently"
+                // with a button that reads **Open** — pressing it launches the app
+                // (#328), and there is no version change for `driveToCompletion` to
+                // see, so it spends its ~24s idle budget and reports a failure.
+                //
+                // Fail-safe by construction: the on-disk check gates the skip, so a
+                // flaky or silently-empty `mas outdated` (it has been unreliable across
+                // macOS releases) can NEVER suppress a genuinely-behind update. `mas`
+                // may only VETO the skip by listing the app as outdated (`!= true`);
+                // "not outdated" and "couldn't check" (nil) both defer to the on-disk
+                // verdict. And because that on-disk gate is evaluated first, `mas
+                // outdated` runs only in the already-current case — never slowing a real
+                // update, and never firing for a user without mas (nil → skip on disk).
+                // Pairs: `displayVersion` against a marketing-only disk read
+                // is equal every time for a vendor that freezes its marketing
+                // string, so "already current" was decided by two strings that
+                // could not differ. The `mas outdated` veto below is what kept
+                // this one honest; the pair is what makes it true on its own.
+                let onDiskNow = Self.readVersionSide(result.app.path)
+                if AppStoreInstallPreflight.bundleAlreadyAt(
+                       target: result.remote?.versionSide, onDisk: onDiskNow),
+                   await masInstaller.outdatedContains(adamID: adamID) != true {
+                    Log.install.notice("App Store: \(result.app.name, privacy: .public) already current (on-disk \(onDiskNow.text(withBuild: true), privacy: .public) ≥ target \(result.remote?.versionSide.text(withBuild: true) ?? "?", privacy: .public), not listed outdated by mas (or it could not check)) — skipping install before download")
+                    await refreshRow(result)
+                    reopenAfterQuit[id] = nil
+                    installing[id] = nil
+                    return false
+                }
                 if result.remote?.appStore?.isRegionMismatch == true {
                     // Region-locked app (listed in a storefront other than the signed-in
                     // account's). mas can't fetch it (wrong storefront) and its product
@@ -3448,6 +3482,10 @@ final class AppListModel {
                         appName: result.app.name,
                         storeName: result.remote?.appStore?.storeName,
                         currentShortVersion: result.app.shortVersion,
+                        // Re-checked at press time: the store's background updater
+                        // can land the update while we navigate to the list, which
+                        // flips the row's button to Open (#328).
+                        targetVersion: result.remote?.versionSide,
                         viaUpdatesList: true
                     ) { stage in
                         Task { @MainActor in self.setStage(id, stage) }
@@ -3459,39 +3497,6 @@ final class AppListModel {
                         Task { @MainActor in self?.withdrawQuit(id: id) }
                     }
                 } else {
-                    // Pre-flight before we drive the store: the row may have gone current
-                    // since the install-time re-check ran — the App Store's own background
-                    // updater can land the update while this row waits its turn at the
-                    // single-slot store gate. If the bundle on disk is already at the target
-                    // AND `mas` (the authority on what a force-reinstall could actually
-                    // fetch) doesn't list it as outdated, there's nothing to install: skip
-                    // the doomed `mas install --force` / AX redrive before downloading
-                    // anything, and settle the row to up-to-date.
-                    //
-                    // Fail-safe by construction: the on-disk check gates the skip, so a
-                    // flaky or silently-empty `mas outdated` (it has been unreliable across
-                    // macOS releases) can NEVER suppress a genuinely-behind update. `mas`
-                    // may only VETO the skip by listing the app as outdated (`!= true`);
-                    // "not outdated" and "couldn't check" (nil) both defer to the on-disk
-                    // verdict. And because that on-disk gate is evaluated first, `mas
-                    // outdated` runs only in the already-current case — never slowing a real
-                    // update, and never firing for a user without mas (nil → skip on disk).
-                    // Pairs: `displayVersion` against a marketing-only disk read
-                    // is equal every time for a vendor that freezes its marketing
-                    // string, so "already current" was decided by two strings that
-                    // could not differ. The `mas outdated` veto below is what kept
-                    // this one honest; the pair is what makes it true on its own.
-                    if let target = result.remote?.versionSide, !target.isEmpty,
-                       case let onDisk = Self.readVersionSide(result.app.path),
-                       !onDisk.isEmpty,
-                       !VersionComparator.isNewer(target, than: onDisk),
-                       await masInstaller.outdatedContains(adamID: adamID) != true {
-                        Log.install.notice("App Store: \(result.app.name, privacy: .public) already current (on-disk \(onDisk.text(withBuild: true), privacy: .public) ≥ target \(target.text(withBuild: true), privacy: .public), not outdated per mas) — skipping install before download")
-                        await refreshRow(result)
-                        reopenAfterQuit[id] = nil
-                        installing[id] = nil
-                        return false
-                    }
                     switch prefs.appStoreUpdateStrategy {
                     case .full:
                         try await masInstaller.install(adamID: adamID) { stage in
@@ -3504,7 +3509,12 @@ final class AppListModel {
                             bundleID: result.app.bundleID,
                             appName: result.app.name,
                             storeName: result.remote?.appStore?.storeName,
-                            currentShortVersion: result.app.shortVersion
+                            currentShortVersion: result.app.shortVersion,
+                            // nil on purpose: a settled product-page button no-ops,
+                            // and the pre-flight above (with its `mas outdated` veto)
+                            // already decided this drive. Re-checking the target here
+                            // would override that veto.
+                            targetVersion: nil
                         ) { stage in
                             Task { @MainActor in self.setStage(id, stage) }
                         } requestQuit: { [weak self] appName in

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -334,8 +334,11 @@ public actor AppStoreAXInstaller {
         // shows, gate it behind the user's Relaunch tap, pressing Continue ourselves
         // only then (see driveToCompletion).
         // We already know (from detection) an update is due, so press regardless of the
-        // localized title — pressing an up-to-date button no-ops. Re-find the button right
-        // before pressing: the ref from the wait can go stale if the page re-rendered.
+        // localized title. On the product page pressing an up-to-date button no-ops; on
+        // the Updates list it does NOT — a settled row's button reads **Open** and
+        // pressing it launches the app, which is what the #328 check below refuses.
+        // Re-find the button right before pressing: the ref from the wait can go stale
+        // if the page re-rendered.
         //
         // #471: this used to be a one-shot `guard` with no retry budget at all, while the
         // wait above got ~12s — so a page that happened to churn in the ~0ms gap between

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -170,6 +170,12 @@ public actor AppStoreAXInstaller {
         case cancelled
         case needsManualConfirmation
         case timedOut
+        /// The bundle was already at the target when the press was due — the
+        /// store's own background updater landed this update during the
+        /// navigation wait (#328). Not a failure: the caller reclassifies it
+        /// against the disk (see `AppListModel.performInstall`), so this text is
+        /// only a fallback for a caller that does not.
+        case alreadyCurrent
         /// We gave up waiting because the app never quit — payload is its name.
         /// Distinct from `timedOut` because the two ask the user for opposite things:
         /// a timeout says "something went wrong, try again", while this one says the
@@ -199,6 +205,8 @@ public actor AppStoreAXInstaller {
                 return "This app needs confirmation in the App Store (e.g. a subscription or purchase). Open the App Store and update it there."
             case .timedOut:
                 return "Timed out waiting for the App Store."
+            case .alreadyCurrent:
+                return "This app is already up to date."
             case .appStillOpen(let appName):
                 return "Quit \(appName) to finish this update. The App Store won’t replace an app while it is open, and it is still open."
             }
@@ -238,6 +246,14 @@ public actor AppStoreAXInstaller {
     ///     Store (verified on macOS 26), so the whole update runs fully in the
     ///     background. Throws `.notInUpdatesList` when the app isn't in the list yet
     ///     (the store surfaces such updates on its own schedule).
+    ///   - targetVersion: the version the caller believes is being installed, when it
+    ///     has one. On the Updates list it is re-checked against the bundle at press
+    ///     time: the store's own background updater can land the update during the
+    ///     navigation wait, which moves the row to "Updated Recently" and its button
+    ///     to **Open** — a button this lookup would otherwise match by name and press,
+    ///     launching the app (#328). Pass nil on the product page: a settled button
+    ///     there no-ops, and a caller whose `mas outdated` veto sent it to the page
+    ///     must not be second-guessed here.
     public func update(
         trackID: Int,
         appPath: URL,
@@ -245,6 +261,7 @@ public actor AppStoreAXInstaller {
         appName: String,
         storeName: String?,
         currentShortVersion: String?,
+        targetVersion: VersionSide?,
         viaUpdatesList: Bool = false,
         onStage: @Sendable @escaping (InstallStage) -> Void,
         requestQuit: @Sendable @escaping (String) -> Void,
@@ -331,6 +348,22 @@ public actor AppStoreAXInstaller {
         ) else {
             Log.install.error("appstore-ax: \(appName, privacy: .public) offer button vanished before press")
             throw viaUpdatesList ? AXError.notInUpdatesList : AXError.offerButtonNotFound
+        }
+        // #328, at the last moment before the press: the caller's pre-flight ran
+        // before this navigation, and on the Updates-list route that window is
+        // where the store's own background updater can still land the update. The
+        // row then moves to "Updated Recently" and its button flips to **Open**,
+        // which this lookup matches and would press by name — launching the app.
+        // Re-read the bundle here; if it already reached the target there is
+        // nothing to install, and throwing lets the caller classify it exactly
+        // like an install that raced to the same state (see its catch).
+        let diskNow = Self.installedVersions(at: appPath, fallbackShort: currentShortVersion)
+        if Self.updatesListPressIsSettled(
+            viaUpdatesList: viaUpdatesList, target: targetVersion,
+            onDisk: VersionSide(marketing: diskNow.short, build: diskNow.build)
+        ) {
+            Log.install.notice("appstore-ax: \(appName, privacy: .public) already at target before press (on-disk \(diskNow.short ?? "?", privacy: .public)/\(diskNow.build ?? "?", privacy: .public)) — the store landed it during navigation; refusing the settled row")
+            throw AXError.alreadyCurrent
         }
         // Sample the screen for a sheet HERE, on this side of the press. Any sheet up
         // now is left over from an earlier install and must be ignored (see
@@ -1545,6 +1578,27 @@ public actor AppStoreAXInstaller {
     /// at once (observed: 8 offer buttons in one poll).
     static func shouldPress(heroOwnsPage: Bool, ownButtonCount: Int) -> Bool {
         heroOwnsPage && ownButtonCount == 1
+    }
+
+    /// Whether a press about to be made on the Updates list must be refused
+    /// because the bundle on disk already reached the target (#328).
+    ///
+    /// Updates-list only, and that is the point: the product page's settled
+    /// button no-ops, and a caller that was sent there *because* `mas outdated`
+    /// vetoed the skip must not be second-guessed at press time. On the list, by
+    /// contrast, a settled row's button reads **Open** and pressing it launches
+    /// the app.
+    ///
+    /// Pure so the route carve-out can be asserted without a live App Store: the
+    /// condition is exactly the part that would silently stop applying if a
+    /// future caller forgot `viaUpdatesList` or dropped the target.
+    static func updatesListPressIsSettled(
+        viaUpdatesList: Bool,
+        target: VersionSide?,
+        onDisk: VersionSide
+    ) -> Bool {
+        guard viaUpdatesList else { return false }
+        return AppStoreInstallPreflight.bundleAlreadyAt(target: target, onDisk: onDisk)
     }
 
     /// Whether the page's own hero lockup names `appName` — i.e. App Store really has

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreInstallPreflight.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreInstallPreflight.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The App Store install pre-flight: whether driving the store can be skipped
+/// because the bundle on disk already carries the offered version.
+///
+/// Both App Store routes re-read the bundle right before they drive the store,
+/// because the offer can go stale while the row waits at the single-slot store
+/// gate — App Store's own background updater may land the update first. On the
+/// product page (mas or AX) a stale drive is a doomed `mas install --force` / AX
+/// redrive. On the **Updates list** — the region-locked route, which matches the
+/// app's row by name and presses its button — it is worse: the settled row has
+/// moved to "Updated Recently" and its button reads **Open**, so the press
+/// launches the app instead of updating it (#328), and `driveToCompletion` then
+/// spends its ~24s idle budget before reporting a failure.
+///
+/// This type is only the on-disk half; the caller pairs it with a `mas outdated`
+/// veto that can still force the drive (see `AppListModel.performInstall`).
+public enum AppStoreInstallPreflight {
+
+    /// True when `onDisk` is already at, or past, `target`.
+    ///
+    /// `!isNewer(target, than: onDisk)` rather than
+    /// ``VersionComparator/hasReached(_:disk:)``, deliberately: this is the
+    /// predicate the product-page pre-flight has always used, and it fails
+    /// toward "already current". `hasReached` needs positive evidence that the
+    /// disk got there, so it answers "not yet" for a pair that is non-empty but
+    /// shares no comparable field (a target carrying only a build, a disk
+    /// carrying only a marketing string). This predicate skips there, and the
+    /// caller's `mas outdated` veto is the second opinion for the product route.
+    ///
+    /// An *empty* side is different and never skips: with nothing to compare at
+    /// all (`VersionSide()` or no remote), the answer is false and the caller
+    /// drives the store as it always did.
+    public static func bundleAlreadyAt(target: VersionSide?, onDisk: VersionSide) -> Bool {
+        guard let target, !target.isEmpty, !onDisk.isEmpty else { return false }
+        return !VersionComparator.isNewer(target, than: onDisk)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreInstallPreflightTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreInstallPreflightTests.swift
@@ -1,0 +1,88 @@
+import Testing
+@testable import DuoUpdaterCore
+
+/// #328 regression: the region-locked Updates-list route matches the app's row by
+/// name and presses its button, so once the store has already landed the update
+/// the row reads **Open** and the press launches the app. The pre-flight both App
+/// Store routes now share is what keeps us from driving the store in that state;
+/// these pin its rule.
+@Suite("AppStoreInstallPreflight")
+struct AppStoreInstallPreflightTests {
+
+    private func side(_ marketing: String? = nil, _ build: String? = nil) -> VersionSide {
+        VersionSide(marketing: marketing, build: build)
+    }
+
+    @Test("a bundle at the target is already there")
+    func diskAtTheTarget() {
+        #expect(AppStoreInstallPreflight.bundleAlreadyAt(target: side("1.0"), onDisk: side("1.0")))
+    }
+
+    @Test("a bundle past the target is already there too")
+    func diskPastTheTarget() {
+        #expect(AppStoreInstallPreflight.bundleAlreadyAt(target: side("1.0"), onDisk: side("1.1")))
+        #expect(AppStoreInstallPreflight.bundleAlreadyAt(
+            target: side("1.0", "9"), onDisk: side("1.0", "10")))
+    }
+
+    /// The #328 shape: the store target carries no build (the lookup reports only
+    /// the marketing string), while the build the store landed carries one. The
+    /// pair is "current", not "cannot tell".
+    @Test("a target without a build still matches a disk that has one")
+    func targetHasNoBuild() {
+        #expect(AppStoreInstallPreflight.bundleAlreadyAt(
+            target: side("1.0", nil), onDisk: side("1.0", "9")))
+    }
+
+    /// The guard would suppress every real update if it were too eager, so a
+    /// genuinely-behind bundle must still be driven.
+    @Test("a bundle behind the target is not")
+    func diskBehindTheTarget() {
+        #expect(!AppStoreInstallPreflight.bundleAlreadyAt(target: side("1.1"), onDisk: side("1.0")))
+        #expect(!AppStoreInstallPreflight.bundleAlreadyAt(
+            target: side("1.0", "10"), onDisk: side("1.0", "9")))
+    }
+
+    /// An empty side is never "already there": the caller must keep driving the
+    /// store exactly as it did before the pre-flight existed.
+    @Test("empty sides are never already current")
+    func emptySides() {
+        #expect(!AppStoreInstallPreflight.bundleAlreadyAt(target: nil, onDisk: side("1.0")))
+        #expect(!AppStoreInstallPreflight.bundleAlreadyAt(target: side("1.0"), onDisk: VersionSide()))
+        #expect(!AppStoreInstallPreflight.bundleAlreadyAt(target: VersionSide(), onDisk: side("1.0")))
+    }
+
+    /// The deliberate difference from `hasReached`: two *non-empty* sides that
+    /// share no comparable field read as "already current" here, because the
+    /// skip direction fails closed and the caller's `mas outdated` veto is the
+    /// second opinion. `hasReached` would call this "not landed".
+    @Test("a non-empty pair with no shared field fails toward already current")
+    func incomparableButNonEmpty() {
+        #expect(AppStoreInstallPreflight.bundleAlreadyAt(
+            target: side(nil, "5"), onDisk: side("1.0", nil)))
+    }
+
+    // MARK: - The press-time guard (#328)
+
+    /// The settled-press refusal is Updates-list-only, and that carve-out is
+    /// load-bearing: the product page's settled button no-ops, and a drive that
+    /// a `mas outdated` veto deliberately sent there must not be second-guessed
+    /// at press time.
+    @Test("the settled-press refusal applies only on the Updates list")
+    func pressRefusalRouteCarveOut() {
+        #expect(AppStoreAXInstaller.updatesListPressIsSettled(
+            viaUpdatesList: true, target: side("1.0"), onDisk: side("1.0")))
+        #expect(!AppStoreAXInstaller.updatesListPressIsSettled(
+            viaUpdatesList: false, target: side("1.0"), onDisk: side("1.0")))
+    }
+
+    /// It needs both halves: no target (the caller has none) or a bundle genuinely
+    /// behind the target must keep the press.
+    @Test("the settled-press refusal needs a target and a settled disk")
+    func pressRefusalNeedsBothHalves() {
+        #expect(!AppStoreAXInstaller.updatesListPressIsSettled(
+            viaUpdatesList: true, target: nil, onDisk: side("1.0")))
+        #expect(!AppStoreAXInstaller.updatesListPressIsSettled(
+            viaUpdatesList: true, target: side("1.1"), onDisk: side("1.0")))
+    }
+}


### PR DESCRIPTION
Fixes #328.

## What

- The product-page pre-flight (bundle on disk already at the target, and `mas outdated` does not list it) now gates **both** App Store routes through a shared Core predicate, `AppStoreInstallPreflight.bundleAlreadyAt(target:onDisk:)`. It used to sit only in the else branch, so the region-locked Updates-list branch drove the store with no guard at all.
- The Updates-list press re-checks the bundle at the last moment before `AXPress`. The caller's pre-flight runs before a navigation wait (launch + deep link + row surfacing), and the store's own background updater can land the update *inside* that window; the row then moves to "Updated Recently" and its button reads **Open**. A settled row is refused (`AXError.alreadyCurrent`) and `AppListModel` classifies it as already-current exactly like an install that raced to the same state.

## Why the press-time half is Updates-list-only

On the product page a settled button no-ops, and the caller may have been sent there *because* `mas outdated` vetoed the skip — re-checking our target at press time would override that veto. On the Updates list a settled button reads **Open**, and pressing it launches the app.

## Verification

- `make test` all green in both worktrees (Core 2619 tests, CLI, app tests, loc/version/prose checks).
- New Core tests pin the pre-flight predicate (including its deliberate fail-toward-current difference from `hasReached`) and the Updates-list-only carve-out of the press-time refusal.
- Mutation-checked: removing the `viaUpdatesList` carve-out reds only the refusal-route test.
- Adversarial review run; findings addressed in this revision (doc accuracy, the `mas` nil wording in the skip log, a test for the non-empty-but-incomparable pair).

## Known limits

- The fix does not identify the **Open** button structurally — the row's AX data carries no adamID, and matching on the localized title is what `offerButton` deliberately avoids. It removes the two paths into the press that were measured: the update already landed before the drive, and it landing during navigation.
- On the pre-flight skip path an app the store closed while updating is not reopened (pre-existing on the product route; the press-time refusal path does reopen a closed app).
