### PR TITLE
Install.apply: make the outcome/counter wiring structurally single-sourced (#445)

### DIFF
--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -402,6 +402,87 @@ public enum Install {
         }
     }
 
+    /// What `apply`'s loop does with one item, once `reconsider` has spoken —
+    /// either install it, or stop here. `#445`: this is the pure mapping the
+    /// issue asked for, and it exists because `RowOutcome`'s five cases are
+    /// exactly 1:1 with `apply`'s five counters. Before this, the ending for
+    /// each `ReconsiderOutcome` case was assembled by hand at its own `case` in
+    /// `apply` — the text printed, the `--json` reason, the route, and which
+    /// counter got incremented were four separately-editable pieces of code
+    /// for the same event, and nothing forced them to agree. Collapsing all
+    /// four into one `Terminal` value, keyed by one `RowOutcome`, makes
+    /// "the emitted row and the incremented counter disagree" (#436's defect)
+    /// structurally impossible rather than merely reviewed-by-hand.
+    enum ItemPlan: Equatable {
+        /// Proceed to backup/replace with this (freshly re-derived) result and
+        /// route — never the plan's stale `offered` (see `reconsider`'s doc
+        /// comment on `.proceed`).
+        case install(UpdateResult, InstallCoordinator.Route)
+        /// Nothing more happens to this item this run.
+        case end(Terminal)
+    }
+
+    /// One item's ending: the `RowOutcome` IS the counter to increment and the
+    /// NDJSON category to emit — there is no second value to keep in sync with
+    /// it. `route` is `nil` exactly when no freshly re-derived route exists to
+    /// report (#404 review #5); `console` is the text-mode line this item
+    /// prints, without the leading three-space indent `apply` adds uniformly
+    /// (so the same string serves both the `print` and the
+    /// `FileHandle.standardError.write` call sites, which historically added
+    /// the indent themselves at each call).
+    struct Terminal: Equatable {
+        let outcome: RowOutcome
+        let reason: String
+        let route: InstallCoordinator.Route?
+        let console: String
+    }
+
+    /// Pure — no I/O, mirroring `reconsider` and `classify`. `offeredVersion`/
+    /// `confirmedVersion` exist only for `.answerRegressed`, whose message and
+    /// `reason` both need to name the two versions that disagreed; every other
+    /// case ignores them. Every string below is copied verbatim from the
+    /// `apply` call sites it replaces (see #404 reviews #2–#8, #435, #436) —
+    /// this is a refactor of WHERE the wiring happens, not a rewording of what
+    /// it says.
+    static func itemPlan(
+        for outcome: ReconsiderOutcome, offeredVersion: String?, confirmedVersion: String?
+    ) -> ItemPlan {
+        switch outcome {
+        case .proceed(let result, let route):
+            return .install(result, route)
+        case .notRequested(let route):
+            return .end(Terminal(
+                outcome: .skipped,
+                reason: "not requested: --route no longer includes it",
+                route: route,
+                console: "skipping: re-checked route is now \(route.rawValue), no longer requested"))
+        case .skip(let why, let route):
+            return .end(Terminal(outcome: .skipped, reason: why, route: route,
+                                  console: "skipping: \(why)"))
+        case .unreadable(let why):
+            return .end(Terminal(outcome: .skipped, reason: why, route: nil,
+                                  console: "skipping: \(why)"))
+        case .cannotConfirm(let message):
+            // `nil` route, not the plan's stale one: `reconsider` returns here
+            // BEFORE ever calling `classify` on a fresh read, so there is no
+            // freshly re-derived route to give (#404 review #5).
+            let reason = message ?? "no source covers this app"
+            return .end(Terminal(
+                outcome: .failed, reason: reason, route: nil,
+                console: "failed: the pre-install re-check could not confirm an update: \(reason)"))
+        case .answerRegressed:
+            // Both versions in the message, because the pair IS the finding:
+            // either number alone reads as an ordinary check.
+            let was = offeredVersion ?? "?"
+            let now = confirmedVersion ?? "?"
+            return .end(Terminal(
+                outcome: .failed,
+                reason: "answer regressed: offered \(was), confirmed \(now)",
+                route: nil,
+                console: "failed: the update source answered \(was), then \(now) — nothing was installed."))
+        }
+    }
+
     static func describe(_ plan: [Planned], refusals: [(UpdateResult, String)]) {
         if !plan.isEmpty {
             print("\nWill install:")
@@ -527,23 +608,12 @@ public enum Install {
             settings, testflight: recheckTestflight,
             announcements: recheckAnnouncements, toolbox: recheckToolbox,
             appStoreSignedIn: nil)
-        var failed = 0
-        var installedCount = 0
-        var skippedCount = 0
-        // Declined elevation is a decision, not a failure (see the catch below),
-        // but it must not vanish from the summary either — counted separately
-        // so `installedCount + failed + skippedCount + declinedCount +
-        // openedInstallerCount` accounts for every item in the plan (#404
-        // review #3, #435).
-        var declinedCount = 0
-        // The `.installer` route's `perform` returns without throwing, but with
-        // `applied == false`: the bytes were fetched and verified and a system
-        // installer window is open, but nothing has replaced the app on disk
-        // yet. Kept apart from `installedCount` (which would be false at the
-        // moment the summary line prints) and from `skippedCount` (real work
-        // already happened here, unlike an actual skip) — see `summaryLine`
-        // (#435).
-        var openedInstallerCount = 0
+        // One counter per `RowOutcome`, and the only place that maps one to the
+        // other (#445) — see `Tally.record`. Before this, `apply` kept five
+        // separate `var`s and incremented one by hand next to each exit from
+        // the loop below, which let the emitted row and the incremented
+        // counter disagree (#436's defect).
+        var tally = Tally()
         // Only items whose bundle was ACTUALLY replaced
         // (`InstallCoordinator.Outcome.applied`) — a `.notRequested`, `.skip`,
         // `.unreadable`, `.cannotConfirm`, or `.answerRegressed` item was never
@@ -567,66 +637,37 @@ public enum Install {
                 checker: recheckChecker)
             let live = liveEnvironment(
                 for: confirmed ?? item.result, plannedElevation: elevationRequiredPaths)
-            let outcome = reconsider(
+            let reconsidered = reconsider(
                 offered: item.result, confirmed: confirmed, settings: settings,
                 environment: live, routes: routes)
+            let outcome = itemPlan(
+                for: reconsidered,
+                offeredVersion: item.result.remote?.displayVersion,
+                confirmedVersion: confirmed?.remote?.displayVersion)
 
             let toInstall: UpdateResult
             let route: InstallCoordinator.Route
             switch outcome {
-            case .proceed(let result, let derivedRoute):
+            case .install(let result, let derivedRoute):
                 toInstall = result
                 route = derivedRoute
-            case .notRequested(let derivedRoute):
-                if !json {
-                    print("   skipping: re-checked route is now \(derivedRoute.rawValue), "
-                        + "no longer requested")
+            case .end(let end):
+                // Every ending's `console` line was written without its
+                // leading indent (see `Terminal`'s doc comment); reproduced
+                // here so the printed text is byte-for-byte what the old,
+                // per-case call sites wrote. A `.failed` ending goes to
+                // stderr unconditionally, matching what `.cannotConfirm` and
+                // `.answerRegressed` always did; every other ending prints to
+                // stdout only when `!json`, matching what `.notRequested`,
+                // `.skip`, and `.unreadable` always did.
+                if end.outcome == .failed {
+                    FileHandle.standardError.write(Data("   \(end.console)\n".utf8))
+                } else if !json {
+                    print("   \(end.console)")
                 }
-                emitSkipped(name: name, route: derivedRoute,
-                            reason: "not requested: --route no longer includes it",
-                            outcome: .skipped, json: json)
-                skippedCount += 1
-                continue
-            case .skip(let why, let derivedRoute):
-                if !json { print("   skipping: \(why)") }
-                emitSkipped(name: name, route: derivedRoute, reason: why, outcome: .skipped, json: json)
-                skippedCount += 1
-                continue
-            case .unreadable(let why):
-                // Not counted as `failed`: like `.alreadyCurrent`/`.managedElsewhere`
-                // above, there is nothing here a retry would change — either the
-                // app really is gone, or its Info.plist needs fixing by hand,
-                // and re-running `duo install` answers neither.
-                if !json { print("   skipping: \(why)") }
-                emitSkipped(name: name, route: nil, reason: why, outcome: .skipped, json: json)
-                skippedCount += 1
-                continue
-            case .cannotConfirm(let message):
-                failed += 1
-                let reason = message ?? "no source covers this app"
-                FileHandle.standardError.write(Data(
-                    "   failed: the pre-install re-check could not confirm an update: \(reason)\n".utf8))
-                // `nil`, not `item.route`: `reconsider` returns here BEFORE ever
-                // calling `classify` on a fresh read, so there is no freshly
-                // re-derived route to give — only the plan's stale one, which
-                // is exactly the value #404 review #5 says not to fall back to.
-                // Caught by code review after the first pass only fixed `.skip`.
-                emitSkipped(name: name, route: nil, reason: reason, outcome: .failed, json: json)
-                continue
-            case .answerRegressed:
-                failed += 1
-                // Both versions in the message, because the pair IS the finding:
-                // either number alone reads as an ordinary check. Same rule
-                // `AppListModel.performInstall` follows for the same case.
-                let was = item.result.remote?.displayVersion ?? "?"
-                let now = confirmed?.remote?.displayVersion ?? "?"
-                FileHandle.standardError.write(Data(
-                    "   failed: the update source answered \(was), then \(now) — nothing was installed.\n".utf8))
-                // `nil` for the same reason as `.cannotConfirm` above: no fresh
-                // route was ever derived for a regressed answer either.
-                emitSkipped(name: name, route: nil,
-                            reason: "answer regressed: offered \(was), confirmed \(now)",
-                            outcome: .failed, json: json)
+                emitSkipped(name: name, route: end.route, reason: end.reason,
+                            outcome: end.outcome, json: json)
+                tally.record(end.outcome)
                 continue
             }
 
@@ -664,31 +705,39 @@ public enum Install {
                 // route returns here with `applied == false` while the system
                 // installer window is still open, and the "still running the old
                 // code" summary below must not call that app's running copy
-                // stale (#404 review #2). The same `applied` bit is what keeps
-                // `installedCount` and `openedInstallerCount` apart (#435) —
-                // keyed off the outcome, not off `route == .installer`, since
-                // `applied` is the documented, already-in-scope signal.
+                // stale (#404 review #2). `rowOutcome(forApplied:)` is the same
+                // function `installedPayload` uses for `emit`'s `--json` row
+                // (#445) — one decision, not two independently-swappable copies
+                // of the same ternary.
+                let category = rowOutcome(forApplied: installOutcome.applied)
                 if installOutcome.applied {
                     attempted.append((name: name, path: toInstall.app.path))
-                    installedCount += 1
-                } else {
-                    openedInstallerCount += 1
                 }
+                tally.record(category)
                 emit(name: name, route: route, outcome: installOutcome, json: json)
             } catch is AuthorizationDeclinedError {
                 // Dismissing the password panel is a decision, not a failure — it
                 // does not count toward `failed`, and it is remembered so neither
                 // `duo` nor the menu bar re-raises the panel for this copy until
                 // the user asks. Written to the same suite the app reads. Still
-                // counted (`declinedCount`) and still emitted (`emitSkipped`): the
-                // old code left this item out of every counter and out of the
-                // `--json` stream, so it vanished from the summary entirely
-                // (#404 review #3).
+                // counted and still emitted (`emitSkipped`): the old code left
+                // this item out of every counter and out of the `--json` stream,
+                // so it vanished from the summary entirely (#404 review #3).
+                //
+                // Bound to one local value used for both calls below (#445) — not
+                // pulled into a `rowOutcome(for: Error)` function, unlike
+                // `rowOutcome(forApplied:)` above: there is only this one call
+                // site for this classification (nothing else in `Install.swift`
+                // maps an error to a `RowOutcome`), so a pure function here would
+                // add a testable unit without removing any real duplication —
+                // and `apply` itself stays untested either way (real I/O). Left
+                // review-only, uncovered; see the PR description.
+                let category: RowOutcome = .declined
                 Settings.recordDeclinedElevation(toInstall.app)
-                declinedCount += 1
+                tally.record(category)
                 emitSkipped(name: name, route: route,
                             reason: "administrator access was declined",
-                            outcome: .declined, json: json)
+                            outcome: category, json: json)
                 FileHandle.standardError.write(Data("""
                        skipped: administrator access was declined, so \(name) will no \
                     longer be offered as a one-click. Undo it from the app's row menu, \
@@ -696,16 +745,20 @@ public enum Install {
                     \(UpdateSettings.declinedElevationKeysKey)`.\n
                     """.utf8))
             } catch {
-                failed += 1
+                // Same reasoning as the `AuthorizationDeclinedError` arm above:
+                // one local value, used for both calls, and left as a literal
+                // rather than a pure function for the same reason.
+                let category: RowOutcome = .failed
                 let message = (error as? LocalizedError)?.errorDescription
                     ?? error.localizedDescription
+                tally.record(category)
                 FileHandle.standardError.write(Data("   failed: \(message)\n".utf8))
                 // The one ending a `--json` consumer most needs to see. Every
                 // other way an approved item can end without being installed
                 // now leaves a row; a failure leaving none would mean the
                 // stream undercounts exactly the failures, which is the
                 // opposite of the property `emitSkipped` was added for.
-                emitSkipped(name: name, route: route, reason: message, outcome: .failed, json: json)
+                emitSkipped(name: name, route: route, reason: message, outcome: category, json: json)
                 if error is AppManagementRequiredError {
                     FileHandle.standardError.write(Data("""
                            Grant App Management to this binary in System Settings ▸ \
@@ -716,10 +769,7 @@ public enum Install {
             }
         }
         if !json {
-            print("\n" + summaryLine(
-                installed: installedCount, failed: failed,
-                skipped: skippedCount, declined: declinedCount,
-                openedInstaller: openedInstallerCount))
+            print("\n" + summaryLine(tally))
             // The bundle on disk is new; the process still running is not. The
             // menu-bar app restarts these itself per the user's preference; the
             // CLI does not quit your apps behind your back, but it must not leave
@@ -734,7 +784,7 @@ public enum Install {
                 print("  duo restart \(stale.joined(separator: " "))")
             }
         }
-        return failed == 0 ? 0 : 1
+        return tally.failed == 0 ? 0 : 1
     }
 
     /// The text-mode summary line, pulled out as a pure function so its exact
@@ -763,6 +813,17 @@ public enum Install {
             + (openedInstaller > 0 ? ", \(openedInstaller) opened in the installer" : "") + "."
     }
 
+    /// Same line, from a `Tally` — the overload `apply` actually calls (#445).
+    /// Forwards to the five-argument form above rather than duplicating its
+    /// phrasing, so `apply` no longer has five positional arguments it could
+    /// mis-wire (the issue's mutation "passing `openedInstaller: 0` at the call
+    /// site" is no longer expressible once the call site only has a `Tally`).
+    static func summaryLine(_ tally: Tally) -> String {
+        summaryLine(
+            installed: tally.installed, failed: tally.failed, skipped: tally.skipped,
+            declined: tally.declined, openedInstaller: tally.openedInstaller)
+    }
+
     /// The machine-readable category every `--json` row (`emit`'s and
     /// `emitSkipped`'s alike) carries, alongside `applied` — which is kept
     /// exactly as it was, so an existing reader does not break; `outcome` is
@@ -774,7 +835,7 @@ public enum Install {
     /// stream as a new, unrecognised category — the same principle as
     /// `RowActions.live` in the menu-bar app: a call site must say which
     /// bucket it is, not fall into a defaulted guess.
-    enum RowOutcome: String {
+    enum RowOutcome: String, Equatable {
         case installed
         /// The `.installer` route only, today: bytes fetched and verified, a
         /// system installer window is open, nothing replaced yet. See
@@ -783,6 +844,41 @@ public enum Install {
         case skipped
         case declined
         case failed
+    }
+
+    /// One counter per `RowOutcome`, and the ONLY place that maps a
+    /// `RowOutcome` to a counter (#445). Before this, `apply` kept five
+    /// separate `var`s and incremented one by hand next to each exit from its
+    /// loop — a call site could increment a DIFFERENT counter than the
+    /// `RowOutcome` it just emitted (exactly #436's defect: a real failure
+    /// counted as a skip), and nothing but reading every call site by hand
+    /// would catch it. `record` is the single place that wiring happens now.
+    struct Tally: Sendable, Equatable {
+        private(set) var installed = 0
+        private(set) var openedInstaller = 0
+        private(set) var skipped = 0
+        private(set) var declined = 0
+        private(set) var failed = 0
+
+        mutating func record(_ outcome: RowOutcome) {
+            switch outcome {
+            case .installed: installed += 1
+            case .openedInstaller: openedInstaller += 1
+            case .skipped: skipped += 1
+            case .declined: declined += 1
+            case .failed: failed += 1
+            }
+        }
+    }
+
+    /// The `applied` → `RowOutcome` decision, single-sourced (#445): before
+    /// this, `installedPayload` computed `outcome.applied ? .installed :
+    /// .openedInstaller` and `apply`'s loop duplicated the identical branch
+    /// for its own counter, so a mutation swapping one branch's two arms
+    /// (#435's fix) was two separate, independently-swappable pieces of code.
+    /// Both call sites now go through this one function.
+    static func rowOutcome(forApplied applied: Bool) -> RowOutcome {
+        applied ? .installed : .openedInstaller
     }
 
     static func emit(
@@ -811,7 +907,7 @@ public enum Install {
     static func installedPayload(
         name: String, route: InstallCoordinator.Route, outcome: InstallCoordinator.Outcome
     ) -> [String: Any] {
-        let category: RowOutcome = outcome.applied ? .installed : .openedInstaller
+        let category = rowOutcome(forApplied: outcome.applied)
         var payload: [String: Any] = [
             "app": name, "route": route.rawValue,
             "bytesDownloaded": outcome.bytesDownloaded,

--- a/CLI/Sources/DuoKit/Install.swift
+++ b/CLI/Sources/DuoKit/Install.swift
@@ -437,15 +437,25 @@ public enum Install {
         let console: String
     }
 
-    /// Pure — no I/O, mirroring `reconsider` and `classify`. `offeredVersion`/
-    /// `confirmedVersion` exist only for `.answerRegressed`, whose message and
-    /// `reason` both need to name the two versions that disagreed; every other
-    /// case ignores them. Every string below is copied verbatim from the
+    /// Pure — no I/O, mirroring `reconsider` and `classify`. `offered`/
+    /// `confirmed` are the SAME two `UpdateResult`s `reconsider` itself was
+    /// called with (not the version strings pulled out of them) — only
+    /// `.answerRegressed` reads them, but taking the results rather than two
+    /// `String?`s closes off a mis-wiring `apply`'s untested call site would
+    /// otherwise be free to make: `offered` is non-optional and `confirmed`
+    /// is `Optional`, so transposing them at the call site is a COMPILE
+    /// ERROR, not a wrong-but-plausible message — the same reasoning
+    /// `summaryLine(_ tally:)` closes off for its five counters, applied
+    /// here to the one remaining pair of positional arguments. It also
+    /// single-sources "`remote?.displayVersion` is the right field to read",
+    /// which a `String?`-taking signature would have left the call site to
+    /// know for itself. Every string below is copied verbatim from the
     /// `apply` call sites it replaces (see #404 reviews #2–#8, #435, #436) —
-    /// this is a refactor of WHERE the wiring happens, not a rewording of what
-    /// it says.
+    /// this is a refactor of WHERE the wiring happens, not a rewording of
+    /// what it says, and that includes the rationale comments, not just the
+    /// user-facing text.
     static func itemPlan(
-        for outcome: ReconsiderOutcome, offeredVersion: String?, confirmedVersion: String?
+        for outcome: ReconsiderOutcome, offered: UpdateResult, confirmed: UpdateResult?
     ) -> ItemPlan {
         switch outcome {
         case .proceed(let result, let route):
@@ -460,21 +470,31 @@ public enum Install {
             return .end(Terminal(outcome: .skipped, reason: why, route: route,
                                   console: "skipping: \(why)"))
         case .unreadable(let why):
+            // Not counted as `failed`: like `.alreadyCurrent`/`.managedElsewhere`
+            // (both folded into `.skip` by `reconsider` before this ever runs),
+            // there is nothing here a retry would change — either the app
+            // really is gone, or its Info.plist needs fixing by hand, and
+            // re-running `duo install` answers neither.
             return .end(Terminal(outcome: .skipped, reason: why, route: nil,
                                   console: "skipping: \(why)"))
         case .cannotConfirm(let message):
             // `nil` route, not the plan's stale one: `reconsider` returns here
             // BEFORE ever calling `classify` on a fresh read, so there is no
-            // freshly re-derived route to give (#404 review #5).
+            // freshly re-derived route to give — only the plan's stale one,
+            // which is exactly the value #404 review #5 says not to fall back
+            // to. Caught by code review after the first pass only fixed `.skip`.
             let reason = message ?? "no source covers this app"
             return .end(Terminal(
                 outcome: .failed, reason: reason, route: nil,
                 console: "failed: the pre-install re-check could not confirm an update: \(reason)"))
         case .answerRegressed:
             // Both versions in the message, because the pair IS the finding:
-            // either number alone reads as an ordinary check.
-            let was = offeredVersion ?? "?"
-            let now = confirmedVersion ?? "?"
+            // either number alone reads as an ordinary check. Same rule
+            // `AppListModel.performInstall` follows for the same case.
+            let was = offered.remote?.displayVersion ?? "?"
+            let now = confirmed?.remote?.displayVersion ?? "?"
+            // `nil` for the same reason as `.cannotConfirm` above: no fresh
+            // route was ever derived for a regressed answer either.
             return .end(Terminal(
                 outcome: .failed,
                 reason: "answer regressed: offered \(was), confirmed \(now)",
@@ -640,10 +660,7 @@ public enum Install {
             let reconsidered = reconsider(
                 offered: item.result, confirmed: confirmed, settings: settings,
                 environment: live, routes: routes)
-            let outcome = itemPlan(
-                for: reconsidered,
-                offeredVersion: item.result.remote?.displayVersion,
-                confirmedVersion: confirmed?.remote?.displayVersion)
+            let outcome = itemPlan(for: reconsidered, offered: item.result, confirmed: confirmed)
 
             let toInstall: UpdateResult
             let route: InstallCoordinator.Route
@@ -835,7 +852,7 @@ public enum Install {
     /// stream as a new, unrecognised category — the same principle as
     /// `RowActions.live` in the menu-bar app: a call site must say which
     /// bucket it is, not fall into a defaulted guess.
-    enum RowOutcome: String, Equatable {
+    enum RowOutcome: String {
         case installed
         /// The `.installer` route only, today: bytes fetched and verified, a
         /// system installer window is open, nothing replaced yet. See
@@ -934,9 +951,9 @@ public enum Install {
     /// line.
     ///
     /// `outcome` is a required parameter, not defaulted (#436): every call site
-    /// in `apply` already knows which counter it is about to increment (it is
-    /// sitting right next to `skippedCount += 1` / `declinedCount += 1` /
-    /// `failed += 1`), so this asks it to say so once more, in a form a
+    /// in `apply` already knows which `RowOutcome` bucket it is about to
+    /// record (`#445`: it is the same value passed to `tally.record(...)`
+    /// right alongside), so this asks it to say so once more, in a form a
     /// `--json` consumer can read back — the same reasoning CLAUDE.md gives
     /// for `RowActions.live` taking no defaults: a new call site should have to
     /// say which bucket it is rather than silently landing in a wrong one.

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -542,6 +542,231 @@ import DuoUpdaterCore
     }
 }
 
+/// #445: `Install.itemPlan` is the pure `ReconsiderOutcome` → `ItemPlan`
+/// mapping the issue asked for — everything `apply`'s loop used to assemble by
+/// hand (the text printed, the `--json` reason, the route, and which
+/// `RowOutcome` bucket the item lands in) for one exit from the loop. Every
+/// case below asserts all four `Terminal` fields, not just `outcome`: a test
+/// that only checked the bucket would stay green if the reason or route
+/// drifted, which is exactly the kind of disagreement #436 was filed about.
+@Suite struct InstallItemPlanTests {
+
+    private func vendorResult(latest: String = "1.2") -> UpdateResult {
+        UpdateResult(
+            app: InstalledApp(
+                name: "Fixture", bundleID: "com.example.fixture", shortVersion: "1.0",
+                buildVersion: "1", path: URL(fileURLWithPath: "/Applications/Fixture.app"),
+                isMASApp: false, sparkleFeedURL: nil),
+            remote: RemoteVersion(
+                shortVersion: latest, version: nil,
+                downloadURL: URL(string: "https://example.com/fixture.dmg"),
+                sourceName: "Vendor", requiresManualInstaller: false,
+                vendorInstallerKind: .dmg),
+            status: .updateAvailable(latest: latest))
+    }
+
+    /// Mutation (reverted after running): changed the `.proceed` case in
+    /// `Install.itemPlan` to `return .end(Terminal(outcome: .skipped, ...))`
+    /// — went red (expected `.install`, got `.end`).
+    @Test func proceedBecomesAnInstallCarryingTheConfirmedResultAndRoute() {
+        let confirmed = vendorResult(latest: "1.2")
+        let plan = Install.itemPlan(for: .proceed(confirmed, .vendor), offeredVersion: nil, confirmedVersion: nil)
+        guard case .install(let result, let route) = plan else {
+            Issue.record("expected an install, got \(plan)")
+            return
+        }
+        #expect(result.remote?.displayVersion == "1.2")
+        #expect(route == .vendor)
+    }
+
+    /// Mutation (reverted after running): in the `.notRequested` case, changed
+    /// `reason: "not requested: --route no longer includes it"` to
+    /// `reason: "not requested"` — went red (reason mismatch).
+    @Test func notRequestedNamesTheRouteInBothReasonAndConsole() {
+        let plan = Install.itemPlan(for: .notRequested(.homebrew), offeredVersion: nil, confirmedVersion: nil)
+        guard case .end(let terminal) = plan else {
+            Issue.record("expected an end, got \(plan)")
+            return
+        }
+        #expect(terminal.outcome == .skipped)
+        #expect(terminal.reason == "not requested: --route no longer includes it")
+        #expect(terminal.route == .homebrew)
+        #expect(terminal.console
+            == "skipping: re-checked route is now homebrew, no longer requested")
+    }
+
+    /// Mutation (reverted after running): in the `.skip` case, changed
+    /// `console: "skipping: \(why)"` to `console: why` (dropped the
+    /// "skipping: " prefix that `apply` no longer adds itself) — went red
+    /// (console text missing the prefix).
+    @Test func skipCarriesTheGivenRouteReasonAndConsoleText() {
+        let plan = Install.itemPlan(
+            for: .skip("already at 1.1 on disk — nothing to install", .vendor),
+            offeredVersion: nil, confirmedVersion: nil)
+        guard case .end(let terminal) = plan else {
+            Issue.record("expected an end, got \(plan)")
+            return
+        }
+        #expect(terminal.outcome == .skipped)
+        #expect(terminal.reason == "already at 1.1 on disk — nothing to install")
+        #expect(terminal.route == .vendor)
+        #expect(terminal.console == "skipping: already at 1.1 on disk — nothing to install")
+    }
+
+    /// #404 review #5: `.unreadable` must carry `route == nil` — there is no
+    /// freshly re-derived route to give. Mutation (reverted after running):
+    /// changed `route: nil` to `route: .vendor` in the `.unreadable` case —
+    /// went red (expected `nil`, got `.vendor`).
+    @Test func unreadableHasNoRoute() {
+        let why = "no readable bundle at /Applications/Fixture.app right now — it may have "
+            + "been uninstalled, or its Info.plist could not be parsed"
+        let plan = Install.itemPlan(for: .unreadable(why), offeredVersion: nil, confirmedVersion: nil)
+        guard case .end(let terminal) = plan else {
+            Issue.record("expected an end, got \(plan)")
+            return
+        }
+        #expect(terminal.outcome == .skipped)
+        #expect(terminal.route == nil)
+        #expect(terminal.reason == why)
+        #expect(terminal.console == "skipping: \(why)")
+    }
+
+    /// `.cannotConfirm(nil)` must still produce the `"no source covers this
+    /// app"` default reason, and carry `route == nil` (#404 review #5).
+    /// Mutation (reverted after running): changed
+    /// `outcome: .failed` to `outcome: .skipped` in the `.cannotConfirm` case
+    /// — **this reinstates #436's exact defect** — went red (expected
+    /// `.failed`, got `.skipped`).
+    @Test func cannotConfirmWithNoMessageDefaultsTheReasonAndIsAFailure() {
+        let plan = Install.itemPlan(for: .cannotConfirm(nil), offeredVersion: nil, confirmedVersion: nil)
+        guard case .end(let terminal) = plan else {
+            Issue.record("expected an end, got \(plan)")
+            return
+        }
+        #expect(terminal.outcome == .failed)
+        #expect(terminal.reason == "no source covers this app")
+        #expect(terminal.route == nil)
+        #expect(terminal.console
+            == "failed: the pre-install re-check could not confirm an update: no source covers this app")
+    }
+
+    @Test func cannotConfirmWithAMessageUsesItVerbatim() {
+        let plan = Install.itemPlan(
+            for: .cannotConfirm("connection timed out"), offeredVersion: nil, confirmedVersion: nil)
+        guard case .end(let terminal) = plan else {
+            Issue.record("expected an end, got \(plan)")
+            return
+        }
+        #expect(terminal.outcome == .failed)
+        #expect(terminal.reason == "connection timed out")
+        #expect(terminal.route == nil)
+        #expect(terminal.console
+            == "failed: the pre-install re-check could not confirm an update: connection timed out")
+    }
+
+    /// #404 review #5: `.answerRegressed` must carry `route == nil`. Mutation
+    /// (reverted after running): changed `outcome: .failed` to
+    /// `outcome: .skipped` in the `.answerRegressed` case — **the other half
+    /// of #436's defect the issue named** — went red (expected `.failed`, got
+    /// `.skipped`).
+    @Test func answerRegressedNamesBothVersionsAndIsAFailure() {
+        let plan = Install.itemPlan(
+            for: .answerRegressed, offeredVersion: "1.1", confirmedVersion: "1.0")
+        guard case .end(let terminal) = plan else {
+            Issue.record("expected an end, got \(plan)")
+            return
+        }
+        #expect(terminal.outcome == .failed)
+        #expect(terminal.reason == "answer regressed: offered 1.1, confirmed 1.0")
+        #expect(terminal.route == nil)
+        #expect(terminal.console
+            == "failed: the update source answered 1.1, then 1.0 — nothing was installed.")
+    }
+
+    /// `offeredVersion`/`confirmedVersion` are `nil` exactly when the caller's
+    /// `UpdateResult`s carry no remote — `apply` passes
+    /// `item.result.remote?.displayVersion` straight through, which can be
+    /// `nil`. Mutation (reverted after running): changed
+    /// `offeredVersion ?? "?"` to `offeredVersion ?? ""` — went red (expected
+    /// "offered ?, confirmed ?", got "offered , confirmed ?").
+    @Test func answerRegressedFallsBackToQuestionMarksWhenVersionsAreMissing() {
+        let plan = Install.itemPlan(for: .answerRegressed, offeredVersion: nil, confirmedVersion: nil)
+        guard case .end(let terminal) = plan else {
+            Issue.record("expected an end, got \(plan)")
+            return
+        }
+        #expect(terminal.reason == "answer regressed: offered ?, confirmed ?")
+    }
+}
+
+/// #445: `RowOutcome`'s five cases are exactly 1:1 with `apply`'s five
+/// counters — `Tally` is the only place that mapping happens, replacing the
+/// five separate `var`s `apply` used to increment by hand next to each exit
+/// from its loop.
+@Suite struct InstallTallyTests {
+
+    /// All five counts distinct and nonzero, so a mutation that increments the
+    /// wrong counter for some case is visible on that case's own field, not
+    /// masked by another field happening to match. Mutation (reverted after
+    /// running): swapped the `.openedInstaller`/`.declined` arms in
+    /// `Tally.record` — went red (`openedInstaller` read 4, `declined` read 2).
+    @Test func recordIncrementsExactlyTheMatchingCounter() {
+        var tally = Install.Tally()
+        tally.record(.installed)
+        for _ in 0..<2 { tally.record(.openedInstaller) }
+        for _ in 0..<3 { tally.record(.skipped) }
+        for _ in 0..<4 { tally.record(.declined) }
+        for _ in 0..<5 { tally.record(.failed) }
+        #expect(tally.installed == 1)
+        #expect(tally.openedInstaller == 2)
+        #expect(tally.skipped == 3)
+        #expect(tally.declined == 4)
+        #expect(tally.failed == 5)
+    }
+
+    @Test func aFreshTallyIsAllZero() {
+        let tally = Install.Tally()
+        #expect(tally.installed == 0)
+        #expect(tally.openedInstaller == 0)
+        #expect(tally.skipped == 0)
+        #expect(tally.declined == 0)
+        #expect(tally.failed == 0)
+    }
+
+    /// `Install.summaryLine(_ tally:)` is the overload `apply` actually calls
+    /// (#445) — it must forward every field to the right positional argument
+    /// of the five-argument form, which the existing
+    /// `summaryLineAccountsForAllFiveBucketsWhenEachIsNonzero` test pins.
+    /// Five distinct, nonzero counts so a transposed forward is visible.
+    /// Mutation (reverted after running): in the `Tally` overload, changed
+    /// `declined: tally.declined` to `declined: tally.skipped` — went red
+    /// (expected "4 declined", the string said "3 declined").
+    @Test func summaryLineFromTallyForwardsEveryFieldToItsOwnArgument() {
+        var tally = Install.Tally()
+        tally.record(.installed)
+        for _ in 0..<2 { tally.record(.openedInstaller) }
+        for _ in 0..<3 { tally.record(.skipped) }
+        for _ in 0..<4 { tally.record(.declined) }
+        for _ in 0..<5 { tally.record(.failed) }
+        #expect(Install.summaryLine(tally)
+            == "1 installed, 5 failed, 3 skipped, 4 declined, 2 opened in the installer.")
+    }
+
+    /// #445, #435: the `applied` → `RowOutcome` decision, single-sourced so
+    /// `installedPayload`'s `--json` category and `apply`'s counter can never
+    /// disagree. Mutation (reverted after running): changed
+    /// `applied ? .installed : .openedInstaller` to
+    /// `applied ? .openedInstaller : .installed` — both tests below went red
+    /// (each expected the opposite of what it got).
+    @Test func rowOutcomeForAppliedIsInstalledWhenTrue() {
+        #expect(Install.rowOutcome(forApplied: true) == .installed)
+    }
+
+    @Test func rowOutcomeForAppliedIsOpenedInstallerWhenFalse() {
+        #expect(Install.rowOutcome(forApplied: false) == .openedInstaller)
+    }
+}
+
 /// #404 review #5 and #3, plus #435/#436: the `--json` payloads for both an
 /// actual install (`installedPayload`) and an item the pre-install re-check
 /// did not install (`skippedPayload`), and the text-mode summary line's

--- a/CLI/Tests/DuoKitTests/InstallTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTests.swift
@@ -223,10 +223,16 @@ import DuoUpdaterCore
 /// item's download can hold open for a long time. `Install.reconsider` is the
 /// pure classification the fix hangs on; `Install.apply` (mostly untested here —
 /// it's I/O around a concrete, unmockable `InstallCoordinator`) does the
-/// re-scan/re-check and calls this right before backup. The `attempted`/
-/// `declinedCount` bookkeeping `apply` does around `coordinator.perform` (#404
-/// review #2, #3) is therefore verified by code reading, not a mutation-tested
-/// unit test here — see the PR description for what was checked by hand.
+/// re-scan/re-check and calls this right before backup. Two things around
+/// `coordinator.perform` remain verified by code reading, not a mutation-tested
+/// unit test here (#404 review #2, #3) — see the PR description for what was
+/// checked by hand: the `attempted` array `apply` builds to name apps still
+/// running the old code afterward, and the `AuthorizationDeclinedError` catch
+/// arm's CHOICE of `.declined` in the first place (`Install.swift`'s own
+/// comment on that arm explains why a pure classifier wasn't worth it there).
+/// What IS mutation-tested, by `#445`'s `InstallTallyTests`, is the other
+/// half: once an outcome has been chosen, `Tally.record` mapping it to the
+/// right counter — see `recordIncrementsExactlyTheMatchingCounter`.
 ///
 /// Each fixture below builds an `offered` (what the plan showed) and a
 /// `confirmed` (what a fresh disk read + source query answers right before
@@ -565,12 +571,26 @@ import DuoUpdaterCore
             status: .updateAvailable(latest: latest))
     }
 
+    /// A result with no `remote` at all — the shape `.answerRegressed`'s
+    /// `?? "?"` fallback exists for. `offered`/`confirmed` are otherwise
+    /// unused by every `itemPlan` case but `.answerRegressed`; this stands in
+    /// for both when a test doesn't care what they are.
+    private func resultWithNoRemote() -> UpdateResult {
+        UpdateResult(
+            app: InstalledApp(
+                name: "Fixture", bundleID: "com.example.fixture", shortVersion: "1.0",
+                buildVersion: "1", path: URL(fileURLWithPath: "/Applications/Fixture.app"),
+                isMASApp: false, sparkleFeedURL: nil),
+            remote: nil, status: .unknown)
+    }
+
     /// Mutation (reverted after running): changed the `.proceed` case in
     /// `Install.itemPlan` to `return .end(Terminal(outcome: .skipped, ...))`
     /// — went red (expected `.install`, got `.end`).
     @Test func proceedBecomesAnInstallCarryingTheConfirmedResultAndRoute() {
         let confirmed = vendorResult(latest: "1.2")
-        let plan = Install.itemPlan(for: .proceed(confirmed, .vendor), offeredVersion: nil, confirmedVersion: nil)
+        let plan = Install.itemPlan(
+            for: .proceed(confirmed, .vendor), offered: resultWithNoRemote(), confirmed: nil)
         guard case .install(let result, let route) = plan else {
             Issue.record("expected an install, got \(plan)")
             return
@@ -583,7 +603,8 @@ import DuoUpdaterCore
     /// `reason: "not requested: --route no longer includes it"` to
     /// `reason: "not requested"` — went red (reason mismatch).
     @Test func notRequestedNamesTheRouteInBothReasonAndConsole() {
-        let plan = Install.itemPlan(for: .notRequested(.homebrew), offeredVersion: nil, confirmedVersion: nil)
+        let plan = Install.itemPlan(
+            for: .notRequested(.homebrew), offered: resultWithNoRemote(), confirmed: nil)
         guard case .end(let terminal) = plan else {
             Issue.record("expected an end, got \(plan)")
             return
@@ -602,7 +623,7 @@ import DuoUpdaterCore
     @Test func skipCarriesTheGivenRouteReasonAndConsoleText() {
         let plan = Install.itemPlan(
             for: .skip("already at 1.1 on disk — nothing to install", .vendor),
-            offeredVersion: nil, confirmedVersion: nil)
+            offered: resultWithNoRemote(), confirmed: nil)
         guard case .end(let terminal) = plan else {
             Issue.record("expected an end, got \(plan)")
             return
@@ -620,7 +641,7 @@ import DuoUpdaterCore
     @Test func unreadableHasNoRoute() {
         let why = "no readable bundle at /Applications/Fixture.app right now — it may have "
             + "been uninstalled, or its Info.plist could not be parsed"
-        let plan = Install.itemPlan(for: .unreadable(why), offeredVersion: nil, confirmedVersion: nil)
+        let plan = Install.itemPlan(for: .unreadable(why), offered: resultWithNoRemote(), confirmed: nil)
         guard case .end(let terminal) = plan else {
             Issue.record("expected an end, got \(plan)")
             return
@@ -638,7 +659,7 @@ import DuoUpdaterCore
     /// — **this reinstates #436's exact defect** — went red (expected
     /// `.failed`, got `.skipped`).
     @Test func cannotConfirmWithNoMessageDefaultsTheReasonAndIsAFailure() {
-        let plan = Install.itemPlan(for: .cannotConfirm(nil), offeredVersion: nil, confirmedVersion: nil)
+        let plan = Install.itemPlan(for: .cannotConfirm(nil), offered: resultWithNoRemote(), confirmed: nil)
         guard case .end(let terminal) = plan else {
             Issue.record("expected an end, got \(plan)")
             return
@@ -652,7 +673,7 @@ import DuoUpdaterCore
 
     @Test func cannotConfirmWithAMessageUsesItVerbatim() {
         let plan = Install.itemPlan(
-            for: .cannotConfirm("connection timed out"), offeredVersion: nil, confirmedVersion: nil)
+            for: .cannotConfirm("connection timed out"), offered: resultWithNoRemote(), confirmed: nil)
         guard case .end(let terminal) = plan else {
             Issue.record("expected an end, got \(plan)")
             return
@@ -671,7 +692,7 @@ import DuoUpdaterCore
     /// `.skipped`).
     @Test func answerRegressedNamesBothVersionsAndIsAFailure() {
         let plan = Install.itemPlan(
-            for: .answerRegressed, offeredVersion: "1.1", confirmedVersion: "1.0")
+            for: .answerRegressed, offered: vendorResult(latest: "1.1"), confirmed: vendorResult(latest: "1.0"))
         guard case .end(let terminal) = plan else {
             Issue.record("expected an end, got \(plan)")
             return
@@ -683,14 +704,15 @@ import DuoUpdaterCore
             == "failed: the update source answered 1.1, then 1.0 — nothing was installed.")
     }
 
-    /// `offeredVersion`/`confirmedVersion` are `nil` exactly when the caller's
-    /// `UpdateResult`s carry no remote — `apply` passes
-    /// `item.result.remote?.displayVersion` straight through, which can be
-    /// `nil`. Mutation (reverted after running): changed
-    /// `offeredVersion ?? "?"` to `offeredVersion ?? ""` — went red (expected
-    /// "offered ?, confirmed ?", got "offered , confirmed ?").
+    /// The version strings read `?? "?"` exactly when the `UpdateResult`s
+    /// carry no `remote` — `apply` passes `item.result`/`confirmed` straight
+    /// through, and either can be a result with no remote. Mutation
+    /// (reverted after running): changed `offered.remote?.displayVersion ??
+    /// "?"` to `?? ""` in `itemPlan`'s `.answerRegressed` case — went red
+    /// (expected "offered ?, confirmed ?", got "offered , confirmed ?").
     @Test func answerRegressedFallsBackToQuestionMarksWhenVersionsAreMissing() {
-        let plan = Install.itemPlan(for: .answerRegressed, offeredVersion: nil, confirmedVersion: nil)
+        let plan = Install.itemPlan(
+            for: .answerRegressed, offered: resultWithNoRemote(), confirmed: resultWithNoRemote())
         guard case .end(let terminal) = plan else {
             Issue.record("expected an end, got \(plan)")
             return


### PR DESCRIPTION
## Re-measurement of the issue (before touching anything)

Confirmed on today's `main` (1ade7aa3), before any change:

- `grep -c "Install.apply(" CLI/Tests/DuoKitTests/InstallTests.swift` → **0**.
- Re-ran all five mutations the issue lists, one at a time, against the unmodified `Install.swift`, then `swift test --package-path CLI --filter InstallTests` after each: all five left the **42/42** suite green.
- The issue's claim that #444 made this pre-existing gap visible checked out — before #444 there were 4 buckets, all with the same shape of gap.

Everything the issue stated checked out. Nothing to correct.

## Design

`RowOutcome`'s five cases are exactly 1:1 with `apply`'s five counters. Rather than bolt tests onto the existing hand-wired loop, this makes the two things that can currently disagree (the emitted `--json` row and the incremented counter) *structurally* the same value:

1. **`Install.Tally`** — one counter per `RowOutcome`, with `mutating func record(_ outcome: RowOutcome)` as the *only* place a `RowOutcome` maps to a counter. `apply` now keeps one `var tally = Tally()` instead of five separate `var`s.

2. **`Install.summaryLine(_ tally: Tally)`** — the overload `apply` now calls. Forwards to the untouched five-argument `summaryLine(installed:failed:skipped:declined:openedInstaller:)`, which keeps its existing tests. The issue's mutation "passing `openedInstaller: 0` at the call site" is no longer expressible: the call site is just `summaryLine(tally)`, no positional arguments to mis-wire.

3. **`Install.ItemPlan` / `Install.Terminal` / `Install.itemPlan(for:offered:confirmed:)`** — the pure `ReconsiderOutcome → ItemPlan` mapping the issue asked for. `Terminal` bundles `outcome` (both the NDJSON category *and* the counter to increment), `reason`, `route`, and `console` (the text-mode line, without the indent `apply` adds once at the print/write call site) into one value. `apply`'s loop is now one switch: `.install` sets `toInstall`/`route`; `.end` prints `console` (stderr, unconditionally, iff `outcome == .failed` — matching what `.cannotConfirm`/`.answerRegressed` always did; stdout gated on `!json` otherwise — matching what `.notRequested`/`.skip`/`.unreadable` always did), calls `emitSkipped(outcome: end.outcome)`, calls `tally.record(end.outcome)`.

   **`offered`/`confirmed` are the two `UpdateResult`s themselves, not two `String?`s** (changed after review — see "Review round 2" below): `offered: UpdateResult, confirmed: UpdateResult?`. Only `.answerRegressed` reads them (via `.remote?.displayVersion`), but taking the results rather than pre-extracted strings closes off a transposition at the one, untested call site inside `apply` — `offered` is non-optional and `confirmed` is `Optional`, so swapping them is a compile error, not a wrong-but-plausible message.

   Every string, and every rationale comment attached to it, is copied verbatim from the `apply` call sites it replaces (#404 reviews #2–#8, #435, #436) — this is a refactor of *where* the wiring happens, not a rewording, and that includes the comments, not just the user-facing text. Diffed the string literals before/after: the only changes are that the old code embedded the three-space indent and trailing newline directly in each literal, and the new code adds them once, uniformly, at the two call sites in `apply`'s `.end` arm — the actual printed/written bytes are identical (independently re-verified by the reviewer against `main`).

4. **`Install.rowOutcome(forApplied:)`** — single-sources the `applied → RowOutcome` decision that `installedPayload` and `apply`'s success path used to compute independently via two copies of the same ternary. Both now call this one function.

5. **The two `catch` arms** (`AuthorizationDeclinedError` → `.declined`, generic → `.failed`) are **left as hand-wired, uncovered code**, deliberately. Each binds one local `let category: RowOutcome = ...` used for both `emitSkipped` and `tally.record`, but I did *not* extract a `rowOutcome(for: Error)` pure classifier: there is only one call site for each of these two classifications anywhere in `Install.swift` (verified: `grep -rn "AuthorizationDeclinedError" CLI/Sources App/Sources DuoUpdaterCore/Sources` shows the CLI has exactly this one catch site), so a pure function would add a testable unit without removing any real duplication, and `apply` itself remains untested regardless (real I/O).

## Review round 2 — four findings, all fixed on this branch

1. **Restored a load-bearing rationale comment** dropped from the `.unreadable` case in `itemPlan` ("Not counted as `failed`... there is nothing here a retry would change...") and the `.answerRegressed` case's cross-reference to `AppListModel.performInstall` and to the `.cannotConfirm` route-nil rationale. Comments moved with the code they document, not just the executable text.

2. **Closed the one remaining mis-wiring the refactor could have closed but didn't**: `itemPlan(for:offeredVersion:confirmedVersion:)` took two `String?` in a fixed order at an untested call site — transposing them produced a wrong-but-plausible message with nothing going red. Changed to `itemPlan(for:offered:confirmed:)`, taking the two `UpdateResult`s directly (`offered: UpdateResult`, `confirmed: UpdateResult?`). A transposition is now a **compile error** (see mutation #11 below) — the same reasoning `summaryLine(_ tally:)` already applied to the five counters, extended to this last pair of positional arguments. Also single-sources "`remote?.displayVersion` is the right field to read."

3. **Reverted `enum RowOutcome: String, Equatable`** — a raw-value enum with no associated values already conforms to `Equatable`; the annotation was redundant and touched a declaration this PR otherwise left alone.

4. **Fixed two stale references to `declinedCount`**, which this PR removed (`grep -rn declinedCount` over the repo now returns nothing):
   - `InstallReconsiderTests`'s doc comment now says which half of the declined-elevation path is mutation-tested (`Tally.record`, via `InstallTallyTests.recordIncrementsExactlyTheMatchingCounter`) and which remains review-only (the catch arm's *choice* of `.declined` in the first place, and the `attempted` bookkeeping) — not just a find-and-replace of the identifier.
   - `emitSkipped`'s doc comment now describes the `Tally`-based mechanism instead of the removed `skippedCount += 1` / `declinedCount += 1` lines.

## Mutation table

All mutations run with `swift test --package-path CLI --filter <suite>` (or `swift build --package-path CLI` for #11), each then reverted (verified via `diff` against a saved-clean copy) before the next.

| # | Mutation | Where | Result | Evidence |
|---|---|---|---|---|
| 1 | `.proceed` case → returns `.end(...)` instead of `.install` | `itemPlan` | **RED** | `proceedBecomesAnInstallCarryingTheConfirmedResultAndRoute` — "expected an install, got .end(...)" |
| 2 | `.notRequested` reason text shortened | `itemPlan` | **RED** | `notRequestedNamesTheRouteInBothReasonAndConsole` — `Expectation failed: terminal.reason == "not requested: --route no longer includes it"` |
| 3 | `.skip` console text drops the "skipping: " prefix | `itemPlan` | **RED** | `skipCarriesTheGivenRouteReasonAndConsoleText` — `Expectation failed: terminal.console == "skipping: already at 1.1 on disk — nothing to install"` |
| 4 | `.unreadable` route `nil` → `.vendor` | `itemPlan` | **RED** (re-confirmed after round 2) | `unreadableHasNoRoute` — `Expectation failed: terminal.route == nil` |
| 5 | `.cannotConfirm` outcome `.failed` → `.skipped` (**issue's exact mutation — reinstates #436's defect**) | `itemPlan` | **RED** | `cannotConfirmWithNoMessageDefaultsTheReasonAndIsAFailure` + `cannotConfirmWithAMessageUsesItVerbatim` — both `Expectation failed: terminal.outcome == .failed` |
| 6 | `.answerRegressed` outcome `.failed` → `.skipped` (**issue's exact mutation**) | `itemPlan` | **RED** | `answerRegressedNamesBothVersionsAndIsAFailure` — `Expectation failed: terminal.outcome == .failed` |
| 7 | `.answerRegressed`'s `offered.remote?.displayVersion ?? "?"` → `?? ""` | `itemPlan` | **RED** (re-confirmed after round 2, now on `offered`/`confirmed` fields instead of pre-extracted strings) | `answerRegressedFallsBackToQuestionMarksWhenVersionsAreMissing` — `Expectation failed: terminal.reason == "answer regressed: offered ?, confirmed ?"` |
| 8 | Swap `.openedInstaller`/`.declined` arms | `Tally.record` | **RED** | `recordIncrementsExactlyTheMatchingCounter` — `tally.openedInstaller == 2` / `tally.declined == 4` both failed; also broke `summaryLineFromTallyForwardsEveryFieldToItsOwnArgument` |
| 9 | `summaryLine(_ tally:)` forwards `tally.skipped` in place of `tally.declined` | `summaryLine(Tally)` | **RED** | `summaryLineFromTallyForwardsEveryFieldToItsOwnArgument` — wrong count in the joined string |
| 10 | Swap `.installed`/`.openedInstaller` ternary branches (**issue's exact mutation**) | `rowOutcome(forApplied:)` | **RED** | `rowOutcomeForAppliedIsInstalledWhenTrue` + `rowOutcomeForAppliedIsOpenedInstallerWhenFalse` — both failed |
| 11 | Transpose `offered`/`confirmed` at `apply`'s call site (`itemPlan(for: reconsidered, offered: confirmed, confirmed: item.result)`) — **the mis-wiring finding 2 asked to close** | `apply`'s call site | **COMPILE ERROR** (was: silent wrong message, uncaught by any test) | `swift build --package-path CLI` fails: `Install.swift:663:64: error: value of optional type 'UpdateResult?' must be unwrapped to a value of type 'UpdateResult'` |

Issue's 5th mutation ("passing `openedInstaller: 0` at the `summaryLine` call site") no longer has a literal equivalent — `apply`'s call site is `summaryLine(tally)`, with nothing to pass positionally. The equivalent risk *inside* the new overload is mutation #9 above, which is caught.

All eleven reverted; full suite green again after each.

### What's still uncovered (honest, not swept under the refactor)

- **`apply`'s own loop is still not driven end-to-end** — it does real I/O (`InstallCoordinator`, disk, the process-wide install lock) and remains untestable directly. Confirmed the following still leave the 55-test suite green:
  - Generic `catch` arm: `let category: RowOutcome = .failed` → `.skipped` (issue's mutation #1).
  - `AuthorizationDeclinedError` catch arm: `let category: RowOutcome = .declined` → `.skipped` (part of issue's mutation #2, the third named site).
  - The final summary call site: `summaryLine(tally)` → `summaryLine(Tally())` (a fresh, always-zero tally).
  - The `attempted` array `apply` builds to name apps still running the old code after install.
- **The two catch arms' classification is deliberately not pulled into a pure function** — see design point 5 above. Review-only.

## Verification

```
$ swift test --package-path CLI --filter InstallTests
...
✔ Test run with 55 tests in 8 suites passed after 0.03x seconds.

$ swift test --package-path CLI
...
✔ Test run with 280 tests in 34 suites passed after 0.14x seconds.
```

`make test` intentionally not run by me (per instructions — run separately by the reviewer before merge; reviewer independently ran it on the round-1 commit and reported it green, Core 2676 unchanged, CLI 267→280).
