### PR TITLE
feed-discover: a declared feed that did not answer is UNREADABLE, not declared

### DIFF
--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -167,8 +167,9 @@ swift run --package-path application-test feed-discover <path-to-.app/.dmg/.zip>
 
 | Verdict | What it means | What to do |
 |---------|---------------|------------|
-| `declared` | Bundle names its own `SUFeedURL`, and the feed has a default (untagged) item or a `ChannelBinding` already exists for this id — **or the feed did not answer, and the channel was never checked** (see item 2 below); `SparkleAppcastSource` resolves it | **STOP.** No recipe. Only changelog + channel remain (see below) |
+| `declared` | Bundle names its own `SUFeedURL`, the feed answered, and either a `ChannelBinding` already exists for this id or the feed has a default (untagged) item; `SparkleAppcastSource` resolves it | **STOP.** No recipe. Only changelog + channel remain (see below) |
 | `NEEDS BINDING` | Bundle names its own `SUFeedURL`, but **every** item in it carries `<sparkle:channel>` and no `ChannelBinding` exists. The address resolves; the channel filter then admits nothing for an install the feed no longer lists | **Do not stop.** No recipe either: write a `ChannelBinding` whose resolver names the tag(s) in `sparkleChannelNames` (the `BetterDisplayChannel` route) |
+| `UNREADABLE` | Bundle names its own `SUFeedURL`, but the feed answered with no appcast item (fetch failed, non-2xx, or nothing parsed) — nothing about it was checked. Reported even when a `ChannelBinding` exists: a tag-only binding (CodeEdit's) still reads exactly this address | **Do not stop.** Re-run; if it persists, `curl` the feed. A dead declared feed means `SparkleAppcastSource` resolves nothing for this app — unless its binding swaps in a different feed (Fork), in which case check that one instead |
 | `ADOPT` (electron) | `app-update.yml` names a fetchable `*-mac.yml`; `ElectronManifestSource` covers it | **STOP**, unless you need a page/changelog link — the generic source carries neither |
 | `ADOPT` (sparkle) | Address found in code and proved against the bundle | Propose a `SparkleFeedCatalog` entry, not a recipe |
 | `review <blocker>` | The blocker names the reason | Continue the audit; the blocker tells you what to investigate |
@@ -190,10 +191,9 @@ one look identical from outside. Three of them, one avoidable read.
    publish one feed per track? See Phase "channels" below. ⚠️ A feed where EVERY
    item is tagged has no default channel, and a stable install then matches zero
    items (measured: OrbStack 7/7 tagged, ClaudeUsageMenuBar 20/20). With no
-   `ChannelBinding`, `feed-discover` reports that shape as `NEEDS BINDING`, not
-   `declared` — **but only when the feed answered**: an unreachable feed has no
-   items to check and still prints `declared`, so if the run was offline or the
-   host is flaky, `curl` the feed and look for an untagged `<item>` yourself.
+   `ChannelBinding`, `feed-discover` reports that shape as `NEEDS BINDING`. A feed
+   it could not read is `UNREADABLE` whether or not a binding exists. Neither
+   prints as `declared`.
    Seeing your installed build in the feed does not clear it: CodeEdit
    (2026-09-12) publishes one item per release, tagged `dev`, so the copy you
    just downloaded matches and an install one version behind matches nothing.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/FeedDiscovery.swift
@@ -152,15 +152,26 @@ public enum FeedDiscovery {
     }
 
     public enum Verdict: Sendable, Equatable {
-        /// The bundle names its own feed, and that feed either has an untagged
-        /// item or this app already has a `ChannelBinding`. Nothing to propose —
-        /// this app is already resolved by `SparkleAppcastSource` today.
-        ///
-        /// ⚠️ The channel half is only checked when the feed answered. A feed
-        /// that did not also lands here: "no untagged item" is vacuously true of
-        /// zero items, and reading it as starvation would flag every declared app
-        /// on an offline run.
+        /// The bundle names its own feed, the feed answered, and either this app
+        /// already has a `ChannelBinding` or the feed has at least one untagged
+        /// item. Nothing to propose — this app is already resolved by
+        /// `SparkleAppcastSource` today.
         case declared(URL)
+        /// The bundle names its own feed, but the feed yielded no appcast item —
+        /// the fetch failed, answered non-2xx, or parsed to nothing — so nothing
+        /// about it was checked. Kept apart from `.declared` because the two used
+        /// to print identically, and an offline run then read as "covered" for an
+        /// app whose feed nobody had read. It may be transient or a dead feed
+        /// (which production cannot resolve either); this verdict cannot tell
+        /// them apart.
+        ///
+        /// Reported even when a `ChannelBinding` exists. A tag-only binding
+        /// (CodeEdit's names `dev` and nothing else) still has production read
+        /// exactly this address, so a binding cannot vouch for a feed nobody
+        /// read. The cost is a false alarm for a feed-swap binding (Fork), whose
+        /// production feed is another address — and `hasResolver` cannot tell the
+        /// two kinds apart without running the resolver.
+        case declaredUnreadable(URL)
         /// The bundle names its own feed, but every item in it carries a
         /// `<sparkle:channel>` and no `ChannelBinding` exists for the app. The
         /// address resolves; the channel filter is what fails. With no binding,
@@ -321,9 +332,18 @@ public enum FeedDiscovery {
             // Gate 3 for a declared feed — see `Verdict.declaredNeedsBinding`.
             // Gates 1 and 2 do not apply: the app names this address itself, so
             // "is this our feed?" is settled, and production already compares
-            // against it. The empty check is load-bearing — see `.declared`.
-            let bound = probe.bundleID.map { ChannelBinding.hasResolver(bundleID: $0) } ?? false
-            if !feedItems.isEmpty, !publishesDefaultChannel(feedItems), !bound {
+            // against it.
+            //
+            // Empty first, before the binding and before the channel test. A
+            // binding cannot vouch for a feed nobody read (see
+            // `Verdict.declaredUnreadable`), and "no untagged item" is vacuously
+            // true of zero items.
+            guard !feedItems.isEmpty else { return .declaredUnreadable(declared) }
+            // A binding answers the channel question outright.
+            if let id = probe.bundleID, ChannelBinding.hasResolver(bundleID: id) {
+                return .declared(declared)
+            }
+            guard publishesDefaultChannel(feedItems) else {
                 return .declaredNeedsBinding(declared)
             }
             return .declared(declared)
@@ -405,9 +425,10 @@ public enum FeedDiscovery {
         case .sparkle, nil:
             var items: [SparkleAppcastItem] = []
             // A declared feed is fetched too: `decide` needs its items to tell
-            // `.declared` from `.declaredNeedsBinding`. It once was not, and the
-            // declared branch then only ever saw an empty feed. (A superseded
-            // address is fetched as well; `decide` returns before reading it.)
+            // `.declared` from `.declaredNeedsBinding` and `.declaredUnreadable`.
+            // It once was not, and the declared branch then only ever saw an
+            // empty feed. (A superseded address is fetched as well; `decide`
+            // returns before reading it.)
             let single = probe.candidates.count == 1 && !isTemplated(probe.candidates[0].raw)
             if let feed = probe.declaredFeed ?? (single ? probe.candidates[0].url : nil),
                let data = await fetch(feed, session: session) {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/FeedDiscoveryTests.swift
@@ -239,15 +239,32 @@ private let declaredFeed = "https://zzfixture.example.test/appcast.xml"
     #expect(verdict == .declared(URL(string: declaredFeed)!))
 }
 
-@Test func aDeclaredFeedThatDidNotAnswerIsNotReadAsAllTagged() {
-    // "No untagged item" is vacuously true of zero items. Mutation: drop the
-    // `!feedItems.isEmpty` guard → every offline run flags every declared app, red.
+@Test func aDeclaredFeedThatDidNotAnswerSaysSoRatherThanClaimingCoverage() {
+    // Zero items means the channel check did not run, so neither `.declared`
+    // (checked, fine) nor `.declaredNeedsBinding` (checked, starved) is true.
+    // Mutation: drop the empty guard → "no untagged item" is vacuously true of
+    // zero items → `.declaredNeedsBinding`, red. Mutation: return `.declared`
+    // from it (the behaviour before this case existed) → red.
     #expect(!ChannelBinding.hasResolver(bundleID: unboundID))
     let verdict = FeedDiscovery.decide(
         probe(id: unboundID, marketing: "0.3.6", build: "47",
               candidate: nil, declared: declaredFeed),
         feedItems: [])
-    #expect(verdict == .declared(URL(string: declaredFeed)!))
+    #expect(verdict == .declaredUnreadable(URL(string: declaredFeed)!))
+}
+
+@Test func aBindingDoesNotVouchForADeclaredFeedNobodyRead() throws {
+    // A tag-only binding — CodeEdit's names `dev` and nothing else — still has
+    // production read exactly the declared address, so an unread feed is
+    // unread whether or not a binding exists. Mutation: ask the binding before
+    // the empty guard → `.declared` ("already resolves this app") for a feed
+    // nobody read, red.
+    let id = BetterDisplayChannel.bundleID
+    try #require(ChannelBinding.hasResolver(bundleID: id))
+    let verdict = FeedDiscovery.decide(
+        probe(id: id, marketing: "1.0", build: "1", candidate: nil, declared: declaredFeed),
+        feedItems: [])
+    #expect(verdict == .declaredUnreadable(URL(string: declaredFeed)!))
 }
 
 // MARK: - the address gates

--- a/application-test/Sources/feed-discover/main.swift
+++ b/application-test/Sources/feed-discover/main.swift
@@ -67,6 +67,11 @@ func describe(_ f: FeedDiscovery.Finding) -> String {
         lines.append("      Info.plist names it, but every item carries <sparkle:channel> and no")
         lines.append("      ChannelBinding exists — once the feed stops listing the installed build,")
         lines.append("      nothing is admitted. Needs a ChannelBinding naming the tag(s).")
+    case .declaredUnreadable(let url):
+        lines.append("   UNREADABLE \(url.absoluteString)")
+        lines.append("      Info.plist names it, but it answered with no appcast item (fetch failed,")
+        lines.append("      non-2xx, or nothing parsed) — the channel check did not run. Re-run, or")
+        lines.append("      read the feed by hand.")
     case .superseded(let declared, let live):
         lines.append("   SUPERSEDED \(declared.absoluteString)")
         lines.append("      the address the Info.plist names — SparkleFeedCatalog replaces it with")
@@ -160,6 +165,9 @@ if argv[1] == "--scan" {
             // Not skipped under `--gaps` either: the address is covered, the
             // channel is not.
             counts["declaredNeedsBinding", default: 0] += 1
+        case .declaredUnreadable:
+            // Not skipped under `--gaps`: nothing about this app was checked.
+            counts["declaredUnreadable", default: 0] += 1
         case .adopt:
             counts["adopt", default: 0] += 1
         case .review(let b, _):


### PR DESCRIPTION
## Why

Follow-up to #530. A declared feed that yielded no appcast item (fetch failed, non-2xx, or parsed to nothing) fell through to `.declared`, which printed the same as a feed that had been read and passed the channel check. So an offline run reported every declared app as "already resolves this app".

## What

- New `Verdict.declaredUnreadable`, printed `UNREADABLE`. `feed-discover --scan --gaps` doesn't skip it.
- The declared branch now checks, in order: superseded → empty feed → binding exists → every item tagged → `declared`. So `.declared` means the feed answered, and either a binding exists or the feed has an untagged item.
- The empty check comes **before** the binding check. A tag-only binding (CodeEdit's only names `dev`) still has production read exactly the declared address, so a binding can't vouch for a feed nobody read. The cost is a false alarm for a feed-swap binding (Fork), and `hasResolver` can't tell the two kinds apart without running the resolver. My first draft checked the binding first; `/code-review` caught it.
- app-audit `SKILL.md`: new `UNREADABLE` row, and the `declared` row drops its "or the feed did not answer" caveat.

## Verification

- Real network: a fixture bundle whose `SUFeedURL` is a real GitHub 404.
  - Before (#530's code): `declared … already resolves this app`.
  - After: `UNREADABLE`.
  - `~/Downloads/CodeEdit.dmg` (bound, feed answers) still reads `declared`.
- The 10 declared-feed and channel-gate tests pass. I ran 7 mutations:
  - M2–M7 each turned exactly the tests the harness predicted red.
  - M1 (drop the empty check) turned two tests red where the harness predicted one: the unbound empty feed now falls to `NEEDS BINDING`, and the bound empty feed now falls to `declared`. That is correct behaviour; my expected set was incomplete.
- `make test` at `08cf6905` plus this diff: exit 0. Core 2662 tests passed (1 existing known issue), CLI 267 tests passed, app tests 23/23, localizable keys and prose-claims gates green.
