### PR TITLE
Match an Updates-list row's whole name, and only if it is unique

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -1487,11 +1487,17 @@ public actor AppStoreAXInstaller {
     /// between them is here, where it can be asserted.
     ///
     /// Every exact match is tried before any loose one, across all needles. That order
-    /// is the safety property: a contains-match on this list can land on a different
+    /// is the safety property: a loose match on this list can land on a different
     /// app (the cn storefront carries both "QQ" and "QQ音乐 - #听我想听#", both cn-only,
     /// so both reach this path and can share a list), and a row that is really ours
     /// must never lose to someone else's substring just because ours was the second
-    /// needle. Loose stays as the last resort for labels that carry decoration.
+    /// needle.
+    ///
+    /// The loose pass is narrower than its name suggests: the name has to be a
+    /// whole run rather than a letter-adjacent prefix of a longer one, and it has
+    /// to select exactly one row — an ambiguous needle is skipped, not guessed
+    /// at, and the next needle is tried. See `carriesName` for what that closes,
+    /// and for the longer separated name it cannot.
     static func rowIndex(matching needles: [String], in rows: [[String]])
     -> (index: Int, needle: String, exact: Bool)? {
         for needle in needles {
@@ -1500,13 +1506,52 @@ public actor AppStoreAXInstaller {
             }
         }
         for needle in needles {
-            if let i = rows.firstIndex(where: { row in
-                row.contains { $0.localizedCaseInsensitiveContains(needle) }
-            }) {
-                return (i, needle, false)
+            let matches = rows.indices.filter { i in
+                rows[i].contains { Self.carriesName(needle, in: $0) }
             }
+            if matches.count == 1 { return (matches[0], needle, false) }
         }
         return nil
+    }
+
+    /// Whether `text` carries `needle` as a whole run — not continued by a letter
+    /// or digit on either side — rather than as the prefix of a concatenated
+    /// longer name.
+    ///
+    /// `localizedCaseInsensitiveContains` accepted any substring, and on this list
+    /// that is another app: updating QQ while its own row is absent — not surfaced
+    /// yet, or already installing — selected "QQ音乐 - #听我想听#" (595615424), a
+    /// different cn-only listing, and we pressed *its* Update button (#331).
+    ///
+    /// The boundary is measured, not assumed. Han characters are letters to this
+    /// class, so the transition inside "QQ音乐" is not a boundary, while the spaces
+    /// around "WeChat" in "WeChat — 微信" and around "钉钉" in
+    /// "钉钉 - AI时代的工作方式" are. A needle whose own edge is punctuation gets no
+    /// constraint on that side, so a store title ending in "#" still matches.
+    ///
+    /// ⚠️ This is not identity, and it does not close every way to press another
+    /// app's row: a longer name joined by a **separator** — "WeChat Work" against
+    /// "WeChat" — still matches, because nothing in the text distinguishes it from
+    /// a decorated title, and the row's AX data carries no adamID (measured; see
+    /// #331). `rowIndex`'s uniqueness rule closes the case where both rows are
+    /// present. The residual miss is our-row-absent with a single space-joined
+    /// longer name on the list; closing that needs an identity signal this list
+    /// does not expose.
+    static func carriesName(_ needle: String, in text: String) -> Bool {
+        guard !needle.isEmpty else { return false }
+        let wordChar = "[\\p{L}\\p{N}_]"
+        // Precomposed on both sides: the old `localizedCaseInsensitiveContains`
+        // compared canonically, and the needle can be decomposed where the row is
+        // not (a bundle's InfoPlist.strings need not be normalized). Measured:
+        // without this, "Café" stops matching a row written "Cafe\u{301} — …".
+        let name = needle.precomposedStringWithCanonicalMapping
+        let left = name.first.map { $0.isLetter || $0.isNumber } == true ? "(?<!\(wordChar))" : ""
+        let right = name.last.map { $0.isLetter || $0.isNumber } == true ? "(?!\(wordChar))" : ""
+        guard let re = try? NSRegularExpression(
+            pattern: left + NSRegularExpression.escapedPattern(for: name) + right,
+            options: [.caseInsensitive]) else { return false }
+        let subject = text.precomposedStringWithCanonicalMapping
+        return re.firstMatch(in: subject, range: NSRange(subject.startIndex..., in: subject)) != nil
     }
 
     /// How one of App Store's `AppStore.shelfItem.*` cells relates to the app we're

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -1471,10 +1471,12 @@ public actor AppStoreAXInstaller {
         // Exactness outranks which name it was, because a loose match on this list can
         // land on another app: the cn storefront carries both "QQ" (451108668) and
         // "QQ音乐 - #听我想听#" (595615424), both cn-only, so both reach this path and
-        // can share a list. Updating QQ while its own row is absent — not surfaced yet,
-        // or already installing — a contains-match on "QQ" selects QQ Music's row, and
-        // we press *its* button. Trying every exact first is what keeps a present row
-        // from losing to someone else's substring.
+        // can share a list. Trying every exact first is what keeps a present row from
+        // losing to someone else's substring. The absent-row half — updating QQ while
+        // its own row is not surfaced yet, or already installing — is `rowIndex`'s
+        // loose rule: a plain contains-match there selected QQ Music's row and pressed
+        // *its* button (#331); see `carriesName` for what it refuses now and what it
+        // still cannot.
         guard let hit = Self.rowIndex(matching: names.needles, in: rows.map(\.1)) else {
             return Binding(button: nil, note: "rows=\(rows.count) matched=none")
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppStoreOfferButtonTests.swift
@@ -187,6 +187,64 @@ struct AppStoreOfferButtonTests {
         #expect(AppStoreAXInstaller.rowIndex(matching: ["Nothing Here"], in: rows) == nil)
     }
 
+    /// The other half of that rescue: a title that is the *prefix* of its own
+    /// decorated row, where the rest of the row is a tagline rather than a longer
+    /// name. Same cn listing as the test above; this is the case loose must keep.
+    @Test func ourTitleWithATaglineAfterItStillMatches() {
+        let rows = [["QQ音乐 - #听我想听#", "Today"]]
+        let hit = AppStoreAXInstaller.rowIndex(matching: ["QQ音乐"], in: rows)
+        #expect(hit?.index == 0)
+        #expect(hit?.exact == false)
+    }
+
+    /// #331: with our own row absent — not surfaced yet, or already installing —
+    /// the loose pass had nothing checking that the row it landed on was *ours*.
+    /// "QQ" is a plain substring of "QQ音乐 - #听我想听#" (595615424), a different
+    /// cn-only listing from QQ (451108668), so we pressed QQ Music's Update button
+    /// and then watched QQ's bundle for six minutes.
+    @Test func aLooseMatchNeverSelectsALongerNameThatStartsWithOurs() {
+        let rows = [["QQ音乐 - #听我想听#", "Today"]]
+        #expect(AppStoreAXInstaller.rowIndex(matching: ["QQ"], in: rows) == nil)
+        // Two of them is no better, and neither is the bare concatenation.
+        let two = [["QQ音乐 - #听我想听#", "Today"], ["QQ浏览器", "Today"]]
+        #expect(AppStoreAXInstaller.rowIndex(matching: ["QQ"], in: two) == nil)
+        // The decorated CJK name is the control: a *whole* run bounded by a
+        // separator still matches, which is what keeps this from dropping loose.
+        #expect(AppStoreAXInstaller.rowIndex(matching: ["钉钉"], in: [["钉钉 - AI时代的工作方式", "Today"]])?.index == 0)
+    }
+
+    /// A loose match that lands on two rows cannot say which is ours, so it must
+    /// refuse rather than take the first — the ambiguous half of #331. This is the
+    /// both-rows-present case; the single-row residual is documented on
+    /// `carriesName`.
+    @Test func anAmbiguousLooseMatchIsRefusedRatherThanGuessed() {
+        let rows = [["WeChat — 微信", "Today"], ["WeChat Work — 企业微信", "Today"]]
+        #expect(AppStoreAXInstaller.rowIndex(matching: ["WeChat"], in: rows) == nil)
+    }
+
+    /// A needle whose own edge is punctuation gets no boundary on that side, so a
+    /// store title ending in "#" can still match where the tagline continues
+    /// straight into a letter. Removing that conditional turns this red — the
+    /// earlier fixture (a space after the "#") could not tell.
+    @Test func aPunctuationEdgedTitleCanStillMatchLoose() {
+        #expect(AppStoreAXInstaller.carriesName(
+            "QQ音乐 - #听我想听#", in: "QQ音乐 - #听我想听#精选"))
+    }
+
+    /// The needle is a literal, not a pattern: parentheses (and any other regex
+    /// metacharacter) must be escaped on the way into the matcher, or "App Beta"
+    /// would match the group "(Beta)" while the literal row would not.
+    @Test func aNeedleWithRegexMetacharactersIsMatchedLiterally() {
+        #expect(AppStoreAXInstaller.carriesName("App (Beta)", in: "App (Beta) — Fixture"))
+        #expect(!AppStoreAXInstaller.carriesName("App (Beta)", in: "App Beta — Fixture"))
+    }
+
+    /// The old loose pass compared canonically; the regex path must not silently
+    /// stop matching a row whose text is decomposed where the needle is not.
+    @Test func aDecomposedRowStillMatchesAComposedName() {
+        #expect(AppStoreAXInstaller.carriesName("Café", in: "Cafe\u{301} — Fixture"))
+    }
+
     /// No store title (the lookup didn't supply one) leaves the bundle name as the
     /// only thing to match on — the behaviour every App Store update had before.
     /// A blank one counts as none: matching on "" makes `heroOwns` false for every


### PR DESCRIPTION
Fixes #331.

## What

`AppStoreAXInstaller.rowIndex`'s loose pass accepted any substring, so updating QQ with its own row absent — not surfaced yet, or already installing — selected "QQ音乐 - #听我想听#" (595615424, a different cn-only listing) and pressed *its* Update button. The loose pass now:

- requires the needle to be a whole run — not continued by a letter or digit on either side. Measured: Han characters are letters to this class, so `QQ` is refused inside `QQ音乐` while `WeChat — 微信` and `钉钉 - AI时代的工作方式` keep matching. A needle whose own edge is punctuation gets no constraint on that side, so a store title ending in `#` still matches.
- requires the match to select exactly one row; an ambiguous needle is skipped and the next needle is tried, not guessed at.

Both sides are NFC-normalized so the canonical equivalence the old `contains`-match had is preserved, and the needle is regex-escaped before it goes into the pattern.

## Known limits (documented on `carriesName`)

Text cannot establish identity: a longer name joined by a **separator** — "WeChat Work" against "WeChat" — still matches when our own row is absent, because nothing in the text tells it from a decorated title, and the row's AX data carries no adamID (measured in the issue: zero hits scanning all 357 elements). The uniqueness rule closes the both-rows-present case; the single space-joined row remains.

## Verification

- `make test` all green (Core 2617 tests, CLI, app tests, loc/version/prose checks).
- New tests pin the boundary, the uniqueness refusal, the punctuation-edged needle, regex escaping and canonical equivalence. Mutation-checked: removing the boundary / the uniqueness rule / the escaping each reds only its own case.
- Adversarial review run; findings addressed in this revision (the overstated "prefix" claim in the comment, a fixture that could not tell the punctuation-edge rule, an escaping test that did not exist).
