### PR TITLE
Requests pane: show the retention floor everywhere it makes a promise (#460)

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -23162,47 +23162,6 @@
         }
       }
     },
-    "no requests recorded yet": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Noch keine Anfragen aufgezeichnet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "aún no se han registrado solicitudes"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "aucune requête enregistrée pour l'instant"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "まだリクエストは記録されていません"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "запросы пока не записаны"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "尚未记录任何请求"
-          }
-        }
-      }
-    },
     "not recorded": {
       "extractionState": "manual",
       "localizations": {
@@ -23240,6 +23199,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "未记录"
+          }
+        }
+      }
+    },
+    "nothing yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "noch nichts"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nada aún"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "rien encore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだありません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "пока нет"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无"
           }
         }
       }
@@ -23445,47 +23445,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "记录追溯到%@"
-          }
-        }
-      }
-    },
-    "records only go back to %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aufzeichnungen reichen nur bis %@ zurück"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "los registros solo llegan hasta %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "limite : %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ からしか記録されていません"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "самые старые записи — лишь %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅追溯到%@"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -23426,7 +23426,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "l'historique remonte à %@"
+            "value": "l'historique commence %@"
           }
         },
         "ja": {
@@ -23467,7 +23467,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "l'historique ne remonte qu'à %@"
+            "value": "limite : %@"
           }
         },
         "ja": {
@@ -23479,7 +23479,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "древнее %@ записей нет"
+            "value": "самые старые записи — лишь %@"
           }
         },
         "zh-Hans": {

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1026,47 +1026,6 @@
         }
       }
     },
-    "%@ · %@ · since %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · seit %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · desde %@"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · depuis %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@・%@・%@ から"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · с %@"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ · %@ · 自 %@"
-          }
-        }
-      }
-    },
     "%@ — click for details": {
       "extractionState": "manual",
       "localizations": {
@@ -2706,6 +2665,137 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld 条事件 · 占用 %@"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld events · %@ on disk · %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld event · %@ on disk · %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld events · %@ on disk · %@"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Ereignis · %@ auf der Festplatte · %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Ereignisse · %@ auf der Festplatte · %@"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld evento · %@ en disco · %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld eventos · %@ en disco · %@"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld événement · %@ sur le disque · %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld événements · %@ sur le disque · %@"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 件のイベント · ディスク上 %@ · %@"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld событие · %@ на диске · %@"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld события · %@ на диске · %@"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld событий · %@ на диске · %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld события · %@ на диске · %@"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 条事件 · 占用 %@ · %@"
                 }
               }
             }
@@ -22984,6 +23074,47 @@
         }
       }
     },
+    "matching %@ · %@ · %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passend: %@ · %@ · %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "coinciden: %@ · %@ · %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "correspondants : %@ · %@ · %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致: %@・%@・%@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "совпадений: %@ · %@ · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匹配：%@ · %@ · %@"
+          }
+        }
+      }
+    },
     "no change": {
       "extractionState": "manual",
       "localizations": {
@@ -23027,6 +23158,47 @@
           "stringUnit": {
             "state": "translated",
             "value": "无变化"
+          }
+        }
+      }
+    },
+    "no requests recorded yet": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Anfragen aufgezeichnet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aún no se han registrado solicitudes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aucune requête enregistrée pour l'instant"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだリクエストは記録されていません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "запросы пока не записаны"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未记录任何请求"
           }
         }
       }
@@ -23232,6 +23404,88 @@
           "stringUnit": {
             "state": "translated",
             "value": "用途：%@"
+          }
+        }
+      }
+    },
+    "records go back to %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufzeichnungen reichen bis %@ zurück"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "los registros llegan hasta %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "l'historique remonte à %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ から記録されています"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "самые старые записи — %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "记录追溯到%@"
+          }
+        }
+      }
+    },
+    "records only go back to %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufzeichnungen reichen nur bis %@ zurück"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "los registros solo llegan hasta %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "l'historique ne remonte qu'à %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ からしか記録されていません"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "древнее %@ записей нет"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅追溯到%@"
           }
         }
       }

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -878,6 +878,14 @@ final class AppListModel {
     /// Everything the store is holding, filter or no filter — the footprint line,
     /// which is about the file on disk and not about the question being asked.
     private(set) var retainedEventCount = 0
+    /// The retention floor — the oldest event of kind `"request"` the store
+    /// still holds, unfiltered by whatever query the pane is showing. `nil`
+    /// means the store holds no request events at all.
+    ///
+    /// Set from the same `coverage(kind:)` call as ``retainedEventCount`` so
+    /// the two can never disagree about which sweep of the store they
+    /// describe (#460).
+    private(set) var retainedEventFloor: Date?
     /// Whether the log has been read at least once.
     ///
     /// Not the same as "the log is empty", and the window has to tell them
@@ -1436,7 +1444,14 @@ final class AppListModel {
         // `kind: "request"` matters: install events live in the same table and
         // are never pruned, so an unfiltered count would report the retained
         // request window as the whole install history.
-        retainedEventCount = await eventStore.coverage(kind: "request").count
+        //
+        // One call for both fields, not two: `retainedEventFloor` is the
+        // retention floor the status bar and range menu warn against, and a
+        // second, separately-timed call could describe a different sweep of
+        // the store than `retainedEventCount` did (#460).
+        let coverage = await eventStore.coverage(kind: "request")
+        retainedEventCount = coverage.count
+        retainedEventFloor = coverage.oldest
         eventStoreBytes = await eventStore.databaseBytes()
         requestLogLoaded = true
     }

--- a/App/Sources/NetworkWindowView.swift
+++ b/App/Sources/NetworkWindowView.swift
@@ -59,6 +59,7 @@ struct NetworkWindowView: View {
                     summary: model.requestSummary,
                     events: model.requestLog,
                     retainedEvents: model.retainedEventCount,
+                    retainedFloor: model.retainedEventFloor,
                     storeBytes: model.eventStoreBytes,
                     onQuery: { await model.reloadRequestLog($0) },
                     onReset: { query in Task { await model.resetRequestLog(query) } },

--- a/App/Sources/RequestCoverageHonesty.swift
+++ b/App/Sources/RequestCoverageHonesty.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Whether a Requests-pane date range is honoured by what the event store
+/// actually retains, and what to say when it is not (#460).
+///
+/// The range menu offers "Last 7 days" whether or not the store has kept
+/// anything close to seven days of events, and until now nothing on screen
+/// said so — the caption hid the only clue (the retention floor) the moment a
+/// range was picked, and the status bar never carried it at all. Fixing that
+/// is a rule ("given the floor and a range, is it honoured, and what do we
+/// say"), and rules belong here rather than in `RequestLogPane`: that file
+/// imports SwiftUI, and `App/project.yml`'s comment on `DuoUpdaterAppTests`
+/// explains why nothing in that target may. This file has no SwiftUI import
+/// and no `AppListModel` dependency so the test target can compile it.
+///
+/// `RequestLogPane` calls ``annotation(since:floor:now:)`` once per
+/// `Range` case for the picker's menu labels, and ``relativeDescription(of:relativeTo:locale:)``
+/// for the caption and the status bar — the same "how far back, in words"
+/// question asked in a neutral voice instead of a warning.
+enum RequestCoverageHonesty {
+    /// What a range's menu row should say about the gap between what it
+    /// promises and what the store can actually back it with, or `nil` when
+    /// the promise is honoured.
+    ///
+    /// - Parameters:
+    ///   - since: the range's cutoff (`RequestLogPane.Range.since`). `nil`
+    ///     means "All time", which promises nothing to fall short of, so this
+    ///     always returns `nil` for it — the range enum is not referenced
+    ///     directly here (see the file comment on why), but every case maps to
+    ///     exactly this `since` value.
+    ///   - floor: the store's retention floor —
+    ///     `EventStore.coverage(kind: "request").oldest`, unfiltered by
+    ///     whatever the user has typed or selected. Using the filtered
+    ///     `RequestLogSummary.oldest` here instead would make the annotation
+    ///     describe the current query rather than the store, and it would
+    ///     disappear the moment a range was picked — which is the bug this
+    ///     type exists to fix.
+    ///   - now: injected rather than read from the clock, so the answer does
+    ///     not depend on when or where the test runs.
+    ///
+    /// `floor == nil` (the store holds no request events at all) is treated as
+    /// *not* honouring any range that has a cutoff — fail closed, matching
+    /// this repo's other "can't tell → don't claim it" rules — rather than as
+    /// vacuously honouring every range. An empty store has kept nothing, so
+    /// nothing it promises is backed by data.
+    static func annotation(since: Date?, floor: Date?, now: Date = Date()) -> String? {
+        guard let since else { return nil }
+        guard let floor else {
+            return String(localized: "no requests recorded yet")
+        }
+        guard floor > since else { return nil }
+        let span = relativeDescription(of: floor, relativeTo: now)
+        return String(localized: "records only go back to \(span)")
+    }
+
+    /// The retention floor in words — "19 hours ago", "3 days ago" — rather
+    /// than a calendar month. A 19-hour window rendered as "since September
+    /// 2026" is not a lie, but the month-granularity template it replaced
+    /// (`RequestLogPane.monthYear`, `MMMyyyy`) erased the magnitude: it read
+    /// as "recording since the start of the month" when the store in fact
+    /// goes back to 1:47 that same morning.
+    ///
+    /// The unit words ("hours", "days") come from `RelativeDateTimeFormatter`,
+    /// i.e. from Foundation's own localization rather than from
+    /// `Localizable.xcstrings` — which is what keeps the catalog entries this
+    /// change adds down to whole phrases with one placeholder each, instead of
+    /// a set of plural rules per supported unit per language.
+    static func relativeDescription(
+        of date: Date, relativeTo now: Date = Date(), locale: Locale = .current
+    ) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = locale
+        formatter.dateTimeStyle = .named
+        return formatter.localizedString(for: date, relativeTo: now)
+    }
+
+    /// The caption and status-bar phrasing — a neutral statement of fact, not
+    /// a warning about an unmet promise (that is ``annotation(since:floor:now:)``).
+    ///
+    /// Deliberately "go back to `<relative phrase>`" rather than "since
+    /// `<relative phrase>`": `relativeDescription` already reads as "N units
+    /// ago", and several languages double-mark the tense when a preposition
+    /// meaning "since" is put in front of an "ago"-phrase (German "seit vor 19
+    /// Stunden", French "depuis il y a 19 heures" both read as mistakes to a
+    /// native speaker). "Go back to" takes an "ago"-phrase as its object
+    /// cleanly in all six languages this catalog carries.
+    static func floorDescription(_ date: Date, relativeTo now: Date = Date()) -> String {
+        String(localized: "records go back to \(relativeDescription(of: date, relativeTo: now))")
+    }
+}

--- a/App/Sources/RequestCoverageHonesty.swift
+++ b/App/Sources/RequestCoverageHonesty.swift
@@ -13,14 +13,28 @@ import Foundation
 /// explains why nothing in that target may. This file has no SwiftUI import
 /// and no `AppListModel` dependency so the test target can compile it.
 ///
-/// `RequestLogPane` calls ``annotation(since:floor:now:)`` once per
-/// `Range` case for the picker's menu labels, and ``relativeDescription(of:relativeTo:locale:)``
-/// for the caption and the status bar — the same "how far back, in words"
-/// question asked in a neutral voice instead of a warning.
+/// `RequestLogPane` calls ``annotation(since:floor:hasLoaded:now:locale:)``
+/// once per `Range` case for the picker's menu labels, and
+/// ``floorDescription(_:relativeTo:)`` for the caption and the status bar —
+/// the same "how far back, in words" question, but the menu's answer has to
+/// be short (it becomes the closed `Picker`'s own label — see
+/// `annotation`'s doc) while the status bar's can be a full sentence, because
+/// the status bar shows it unconditionally and the menu doesn't have to
+/// repeat it.
 enum RequestCoverageHonesty {
     /// What a range's menu row should say about the gap between what it
     /// promises and what the store can actually back it with, or `nil` when
-    /// the promise is honoured.
+    /// there is nothing to say.
+    ///
+    /// Deliberately short — the bare relative phrase ("19 hours ago"), not a
+    /// sentence — because a `Picker`'s selected row becomes the label of the
+    /// *closed* control: measured with `NSFont.systemFont(ofSize:
+    /// NSFont.systemFontSize)`, "Last 7 days" is 68.5pt but "Last 7 days
+    /// (records only go back to 19 hours ago)" is 306pt in English and over
+    /// 400pt in German and Russian, wide enough to crowd the query field out
+    /// of a 640pt-minimum window. The status bar already states the same
+    /// fact as a full sentence unconditionally (``floorDescription(_:relativeTo:)``),
+    /// so the menu only needs a short cue, not a repeat of the whole claim.
     ///
     /// - Parameters:
     ///   - since: the range's cutoff (`RequestLogPane.Range.since`). `nil`
@@ -35,6 +49,16 @@ enum RequestCoverageHonesty {
     ///     describe the current query rather than the store, and it would
     ///     disappear the moment a range was picked — which is the bug this
     ///     type exists to fix.
+    ///   - hasLoaded: whether the log has been read at least once
+    ///     (`RequestLogPane.hasLoaded`). `retainedFloor` is `nil` in two
+    ///     situations that must not read the same way: an empty store, and
+    ///     the pre-load window before `reloadRequestLog` has ever run (it
+    ///     `await`s a flush and three queries against the whole store before
+    ///     `retainedFloor` is set at all). Reporting the second one as "empty"
+    ///     re-commits #460's own mistake — claiming something about the store
+    ///     that is not actually known yet — for however long that `Task`
+    ///     takes. `hasLoaded` defaults to `true` because every caller except
+    ///     the one narrow pre-load window has already loaded.
     ///   - now: injected rather than read from the clock, so the answer does
     ///     not depend on when or where the test runs.
     ///   - locale: forwarded to ``relativeDescription(of:relativeTo:locale:)``.
@@ -47,21 +71,22 @@ enum RequestCoverageHonesty {
     ///     `note?.contains("19")` only passed on a host whose locale renders
     ///     Western digits.
     ///
-    /// `floor == nil` (the store holds no request events at all) is treated as
-    /// *not* honouring any range that has a cutoff — fail closed, matching
-    /// this repo's other "can't tell → don't claim it" rules — rather than as
-    /// vacuously honouring every range. An empty store has kept nothing, so
-    /// nothing it promises is backed by data.
+    /// `floor == nil` *after loading* (the store holds no request events at
+    /// all) is treated as *not* honouring any range that has a cutoff — fail
+    /// closed, matching this repo's other "can't tell → don't claim it"
+    /// rules — rather than as vacuously honouring every range. An empty store
+    /// has kept nothing, so nothing it promises is backed by data.
     static func annotation(
-        since: Date?, floor: Date?, now: Date = Date(), locale: Locale = .current
+        since: Date?, floor: Date?, hasLoaded: Bool = true, now: Date = Date(),
+        locale: Locale = .current
     ) -> String? {
         guard let since else { return nil }
+        guard hasLoaded else { return nil }
         guard let floor else {
-            return String(localized: "no requests recorded yet")
+            return String(localized: "nothing yet")
         }
         guard floor > since else { return nil }
-        let span = relativeDescription(of: floor, relativeTo: now, locale: locale)
-        return String(localized: "records only go back to \(span)")
+        return relativeDescription(of: floor, relativeTo: now, locale: locale)
     }
 
     /// The retention floor in words — "19 hours ago", "3 days ago" — rather
@@ -85,8 +110,9 @@ enum RequestCoverageHonesty {
         return formatter.localizedString(for: date, relativeTo: now)
     }
 
-    /// The caption and status-bar phrasing — a neutral statement of fact, not
-    /// a warning about an unmet promise (that is ``annotation(since:floor:now:)``).
+    /// The caption and status-bar phrasing — a full sentence, shown
+    /// unconditionally (see ``annotation(since:floor:hasLoaded:now:locale:)``'s
+    /// doc for why the menu does not repeat it).
     ///
     /// The English source is "go back to `<relative phrase>`" rather than
     /// "since `<relative phrase>`": `relativeDescription` already reads as "N
@@ -96,42 +122,28 @@ enum RequestCoverageHonesty {
     ///
     /// That does not mean every language's catalog entry reuses an English
     /// "go back to" shape — composing the actual sentence (19 hours / 3 days,
-    /// substituted into each template) surfaced the same clash inside two of
-    /// the six translations themselves:
+    /// substituted into the template) surfaced the same clash in French:
+    /// `l'historique remonte à %@` composed to `remonte à il y a 19 heures` —
+    /// "à" stacked directly on "il y a" ("at" + "ago"), the same mistake in
+    /// French this comment used to claim French avoided. Fixed to
+    /// `l'historique commence %@` ("the log started `<phrase>`"), which takes
+    /// "il y a 19 heures" as a plain adverbial with no preposition in front of
+    /// it.
     ///
-    /// - **fr**: `l'historique remonte à %@` composed to `remonte à il y a 19
-    ///   heures` — "à" stacked directly on "il y a" ("at" + "ago"), the same
-    ///   mistake in French this comment used to claim French avoided. Fixed to
-    ///   `l'historique commence %@` ("the log started `<phrase>`"), which
-    ///   takes "il y a 19 heures" as a plain adverbial with no preposition in
-    ///   front of it. The paired warning key (``annotation``'s
-    ///   `records only go back to %@`) had the identical bug
-    ///   (`ne remonte qu'à il y a 19 heures`) and is now the unrelated
-    ///   construction `limite : %@` ("limit: `<phrase>`") — a colon-label
-    ///   avoids the elision question a `que`-before-the-argument fix would
-    ///   have raised (`que` vs `qu'` depends on whether the substituted phrase
-    ///   starts with a vowel sound, which varies: "il y a…" does, but a
-    ///   calendar-named result like "la semaine dernière" does not).
-    /// - **ru**: `древнее %@ записей нет` composed to `древнее 19 часов назад
-    ///   записей нет` — `древнее` ("older than") is a comparative that wants a
-    ///   genitive noun, and "19 часов назад" is an adverbial "ago"-phrase, not
-    ///   a noun in that case. Fixed to `самые старые записи — лишь %@` ("the
-    ///   oldest records — only `<phrase>`"), reusing the neutral key's
-    ///   dash-apposition (which has no case requirement) with `лишь` ("only")
-    ///   added.
-    ///
-    /// The other four — **de** (`bis vor %@ zurück`, using the standalone "bis
+    /// The other five — **de** (`bis vor %@ zurück`, the standalone "bis
     /// vor …" idiom, e.g. "bis vor Kurzem"), **es** (`hasta hace %@`, the same
     /// "hasta hace poco" shape), **ja** (`%@から…`, where relative phrases
     /// already end in "前" and "前から" is the ordinary way to say "since …
-    /// ago"), and **zh-Hans** (`追溯到%@`, "traces back to `<phrase>`") — were
-    /// each composed the same way (19 hours, 3 days) and read correctly by the
-    /// same non-native reasoning that caught the fr/ru cases.
+    /// ago"), **ru** (`самые старые записи — %@`, dash-apposition, no
+    /// preposition to clash), and **zh-Hans** (`追溯到%@`, "traces back to
+    /// `<phrase>`") — were each composed the same way (19 hours, 3 days) and
+    /// read correctly by the same non-native reasoning that caught the French
+    /// case.
     ///
-    /// **None of the six — including the two fixes above — has been checked by
-    /// a native speaker.** Treat all six as 未验证 (unverified) beyond that
-    /// reasoning; ru and fr are the two this comment can say were *wrong*
-    /// before, not the two guaranteed right now.
+    /// **None of the six — including the French fix — has been checked by a
+    /// native speaker.** Treat all six as 未验证 (unverified) beyond that
+    /// reasoning; French is the one this comment can say was *wrong* before,
+    /// not the one guaranteed right now.
     static func floorDescription(_ date: Date, relativeTo now: Date = Date()) -> String {
         String(localized: "records go back to \(relativeDescription(of: date, relativeTo: now))")
     }

--- a/App/Sources/RequestCoverageHonesty.swift
+++ b/App/Sources/RequestCoverageHonesty.swift
@@ -37,19 +37,30 @@ enum RequestCoverageHonesty {
     ///     type exists to fix.
     ///   - now: injected rather than read from the clock, so the answer does
     ///     not depend on when or where the test runs.
+    ///   - locale: forwarded to ``relativeDescription(of:relativeTo:locale:)``.
+    ///     Defaulted to `.current` for real callers (the point of a relative
+    ///     phrase is to match the device's own locale), but a test that does
+    ///     not pin this explicitly is a test that asks the host what locale it
+    ///     is in — CLAUDE.md's 2026-09-09 rule. Before this parameter existed,
+    ///     `annotation` had no way to avoid that: it always fell through to
+    ///     `.current` with no seam for a test to inject anything else, so
+    ///     `note?.contains("19")` only passed on a host whose locale renders
+    ///     Western digits.
     ///
     /// `floor == nil` (the store holds no request events at all) is treated as
     /// *not* honouring any range that has a cutoff — fail closed, matching
     /// this repo's other "can't tell → don't claim it" rules — rather than as
     /// vacuously honouring every range. An empty store has kept nothing, so
     /// nothing it promises is backed by data.
-    static func annotation(since: Date?, floor: Date?, now: Date = Date()) -> String? {
+    static func annotation(
+        since: Date?, floor: Date?, now: Date = Date(), locale: Locale = .current
+    ) -> String? {
         guard let since else { return nil }
         guard let floor else {
             return String(localized: "no requests recorded yet")
         }
         guard floor > since else { return nil }
-        let span = relativeDescription(of: floor, relativeTo: now)
+        let span = relativeDescription(of: floor, relativeTo: now, locale: locale)
         return String(localized: "records only go back to \(span)")
     }
 
@@ -77,13 +88,50 @@ enum RequestCoverageHonesty {
     /// The caption and status-bar phrasing — a neutral statement of fact, not
     /// a warning about an unmet promise (that is ``annotation(since:floor:now:)``).
     ///
-    /// Deliberately "go back to `<relative phrase>`" rather than "since
-    /// `<relative phrase>`": `relativeDescription` already reads as "N units
-    /// ago", and several languages double-mark the tense when a preposition
-    /// meaning "since" is put in front of an "ago"-phrase (German "seit vor 19
-    /// Stunden", French "depuis il y a 19 heures" both read as mistakes to a
-    /// native speaker). "Go back to" takes an "ago"-phrase as its object
-    /// cleanly in all six languages this catalog carries.
+    /// The English source is "go back to `<relative phrase>`" rather than
+    /// "since `<relative phrase>`": `relativeDescription` already reads as "N
+    /// units ago", and English (and several other languages) double-mark the
+    /// tense when a preposition meaning "since" is put directly in front of an
+    /// "ago"-phrase.
+    ///
+    /// That does not mean every language's catalog entry reuses an English
+    /// "go back to" shape — composing the actual sentence (19 hours / 3 days,
+    /// substituted into each template) surfaced the same clash inside two of
+    /// the six translations themselves:
+    ///
+    /// - **fr**: `l'historique remonte à %@` composed to `remonte à il y a 19
+    ///   heures` — "à" stacked directly on "il y a" ("at" + "ago"), the same
+    ///   mistake in French this comment used to claim French avoided. Fixed to
+    ///   `l'historique commence %@` ("the log started `<phrase>`"), which
+    ///   takes "il y a 19 heures" as a plain adverbial with no preposition in
+    ///   front of it. The paired warning key (``annotation``'s
+    ///   `records only go back to %@`) had the identical bug
+    ///   (`ne remonte qu'à il y a 19 heures`) and is now the unrelated
+    ///   construction `limite : %@` ("limit: `<phrase>`") — a colon-label
+    ///   avoids the elision question a `que`-before-the-argument fix would
+    ///   have raised (`que` vs `qu'` depends on whether the substituted phrase
+    ///   starts with a vowel sound, which varies: "il y a…" does, but a
+    ///   calendar-named result like "la semaine dernière" does not).
+    /// - **ru**: `древнее %@ записей нет` composed to `древнее 19 часов назад
+    ///   записей нет` — `древнее` ("older than") is a comparative that wants a
+    ///   genitive noun, and "19 часов назад" is an adverbial "ago"-phrase, not
+    ///   a noun in that case. Fixed to `самые старые записи — лишь %@` ("the
+    ///   oldest records — only `<phrase>`"), reusing the neutral key's
+    ///   dash-apposition (which has no case requirement) with `лишь` ("only")
+    ///   added.
+    ///
+    /// The other four — **de** (`bis vor %@ zurück`, using the standalone "bis
+    /// vor …" idiom, e.g. "bis vor Kurzem"), **es** (`hasta hace %@`, the same
+    /// "hasta hace poco" shape), **ja** (`%@から…`, where relative phrases
+    /// already end in "前" and "前から" is the ordinary way to say "since …
+    /// ago"), and **zh-Hans** (`追溯到%@`, "traces back to `<phrase>`") — were
+    /// each composed the same way (19 hours, 3 days) and read correctly by the
+    /// same non-native reasoning that caught the fr/ru cases.
+    ///
+    /// **None of the six — including the two fixes above — has been checked by
+    /// a native speaker.** Treat all six as 未验证 (unverified) beyond that
+    /// reasoning; ru and fr are the two this comment can say were *wrong*
+    /// before, not the two guaranteed right now.
     static func floorDescription(_ date: Date, relativeTo now: Date = Date()) -> String {
         String(localized: "records go back to \(relativeDescription(of: date, relativeTo: now))")
     }

--- a/App/Sources/RequestLogPane.swift
+++ b/App/Sources/RequestLogPane.swift
@@ -127,8 +127,14 @@ struct RequestLogPane: View {
     private var range: Range { filter.range }
     private var selection: UUID? { filter.selection }
 
-    /// A range's label, with a parenthetical when the store cannot actually
-    /// back it — "Last 7 days (records only go back to 19 hours ago)".
+    /// A range's label, with a short parenthetical when the store cannot
+    /// actually back it — "Last 7 days (19 hours ago)".
+    ///
+    /// `hasLoaded` matters here specifically (and not just at ``emptyState``):
+    /// `retainedFloor` reads `nil` both before the first load and for a truly
+    /// empty store, and this is the one call site that would otherwise
+    /// re-commit #460's own mistake — declaring the store empty while
+    /// `reloadRequestLog`'s `Task` is still awaiting its flush and queries.
     ///
     /// Plain interpolation, not `String(localized:)`: `range.label` and `note`
     /// are both already fully localized strings, so after specifier removal
@@ -138,8 +144,9 @@ struct RequestLogPane: View {
     /// implied a translatability step that was not actually happening — the
     /// lookup would always miss and fall back to the same interpolated value.
     private func rangeMenuLabel(_ range: Range) -> String {
-        guard let note = RequestCoverageHonesty.annotation(since: range.since, floor: retainedFloor)
-        else { return range.label }
+        guard let note = RequestCoverageHonesty.annotation(
+            since: range.since, floor: retainedFloor, hasLoaded: hasLoaded
+        ) else { return range.label }
         return "\(range.label) (\(note))"
     }
 

--- a/App/Sources/RequestLogPane.swift
+++ b/App/Sources/RequestLogPane.swift
@@ -46,6 +46,12 @@ struct RequestLogPane: View {
     let summary: RequestLogSummary
     let events: [DuoEvent]
     let retainedEvents: Int
+    /// The retention floor — `AppListModel.retainedEventFloor` —
+    /// unfiltered by whatever the pane is currently asking. Carried alongside
+    /// `retainedEvents` for the same reason that count is: it is a fact about
+    /// the store on disk, not about the query, so it stays visible whether or
+    /// not a filter or a range is selected (#460).
+    let retainedFloor: Date?
     let storeBytes: Int64
     /// Re-runs the query. Async so the caller can flush the store first.
     var onQuery: (RequestQuery) async -> Void = { _ in }
@@ -120,6 +126,14 @@ struct RequestLogPane: View {
     }
     private var range: Range { filter.range }
     private var selection: UUID? { filter.selection }
+
+    /// A range's label, with a parenthetical when the store cannot actually
+    /// back it — "Last 7 days (records only go back to 19 hours ago)".
+    private func rangeMenuLabel(_ range: Range) -> String {
+        guard let note = RequestCoverageHonesty.annotation(since: range.since, floor: retainedFloor)
+        else { return range.label }
+        return String(localized: "\(range.label) (\(note))")
+    }
 
     private var query: RequestQuery {
         var query = RequestQuery.window(text)
@@ -250,15 +264,29 @@ struct RequestLogPane: View {
     /// Says which question the number above answers. It has to name the filter:
     /// the same headline means two different things filtered and unfiltered, and
     /// nothing else on screen distinguishes them.
+    ///
+    /// The trailing span always comes from ``retainedFloor`` — the store's
+    /// retention floor — never from `summary.oldest`. `summary.oldest` is the
+    /// oldest row matching the *current query*, so it moves when the user
+    /// types or picks a range; reading it here would make the caption describe
+    /// the filter rather than the store, and it would vanish the moment a
+    /// range was selected — the exact bug (#460) this file exists to fix.
+    /// `isFiltered` still governs the count wording ("matching N requests" is
+    /// correct once a range narrows the count), but the retention floor
+    /// survives into both branches.
     @ViewBuilder
     private var caption: some View {
         let requests = String(localized: "\(summary.requests) requests")
         let hosts = String(localized: "\(summary.hostCount) hosts")
         Group {
             if isFiltered {
-                Text("matching \(requests) · \(hosts)")
-            } else if let since = summary.oldest {
-                Text("\(requests) · \(hosts) · since \(Self.monthYear.string(from: since))")
+                if let retainedFloor {
+                    Text("matching \(requests) · \(hosts) · \(RequestCoverageHonesty.floorDescription(retainedFloor))")
+                } else {
+                    Text("matching \(requests) · \(hosts)")
+                }
+            } else if let retainedFloor {
+                Text("\(requests) · \(hosts) · \(RequestCoverageHonesty.floorDescription(retainedFloor))")
             } else {
                 Text("\(requests) · \(hosts)")
             }
@@ -402,7 +430,15 @@ struct RequestLogPane: View {
                 placeholder: "host:  app:  purpose:  status:  size>10MB")
 
             Picker("Range", selection: $filter.range) {
-                ForEach(Range.allCases) { Text($0.label).tag($0) }
+                // The annotation lives here rather than on `Range` itself:
+                // `Range.label` is a static computed property with no access
+                // to `retainedFloor`, and the row that can least afford to be
+                // wrong is the one for a range the store cannot actually back
+                // — see `RequestCoverageHonesty`. Never disabled: a greyed-out
+                // row reads as broken, not as "true but unsupported".
+                ForEach(Range.allCases) { range in
+                    Text(rangeMenuLabel(range)).tag(range)
+                }
             }
             .labelsHidden()
             .fixedSize()
@@ -772,9 +808,19 @@ struct RequestLogPane: View {
                 .help("Paused while a row is selected, so the list does not move under you")
             }
             Spacer()
-            Text("\(retainedEvents) events · \(ByteFormat.string(storeBytes)) on disk")
-                .foregroundStyle(.tertiary)
-                .monospacedDigit()
+            // Always shown, filtered or not — the store's footprint is a fact
+            // about the file on disk, not about the query above it. Before
+            // #460 this line had a count and a size but no span, so the range
+            // menu's promise had nothing on screen to check it against.
+            if let retainedFloor {
+                Text("\(retainedEvents) events · \(ByteFormat.string(storeBytes)) on disk · \(RequestCoverageHonesty.floorDescription(retainedFloor))")
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
+            } else {
+                Text("\(retainedEvents) events · \(ByteFormat.string(storeBytes)) on disk")
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
+            }
             Button("Export JSON") { onExport(query) }
                 .buttonStyle(.link)
             Button(role: .destructive) {
@@ -895,12 +941,6 @@ struct RequestLogPane: View {
     private static func millis(_ seconds: TimeInterval) -> Int {
         Int((seconds * 1000).rounded())
     }
-
-    private static let monthYear: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.setLocalizedDateFormatFromTemplate("MMMyyyy")
-        return formatter
-    }()
 
     private static let stamp: DateFormatter = {
         let formatter = DateFormatter()

--- a/App/Sources/RequestLogPane.swift
+++ b/App/Sources/RequestLogPane.swift
@@ -129,10 +129,18 @@ struct RequestLogPane: View {
 
     /// A range's label, with a parenthetical when the store cannot actually
     /// back it — "Last 7 days (records only go back to 19 hours ago)".
+    ///
+    /// Plain interpolation, not `String(localized:)`: `range.label` and `note`
+    /// are both already fully localized strings, so after specifier removal
+    /// the composed key would be `%@ (%@)` — no letters left, which is exactly
+    /// why `check_localizable_keys.py` never requires (or would even notice)
+    /// a catalog entry for it. Wrapping the interpolation in `String(localized:)`
+    /// implied a translatability step that was not actually happening — the
+    /// lookup would always miss and fall back to the same interpolated value.
     private func rangeMenuLabel(_ range: Range) -> String {
         guard let note = RequestCoverageHonesty.annotation(since: range.since, floor: retainedFloor)
         else { return range.label }
-        return String(localized: "\(range.label) (\(note))")
+        return "\(range.label) (\(note))"
     }
 
     private var query: RequestQuery {
@@ -784,6 +792,24 @@ struct RequestLogPane: View {
 
     // MARK: - Footer
 
+    /// The status bar's footprint line, built as one already-localized `String`
+    /// so `statusBar` can hold exactly one `Text` with exactly one set of
+    /// modifiers rather than branching on `retainedFloor` twice.
+    ///
+    /// `String(localized:)`, not plain interpolation: a bare Swift string
+    /// built with `"\(retainedEvents) events · …"` would skip the localization
+    /// catalog entirely (and with it the plural rule on `retainedEvents`) —
+    /// `Text`'s own interpolation-to-`LocalizedStringKey` machinery is what
+    /// makes that automatic, and building the `String` by hand loses it unless
+    /// it goes through `String(localized:)` explicitly, the same way `caption`
+    /// already builds its `requests`/`hosts` locals below.
+    private var footprintLine: String {
+        guard let retainedFloor else {
+            return String(localized: "\(retainedEvents) events · \(ByteFormat.string(storeBytes)) on disk")
+        }
+        return String(localized: "\(retainedEvents) events · \(ByteFormat.string(storeBytes)) on disk · \(RequestCoverageHonesty.floorDescription(retainedFloor))")
+    }
+
     private var statusBar: some View {
         HStack(spacing: 10) {
             // Says when the list is a window onto the matches rather than all of
@@ -812,15 +838,14 @@ struct RequestLogPane: View {
             // about the file on disk, not about the query above it. Before
             // #460 this line had a count and a size but no span, so the range
             // menu's promise had nothing on screen to check it against.
-            if let retainedFloor {
-                Text("\(retainedEvents) events · \(ByteFormat.string(storeBytes)) on disk · \(RequestCoverageHonesty.floorDescription(retainedFloor))")
-                    .foregroundStyle(.tertiary)
-                    .monospacedDigit()
-            } else {
-                Text("\(retainedEvents) events · \(ByteFormat.string(storeBytes)) on disk")
-                    .foregroundStyle(.tertiary)
-                    .monospacedDigit()
-            }
+            //
+            // The string is built first so there is exactly one `Text` and one
+            // set of modifiers — the branch is only in the text, not in the
+            // view, so there is nothing to keep in sync between two copies of
+            // `.foregroundStyle`/`.monospacedDigit`.
+            Text(footprintLine)
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
             Button("Export JSON") { onExport(query) }
                 .buttonStyle(.link)
             Button(role: .destructive) {

--- a/App/Tests/RequestCoverageHonestyTests.swift
+++ b/App/Tests/RequestCoverageHonestyTests.swift
@@ -67,8 +67,13 @@ struct RequestCoverageHonestyTests {
         let since = Self.daysAgo(7)           // "Last 7 days"
         let floor = Self.hoursAgo(19)         // store only goes back 19 hours
         let note = RequestCoverageHonesty.annotation(since: since, floor: floor, now: Self.now, locale: Self.usLocale)
-        #expect(note != nil)
-        #expect(note?.contains("19") == true)
+        // Exact match, not a substring check: the annotation is deliberately
+        // short — just the bare relative phrase, no wrapping sentence — so
+        // with the locale and clock both pinned there is exactly one correct
+        // string (round 2 of #537's review: a `Picker`'s selected row becomes
+        // its closed control's own label, and "records only go back to 19
+        // hours ago" measured 306pt against 68.5pt for the plain label).
+        #expect(note == "19 hours ago")
     }
 
     /// A "Last 30 days" cutoff against the same 19-hour floor must also be
@@ -97,16 +102,21 @@ struct RequestCoverageHonestyTests {
         #expect(RequestCoverageHonesty.annotation(since: nil, floor: floor, now: Self.now) == nil)
     }
 
-    // MARK: annotation — empty store
+    // MARK: annotation — empty store (loaded)
 
-    /// An empty store (`floor == nil`) must NOT read as "everything is
-    /// covered". It is the opposite: nothing has been kept, so no promise is
-    /// backed by data, and every range with a cutoff must be annotated.
+    /// An empty store (`floor == nil`) that HAS finished loading (`hasLoaded`
+    /// defaults to `true` here) must NOT read as "everything is covered". It
+    /// is the opposite: nothing has been kept, so no promise is backed by
+    /// data, and every range with a cutoff must be annotated.
     ///
     /// Mutation: `guard let floor else { return nil }` instead of returning
-    /// the "nothing recorded" message — this case is the only one that tells
+    /// the "nothing yet" message — this case is the only one that tells
     /// "no annotation" and "empty-store annotation" apart, since both are
     /// non-crashing and the wrong one is silent.
+    ///
+    /// Contrast with ``theFirstLoadWindowIsNeverAnnotated()`` below: the same
+    /// `floor: nil` input must answer differently depending on `hasLoaded` —
+    /// that is exactly the distinction round 2 of #537's review asked for.
     @Test func anEmptyStoreIsNotTreatedAsFullyCovered() {
         let since = Self.daysAgo(7)
         #expect(RequestCoverageHonesty.annotation(since: since, floor: nil, now: Self.now) != nil)
@@ -116,6 +126,38 @@ struct RequestCoverageHonestyTests {
     /// "no promise" rule and the "empty store" rule must compose, not race.
     @Test func allTimeIsNeverAnnotatedEvenWhenEmpty() {
         #expect(RequestCoverageHonesty.annotation(since: nil, floor: nil, now: Self.now) == nil)
+    }
+
+    // MARK: annotation — the pre-load window
+
+    /// `retainedFloor` reads `nil` in the pre-load window too, not only for a
+    /// truly empty store — `NetworkWindowView` renders the pane immediately
+    /// and only then runs `reloadRequestLog`, which awaits a flush and three
+    /// queries against the whole store before `retainedFloor` is ever set.
+    /// A store holding 40,000 events must not be announced as "nothing yet"
+    /// for however long that `Task` takes — which is exactly what happened
+    /// before `hasLoaded` was threaded into `annotation` (round 2 of #537's
+    /// review: "the fix re-commits the issue's own sin during the pre-load
+    /// window").
+    ///
+    /// Mutation: drop the `guard hasLoaded else { return nil }` line (or
+    /// default-ignore the parameter) — this case is the only one that tells
+    /// "not loaded yet, say nothing" apart from "loaded and empty, say so":
+    /// both take `floor: nil`, and the wrong answer is silent, not a crash.
+    @Test func theFirstLoadWindowIsNeverAnnotated() {
+        let since = Self.daysAgo(7)           // "Last 7 days"
+        #expect(RequestCoverageHonesty.annotation(
+            since: since, floor: nil, hasLoaded: false, now: Self.now
+        ) == nil)
+    }
+
+    /// `.all` gets no annotation in the pre-load window either — the same
+    /// "no promise, nothing to say" composition as
+    /// ``allTimeIsNeverAnnotatedEvenWhenEmpty()``, one guard further out.
+    @Test func allTimeIsNeverAnnotatedBeforeLoading() {
+        #expect(RequestCoverageHonesty.annotation(
+            since: nil, floor: nil, hasLoaded: false, now: Self.now
+        ) == nil)
     }
 
     // MARK: relativeDescription

--- a/App/Tests/RequestCoverageHonestyTests.swift
+++ b/App/Tests/RequestCoverageHonestyTests.swift
@@ -54,10 +54,19 @@ struct RequestCoverageHonestyTests {
     ///
     /// Mutation: flip the `floor > since` comparison — this case would then
     /// wrongly report the range as honoured (`nil`).
+    ///
+    /// `locale: Self.usLocale` matters here specifically, unlike the nil/
+    /// non-nil checks elsewhere in this file: this is the one assertion that
+    /// inspects the *contents* of the note (`contains("19")`), and without a
+    /// pinned locale `annotation` falls through to `Locale.current` — a host
+    /// whose locale renders non-Western digits would fail this for a reason
+    /// that has nothing to do with the code under test. CLAUDE.md's 2026-09-09
+    /// rule: "would this test's answer change on another machine?" — before
+    /// this parameter existed on `annotation`, the answer was yes.
     @Test func aRangeTheStoreCannotBackGetsAnnotated() {
         let since = Self.daysAgo(7)           // "Last 7 days"
         let floor = Self.hoursAgo(19)         // store only goes back 19 hours
-        let note = RequestCoverageHonesty.annotation(since: since, floor: floor, now: Self.now)
+        let note = RequestCoverageHonesty.annotation(since: since, floor: floor, now: Self.now, locale: Self.usLocale)
         #expect(note != nil)
         #expect(note?.contains("19") == true)
     }

--- a/App/Tests/RequestCoverageHonestyTests.swift
+++ b/App/Tests/RequestCoverageHonestyTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+
+/// #460: the Requests pane's range menu offered "Last 7 days" whether or not
+/// the store had kept anything close to seven days, and the caption dropped
+/// the only clue (the retention floor) the moment a range was picked. Every
+/// case here is anchored to one of the mutations named in its comment; a case
+/// that survives its own mutation is decoration, not a test.
+struct RequestCoverageHonestyTests {
+
+    // A fixed instant, not `Date()` — CLAUDE.md's rule against letting a
+    // test's answer depend on the host clock. Every date below is built
+    // relative to this one.
+    private static let now = Date(timeIntervalSince1970: 1_757_640_000) // 2025-09-11T20:00:00Z
+    private static let usLocale = Locale(identifier: "en_US_POSIX")
+
+    private static func hoursAgo(_ hours: Double) -> Date {
+        now.addingTimeInterval(-hours * 3600)
+    }
+    private static func daysAgo(_ days: Double) -> Date {
+        now.addingTimeInterval(-days * 86_400)
+    }
+
+    // MARK: annotation — honoured ranges
+
+    /// The store's floor reaches further back than the range asks for, so the
+    /// range is honoured and gets no annotation.
+    ///
+    /// Mutation: flip the `floor > since` comparison (e.g. to `floor < since`
+    /// or `floor >= since`) — this case would then wrongly grow a
+    /// parenthetical on a range the store can fully back.
+    @Test func aRangeTheStoreFullyCoversIsNotAnnotated() {
+        let since = Self.daysAgo(7)          // "Last 7 days"
+        let floor = Self.daysAgo(30)         // store goes back a month
+        #expect(RequestCoverageHonesty.annotation(since: since, floor: floor, now: Self.now) == nil)
+    }
+
+    /// The boundary: the store's oldest event lands exactly on the range's
+    /// cutoff. Treated as honoured (`floor > since` is false when they're
+    /// equal), not as falling short by one instant.
+    ///
+    /// Mutation: `floor >= since` instead of `floor > since` — this exact
+    /// case is the only one that tells the two apart.
+    @Test func aFloorExactlyAtTheCutoffIsHonoured() {
+        let since = Self.daysAgo(7)
+        #expect(RequestCoverageHonesty.annotation(since: since, floor: since, now: Self.now) == nil)
+    }
+
+    // MARK: annotation — unhonoured ranges
+
+    /// The store's floor is newer than the range's cutoff — exactly #460's
+    /// reported case, a 19-hour-old store against "Last 7 days" — so the menu
+    /// row must say so.
+    ///
+    /// Mutation: flip the `floor > since` comparison — this case would then
+    /// wrongly report the range as honoured (`nil`).
+    @Test func aRangeTheStoreCannotBackGetsAnnotated() {
+        let since = Self.daysAgo(7)           // "Last 7 days"
+        let floor = Self.hoursAgo(19)         // store only goes back 19 hours
+        let note = RequestCoverageHonesty.annotation(since: since, floor: floor, now: Self.now)
+        #expect(note != nil)
+        #expect(note?.contains("19") == true)
+    }
+
+    /// A "Last 30 days" cutoff against the same 19-hour floor must also be
+    /// annotated — guards against a mutation that special-cases the largest
+    /// range (`.month`) and leaves it unannotated while still annotating
+    /// `.week`.
+    ///
+    /// Mutation: drop the annotation for the widest range only (an `if since
+    /// != daysAgo(30)` guard slipped into the real function).
+    @Test func theWidestRangeIsAnnotatedTooWhenUnhonoured() {
+        let since = Self.daysAgo(30)          // "Last 30 days"
+        let floor = Self.hoursAgo(19)
+        #expect(RequestCoverageHonesty.annotation(since: since, floor: floor, now: Self.now) != nil)
+    }
+
+    // MARK: annotation — .all is never annotated
+
+    /// `since: nil` stands for "All time", which promises nothing to fall
+    /// short of — it must never get a parenthetical, no matter how young the
+    /// store is.
+    ///
+    /// Mutation: return the annotation for `.all` (drop the `guard let since`
+    /// early return).
+    @Test func allTimeIsNeverAnnotated() {
+        let floor = Self.hoursAgo(1)          // store is almost brand new
+        #expect(RequestCoverageHonesty.annotation(since: nil, floor: floor, now: Self.now) == nil)
+    }
+
+    // MARK: annotation — empty store
+
+    /// An empty store (`floor == nil`) must NOT read as "everything is
+    /// covered". It is the opposite: nothing has been kept, so no promise is
+    /// backed by data, and every range with a cutoff must be annotated.
+    ///
+    /// Mutation: `guard let floor else { return nil }` instead of returning
+    /// the "nothing recorded" message — this case is the only one that tells
+    /// "no annotation" and "empty-store annotation" apart, since both are
+    /// non-crashing and the wrong one is silent.
+    @Test func anEmptyStoreIsNotTreatedAsFullyCovered() {
+        let since = Self.daysAgo(7)
+        #expect(RequestCoverageHonesty.annotation(since: since, floor: nil, now: Self.now) != nil)
+    }
+
+    /// `.all` still gets no annotation even against an empty store — the
+    /// "no promise" rule and the "empty store" rule must compose, not race.
+    @Test func allTimeIsNeverAnnotatedEvenWhenEmpty() {
+        #expect(RequestCoverageHonesty.annotation(since: nil, floor: nil, now: Self.now) == nil)
+    }
+
+    // MARK: relativeDescription
+
+    /// The headline behaviour #460 asked for: a 19-hour gap reads as "19
+    /// hours ago", not as a calendar month.
+    ///
+    /// Mutation: format with the deleted `MMMyyyy` template instead of
+    /// `RelativeDateTimeFormatter` — the result would contain a month name
+    /// ("September") and no "19".
+    @Test func aNineteenHourFloorReadsAsHoursNotAMonth() {
+        let floor = Self.hoursAgo(19)
+        let text = RequestCoverageHonesty.relativeDescription(of: floor, relativeTo: Self.now, locale: Self.usLocale)
+        #expect(text.contains("19"))
+        #expect(!text.contains("September"))
+    }
+
+    /// A multi-day gap reads in days, exercising the other end of the unit
+    /// range the formatter picks from.
+    @Test func aThreeDayFloorReadsInDays() {
+        let floor = Self.daysAgo(3)
+        let text = RequestCoverageHonesty.relativeDescription(of: floor, relativeTo: Self.now, locale: Self.usLocale)
+        #expect(text.contains("3"))
+    }
+}

--- a/App/project.yml
+++ b/App/project.yml
@@ -59,6 +59,7 @@ targets:
     sources:
       - path: Tests
       - path: Sources/ScanRowAssembly.swift
+      - path: Sources/RequestCoverageHonesty.swift
     dependencies:
       - package: DuoUpdaterCore
         product: DuoUpdaterCore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.93
+
+**The Requests window now shows how far back its log actually reaches, and marks date ranges it can't fully cover.** Before, picking "Last 30 days" on a log that only went back a few hours looked exactly like picking "Last 24 hours," with nothing on screen explaining why.
+
 ## 0.3.92
 
 **Some self-updating apps no longer look up to date while a newer version is out.** For apps whose update information sits behind a slow-to-refresh download server, Duo Updater could keep seeing an older version for days after a release.


### PR DESCRIPTION
Fixes #460.

## Re-measurement against today's code

All three of the issue's claims check out:

- **Range menu** (`RequestLogPane.swift:404`, now ~433): the four `Range` cases render unconditionally via `Text($0.label)` — no reference to coverage anywhere in the picker.
- **Caption's `isFiltered` branch** (`RequestLogPane.swift:258`, now ~278): `isFiltered` folds `range != .all` into the same flag that also covers free-text search, and the filtered branch (`Text("matching \(requests) · \(hosts)")`) carried no time information at all — confirmed by reading the branch, not by running the app.
- **Status bar** (`RequestLogPane.swift:775`, now ~811): `"\(retainedEvents) events · \(bytes) on disk"` — count and size, no span. Confirmed.

One correction to the issue's own follow-up: it says `RequestQuery.sqlPredicate()` starts with `kind = 'request'`, so install events never leak into the query — I re-checked this too and it's accurate; nothing in this PR touches that.

The one distinction the issue flagged as easy to get wrong — `RequestLogSummary.oldest` (filtered, moves with the query) vs `EventStore.coverage(kind: "request").oldest` (the retention floor, unfiltered) — is exactly what `AppListModel.reloadRequestLog` now threads through as `retainedEventFloor`, from the *same* `coverage(kind:)` call that already produced `retainedEventCount`. Every "how far back" statement in this PR (caption, status bar, menu) reads that field; `summary.oldest` is no longer read anywhere in `RequestLogPane.swift`.

## The three sites, before → after

**1. Range menu** — each row gets a short parenthetical only when the store can't back it; `.all` is never annotated; disabled state is never used. (Shortened in round 2 of review — see below — after a full-sentence version was measured to blow up the closed `Picker`'s own width.)
- Before: `Last 24 hours` / `Last 7 days` / `Last 30 days` / `All time` — always plain.
- After (store retains 19 hours, loaded): `Last 24 hours` (plain — honoured) / `Last 7 days (19 hours ago)` / `Last 30 days (19 hours ago)` / `All time` (plain — never annotated).
- After (store is empty, loaded, `retainedEventFloor == nil`): `Last 24 hours (nothing yet)` / … / `All time` (plain).
- After (pane visible but the first `reloadRequestLog` hasn't completed yet — `hasLoaded == false`): every row plain, same as "honoured" — silence, not a claim about a store that hasn't been read yet.

**2. Caption** — the retention floor now survives into the filtered branch.
- Before (range picked): `matching 12 requests · 3 hosts`
- After (range picked, store retains 19h): `matching 12 requests · 3 hosts · records go back to 19 hours ago`
- Before (unfiltered): `40,892 requests · 6 hosts · since September 2026` (month granularity, from `summary.oldest` formatted with the now-deleted `MMMyyyy` template)
- After (unfiltered): `40,892 requests · 6 hosts · records go back to 19 hours ago` (relative granularity, from the coverage floor)

**3. Status bar** — always shows the span now, filtered or not.
- Before: `40,892 events · 2.1 MB on disk`
- After: `40,892 events · 2.1 MB on disk · records go back to 19 hours ago`

## Where the logic lives

`App/Sources/RequestCoverageHonesty.swift` — pure, no SwiftUI import, no `AppListModel` dependency, added to `DuoUpdaterAppTests` in `App/project.yml`. Two functions:
- `annotation(since:floor:hasLoaded:now:locale:)` — is a range honoured, and if not, what (short) thing should the menu say. `hasLoaded` (added in round 3 of review) keeps "not loaded yet" from reading as "empty".
- `relativeDescription(of:relativeTo:locale:)` / `floorDescription(_:relativeTo:)` — the "19 hours ago" rendering (via `RelativeDateTimeFormatter`, so the unit words come from Foundation's own localization, keeping the new catalog entries to whole phrases with one placeholder each).

`RequestLogPane.swift` only renders what it returns (`rangeMenuLabel(_:)` for the picker, `RequestCoverageHonesty.floorDescription` for caption/status bar).

## Mutation table

Every mutation below was actually applied to `RequestCoverageHonesty.swift`, run through `scripts/app-tests.sh`, confirmed red, then reverted (the file is unmodified in this PR relative to that testing).

| # | Mutation | Test that catches it | Raw assertion message |
|---|---|---|---|
| 1 | `guard floor > since` → `guard floor >= since` | `aFloorExactlyAtTheCutoffIsHonoured` | `Expectation failed: RequestCoverageHonesty.annotation(since: since, floor: since, now: Self.now) == nil` (re-run after rounds 2 and 3 — still red the same way each time) |
| 2 | Special-case suppressing the annotation once the gap is ≥29 days (simulating "drop the annotation for `.month` only") | `theWidestRangeIsAnnotatedTooWhenUnhonoured` | `Expectation failed: RequestCoverageHonesty.annotation(since: since, floor: floor, now: Self.now) != nil` |
| 3 | `guard let since else { return nil }` → default nil `since` to `.distantPast` (simulating "return the annotation for `.all`") | `allTimeIsNeverAnnotated`, `allTimeIsNeverAnnotatedEvenWhenEmpty` | `Expectation failed: RequestCoverageHonesty.annotation(since: nil, floor: floor, now: Self.now) == nil` (and the empty-store variant) |
| 4 | `guard let floor else { return … } ` → `return nil` (treat `oldest == nil` as fully covered) | `anEmptyStoreIsNotTreatedAsFullyCovered` | `Expectation failed: RequestCoverageHonesty.annotation(since: since, floor: nil, now: Self.now) != nil` (re-run after rounds 2 and 3 — still red the same way each time; the message the mutated branch used to return changed from `"no requests recorded yet"` to `"nothing yet"` in round 3, the test itself did not) |
| 5 | Use `summary.oldest` instead of the coverage floor | **not exercised by a mutation** — this is a wiring choice in `AppListModel.reloadRequestLog`/`RequestLogPane`, outside what `RequestCoverageHonesty`'s pure-function tests can see (the function only ever receives a `Date?` named `floor`; it has no notion of where the caller sourced it). Verified by code inspection instead: `retainedEventFloor` is set only from `eventStore.coverage(kind: "request").oldest`, and `summary.oldest` is no longer referenced anywhere in `RequestLogPane.swift` (`grep -n "summary.oldest" App/Sources/RequestLogPane.swift` matches only a doc comment). |
| 6 | Drop `guard hasLoaded else { return nil }` (round 3, finding 5) | `theFirstLoadWindowIsNeverAnnotated` | `Expectation failed: RequestCoverageHonesty.annotation( since: since, floor: nil, hasLoaded: false, now: Self.now ) == nil` |

Green baseline after every mutation above was reverted: `./scripts/app-tests.sh` → `✓ App tests — 34 of 34 cases executed` (`RequestCoverageHonestyTests` — 11 cases after round 3's two additions — plus the pre-existing `ScanRowAssemblyTests`, unaffected by this change).

## Review round 2 — four findings, all fixed on this branch

1. **Locale-leaking test (must fix).** `annotation(since:floor:now:)` had no `locale` parameter, so it always fell through to `Locale.current` — `aRangeTheStoreCannotBackGetsAnnotated`'s `note?.contains("19")` only passed on a host whose locale renders Western digits. Added `locale: Locale = .current`, forwarded to `relativeDescription`; the test now pins `en_US_POSIX`, the same seam `relativeDescription`'s own tests already used.

2. **The "composes cleanly in all six languages" claim was never measured (must fix).** I built the actual composed sentences — `RelativeDateTimeFormatter`'s real output for 19 hours and 3 days, substituted into each template — for all six languages. Two were wrong:

   - **fr**: `l'historique remonte à %@` / `l'historique ne remonte qu'à %@` both compose to `remonte à il y a 19 heures` / `ne remonte qu'à il y a 19 heures` — "à" stacked directly on "il y a" ("at" + "ago"), the exact mistake the old comment claimed French avoided. Fixed to `l'historique commence %@` (neutral) and `limite : %@` (warning) — neither needs a preposition in front of the substituted phrase, so there's nothing left to stack.
   - **ru**: `древнее %@ записей нет` composes to `древнее 19 часов назад записей нет` — `древнее` ("older than") is a comparative that wants a genitive noun, and "19 часов назад" is an adverbial "ago"-phrase, not a noun in that case. Fixed to `самые старые записи — лишь %@`, reusing the neutral key's case-free dash-apposition with `лишь` ("only") added.

   Composed sentences for all six, both fixed:

   | Lang | Template (neutral / warning) | Composed — 19 hours | Composed — 3 days |
   |---|---|---|---|
   | en | `records go back to %@` / `records only go back to %@` | records go back to 19 hours ago / records only go back to 19 hours ago | records go back to 3 days ago / records only go back to 3 days ago |
   | de | `Aufzeichnungen reichen bis %@ zurück` / `… nur bis %@ zurück` | Aufzeichnungen reichen bis vor 19 Stunden zurück / … reichen nur bis vor 19 Stunden zurück | … bis vor 3 Tagen zurück / … nur bis vor 3 Tagen zurück |
   | es | `los registros llegan hasta %@` / `los registros solo llegan hasta %@` | los registros llegan hasta hace 19 horas / los registros solo llegan hasta hace 19 horas | … hasta hace 3 días / … solo llegan hasta hace 3 días |
   | fr | `l'historique commence %@` / `limite : %@` (both fixed this round) | l'historique commence il y a 19 heures / limite : il y a 19 heures | l'historique commence il y a 3 jours / limite : il y a 3 jours |
   | ja | `%@ から記録されています` / `%@ からしか記録されていません` | 19 時間前から記録されています / 19 時間前からしか記録されていません | 3 日前から記録されています / 3 日前からしか記録されていません |
   | ru | `самые старые записи — %@` / `самые старые записи — лишь %@` (warning fixed this round) | самые старые записи — 19 часов назад / самые старые записи — лишь 19 часов назад | … — 3 дня назад / … — лишь 3 дня назад |
   | zh-Hans | `记录追溯到%@` / `仅追溯到%@` | 记录追溯到19小时前 / 仅追溯到19小时前 | 记录追溯到3天前 / 仅追溯到3天前 |

   `RelativeDateTimeFormatter` output used above (`en_US`/`de_DE`/`es_ES`/`fr_FR`/`ja_JP`/`ru_RU`/`zh_Hans_CN`, `.named` style, computed with a small standalone Swift script, not guessed): 19h ago → "19 hours ago" / "vor 19 Stunden" / "hace 19 horas" / "il y a 19 heures" / "19 時間前" / "19 часов назад" / "19小时前"; 3d ago → "3 days ago" / "vor 3 Tagen" / "hace 3 días" / "il y a 3 jours" / "3 日前" / "3 дня назад" / "3天前".

   de/es/ja/zh-Hans read correctly to the same non-native reasoning that caught the fr/ru bugs — but **none of the six, including the two fixes, has been checked by a native speaker.** The doc comment on `floorDescription` now says this explicitly instead of asserting a cross-language claim that was never measured.

3. **Status bar duplicated modifiers (should fix).** Collapsed the two `Text` branches (each repeating `.foregroundStyle(.tertiary)`/`.monospacedDigit()`) into one `footprintLine: String` computed property feeding a single `Text`.

4. **`String(localized:)` wrapper that does nothing (minor).** `rangeMenuLabel` wrapped an interpolation of two already-localized strings; after specifier removal the key is `%@ (%@)` with no letters, so `check_localizable_keys.py` exempts it and the lookup always misses. Switched to plain interpolation.

Re-verified in the foreground after all four fixes:

```
$ ./scripts/app-tests.sh
✓ App tests — 32 of 32 cases executed

$ python3 scripts/check_localizable_keys.py
✓ localizable keys agree — 536 in the catalog, all reachable
```

Re-ran two mutations against the changed code (both still red, confirming the fixes didn't disturb the guarded behavior):
- `guard floor > since` → `guard floor >= since`: `aFloorExactlyAtTheCutoffIsHonoured` fails with `Expectation failed: RequestCoverageHonesty.annotation(since: since, floor: since, now: Self.now) == nil`.
- nil-floor branch changed to `return nil` instead of the "no requests recorded yet" message: `anEmptyStoreIsNotTreatedAsFullyCovered` fails with `Expectation failed: RequestCoverageHonesty.annotation(since: since, floor: nil, now: Self.now) != nil`.

## Review round 3 — two findings, both fixed on this branch

5. **The fix re-committed the issue's own sin during the pre-load window (must fix).** `rangeMenuLabel` read a `nil` `retainedFloor` as "the store is empty" — but `retainedFloor` is *also* `nil` before the first load: `NetworkWindowView` renders the pane immediately and only then runs `.task` → `reloadRequestLog`, which first `await`s `eventStore.flush()` and then three queries against the whole store. For that window every bounded range claimed the store held nothing, while it actually held tens of thousands of events. Fixed by threading the pane's existing `hasLoaded` (already used at `:164` for exactly this distinction, `if hasLoaded { emptyState } else { Color.clear }`) into `annotation(since:floor:hasLoaded:now:locale:)`: not loaded yet says nothing; loaded-and-empty still says so. Two new tests pin the contrast — `anEmptyStoreIsNotTreatedAsFullyCovered` (`hasLoaded` defaults to `true`) and `theFirstLoadWindowIsNeverAnnotated` (`hasLoaded: false`) — both take `floor: nil` and must answer differently.

6. **The annotation also becomes the collapsed `Picker`'s own label, and it was very wide (must fix).** A `Picker`'s selected row is what the closed control displays. Measured with `NSFont.systemFont(ofSize: NSFont.systemFontSize)`:

   ```
   en before    68.5pt  Last 7 days
   en after    306.0pt  Last 7 days (records only go back to 19 hours ago)
   ru after    416.6pt  Последние 7 дней (самые старые записи — лишь 19 часов назад)
   de after    425.2pt  Letzte 7 Tage (Aufzeichnungen reichen nur bis vor 19 Stunden zurück)
   ```

   With the window's 640pt `minWidth` and `queryBar` splitting that between `QueryTokenField` and this `Picker` under `.fixedSize()`, that's roughly two thirds of the bar going to the picker on a German or Russian system at minimum width — and it fires in exactly the state the feature exists for, since `.all` (the default) is never annotated.

   Shortened the annotation to the bare relative phrase ("19 hours ago") or, for an empty store, "nothing yet" — no wrapping sentence. The status bar already states the full sentence unconditionally (`floorDescription`), so the menu only needs a short cue, not a repeat of the whole claim. This also retires two of the three sentence-shaped catalog keys round 1/2 had to reason through grammar for (`records only go back to %@`, `no requests recorded yet`); the relative-time case now reuses `RelativeDateTimeFormatter`'s own localized output directly, with no template of ours left to get wrong. Added one short new key (`nothing yet`), translated in all six languages — common, low-risk UI vocabulary ("noch nichts" / "nada aún" / "rien encore" / "まだありません" / "пока нет" / "暂无").

   Re-measured, same four rows:

   ```
   en before          68.5pt  Last 7 days
   en after (short)  159.9pt  Last 7 days (19 hours ago)
   ru after (short)  168.6pt  За 7 дней (19 часов назад)
   de after (short)  185.9pt  Letzte 7 Tage (vor 19 Stunden)
   ```

Re-verified in the foreground after both fixes:

```
$ ./scripts/app-tests.sh
✓ App tests — 34 of 34 cases executed

$ python3 scripts/check_localizable_keys.py
✓ localizable keys agree — 535 in the catalog, all reachable
```

Re-ran the same two round-2 mutations against the round-3 code (both still red), plus the new finding-5 mutation:
- `guard floor > since` → `guard floor >= since`: `aFloorExactlyAtTheCutoffIsHonoured` fails.
- nil-floor branch changed to `return nil` instead of the "nothing yet" message: `anEmptyStoreIsNotTreatedAsFullyCovered` fails.
- `guard hasLoaded else { return nil }` removed: `theFirstLoadWindowIsNeverAnnotated` fails with `Expectation failed: RequestCoverageHonesty.annotation( since: since, floor: nil, hasLoaded: false, now: Self.now ) == nil`.

## Deviation from #460's suggested menu wording

#460 suggested `Last 7 days (records only go back to 19 hours ago)` for the range-menu annotation — a full sentence with a subject ("records"). This PR ships the bare relative phrase instead: `Last 7 days (19 hours ago)`. That is a deliberate, considered deviation, not an oversight or a corner cut for convenience — a reviewer comparing the issue to the PR shouldn't have to guess which.

1. **Width, but not decisively.** Round 3 measured the sentence-length form as the closed `Picker`'s own displayed label — 306.0pt (en) / 416.6pt (ru) / 425.2pt (de) against 68.5pt for the plain label, inside a 640pt-minimum window. But width alone doesn't force the bare phrase: a middle form that keeps the subject — `Last 7 days (only to 19 hours ago)` / `Letzte 7 Tage (nur bis vor 19 Stunden)` / `Последние 7 дней (только до 19 часов назад)` — measures 204.4pt / 230.8pt, comfortably inside the window. So the width constraint stops binding one step up from where this PR landed.

2. **Grammar risk — the argument that actually decided it.** Any phrasing with a subject needs a preposition in front of the "ago"-phrase (`to`/`bis vor`/`до`), and that is *exactly* the construction that produced the two real grammar bugs round 2 of this review found and fixed: French `l'historique remonte à il y a 19 heures` ("à" stacked directly on "il y a" — "at" + "ago") and Russian `древнее 19 часов назад записей нет` (a genitive-demanding comparative governing an adverbial "ago"-phrase). Shipping `only to %@` / `nur bis vor %@` / `только до %@` would reopen that identical risk across all six catalog languages, for a cue the status bar already states in full and unconditionally (`floorDescription`). The bare relative phrase needs no preposition in front of it, in any of the six, because it needs no template of ours at all — it is `RelativeDateTimeFormatter`'s own localized output, unwrapped.

So round 3's shortening is not only a width fix: it also retires the two riskiest translated constructions this PR touched, in favor of text that Foundation's own localization is responsible for rather than this catalog's translations.

## Verification

```
$ ./scripts/app-tests.sh
✓ App tests — 34 of 34 cases executed

$ python3 scripts/check_localizable_keys.py
✓ localizable keys agree — 535 in the catalog, all reachable
```

Per instructions, I did **not** run `make test` or `make gallery` myself (this change doesn't touch row rendering). The coordinator has since run the full suite on this branch and reported it green: Core 2676, App 32/32 (pre-round-3 count — round 3 adds 2 more), 536 catalog keys (pre-round-3 count — round 3 nets to 535, having removed 2 sentence-shaped keys and added 1 short one).

## What I did NOT verify

- **Rendered width of the menu row's short form.** Round 3 measured the *closed* `Picker` control's width (the finding was specifically that the sentence-length version dominated it) but did not re-measure the row against real app names the way CLAUDE.md's popover-width discipline asks — this window's queryBar doesn't hold an app name at all, so that specific composition doesn't apply here the way it does in the popover, but I have not independently confirmed that.
- **On-screen appearance.** I did not build and run the app to look at the three sites, or the range menu specifically — every number above (round 2's grammar, round 3's widths) came from small standalone Swift scripts using the same measurement primitives the app itself would use (`RelativeDateTimeFormatter`, `NSFont.systemFont`), not from a screenshot of the running window. I avoided `make install` because it overwrites the one shared, signed app build other sessions may currently be using.
- **Native-speaker translation review — still open for all six languages.** Round 2 composed the surviving sentence (`records go back to %@`, still used by the status bar) for all six languages and fixed a real French bug; round 3 retired the two riskiest constructions entirely (the menu no longer builds a sentence around a relative phrase) and added one short, common phrase (`nothing yet`) I'm lower-risk about precisely because "nothing yet"-shaped UI vocabulary is common and mundane in all six. None of this is native-speaker-reviewed.
- **Mutation 5** (see table) is not exercised by an automated test; only by reading the wiring.



