### PR TITLE
duo verify: warn when a *-mac.yml recipe reads a stale CDN edge copy

### DIFF
--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -566,8 +566,10 @@ An audit that does not know a field exists will report the situation it covers a
 
 Adjacent machinery an audit should also weigh: `DeltaApplier` (applies Sparkle
 binary patches), `VendorAppcastDeltas` (pulls them out of an appcast),
-`RecipeSanity` (flags a version that appears verbatim in the request URL, and a
-feed that reads behind the installed copy).
+`RecipeSanity` (flags a version that appears verbatim in the request URL, a
+feed that reads behind the installed copy, and — via `duo verify` — a `*-mac.yml`
+recipe whose bare address answers a different version than the same address with
+electron-updater's `noCache` query, i.e. a CDN edge copy shadowing the origin).
 
 ### Phase 4: One-click install feasibility
 

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -678,9 +678,11 @@ public enum Verify {
     /// it is a warning rather than `.broken`: an issue needs the disagreement to
     /// survive into the next sweep, and Kimi's lasted days.
     ///
-    /// Costs one extra request per such recipe. A second fetch that fails says
-    /// nothing: the sweep has already judged the recipe's real request, and this
-    /// only compares two answers.
+    /// Costs one extra request per such recipe, which the finding's `attempts` does
+    /// NOT count — the finding is classified before this runs, and it sits outside
+    /// the recipe's `GatewayRetry` tally, the same gap `rolloutTrackComplaint` has.
+    /// A second fetch that fails says nothing: the sweep has already judged the
+    /// recipe's real request, and this only compares two answers.
     ///
     /// ⚠️ The query rides the FIRST hop only. Granola's `api.granola.ai` answers
     /// with a redirect to a CloudFront URL that carries no query (request ledger,

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -399,6 +399,10 @@ public enum Verify {
             if let note = await rolloutTrackComplaint(recipe, source: source) {
                 finding = finding.observing(note)
             }
+            if outcome.succeeded, let version = finding.version,
+               let complaint = await edgeCopyComplaint(recipe, bareVersion: version, source: source) {
+                finding = finding.adding(warning: complaint)
+            }
             // "This one only detects, and its own answer names an installer." The
             // sweep could not previously ask that, which is how three recipes kept
             // a blocker that had stopped being true — see
@@ -662,6 +666,40 @@ public enum Verify {
             + "rolloutTrackDefaulted: no value at \(track.selector.displayPath), so this"
             + " machine is asking as `\(track.selector.fallback ?? "?")` while the vendor is"
             + " serving two tracks (\(ours) vs \(contrast) for \(track.contrastTrackName))"
+    }
+
+    /// Kimi's failure, asked of every recipe that reads an electron manifest: does
+    /// the bare address answer the same version as the origin? See
+    /// `RecipeSanity.readsElectronManifest` for why it is asked and of whom.
+    ///
+    /// A WARNING, not a note, unlike `rolloutTrackComplaint`: this one does accuse
+    /// the recipe — it is reading an older version than the vendor publishes. A
+    /// CDN still propagating a release can disagree for minutes, and that is why
+    /// it is a warning rather than `.broken`: an issue needs the disagreement to
+    /// survive into the next sweep, and Kimi's lasted days.
+    ///
+    /// Costs one extra request per such recipe. A second fetch that fails says
+    /// nothing: the sweep has already judged the recipe's real request, and this
+    /// only compares two answers.
+    ///
+    /// ⚠️ The query rides the FIRST hop only. Granola's `api.granola.ai` answers
+    /// with a redirect to a CloudFront URL that carries no query (request ledger,
+    /// 2026-09-12: the queried request's next hop went out bare, and URLCache
+    /// revalidated it as the same document), so for that recipe the two answers
+    /// are the same fetch by construction and this can never disagree. That is
+    /// still the right comparison — electron-updater's own request loses the
+    /// query at the same redirect, so the app reads what the recipe reads — but
+    /// "no complaint" there means "same as the app", not "same as the origin".
+    static func edgeCopyComplaint(
+        _ recipe: VendorProbeRecipe, bareVersion: String, source: VendorProbeSource
+    ) async -> String? {
+        guard RecipeSanity.readsElectronManifest(recipe) else { return nil }
+        let origin = await source.probeDiagnostic(
+            recipe.with(url: ElectronUpdateConfig.noCacheURL(for: recipe.url)))
+        guard let remote = origin.remote,
+              let version = remote.shortVersion ?? remote.version
+        else { return nil }
+        return RecipeSanity.edgeCopyComplaint(bare: bareVersion, origin: version)
     }
 
     // MARK: - GitHub rules

--- a/CLI/Tests/DuoKitTests/EdgeCopyCheckTests.swift
+++ b/CLI/Tests/DuoKitTests/EdgeCopyCheckTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import DuoKit
+import DuoUpdaterCore
+
+// `Verify.edgeCopyComplaint` end to end: a real `VendorProbeSource` probe against
+// a stubbed CDN, twice — once as the sweep asks, once with the `noCache` query.
+//
+// Not covered here: that `sweepVendor` calls it at all. The sweep runs the live
+// registry over the network, so dropping that call would leave these green.
+
+/// A CDN in two moods, chosen by host. `edge-copy.invalid` answers the bare
+/// address from a stale copy and a request carrying a query from the origin —
+/// Kimi's manifest host, 2026-09-11. `in-sync.invalid` serves one document either
+/// way. Stateless, so the parallel runner cannot trip over it.
+private final class EdgeCDNProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool {
+        ["edge-copy.invalid", "in-sync.invalid"].contains(request.url?.host ?? "")
+    }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        guard let url = request.url else { return }
+        let stale = url.host == "edge-copy.invalid" && url.query == nil
+        let body = "version: \(stale ? "3.2.5" : "3.2.7")\n"
+            + "files:\n  - url: App-\(stale ? "3.2.5" : "3.2.7")-arm64-mac.zip\n"
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/yaml"])!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func manifestRecipe(host: String) -> VendorProbeRecipe {
+    VendorProbeRecipe(
+        bundleID: "com.duoupdater.test.edgecopy.\(host)",
+        url: URL(string: "https://\(host)/app/upgrade/latest-mac.yml")!,
+        mode: .responseBody,
+        versionPattern: #"(?m)^version:\s*([0-9]+(?:\.[0-9]+)+)\s*$"#)
+}
+
+private func stubbedSource(_ recipe: VendorProbeRecipe) -> VendorProbeSource {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [EdgeCDNProtocol.self]
+    return VendorProbeSource(recipes: [recipe], session: URLSession(configuration: configuration))
+}
+
+@Test func aStaleEdgeCopyIsReportedAgainstTheOrigin() async throws {
+    let recipe = manifestRecipe(host: "edge-copy.invalid")
+    #expect(RecipeSanity.readsElectronManifest(recipe))
+    let source = stubbedSource(recipe)
+
+    // What the sweep itself reads: the bare address, and so the stale copy.
+    let bare = await source.probeDiagnostic(recipe)
+    let bareVersion = try #require(bare.remote?.shortVersion ?? bare.remote?.version)
+    #expect(bareVersion == "3.2.5")
+
+    let complaint = try #require(
+        await Verify.edgeCopyComplaint(recipe, bareVersion: bareVersion, source: source))
+    #expect(complaint.contains("3.2.5") && complaint.contains("3.2.7"))
+}
+
+@Test func anEndpointThatAgreesWithItselfStaysQuiet() async throws {
+    let recipe = manifestRecipe(host: "in-sync.invalid")
+    let source = stubbedSource(recipe)
+    let bare = await source.probeDiagnostic(recipe)
+    let bareVersion = try #require(bare.remote?.shortVersion ?? bare.remote?.version)
+    #expect(bareVersion == "3.2.7")
+    #expect(await Verify.edgeCopyComplaint(recipe, bareVersion: bareVersion, source: source) == nil)
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifest.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ElectronManifest.swift
@@ -78,18 +78,26 @@ public struct ElectronUpdateConfig: Sendable, Hashable {
     /// (`…/feed?token=abc/latest-mac.yml`). A gap in `manifestURL` that predates
     /// this function and is left as it was.
     func manifestRequestURL(noCache token: String = Self.noCacheToken()) -> URL? {
-        guard let manifest = manifestURL else { return nil }
-        guard manifest.query == nil,
-              var components = URLComponents(url: manifest, resolvingAgainstBaseURL: false)
-        else { return manifest }
+        manifestURL.map { Self.noCacheURL(for: $0, token: token) }
+    }
+
+    /// `url` with electron-updater's `noCache` query added, or `url` itself when it
+    /// already carries a query. The one spelling of that request: this source
+    /// fetches with it, and `duo verify` uses it to ask a `*-mac.yml` recipe's
+    /// endpoint whether the bare address is being answered from a stale edge copy
+    /// (`RecipeSanity.readsElectronManifest`).
+    public static func noCacheURL(for url: URL, token: String = noCacheToken()) -> URL {
+        guard url.query == nil,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return url }
         components.queryItems = [URLQueryItem(name: "noCache", value: token)]
-        return components.url ?? manifest
+        return components.url ?? url
     }
 
     /// electron-updater's token, `Date.now().toString(32)`: epoch milliseconds in
     /// base 32. Only its uniqueness matters to a CDN; the spelling is kept so the
     /// request looks like the app's own.
-    static func noCacheToken(now: Date = Date()) -> String {
+    public static func noCacheToken(now: Date = Date()) -> String {
         String(Int64((now.timeIntervalSince1970 * 1000).rounded(.down)), radix: 32)
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RecipeSanity.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RecipeSanity.swift
@@ -204,4 +204,41 @@ public enum RecipeSanity {
     /// Codeberg and GitHub both mint these for every release, whether or not the
     /// project ships a binary.
     private static let sourceArchivePaths = ["/archive/", "/tarball", "/zipball"]
+
+    // MARK: - CDN edge copies
+
+    /// Whether `duo verify` should ask this recipe's endpoint a second time with
+    /// electron-updater's `noCache` query: it reads an electron-builder manifest
+    /// (`*-mac.yml`) with a plain GET and states no query of its own — the one
+    /// shape where the query asks the same question of the origin instead of a
+    /// CDN's edge copy.
+    ///
+    /// Why this exists: Kimi's `latest-mac.yml`, 2026-09-11. Its CDN served the
+    /// bare address from an edge copy four and a half days old, ignoring the
+    /// origin's `Cache-Control: no-cache`, while the same address with the query
+    /// reached the origin. The app's own updater always sends the query, so the
+    /// vendor never sees the stale copy; a recipe reading the bare address reads
+    /// an old version, and every check passes — the version resolves, the URL
+    /// resolves, nothing errors. `ElectronManifestSource` now sends the query
+    /// itself. Recipes are left fetching the bare address (most of their CDNs
+    /// do not cache it, and some leave the query out of the cache key so it would
+    /// not help), and this is what would notice when that stops being true.
+    public static func readsElectronManifest(_ recipe: VendorProbeRecipe) -> Bool {
+        guard case .responseBody = recipe.mode, recipe.requestBody == nil,
+              recipe.url.query == nil
+        else { return false }
+        return recipe.url.path.hasSuffix("-mac.yml")
+    }
+
+    /// The warning when a recipe's bare address and the same address with a
+    /// `noCache` query answer different versions, nil when they agree. Compared
+    /// as strings on purpose: both answers came out of the same recipe's own
+    /// pattern, and a difference in EITHER direction means the two addresses are
+    /// not serving the same document.
+    public static func edgeCopyComplaint(bare: String, origin: String) -> String? {
+        guard bare != origin else { return nil }
+        return "the bare address answers \(bare), but the same address with a noCache query"
+            + " answers \(origin) — a CDN edge copy is shadowing the origin (the app's own"
+            + " electron-updater always sends that query)"
+    }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -1008,6 +1008,7 @@ public struct VendorProbeRecipe: Sendable {
     private func copy(url: URL? = nil, entryStartPattern: String?? = nil) -> Self {
         Self(
             bundleID: bundleID, url: url ?? self.url, mode: mode, versionPattern: versionPattern,
+            transientBodyPattern: transientBodyPattern, trackClosedPattern: trackClosedPattern,
             downloadURL: downloadURL, changelogURL: changelogURL, selectHighest: selectHighest,
             versionIsBuild: versionIsBuild, buildNamespace: buildNamespace,
             displayVersionPattern: displayVersionPattern,
@@ -1016,7 +1017,7 @@ public struct VendorProbeRecipe: Sendable {
             install: install, requestBody: requestBody, requestHeaders: requestHeaders,
             followRedirects: followRedirects, channel: channel, identities: identities,
             track: track, variant: variant, hostRequirement: hostRequirement,
-            installedVersionPattern: installedVersionPattern)
+            installedVersionPattern: installedVersionPattern, buildLineage: buildLineage)
     }
 
     /// Whether this recipe's build can run on the described machine. A recipe with

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EdgeCopyCheckTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EdgeCopyCheckTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+// `duo verify`'s edge-copy check: which recipes it asks, and what it says. The
+// network half lives in the CLI (`Verify.edgeCopyComplaint`); these are the rules.
+
+// MARK: - Derived from the registry
+
+/// Every recipe that reads an electron manifest is inside the check. A `*-mac.yml`
+/// recipe the predicate turns away — it grew a query, or started POSTing — would
+/// otherwise leave the sweep without anyone deciding it should.
+@Test func everyElectronManifestRecipeIsAskedAboutEdgeCopies() {
+    let manifests = VendorProbeRegistry.recipes.filter { $0.url.path.hasSuffix("-mac.yml") }
+    #expect(!manifests.isEmpty,
+            "no *-mac.yml recipes found — did the registry or this filter change?")
+    let skipped = manifests.filter { !RecipeSanity.readsElectronManifest($0) }.map(\.recipeID)
+    #expect(skipped.isEmpty,
+            "*-mac.yml recipes the edge-copy check would skip: \(skipped)")
+}
+
+// MARK: - The rules themselves
+
+@Test func onlyAPlainManifestFetchIsAsked() throws {
+    let manifest = try #require(
+        VendorProbeRegistry.recipes.first { RecipeSanity.readsElectronManifest($0) })
+    // A query the recipe states itself: adding ours would change the request.
+    #expect(!RecipeSanity.readsElectronManifest(
+        manifest.with(url: URL(string: "https://example.invalid/latest-mac.yml?channel=x")!)))
+    // Not an electron manifest at all.
+    #expect(!RecipeSanity.readsElectronManifest(
+        manifest.with(url: URL(string: "https://example.invalid/appcast.xml")!)))
+    #expect(!RecipeSanity.readsElectronManifest(
+        manifest.with(url: URL(string: "https://example.invalid/latest.yml")!)))
+}
+
+@Test func onlyADisagreementIsAComplaint() throws {
+    #expect(RecipeSanity.edgeCopyComplaint(bare: "3.2.7", origin: "3.2.7") == nil)
+    let complaint = try #require(RecipeSanity.edgeCopyComplaint(bare: "3.2.5", origin: "3.2.7"))
+    #expect(complaint.contains("3.2.5") && complaint.contains("3.2.7"))
+    // Either direction: the two addresses are simply not serving the same document.
+    #expect(RecipeSanity.edgeCopyComplaint(bare: "3.2.7", origin: "3.2.5") != nil)
+}
+
+@Test func theCheckAsksWithTheSameQueryTheSourceSends() {
+    let url = URL(string: "https://example.invalid/app/upgrade/latest-mac.yml")!
+    #expect(ElectronUpdateConfig.noCacheURL(for: url, token: "k3v9")
+        == URL(string: "https://example.invalid/app/upgrade/latest-mac.yml?noCache=k3v9"))
+    let stated = URL(string: "https://example.invalid/latest-mac.yml?channel=x")!
+    #expect(ElectronUpdateConfig.noCacheURL(for: stated, token: "k3v9") == stated)
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeRecipeCopyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeRecipeCopyTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+// `VendorProbeRecipe.with(url:)` / `with(entryStartPattern:)` promise to change ONE
+// field and carry every other one over. `copy(...)` used to drop three of them —
+// `transientBodyPattern`, `trackClosedPattern`, `buildLineage` all have defaults,
+// so leaving them out of the rebuild compiled fine and reset them to nil. That
+// mattered once `duo verify`'s edge-copy check started re-probing recipes through
+// `with(url:)`: a recipe that honours an error envelope or a closed track on its
+// first probe would not on its second.
+//
+// Compared by reflection, field by field, across the whole registry, so a field
+// added to the recipe later and forgotten in `copy` goes red here too.
+
+private func fields(_ recipe: VendorProbeRecipe, excluding skipped: String) -> [String: String] {
+    var out: [String: String] = [:]
+    for child in Mirror(reflecting: recipe).children {
+        guard let label = child.label, label != skipped else { continue }
+        out[label] = String(describing: child.value)
+    }
+    return out
+}
+
+@Test func withURLCarriesEveryOtherField() {
+    let elsewhere = URL(string: "https://example.invalid/elsewhere")!
+    for recipe in VendorProbeRegistry.recipes {
+        let copy = recipe.with(url: elsewhere)
+        #expect(copy.url == elsewhere)
+        #expect(fields(copy, excluding: "url") == fields(recipe, excluding: "url"),
+                "with(url:) changed more than the URL of \(recipe.recipeID)")
+    }
+}
+
+@Test func withEntryStartPatternCarriesEveryOtherField() {
+    for recipe in VendorProbeRegistry.recipes {
+        let copy = recipe.with(entryStartPattern: "<entry")
+        #expect(copy.entryStartPattern == "<entry")
+        #expect(fields(copy, excluding: "entryStartPattern")
+                    == fields(recipe, excluding: "entryStartPattern"),
+                "with(entryStartPattern:) changed more than that field of \(recipe.recipeID)")
+    }
+}
+
+/// The comparison above can only catch a dropped field that some recipe actually
+/// sets. These three are the ones that were dropped; if the registry ever stops
+/// using one, the reflection test loses its teeth for it without a word.
+@Test func theRegistryExercisesTheFieldsCopyUsedToDrop() {
+    let recipes = VendorProbeRegistry.recipes
+    #expect(recipes.contains { $0.transientBodyPattern != nil })
+    #expect(recipes.contains { $0.trackClosedPattern != nil })
+    #expect(recipes.contains { $0.buildLineage != nil })
+}


### PR DESCRIPTION
## What

`duo verify` now asks every VendorProbe recipe that reads an electron-builder manifest (`*-mac.yml`, plain GET, no query of its own) a second time, with electron-updater's `noCache` query, and **warns** if the two answers name different versions.

- Rules live in the core next to the registry: `RecipeSanity.readsElectronManifest` (which recipes) and `RecipeSanity.edgeCopyComplaint` (the warning).
- `ElectronUpdateConfig.noCacheURL(for:)` becomes the single public spelling of the query, shared with `ElectronManifestSource` (#527).
- Wired into `Verify.sweepVendor` via `Verify.edgeCopyComplaint`.

## Why

Follow-up to #527. Kimi's CDN served the bare `latest-mac.yml` from a days-old edge copy while the queried address reached the origin. #527 made `ElectronManifestSource` send the query. The 13 recipes that read `*-mac.yml` still fetch the bare address on purpose — measured 2026-09-11, adding the query changed nothing for any of them (6 aren't cached, 4 cache for minutes, 3 leave the query out of the cache key). The failure is invisible when it happens (the version and URL both resolve), so this makes it visible instead of changing behaviour.

**Warning, not broken**: a CDN still propagating a release can disagree for minutes; an issue needs the disagreement to survive into the next sweep, and Kimi's lasted days.

## Verification

- `make test`: green — Core 2649 tests / 223 suites, CLI 267 / 32, App tests 23/23, all python gates ✓.
- Mutations, each run and each red: second fetch without the query (CLI test); predicate always false (registry-derived + shape test); complaint when versions agree; predicate ignoring a stated query.
- Live full sweep (`make cli` then `duo verify`, 186 s): **0 edge-copy warnings** of 376 findings. The request ledger shows the second, queried request went out for all 13 recipes (Signal ×2, Termius ×2, one each for the rest). The single ⚠ in the run is LibreOffice's pre-existing `remote is BEHIND the installed copy`, unrelated.

## Known limits

- **Redirecting endpoints**: the query rides the first hop only. Granola's `api.granola.ai` redirects to a CloudFront URL without it, so for Granola the two fetches are the same document by construction. Documented in `Verify.edgeCopyComplaint`: that is also all the app's own updater gets, so "no complaint" there means "same as the app", not "same as the origin".
- Not covered by tests: that `sweepVendor` calls the check at all (the sweep runs the live registry over the network).
- Costs one extra request per such recipe per sweep.
