### PR TITLE
feed-discover: flag declared feeds that no binding can serve

### DIFF
--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -167,7 +167,8 @@ swift run --package-path application-test feed-discover <path-to-.app/.dmg/.zip>
 
 | Verdict | What it means | What to do |
 |---------|---------------|------------|
-| `declared` | Bundle names its own `SUFeedURL`; `SparkleAppcastSource` already resolves it | **STOP.** No recipe. Only changelog + channel remain (see below) |
+| `declared` | Bundle names its own `SUFeedURL`, and the feed has a default (untagged) item or a `ChannelBinding` already exists for this id — **or the feed did not answer, and the channel was never checked** (see item 2 below); `SparkleAppcastSource` resolves it | **STOP.** No recipe. Only changelog + channel remain (see below) |
+| `NEEDS BINDING` | Bundle names its own `SUFeedURL`, but **every** item in it carries `<sparkle:channel>` and no `ChannelBinding` exists. The address resolves; the channel filter then admits nothing for an install the feed no longer lists | **Do not stop.** No recipe either: write a `ChannelBinding` whose resolver names the tag(s) in `sparkleChannelNames` (the `BetterDisplayChannel` route) |
 | `ADOPT` (electron) | `app-update.yml` names a fetchable `*-mac.yml`; `ElectronManifestSource` covers it | **STOP**, unless you need a page/changelog link — the generic source carries neither |
 | `ADOPT` (sparkle) | Address found in code and proved against the bundle | Propose a `SparkleFeedCatalog` entry, not a recipe |
 | `review <blocker>` | The blocker names the reason | Continue the audit; the blocker tells you what to investigate |
@@ -188,7 +189,14 @@ one look identical from outside. Three of them, one avoidable read.
 2. **channel** — does the feed carry `<sparkle:channel>` tags, or does the vendor
    publish one feed per track? See Phase "channels" below. ⚠️ A feed where EVERY
    item is tagged has no default channel, and a stable install then matches zero
-   items (measured: OrbStack 7/7 tagged, ClaudeUsageMenuBar 20/20).
+   items (measured: OrbStack 7/7 tagged, ClaudeUsageMenuBar 20/20). With no
+   `ChannelBinding`, `feed-discover` reports that shape as `NEEDS BINDING`, not
+   `declared` — **but only when the feed answered**: an unreachable feed has no
+   items to check and still prints `declared`, so if the run was offline or the
+   host is flaky, `curl` the feed and look for an untagged `<item>` yourself.
+   Seeing your installed build in the feed does not clear it: CodeEdit
+   (2026-09-12) publishes one item per release, tagged `dev`, so the copy you
+   just downloaded matches and an install one version behind matches nothing.
 
 Everything else — version parsing, download URL, EdDSA verification, release
 history, OS floor — the generic source already does.
@@ -695,18 +703,25 @@ Every audit produces a document. This keeps documentation in sync with code.
 
 ### Relationship to existing tracking docs
 
-The repo has three **global-view** documents. Per-app audit docs are the
-**deep-dive per app**. They serve different purposes and must stay in sync:
+There are three **global-view** documents; per-app audit docs are the
+**deep-dive per app**. They serve different purposes and must stay in sync.
+
+⚠️ **Only one of the three is in the repository.** `.gitignore` excludes `/docs/*`
+(everything under `docs/` except `app-audits/` and the files it re-includes),
+because those notes record which apps are installed on one machine. So the two
+marked *local* below exist only on the machine that keeps them — a fresh clone,
+CI, or a subagent in another checkout will not find them. Update them if they
+are present where you are running; never `git add -f` them.
 
 | Document | Scope | Role |
 |----------|-------|------|
 | `docs/app-audits/<id>.md` | Single app, full depth | **Source of truth** for one app's integration |
-| `docs/app-onboarding-status.md` | All apps, one line each | Done / Skipped / TODO status board |
+| `docs/app-onboarding-status.md` (*local*) | All apps, one line each | Done / Skipped / TODO status board |
 | `CHANNEL_COVERAGE_TODO.md` | All apps, channel gaps | Which channels are missing and why |
-| `docs/top50-coverage-todo.md` | Top-50 apps, progress | Priority tracking |
+| `docs/top50-coverage-todo.md` (*local*) | Top-50 apps, progress | Priority tracking |
 
 **After completing an audit, also update the relevant global docs:**
-- If a new app is integrated → add it to `app-onboarding-status.md` § Done
+- If a new app is integrated → add it to `app-onboarding-status.md` § Done (if that local file exists)
 - If an app is investigated and skipped → add it to § Skipped (with reason)
 - If channel gaps are found → update `CHANNEL_COVERAGE_TODO.md`
 - If a previously-TODO app is now done → move it in the global doc

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
@@ -31,7 +31,8 @@ public enum FeedDiscovery {
         /// `Info.plist` `SUFeedURL` — the app speaking for itself. Handled apart
         /// from the others: an app that names its own feed needs no proposal,
         /// because `AppScanner` already reads this key and `SparkleAppcastSource`
-        /// is already resolving it.
+        /// is already resolving it. It can still need a `ChannelBinding` — see
+        /// `Verdict.declaredNeedsBinding`.
         case infoPlist
         /// The app's own preferences domain. Sparkle's own docs recommend the
         /// Info.plist key "even if you change it later programmatically", so a
@@ -151,9 +152,39 @@ public enum FeedDiscovery {
     }
 
     public enum Verdict: Sendable, Equatable {
-        /// The bundle names its own feed. Nothing to propose — this app is
-        /// already resolved by `SparkleAppcastSource` today.
+        /// The bundle names its own feed, and that feed either has an untagged
+        /// item or this app already has a `ChannelBinding`. Nothing to propose —
+        /// this app is already resolved by `SparkleAppcastSource` today.
+        ///
+        /// ⚠️ The channel half is only checked when the feed answered. A feed
+        /// that did not also lands here: "no untagged item" is vacuously true of
+        /// zero items, and reading it as starvation would flag every declared app
+        /// on an offline run.
         case declared(URL)
+        /// The bundle names its own feed, but every item in it carries a
+        /// `<sparkle:channel>` and no `ChannelBinding` exists for the app. The
+        /// address resolves; the channel filter is what fails. With no binding,
+        /// `SparkleAppcastSource.allowedChannels` admits the untagged channel plus
+        /// the tag of whichever item matches the installed version — so once the
+        /// feed stops listing that version, it admits no item at all.
+        ///
+        /// Measured on CodeEdit, 2026-09-12: its feed carries ONE item per
+        /// release, always tagged `dev`. This fires even when the installed build
+        /// IS in the feed, because that is what a discovery run normally sees (you
+        /// probe the build you just downloaded) — and it is the one state in which
+        /// the app still resolves.
+        ///
+        /// A case of its own rather than an annotation on `.declared`, for the
+        /// reason `.superseded` is: every `case .declared:` already written —
+        /// `feed-discover --scan --gaps` skips it — would keep compiling and keep
+        /// hiding this. A new case stops each of those switches compiling until
+        /// someone decides.
+        ///
+        /// Asked through `ChannelBinding.hasResolver`, not by running a resolver:
+        /// the question is whether a person has already made the channel decision
+        /// for this app, and that must not depend on the Mac asking. It does NOT
+        /// check that the binding names the right tags.
+        case declaredNeedsBinding(URL)
         /// The bundle names an address AND `SparkleFeedCatalog` supersedes it —
         /// the vendor abandoned that feed, and production reads the live one.
         ///
@@ -287,6 +318,14 @@ public enum FeedDiscovery {
                 forBundleID: probe.bundleID, declaredFeed: declared) {
                 return .superseded(declared: declared, live: live)
             }
+            // Gate 3 for a declared feed — see `Verdict.declaredNeedsBinding`.
+            // Gates 1 and 2 do not apply: the app names this address itself, so
+            // "is this our feed?" is settled, and production already compares
+            // against it. The empty check is load-bearing — see `.declared`.
+            let bound = probe.bundleID.map { ChannelBinding.hasResolver(bundleID: $0) } ?? false
+            if !feedItems.isEmpty, !publishesDefaultChannel(feedItems), !bound {
+                return .declaredNeedsBinding(declared)
+            }
             return .declared(declared)
         }
         guard probe.shipsSparkle else { return .noKnownUpdater }
@@ -338,16 +377,25 @@ public enum FeedDiscovery {
 
         // Gate 3 — would a stable install match anything? See
         // `Blocker.everyItemChannelTagged`.
-        guard feedItems.contains(where: { ($0.channel?.nonEmpty) == nil }) else {
+        guard publishesDefaultChannel(feedItems) else {
             return .review(.everyItemChannelTagged, candidate.url)
         }
 
         return .adopt(candidate.url)
     }
 
-    /// Probe a bundle, fetch its single candidate feed if it has one, and return
-    /// the verdict. The fetch uses the same revalidating policy the production
-    /// source does, so a discovery run and a real check see the same bytes.
+    /// Whether any item sits on Sparkle's default channel. One predicate for both
+    /// gate-3 sites, and asked through `SparkleAppcastSource.normalizeChannel` —
+    /// the call `usableItems` filters with — so the gate and the source cannot
+    /// disagree about what "untagged" means.
+    static func publishesDefaultChannel(_ items: [SparkleAppcastItem]) -> Bool {
+        items.contains { SparkleAppcastSource.normalizeChannel($0.channel) == nil }
+    }
+
+    /// Probe a bundle, fetch the feed it declares — or else its single candidate
+    /// feed, if it has one — and return the verdict. The fetch uses the same
+    /// revalidating policy the production source does, so a discovery run and a
+    /// real check see the same bytes.
     public static func examine(
         bundleAt bundleURL: URL, session: URLSession = .updates
     ) async -> Finding {
@@ -356,12 +404,14 @@ public enum FeedDiscovery {
         switch probe.family {
         case .sparkle, nil:
             var items: [SparkleAppcastItem] = []
-            if probe.declaredFeed == nil, probe.candidates.count == 1,
-               !isTemplated(probe.candidates[0].raw) {
-                let feed = probe.candidates[0].url
-                if let data = await fetch(feed, session: session) {
-                    items = SparkleAppcastParser.parse(data, relativeTo: feed)
-                }
+            // A declared feed is fetched too: `decide` needs its items to tell
+            // `.declared` from `.declaredNeedsBinding`. It once was not, and the
+            // declared branch then only ever saw an empty feed. (A superseded
+            // address is fetched as well; `decide` returns before reading it.)
+            let single = probe.candidates.count == 1 && !isTemplated(probe.candidates[0].raw)
+            if let feed = probe.declaredFeed ?? (single ? probe.candidates[0].url : nil),
+               let data = await fetch(feed, session: session) {
+                items = SparkleAppcastParser.parse(data, relativeTo: feed)
             }
             verdict = decide(probe, feedItems: items)
         case .electron:

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
@@ -190,6 +190,66 @@ private func item(
     #expect(verdict == .adopt(URL(string: "https://example.invalid/appcast.xml")!))
 }
 
+// MARK: - the channel gate, on a declared feed
+
+/// No `ChannelBinding` case can match this id. Asserted in each test rather than
+/// assumed: the day someone binds it, these stop measuring the "no binding" half.
+private let unboundID = "com.duoupdater.test.zzfixture.unbound"
+private let declaredFeed = "https://zzfixture.example.test/appcast.xml"
+
+@Test func aDeclaredFeedWithNoDefaultChannelAndNoBindingIsNotCoverage() {
+    // CodeEdit 0.3.6, 2026-09-12: bundle `0.3.6`/`47`; its declared feed's ONE
+    // item is `0.3.6`/`47` tagged `dev`. The installed build IS in the feed — the
+    // state a discovery run normally sees, and the only one in which the app
+    // still resolves. Mutation: delete the declared-feed gate in `decide` →
+    // `.declared`, red.
+    #expect(!ChannelBinding.hasResolver(bundleID: unboundID))
+    let verdict = FeedDiscovery.decide(
+        probe(id: unboundID, marketing: "0.3.6", build: "47",
+              candidate: nil, declared: declaredFeed),
+        feedItems: [item(short: "0.3.6", version: "47", channel: "dev")])
+    #expect(verdict == .declaredNeedsBinding(URL(string: declaredFeed)!))
+}
+
+@Test func aBoundAppsAllTaggedDeclaredFeedIsStillDeclared() throws {
+    // Synthetic feed shape; the id is real because the branch under test is
+    // "a binding exists". BetterDisplay is the route `NEEDS BINDING` points at —
+    // a resolver naming the tags outright — and once one exists, repeating the
+    // warning would make it permanent noise. Mutation: drop the `hasResolver`
+    // clause → `.declaredNeedsBinding`, red.
+    let id = BetterDisplayChannel.bundleID
+    try #require(ChannelBinding.hasResolver(bundleID: id))
+    let verdict = FeedDiscovery.decide(
+        probe(id: id, marketing: "1.0", build: "1", candidate: nil, declared: declaredFeed),
+        feedItems: [item(short: "1.0", version: "1", channel: "dev")])
+    #expect(verdict == .declared(URL(string: declaredFeed)!))
+}
+
+@Test func oneUntaggedItemKeepsADeclaredFeedDeclared() {
+    // Mutation: fire on "some item is tagged" instead of "no item is untagged"
+    // → `.declaredNeedsBinding`, red.
+    #expect(!ChannelBinding.hasResolver(bundleID: unboundID))
+    let verdict = FeedDiscovery.decide(
+        probe(id: unboundID, marketing: "2.2.3", build: "20963",
+              candidate: nil, declared: declaredFeed),
+        feedItems: [
+            item(short: "2.2.3", version: "20963"),
+            item(short: "2.3.0", version: "21000", channel: "beta"),
+        ])
+    #expect(verdict == .declared(URL(string: declaredFeed)!))
+}
+
+@Test func aDeclaredFeedThatDidNotAnswerIsNotReadAsAllTagged() {
+    // "No untagged item" is vacuously true of zero items. Mutation: drop the
+    // `!feedItems.isEmpty` guard → every offline run flags every declared app, red.
+    #expect(!ChannelBinding.hasResolver(bundleID: unboundID))
+    let verdict = FeedDiscovery.decide(
+        probe(id: unboundID, marketing: "0.3.6", build: "47",
+              candidate: nil, declared: declaredFeed),
+        feedItems: [])
+    #expect(verdict == .declared(URL(string: declaredFeed)!))
+}
+
 // MARK: - the address gates
 
 @Test func aTemplatedLiteralIsNeverAnAddress() throws {
@@ -485,4 +545,64 @@ private final class EdgeCopyProtocol: URLProtocol, @unchecked Sendable {
     // propose, never the one-off query it was fetched with.
     #expect(finding.verdict
         == .adopt(URL(string: "https://kimi-img.example.test/app/upgrade/latest-mac.yml")!))
+}
+
+/// CodeEdit's declared feed as it read on 2026-09-12, trimmed to the fields the
+/// gate reads: one item, tagged `dev`.
+private final class DevOnlyFeedProtocol: URLProtocol, @unchecked Sendable {
+    static let body = """
+        <?xml version="1.0" standalone="yes"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+          <channel>
+            <title>CodeEdit</title>
+            <item>
+              <title>0.3.6</title>
+              <sparkle:channel>dev</sparkle:channel>
+              <sparkle:version>47</sparkle:version>
+              <sparkle:shortVersionString>0.3.6</sparkle:shortVersionString>
+              <enclosure url="https://zzfixture.example.test/CodeEdit.dmg" length="1" type="application/octet-stream"/>
+            </item>
+          </channel>
+        </rss>
+        """
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        guard let url = request.url else { return }
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+@Test func discoveryFetchesADeclaredFeedToAskTheChannelQuestion() async throws {
+    // The defect was not in `decide`: `examine` never fetched a declared feed, so
+    // the declared branch only ever saw zero items and the `decide` tests above
+    // could all pass while the tool still printed `declared` for CodeEdit.
+    // Mutation: put back the `declaredFeed == nil` condition on the fetch →
+    // `.declared`, red.
+    #expect(!ChannelBinding.hasResolver(bundleID: unboundID))
+    let fm = FileManager.default
+    let bundle = fm.temporaryDirectory
+        .appendingPathComponent("ZZFixture-DeclaredDevOnly-\(UUID().uuidString).app")
+    defer { try? fm.removeItem(at: bundle) }
+    let contents = bundle.appendingPathComponent("Contents")
+    try fm.createDirectory(at: contents, withIntermediateDirectories: true)
+    let plist: [String: Any] = [
+        "CFBundleIdentifier": unboundID,
+        "CFBundleShortVersionString": "0.3.6",
+        "CFBundleVersion": "47",
+        "SUFeedURL": declaredFeed,
+    ]
+    try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        .write(to: contents.appendingPathComponent("Info.plist"))
+
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [DevOnlyFeedProtocol.self]
+    let finding = await FeedDiscovery.examine(
+        bundleAt: bundle, session: URLSession(configuration: configuration))
+    #expect(finding.verdict == .declaredNeedsBinding(URL(string: declaredFeed)!))
 }

--- a/application-test/Sources/feed-discover/main.swift
+++ b/application-test/Sources/feed-discover/main.swift
@@ -62,6 +62,11 @@ func describe(_ f: FeedDiscovery.Finding) -> String {
     case .declared(let url):
         lines.append("   declared  \(url.absoluteString)")
         lines.append("      (Info.plist names it; SparkleAppcastSource already resolves this app)")
+    case .declaredNeedsBinding(let url):
+        lines.append("   NEEDS BINDING \(url.absoluteString)")
+        lines.append("      Info.plist names it, but every item carries <sparkle:channel> and no")
+        lines.append("      ChannelBinding exists — once the feed stops listing the installed build,")
+        lines.append("      nothing is admitted. Needs a ChannelBinding naming the tag(s).")
     case .superseded(let declared, let live):
         lines.append("   SUPERSEDED \(declared.absoluteString)")
         lines.append("      the address the Info.plist names — SparkleFeedCatalog replaces it with")
@@ -151,6 +156,10 @@ if argv[1] == "--scan" {
             // kind of declared feed that is a coverage question rather than an
             // answer to one.
             counts["superseded", default: 0] += 1
+        case .declaredNeedsBinding:
+            // Not skipped under `--gaps` either: the address is covered, the
+            // channel is not.
+            counts["declaredNeedsBinding", default: 0] += 1
         case .adopt:
             counts["adopt", default: 0] += 1
         case .review(let b, _):

--- a/docs/update-manifest-families.md
+++ b/docs/update-manifest-families.md
@@ -46,6 +46,12 @@ electron 反过来：渠道带外、写在包里、零推断；代价是每轨�
 `SparkleAppcastSource` 覆盖了**；剩下要人判的占多数；能自动采纳的极少数，而且**跑出来的
 那几个早就有覆盖**。
 
+（「自带 `SUFeedURL` 就算覆盖」有一个例外：feed 里**每一条**都带 `<sparkle:channel>`、又没有
+`ChannelBinding` 的，地址能解析；feed 还列着本机那个 build 时一切正常，一旦不再列出，渠道过滤
+就一条也放不进。`feed-discover`
+现在把这种判成 `NEEDS BINDING` 而不是 `declared`。实例是 CodeEdit，2026-09-12：每个版本只发
+一条、恒带 `dev`。）
+
 **净新增 = 0。** 原因是一条通则：
 
 > 会把地址藏在代码里的 app，恰恰同时在干别的非标准事——模板拼地址、灰度分桶、按架构分 feed、按 macOS 大版本分目录。老实的 app 直接把地址写进 `SUFeedURL` / `app-update.yml`，而那些本来就不需要发现。


### PR DESCRIPTION
## Why

`FeedDiscovery.examine` only fetched a feed when the bundle named none, so a declared `SUFeedURL` never reached gate 3 (`everyItemChannelTagged`). CodeEdit's declared feed carries one item per release, always tagged `dev`. Without a `ChannelBinding`, `SparkleAppcastSource.allowedChannels` admits nothing once the feed stops listing the installed build, yet `feed-discover` printed `declared … already resolves this app`, and the app-audit skill reads `declared` as "STOP, no recipe".

## What

- `examine` now fetches the declared feed. `decide` returns the new `Verdict.declaredNeedsBinding` when every item is tagged and `ChannelBinding.hasResolver` is false. An empty or unreachable feed stays `.declared`, because "no untagged item" is vacuously true of zero items.
- It's a new case, not an annotation on `.declared`: `feed-discover --scan --gaps` has `case .declared: continue`, and an annotation would keep compiling and keep hiding it. This follows the same reasoning as `.superseded`.
- Gate 3 and the new check share `publishesDefaultChannel`, which calls `SparkleAppcastSource.normalizeChannel`. The parser already trims channel values, so gate 3's behaviour is unchanged.
- `feed-discover` prints `NEEDS BINDING` and doesn't skip it under `--gaps`.
- app-audit `SKILL.md`: new `NEEDS BINDING` row, and the `declared` row no longer promises a channel check that may not have run. `docs/app-onboarding-status.md` and `docs/top50-coverage-todo.md` are marked local-only (gitignored by `/docs/*`), not deleted, because they are still maintained on one machine.

## Verification

- Real bundle, `feed-discover ~/Downloads/CodeEdit.dmg`:
  - at `7d5e2426`, without this change: `declared`
  - with this change: `NEEDS BINDING`
  - after rebasing onto #529, which adds `CodeEditChannel`: `declared` again. This exercises the `hasResolver` branch on a real bundle.
- 5 new tests in `FeedDiscoveryTests`, each naming a mutation: delete the gate, drop `hasResolver`, fire on any-tagged, drop the empty guard, stop fetching the declared feed. All five mutations were run; each turned only its own case red.
- `make test` at `7d5e2426` plus this diff: exit 0. Core 2650 passed (1 existing known issue in `GitHubReleaseRuleTests`), CLI 265 passed, app tests 23/23.
- `feed-discover --scan` on the author's Mac: ClaudeUsageMenuBar's declared feed (all items tagged, no binding) now reads `NEEDS BINDING`. It wasn't changed here.

## Known limits

- An unreachable declared feed still prints `declared` with the channel check not run. The skill says so; the tool output does not.
- `hasResolver` asks whether a binding exists, not whether it names the right tags.
- `feed-discover --scan` now makes one request per declared app.
