### PR TITLE
Persist Tauri crate-proof verdicts to disk across processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.92
 
-Under the hood: the Homebrew list in the menu fills in faster.
+Under the hood: the Homebrew list in the menu fills in faster, and `duo` commands start faster.
 
 ## 0.3.91
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
@@ -1330,24 +1330,14 @@ public actor EventStore {
     /// a request, which is most of the suite; that is why the guard lives here
     /// and not in ``DuoStateDirectory``, whose fallback several tests assert.
     public static func defaultFileURL() -> URL {
-        let base = isTestProcess && ProcessInfo.processInfo.environment["DUO_STATE_DIR"] == nil
+        let base = DuoStateDirectory.isTestProcess
+            && ProcessInfo.processInfo.environment["DUO_STATE_DIR"] == nil
             ? FileManager.default.temporaryDirectory
                 .appendingPathComponent("duo-events-tests", isDirectory: true)
             : DuoStateDirectory.base
         return base
             .appendingPathComponent("com.duoupdater.app", isDirectory: true)
             .appendingPathComponent("events.sqlite")
-    }
-
-    /// Whether this is a test host. Both runners are named because they differ:
-    /// SwiftPM runs the suite as `swiftpm-testing-helper` with no XCTest
-    /// environment at all (measured), while Xcode uses `xctest` and an
-    /// `.xctest` bundle.
-    static var isTestProcess: Bool {
-        let name = ProcessInfo.processInfo.processName
-        return name == "swiftpm-testing-helper" || name == "xctest"
-            || Bundle.main.bundleURL.pathExtension == "xctest"
-            || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
 }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppRuntime.swift
@@ -337,6 +337,13 @@ public enum AppRuntimeDetector {
         // is also why a debug build takes 104s for that sweep and a release build
         // half a second.
         //
+        // "A second sweep" used to mean only a second sweep in the same
+        // process. Since `TauriProofStore`, the verdict this walk reaches is
+        // also written to disk, so the process reading it back does not have
+        // to be the one that paid for it: the menu-bar app's first scan after
+        // an update, and every `duo list` after that, share one walk instead
+        // of each starting cold.
+        //
         // The residual risk moved rather than vanished, and it moved to the safer
         // side: an app now reads as native when its binary keeps no `tauri-` crate
         // path — or when that binary could not be read at this moment, since the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -401,6 +401,9 @@ public enum RuntimeVersion {
     ///   of the same `cargo build` and carry the same crate paths, so the answer
     ///   agrees — it is the bytes read, not the verdict, that are larger than they
     ///   need to be. One of the six candidates here (CC Switch) is fat.
+    ///
+    /// A verdict this reaches is persisted past this process — see
+    /// `TauriProofStore.proverGeneration` for what that requires of edits here.
     public static func carriesTauriCrate(bundleAt bundleURL: URL) -> Bool {
         read(.tauri, bundleAt: bundleURL, scanningBinaries: true) != nil
     }
@@ -464,6 +467,9 @@ public enum RuntimeVersion {
     /// A closure that hands back one chunk at a time is enough to say all of it, and
     /// it is the shape this file's neighbours already use (`LibraryReader`,
     /// `TauriProof`).
+    ///
+    /// A change to the boundary/window/carry logic below needs a bump of
+    /// `TauriProofStore.proverGeneration` — see its doc comment.
     static func probe(
         reading next: () throws -> Data?,
         for prefix: String,
@@ -613,6 +619,9 @@ public enum RuntimeVersion {
     ///
     /// Only the *search* moved. Both window-edge rules and the identifier guard are
     /// unchanged, and so is the order they run in.
+    ///
+    /// A rule change here — the digit run, the identifier guard, the component
+    /// count — needs a bump of `TauriProofStore.proverGeneration`.
     private static func firstVersion(
         in bytes: Data,
         after needle: Data,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/RuntimeVersion.swift
@@ -100,9 +100,24 @@ public enum RuntimeVersion {
         // binary does not, so this is reachable — and it costs a missing version
         // label, not a wrong runtime.
         let executable = executableURL(bundleAt: bundleURL)
-        let key = executable.flatMap { executableIdentity(of: $0) }
-            .map { "\(bundleURL.path)|\(runtime.rawValue)|\($0)" }
+        let identity = executable.flatMap { executableIdentity(of: $0) }
+        let key = identity.map { "\(bundleURL.path)|\(runtime.rawValue)|\($0)" }
         if let key, let remembered = cached(key) { return remembered }
+
+        // `.tauri`'s verdict also outlives *this* process — see
+        // `TauriProofStore`. The lookup sits here, above the `scanningBinaries`
+        // guard the switch below applies, for the same reason the in-memory
+        // lookup above does: a caller that forbade scanning still gets an
+        // answer someone else — an earlier call in this process, or a
+        // previous process entirely — already paid for. Only `.tauri` reaches
+        // here because that is the only runtime `record` is ever called for;
+        // see the doc comment on `cache` for why Electron and Chromium's `nil`
+        // must not survive past the process that reached it.
+        if runtime == .tauri, let identity,
+           let diskAnswer = TauriProofStore.shared.lookup(forBundleAt: bundleURL.path, identity: identity) {
+            if let key { remember(diskAnswer, for: key) }
+            return diskAnswer
+        }
 
         let version: String?
         switch runtime {
@@ -116,9 +131,11 @@ public enum RuntimeVersion {
             guard scanningBinaries, let executable else { return nil }
             // The one place the difference between "proved absent" and "could not
             // read" matters, because a nil here is a *verdict* — `carriesTauriCrate`
-            // turns it into "this app is not Tauri" and the cache would keep that
-            // for the life of the process. A half-read binary must therefore leave
-            // no trace: no answer, nothing remembered, asked again next time.
+            // turns it into "this app is not Tauri", and that verdict is
+            // remembered twice over: in `cache`, for the life of this process, and
+            // in `TauriProofStore` on disk, for every process after it. A
+            // half-read binary must therefore leave no trace in either: no
+            // answer, nothing remembered, asked again next time.
             switch probe(executable, for: "tauri-", components: 3) {
             case .found(let found): version = found
             case .absent:           version = nil
@@ -145,6 +162,13 @@ public enum RuntimeVersion {
         // `appVersion` used to be the one thing that could vary between two callers
         // of the same bundle.
         if let key, version != nil || scanningBinaries { remember(version, for: key) }
+        // Reached only when `scanningBinaries` was true — the guard at the top
+        // of `case .tauri` above already returned for a caller that forbade
+        // it — so this never persists the "answer about the caller" nil the
+        // paragraph above describes, for the same reason `remember` does not.
+        if runtime == .tauri, let identity {
+            TauriProofStore.shared.record(version, forBundleAt: bundleURL.path, identity: identity)
+        }
         return version
     }
 
@@ -165,7 +189,12 @@ public enum RuntimeVersion {
     /// rather than on the bytes read; and a filesystem with coarse timestamps could
     /// in principle hold two same-sized binaries under one key. Neither shape
     /// appears in `/Applications`.
-    private static func executableIdentity(of executable: URL) -> String? {
+    ///
+    /// Internal rather than `private`, for the same reason as `scanOverlap` and
+    /// `scanChunkSize`: the disk-cache tests need to seed `TauriProofStore` under
+    /// the exact identity `read` will look up, and hand-computing that string a
+    /// second time in test code would drift the moment this format changes.
+    static func executableIdentity(of executable: URL) -> String? {
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: executable.path),
               let size = attributes[.size] as? NSNumber,
               let modified = attributes[.modificationDate] as? Date
@@ -186,6 +215,12 @@ public enum RuntimeVersion {
     /// `Synchronization.Mutex` would be the modern way to hold this and needs
     /// macOS 15; the package targets 14. A lock around a dictionary is what the
     /// rest of this package does.
+    ///
+    /// This is the in-process half only. `.tauri`'s verdicts — found or proved
+    /// absent, never `.unreadable` — are mirrored to `TauriProofStore` on disk,
+    /// so the walk that fills this dictionary the first time something asks
+    /// does not have to run again for the next process to ask: `duo list`
+    /// used to re-pay it, once per candidate bundle, on every invocation.
     private nonisolated(unsafe) static var cache: [String: String?] = [:]
     private static let cacheLock = NSLock()
 
@@ -344,7 +379,11 @@ public enum RuntimeVersion {
     /// is not, and if it is, the version is right beside it — so the detector
     /// asking "is this Tauri" during a scan and the detail view asking "which
     /// Tauri" later share one cache entry, and the walk happens once per binary
-    /// rather than once per asker.
+    /// rather than once per asker. Since `TauriProofStore`, "once per binary"
+    /// no longer means once per binary *per process*: the menu-bar app pays for
+    /// a bundle's walk at most once between updates, and `duo` — a fresh
+    /// process on every invocation — reads that answer back rather than
+    /// re-paying it on every `duo list`.
     ///
     /// `tauri-runtime-wry-2.11.4` deliberately does not match: the character after
     /// the prefix has to be a digit, so only the framework crate itself is read.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
@@ -85,27 +85,45 @@ final class TauriProofStore: @unchecked Sendable {
     /// The instance `RuntimeVersion` calls through. Production code should
     /// only ever touch this one; the `init(fileURL:)` override below exists for
     /// tests that model two processes sharing one file.
+    ///
+    /// `resolvedFileURL` is fixed at construction — see `init`'s doc comment
+    /// for why that matters specifically for a singleton, and
+    /// `TauriProofStoreTests.sharedsResolvedPathIsFixedRegardlessOfLaterDUOStateDirChanges`
+    /// for the test that pins it.
     static let shared = TauriProofStore()
 
-    /// Set only by tests. `nil` means "resolve `defaultFileURL()` fresh on
-    /// every access", which is deliberate and not an oversight: a `fileURL`
-    /// captured once at init, the way the other on-disk stores do it, would be
-    /// fine for them because they are constructed fresh per test or per
-    /// short-lived caller. `shared` is not — it is first touched at an
-    /// effectively random point across an entire `swift test` run, which is
-    /// exactly the shape `DuoStateDirectoryTests` exists to worry about
-    /// (`setenv` toggling `DUO_STATE_DIR` mid-suite). Resolving fresh on every
-    /// call shrinks that race window from "the rest of the process" to "one
-    /// lookup or record call", the same guarantee `DuoStateDirectory.base`
-    /// already gives every other reader of `DUO_STATE_DIR`.
-    private let fileURLOverride: URL?
     private let lock = NSLock()
 
-    init(fileURL: URL? = nil) {
-        self.fileURLOverride = fileURL
-    }
+    /// Where this instance reads and writes, decided once, here, rather than
+    /// re-read on every `lookup`/`record` call.
+    ///
+    /// That distinction only matters for `shared`, which is a process-wide
+    /// singleton touched at an effectively random point across an entire
+    /// `swift test` run — by tests that legitimately `setenv("DUO_STATE_DIR",
+    /// ...)` for the duration of their own scope and restore it afterward. If
+    /// this store re-resolved `DUO_STATE_DIR` on every access, two calls one
+    /// test makes — `record` then `lookup`, say — could land on two different
+    /// files if another suite's `setenv` fell in between. That is not
+    /// hypothetical: `EventStoreTests` carried a `defer` that failed to
+    /// restore `DUO_STATE_DIR` to "unset" when it had been unset before
+    /// (fixed alongside this store), which meant every `TauriProofStore`
+    /// access for the rest of the process silently read and wrote
+    /// `/tmp/duo-state-test/com.duoupdater.app/tauri-proofs.json` — a file
+    /// every worktree's test run shares — instead of its own scratch file.
+    /// Resolving once, at construction, means `shared`'s target is decided
+    /// before any of that can reach it, and cannot be moved afterward by
+    /// anything another suite does to the environment.
+    ///
+    /// Every other on-disk store in this package also resolves once, at
+    /// construction — the difference is only that they are built fresh per
+    /// test or per short-lived caller, so "once" and "fresh enough" have
+    /// always been the same thing for them. `shared` is the one long-lived
+    /// exception, which is what made it worth writing down here.
+    let resolvedFileURL: URL   // internal: asserted by TauriProofStoreTests
 
-    private var fileURL: URL { fileURLOverride ?? Self.defaultFileURL() }
+    init(fileURL: URL? = nil) {
+        self.resolvedFileURL = fileURL ?? Self.defaultFileURL()
+    }
 
     /// `nil` means "no record for this path at all". `.some(nil)` means "there
     /// is a record, and it says no crate was found" — the two must stay
@@ -116,7 +134,8 @@ final class TauriProofStore: @unchecked Sendable {
     func lookup(forBundleAt path: String, identity: String) -> String?? {
         lock.lock()
         defer { lock.unlock() }
-        guard let entry = Self.load(from: fileURL)[path], entry.identity == identity else { return nil }
+        guard let entry = Self.load(from: resolvedFileURL)[path], entry.identity == identity
+        else { return nil }
         return entry.version
     }
 
@@ -131,14 +150,13 @@ final class TauriProofStore: @unchecked Sendable {
     func record(_ version: String?, forBundleAt path: String, identity: String) {
         lock.lock()
         defer { lock.unlock() }
-        var entries = Self.load(from: fileURL)
+        var entries = Self.load(from: resolvedFileURL)
         entries[path] = Entry(identity: identity, version: version)
         let contents = FileContents(generation: Self.proverGeneration, entries: entries)
         guard let data = try? JSONEncoder().encode(contents) else { return }
-        let url = fileURL
         try? FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try? data.write(to: url, options: .atomic)
+            at: resolvedFileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? data.write(to: resolvedFileURL, options: .atomic)
     }
 
     /// A file that does not exist, cannot be parsed, was stamped by a
@@ -159,17 +177,20 @@ final class TauriProofStore: @unchecked Sendable {
     /// Where a test process's `.shared` writes, when `DUO_STATE_DIR` is unset.
     ///
     /// Unlike `EventStore`'s equivalent (`duo-events-tests`, a fixed name every
-    /// test process shares), this carries a UUID computed once, at first
-    /// access, and held for the rest of the process — because unlike
-    /// `EventStore`, which prunes itself by age and byte budget, this store
-    /// only ever grows: every `record` call adds an entry and nothing ever
-    /// removes one. Measured 2026-09-11: after a handful of `swift test` runs
-    /// sharing a fixed test path, that file held 40 entries across 5.9 KB, none
-    /// of them cleaned up, still there for the next run to read stale answers
-    /// from — and two worktrees testing at once would share it besides. A UUID
-    /// per process means every run starts from an empty store and leaves
-    /// nothing behind for the next one, which is what a test wants: bounded
-    /// scratch space, not accumulating history.
+    /// test process shares), this carries a UUID computed once — because
+    /// unlike `EventStore`, which prunes itself by age and byte budget, this
+    /// store only ever grows: every `record` call adds an entry and nothing
+    /// ever removes one. Measured 2026-09-11: after a handful of `swift test`
+    /// runs sharing a fixed test path, that file held 40 entries across
+    /// 5.9 KB.
+    ///
+    /// This does NOT mean nothing is left on disk — an earlier version of
+    /// this comment overclaimed that. Each run's small file stays in
+    /// `TMPDIR` until the operating system's own periodic cleanup removes it,
+    /// same as any other scratch file this package writes there; nothing here
+    /// deletes it. What the UUID actually buys is narrower: no run ever reads
+    /// a PREVIOUS run's entries, and two worktrees testing at once never
+    /// share one.
     private static let testProcessScratchName = "duo-tauri-proofs-tests-\(UUID().uuidString)"
 
     static func defaultFileURL() -> URL {   // internal: asserted by DuoStateDirectoryTests

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// The disk half of `RuntimeVersion`'s Tauri cache — what lets the verdict a
+/// process's binary walk reaches outlive that process.
+///
+/// `RuntimeVersion.cache` (see its doc comment) already remembers an answer for
+/// the life of one process, keyed on the executable's size and modification
+/// date. That is enough for the menu-bar app, which walks a candidate's binary
+/// at most once per launch. It is not enough for `duo`: every invocation is a
+/// fresh process, so without this store `duo list` re-walks every Tauri
+/// candidate's executable on every call — measured at 400–730 ms across the
+/// bundles this machine's filter admits, out of a total `duo list` runtime of
+/// 0.7–1.0 s. This file exists to make the second and later calls skip that
+/// walk entirely.
+///
+/// Only `.tauri` is stored here, and that is a decision made in
+/// `RuntimeVersion.read`, not in this file — see the comment on its `cache` for
+/// why Electron and Chromium's `nil` is not a verdict in the same sense and
+/// must not be persisted past the process that reached it. This type has no
+/// opinion about that; it just remembers whatever `record` is given, against
+/// the same size-and-modification-date identity `RuntimeVersion` already uses,
+/// so a rewritten binary (an update, or a scan racing an install) is silently a
+/// new question rather than a stale hit.
+///
+/// One entry per bundle path. A new identity for a path overwrites the old
+/// entry rather than adding beside it, so the file's size is bounded by "how
+/// many bundles have ever been proved on this machine" — a few, since
+/// `AppRuntimeDetector`'s filter is what limits which bundles ever reach here —
+/// and needs no separate pruning pass.
+final class TauriProofStore: @unchecked Sendable {
+
+    /// `version` is `nil` for a proved absence ("no `tauri-` crate in this
+    /// binary") — a real, expensive-to-reach answer, not the lack of one. There
+    /// is deliberately no way to represent ".unreadable" here: `RuntimeVersion`
+    /// never calls `record` for it, so the type does not need to say it either.
+    struct Entry: Codable, Equatable {
+        var identity: String
+        var version: String?
+    }
+
+    /// The instance `RuntimeVersion` calls through. Production code should
+    /// only ever touch this one; the `init(fileURL:)` override below exists for
+    /// tests that model two processes sharing one file.
+    static let shared = TauriProofStore()
+
+    /// Set only by tests. `nil` means "resolve `defaultFileURL()` fresh on
+    /// every access", which is deliberate and not an oversight: a `fileURL`
+    /// captured once at init, the way the other on-disk stores do it, would be
+    /// fine for them because they are constructed fresh per test or per
+    /// short-lived caller. `shared` is not — it is first touched at an
+    /// effectively random point across an entire `swift test` run, which is
+    /// exactly the shape `DuoStateDirectoryTests` exists to worry about
+    /// (`setenv` toggling `DUO_STATE_DIR` mid-suite). Resolving fresh on every
+    /// call shrinks that race window from "the rest of the process" to "one
+    /// lookup or record call", the same guarantee `DuoStateDirectory.base`
+    /// already gives every other reader of `DUO_STATE_DIR`.
+    private let fileURLOverride: URL?
+    private let lock = NSLock()
+
+    init(fileURL: URL? = nil) {
+        self.fileURLOverride = fileURL
+    }
+
+    private var fileURL: URL { fileURLOverride ?? Self.defaultFileURL() }
+
+    /// `nil` means "no record for this path at all". `.some(nil)` means "there
+    /// is a record, and it says no crate was found" — the two must stay
+    /// distinguishable, because the second is a real answer `RuntimeVersion`
+    /// should return without walking anything, and the first is not an answer
+    /// at all. A record whose `identity` does not match the caller's is treated
+    /// as no record, which is what makes a rewritten binary a fresh question.
+    func lookup(forBundleAt path: String, identity: String) -> String?? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let entry = Self.load(from: fileURL)[path], entry.identity == identity else { return nil }
+        return entry.version
+    }
+
+    /// Records one verdict, replacing whatever was there for `path` before.
+    ///
+    /// Reads the file fresh immediately before writing and merges into it,
+    /// rather than writing whatever this instance last loaded — so the app and
+    /// `duo` racing to record two different bundles do not clobber one
+    /// another's entries. Two writers racing on the *same* path can still lose
+    /// one of their two writes; the loser simply re-proves that one bundle next
+    /// time it is asked, which costs one walk and nothing else.
+    func record(_ version: String?, forBundleAt path: String, identity: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        var entries = Self.load(from: fileURL)
+        entries[path] = Entry(identity: identity, version: version)
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        let url = fileURL
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// A file that does not exist, cannot be parsed, or decodes to something
+    /// that is no longer this shape reads as empty rather than throwing —
+    /// costs one re-proof per entry that was lost and nothing else, the same
+    /// failure mode every other JSON-backed store in this package chooses.
+    private static func load(from url: URL) -> [String: Entry] {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([String: Entry].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+
+    static func defaultFileURL() -> URL {   // internal: asserted by DuoStateDirectoryTests
+        let base = DuoStateDirectory.isTestProcess
+            && ProcessInfo.processInfo.environment["DUO_STATE_DIR"] == nil
+            ? FileManager.default.temporaryDirectory
+                .appendingPathComponent("duo-tauri-proofs-tests", isDirectory: true)
+            : DuoStateDirectory.base
+        return base
+            .appendingPathComponent("com.duoupdater.app", isDirectory: true)
+            .appendingPathComponent("tauri-proofs.json")
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
@@ -8,10 +8,12 @@ import Foundation
 /// date. That is enough for the menu-bar app, which walks a candidate's binary
 /// at most once per launch. It is not enough for `duo`: every invocation is a
 /// fresh process, so without this store `duo list` re-walks every Tauri
-/// candidate's executable on every call — measured at 400–730 ms across the
-/// bundles this machine's filter admits, out of a total `duo list` runtime of
-/// 0.7–1.0 s. This file exists to make the second and later calls skip that
-/// walk entirely.
+/// candidate's executable on every call. Measured 2026-09-11 during review, on
+/// a 14-core M3 Max under load: a cold Tauri sweep across this machine's
+/// candidates took 400–730 ms of a 0.7–1.0 s `duo list` — a range, not a
+/// promise about any other machine's population of Tauri apps, only about how
+/// much of one `duo list` a repeated whole-binary walk can consume. This file
+/// exists to make the second and later calls skip that walk entirely.
 ///
 /// Only `.tauri` is stored here, and that is a decision made in
 /// `RuntimeVersion.read`, not in this file — see the comment on its `cache` for
@@ -36,6 +38,48 @@ final class TauriProofStore: @unchecked Sendable {
     struct Entry: Codable, Equatable {
         var identity: String
         var version: String?
+    }
+
+    /// The proof logic's generation, in the sense `Changelog.parserGeneration`
+    /// already establishes for this package: every entry on disk is stamped
+    /// with the generation that produced it, and a stored entry whose stamp
+    /// does not match the running build's — including a file predating this
+    /// field entirely, which fails to decode against `FileContents` below and
+    /// is treated exactly the same as a mismatch — is not read back. Read the
+    /// doc comment there first; the reasoning is identical, only the shape of
+    /// "wrong" differs.
+    ///
+    /// Before this field, an app relaunch or a `duo` invocation cleared
+    /// `RuntimeVersion.cache` for free, simply by ending the process that held
+    /// it — so a fix to the byte-search rules below took effect the moment the
+    /// new build ran. Once a verdict can outlive the build that computed it,
+    /// that stops being true: a bug in `probe`/`firstVersion` (three of which
+    /// review has already found in this exact file — see the doc comment on
+    /// `RuntimeVersion.probe(reading:for:components:)`) would otherwise be
+    /// baked into `~/Library/Application Support/com.duoupdater.app/`
+    /// forever, or until the vendor app it misjudged happens to update.
+    ///
+    /// **Bump this whenever a change could alter what a PREVIOUSLY-proved
+    /// bundle's verdict would come out as** — not merely a change that widens
+    /// what a *newly-encountered* binary can match:
+    /// - the needle prefix or component count `RuntimeVersion.read` passes to
+    ///   `probe` for `.tauri`;
+    /// - `firstVersion`'s rules: the digit run, the identifier guard, how a
+    ///   component count is enforced, `isFinal`;
+    /// - `probe`'s window/carry/boundary logic — `scanOverlap`, `scanChunkSize`,
+    ///   or the loop that stitches chunks together.
+    ///
+    /// One line per bump — what changed and why:
+    /// - 1: baseline, introduced with the field itself.
+    static let proverGeneration = 1
+
+    /// The on-disk shape: a generation stamp alongside the entries it stamps,
+    /// so a mismatch — including the shape below, which has none at all — is a
+    /// decode failure and therefore an empty store rather than a partially
+    /// trusted one.
+    private struct FileContents: Codable {
+        var generation: Int
+        var entries: [String: Entry]
     }
 
     /// The instance `RuntimeVersion` calls through. Production code should
@@ -89,29 +133,50 @@ final class TauriProofStore: @unchecked Sendable {
         defer { lock.unlock() }
         var entries = Self.load(from: fileURL)
         entries[path] = Entry(identity: identity, version: version)
-        guard let data = try? JSONEncoder().encode(entries) else { return }
+        let contents = FileContents(generation: Self.proverGeneration, entries: entries)
+        guard let data = try? JSONEncoder().encode(contents) else { return }
         let url = fileURL
         try? FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? data.write(to: url, options: .atomic)
     }
 
-    /// A file that does not exist, cannot be parsed, or decodes to something
-    /// that is no longer this shape reads as empty rather than throwing —
-    /// costs one re-proof per entry that was lost and nothing else, the same
-    /// failure mode every other JSON-backed store in this package chooses.
+    /// A file that does not exist, cannot be parsed, was stamped by a
+    /// different `proverGeneration`, or predates the stamp entirely (which
+    /// fails to decode against `FileContents` and lands in the same `try?`)
+    /// reads as empty rather than throwing or trusting a verdict this build
+    /// might disagree with — costs one re-proof per entry that was lost and
+    /// nothing else, the same failure mode every other JSON-backed store in
+    /// this package chooses.
     private static func load(from url: URL) -> [String: Entry] {
         guard let data = try? Data(contentsOf: url),
-              let decoded = try? JSONDecoder().decode([String: Entry].self, from: data)
+              let decoded = try? JSONDecoder().decode(FileContents.self, from: data),
+              decoded.generation == proverGeneration
         else { return [:] }
-        return decoded
+        return decoded.entries
     }
+
+    /// Where a test process's `.shared` writes, when `DUO_STATE_DIR` is unset.
+    ///
+    /// Unlike `EventStore`'s equivalent (`duo-events-tests`, a fixed name every
+    /// test process shares), this carries a UUID computed once, at first
+    /// access, and held for the rest of the process — because unlike
+    /// `EventStore`, which prunes itself by age and byte budget, this store
+    /// only ever grows: every `record` call adds an entry and nothing ever
+    /// removes one. Measured 2026-09-11: after a handful of `swift test` runs
+    /// sharing a fixed test path, that file held 40 entries across 5.9 KB, none
+    /// of them cleaned up, still there for the next run to read stale answers
+    /// from — and two worktrees testing at once would share it besides. A UUID
+    /// per process means every run starts from an empty store and leaves
+    /// nothing behind for the next one, which is what a test wants: bounded
+    /// scratch space, not accumulating history.
+    private static let testProcessScratchName = "duo-tauri-proofs-tests-\(UUID().uuidString)"
 
     static func defaultFileURL() -> URL {   // internal: asserted by DuoStateDirectoryTests
         let base = DuoStateDirectory.isTestProcess
             && ProcessInfo.processInfo.environment["DUO_STATE_DIR"] == nil
             ? FileManager.default.temporaryDirectory
-                .appendingPathComponent("duo-tauri-proofs-tests", isDirectory: true)
+                .appendingPathComponent(testProcessScratchName, isDirectory: true)
             : DuoStateDirectory.base
         return base
             .appendingPathComponent("com.duoupdater.app", isDirectory: true)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift
@@ -110,9 +110,19 @@ final class TauriProofStore: @unchecked Sendable {
     /// access for the rest of the process silently read and wrote
     /// `/tmp/duo-state-test/com.duoupdater.app/tauri-proofs.json` — a file
     /// every worktree's test run shares — instead of its own scratch file.
-    /// Resolving once, at construction, means `shared`'s target is decided
-    /// before any of that can reach it, and cannot be moved afterward by
-    /// anything another suite does to the environment.
+    /// Resolving once, at construction, means nothing another suite does to
+    /// the environment can move `shared`'s target afterward.
+    ///
+    /// Once is not enough on its own, though, because *construction* is the
+    /// moment in question: `shared` is a lazily initialised `static let`, so
+    /// it is built at its first touch, and that touch can itself fall inside
+    /// another test's `setenv` window. Resolved through `defaultFileURL()`
+    /// there, the whole process would stay pinned to that test's directory —
+    /// the same leak, arriving by chance instead of every time. So in a test
+    /// process the default store does not consult `DUO_STATE_DIR` at all and
+    /// always takes the per-process scratch file. `defaultFileURL()` still
+    /// honours the override, which is what `DuoStateDirectoryTests` asserts
+    /// and what a real process (`duo verify` sets it at launch) resolves.
     ///
     /// Every other on-disk store in this package also resolves once, at
     /// construction — the difference is only that they are built fresh per
@@ -122,7 +132,8 @@ final class TauriProofStore: @unchecked Sendable {
     let resolvedFileURL: URL   // internal: asserted by TauriProofStoreTests
 
     init(fileURL: URL? = nil) {
-        self.resolvedFileURL = fileURL ?? Self.defaultFileURL()
+        self.resolvedFileURL = fileURL
+            ?? (DuoStateDirectory.isTestProcess ? Self.testProcessScratchFileURL : Self.defaultFileURL())
     }
 
     /// `nil` means "no record for this path at all". `.some(nil)` means "there
@@ -174,7 +185,9 @@ final class TauriProofStore: @unchecked Sendable {
         return decoded.entries
     }
 
-    /// Where a test process's `.shared` writes, when `DUO_STATE_DIR` is unset.
+    /// Where a test process's default store writes — always, whatever
+    /// `DUO_STATE_DIR` says (see `resolvedFileURL`) — and where
+    /// `defaultFileURL()` points in a test process while the override is unset.
     ///
     /// Unlike `EventStore`'s equivalent (`duo-events-tests`, a fixed name every
     /// test process shares), this carries a UUID computed once — because
@@ -191,15 +204,17 @@ final class TauriProofStore: @unchecked Sendable {
     /// deletes it. What the UUID actually buys is narrower: no run ever reads
     /// a PREVIOUS run's entries, and two worktrees testing at once never
     /// share one.
-    private static let testProcessScratchName = "duo-tauri-proofs-tests-\(UUID().uuidString)"
+    static let testProcessScratchFileURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("duo-tauri-proofs-tests-\(UUID().uuidString)", isDirectory: true)
+        .appendingPathComponent("com.duoupdater.app", isDirectory: true)
+        .appendingPathComponent("tauri-proofs.json")
 
     static func defaultFileURL() -> URL {   // internal: asserted by DuoStateDirectoryTests
-        let base = DuoStateDirectory.isTestProcess
-            && ProcessInfo.processInfo.environment["DUO_STATE_DIR"] == nil
-            ? FileManager.default.temporaryDirectory
-                .appendingPathComponent(testProcessScratchName, isDirectory: true)
-            : DuoStateDirectory.base
-        return base
+        if DuoStateDirectory.isTestProcess
+            && ProcessInfo.processInfo.environment["DUO_STATE_DIR"] == nil {
+            return testProcessScratchFileURL
+        }
+        return DuoStateDirectory.base
             .appendingPathComponent("com.duoupdater.app", isDirectory: true)
             .appendingPathComponent("tauri-proofs.json")
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/DuoStateDirectory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/DuoStateDirectory.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// Where DuoUpdater keeps its own on-disk state — the traffic log, the release
-/// timeline, the changelog cache, formula release notes, and rollback backups.
+/// timeline, the changelog cache, formula release notes, the Tauri crate-proof
+/// cache, and rollback backups.
 ///
 /// This exists so a second DuoUpdater process can be pointed somewhere else.
 /// The nightly `duo verify` sweep runs on the same machine and as the same user
@@ -30,5 +31,27 @@ public enum DuoStateDirectory {
         }
         return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
+    }
+
+    /// Whether this process is a test host, for the stores that must never
+    /// write into the developer's own state even when `DUO_STATE_DIR` is unset.
+    ///
+    /// Moved here from `EventStore`, which used to be the only store that
+    /// needed this question. `TauriProofStore` needs the identical check now,
+    /// and leaving it where it was would have meant a second, private copy of
+    /// the same few lines — exactly the drift this repository's own rules warn
+    /// about. `EventStore.defaultFileURL()` still decides *whether* to redirect
+    /// itself (see the comment there for why that decision stays local rather
+    /// than moving into `base` above); only the "is this a test process"
+    /// question moved.
+    ///
+    /// Both runners are named because they differ: SwiftPM runs the suite as
+    /// `swiftpm-testing-helper` with no XCTest environment at all (measured),
+    /// while Xcode uses `xctest` and an `.xctest` bundle.
+    public static var isTestProcess: Bool {
+        let name = ProcessInfo.processInfo.processName
+        return name == "swiftpm-testing-helper" || name == "xctest"
+            || Bundle.main.bundleURL.pathExtension == "xctest"
+            || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/DuoStateDirectory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/DuoStateDirectory.swift
@@ -48,7 +48,7 @@ public enum DuoStateDirectory {
     /// Both runners are named because they differ: SwiftPM runs the suite as
     /// `swiftpm-testing-helper` with no XCTest environment at all (measured),
     /// while Xcode uses `xctest` and an `.xctest` bundle.
-    public static var isTestProcess: Bool {
+    static var isTestProcess: Bool {
         let name = ProcessInfo.processInfo.processName
         return name == "swiftpm-testing-helper" || name == "xctest"
             || Bundle.main.bundleURL.pathExtension == "xctest"

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DuoStateDirectoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DuoStateDirectoryTests.swift
@@ -45,6 +45,8 @@ struct DuoStateDirectoryTests {
             #expect(BackupStore.root.path == "/tmp/duo-state-test/DuoUpdater/Backups")
             #expect(GitHubConditionalCache.defaultFileURL().path
                 == "/tmp/duo-state-test/com.duoupdater.app/github-conditional-cache.json")
+            #expect(TauriProofStore.defaultFileURL().path
+                == "/tmp/duo-state-test/com.duoupdater.app/tauri-proofs.json")
             // Resolved in the initialiser, so it must be constructed inside the
             // override; reading it back is what needs the await.
             return ChangelogDiskCache()

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreTests.swift
@@ -746,6 +746,33 @@ struct EventStoreTests {
                 "the batch was dropped rather than deferred")
     }
 
+    /// Runs `body` with `DUO_STATE_DIR` unset, restoring exactly what was
+    /// there before — including restoring to "unset" when nothing was there.
+    ///
+    /// Mirrors `DuoStateDirectoryTests.withStateDir`, whose `defer` already
+    /// gets that case right; this file's own inline version did not, until
+    /// this fix. `previous == nil` (the common case — nothing else in this
+    /// suite normally sets `DUO_STATE_DIR`) used to leave the variable set to
+    /// whatever the test body last set it to for the rest of the *process*,
+    /// not just the rest of this test — a real consequence, not a
+    /// hypothetical one: `TauriProofStore.shared` resolves its file location
+    /// exactly once, at first touch, so any test that happened to touch it
+    /// after this leak silently read and wrote
+    /// `/tmp/duo-state-test/com.duoupdater.app/tauri-proofs.json` — a file
+    /// every worktree's test run shares — instead of its own per-process
+    /// scratch file. See `theStateDirIsRestoredToUnsetNotLeftDangling` below
+    /// for the test that pins the restore itself, which `testProcessesGetTheirOwnStore`
+    /// cannot: a `defer` firing correctly is invisible from inside the
+    /// function it belongs to.
+    private func withDUOStateDirUnset<T>(_ body: () -> T) -> T {
+        let previous = ProcessInfo.processInfo.environment["DUO_STATE_DIR"]
+        unsetenv("DUO_STATE_DIR")
+        defer {
+            if let previous { setenv("DUO_STATE_DIR", previous, 1) } else { unsetenv("DUO_STATE_DIR") }
+        }
+        return body()
+    }
+
     /// The test suite must not write into the developer's own store.
     ///
     /// It did: after one `make test` the real database held 1643 `cli` events,
@@ -753,19 +780,34 @@ struct EventStoreTests {
     /// contacted — and those rows are in the never-pruned totals for good.
     @Test("A test process never writes to the real event store")
     func testProcessesGetTheirOwnStore() {
+        withDUOStateDirUnset {
+            #expect(DuoStateDirectory.isTestProcess, "this suite is running in one")
+            let path = EventStore.defaultFileURL().path
+            #expect(!path.contains("Application Support"),
+                    "the suite would write into the user's own store at \(path)")
+            // An explicit override still wins — the escape hatch every other store
+            // honours must not be shadowed by the test-process guard.
+            setenv("DUO_STATE_DIR", "/tmp/duo-state-test", 1)
+            #expect(EventStore.defaultFileURL().path
+                    == "/tmp/duo-state-test/com.duoupdater.app/events.sqlite")
+        }
+    }
+
+    /// Pins the restore half of `withDUOStateDirUnset`, which the test above
+    /// cannot pin on its own — see that helper's doc comment for the real
+    /// incident this reproduces. Deliberately unsets `DUO_STATE_DIR` itself
+    /// first, so `previous` inside the helper is `nil`: that is the exact
+    /// branch the bug lived in.
+    @Test func theStateDirIsRestoredToUnsetNotLeftDangling() {
         let previous = ProcessInfo.processInfo.environment["DUO_STATE_DIR"]
         unsetenv("DUO_STATE_DIR")
         defer { if let previous { setenv("DUO_STATE_DIR", previous, 1) } }
 
-        #expect(DuoStateDirectory.isTestProcess, "this suite is running in one")
-        let path = EventStore.defaultFileURL().path
-        #expect(!path.contains("Application Support"),
-                "the suite would write into the user's own store at \(path)")
-        // An explicit override still wins — the escape hatch every other store
-        // honours must not be shadowed by the test-process guard.
-        setenv("DUO_STATE_DIR", "/tmp/duo-state-test", 1)
-        #expect(EventStore.defaultFileURL().path
-                == "/tmp/duo-state-test/com.duoupdater.app/events.sqlite")
+        withDUOStateDirUnset {
+            setenv("DUO_STATE_DIR", "/tmp/duo-state-test-restore-check", 1)
+        }
+        #expect(ProcessInfo.processInfo.environment["DUO_STATE_DIR"] == nil,
+                "DUO_STATE_DIR must be restored to unset, not left at whatever the body last set it to")
     }
 
     /// The retention ceiling and the reported size must mean the on-disk

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreTests.swift
@@ -757,7 +757,7 @@ struct EventStoreTests {
         unsetenv("DUO_STATE_DIR")
         defer { if let previous { setenv("DUO_STATE_DIR", previous, 1) } }
 
-        #expect(EventStore.isTestProcess, "this suite is running in one")
+        #expect(DuoStateDirectory.isTestProcess, "this suite is running in one")
         let path = EventStore.defaultFileURL().path
         #expect(!path.contains("Application Support"),
                 "the suite would write into the user's own store at \(path)")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift
@@ -432,6 +432,77 @@ private let stamp = Date(timeIntervalSince1970: 1_700_000_000)
     #expect(b.version(.tauri) == nil, "the proven absence is remembered, not walked again")
 }
 
+// MARK: - Disk persistence for `.tauri` (`TauriProofStore`)
+//
+// These exercise `RuntimeVersion.read` end to end, through the production
+// `TauriProofStore.shared` it actually calls — not a store instance built for
+// the test, which is what `TauriProofStoreTests` covers instead. Each test
+// below uses a never-before-seen `VersionBundle`, so `RuntimeVersion.cache`
+// (the in-memory dictionary shared by every test in this process) cannot be
+// the thing answering; only the disk store or a fresh walk can be.
+
+@Test func aTauriAnswerComesFromDiskInsteadOfAFreshWalk() throws {
+    let b = try VersionBundle("DiskCached"); defer { b.cleanUp() }
+    try b.executable("DiskCached", containing: "registry/src/index/tauri-2.11.5/src/lib.rs")
+    let executable = b.bundle.appendingPathComponent("Contents/MacOS/DiskCached")
+    let identity = try #require(RuntimeVersion.executableIdentity(of: executable))
+
+    // Plant a disk answer that disagrees with what the binary actually
+    // contains. Returning it — rather than the real 2.11.5 — is the only way
+    // to tell "the disk store decided this" apart from "a fresh walk did",
+    // since a fresh walk would report the real version regardless.
+    TauriProofStore.shared.record("9.9.9", forBundleAt: b.bundle.path, identity: identity)
+    #expect(b.version(.tauri) == "9.9.9",
+            "a matching disk record must win over a fresh walk of the real binary")
+
+    // Change the executable's modification date: the identity the disk
+    // record was keyed on no longer matches, so the stale entry must not be
+    // read back, and the real, freshly-walked answer must win instead.
+    try FileManager.default.setAttributes(
+        [.modificationDate: Date(timeIntervalSince1970: 1_700_000_555)],
+        ofItemAtPath: executable.path)
+    #expect(b.version(.tauri) == "2.11.5",
+            "a changed identity must not be answered from the now-stale disk record")
+}
+
+@Test(.enabled(if: geteuid() != 0, "chmod 000 does not stop root, and this turns on a read failing"))
+func anUnreadableBinaryLeavesNoDiskRecordBehind() throws {
+    let b = try VersionBundle("Locked"); defer { b.cleanUp() }
+    try b.executable("Locked", containing: "registry/src/index/tauri-2.11.5/src/lib.rs")
+    let executable = b.bundle.appendingPathComponent("Contents/MacOS/Locked")
+    let identity = try #require(RuntimeVersion.executableIdentity(of: executable),
+                                 "identity comes from stat, which chmod 000 does not block")
+
+    try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: executable.path)
+    defer {
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: executable.path)
+    }
+
+    #expect(b.version(.tauri) == nil)
+    #expect(TauriProofStore.shared.lookup(forBundleAt: b.bundle.path, identity: identity) == nil,
+            "an unreadable binary proved nothing and must leave no disk record at all")
+}
+
+@Test func aNonTauriRuntimeIsNotPersistedToDisk() throws {
+    // Electron's re-signed shape is the closest thing to Tauri's cost here —
+    // it also walks a whole binary — and the one most likely to end up on
+    // disk by mistake if the `runtime == .tauri` guard were ever loosened.
+    let b = try VersionBundle("Kiro"); defer { b.cleanUp() }
+    try b.framework("Electron Framework.framework", plist: [
+        "CFBundleIdentifier": "dev.kiro.desktop.com.github.Electron.framework",
+        "CFBundleVersion": "1.0.411",
+    ])
+    let binary = b.bundle.appendingPathComponent(
+        "Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework")
+    try Data("ua Chrome/136.0.0.0 Electron/39.6.0 Safari/537.36".utf8).write(to: binary)
+    #expect(b.version(.electron) == "39.6.0")
+
+    let executable = b.bundle.appendingPathComponent("Contents/MacOS/Kiro")
+    let identity = try #require(RuntimeVersion.executableIdentity(of: executable))
+    #expect(TauriProofStore.shared.lookup(forBundleAt: b.bundle.path, identity: identity) == nil,
+            "only .tauri is written to disk — Electron's nil is not a verdict, see RuntimeVersion.cache")
+}
+
 @Test(.enabled(if: geteuid() != 0, "chmod 000 does not stop root, and these turn on a read failing"))
 func aBinaryThatCannotBeReadThroughIsNotRememberedAsProofOfAbsence() throws {
     // The distinction `Probe` exists for. A nil from the Tauri reader is a verdict —

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
@@ -70,6 +70,45 @@ struct TauriProofStoreTests {
             .lookup(forBundleAt: "/Applications/Anything.app", identity: "id") == .some("1.0.0"))
     }
 
+    /// A record stamped by a different `TauriProofStore.proverGeneration` must
+    /// not be trusted — the same rule `Changelog.parserGeneration` already
+    /// enforces, and for the identical reason: it might have been produced by
+    /// a `probe`/`firstVersion` rule this build no longer agrees with.
+    @Test func aRecordWrittenUnderAnOldGenerationIsIgnored() throws {
+        let file = scratchFile(); defer { try? FileManager.default.removeItem(at: file) }
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let staleGeneration = TauriProofStore.proverGeneration - 1
+        let json = """
+        {"generation": \(staleGeneration), "entries": \
+        {"/Applications/Old.app": {"identity": "id-1", "version": "9.9.9"}}}
+        """
+        try Data(json.utf8).write(to: file)
+
+        let store = TauriProofStore(fileURL: file)
+        #expect(store.lookup(forBundleAt: "/Applications/Old.app", identity: "id-1") == nil,
+                "a record stamped with a different proverGeneration must not be trusted")
+    }
+
+    /// A file predating the generation field entirely — the flat
+    /// `[path: Entry]` shape this store originally shipped with, before this
+    /// review round added the stamp — must be treated exactly the same as a
+    /// generation mismatch: fails to decode against `FileContents` and reads
+    /// as empty, not as a trusted pre-generation store.
+    @Test func aFileFromBeforeTheGenerationFieldExistedIsIgnored() throws {
+        let file = scratchFile(); defer { try? FileManager.default.removeItem(at: file) }
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let json = """
+        {"/Applications/Old.app": {"identity": "id-1", "version": "9.9.9"}}
+        """
+        try Data(json.utf8).write(to: file)
+
+        let store = TauriProofStore(fileURL: file)
+        #expect(store.lookup(forBundleAt: "/Applications/Old.app", identity: "id-1") == nil,
+                "a pre-generation file must not be trusted")
+    }
+
     @Test func aSecondWriterMergesRatherThanOverwritingTheFirstsEntry() {
         // Models two processes recording two different bundles against the
         // same file without either instance having read the other's write

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `TauriProofStore` in isolation — two instances pointed at the same file,
+/// modelling two processes sharing it, rather than the global `.shared`
+/// singleton `RuntimeVersion` calls through. See `RuntimeVersionTests` for the
+/// tests that exercise `.shared` through `RuntimeVersion.read`.
+struct TauriProofStoreTests {
+
+    /// A fresh, never-before-used path per test, so tests cannot see each
+    /// other's writes.
+    private func scratchFile() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("tauri-proof-store-test-\(UUID().uuidString)")
+            .appendingPathComponent("tauri-proofs.json")
+    }
+
+    @Test func aFoundVersionRoundTripsThroughAnotherInstance() {
+        let file = scratchFile(); defer { try? FileManager.default.removeItem(at: file) }
+        let writer = TauriProofStore(fileURL: file)
+        writer.record("2.11.5", forBundleAt: "/Applications/Shell.app", identity: "100-1700000000.0")
+
+        // A second instance, not the one that wrote — the point being tested
+        // is the file, not whatever the writer kept in memory.
+        let reader = TauriProofStore(fileURL: file)
+        #expect(reader.lookup(forBundleAt: "/Applications/Shell.app", identity: "100-1700000000.0")
+            == .some("2.11.5"))
+    }
+
+    /// `.some(nil)` — a recorded "no crate found" — must come back distinct
+    /// from "no record at all", which is plain `nil`. Collapsing the two would
+    /// make a proved absence indistinguishable from a bundle nobody has asked
+    /// about, and `RuntimeVersion` relies on telling them apart to avoid
+    /// re-walking a binary that was already proved not to be Tauri.
+    @Test func anAbsentVerdictRoundTripsAsSomeNilNotAsNoRecord() {
+        let file = scratchFile(); defer { try? FileManager.default.removeItem(at: file) }
+        let writer = TauriProofStore(fileURL: file)
+        writer.record(nil, forBundleAt: "/Applications/Shell.app", identity: "id-1")
+
+        let reader = TauriProofStore(fileURL: file)
+        let answer = reader.lookup(forBundleAt: "/Applications/Shell.app", identity: "id-1")
+        #expect(answer != nil, "a recorded absence is a record, not the lack of one")
+        #expect(answer == .some(nil))
+    }
+
+    @Test func aChangedIdentityIsNotAHit() {
+        let file = scratchFile(); defer { try? FileManager.default.removeItem(at: file) }
+        let writer = TauriProofStore(fileURL: file)
+        writer.record("2.11.5", forBundleAt: "/Applications/Shell.app", identity: "id-1")
+
+        let reader = TauriProofStore(fileURL: file)
+        #expect(reader.lookup(forBundleAt: "/Applications/Shell.app", identity: "id-2") == nil,
+                "a bundle rewritten under the same path must be a fresh question, not a stale hit")
+    }
+
+    @Test func aCorruptFileReadsAsEmptyRatherThanThrowing() throws {
+        let file = scratchFile(); defer { try? FileManager.default.removeItem(at: file) }
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("not json at all".utf8).write(to: file)
+
+        let store = TauriProofStore(fileURL: file)
+        #expect(store.lookup(forBundleAt: "/Applications/Anything.app", identity: "id") == nil)
+
+        // And a store that read a corrupt file can still write — the failure
+        // must not be sticky.
+        store.record("1.0.0", forBundleAt: "/Applications/Anything.app", identity: "id")
+        #expect(TauriProofStore(fileURL: file)
+            .lookup(forBundleAt: "/Applications/Anything.app", identity: "id") == .some("1.0.0"))
+    }
+
+    @Test func aSecondWriterMergesRatherThanOverwritingTheFirstsEntry() {
+        // Models two processes recording two different bundles against the
+        // same file without either instance having read the other's write
+        // first — the shape `record`'s read-before-write exists for.
+        let file = scratchFile(); defer { try? FileManager.default.removeItem(at: file) }
+        let first = TauriProofStore(fileURL: file)
+        first.record("2.11.5", forBundleAt: "/Applications/A.app", identity: "id-a")
+
+        let second = TauriProofStore(fileURL: file)
+        second.record("3.0.0", forBundleAt: "/Applications/B.app", identity: "id-b")
+
+        let reader = TauriProofStore(fileURL: file)
+        #expect(reader.lookup(forBundleAt: "/Applications/A.app", identity: "id-a") == .some("2.11.5"),
+                "the second writer's record must not have clobbered the first's")
+        #expect(reader.lookup(forBundleAt: "/Applications/B.app", identity: "id-b") == .some("3.0.0"))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
@@ -125,4 +125,29 @@ struct TauriProofStoreTests {
                 "the second writer's record must not have clobbered the first's")
         #expect(reader.lookup(forBundleAt: "/Applications/B.app", identity: "id-b") == .some("3.0.0"))
     }
+
+    /// `.shared` resolves `resolvedFileURL` once, at construction — see the
+    /// doc comment there for the real incident (an `EventStoreTests` `defer`
+    /// bug) that motivated it. This is what proves the fix: touch `.shared`
+    /// once to force resolution (idempotent — later calls just read the same
+    /// stored value), then change `DUO_STATE_DIR` and confirm the resolved
+    /// path did not move.
+    ///
+    /// Deliberately does not assert anything about what `resolvedBefore` IS —
+    /// only that a later `setenv` cannot change it. `.shared` may already
+    /// have been touched by another test in this process by the time this
+    /// one runs, which is fine and expected; it is exactly the "touched at an
+    /// effectively random point" shape the doc comment describes.
+    @Test func sharedsResolvedPathIsFixedRegardlessOfLaterDUOStateDirChanges() {
+        let resolvedBefore = TauriProofStore.shared.resolvedFileURL
+
+        let previous = ProcessInfo.processInfo.environment["DUO_STATE_DIR"]
+        setenv("DUO_STATE_DIR", "/tmp/duo-tauri-should-never-be-read-\(UUID().uuidString)", 1)
+        defer {
+            if let previous { setenv("DUO_STATE_DIR", previous, 1) } else { unsetenv("DUO_STATE_DIR") }
+        }
+
+        #expect(TauriProofStore.shared.resolvedFileURL == resolvedBefore,
+                ".shared must not re-resolve its file location after a later DUO_STATE_DIR change")
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift
@@ -150,4 +150,29 @@ struct TauriProofStoreTests {
         #expect(TauriProofStore.shared.resolvedFileURL == resolvedBefore,
                 ".shared must not re-resolve its file location after a later DUO_STATE_DIR change")
     }
+
+    /// The other half of the same fix: resolving once does not help if the
+    /// one resolution happens inside another test's `setenv` window, and
+    /// `.shared` is built at whatever moment first touches it. So in a test
+    /// process the default store must not consult `DUO_STATE_DIR` at all.
+    ///
+    /// Builds a default store *while* the override is set — the exact moment
+    /// `.shared`'s first touch could land in — and requires the per-process
+    /// scratch file anyway. Resolving through `defaultFileURL()` instead lands
+    /// it under the override and fails this test deterministically, which the
+    /// test above cannot do: whether `.shared` happened to be touched inside a
+    /// window is up to the scheduler.
+    @Test func aDefaultStoreBuiltInATestProcessIgnoresDUOStateDir() {
+        let override = "/tmp/duo-tauri-should-never-be-read-\(UUID().uuidString)"
+        let previous = ProcessInfo.processInfo.environment["DUO_STATE_DIR"]
+        setenv("DUO_STATE_DIR", override, 1)
+        defer {
+            if let previous { setenv("DUO_STATE_DIR", previous, 1) } else { unsetenv("DUO_STATE_DIR") }
+        }
+
+        let store = TauriProofStore()
+        #expect(store.resolvedFileURL == TauriProofStore.testProcessScratchFileURL)
+        #expect(!store.resolvedFileURL.path.hasPrefix(override))
+        #expect(TauriProofStore.shared.resolvedFileURL == TauriProofStore.testProcessScratchFileURL)
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProverGenerationGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProverGenerationGuardTests.swift
@@ -74,6 +74,25 @@ import Foundation
                 "if this is an intentional change, bump TauriProofStore.proverGeneration")
     }
 
+    /// The three fixtures above drive `probe` directly with this file's own
+    /// `"tauri-"`/`3` literals, which do not move if the PRODUCTION call
+    /// site's arguments change — `RuntimeVersion.read`'s `.tauri` case passes
+    /// its own copies of that needle and component count to `probe`, and
+    /// nothing here reads them back. This test goes through
+    /// `RuntimeVersion.read(.tauri, ...)` itself, on a real (if minimal)
+    /// bundle, so a change to either literal at the production call site —
+    /// not just a change to `probe`/`firstVersion` themselves — moves this
+    /// test too.
+    @Test func aPlainCratePathIsFoundThroughTheProductionCallSite() throws {
+        let bundle = try MinimalBundle(
+            named: "GenerationGuardFixture",
+            executableContaining: "registry/src/index/tauri-2.11.5/src/lib.rs")
+        defer { bundle.cleanUp() }
+        let version = RuntimeVersion.read(.tauri, bundleAt: bundle.url, scanningBinaries: true)
+        #expect(version == "2.11.5",
+                "if this is an intentional change, bump TauriProofStore.proverGeneration")
+    }
+
     private func chunks(_ strings: [String]) -> RuntimeVersion.Probe {
         chunks(bytes: strings.map { Data($0.utf8) })
     }
@@ -86,5 +105,33 @@ import Foundation
                 return remaining.removeFirst()
             },
             for: "tauri-", components: 3)
+    }
+}
+
+/// A bundle just complete enough for `RuntimeVersion.read`'s `.tauri` case: an
+/// `Info.plist` naming its executable, and the executable itself holding the
+/// payload. Not `VersionBundle` from `RuntimeVersionTests.swift` — that type
+/// is private to that file — but the same essential shape, pared down to
+/// what this file needs. `RuntimeVersion.read(.tauri, ...)` is called
+/// directly (not through `AppRuntimeDetector`), so none of the
+/// `LSRequiresCarbon`/`CSResourcesFileMapped`/WebKit plist-fingerprint
+/// filtering that gates real scans applies here — same as `VersionBundle`.
+private struct MinimalBundle {
+    let url: URL
+
+    init(named name: String, executableContaining text: String) throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("generation-guard-\(UUID().uuidString)")
+            .appendingPathComponent("\(name).app")
+        let macOS = url.appendingPathComponent("Contents/MacOS")
+        try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+        try Data(text.utf8).write(to: macOS.appendingPathComponent(name))
+        let plist = try PropertyListSerialization.data(
+            fromPropertyList: ["CFBundleExecutable": name], format: .xml, options: 0)
+        try plist.write(to: url.appendingPathComponent("Contents/Info.plist"))
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProverGenerationGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProverGenerationGuardTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The mechanical guard `TauriProofStore.proverGeneration` needed but didn't
+/// have — the same shape `ChangelogParserGenerationGuardTests` already gives
+/// `Changelog.parserGeneration`, for the identical reason: a hand-maintained
+/// "bump this when X changes" comment is not enforced by anything on its own,
+/// so a change to `RuntimeVersion.probe`/`firstVersion` that alters what an
+/// ALREADY-PROVED bundle's verdict would come out as could ship without
+/// anyone touching the generation number — and every value `TauriProofStore`
+/// already has on disk for that bundle would then silently go stale-WRONG
+/// (an old build's crate-path rules, misapplied forever to that one bundle)
+/// instead of stale-safe.
+///
+/// Three fixtures, chosen to jointly cover every trigger
+/// `TauriProofStore.proverGeneration`'s doc comment lists, driven directly
+/// through `RuntimeVersion.probe(reading:for:components:)` rather than
+/// through a real bundle on disk — the same choice the "driven through its
+/// own seam" section of `RuntimeVersionTests` already makes, and for the same
+/// reason: it is the only way to place a payload exactly on a chunk boundary
+/// without depending on `FileHandle`'s own read sizes.
+///
+/// - a plain `tauri-<version>` match — the needle prefix and the digit-run
+///   rule in `firstVersion`;
+/// - a wry-only binary, which must read as `.absent` — the identifier guard
+///   that is the entire reason `.tauri` needs a whole-binary walk to prove
+///   absence rather than stopping at "not found in this chunk";
+/// - a version cut by a chunk boundary, at the REAL `RuntimeVersion.scanChunkSize`
+///   — the window/carry/`isFinal` logic that `scanOverlap` and `scanChunkSize`
+///   feed.
+///
+/// A change to any of those moves this test. The fix is always the same
+/// two-part edit: bump `TauriProofStore.proverGeneration` (with a one-line log
+/// entry on its doc comment) and update the expected value below to match —
+/// exactly the discipline `ChangelogParserGenerationGuardTests` already
+/// documents for its own generation number.
+@Suite struct TauriProverGenerationGuardTests {
+
+    /// Pinned alongside the three fixture checks below on purpose: bumping the
+    /// generation without touching this file is still *possible* (nothing
+    /// forces them to be edited in the same commit), but keeping them next to
+    /// each other means a reviewer scanning this file sees both move together.
+    @Test func pinnedGeneration() {
+        #expect(TauriProofStore.proverGeneration == 1)
+    }
+
+    @Test func aPlainCratePathIsFound() {
+        let outcome = chunks(["junk/registry/src/index/tauri-2.11.5/src/lib.rsmore junk"])
+        #expect(outcome == .found("2.11.5"),
+                "if this is an intentional change, bump TauriProofStore.proverGeneration")
+    }
+
+    @Test func aWryOnlyBinaryIsProvedAbsentNotFound() {
+        let outcome = chunks([
+            "registry/src/index/wry-0.53.3/src/lib.rs and tauri-runtime-wry-2.11.4/src/lib.rs",
+        ])
+        #expect(outcome == .absent,
+                "if this is an intentional change, bump TauriProofStore.proverGeneration")
+    }
+
+    /// `tauri-2.11.50` split so the boundary falls between the `5` and the
+    /// `0`, at the exact `scanChunkSize` a real file read would split on —
+    /// not a toy chunk size, so a change to that constant moves this test too.
+    @Test func aVersionCutByTheRealChunkBoundaryIsReadWhole() {
+        let chunkSize = RuntimeVersion.scanChunkSize
+        let splitPrefix = " tauri-2.11.5"
+        let firstChunk = Data(repeating: UInt8(ascii: "."), count: chunkSize - splitPrefix.utf8.count)
+            + Data(splitPrefix.utf8)
+        let secondChunk = Data("0 ".utf8)
+
+        let outcome = chunks(bytes: [firstChunk, secondChunk])
+        #expect(outcome == .found("2.11.50"),
+                "if this is an intentional change, bump TauriProofStore.proverGeneration")
+    }
+
+    private func chunks(_ strings: [String]) -> RuntimeVersion.Probe {
+        chunks(bytes: strings.map { Data($0.utf8) })
+    }
+
+    private func chunks(bytes: [Data]) -> RuntimeVersion.Probe {
+        var remaining = bytes
+        return RuntimeVersion.probe(
+            reading: {
+                guard !remaining.isEmpty else { return nil }
+                return remaining.removeFirst()
+            },
+            for: "tauri-", components: 3)
+    }
+}


### PR DESCRIPTION
## Problem

`RuntimeVersion.read(.tauri, ...)` only remembers an answer for the life of one process (`RuntimeVersion.cache`). That's fine for the menu-bar app, which walks a candidate binary at most once per launch, but every `duo` CLI invocation is a fresh process — so `duo list` re-walked every Tauri candidate's executable on every call. Measured 2026-09-11 on this machine (14-core M3 Max, under load): a cold Tauri sweep across the real candidates installed here took 400–730 ms of a 0.7–1.0 s `duo list`.

## Design

Add `TauriProofStore` (`DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/TauriProofStore.swift`): a small JSON-backed store at `com.duoupdater.app/tauri-proofs.json`, one entry per bundle path, keyed on the same size+mtime `executableIdentity` `RuntimeVersion.cache` already uses.

- **Only `.tauri` is persisted.** Electron/Chromium's `nil` from `RuntimeVersion.read` is "could not read *right now*," not a verdict — it's flattened out of `.unreadable` by the `scan` helper those readers share — so persisting it would pin a transient read failure past the process that hit it. `.tauri` is the one runtime where `nil` (`.absent`) is a real, walked-the-whole-binary verdict, and `.unreadable` never reaches `record` at all.
- **Lookup order:** memory (`RuntimeVersion.cache`) → disk (`.tauri` only) → walk. The disk lookup sits above the `scanningBinaries` guard, exactly where the memory lookup already sits, so a caller that forbids scanning still gets an answer someone else already paid for.
- **Identity-based invalidation:** a stored identity that doesn't match the current executable's size+mtime is treated as no record — a rewritten binary (an update, or an install racing a scan) is a fresh question, not a stale hit.
- **Generation-stamped** (`TauriProofStore.proverGeneration`, following the existing `Changelog.parserGeneration` pattern in this repo): every entry is stamped with the generation that produced it, and a stamp mismatch — including a file from before this field existed — is treated as no record. This exists because persistence changes the failure mode of a bug in `probe`/`firstVersion`: before, an app relaunch cleared the in-memory cache for free and a rule fix took effect immediately; now a bad verdict could otherwise outlive the build that computed it, sitting on disk until the vendor app itself updates.
- **Read-merge-write on record()**, under an `NSLock` for in-process concurrency (style matches `RuntimeVersion.cacheLock`). Two processes racing on *different* bundles don't clobber each other; racing on the *same* bundle can lose one write, which just costs one re-proof next time — documented as an accepted tradeoff.
- **`TauriProofStore.shared`'s file path resolves fresh on every access** rather than being captured once at init, unlike the package's other on-disk stores. Those are constructed fresh per test/per caller; `.shared` is a long-lived singleton touched at an effectively random point across an entire `swift test` run, which is exactly the `DUO_STATE_DIR`-toggling race `DuoStateDirectoryTests` exists to worry about. Resolving fresh shrinks the exposure window from "the rest of the process" to "one lookup/record call."
- **Test-process isolation:** moved `EventStore.isTestProcess` into `DuoStateDirectory.isTestProcess` (internal) so `TauriProofStore` can share it instead of duplicating it. The test-mode scratch path carries a UUID computed once per process (not a fixed shared name) — a fixed name accumulated entries across every `swift test` run forever, since this store (unlike `EventStore`) has no pruning; measured 40 entries / 5.9 KB after a handful of runs sharing the old fixed path.

Updated the comments in `RuntimeVersion.swift`/`AppRuntime.swift` that described the cache as process-scoped/"once per asker" to reflect that `.tauri`'s verdict now also survives across processes.

## Testing

- `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProofStoreTests.swift` — the store in isolation (two instances pointed at one file, modelling two processes): found/absent round-trip, `.some(nil)` vs `nil` distinguished, identity mismatch is a miss, corrupt file reads as empty and can still write, a second writer merges rather than clobbering, a stale-generation record is ignored, a pre-generation-field file is ignored.
- `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RuntimeVersionTests.swift` — three new tests exercising `RuntimeVersion.read` end to end through the real `TauriProofStore.shared` (not a test-constructed instance): a planted disk answer wins over a fresh walk, then a changed identity invalidates it and the real answer wins; an unreadable binary leaves no disk record; a non-`.tauri` runtime (Electron) is never persisted.
- `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TauriProverGenerationGuardTests.swift` — new, mirrors `ChangelogParserGenerationGuardTests`: pins `RuntimeVersion.probe`'s actual output for three fixtures (plain match, wry-only absence, a version cut across the real `scanChunkSize` boundary) so a rule change that should bump `proverGeneration` fails loudly here instead of silently.
- `DuoStateDirectoryTests` — added an assertion that `TauriProofStore.defaultFileURL()` follows `DUO_STATE_DIR` like every other store.

### Mutation testing (all reverted after confirming red)

1. Disabled the disk lookup in `RuntimeVersion.read` → `aTauriAnswerComesFromDiskInsteadOfAFreshWalk` failed (`b.version(.tauri) == "9.9.9"` → false, got `"2.11.5"` — the real value, proving the disk shortcut was actually load-bearing).
2. Made the `.unreadable` case also write to disk → `anUnreadableBinaryLeavesNoDiskRecordBehind` failed (lookup returned `.some(nil)` instead of `nil`).
3. Removed the `runtime == .tauri` restriction on the disk write → `aNonTauriRuntimeIsNotPersistedToDisk` failed (Electron's `"39.6.0"` showed up in the store).
4. Removed the generation-equality check in `TauriProofStore.load` → `aRecordWrittenUnderAnOldGenerationIsIgnored` failed (returned the stale `"9.9.9"`); the pre-generation-field fixture stayed green on its own (still fails to decode structurally either way).

### Real-path verification

Built `CLI` in release mode on this branch and, separately, `git archive origin/main` into a scratch tree and built that unmodified as a baseline. Ran `duo list` three times each under a fresh, isolated `DUO_STATE_DIR` (170 real installed apps, 9 of them real Tauri candidates on this machine):

```
baseline (origin/main):  0.92s / 1.03s / 1.05s   (warm, no persistence)
this branch:             0.37s / 0.33s            (warm, second/third call read the disk cache)
```

`duo list --json` output is byte-identical between the two builds (170 lines each, `diff` empty). `duo list` doesn't surface a `runtime` field in its JSON at all (grepped `CLI/Sources` — confirmed), so I additionally read the populated `tauri-proofs.json` after a real run and cross-checked its 9 entries: 8 real Tauri apps with their actual crate versions (e.g. Clash Verge 2.11.5, CC Switch 2.10.3), and Longbridge correctly recorded as absent (`version` key omitted) — matching the wry-only-not-Tauri case this repo's own comments already document for that exact app.

## Not done / open question for the reviewer

Nothing else flagged from the second review pass beyond what's already folded in above.
