### PR TITLE
Fetch Electron manifests past CDN edge copies; add Kimi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.92
 
+**Some self-updating apps no longer look up to date while a newer version is out.** For apps whose update information sits behind a slow-to-refresh download server, Duo Updater could keep seeing an older version for days after a release.
+
+**Kimi is now supported: update checks and release notes.**
+
 Under the hood: the Homebrew list in the menu fills in faster, and `duo` commands start faster.
 
 ## 0.3.91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Some self-updating apps no longer look up to date while a newer version is out.** For apps whose update information sits behind a slow-to-refresh download server, Duo Updater could keep seeing an older version for days after a release.
 
-**Kimi is now supported: update checks and release notes.**
+**Kimi's release notes now show up in Duo Updater.**
 
 Under the hood: the Homebrew list in the menu fills in faster, and `duo` commands start faster.
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -3407,6 +3407,32 @@ public enum ChangelogRecipeRegistry {
             entryPattern: qoderEntryPattern,
             itemPatterns: [#"<li[^>]*>(?<item>.*?)</li>"#]),
 
+        // Kimi — the version comes from `ElectronManifestSource` (the bundle's own
+        // `app-update.yml`), which carries no notes; the manifest's `releaseNotes`
+        // is a one-line Chinese summary anyway (3.2.7's, 2026-09-11:
+        // `新增滚动截图与插件推荐`). The full notes are this help-centre page.
+        //
+        // Server-rendered: one `<h2 id="327-2026-09-11">3.2.7 (2026-09-11)</h2>` per
+        // release, newest first, then `<p><strong>New|Changed|Fixed</strong></p>` +
+        // `<ul>` groups. An entry is version/date/items, so those labels are not
+        // carried and the groups flatten in document order (New first).
+        //
+        // Two shapes the patterns are built around, both on the page 2026-09-11:
+        // - The last release is followed by `</ul></div><section …>Was this article
+        //   helpful?`, so the body stops at the next `<h2` OR that `</div>`.
+        // - 3.2.1 nests a `<ul>` inside an `<li>`. A lazy `<li>(.*?)</li>` stops at
+        //   the first `</li>` it meets — the child's — and glues the parent line to
+        //   its first sub-item. The item stops at the next `<li`/`</li>` instead, so
+        //   the parent and each child come out as lines of their own.
+        ChangelogRecipe(
+            bundleID: "com.moonshot.kimichat",
+            source: URL(string: "https://www.kimi.com/en/help/kimi-work/release-notes")!,
+            entryPattern:
+                #"<h2[^>]*>\s*(?<version>[0-9]+(?:\.[0-9]+)+)\s*"#
+                + #"(?:\((?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})\))?\s*</h2>"#
+                + #"(?<body>.*?)(?=<h2\b|</div>)"#,
+            itemPatterns: [#"<li[^>]*>(?<item>(?:(?!</?li\b).)*)"#]),
+
         // Windscribe — the version comes from the vendor's own API (see
         // `VendorProbeRegistry`), but the notes come from GitHub, and that split
         // is the point rather than an accident.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifest.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifest.swift
@@ -53,8 +53,8 @@ public struct ElectronUpdateConfig: Sendable, Hashable {
     /// `noCache` query on the end. Fetch with this; resolve artifacts against
     /// `manifestURL`.
     ///
-    /// The query is what gets a request past a CDN's edge copy, and no request
-    /// header substitutes for it. electron-updater's `GenericProvider` builds the
+    /// The query is what gets a request past a CDN's edge copy; none of the three
+    /// request headers tried below substituted for it. electron-updater's `GenericProvider` builds the
     /// manifest address with `newUrlFromBase(…, isAddNoCacheQuery)`, which appends
     /// `noCache=<Date.now() in base 32>`, and `isAddNoCacheQuery` is true unless the
     /// app sends an `Authorization` / `PRIVATE-TOKEN` header (electron-builder
@@ -72,8 +72,11 @@ public struct ElectronUpdateConfig: Sendable, Hashable {
     /// nothing to offer for as long as the edge copy lived.
     ///
     /// An address that already carries a query is returned untouched rather than
-    /// having that query overwritten; electron-updater likewise adds no `noCache`
-    /// when the configured address states a query of its own.
+    /// having that query overwritten. That is NOT parity with electron-updater for
+    /// such a config: it requests `<url>/latest-mac.yml?<the config's query>`, while
+    /// `manifestURL`'s string concatenation puts the channel file inside the query
+    /// (`…/feed?token=abc/latest-mac.yml`). A gap in `manifestURL` that predates
+    /// this function and is left as it was.
     func manifestRequestURL(noCache token: String = Self.noCacheToken()) -> URL? {
         guard let manifest = manifestURL else { return nil }
         guard manifest.query == nil,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifest.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifest.swift
@@ -49,6 +49,47 @@ public struct ElectronUpdateConfig: Sendable, Hashable {
         return URL(string: "\(base)/\(channel)-mac.yml")
     }
 
+    /// `manifestURL` as electron-updater actually requests it: with a throwaway
+    /// `noCache` query on the end. Fetch with this; resolve artifacts against
+    /// `manifestURL`.
+    ///
+    /// The query is what gets a request past a CDN's edge copy, and no request
+    /// header substitutes for it. electron-updater's `GenericProvider` builds the
+    /// manifest address with `newUrlFromBase(…, isAddNoCacheQuery)`, which appends
+    /// `noCache=<Date.now() in base 32>`, and `isAddNoCacheQuery` is true unless the
+    /// app sends an `Authorization` / `PRIVATE-TOKEN` header (electron-builder
+    /// `AppUpdater.ts`, issue #3021). So every check an electron-builder app makes
+    /// on its own reaches the origin, and the vendor never has to keep its edge
+    /// copies fresh.
+    ///
+    /// Measured 2026-09-11 on Kimi's `kimi-img.moonshot.cn/app/upgrade/latest-mac.yml`:
+    /// the bare address answered `3.2.5` from an edge copy four and a half days old
+    /// (`Age: 384307`), and `Cache-Control: no-cache`, `max-age=0` and
+    /// `Pragma: no-cache` on the request all got that same copy; with the query it
+    /// answered `3.2.7` from origin (`Age: 0`), the version Kimi's own updater
+    /// reported as latest. Reading the bare address, this source called a 3.2.7
+    /// install up to date against `3.2.5`, and would leave a 3.2.5 install with
+    /// nothing to offer for as long as the edge copy lived.
+    ///
+    /// An address that already carries a query is returned untouched rather than
+    /// having that query overwritten; electron-updater likewise adds no `noCache`
+    /// when the configured address states a query of its own.
+    func manifestRequestURL(noCache token: String = Self.noCacheToken()) -> URL? {
+        guard let manifest = manifestURL else { return nil }
+        guard manifest.query == nil,
+              var components = URLComponents(url: manifest, resolvingAgainstBaseURL: false)
+        else { return manifest }
+        components.queryItems = [URLQueryItem(name: "noCache", value: token)]
+        return components.url ?? manifest
+    }
+
+    /// electron-updater's token, `Date.now().toString(32)`: epoch milliseconds in
+    /// base 32. Only its uniqueness matters to a CDN; the spelling is kept so the
+    /// request looks like the app's own.
+    static func noCacheToken(now: Date = Date()) -> String {
+        String(Int64((now.timeIntervalSince1970 * 1000).rounded(.down)), radix: 32)
+    }
+
     /// Read the config a packaged Electron app carries, if it carries one.
     public static func read(fromBundleAt bundleURL: URL) -> ElectronUpdateConfig? {
         guard let text = try? String(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifestSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifestSource.swift
@@ -70,7 +70,9 @@ public struct ElectronManifestSource: UpdateSource {
         // app would go quietly blind to new releases. That covers OUR cache; the
         // query above covers the CDN's. With a new query on every fetch there is
         // never anything here to revalidate, so each check is a full body — a few
-        // hundred bytes, the same cost the app's own updater pays.
+        // hundred bytes, the same cost the app's own updater pays. The session's
+        // memory cache still stores each one-off response under a key nothing asks
+        // for again; at that size against its 64 MB cap it is noise.
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
 
@@ -131,9 +133,10 @@ public struct ElectronManifestSource: UpdateSource {
         // Probing that sibling moved a `channel: latest` install across release
         // trains whenever the two happened to publish the same version (#204).
         //
-        // And the bare address, not `fetchURL`: artifacts resolve against the base
-        // without the token, as electron-updater's do, so a one-off query never
-        // rides into a download URL.
+        // And the bare address, not `fetchURL`: that is what electron-updater
+        // resolves artifacts against. A relative reference drops the base's query
+        // anyway (RFC 3986 §5.2.2), so this is the clear spelling of that, not the
+        // only thing keeping the token out of a download URL.
         let resolvedURL = manifestURL
 
         // MARKETING ONLY, and `version:` is the one string the manifest carries.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifestSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifestSource.swift
@@ -51,7 +51,8 @@ public struct ElectronManifestSource: UpdateSource {
     private static let hostArch = "arm64"
 
     public func latestVersion(for app: InstalledApp) async throws -> RemoteVersion? {
-        guard let config = app.electronUpdate, let manifestURL = config.manifestURL else {
+        guard let config = app.electronUpdate, let manifestURL = config.manifestURL,
+              let fetchURL = config.manifestRequestURL() else {
             return nil
         }
         // A bundle id when the scanner found one, the manifest address otherwise
@@ -59,11 +60,17 @@ public struct ElectronManifestSource: UpdateSource {
         // `RecipeHealth`'s diagnostics can list this manifest under.
         let healthID = app.bundleID ?? manifestURL.absoluteString
 
-        var request = URLRequest(url: manifestURL)
+        // `fetchURL`, not `manifestURL`: the same address plus electron-updater's
+        // `noCache` query, the only thing that gets past a CDN's edge copy — see
+        // `ElectronUpdateConfig.manifestRequestURL` for the Kimi measurement.
+        var request = URLRequest(url: fetchURL)
         request.timeoutInterval = 15
         // Same reasoning as `SparkleAppcastSource`: a static manifest behind a CDN
         // that stamps a long max-age would otherwise stay "fresh" forever and the
-        // app would go quietly blind to new releases.
+        // app would go quietly blind to new releases. That covers OUR cache; the
+        // query above covers the CDN's. With a new query on every fetch there is
+        // never anything here to revalidate, so each check is a full body — a few
+        // hundred bytes, the same cost the app's own updater pays.
         request.cachePolicy = URLRequest.versionFeedCachePolicy
         request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
 
@@ -123,6 +130,10 @@ public struct ElectronManifestSource: UpdateSource {
         // read only by a build whose own `app-update.yml` says `channel: arm64`.
         // Probing that sibling moved a `channel: latest` install across release
         // trains whenever the two happened to publish the same version (#204).
+        //
+        // And the bare address, not `fetchURL`: artifacts resolve against the base
+        // without the token, as electron-updater's do, so a one-off query never
+        // rides into a download URL.
         let resolvedURL = manifestURL
 
         // MARKETING ONLY, and `version:` is the one string the manifest carries.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
@@ -369,7 +369,13 @@ public enum FeedDiscovery {
                 verdict = .review(.electronProviderNeedsConstruction, nil)
                 break
             }
-            let body = await fetch(manifest, session: session).flatMap {
+            // Fetched the way the app's own updater fetches it, `noCache` query
+            // and all — see `ElectronUpdateConfig.manifestRequestURL`. A bare
+            // fetch read Kimi's CDN edge copy and reported
+            // `electronVersionMismatch` against a manifest the app was reading
+            // fine. The verdict still names the bare address.
+            let fetchURL = probe.electron?.manifestRequestURL() ?? manifest
+            let body = await fetch(fetchURL, session: session).flatMap {
                 String(data: $0, encoding: .utf8)
             }
             // The config's `channel` already names the exact macOS manifest the

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -2893,3 +2893,86 @@ private let eudicAppcastFixture = #"""
     ])
     #expect(!log.entries.contains { $0.items.contains { $0.contains("在线学习记录同步") } })
 }
+
+// Kimi's release-notes page, cut from the real one (2026-09-11): 3.2.1 is the
+// release with a list nested inside a list item, 3.1.9 carries an entity, and 3.1.6
+// is the last release — followed, as on the page, by the feedback widget and the
+// table of contents, whose `<li>`s the last entry must not absorb.
+private let kimiReleaseNotesFixture = #"""
+<h2 id="321-2026-08-21" class="mt-8 scroll-mt-10 leading-[32px] text-[20px] font-semibold tracking-[-0.03em] text-(--Labels-Primary)">3.2.1 (2026-08-21)</h2>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>New</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">Added a global Launcher: summon a floating capsule input box on the desktop anytime, anywhere with a global hotkey<!-- -->
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">When summoned, it automatically brings in the files currently selected in Finder / File Explorer, and supports pasting images, adding attachments, and dragging in screenshots</li>
+<li class="text-[18px] leading-[28px]">Type “/” to open the plugin and skill menu (pinyin search supported) and choose a workspace</li>
+<li class="text-[18px] leading-[28px]">Hold the hotkey to dictate; after submitting, it collapses into a mini capsule, and you can jump back to the main app with one click to view the answer</li>
+</ul>
+</li>
+<li class="text-[18px] leading-[28px]">Added message queueing: while the Agent is responding, you can keep sending messages; new messages are queued automatically, with support for drag-to-reorder, edit, delete, and detail preview</li>
+<li class="text-[18px] leading-[28px]">Voice dictation in the Work input box: click the microphone or hold the hotkey to start dictating, with mixed Chinese-English recognition</li>
+</ul>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>Changed</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">Message notification logic updated: you can switch message notification rules in Settings</li>
+</ul>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>Fixed</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">Optimized standby power consumption, reducing background resource usage while the app is idle</li>
+<li class="text-[18px] leading-[28px]">Fixed an issue where the Dock icon disappeared on macOS</li>
+<li class="text-[18px] leading-[28px]">Fixed several bugs and improved some interactions and stability</li>
+</ul>
+<h2 id="319-2026-08-15" class="mt-8 scroll-mt-10 leading-[32px] text-[20px] font-semibold tracking-[-0.03em] text-(--Labels-Primary)">3.1.9 (2026-08-15)</h2>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>New</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">Personal plugin marketplace is live: the plugin marketplace now has a &quot;Personal Plugins&quot; section where you can browse and install plugins from individual developers</li>
+</ul>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>Fixed</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">Fixed an issue where streaming Markdown content occasionally failed to refresh</li>
+<li class="text-[18px] leading-[28px]">Fixed several bugs and improved some interactions and stability</li>
+</ul>
+<h2 id="316-2026-07-29" class="mt-8 scroll-mt-10 leading-[32px] text-[20px] font-semibold tracking-[-0.03em] text-(--Labels-Primary)">3.1.6 (2026-07-29)</h2>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>New</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">PPT slide editor is live: open and edit slides right in the workspace — changes take effect immediately</li>
+<li class="text-[18px] leading-[28px]">Screenshot annotation is now supported for files in the preview area and in the browser; finished annotations can be sent directly to the Agent for revision</li>
+<li class="text-[18px] leading-[28px]">Storage drive migration is now supported on Windows: Work data can be moved to another drive</li>
+<li class="text-[18px] leading-[28px]">The Windows installer now supports choosing a custom install location</li>
+</ul>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>Changed</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">Improved some token efficiency issues</li>
+</ul>
+<p class="mt-4 text-[18px] leading-[26px] text-(--Labels-Primary)"><strong>Fixed</strong></p>
+<ul class="pl-4 text-(--Labels-Primary) [&amp;&gt;li]:mt-2 [&amp;&gt;li]:relative [&amp;&gt;li]:pl-4 [&amp;&gt;li]:before:absolute [&amp;&gt;li]:before:left-0 [&amp;&gt;li]:before:top-[11px] [&amp;&gt;li]:before:h-[6px] [&amp;&gt;li]:before:w-[6px] [&amp;&gt;li]:before:rounded-full [&amp;&gt;li]:before:bg-current">
+<li class="text-[18px] leading-[28px]">Fixed several bugs and improved some interactions</li>
+</ul></div><section class="my-12" aria-label="Document feedback"><div class="flex h-8 items-center justify-between gap-4"><p class="min-w-0 text-[16px] font-medium leading-6 text-(--Labels-Primary)">Was this article helpful?</p></section>
+<nav aria-label="Table of contents"><ul class=""><li class="select-none"><button type="button" class="relative py-2 pr-6 w-full text-sm font-normal text-left transition-colors cursor-pointer hover:text-(--Labels-Primary) focus:outline-none text-(--Labels-Secondary)" style="padding-left:24px"><span class="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-[calc(100%)] bg-(--Fills-F2)"></span><span class="block truncate" title="3.2.7 (2026-09-11)">3.2.7 (2026-09-11)</span></button></li><li class="select-none"><button type="button" class="relative py-2 pr-6 w-full text-sm font-normal text-left transition-colors cursor-pointer hover:text-(--Labels-Primary) focus:outline-none text-(--Labels-Secondary)" style="padding-left:24px"><span class="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-[calc(100%)] bg-(--Fills-F2)"></span><span class="block truncate" title="3.2.6 (2026-09-07)">3.2.6 (2026-09-07)</span></button></li></ul></nav>
+"""#
+
+@Test func kimiReadsEachReleaseAndKeepsNestedLinesApart() throws {
+    let recipe = try #require(ChangelogRecipeRegistry.recipe(forBundleID: "com.moonshot.kimichat"))
+    let log = try #require(ChangelogExtractor.extract(from: kimiReleaseNotesFixture, using: recipe))
+
+    #expect(log.entries.map(\.version) == ["3.2.1", "3.1.9", "3.1.6"])
+    #expect(log.entries.map(\.date) == ["2026-08-21", "2026-08-15", "2026-07-29"])
+
+    // The nested list: the parent line and each child are lines of their own. A
+    // lazy `<li>(.*?)</li>` glues the parent onto its first child (9 lines, not 10).
+    #expect(log.entries[0].items.count == 10)
+    #expect(log.entries[0].items[0]
+        == "Added a global Launcher: summon a floating capsule input box on the desktop anytime, anywhere with a global hotkey")
+    #expect(log.entries[0].items[1].hasPrefix("When summoned, it automatically brings in the files"))
+    #expect(log.entries[0].items[4].hasPrefix("Added message queueing:"))
+
+    #expect(log.entries[1].items.first
+        == "Personal plugin marketplace is live: the plugin marketplace now has a \"Personal Plugins\" section where you can browse and install plugins from individual developers")
+
+    // The last release stops at the article's `</div>`. Without that stop it runs
+    // on into the table of contents and gains "3.2.7 (2026-09-11)" and
+    // "3.2.6 (2026-09-07)" as change lines.
+    #expect(log.entries[2].items.count == 6)
+    #expect(log.entries[2].items.last == "Fixed several bugs and improved some interactions")
+    #expect(!log.entries.contains { $0.items.contains { $0.contains("(2026-") || $0.contains("helpful") } })
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ElectronManifestTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ElectronManifestTests.swift
@@ -116,6 +116,31 @@ import Foundation
     #expect(manifest("beta") == URL(string: "https://example.invalid/releases/beta-mac.yml"))
 }
 
+@Test func theManifestIsRequestedTheWayElectronUpdaterRequestsIt() {
+    let cfg = ElectronUpdateConfig(
+        provider: "generic", url: "https://example.invalid/app/upgrade/",
+        owner: nil, repo: nil, channel: "latest")
+    #expect(cfg.manifestRequestURL(noCache: "k3v9")
+        == URL(string: "https://example.invalid/app/upgrade/latest-mac.yml?noCache=k3v9"))
+    // What artifacts resolve against stays bare.
+    #expect(cfg.manifestURL == URL(string: "https://example.invalid/app/upgrade/latest-mac.yml"))
+
+    // A query already in the address is left alone, not overwritten.
+    let stated = ElectronUpdateConfig(
+        provider: "generic", url: "https://example.invalid/feed?token=abc",
+        owner: nil, repo: nil, channel: "latest")
+    #expect(stated.manifestRequestURL(noCache: "k3v9") == stated.manifestURL)
+
+    // No address, no request — `github`/`s3` are still never constructed.
+    let github = ElectronUpdateConfig(
+        provider: "github", url: nil, owner: "o", repo: "r", channel: "latest")
+    #expect(github.manifestRequestURL(noCache: "k3v9") == nil)
+
+    // electron-updater's spelling: epoch milliseconds in base 32.
+    #expect(ElectronUpdateConfig.noCacheToken(now: Date(timeIntervalSince1970: 1_757_570_000.5))
+        == String(1_757_570_000_500, radix: 32))
+}
+
 @Test func theInstallerKindComesFromTheChosenArtifact() {
     #expect(ElectronManifestSource.kind(of: "Notion-arm64-7.31.3.zip") == .zip)
     #expect(ElectronManifestSource.kind(of: "Canva-1.124.1-universal.dmg") == .dmg)
@@ -158,15 +183,28 @@ struct ElectronManifestSourceTests {
         }
 
         nonisolated(unsafe) static var routes: [String: Response] = [:]
+        /// Served INSTEAD of `routes` to a request that carries no query: the stale
+        /// copy a CDN edge holds for the bare address, which only a query gets past.
+        nonisolated(unsafe) static var edgeCopies: [String: Response] = [:]
+        /// Recorded and routed WITHOUT the query — the source puts a fresh
+        /// `noCache` token on every manifest fetch, and a random token cannot be a
+        /// route key. `requestedQueries` keeps what was stripped, index for index.
         nonisolated(unsafe) static var requestedURLs: [String] = []
+        nonisolated(unsafe) static var requestedQueries: [String?] = []
 
         override class func canInit(with request: URLRequest) -> Bool { true }
         override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
         override func startLoading() {
             guard let url = request.url else { return }
-            Self.requestedURLs.append(url.absoluteString)
-            guard let route = Self.routes[url.absoluteString] else {
+            var bare = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            let query = bare?.query
+            bare?.query = nil
+            let key = bare?.url?.absoluteString ?? url.absoluteString
+            Self.requestedURLs.append(key)
+            Self.requestedQueries.append(query)
+            let served = query == nil ? (Self.edgeCopies[key] ?? Self.routes[key]) : Self.routes[key]
+            guard let route = served else {
                 let response = HTTPURLResponse(
                     url: url, statusCode: 404, httpVersion: "HTTP/1.1", headerFields: nil)!
                 client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
@@ -243,6 +281,46 @@ struct ElectronManifestSourceTests {
 
         let entry = await RecipeHealth.shared.snapshot().first { $0.id == bundleID }
         #expect(entry?.isHealthy == true)
+    }
+
+    @Test func theManifestIsReadPastACDNsEdgeCopy() async throws {
+        // Kimi's shape, 2026-09-11 (real bodies, trimmed): the bare address is an
+        // edge copy days behind the origin, and only a request carrying a query
+        // reaches the origin. electron-updater always sends `noCache`, so the app
+        // itself saw 3.2.7 while a bare fetch saw 3.2.5.
+        let domain = "https://kimi-img.example.test/app/upgrade"
+        FixtureProtocol.requestedURLs = []
+        FixtureProtocol.requestedQueries = []
+        FixtureProtocol.edgeCopies = [
+            "\(domain)/latest-mac.yml": .init(status: 200, body: """
+                version: 3.2.5
+                files:
+                  - url: Kimi-3.2.5-arm64-mac.zip
+                    sha512: STALESHA==
+                    size: 419681752
+                """, transportFailure: false),
+        ]
+        defer { FixtureProtocol.edgeCopies = [:] }
+        FixtureProtocol.routes = [
+            "\(domain)/latest-mac.yml": .init(status: 200, body: """
+                version: 3.2.7
+                files:
+                  - url: Kimi-3.2.7-arm64-mac.zip
+                    sha512: FRESHSHA==
+                    size: 430688879
+                """, transportFailure: false),
+        ]
+        let bundleID = "com.duoupdater.test.electron.cdnEdgeCopy"
+
+        let remote = try #require(await ElectronManifestSource(session: fixtureSession())
+            .latestVersion(for: electronApp(bundleID: bundleID, domain: domain)))
+        #expect(remote.shortVersion == "3.2.7")
+        #expect(remote.expectedSHA512 == "FRESHSHA==")
+        // The artifact resolves against the bare address: no token in the download.
+        #expect(remote.downloadURL == URL(string: "\(domain)/Kimi-3.2.7-arm64-mac.zip"))
+        #expect(FixtureProtocol.requestedURLs == ["\(domain)/latest-mac.yml"])
+        #expect(FixtureProtocol.requestedQueries.count == 1)
+        #expect(FixtureProtocol.requestedQueries.first??.hasPrefix("noCache=") == true)
     }
 
     // MARK: - #291: end-to-end coverage for real vendor shapes, without the

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ElectronManifestTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ElectronManifestTests.swift
@@ -125,7 +125,9 @@ import Foundation
     // What artifacts resolve against stays bare.
     #expect(cfg.manifestURL == URL(string: "https://example.invalid/app/upgrade/latest-mac.yml"))
 
-    // A query already in the address is left alone, not overwritten.
+    // A query already in the address is left alone, not overwritten. (Not parity
+    // with electron-updater for this config — `manifestURL` concatenates the
+    // channel file into the query; see `manifestRequestURL`.)
     let stated = ElectronUpdateConfig(
         provider: "generic", url: "https://example.invalid/feed?token=abc",
         owner: nil, repo: nil, channel: "latest")
@@ -316,7 +318,7 @@ struct ElectronManifestSourceTests {
             .latestVersion(for: electronApp(bundleID: bundleID, domain: domain)))
         #expect(remote.shortVersion == "3.2.7")
         #expect(remote.expectedSHA512 == "FRESHSHA==")
-        // The artifact resolves against the bare address: no token in the download.
+        // No token in the download URL.
         #expect(remote.downloadURL == URL(string: "\(domain)/Kimi-3.2.7-arm64-mac.zip"))
         #expect(FixtureProtocol.requestedURLs == ["\(domain)/latest-mac.yml"])
         #expect(FixtureProtocol.requestedQueries.count == 1)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
@@ -437,3 +437,52 @@ private func electronProbe(marketing: String) -> FeedDiscovery.BundleProbe {
             provider: "generic", url: "https://example.invalid",
             owner: nil, repo: nil, channel: "latest"))
 }
+
+/// A CDN that holds a stale edge copy of every address and only goes to origin for
+/// a request that carries a query — Kimi's manifest host, 2026-09-11. Stateless,
+/// so it is safe under the parallel runner.
+private final class EdgeCopyProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        guard let url = request.url else { return }
+        let body = url.query == nil ? "version: 3.2.5\n" : "version: 3.2.7\n"
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+@Test func discoveryReadsTheManifestPastACDNsEdgeCopy() async throws {
+    // A bare fetch reads the 3.2.5 edge copy and reports `electronVersionMismatch`
+    // against a 3.2.7 bundle whose own updater reads the manifest fine.
+    let fm = FileManager.default
+    let bundle = fm.temporaryDirectory
+        .appendingPathComponent("ZZFixture-EdgeCopy-\(UUID().uuidString).app")
+    defer { try? fm.removeItem(at: bundle) }
+    let resources = bundle.appendingPathComponent("Contents/Resources")
+    try fm.createDirectory(at: resources, withIntermediateDirectories: true)
+    let plist: [String: Any] = [
+        "CFBundleIdentifier": "com.duoupdater.test.zzfixture.edgecopy",
+        "CFBundleShortVersionString": "3.2.7",
+        "CFBundleVersion": "3.2.7",
+    ]
+    try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        .write(to: bundle.appendingPathComponent("Contents/Info.plist"))
+    try "provider: generic\nurl: https://kimi-img.example.test/app/upgrade/\n"
+        .write(to: resources.appendingPathComponent("app-update.yml"),
+               atomically: true, encoding: .utf8)
+
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [EdgeCopyProtocol.self]
+    let finding = await FeedDiscovery.examine(
+        bundleAt: bundle, session: URLSession(configuration: configuration))
+
+    // Adopted, and against the bare address: the verdict names what a person would
+    // propose, never the one-off query it was fetched with.
+    #expect(finding.verdict
+        == .adopt(URL(string: "https://kimi-img.example.test/app/upgrade/latest-mac.yml")!))
+}

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -148,7 +148,6 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 - [x] [**Ghostty**](com-mitchellh-ghostty.md) · `com.mitchellh.ghostty` — C (two-stage), detection still unknown
 - [x] [**Ollama**](com-electron-ollama.md) · `com.electron.ollama` — C, detection still unknown
-- [x] [**Kimi**](com-moonshot-kimichat.md) · `com.moonshot.kimichat` — C · 检测走 ElectronManifestSource（bundle 自带 `app-update.yml`）· manifest 要带 `noCache` 查询串才过得了 CDN 边缘副本 · 官网 DMG 是安装器 · 2026-09-11
 - [x] [**AppCleaner**](net-freemacsoft-AppCleaner.md) · `net.freemacsoft.AppCleaner` — C + Sparkle verified
 - [x] [**Calibre**](net-kovidgoyal-calibre.md) · `net.kovidgoyal.calibre` — C + Homebrew
 - [x] [**Audacity**](org-audacityteam-audacity.md) · `org.audacityteam.audacity` — C + Homebrew
@@ -156,6 +155,10 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**JetBrains Air**](com-jetbrains-air.md) · `com.jetbrains.air` — C + Toolbox/Sparkle
 - [x] [**欧路词典 (Eudic)**](com-eusoft-eudic.md) · `com.eusoft.eudic` — C + Sparkle **1**.27.3 · recipe 的 `source` 就是 appcast 本身：整部历史（1 个 `<h2>` + 34 个 `<h3>`、0 个 `<li>`）塞在最新一条 item 的 `<description>` 里，原本十六年记录全挂在「26.9.0」标题下；34 个标题里 7 个是标签「更新内容」，故按"含点分数字的标题"切而非按标签 · live feed + fixture 双证 29 条 ✓ · 另记两个已修的坑：`CFBundleDisplayName` 是**空串**（行里没名字）、未登录时的登录 sheet 挡住退出（Relaunch 静默失败）· 2026-09-01
 - [x] [**Rockxy**](com-amunx-rockxy-community.md) · `com.amunx.rockxy.community` — C + Sparkle verified · appcast 是原地重写的单条文件（1 个 `<item>`），inline notes 只够一格版本轨，故 changelog 走 GitHub releases（40/40 解析，0 prerelease）· 只有一条轨：prod 与 staging 两个 xcconfig 指向同一个 feed、同一个 bundle id · 2026-09-09
+
+## Electron-covered (auto-detected via the bundle's `app-update.yml`, no version recipe)
+
+- [x] [**Kimi**](com-moonshot-kimichat.md) · `com.moonshot.kimichat` — C · 检测走 ElectronManifestSource · manifest 要带 `noCache` 查询串才过得了 CDN 边缘副本 · 官网 DMG 是安装器 · 2026-09-11
 
 ## Sparkle-covered (auto-detected, no custom recipe)
 

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -148,6 +148,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 
 - [x] [**Ghostty**](com-mitchellh-ghostty.md) · `com.mitchellh.ghostty` — C (two-stage), detection still unknown
 - [x] [**Ollama**](com-electron-ollama.md) · `com.electron.ollama` — C, detection still unknown
+- [x] [**Kimi**](com-moonshot-kimichat.md) · `com.moonshot.kimichat` — C · 检测走 ElectronManifestSource（bundle 自带 `app-update.yml`）· manifest 要带 `noCache` 查询串才过得了 CDN 边缘副本 · 官网 DMG 是安装器 · 2026-09-11
 - [x] [**AppCleaner**](net-freemacsoft-AppCleaner.md) · `net.freemacsoft.AppCleaner` — C + Sparkle verified
 - [x] [**Calibre**](net-kovidgoyal-calibre.md) · `net.kovidgoyal.calibre` — C + Homebrew
 - [x] [**Audacity**](org-audacityteam-audacity.md) · `org.audacityteam.audacity` — C + Homebrew

--- a/docs/app-audits/com-moonshot-kimichat.md
+++ b/docs/app-audits/com-moonshot-kimichat.md
@@ -1,0 +1,176 @@
+# Kimi
+
+审计 2026-09-11。
+
+## 基本信息
+
+- Bundle ID: `com.moonshot.kimichat`
+- App 名: `Kimi.app`（产品名 Kimi Work，更新说明页在 `kimi.com/en/help/kimi-work/release-notes`）
+- Team ID: `2J9472RW75` — Beijing Moonshot Technology Co., Ltd
+- 观测版本: `3.2.7`（`CFBundleShortVersionString` 与 `CFBundleVersion` 都是 `3.2.7`），
+  `LSMinimumSystemVersion` 12.0，主程序只有 arm64
+- 自更新机制: **electron-updater**（`Contents/Frameworks/` 下有 `Squirrel.framework` +
+  `Electron Framework.framework`），bundle 自带 `Contents/Resources/app-update.yml`：
+
+  ```yaml
+  provider: generic
+  url: https://kimi-img.moonshot.cn/app/upgrade/
+  updaterCacheDirName: kimi-desktop-updater
+  ```
+
+**官网 DMG 里装的不是 app，是安装器。** `kimi_3.2.7.dmg` 顶层只有 `Kimi Installer.app`
+（`com.moonshot.kimichat.installer`，同 Team，3.2.7）；真正的 `Kimi.app` 在它的
+`Contents/Helpers/Kimi.app`（`codesign --verify --deep --strict` 通过，同 Team、同版本）。
+安装器二进制的字符串显示它做的是：要求先退出 Kimi、以 `.Kimi.app.installing` /
+`.Kimi.app.backup` 原子替换 `/Applications/Kimi.app`、顺带升级
+`~/.kimi-webbridge/bin/kimi-webbridge`。Homebrew cask `kimi` 的 `app` 也是直接取
+`Kimi Installer.app/Contents/Helpers/Kimi.app`。所以 `feed-discover` 对这个 DMG 报的
+`noKnownUpdater` 说的是**安装器**，不是 Kimi。
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+| | Sparkle | Homebrew | MAS | GitHub | VendorProbe | Electron |
+|---|---|---|---|---|---|---|
+| **stable** | — | 未验证 | 没查 | 没查 | — | ✓ + changelog recipe |
+
+当前生效源：**Electron**（`ElectronManifestSource`，读 bundle 自带的 `app-update.yml`）。
+不需要 VendorProbe recipe。
+
+- **Sparkle** — 没有 `SUFeedURL`。
+- **Homebrew** — cask `kimi` 存在、没有 `auto_updates`，`livecheck` 用 `header_match` 读
+  `appsupport.moonshot.cn/api/app/pkg/latest/macos/download` 的 302。但 `HomebrewCaskSource`
+  只对 Caskroom 里真有这个 cask 的副本生效，官网装的副本它不答；brew 装的副本（artifact 是
+  上面那条嵌套路径）会不会被它匹配上，没验证。
+- **MAS / GitHub** — 没查。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---|---|---|---|---|---|
+| stable | `com.moonshot.kimichat` | 独立 | — | — | ✓ |
+
+`app-update.yml` 没写 `channel`（即 `latest`）。同目录的 `beta-mac.yml`、`alpha-mac.yml`、
+`latest-mac-arm64.yml` 在 2026-09-11 都是 404。没发现别的轨道。
+
+## 更新检测
+
+- 源: `ElectronManifestSource`
+- 端点: `https://kimi-img.moonshot.cn/app/upgrade/latest-mac.yml`（electron-updater generic
+  provider 的默认 manifest），实际请求带 `?noCache=<token>`
+- 版本方案: manifest 只有一个 `version`，与 `CFBundleShortVersionString` 同构（`3.2.7`）
+
+### ⚠️ CDN 边缘缓存：不带查询串读到的是旧版本
+
+2026-09-11 同一时段、同一出口的实测：
+
+| 请求 | 回答 | `Age` | `Last-Modified` |
+|---|---|---|---|
+| 裸地址 | `version: 3.2.5` | 384307 | Fri, 04 Sep 2026 15:04:47 GMT |
+| 裸地址 + `Cache-Control: no-cache` / `max-age=0` / `Pragma: no-cache` | `3.2.5` | ~384381 | 同上 |
+| 裸地址 + 旧 `If-None-Match` | 304 | ~384382 | — |
+| `?noCache=<随机>` | `version: 3.2.7`（`releaseDate: 2026-09-10T15:39:50.574Z`） | 0 | Fri, 11 Sep 2026 06:11:26 GMT |
+
+请求头一律无效，只有查询串能穿过边缘副本。electron-updater 每次都带
+`noCache=<Date.now().toString(32)>`：`GenericProvider.getLatestVersion` 调
+`newUrlFromBase(channelFile, baseUrl, isAddNoCacheQuery)`，而 `AppUpdater.isAddNoCacheQuery`
+在请求头里没有 `authorization` / `private-token` 时恒为 true（electron-builder 源码，
+issue #3021）。所以 Kimi 自己的更新器读到的是源站——它的日志
+（`~/Library/Logs/kimi-desktop/main.log`）同一晚记的是
+`Update for version 3.2.7 is not available (latest version: 3.2.7, downgrade is disallowed)`。
+
+修之前 `ElectronManifestSource` 读的是裸地址：`duo check Kimi --all --json` 给出
+`"latestVersion":"3.2.5","source":"Electron","status":"up-to-date"`。3.2.7 的副本被对着
+3.2.5 判成"最新"，而 3.2.5 / 3.2.6 的副本在边缘副本存活期间看不到任何更新。现在
+`ElectronUpdateConfig.manifestRequestURL` 照 electron-updater 的做法加 `noCache`
+（地址本身已带查询串时不动），所有走 generic provider 的 Electron app 一起受益；artifact
+URL 仍对裸地址解析，token 不会进下载地址。`FeedDiscovery` 的 manifest 读取走同一个函数，
+所以它对 Kimi 报的 `electronVersionMismatch` 也是这个缓存造成的假信号。
+
+修之后（`make cli` 之后，同一晚）：`duo check Kimi --all --json` 给出
+`"latestVersion":"3.2.7","source":"Electron","status":"up-to-date"`；`feed-discover` 对已装
+bundle 的判定从 `review electronVersionMismatch` 变成 `ADOPT
+https://kimi-img.moonshot.cn/app/upgrade/latest-mac.yml`。
+
+### 不是版本源的两样东西
+
+- **官网下载端点** `appsupport.moonshot.cn/api/app/pkg/latest/macos/download`：302 到
+  `kimi-img.moonshot.cn/app/download/mac/kimi_3.2.7.dmg`，响应不带 `Age`（动态）。
+  Homebrew 的 livecheck 读它。我们不用：它给的是安装器 DMG（见上），而 manifest 已经给出
+  版本和带 sha512 的 zip。
+- **`UpgradePolicyService`**：日志反复出现 `fetchUpgradePolicy: target=3.2.5 strategy=force
+  hasDownloadUrl=true`。看起来是"低于 3.2.5 强制升级"的下限，不是"最新版本"（推断，
+  端点没抓）。
+
+### 为什么 app 里找不到「检查更新」
+
+日志里更新器在启动后几秒自己跑 `Checking for update`，状态 `status=hidden`，没有 UI。主进程
+代码里 autoUpdater 旁边有一个 `4 * 60 * 60 * 1e3` 的常量——推断是 4 小时一次的定时检查；
+代码是混淆过的，没有逐行确认。没找到菜单项。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 有（differential download） | 没查 | 不能 |
+| 证据 | 主进程里是 electron-updater 的 `isUseMultipleRangeRequest` / `isUrlProbablySupportMultiRangeRequests`（blockmap 分块下载） | 没查 `*.zip.blockmap` 是否存在 | `DeltaApplier` 只吃 Sparkle binary delta，没有 blockmap 机制 |
+
+- 格式: electron-builder blockmap（不是二进制补丁）
+- 阻塞项: 需要新机制，而收益只是下载量
+
+## Changelog
+
+- 来源: recipe（`ChangelogRecipeRegistry`，`com.moonshot.kimichat`）→
+  `https://www.kimi.com/en/help/kimi-work/release-notes`
+- 结构: 服务端渲染，每个版本一个 `<h2 id="327-2026-09-11">3.2.7 (2026-09-11)</h2>`，新的在前，
+  下面是 `<p><strong>New|Changed|Fixed</strong></p>` + `<ul>` 分组。2026-09-11 页面上 13 个版本
+  （3.2.7 … 3.1.6），recipe 在真实页面上 13/13 命中、每条都有条目；`duo verify --only moonshot`
+  （2026-09-11）changelog ✓。
+- 分组标签不保留：`Changelog.Entry` 只有 version/date/items，New/Changed/Fixed 按文档顺序拍平。
+- 两个坑都在真实页面上：
+  - 3.2.1 有一个嵌套在 `<li>` 里的 `<ul>`。惰性 `<li>(.*?)</li>` 会停在子项的 `</li>`，把父行和
+    第一个子项粘成一行（9 行而不是 10 行）；item 改为停在下一个 `<li`/`</li>`。
+  - 最后一个版本后面是 `</ul></div>` + 反馈组件 + 目录（13 个 `<li>`，每个的文字就是
+    `3.2.7 (2026-09-11)` 这种）。body 停在下一个 `<h2` **或** `</div>`，否则最后一个版本会把目录
+    吞成条目。
+- manifest 的 `releaseNotes` 只有一句中文摘要（3.2.7：`新增滚动截图与插件推荐`），而且
+  `ElectronManifestSource` 本来就不带 notes，所以 recipe 是唯一的结构化来源。
+- 跟随 channel: 只有一条轨道。
+
+## 一键安装
+
+- 状态: 由 `ElectronManifestSource` 提供——manifest 的 `files:` 里有
+  `Kimi-3.2.7-arm64-mac.zip`（sha512 + size），走 `VendorInstaller` 的 zip 路线 + Team ID 闸。
+  **这次没下载 zip 验内部结构**（electron-builder 的 mac zip 顶层就是 `.app` 是惯例，未验证）。
+  zip 本身 2026-09-11 HEAD 200、`application/zip`、430688879 字节。
+- 格式: zip
+- **读的是**: 厂商更新器给每个已装副本的同一份 manifest。manifest 里没有
+  `stagingPercentage`（2026-09-11），所以没有"轨道最新 vs 本机被分配"的分别（electron-updater
+  在没有 `stagingPercentage` 时不分桶——推断，没读那段源码确认）。
+- 官网 DMG 路线不适用：它装的是安装器，不是 app。
+
+## 已知问题
+
+- `ElectronManifestSource` 不在 `duo verify` 的扫描范围里（它没有表，地址在 bundle 里），
+  这个 app 的检测只能靠 `duo check` / `electron-verify` 复验。
+- Kimi 自己不提供手动检查更新的入口（见上）。
+
+## 如何复验
+
+```bash
+# 1. 边缘副本 vs 源站：两行应当给出不同的 version（边缘副本还没过期时）
+python3 - <<'PY'
+import urllib.request, uuid
+u = "https://kimi-img.moonshot.cn/app/upgrade/latest-mac.yml"
+for q in ["", "?noCache=" + uuid.uuid4().hex[:10]]:
+    r = urllib.request.urlopen(urllib.request.Request(u + q, headers={"User-Agent": "Mozilla/5.0"}))
+    print(repr(q), r.read().decode().splitlines()[0], "Age:", r.headers.get("Age"))
+PY
+
+# 2. 生产源读到的版本（make cli 之后）
+duo check Kimi --all --json
+
+# 3. changelog recipe 对真实页面
+duo verify --only moonshot
+```

--- a/docs/app-audits/com-moonshot-kimichat.md
+++ b/docs/app-audits/com-moonshot-kimichat.md
@@ -93,9 +93,14 @@ URL 仍对裸地址解析，token 不会进下载地址。`FeedDiscovery` 的 ma
 bundle 的判定从 `review electronVersionMismatch` 变成 `ADOPT
 https://kimi-img.moonshot.cn/app/upgrade/latest-mac.yml`。
 
+**只修了"bundle 自带 `app-update.yml`"这一条路。** `VendorProbeRegistry` 里另有 13 条 recipe
+直接读 `*-mac.yml`（Signal、Typeless、Canva 等），仍然是裸地址。复审时逐条对比过裸地址和带
+`noCache` 的回答，2026-09-11 版本全部一致（转引自复审 agent 的扫描，未复测）——今天没有分歧，
+但 Kimi 这种形状对它们只差一个 CDN 配置，而且没有东西会发现。
+
 ### 不是版本源的两样东西
 
-- **官网下载端点** `appsupport.moonshot.cn/api/app/pkg/latest/macos/download`：302 到
+- **官网下载端点** `appsupport.moonshot.cn/api/app/pkg/latest/macos/download`：GET 时 302 到
   `kimi-img.moonshot.cn/app/download/mac/kimi_3.2.7.dmg`，响应不带 `Age`（动态）。
   Homebrew 的 livecheck 读它。我们不用：它给的是安装器 DMG（见上），而 manifest 已经给出
   版本和带 sha512 的 zip。


### PR DESCRIPTION
## What

1. **`ElectronManifestSource` now fetches a generic provider's manifest the way electron-updater does** — with a throwaway `noCache=<epoch ms, base 32>` query — via `ElectronUpdateConfig.manifestRequestURL`. Artifact URLs still resolve against the bare address. `FeedDiscovery.examine` fetches the same way; its verdict still names the bare address.
2. **Kimi** (`com.moonshot.kimichat`): new `ChangelogRecipe` over `kimi.com/en/help/kimi-work/release-notes`, plus the app audit. Version detection needs no recipe — the bundle ships an electron-builder `app-update.yml` (generic provider), so `ElectronManifestSource` already covers it once (1) is fixed.

## Why (measured 2026-09-11)

`https://kimi-img.moonshot.cn/app/upgrade/latest-mac.yml`:

| request | answer | `Age` |
|---|---|---|
| bare | `version: 3.2.5` | 384307 (≈4.4 days) |
| bare + `Cache-Control: no-cache` / `max-age=0` / `Pragma: no-cache` | `3.2.5` | same edge copy |
| `?noCache=<random>` | `version: 3.2.7` | 0 (origin) |

electron-updater always adds that query (`GenericProvider.getLatestVersion` → `newUrlFromBase(…, isAddNoCacheQuery)`; `AppUpdater.isAddNoCacheQuery` is true unless the app sends `authorization` / `private-token`), which is why Kimi's own updater logged `latest version: 3.2.7` while we read 3.2.5.

## Red → green in the product

- Before: `duo check Kimi --all --json` → `"latestVersion":"3.2.5","source":"Electron","status":"up-to-date"` (installed 3.2.7).
- After (`make cli`): `"latestVersion":"3.2.7","source":"Electron"`.
- `feed-discover /Applications/Kimi.app`: `review electronVersionMismatch` → `ADOPT …/latest-mac.yml`.
- `duo verify --only moonshot`: changelog ✓ 1.

## Tests

- `make test`: green — Core 2645 tests / 223 suites, App tests 23/23, all python gates ✓.
- Mutations, each run and each red: fetch the bare address in the source (M1) and in discovery (M5); overwrite a stated query (M2); lazy `<li>(.*?)</li>` item (M3); drop the `</div>` stop in the entry pattern (M4).
- The Kimi changelog fixture is cut from the real page and keeps both traps: 3.2.1 nests a list inside a list item, and the last release is followed by the page's table of contents (13 `<li>`s on the live page).

## Risk

This changes the fetch for **every** Electron app that `ElectronManifestSource` resolves (generic provider, no bespoke recipe ahead of it): each check now sends a unique query and can never be a 304. That is the request the vendor's own app makes on every check, and the response is a few hundred bytes.

An adversarial review of this is running; findings will land as follow-up commits on this PR before it is called mergeable.

## Not verified

- One-click for Kimi goes through the generic zip path (`Kimi-3.2.7-arm64-mac.zip` + manifest sha512). The zip was not downloaded to inspect its layout.
- The official DMG is an installer wrapper (`Kimi Installer.app/Contents/Helpers/Kimi.app`); not used by any route here.
