### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.3",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.52386.3",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -133,7 +133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
@@ -144,7 +144,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 497,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0,
@@ -154,7 +154,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -163,7 +163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
@@ -172,7 +172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -181,7 +181,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0-rc",
       "sweepsSinceComment" : 0
@@ -190,7 +190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
@@ -199,7 +199,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
@@ -210,7 +210,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 507,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0,
@@ -220,7 +220,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -229,7 +229,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -238,7 +238,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -247,7 +247,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -256,7 +256,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -265,7 +265,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -274,7 +274,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -283,26 +283,25 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
     "changelog:com.google.antigravity:-" : {
-      "consecutiveActionable" : 1,
+      "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodEntryCount" : 19,
-      "lastGoodVersion" : "2.12.2",
-      "lastSignature" : "newest changelog entry (2.12.2) trails t",
-      "sweepsSinceComment" : 1
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodEntryCount" : 20,
+      "lastGoodVersion" : "2.13.0",
+      "sweepsSinceComment" : 0
     },
     "changelog:com.henrikruscon.Alcove:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -311,7 +310,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -320,7 +319,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -329,7 +328,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -338,7 +337,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -347,7 +346,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
@@ -356,7 +355,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -365,7 +364,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.137",
       "sweepsSinceComment" : 0
@@ -374,7 +373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -383,7 +382,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 13,
       "lastGoodVersion" : "3.2.7",
       "sweepsSinceComment" : 0
@@ -394,9 +393,9 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "",
+      "lastGoodVersion" : "26.908",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "newest changelog entry (26.727) trails t"
     },
@@ -404,7 +403,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "135.0.5973.123",
       "sweepsSinceComment" : 0
@@ -413,7 +412,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -422,7 +421,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -431,7 +430,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "12.27.7",
       "sweepsSinceComment" : 0
@@ -440,7 +439,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
@@ -451,7 +450,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0,
@@ -461,7 +460,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -470,7 +469,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -479,7 +478,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
@@ -488,7 +487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
@@ -497,7 +496,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -506,7 +505,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -515,7 +514,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -526,7 +525,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0,
@@ -536,7 +535,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -545,7 +544,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -554,7 +553,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -563,7 +562,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -572,7 +571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -581,7 +580,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 10, 2026",
       "sweepsSinceComment" : 0
@@ -590,7 +589,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260909.1",
       "sweepsSinceComment" : 0
@@ -599,7 +598,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -608,7 +607,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -617,7 +616,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -626,7 +625,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -635,7 +634,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -646,7 +645,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -656,7 +655,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.5.6",
       "sweepsSinceComment" : 0
@@ -665,16 +664,16 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
-      "lastGoodVersion" : "acef210f",
+      "lastGoodVersion" : "2237d994",
       "sweepsSinceComment" : 0
     },
     "changelog:dev.kdrag0n.MacVirt:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -683,7 +682,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -692,7 +691,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
@@ -701,7 +700,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.09.08.26.03",
       "sweepsSinceComment" : 0
@@ -710,7 +709,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
@@ -719,7 +718,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
@@ -728,7 +727,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -737,7 +736,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -746,7 +745,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
@@ -755,7 +754,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -764,7 +763,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -773,7 +772,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
@@ -782,7 +781,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
@@ -793,7 +792,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 493,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0,
@@ -803,7 +802,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.7.0",
       "sweepsSinceComment" : 0
@@ -812,7 +811,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -821,7 +820,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -830,7 +829,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.4.4",
       "sweepsSinceComment" : 0
@@ -839,7 +838,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -848,7 +847,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
@@ -857,7 +856,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -866,7 +865,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -875,7 +874,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -884,7 +883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -893,7 +892,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4.3.7",
       "sweepsSinceComment" : 0
@@ -902,7 +901,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -911,7 +910,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 14,
       "lastGoodVersion" : "0.1.19",
       "sweepsSinceComment" : 0
@@ -920,7 +919,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.1.0",
       "sweepsSinceComment" : 0
@@ -929,7 +928,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
@@ -938,7 +937,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
@@ -946,7 +945,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -954,7 +953,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -962,7 +961,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -970,7 +969,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -978,7 +977,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -986,7 +985,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "11.17",
       "sweepsSinceComment" : 0
     },
@@ -994,7 +993,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -1002,7 +1001,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1010,7 +1009,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.3.10",
       "sweepsSinceComment" : 0
     },
@@ -1018,7 +1017,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -1026,7 +1025,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1034,7 +1033,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1042,7 +1041,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1050,7 +1049,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.135.06055",
       "sweepsSinceComment" : 0
     },
@@ -1058,7 +1057,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1066,7 +1065,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1074,7 +1073,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1082,7 +1081,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1090,7 +1089,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1098,7 +1097,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1106,7 +1105,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1114,7 +1113,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1122,7 +1121,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
@@ -1130,7 +1129,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1138,7 +1137,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1146,7 +1145,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1154,7 +1153,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1162,7 +1161,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1170,7 +1169,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1178,7 +1177,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1186,7 +1185,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.1.0-beta.6",
       "sweepsSinceComment" : 0
     },
@@ -1194,7 +1193,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1202,7 +1201,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1210,7 +1209,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1218,7 +1217,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1226,7 +1225,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1234,7 +1233,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1242,7 +1241,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1250,7 +1249,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1258,7 +1257,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1266,7 +1265,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1274,7 +1273,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1282,7 +1281,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.20.3",
       "sweepsSinceComment" : 0
     },
@@ -1290,7 +1289,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1298,7 +1297,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1306,7 +1305,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1314,7 +1313,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1322,7 +1321,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.1.19",
       "sweepsSinceComment" : 0
     },
@@ -1330,7 +1329,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1338,7 +1337,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.16.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1346,7 +1345,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1354,7 +1353,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1362,7 +1361,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1370,7 +1369,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1378,7 +1377,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1386,7 +1385,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1394,7 +1393,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1402,7 +1401,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1410,7 +1409,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1418,7 +1417,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1426,7 +1425,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1434,7 +1433,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1442,7 +1441,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -1450,7 +1449,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1458,7 +1457,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1466,7 +1465,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1474,7 +1473,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0
     },
@@ -1482,15 +1481,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "1.23.0",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     },
     "github:pingdotgg\/t3code:alpha" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1498,15 +1497,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "0.0.41-nightly.20260911.1551",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "0.0.41-nightly.20260911.1564",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1514,7 +1513,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1522,7 +1521,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1530,7 +1529,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1538,7 +1537,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1546,7 +1545,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1554,7 +1553,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1562,7 +1561,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1570,7 +1569,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1578,7 +1577,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1586,7 +1585,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1594,7 +1593,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1602,7 +1601,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1610,7 +1609,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1618,7 +1617,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1626,7 +1625,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1634,7 +1633,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1642,7 +1641,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1672,7 +1671,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.12.1",
       "sweepsSinceComment" : 0
     },
@@ -1680,7 +1679,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1688,7 +1687,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
@@ -1696,7 +1695,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
@@ -1704,7 +1703,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.22b",
       "sweepsSinceComment" : 0
     },
@@ -1844,7 +1843,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.9.9",
       "sweepsSinceComment" : 0
     },
@@ -1852,7 +1851,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1860,7 +1859,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1868,7 +1867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1876,7 +1875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1884,7 +1883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1892,7 +1891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1900,7 +1899,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1908,7 +1907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1916,15 +1915,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "1.52386.0",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "1.52386.3",
       "sweepsSinceComment" : 0
     },
     "vendor:com.anthropic.claudefordesktop:stable:rollout" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1932,7 +1931,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.47.0",
       "sweepsSinceComment" : 0
     },
@@ -1940,7 +1939,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1948,7 +1947,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
@@ -1956,7 +1955,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -1964,7 +1963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -1972,7 +1971,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -1980,7 +1979,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -1988,7 +1987,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1996,7 +1995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.96.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2004,15 +2003,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "1.97.27.0",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "1.97.29.0",
       "sweepsSinceComment" : 0
     },
     "vendor:com.bytedance.inputmethod.doubaoime:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2020,7 +2019,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.125.1",
       "sweepsSinceComment" : 0
     },
@@ -2028,7 +2027,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
     },
@@ -2036,7 +2035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2044,7 +2043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2052,7 +2051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2060,7 +2059,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.6.827",
       "sweepsSinceComment" : 0
     },
@@ -2068,7 +2067,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.10.23",
       "sweepsSinceComment" : 0
     },
@@ -2076,7 +2075,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2084,7 +2083,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2092,7 +2091,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2100,7 +2099,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "154.0.8037.17",
       "sweepsSinceComment" : 0
     },
@@ -2108,7 +2107,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "155.0.8053.0",
       "sweepsSinceComment" : 0
     },
@@ -2116,7 +2115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "155.0.8048.0",
       "sweepsSinceComment" : 0
     },
@@ -2124,7 +2123,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2132,7 +2131,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.111.1.839",
       "sweepsSinceComment" : 0
     },
@@ -2140,7 +2139,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2148,7 +2147,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.2.1 Canary 5",
       "sweepsSinceComment" : 0
     },
@@ -2156,7 +2155,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2164,7 +2163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2172,7 +2171,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.13.0",
       "sweepsSinceComment" : 0
     },
@@ -2180,7 +2179,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.559.2",
       "sweepsSinceComment" : 0
     },
@@ -2188,7 +2187,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2196,7 +2195,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2204,7 +2203,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.0.1321",
       "sweepsSinceComment" : 0
     },
@@ -2212,7 +2211,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.0.260",
       "sweepsSinceComment" : 0
     },
@@ -2220,7 +2219,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "263.4732.28",
       "sweepsSinceComment" : 0
     },
@@ -2228,7 +2227,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2236,7 +2235,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2244,7 +2243,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2254,7 +2253,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "9.5.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -2264,7 +2263,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2272,7 +2271,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2280,7 +2279,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
@@ -2288,7 +2287,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2296,7 +2295,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2304,15 +2303,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "26.150.0804",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "26.153.0809",
       "sweepsSinceComment" : 0
     },
     "vendor:com.microsoft.Outlook:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2320,7 +2319,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2328,7 +2327,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.137.0",
       "sweepsSinceComment" : 0
     },
@@ -2336,7 +2335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.138.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -2344,7 +2343,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2352,7 +2351,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "154.0.4258.12",
       "sweepsSinceComment" : 0
     },
@@ -2360,7 +2359,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "155.0.4268.0",
       "sweepsSinceComment" : 0
     },
@@ -2368,7 +2367,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "153.0.4234.32",
       "sweepsSinceComment" : 0
     },
@@ -2376,7 +2375,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2384,7 +2383,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2392,15 +2391,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "26213.1006.5011.1671",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "26225.1706.5101.3140",
       "sweepsSinceComment" : 0
     },
     "vendor:com.mongodb.compass:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2408,7 +2407,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.40.0",
       "sweepsSinceComment" : 0
     },
@@ -2416,7 +2415,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2424,7 +2423,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "26.908.40834",
       "sweepsSinceComment" : 0
     },
@@ -2432,7 +2431,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "135.0.5973.133",
       "sweepsSinceComment" : 0
     },
@@ -2440,7 +2439,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
@@ -2448,7 +2447,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
     },
@@ -2456,7 +2455,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "12.27.7",
       "sweepsSinceComment" : 0
     },
@@ -2464,7 +2463,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2472,7 +2471,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2480,7 +2479,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.104.29",
       "sweepsSinceComment" : 0
     },
@@ -2488,7 +2487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.3.1.0",
       "sweepsSinceComment" : 0
     },
@@ -2496,7 +2495,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.8",
       "sweepsSinceComment" : 0
     },
@@ -2504,7 +2503,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.8",
       "sweepsSinceComment" : 0
     },
@@ -2512,7 +2511,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2520,7 +2519,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2528,7 +2527,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2536,7 +2535,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2544,7 +2543,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2552,7 +2551,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2562,7 +2561,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.2.8",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2571,7 +2570,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2581,7 +2580,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2590,7 +2589,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0
     },
@@ -2598,7 +2597,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2606,7 +2605,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2614,7 +2613,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2622,7 +2621,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2630,7 +2629,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2638,7 +2637,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2646,7 +2645,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2654,15 +2653,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "3.20.10",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "3.20.14",
       "sweepsSinceComment" : 0
     },
     "vendor:com.unity3d.unityhub:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.21.2",
       "sweepsSinceComment" : 0
     },
@@ -2670,7 +2669,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "8.3.4157.3",
       "sweepsSinceComment" : 0
     },
@@ -2678,7 +2677,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2686,7 +2685,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2694,7 +2693,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2702,7 +2701,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2710,7 +2709,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2718,7 +2717,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2726,7 +2725,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2734,7 +2733,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2742,15 +2741,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
-      "lastGoodVersion" : "acef210f",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
+      "lastGoodVersion" : "2237d994",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.commandline.waveterm:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2758,7 +2757,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2766,7 +2765,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2774,7 +2773,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2782,7 +2781,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2790,7 +2789,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.2026.09.11.08.26.00",
       "sweepsSinceComment" : 0
     },
@@ -2798,7 +2797,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2806,7 +2805,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2814,7 +2813,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2822,7 +2821,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2026091101",
       "sweepsSinceComment" : 0
     },
@@ -2830,7 +2829,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2838,7 +2837,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2846,7 +2845,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2854,7 +2853,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2862,7 +2861,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.103.219",
       "sweepsSinceComment" : 0
     },
@@ -2870,7 +2869,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2878,7 +2877,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2886,7 +2885,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2894,7 +2893,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2902,7 +2901,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "26.36.21",
       "sweepsSinceComment" : 0
     },
@@ -2910,7 +2909,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
@@ -2918,7 +2917,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2926,7 +2925,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.2.6",
       "sweepsSinceComment" : 0
     },
@@ -2934,7 +2933,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2942,7 +2941,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2950,24 +2949,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 1,
+      "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "infraSince" : "2026-09-11T20:23:45Z",
-      "lastGoodAt" : "2026-09-11T14:23:57Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 0
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2975,7 +2973,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -2983,7 +2981,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -2991,7 +2989,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2999,7 +2997,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -3007,7 +3005,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "158.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3015,7 +3013,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "158.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3023,7 +3021,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -3031,7 +3029,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -3039,7 +3037,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -3047,7 +3045,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3055,7 +3053,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3063,7 +3061,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3071,7 +3069,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "8.28.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -3079,7 +3077,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "8.27.0",
       "sweepsSinceComment" : 0
     },
@@ -3089,7 +3087,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "10.0.2",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -3098,7 +3096,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3106,11 +3104,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-11T20:23:45Z",
+      "lastGoodAt" : "2026-09-12T02:20:18Z",
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-11T20:23:45Z"
+  "updatedAt" : "2026-09-12T02:20:19Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.