### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.3",
       "sweepsSinceComment" : 0
@@ -106,16 +106,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "1.52386.0",
+      "lastGoodVersion" : "1.52386.3",
       "sweepsSinceComment" : 0
     },
     "changelog:com.anythingllm:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -133,7 +133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
@@ -144,7 +144,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 497,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0,
@@ -154,7 +154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -163,7 +163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
@@ -172,7 +172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -181,7 +181,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-rc",
       "sweepsSinceComment" : 0
@@ -190,7 +190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -199,7 +199,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
@@ -210,7 +210,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 507,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0,
@@ -220,7 +220,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -229,7 +229,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -238,7 +238,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -247,7 +247,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -256,7 +256,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -265,7 +265,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -274,7 +274,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -283,25 +283,26 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
     "changelog:com.google.antigravity:-" : {
-      "consecutiveActionable" : 0,
+      "consecutiveActionable" : 1,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.12.2",
-      "sweepsSinceComment" : 0
+      "lastSignature" : "newest changelog entry (2.12.2) trails t",
+      "sweepsSinceComment" : 1
     },
     "changelog:com.henrikruscon.Alcove:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -310,7 +311,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -319,7 +320,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -328,7 +329,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -337,7 +338,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -346,7 +347,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
@@ -355,7 +356,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -364,7 +365,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.137",
       "sweepsSinceComment" : 0
@@ -373,9 +374,18 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
+      "sweepsSinceComment" : 0
+    },
+    "changelog:com.moonshot.kimichat:-" : {
+      "consecutiveActionable" : 0,
+      "consecutiveInfra" : 0,
+      "consecutiveInstallTransient" : 0,
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodEntryCount" : 13,
+      "lastGoodVersion" : "3.2.7",
       "sweepsSinceComment" : 0
     },
     "changelog:com.openai.codex:-" : {
@@ -384,7 +394,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0,
@@ -394,7 +404,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "135.0.5973.123",
       "sweepsSinceComment" : 0
@@ -403,7 +413,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -412,7 +422,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -421,16 +431,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 30,
-      "lastGoodVersion" : "12.27.6",
+      "lastGoodVersion" : "12.27.7",
       "sweepsSinceComment" : 0
     },
     "changelog:com.qoder.app:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
@@ -441,7 +451,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0,
@@ -451,7 +461,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -460,7 +470,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -469,7 +479,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
@@ -478,7 +488,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -487,7 +497,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -496,7 +506,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -505,7 +515,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -516,7 +526,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0,
@@ -526,7 +536,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -535,7 +545,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -544,7 +554,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -553,7 +563,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -562,7 +572,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -571,7 +581,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 10, 2026",
       "sweepsSinceComment" : 0
@@ -580,7 +590,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260909.1",
       "sweepsSinceComment" : 0
@@ -589,7 +599,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -598,7 +608,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -607,7 +617,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -616,7 +626,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -625,7 +635,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -636,7 +646,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -646,7 +656,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.5.6",
       "sweepsSinceComment" : 0
@@ -655,16 +665,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "8545a7d8",
+      "lastGoodVersion" : "acef210f",
       "sweepsSinceComment" : 0
     },
     "changelog:dev.kdrag0n.MacVirt:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -673,8 +683,8 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodEntryCount" : 9,
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
     },
@@ -682,7 +692,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
@@ -691,16 +701,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "0.2026.09.09.08.26.02",
+      "lastGoodVersion" : "0.2026.09.09.08.26.03",
       "sweepsSinceComment" : 0
     },
     "changelog:dev.zed.Zed-Preview:preview" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
@@ -709,7 +719,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
@@ -718,7 +728,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -727,7 +737,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -736,7 +746,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
@@ -745,7 +755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -754,7 +764,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -763,7 +773,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
@@ -772,7 +782,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
@@ -783,7 +793,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 493,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0,
@@ -793,7 +803,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.7.0",
       "sweepsSinceComment" : 0
@@ -802,7 +812,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -811,7 +821,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -829,7 +839,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -838,7 +848,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
@@ -847,7 +857,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -856,7 +866,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -865,7 +875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -874,7 +884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -883,16 +893,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 15,
-      "lastGoodVersion" : "5.0.5",
+      "lastGoodVersion" : "4.3.7",
       "sweepsSinceComment" : 0
     },
     "changelog:pro.betterdisplay.BetterDisplay:unstable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -901,7 +911,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 14,
       "lastGoodVersion" : "0.1.19",
       "sweepsSinceComment" : 0
@@ -910,7 +920,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.1.0",
       "sweepsSinceComment" : 0
@@ -919,7 +929,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
@@ -928,7 +938,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
@@ -936,7 +946,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -944,7 +954,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -952,7 +962,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -960,7 +970,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -968,7 +978,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -976,7 +986,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "11.17",
       "sweepsSinceComment" : 0
     },
@@ -984,7 +994,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -992,7 +1002,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1000,7 +1010,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.3.10",
       "sweepsSinceComment" : 0
     },
@@ -1008,7 +1018,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -1016,7 +1026,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1024,7 +1034,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1032,7 +1042,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1040,7 +1050,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.135.06055",
       "sweepsSinceComment" : 0
     },
@@ -1048,7 +1058,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1056,7 +1066,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1064,7 +1074,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1072,7 +1082,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1080,7 +1090,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1088,7 +1098,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1096,7 +1106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1104,7 +1114,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1112,7 +1122,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
@@ -1120,7 +1130,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1128,7 +1138,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1136,7 +1146,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1144,7 +1154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1152,7 +1162,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1160,7 +1170,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1168,7 +1178,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1176,7 +1186,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1184,7 +1194,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1192,7 +1202,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1200,7 +1210,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1208,7 +1218,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1216,7 +1226,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1224,7 +1234,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1232,7 +1242,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1240,7 +1250,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1248,7 +1258,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1256,7 +1266,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1264,7 +1274,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1272,15 +1282,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "3.20.2",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "3.20.3",
       "sweepsSinceComment" : 0
     },
     "github:flameshot-org\/flameshot:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1288,7 +1298,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1296,7 +1306,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1304,7 +1314,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1312,7 +1322,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.1.19",
       "sweepsSinceComment" : 0
     },
@@ -1320,7 +1330,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1328,7 +1338,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1336,7 +1346,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1344,7 +1354,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1352,7 +1362,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1360,7 +1370,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1368,7 +1378,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1376,7 +1386,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1384,7 +1394,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1392,7 +1402,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1400,7 +1410,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1408,7 +1418,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1416,7 +1426,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1424,7 +1434,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1432,7 +1442,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -1440,7 +1450,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1448,7 +1458,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1456,7 +1466,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1464,7 +1474,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0
     },
@@ -1472,7 +1482,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.23.0",
       "sweepsSinceComment" : 0
     },
@@ -1480,7 +1490,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1488,15 +1498,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "0.0.41-nightly.20260911.1533",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "0.0.41-nightly.20260911.1551",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1504,7 +1514,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1512,7 +1522,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1520,7 +1530,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1528,7 +1538,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1536,7 +1546,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1544,7 +1554,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1552,7 +1562,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1560,7 +1570,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1568,7 +1578,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1576,7 +1586,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1584,7 +1594,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1592,7 +1602,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1600,7 +1610,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1608,7 +1618,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1616,7 +1626,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1624,7 +1634,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1632,7 +1642,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1662,7 +1672,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1670,7 +1680,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1678,7 +1688,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
@@ -1686,7 +1696,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
@@ -1694,7 +1704,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1834,7 +1844,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.9.9",
       "sweepsSinceComment" : 0
     },
@@ -1842,7 +1852,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1850,7 +1860,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1858,7 +1868,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1866,7 +1876,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1874,7 +1884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1882,7 +1892,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1890,7 +1900,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1898,7 +1908,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1906,7 +1916,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.52386.0",
       "sweepsSinceComment" : 0
     },
@@ -1914,7 +1924,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1922,7 +1932,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.47.0",
       "sweepsSinceComment" : 0
     },
@@ -1930,7 +1940,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1938,7 +1948,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
@@ -1946,7 +1956,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1954,7 +1964,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1962,7 +1972,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1970,7 +1980,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1978,7 +1988,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1986,7 +1996,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.96.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1994,15 +2004,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "1.97.22.0",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "1.97.27.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.bytedance.inputmethod.doubaoime:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2010,7 +2020,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.125.1",
       "sweepsSinceComment" : 0
     },
@@ -2018,7 +2028,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
     },
@@ -2026,7 +2036,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2034,7 +2044,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2042,7 +2052,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2050,7 +2060,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.6.827",
       "sweepsSinceComment" : 0
     },
@@ -2058,15 +2068,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "3.9.19",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "3.10.23",
       "sweepsSinceComment" : 0
     },
     "vendor:com.figma.Desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2074,7 +2084,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2082,7 +2092,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2090,7 +2100,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "154.0.8037.17",
       "sweepsSinceComment" : 0
     },
@@ -2098,15 +2108,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "155.0.8052.0",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "155.0.8053.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.google.Chrome.dev:dev" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "155.0.8048.0",
       "sweepsSinceComment" : 0
     },
@@ -2114,7 +2124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2122,7 +2132,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.111.1.839",
       "sweepsSinceComment" : 0
     },
@@ -2130,7 +2140,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2138,7 +2148,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.2.1 Canary 5",
       "sweepsSinceComment" : 0
     },
@@ -2146,7 +2156,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2154,7 +2164,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2162,15 +2172,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "2.12.2",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "2.13.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.granola.app:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.559.2",
       "sweepsSinceComment" : 0
     },
@@ -2178,7 +2188,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2186,7 +2196,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2194,15 +2204,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "0.0.1319",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "0.0.1321",
       "sweepsSinceComment" : 0
     },
     "vendor:com.hnc.DiscordPTB:ptb" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.0.260",
       "sweepsSinceComment" : 0
     },
@@ -2210,7 +2220,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "263.4732.28",
       "sweepsSinceComment" : 0
     },
@@ -2218,7 +2228,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2226,7 +2236,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2234,7 +2244,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2244,7 +2254,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "9.5.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -2254,7 +2264,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2262,7 +2272,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2270,7 +2280,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
@@ -2278,7 +2288,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2286,7 +2296,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2294,7 +2304,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "26.150.0804",
       "sweepsSinceComment" : 0
     },
@@ -2302,7 +2312,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2310,7 +2320,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2318,7 +2328,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.137.0",
       "sweepsSinceComment" : 0
     },
@@ -2326,7 +2336,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.138.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -2334,7 +2344,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2342,15 +2352,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "154.0.4258.9",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "154.0.4258.12",
       "sweepsSinceComment" : 0
     },
     "vendor:com.microsoft.edgemac.Dev:dev" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "155.0.4268.0",
       "sweepsSinceComment" : 0
     },
@@ -2358,7 +2368,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "153.0.4234.32",
       "sweepsSinceComment" : 0
     },
@@ -2366,7 +2376,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2374,7 +2384,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2382,7 +2392,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "26213.1006.5011.1671",
       "sweepsSinceComment" : 0
     },
@@ -2390,7 +2400,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2398,15 +2408,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "4.39.1",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "4.40.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.openai.chat:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2414,15 +2424,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "26.903.71938",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "26.908.40834",
       "sweepsSinceComment" : 0
     },
     "vendor:com.operasoftware.Opera:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "135.0.5973.133",
       "sweepsSinceComment" : 0
     },
@@ -2430,7 +2440,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2438,7 +2448,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2446,15 +2456,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "12.27.6",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "12.27.7",
       "sweepsSinceComment" : 0
     },
     "vendor:com.qoder.app:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2462,7 +2472,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2470,7 +2480,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.104.29",
       "sweepsSinceComment" : 0
     },
@@ -2478,7 +2488,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.3.1.0",
       "sweepsSinceComment" : 0
     },
@@ -2486,7 +2496,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.8",
       "sweepsSinceComment" : 0
     },
@@ -2494,7 +2504,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.8",
       "sweepsSinceComment" : 0
     },
@@ -2502,7 +2512,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2510,7 +2520,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2518,7 +2528,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2526,7 +2536,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2534,7 +2544,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2542,7 +2552,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2552,7 +2562,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.2.8",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2561,7 +2571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2571,7 +2581,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2580,7 +2590,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0
     },
@@ -2588,7 +2598,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2596,7 +2606,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2604,7 +2614,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2612,7 +2622,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2620,7 +2630,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2628,7 +2638,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2636,7 +2646,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2644,7 +2654,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.20.10",
       "sweepsSinceComment" : 0
     },
@@ -2652,7 +2662,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.21.2",
       "sweepsSinceComment" : 0
     },
@@ -2660,7 +2670,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "8.3.4157.3",
       "sweepsSinceComment" : 0
     },
@@ -2668,7 +2678,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2676,7 +2686,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2684,7 +2694,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2692,7 +2702,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2700,7 +2710,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2708,7 +2718,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2716,7 +2726,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2724,7 +2734,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2732,15 +2742,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
-      "lastGoodVersion" : "8545a7d8",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodVersion" : "acef210f",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.commandline.waveterm:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2748,7 +2758,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2756,7 +2766,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2764,7 +2774,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2772,7 +2782,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2780,7 +2790,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.2026.09.11.08.26.00",
       "sweepsSinceComment" : 0
     },
@@ -2788,7 +2798,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2796,7 +2806,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2804,7 +2814,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2812,7 +2822,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2026091101",
       "sweepsSinceComment" : 0
     },
@@ -2820,7 +2830,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2828,7 +2838,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2836,7 +2846,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2844,7 +2854,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2852,7 +2862,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.103.219",
       "sweepsSinceComment" : 0
     },
@@ -2860,7 +2870,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2868,7 +2878,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2876,7 +2886,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2884,7 +2894,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2892,7 +2902,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "26.36.21",
       "sweepsSinceComment" : 0
     },
@@ -2900,7 +2910,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
@@ -2908,7 +2918,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2916,7 +2926,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.2.6",
       "sweepsSinceComment" : 0
     },
@@ -2924,7 +2934,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2932,7 +2942,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2940,23 +2950,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
+      "infraSince" : "2026-09-11T20:23:45Z",
       "lastGoodAt" : "2026-09-11T14:23:57Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 0
+      "sweepsSinceComment" : 1
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2964,7 +2975,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2972,7 +2983,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2980,7 +2991,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2988,7 +2999,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2996,7 +3007,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "158.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3004,7 +3015,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "158.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3012,7 +3023,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -3020,7 +3031,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -3028,7 +3039,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -3036,7 +3047,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3044,7 +3055,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3052,7 +3063,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3060,7 +3071,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "8.28.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -3068,7 +3079,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "8.27.0",
       "sweepsSinceComment" : 0
     },
@@ -3078,7 +3089,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "10.0.2",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -3087,7 +3098,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3095,11 +3106,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-11T20:23:45Z",
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-11T14:23:58Z"
+  "updatedAt" : "2026-09-11T20:23:45Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.