### PR TITLE
Add CodeEdit: accept its dev-tagged appcast items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Kimi's release notes now show up in Duo Updater.**
 
+**CodeEdit updates now show up.** A newer CodeEdit used to leave its row as a question mark instead of offering the update.
+
 Under the hood: the Homebrew list in the menu fills in faster, and `duo` commands start faster.
 
 ## 0.3.91

--- a/CHANNEL_COVERAGE_TODO.md
+++ b/CHANNEL_COVERAGE_TODO.md
@@ -130,6 +130,20 @@ Info.plist 在 2.02 上**完全不可用**（版本是 Electron 的 `36.6.0`）�
   `.artifact(/nightly/Superconductor-nightly-<sha8>-arm64.dmg)`。版本是 commit hash，排序靠
   `BuildLineage`（`changelog.json`）。stable 重开时的待办见审计文档。
 
+### Pattern C 续 — CodeEdit（2026-09-12 接，`dev` 是唯一轨的标签）
+
+- **CodeEdit** `app.codeedit.CodeEdit` — Info.plist 自带 `SUFeedURL`
+  （`releases/latest/download/appcast.xml`），通用 `SparkleAppcastSource` 覆盖。每个 release 的
+  appcast **只有一条 item**，且都打 `<sparkle:channel>dev</sparkle:channel>`（厂商 CI 写死
+  `SPARKLE_CHANNEL: dev`；app 的 `allowedChannels` 无条件返回 `["dev"]`；GitHub release 均非
+  prerelease）——`dev` 是唯一那条轨的标签，不是预发布轨。没有 binding 时，落后一版的副本不在
+  feed 里，推断回退到默认 channel，匹配零条 → unknown。`CodeEditChannel` 是常量 binding：
+  `.stable` + `sparkleChannelNames: ["dev"]`，不进 `boundBundleIDs`（没有偏好可监听）。
+  **重开条件**：厂商源码里被注释掉的 `if includePrereleaseVersions { return ["dev"] } return []`
+  一旦启用，stable 会变成无标签、`dev` 变成 opt-in，届时 binding 必须改读
+  `includePrereleaseVersions`，否则会把 `dev` 推给 stable 用户。见
+  [审计](docs/app-audits/app-codeedit-CodeEdit.md)。
+
 ### 版本后缀分流 续 — Yaak（2026-09-06 接）
 
 共享 `app.yaak.desktop`，两轨都是 GitHub。beta 包的 `CFBundleShortVersionString` 原样

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -152,8 +152,9 @@ public enum ChannelBinding {
     /// "did the user just flip a channel toggle in the vendor app itself" recheck
     /// to only these apps, instead of polling every installed app's prefs.
     ///
-    /// Deliberately excludes Ghostty: its binding is a fixed stable-only feed
-    /// override with no user-settable preference, so there is nothing to watch.
+    /// Deliberately excludes Ghostty and CodeEdit: each binding is a constant (a
+    /// fixed stable-only feed override; a fixed `<sparkle:channel>` tag) with no
+    /// user-settable preference behind it, so there is nothing to watch.
     public static let boundBundleIDs: Set<String> = [
         DuoPasteChannel.bundleID.lowercased(),
         ForkChannel.bundleID.lowercased(),
@@ -378,6 +379,7 @@ public enum ChannelBinding {
             return WindscribeChannel.resolveCurrent
         case SuperconductorChannel.bundleID.lowercased():
             return SuperconductorChannel.resolveCurrent
+        case CodeEditChannel.bundleID.lowercased(): return CodeEditChannel.resolveCurrent
         default:                       return nil
         }
     }
@@ -436,10 +438,12 @@ public enum ChannelBinding {
          BetterDisplayChannel.resolve(preEnabled: false, internalEnabled: true)),
         (BetterDisplayChannel.bundleID,
          BetterDisplayChannel.resolve(preEnabled: true, internalEnabled: true)),
-        // The remaining two have no user-settable channel choice to drive.
-        // Ghostty is a fixed stable-only feed override, so `resolveCurrent()` is
-        // already a constant.
+        // The remaining three have no user-settable channel choice to drive.
+        // Ghostty is a fixed stable-only feed override and CodeEdit a fixed feed
+        // tag (see `CodeEditChannel`), so `resolveCurrent()` is already a
+        // constant for both.
         (GhosttyChannel.bundleID, GhosttyChannel.resolveCurrent()),
+        (CodeEditChannel.bundleID, CodeEditChannel.resolveCurrent()),
     ] + (CleanShotChannel.resolve(activationKey: CleanShotChannel.placeholderActivationKey)
         .map { [(CleanShotChannel.bundleID, $0)] } ?? [])
     // CotEditor answers for ONE of its two preference values — an unticked box

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CodeEditChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/CodeEditChannel.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// CodeEdit (`app.codeedit.CodeEdit`) — a Sparkle app with ONE release line whose
+/// every appcast item is tagged `<sparkle:channel>dev</sparkle:channel>`.
+///
+/// The tag is a label, not a prerelease track. CodeEdit's release workflow
+/// (`.github/workflows/pre-release.yml`) generates every appcast with
+/// `SPARKLE_CHANNEL: dev`, and the app's own `SPUUpdaterDelegate.allowedChannels`
+/// returns `["dev"]` unconditionally — whatever its "include pre-release versions"
+/// setting says, every CodeEdit install is offered exactly the `dev` items. The
+/// GitHub releases those items point at are not marked prerelease.
+///
+/// Why a binding is needed at all: each release's appcast carries ONLY that
+/// release (v0.2.0, v0.3.4, v0.3.5 and v0.3.6 checked, one item each). Without a
+/// binding, `SparkleAppcastSource.allowedChannels` infers the channel from the
+/// installed build's own feed item — which exists only while the install is
+/// current. One release behind, the build is absent, the inference falls back to
+/// the default channel, and a feed with no untagged item offers nothing: the row
+/// reads unknown instead of offering the update.
+///
+/// `.stable`, because this is the app's only line, and
+/// `channelBindingsNeedingProof` is right to treat it as having no other channel
+/// to cross into.
+///
+/// ⚠️ Revisit when CodeEdit ships what it calls a production build. The same
+/// delegate carries a commented-out branch — `if includePrereleaseVersions {
+/// return ["dev"] } return []`, under "TODO: Uncomment when production build is
+/// released" — i.e. an untagged stable line with `dev` becoming opt-in. From that
+/// day this constant would offer `dev` builds to stable users, and the binding
+/// would have to read `includePrereleaseVersions` from the app's defaults instead.
+/// Reading it NOW would be wrong in the other direction: it defaults to false, so
+/// every install would fall back to the default channel and see nothing.
+///
+/// Not in `boundBundleIDs`, same as Ghostty: nothing a user sets changes the answer.
+enum CodeEditChannel {
+    static let bundleID = "app.codeedit.CodeEdit"
+
+    /// The only `<sparkle:channel>` value CodeEdit's appcasts carry.
+    static let feedTag = "dev"
+
+    static func resolveCurrent() -> ResolvedChannel {
+        ResolvedChannel(channel: .stable, sparkleChannelNames: [feedTag])
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
@@ -163,10 +163,12 @@ import Foundation
     /// way to reflect over a switch's cases.
     @Test func everyBindingIsEnumerated() {
         let enumerated = Set(ChannelBinding.allResolutions.map { $0.bundleID.lowercased() })
-        // Ghostty is deliberately outside `boundBundleIDs` (no user-settable
-        // preference to watch) but is still a real binding, so it is enumerated.
+        // Ghostty and CodeEdit are deliberately outside `boundBundleIDs` (no
+        // user-settable preference to watch) but are still real bindings, so they
+        // are enumerated.
         let expected = ChannelBinding.boundBundleIDs
-            .union([GhosttyChannel.bundleID.lowercased()])
+            .union([GhosttyChannel.bundleID.lowercased(),
+                    CodeEditChannel.bundleID.lowercased()])
             .subtracting(ChannelBinding.vendorProbeBackedBindings)
         #expect(enumerated == expected,
                 "allResolutions drifted from the resolvers: missing \(expected.subtracting(enumerated).sorted()), extra \(enumerated.subtracting(expected).sorted())")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CodeEditChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/CodeEditChannelTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// CodeEdit publishes ONE appcast item per release and tags every one of them
+/// `<sparkle:channel>dev</sparkle:channel>` — there is no untagged item, ever.
+/// The installed bundle's `SUFeedURL` (`releases/latest/download/appcast.xml`)
+/// therefore always serves a feed with no default channel, and the only item in
+/// it is the newest release.
+///
+/// Captured verbatim from the v0.3.6 release asset on 2026-09-12, except the
+/// `<description>` body, which is cut down to its heading (25 KB of GitHub
+/// markup with no bearing on selection). v0.2.0, v0.3.4 and v0.3.5 have the same
+/// shape: one item, tagged `dev`.
+private let codeEditFeedFixture = #"""
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <title>CodeEdit</title>
+        <item>
+            <title>0.3.6</title>
+            <pubDate>Tue, 26 Aug 2025 11:24:14 -0700</pubDate>
+            <link>https://github.com/CodeEditApp/CodeEdit</link>
+            <sparkle:fullReleaseNotesLink>https://codeedit.app/whats-new/</sparkle:fullReleaseNotesLink>
+            <sparkle:channel>dev</sparkle:channel>
+            <sparkle:version>47</sparkle:version>
+            <sparkle:shortVersionString>0.3.6</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/CodeEditApp/CodeEdit/releases/download/v0.3.6/CodeEdit.dmg" length="35962501" type="application/octet-stream" sparkle:edSignature="TrnQ8D6wY4q3zM3/LoubifHSMypcBL+Fvm0J9gaumqAAjhBqdiayaj3cWbSuaUOIqgp/qUgKF+dTNxVOG2shAw=="/>
+            <description><![CDATA[
+<h1>Task Output, External File Changes, Invisible Characters</h1>
+            ]]></description>
+        </item>
+    </channel>
+</rss>
+"""#
+
+@Suite struct CodeEditChannelTests {
+    /// Spelled out rather than taken from the binding: it is what the real bundle
+    /// reports (`CFBundleIdentifier` of the v0.3.6 dmg), so a binding keyed on
+    /// anything else fails here instead of silently never matching.
+    private static let bundleID = "app.codeedit.CodeEdit"
+
+    private var items: [SparkleAppcastItem] {
+        SparkleAppcastParser.parse(Data(codeEditFeedFixture.utf8))
+    }
+
+    /// An install at a given version, wearing whatever `ChannelBinding` resolves
+    /// for CodeEdit — the same fields `AppScanner` copies out of it, including
+    /// `channelIsAuthoritative`, which is only true when a binding answered.
+    private func scannedApp(short: String, build: String) -> InstalledApp {
+        let bound = ChannelBinding.resolve(bundleID: Self.bundleID)
+        return InstalledApp(
+            name: "CodeEdit", bundleID: Self.bundleID,
+            shortVersion: short, buildVersion: build,
+            path: URL(fileURLWithPath: "/Applications/ZZFixture-CodeEdit.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://github.com/CodeEditApp/CodeEdit/releases/latest/download/appcast.xml"),
+            sparkleChannelNames: bound?.sparkleChannelNames ?? [],
+            sparkleEdPublicKey: "key",
+            releaseChannel: bound?.channel ?? .stable,
+            channelIsAuthoritative: bound != nil)
+    }
+
+    private func best(for app: InstalledApp) -> String? {
+        SparkleAppcastSource.bestItem(
+            for: app, from: items, osVersion: "27.0", hostArch: .arm64,
+            allowingIntelTranslation: true
+        )?.shortVersionString
+    }
+
+    // MARK: - The fixture itself
+
+    @Test func theFeedHasNoDefaultChannel() {
+        #expect(items.count == 1)
+        #expect(items.allSatisfy { $0.channel == "dev" },
+                "every item is tagged; none sits on the default channel")
+    }
+
+    // MARK: - Selection
+
+    /// The case the binding exists for. The feed only ever holds the newest
+    /// release, so an install one version behind is NOT in it — and without a
+    /// binding `allowedChannels` falls back to the default channel alone, which
+    /// matches zero items: the row reads unknown instead of offering 0.3.6.
+    ///
+    /// Mutations that turn this red: removing CodeEdit's case from the
+    /// `ChannelBinding` switch; resolving with empty `sparkleChannelNames`
+    /// (a `.stable` channel derives no tag); retyping the tag.
+    @Test func anInstallBehindTheFeedIsOfferedTheNewRelease() {
+        #expect(best(for: scannedApp(short: "0.3.5", build: "46")) == "0.3.6")
+    }
+
+    /// The up-to-date install is in the feed, so this passed before the binding
+    /// too (the running build's own item names `dev`). It is still a mutation
+    /// target: an authoritative binding switches the build-match inference OFF,
+    /// so resolving with empty `sparkleChannelNames` or a retyped tag loses this
+    /// install as well — both turn it red.
+    @Test func theCurrentInstallStillMatchesItsOwnItem() {
+        #expect(best(for: scannedApp(short: "0.3.6", build: "47")) == "0.3.6")
+    }
+
+    /// Why a binding and not the generic inference: with nothing authoritative,
+    /// an install missing from the feed is assumed to be on the default channel.
+    /// A fixture guard, not a mutation target — it holds whatever the binding
+    /// does, and fails only if the fixture stops describing CodeEdit's feed.
+    @Test func withoutABindingAnInstallBehindTheFeedSeesNothing() {
+        let unbound = InstalledApp(
+            name: "CodeEdit", bundleID: Self.bundleID,
+            shortVersion: "0.3.5", buildVersion: "46",
+            path: URL(fileURLWithPath: "/Applications/ZZFixture-CodeEdit.app"),
+            isMASApp: false,
+            sparkleFeedURL: URL(string: "https://github.com/CodeEditApp/CodeEdit/releases/latest/download/appcast.xml"),
+            sparkleEdPublicKey: "key",
+            releaseChannel: .stable, channelIsAuthoritative: false)
+        #expect(best(for: unbound) == nil)
+    }
+}

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -189,6 +189,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**OpenUsage**](com-robinebers-openusage.md) · `com.robinebers.openusage` — S(stable+beta) C · 真包 v0.7.10 挂载验证 ✓（beta 显式 channel tag，beta 包实测正确升 stable）· **feed 51 条全无 `<description>`**，changelog 走 `ChangelogCatalog` 兜底到 GitHub releases（2026-08-31 补）· 2026-08-31
 - [x] [**Supacode**](app-supabit-supacode.md) · `app.supabit.supacode` — S · default+tip 两轨真包验证 ✓（tip 经 build 反查推断，零 recipe）· **2026-08-31 复验发现 tip 轨当时被判成 default**（tip 包 short 与 default 条目同为 `0.10.8`，渠道推断按文档序先撞上 short），引擎已修为两趟匹配；tip 条目本身无 changelog · 2026-08-31
 - [x] [**PDF Expert**](com-readdle-PDFExpert-Mac.md) · `com.readdle.PDFExpert-Mac` — S C · ⚠️ bundle 的 `SUFeedURL` 指着一份 **2022 年冻结**的 feed（build 764），其中一条没有 `maximumSystemVersion`，于是通用 Sparkle 源在现代 Mac 上读到 2.5.22 并判「已是最新」——零报错、cask 又是 `auto_updates` 无人兜底，这个 app 一直是隐形的。新增 `SparkleFeedCatalog.supersededFeeds` 按**死地址**（不是 bundle id）换到 pem3 feed；判据是 pem3 的 `edSignature` 用装机 bundle 自己的 `SUPublicEDKey` 验签通过 ✓。changelog 走 recipe 解 `fullReleaseNotesLink` 那张页（88 条，appcast 那份只有最新一版）· **一键真机端到端 ✓**（降到官方 3.13.1 再让引擎装回 3.13.2，走的是 781 KB 增量包而非 128 MB 全量，签名/公证/回滚点全绿）· 2026-09-04
+- [x] [**CodeEdit**](app-codeedit-CodeEdit.md) · `app.codeedit.CodeEdit` — S · 每个 release 的 appcast 只有一条、且都打 `dev` tag（没有默认 channel），落后一版的副本会读成 unknown；加常量 `ChannelBinding` 放行 `dev` · 真包 v0.3.6 挂载验证 ✓ · 2026-09-12
 
 ## Investigated — blocked safely
 

--- a/docs/app-audits/app-codeedit-CodeEdit.md
+++ b/docs/app-audits/app-codeedit-CodeEdit.md
@@ -1,0 +1,119 @@
+# CodeEdit
+
+## 基本信息
+- Bundle ID: `app.codeedit.CodeEdit`
+- Team ID: `9VS2VKC5LQ`（Developer ID Application: Austin Condiff；`spctl` 判 Notarized Developer ID）
+- 观测版本: 0.3.6（`CFBundleVersion` 47），取自官方 v0.3.6 release 资产 `CodeEdit.dmg`，只读挂载读取
+- 自更新机制: Sparkle 2.3.0（Info.plist 带 `SUFeedURL` + `SUPublicEDKey`）
+- 架构 / OS: universal（x86_64 + arm64）；`LSMinimumSystemVersion` 13.0
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|              | Sparkle | Homebrew | MAS  | GitHub | VendorProbe |
+|--------------|---------|----------|------|--------|-------------|
+| **stable**   | ✓       | ✗        | 未查 | —      | —           |
+
+当前生效源（`UpdateChecker` 优先链中第一个应答的）: **Sparkle**。bundle 自带 `SUFeedURL`，
+通用 `SparkleAppcastSource` 直接读；另加一条常量 `ChannelBinding`（`CodeEditChannel`），原因见下。
+
+- Homebrew ✗：cask `codeedit` 是 `auto_updates`，`HomebrewCaskSource` 让位，不作检测源。
+- GitHub —：Sparkle 在优先链更前，且 appcast 的 enclosure 本来就指向 GitHub release 资产，不需要第二条源。
+
+## Channel 详情
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable（唯一轨） | `app.codeedit.CodeEdit` | — | 无（常量 binding） | feed 每条 item 都打 `<sparkle:channel>dev</sparkle:channel>`，binding 放行 `dev` | ✓ |
+
+**`dev` 是唯一那条轨的标签，不是预发布轨。** 三条独立证据：
+
+1. 厂商发版 workflow `.github/workflows/pre-release.yml` 写死 `SPARKLE_CHANNEL: dev`，
+   `generate_appcast --channel "$SPARKLE_CHANNEL"`，每个版本都这样生成。
+2. app 自己的 `SoftwareUpdater.allowedChannels(for:)` 无条件返回 `["dev"]`——它身上那个
+   `includePrereleaseVersions` 设置此刻不影响任何事。
+3. GitHub releases 列表（v0.3.6 往前 15 个）`prerelease` 全为 false。
+
+**为什么需要 binding。** 每个 release 的 `appcast.xml` 资产**只含那一个版本**（v0.2.0、v0.3.4、
+v0.3.5、v0.3.6 四份实测均为 1 条 item、tag `dev`）。没有 binding 时，`allowedChannels` 靠「装机
+build 在 feed 里对应哪条 item」推断 channel——这只在副本已是最新时成立。落后一版，build 不在
+feed 里，推断回退到默认 channel，而这份 feed 没有任何无 tag 的 item：匹配零条 → `.unknown`，
+行上是问号而不是「有更新」。`CodeEditChannelTests.anInstallBehindTheFeedIsOfferedTheNewRelease`
+在加 binding 前实测为红（0.3.5/46 得到 nil），加后为绿（得到 0.3.6）。
+
+binding 解析为 `.stable` + `sparkleChannelNames: ["dev"]`，不进 `boundBundleIDs`（没有用户可设的
+偏好需要监听，同 Ghostty）。`.stable` 同时意味着 `channelBindingsNeedingProof` 不要求 proof——
+这里没有别的轨可串。
+
+## 更新检测
+- 源: `SparkleAppcastSource`
+- 端点: `https://github.com/CodeEditApp/CodeEdit/releases/latest/download/appcast.xml`
+  （Info.plist 声明的地址；GitHub 的 `releases/latest/download/` 路径取最新 release 的同名资产）。
+  app 运行时另走一步：`SoftwareUpdater` 先调 GitHub API 取 latest tag，再
+  `setFeedURL(releases/download/<tag>/appcast.xml)`——指向的是同一份资产。
+- 版本方案: `sparkle:version` 47 = `CFBundleVersion`，`sparkle:shortVersionString` 0.3.6 =
+  `CFBundleShortVersionString`，两个命名空间都对得上，不需要 `versionIsBuild`。
+- OS 上下限: feed `minimumSystemVersion` 13.0，**没有** `maximumSystemVersion`（四份 appcast 同）。
+- 注意事项: feed 只有一条 item，所以 release history 永远只有 1 条。
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 有（未 strings 核对） | 无 | 无可消费 |
+| 证据 | bundle 内 `Sparkle.framework` 2.3.0，带 `Autoupdate` | 四份 appcast 均无 `<sparkle:deltas>`；workflow 显式 `--maximum-deltas 0`；channel-verify `deltas 0`（2026-09-12） | 服务端不发，`VendorAppcastDeltas` 无从取 |
+
+- 格式: 不适用
+- 阻塞项: 厂商主动关掉了（`--maximum-deltas 0`）
+
+## Changelog
+- 来源: Sparkle inline `<description>`（GitHub release 正文渲染成的 HTML，`h1`/`h2`/`ul` 结构），
+  channel-verify 读到 25263 字符 inline；另有 `sparkle:fullReleaseNotesLink` → `https://codeedit.app/whats-new/`
+- 跟随 channel: 不适用（单轨）
+- Recipe 状态: 不需要。代价是只有最新一版的说明（feed 只含一条）。
+
+## 一键安装
+- 状态: 走 Sparkle 通用一键路径。签名前提已在真包上核对：enclosure 的 `sparkle:edSignature` 用
+  bundle 自己的 `SUPublicEDKey` 对 v0.3.6 dmg（35962501 字节，sha256 `fa5478f8…eac9`）验签通过，
+  翻转一个字节后验签失败（负对照）。**端到端安装未跑。**
+- 格式: dmg
+- **读的是**: 人人可手动下载的 GA——enclosure 就是 GitHub Releases 页上公开的 `CodeEdit.dmg`，没有灰度参数。
+- 阻塞: 无
+
+## 已知问题
+- **重开条件**：`SoftwareUpdater.allowedChannels` 里有一段被注释掉的
+  `if includePrereleaseVersions { return ["dev"] } return []`，注释写着 "Uncomment when production
+  build is released"。启用那天，stable 会变成无 tag、`dev` 变成 opt-in，而这条常量 binding 会把
+  `dev` 构建推给 stable 用户——届时必须改成读 `includePrereleaseVersions`。**现在读它是错的**：
+  它默认 false，所有副本都会回退到默认 channel、看不到任何更新。
+- `feed-discover` 对本 app 只给出 `declared`，没有报「每条 item 都有 tag」：`FeedDiscovery.decide`
+  在检查那一条（gate 3）之前就对 declared feed 返回了。已另开任务处理。
+- channel-verify 把这条 binding 描述为「read from this app's own preference」——那是 harness 对所有
+  binding 的通用措辞，对常量 binding 不准确。
+
+## 如何复验
+
+```sh
+# 身份 + feed 判定（只读挂载，自动卸载）
+swift run --package-path application-test feed-discover <CodeEdit.dmg>
+swift run --package-path application-test channel-verify <CodeEdit.dmg>
+# 单测（含加 binding 前为红的那一条）
+swift test --package-path DuoUpdaterCore --filter CodeEditChannelTests
+# 每个 release 的 appcast 形状
+gh release download v0.3.5 -R CodeEditApp/CodeEdit -p appcast.xml -O - | grep -c '<item>'
+```
+
+2026-09-12 实测（v0.3.6 官方 dmg）：
+- `feed-discover` → `declared  https://github.com/CodeEditApp/CodeEdit/releases/latest/download/appcast.xml`
+- `channel-verify`（加 binding 后）→ bundle id `app.codeedit.CodeEdit`、short 0.3.6、build 47、
+  detected channel stable、winning source Sparkle、latest 0.3.6、download
+  `https://github.com/CodeEditApp/CodeEdit/releases/download/v0.3.6/CodeEdit.dmg`、status up to date
+- appcast 形状：v0.2.0 / v0.3.4 / v0.3.5 / v0.3.6 各 1 条 item，channel 均为 `dev`，build 分别 39 / 45 / 46 / 47
+- 变异验证：删掉 switch 里的 case、把 tag 置空、把 tag 改成 `Dev`，三者都让
+  `anInstallBehindTheFeedIsOfferedTheNewRelease` 变红（第一个还让 `everyBindingIsEnumerated` 变红）
+
+## 建议下一步
+1. 盯厂商那段被注释的 `allowedChannels` 分支；启用后按「已知问题」第一条改 binding，并补一条
+   stable 副本不被推 `dev` 的用例。
+2. 可选：若要看到历史版本说明，可给 `ChangelogCatalog` 加 GitHub releases 兜底（feed 只含最新一条）。


### PR DESCRIPTION
## What

Adds CodeEdit (`app.codeedit.CodeEdit`). Detection, release notes and the one-click enclosure all come from the bundle's own `SUFeedURL` through the generic `SparkleAppcastSource`; the only code is a fixed `ChannelBinding` (`CodeEditChannel`).

## Why a binding

CodeEdit tags every appcast item `<sparkle:channel>dev</sparkle:channel>`, and each release's `appcast.xml` carries **only that release** (v0.2.0, v0.3.4, v0.3.5, v0.3.6 checked: one item each, all `dev`). Without a binding, `allowedChannels` infers the channel from the installed build's own feed item — which only exists while the install is current. One release behind, the build is absent, inference falls back to the default channel, and a feed with no untagged item offers nothing: the row reads unknown instead of offering the update.

`dev` is CodeEdit's only line, not a prerelease track: the vendor's `pre-release.yml` hardcodes `SPARKLE_CHANNEL: dev`, the app's own `allowedChannels` returns `["dev"]` unconditionally, and no GitHub release is marked prerelease. So the binding resolves to `.stable` + `sparkleChannelNames: ["dev"]` — no channel proof needed (`channelBindingsNeedingProof` drops stable), and not in `boundBundleIDs` (nothing to watch, same as Ghostty).

**Revisit trigger** (in the doc comment, the audit and `CHANNEL_COVERAGE_TODO.md`): the app carries a commented-out `if includePrereleaseVersions { return ["dev"] } return []` for "when production build is released". If that ships, this constant would offer `dev` to stable users and must switch to reading `includePrereleaseVersions`. Reading it today would be wrong the other way — it defaults to false.

## Verification

- `CodeEditChannelTests.anInstallBehindTheFeedIsOfferedTheNewRelease`: **red before the binding** (0.3.5/46 → nil), green after (→ 0.3.6).
- Mutations, each red: remove the switch case (also reddens `everyBindingIsEnumerated`); empty `sparkleChannelNames`; retype the tag.
- `channel-verify` on the official v0.3.6 dmg: bundle `app.codeedit.CodeEdit` 0.3.6 (47), winning source Sparkle, status up to date.
- Enclosure `edSignature` verified against the bundle's own `SUPublicEDKey` on the real dmg (flipped-byte negative control rejected). Team `9VS2VKC5LQ`, notarized. End-to-end install not run.
- `make test`: exit 0 — 2649 tests / 224 suites (1 pre-existing known issue in `ankiZeroPaddedTagComparesEqualToInstalled`), 265 CLI tests, app tests 23/23, all script gates green.
- `/code-review` (medium): no findings.

## Not in this PR

`feed-discover` reported plain `declared` for CodeEdit because `FeedDiscovery.decide` returns `.declared` before the `everyItemChannelTagged` gate. Being handled in a separate task.
