### PR TITLE
Fix events_app_at comment, add event-store schema-drift gate (#462)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
@@ -1140,6 +1140,14 @@ public actor EventStore {
         // than repaired. If you are looking for it because a comment or an old
         // report mentioned it: it does not exist, on any machine, and grepping
         // the repo for `events_app_at` today turns up only this comment.
+        //
+        // This claim has an expiry date, not just a grep: `EventStoreSchemaDriftTests
+        // .freshInstallSchemaMatchesDeclaration` asserts the exact index set below
+        // against `createSchema`'s declaration. The day someone adds `(app_id, at)`
+        // back — #459 Stage 3 is expected to want it — that test goes red naming the
+        // new index, and whoever updates the test's expected set should update this
+        // paragraph in the same commit, not leave it asserting an absence that just
+        // became false.
         addColumnIfMissing(db, table: "events", column: "app_id", type: "TEXT")
         // Denormalised because the summary asks about it on every row, on every
         // refresh, and asking the payload meant a JSON parse per row that no

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
@@ -1127,8 +1127,19 @@ public actor EventStore {
         // after it. `sqlite3_exec` abandons the rest of a batch at the first
         // error, so with the repair afterwards, an older database failed on the
         // first statement mentioning the new column and skipped everything after
-        // it. Measured: `events_app_at` was missing from the real store, and so
-        // was every statement that followed it.
+        // it. Measured: back when the batch below still had a
+        // `CREATE INDEX events_app_at ON events(app_id, at)`, `app_id` did not
+        // exist yet on an upgraded database, so that statement failed and
+        // `events_app_at` was missing from the real store — along with every
+        // statement that followed it in the batch.
+        //
+        // `events_app_at` itself is gone now, not just fixed: once the ordering
+        // bug above was found, nothing in the codebase actually queried it — the
+        // `app:` filter is a leading-wildcard `LIKE '%x%'`, which cannot use an
+        // index regardless of ordering — so the dead index was deleted rather
+        // than repaired. If you are looking for it because a comment or an old
+        // report mentioned it: it does not exist, on any machine, and grepping
+        // the repo for `events_app_at` today turns up only this comment.
         addColumnIfMissing(db, table: "events", column: "app_id", type: "TEXT")
         // Denormalised because the summary asks about it on every row, on every
         // refresh, and asking the payload meant a JSON parse per row that no

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreSchemaDriftTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreSchemaDriftTests.swift
@@ -1,0 +1,201 @@
+import Testing
+import Foundation
+import SQLite3
+@testable import DuoUpdaterCore
+
+/// The gate issue #462 asked for: an upgraded machine and a fresh install can
+/// end up with different `events` table shapes, and nothing checked. Three
+/// leftovers on a real upgraded machine motivated the issue — an orphaned
+/// `task_id` column, `events_host_at` unable to serve the window's `host:`
+/// filter, and an `events_app_at` index that only ever existed in a comment —
+/// but the defect underneath all three is structural, not any one column or
+/// index. These tests pin the structural property.
+@Suite(.serialized)
+struct EventStoreSchemaDriftTests {
+
+    private static func store(fileURL: URL) -> EventStore {
+        EventStore(fileURL: fileURL, flushEventCount: 1, flushDelay: .milliseconds(10))
+    }
+
+    private static func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("events-schema-\(UUID().uuidString).sqlite")
+    }
+
+    private static func remove(_ url: URL) {
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(
+                at: url.deletingLastPathComponent()
+                    .appendingPathComponent(url.lastPathComponent + suffix))
+        }
+    }
+
+    // MARK: - Raw inspection
+
+    /// `pragma_table_info` column names in declaration order — the same shape
+    /// `createSchema`'s `CREATE TABLE` and any prior `ALTER TABLE ADD COLUMN`
+    /// leave behind. A second, independent connection, never the store's own:
+    /// the point is to see exactly what is on disk, not what the store's API
+    /// says it wrote.
+    private static func columnNames(table: String, at url: URL) throws -> [String] {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK,
+              let db else { throw URLError(.cannotOpenFile) }
+        defer { sqlite3_close_v2(db) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            db, "SELECT name FROM pragma_table_info(?) ORDER BY cid;", -1, &statement, nil
+        ) == SQLITE_OK, let statement else { throw URLError(.cannotOpenFile) }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, table, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        var names: [String] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let raw = sqlite3_column_text(statement, 0) { names.append(String(cString: raw)) }
+        }
+        return names
+    }
+
+    /// Explicitly-created indexes on `table` — `sqlite_autoindex_*` (the
+    /// implicit index behind `PRIMARY KEY`) excluded, since `createSchema`
+    /// never issues a `CREATE INDEX` for those and this is checking what it
+    /// declares.
+    private static func indexNames(table: String, at url: URL) throws -> Set<String> {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK,
+              let db else { throw URLError(.cannotOpenFile) }
+        defer { sqlite3_close_v2(db) }
+        var statement: OpaquePointer?
+        let sql = """
+            SELECT name FROM sqlite_master
+            WHERE type = 'index' AND tbl_name = ? AND name NOT LIKE 'sqlite_autoindex%';
+            """
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else { throw URLError(.cannotOpenFile) }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, table, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        var names: Set<String> = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let raw = sqlite3_column_text(statement, 0) { names.insert(String(cString: raw)) }
+        }
+        return names
+    }
+
+    // MARK: - Fixtures
+
+    /// A table shaped like a real machine that upgraded through several schema
+    /// versions: `app_id` already added, `task_id` still sitting there from
+    /// before it fell out of `createSchema`'s declared column list (#462 item
+    /// 1), `from_cache` not yet added. Column order and presence matches
+    /// `pragma_table_info` measured against the live store on this machine
+    /// 2026-09-12 (`id, at, client, kind, purpose, host, status, bytes_in,
+    /// bytes_out, payload, app_id, task_id, from_cache`), minus `from_cache` so
+    /// the migration path below has at least one column left to add — the same
+    /// role `addColumnIfMissing` plays on every real launch.
+    private static func makeUpgradedMachineSchema(at url: URL) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &db,
+                              SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK,
+              let db else { throw URLError(.cannotCreateFile) }
+        defer { sqlite3_close_v2(db) }
+        let sql = """
+            PRAGMA auto_vacuum=INCREMENTAL;
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE events (
+              id        TEXT PRIMARY KEY,
+              at        INTEGER NOT NULL,
+              client    TEXT    NOT NULL,
+              kind      TEXT    NOT NULL,
+              purpose   TEXT,
+              host      TEXT,
+              status    INTEGER,
+              bytes_in  INTEGER,
+              bytes_out INTEGER,
+              payload   TEXT    NOT NULL,
+              app_id    TEXT,
+              task_id   TEXT
+            );
+            CREATE INDEX events_at ON events(at);
+            CREATE TABLE totals (
+              client TEXT NOT NULL, purpose TEXT NOT NULL, host TEXT NOT NULL,
+              requests INTEGER NOT NULL DEFAULT 0, cached INTEGER NOT NULL DEFAULT 0,
+              not_modified INTEGER NOT NULL DEFAULT 0, failures INTEGER NOT NULL DEFAULT 0,
+              bytes_sent INTEGER NOT NULL DEFAULT 0, bytes_received INTEGER NOT NULL DEFAULT 0,
+              first_seen INTEGER NOT NULL, last_seen INTEGER NOT NULL,
+              PRIMARY KEY (client, purpose, host));
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            """
+        guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+            throw URLError(.cannotCreateFile)
+        }
+    }
+
+    // MARK: - Tests
+
+    /// A fresh install's `events` table must be exactly the twelve columns and
+    /// three indexes `createSchema` declares — not "whatever `addColumnIfMissing`
+    /// happened to add plus whatever the `CREATE TABLE` says", which is how a
+    /// stray column like `task_id` could exist in the declaration without
+    /// anyone noticing it never runs on a fresh install (or vice versa).
+    ///
+    /// Mutation-verified 2026-09-12: temporarily removing `bytes_out` from the
+    /// `CREATE TABLE` in `createSchema` turns this red, printing both arrays —
+    /// the declared list without `bytes_out` next to the expected list with it —
+    /// which is what "naming the column" looks like for an array equality
+    /// assertion. Reverted immediately after.
+    @Test("A fresh install's events table is exactly what createSchema declares")
+    func freshInstallSchemaMatchesDeclaration() async throws {
+        let url = Self.tempURL()
+        defer { Self.remove(url) }
+        let store = Self.store(fileURL: url)
+        _ = await store.schemaProblems() // forces open() -> createSchema()
+
+        let columns = try Self.columnNames(table: "events", at: url)
+        #expect(columns == [
+            "id", "at", "client", "kind", "purpose", "host",
+            "app_id", "from_cache", "status", "bytes_in", "bytes_out", "payload",
+        ])
+
+        let indexes = try Self.indexNames(table: "events", at: url)
+        #expect(indexes == ["events_at", "events_kind_at", "events_host_at"])
+    }
+
+    /// #462 item 1, settled rather than argued from the SQL shape: run the
+    /// store's real migration path (`open()` → `addColumnIfMissing` ×2 →
+    /// `CREATE TABLE IF NOT EXISTS`) over a database shaped like a real
+    /// upgraded machine, and compare the result to what a fresh install gets
+    /// from the identical code path.
+    ///
+    /// **Expected to fail today.** `task_id` survives the migration — nothing
+    /// in `createSchema` drops a column it does not declare — so the upgraded
+    /// shape carries an extra column the fresh shape never has. That failure
+    /// *is* the evidence for issue #462 item 1: an upgraded machine and a
+    /// fresh install do not have the same `events` table shape. Turning this
+    /// green means deciding what to do about `task_id` (see the issue and the
+    /// PR description for the two options and their costs) — a decision this
+    /// PR deliberately does not make.
+    @Test("An upgraded machine's schema matches a fresh install's after migration")
+    func upgradedMachineSchemaMatchesFreshInstallAfterMigration() async throws {
+        let (oldURL, freshURL) = (Self.tempURL(), Self.tempURL())
+        defer { Self.remove(oldURL); Self.remove(freshURL) }
+        try Self.makeUpgradedMachineSchema(at: oldURL)
+
+        let upgraded = Self.store(fileURL: oldURL)
+        _ = await upgraded.schemaProblems()
+        let fresh = Self.store(fileURL: freshURL)
+        _ = await fresh.schemaProblems()
+
+        let upgradedColumns = try Self.columnNames(table: "events", at: oldURL)
+        let freshColumns = try Self.columnNames(table: "events", at: freshURL)
+
+        withKnownIssue("""
+            #462 item 1: task_id is an orphan column — createSchema declares 12 \
+            columns and does not include it, but a machine that already had it \
+            (from an old schema version) keeps it forever because nothing drops \
+            an undeclared column. A fresh install never gets it. The two shapes \
+            diverge. Delete this wrapper once #462 is resolved one way or the \
+            other for task_id.
+            """) {
+            #expect(upgradedColumns == freshColumns)
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreSchemaDriftTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreSchemaDriftTests.swift
@@ -10,7 +10,11 @@ import SQLite3
 /// filter, and an `events_app_at` index that only ever existed in a comment —
 /// but the defect underneath all three is structural, not any one column or
 /// index. These tests pin the structural property.
-@Suite(.serialized)
+///
+/// Not `.serialized`: every test builds its own `UUID`-named temp database and
+/// touches nothing shared, so there is no ordering or isolation hazard here to
+/// document.
+@Suite
 struct EventStoreSchemaDriftTests {
 
     private static func store(fileURL: URL) -> EventStore {
@@ -163,16 +167,34 @@ struct EventStoreSchemaDriftTests {
     /// store's real migration path (`open()` → `addColumnIfMissing` ×2 →
     /// `CREATE TABLE IF NOT EXISTS`) over a database shaped like a real
     /// upgraded machine, and compare the result to what a fresh install gets
-    /// from the identical code path.
+    /// from the identical code path — columns *and* indexes.
     ///
-    /// **Expected to fail today.** `task_id` survives the migration — nothing
-    /// in `createSchema` drops a column it does not declare — so the upgraded
-    /// shape carries an extra column the fresh shape never has. That failure
-    /// *is* the evidence for issue #462 item 1: an upgraded machine and a
-    /// fresh install do not have the same `events` table shape. Turning this
-    /// green means deciding what to do about `task_id` (see the issue and the
-    /// PR description for the two options and their costs) — a decision this
-    /// PR deliberately does not make.
+    /// The index half is the one that matters for the historical failure this
+    /// area is actually about (see the rewritten `events_app_at` comment in
+    /// `createSchema`): a `CREATE INDEX` that fails on an upgraded database
+    /// takes every statement after it in the same `sqlite3_exec` batch down
+    /// with it. This fixture deliberately leaves `from_cache` un-added so the
+    /// migration path has a real `addColumnIfMissing` call to run — if that
+    /// call, or any statement before the index-creation batch, is ever moved
+    /// to *after* the batch (or made to fail on an upgraded shape), the batch
+    /// is abandoned and `events_kind_at`/`events_host_at` are silently never
+    /// created on upgraded machines. This assertion is outside the
+    /// `withKnownIssue` below because it passes today — both sides end up with
+    /// the same three indexes — and its job is to keep it that way, not to
+    /// record a known divergence.
+    ///
+    /// Mutation-verified 2026-09-12: moving the `app_id` `addColumnIfMissing`
+    /// call to after the `exec` batch turns this half red, naming the missing
+    /// indexes. Reverted immediately after.
+    ///
+    /// **The column half is expected to fail today.** `task_id` survives the
+    /// migration — nothing in `createSchema` drops a column it does not
+    /// declare — so the upgraded shape carries an extra column the fresh shape
+    /// never has. That failure *is* the evidence for issue #462 item 1: an
+    /// upgraded machine and a fresh install do not have the same `events`
+    /// table shape. Turning this green means deciding what to do about
+    /// `task_id` (see the issue and the PR description for the two options and
+    /// their costs) — a decision this PR deliberately does not make.
     @Test("An upgraded machine's schema matches a fresh install's after migration")
     func upgradedMachineSchemaMatchesFreshInstallAfterMigration() async throws {
         let (oldURL, freshURL) = (Self.tempURL(), Self.tempURL())
@@ -183,6 +205,11 @@ struct EventStoreSchemaDriftTests {
         _ = await upgraded.schemaProblems()
         let fresh = Self.store(fileURL: freshURL)
         _ = await fresh.schemaProblems()
+
+        let upgradedIndexes = try Self.indexNames(table: "events", at: oldURL)
+        let freshIndexes = try Self.indexNames(table: "events", at: freshURL)
+        #expect(upgradedIndexes == freshIndexes)
+        #expect(upgradedIndexes == ["events_at", "events_kind_at", "events_host_at"])
 
         let upgradedColumns = try Self.columnNames(table: "events", at: oldURL)
         let freshColumns = try Self.columnNames(table: "events", at: freshURL)


### PR DESCRIPTION
# Issue #462 — three structural leftovers in the event store

## Update: review findings addressed (this section first, since it's the newest thing here)

A review of the first version of this PR found three issues, addressed in a follow-up commit on this same branch:

**1 (must fix) — the upgrade test only guarded columns, not the index-level hazard the comment it's next to actually documents.** `upgradedMachineSchemaMatchesFreshInstallAfterMigration` compared `pragma_table_info` column names only. The historical failure this whole area is about (preserved in the rewritten `events_app_at` comment) was index-level: a `CREATE INDEX` that fails on an upgraded database takes every statement after it in the same `sqlite3_exec` batch with it. That scenario was still uncovered — moving an `addColumnIfMissing` call to after the batch, or adding a statement that fails on an upgraded shape, left both tests green while `events_kind_at`/`events_host_at` silently stopped being created on upgraded machines.

Added an index-set comparison to the same test, placed **outside** the `withKnownIssue` wrapper since it passes today (both sides end up with `events_at`, `events_kind_at`, `events_host_at`) — its job is to keep that true, not to record a known divergence.

Mutation-verified by temporarily reproducing the historical shape: moved `from_cache`'s `addColumnIfMissing` call to after the batch, and inserted a synthetic `CREATE INDEX events_from_cache_at ON events(from_cache)` ahead of `events_kind_at`/`events_host_at` in the batch (standing in for the real historical `events_app_at ON events(app_id, at)`, which depended on `app_id` the same way). Ran `swift test --package-path DuoUpdaterCore --filter EventStoreSchemaDriftTests` in the foreground with the mutation in place:

```
✘ Test "An upgraded machine's schema matches a fresh install's after migration" recorded an issue at EventStoreSchemaDriftTests.swift:211:9: Expectation failed: upgradedIndexes == freshIndexes
↳ upgradedIndexes == freshIndexes → false
↳   upgradedIndexes → ["events_at"]
↳   freshIndexes → ["events_from_cache_at", "events_host_at", "events_kind_at", "events_at"]
✘ Test "An upgraded machine's schema matches a fresh install's after migration" recorded an issue at EventStoreSchemaDriftTests.swift:212:9: Expectation failed: upgradedIndexes == ["events_at", "events_kind_at", "events_host_at"]
↳ upgradedIndexes → ["events_at"]
```

On the upgraded fixture the batch aborted right after the synthetic statement failed (no `from_cache` column yet), so `events_kind_at` and `events_host_at` were never created — only `events_at`, which ran before the failure, survived. The fresh install was unaffected (its `CREATE TABLE` declares `from_cache` inline, so the synthetic index succeeds too). The new assertion caught this and named the missing indexes. Reverted immediately after — `git diff` on `EventStore.swift` shows zero difference from before the mutation, confirmed by rerunning the same filtered test green.

**2 (should fix) — the `events_app_at` comment asserted an absence with no gate pointing at it.** It said the index "does not exist, on any machine" and that grepping turns up only that comment — both true today, but nothing would tell a future reader when that stopped being true (e.g., the day #459 Stage 3 adds `(app_id, at)` back). Added a sentence naming `EventStoreSchemaDriftTests.freshInstallSchemaMatchesDeclaration` as the test that goes red — naming the new index — the day that happens, so the comment and its gate are each findable from the other.

**3 (minor) — dropped `@Suite(.serialized)`.** Every test in the suite builds its own `UUID`-named temp database and shares no state, so the trait taught a constraint that doesn't exist. Documented the omission instead of leaving it silent.

Verification after the fix: `swift test --package-path DuoUpdaterCore --filter EventStoreSchemaDriftTests` (foreground) — green, 1 known issue (the `task_id` divergence, unchanged). Broader check `--filter "EventStore|InstallEventMigration|RequestQuery|RequestLogExport"` — 82 tests, 8 suites, green, 1 known issue. Coordinator separately ran full `make test` on this branch: 2678 tests, 2 known issues (up from main's 1 — the new `task_id` known issue is visible in the summary, not hiding in it).

---

## Part A — measurements (live store, opened read-only: `sqlite3 "file:$HOME/Library/Application Support/com.duoupdater.app/events.sqlite?mode=ro" ...`)

Snapshot taken 2026-09-12 ~12:05 local (the app was running and actively writing/pruning throughout this investigation, so later spot-checks show different row counts and file sizes — that is the live app doing its job, not a discrepancy in these numbers).

### 1. `task_id`

```
sqlite> select name from pragma_table_info('events');
id
at
client
kind
purpose
host
status
bytes_in
bytes_out
payload
app_id
task_id
from_cache

sqlite> select count(*) from pragma_table_info('events') where name='task_id';
1

sqlite> select count(*) from events where task_id is not null;
0

sqlite> select count(*) from events;
41812
```

`task_id` exists on the live table (confirmed) and is **not** in `createSchema`'s `CREATE TABLE` (confirmed by reading the source — 12 columns declared, `task_id` absent) and is **not** added by `addColumnIfMissing` (confirmed by reading the source — only `app_id` and `from_cache` are ever added). `grep -rn "task_id" App CLI DuoUpdaterCore` (excluding `.build`) returns **zero matches** — the only thing that exists is the Swift property `taskID` (camelCase) on `RequestEvent`/`RequestMetricsRecorder`, which lives in the JSON payload, never in a SQL column named `task_id`. And on the live machine, **every one of the 41,812 rows has `task_id IS NULL`** — the column is not merely unused by code, it holds no data on this machine either.

### 2. `events_host_at` — settled, not inferred

The issue explicitly flagged this ⚠️ 未验证 (inferred from SQL shape, not measured). Building the exact SQL each code path generates (quoting `RequestQuery.sqlPredicate()` and `EventStore.rawRows`/`requestRows` verbatim) and running `EXPLAIN QUERY PLAN` against the live store:

**(a) The window's `host:` filter** (`RequestQuery.sqlPredicate()` builds `anyOf("host", hosts, like: true)`, which is `"(host LIKE ?)"` bound to `"%x%"`; `requestRows` wraps that as `SELECT id, at, client, kind, payload FROM events WHERE kind = 'request' AND (host LIKE ?) ORDER BY at DESC, rowid DESC LIMIT ?`):

```
sqlite> EXPLAIN QUERY PLAN SELECT id, at, client, kind, payload FROM events
   ...> WHERE kind = 'request' AND (host LIKE '%x%') ORDER BY at DESC, rowid DESC LIMIT 500;
QUERY PLAN
`--SEARCH events USING INDEX events_kind_at (kind=?)
```

**Verdict: confirmed, not just plausible.** The planner does not touch `events_host_at` at all for this shape — it uses `events_kind_at` for the `kind='request'` equality (and gets the `ORDER BY at DESC` for free from that index's column order, no separate sort step). A leading-wildcard `LIKE` genuinely cannot use an index, exactly as the issue inferred.

**(b) `duo events --host`** (`EventStore.rawRows`, `query.host != nil` → `"host = ?"`, exact match):

```
sqlite> EXPLAIN QUERY PLAN SELECT id, at, client, kind, payload FROM events
   ...> WHERE host = 'github.com' ORDER BY at DESC, rowid DESC LIMIT 500;
QUERY PLAN
`--SEARCH events USING INDEX events_host_at (host=?)
```

This is the one path `events_host_at` actually serves.

**(c) The `kind`-prefixed index the issue also called suspicious** (`kind` only has two values, `request`/`install`):

```
sqlite> EXPLAIN QUERY PLAN SELECT id, at, client, kind, payload FROM events
   ...> WHERE kind = 'request' ORDER BY at DESC, rowid DESC LIMIT 500;
QUERY PLAN
`--SEARCH events USING INDEX events_kind_at (kind=?)
```

Low cardinality on `kind` alone undersells it: `events_kind_at` is `(kind, at)`, so for the two hottest query shapes above it both narrows to one partition *and* returns rows pre-sorted by `at`, avoiding a separate sort step entirely. It is not the dead weight the issue's aside suggested — it is pulling real weight. (This is a finding, not a request to touch it — no index changes are in this PR.)

### 3. `events_app_at`

```
$ grep -rn "events_app_at" . | grep -v '.build/'
DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift:1130: [the one comment, before this PR's fix]
```

Confirmed by `git log --all -p -S"events_app_at"`: `events_app_at` **did exist once** — it was a real `CREATE INDEX events_app_at ON events(app_id, at)` added in 5a8a3b70, and was the actual casualty of the ordering bug the comment describes (the `addColumnIfMissing(app_id)` call ran *after* the batch, so on an upgraded database the batch's `CREATE INDEX ... ON events(app_id, ...)` failed for want of the `app_id` column, and `sqlite3_exec` abandoned everything after it in the same batch). It was then **deleted outright** in 0d7e59a6 — the same commit that fixed the ordering — because "nothing queried it." The comment kept naming it as if it still existed. Fixed in this PR (see below); the historical detail is preserved, not deleted.

### 4. On-disk index cost (`dbstat` is available in this system's sqlite3)

```
$ sqlite3 --version
3.54.0 2026-04-09 12:25:13 8fa8248e303219400c646a885e36dfc52eae33d83f4412e3f369b2be5373aapl (64-bit)

sqlite> SELECT name, SUM(pgsize) FROM dbstat WHERE name LIKE 'events_%' GROUP BY name;
events_at|827392
events_host_at|1830912
events_kind_at|1204224

sqlite> SELECT name, SUM(pgsize) FROM dbstat GROUP BY name ORDER BY 2 DESC;
events|56184832
sqlite_autoindex_events_1|2568192
events_host_at|1830912
events_kind_at|1204224
events_at|827392
totals|73728
sqlite_autoindex_totals_1|49152
sqlite_schema|4096
sqlite_autoindex_meta_1|4096
meta|4096
```

`events_host_at` is the single largest secondary index on the table (~1.75 MiB) while serving exactly one query shape (`duo events --host`'s exact match) — the window's `host:` chip, the much more common path, cannot use it at all (settled above).

## Part B — shipped (no decision attached)

1. **Fixed the `events_app_at` comment** in `createSchema` (`DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift`). It now says what actually happened (the index existed once, failed to get created on an upgraded machine because of the ordering bug, and was then deleted once nothing was found to query it — not "repaired"), and states plainly that it does not exist anywhere today. The migration-ordering lesson (`addColumnIfMissing` must run before the batch; `sqlite3_exec` abandons the rest of a batch at its first error) is preserved, not deleted.

2. **Added `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreSchemaDriftTests.swift`** — the gate the issue was really asking for: nothing previously checked that an upgraded machine and a fresh install produce the same `events` table shape.
   - `freshInstallSchemaMatchesDeclaration` opens a fresh temp store, forces `open()`/`createSchema()` via the existing public `schemaProblems()` method, and asserts the on-disk column list (`pragma_table_info`) and explicit index list (`sqlite_master`, autoindexes excluded) match `createSchema`'s declaration exactly.
     - **Mutation-verified**: temporarily removed `bytes_out` from the `CREATE TABLE` in `createSchema`, ran the suite — test went red, printing both arrays (expected list with `bytes_out`, actual list without it):
       ```
       ✘ Test "A fresh install's events table is exactly what createSchema declares" recorded an issue …
       ↳ columns → ["id", "at", "client", "kind", "purpose", "host", "app_id", "from_cache", "status", "bytes_in", "payload"]
       ↳ [ … "bytes_in", "bytes_out", "payload" … ] → [ … "bytes_in", "bytes_out", "payload" ]
       ```
       Reverted immediately after (`git diff` on `EventStore.swift` is clean of this mutation in the final commit).
   - `upgradedMachineSchemaMatchesFreshInstallAfterMigration` builds a raw sqlite file shaped like a real upgraded machine (`task_id` present, matching the live store's actual column set minus `from_cache`), runs the store's real migration path (`open()` → `addColumnIfMissing` ×2 → `CREATE TABLE IF NOT EXISTS`) over it via `schemaProblems()`, and compares the resulting shape to a fresh install's.
     - **This test is red today**, which is the point — captured before wrapping it:
       ```
       ✘ Test "An upgraded machine's schema matches a fresh install's after migration" recorded an issue …
       ↳ upgradedColumns == freshColumns → false
       ↳   upgradedColumns → ["id", "at", "client", "kind", "purpose", "host", "status", "bytes_in", "bytes_out", "payload", "app_id", "task_id", "from_cache"]
       ↳   freshColumns → ["id", "at", "client", "kind", "purpose", "host", "app_id", "from_cache", "status", "bytes_in", "bytes_out", "payload"]
       ```
     - Wrapped in `withKnownIssue("#462 item 1: …")`, matching this repo's existing convention (`GitHubReleaseRuleTests.swift` is the only other user of `withKnownIssue`; `grep -rn "\.disabled(" DuoUpdaterCore/Tests` returns zero hits, so `withKnownIssue` — not `.disabled` — is the actual prior art here). With the wrapper, the suite passes overall while still recording and printing the known issue on every run:
       ```
       ━ Suite EventStoreSchemaDriftTests passed after 0.041 seconds with 1 known issue.
       ```
     Delete the wrapper once a decision on `task_id` (see Part C) makes this shape actually converge.

Verification: `swift test --package-path DuoUpdaterCore --filter EventStoreSchemaDriftTests` and `swift test --package-path DuoUpdaterCore --filter "EventStore|InstallEventMigration|RequestQuery|RequestLogExport"` (82 tests, 8 suites) — all green (1 known issue, as intended). `make test` was not run (per instructions — the user runs it before merging).

## Part C — proposals only, not implemented

### `task_id`: recommend **drop it**, but not in this PR, and not via `ALTER TABLE … DROP COLUMN`

- **What it costs today**: nothing at runtime — it holds no data (0/41,812 rows non-NULL, measured above) and no code path reads or writes it (`grep` returns zero hits outside this column's own existence). Its only cost is the one this issue is about: the schema-drift hazard, and the risk that #459 Stage 2 (making `taskID` a real column) collides with an existing column of the same name that has a different meaning/history.
- **What the honest fix costs**: `sqlite3 --version` on this machine is `3.54.0` (checked above), which **does support** `ALTER TABLE … DROP COLUMN` (added in SQLite 3.35.0, 2021). But "supported" undersells what it does to a ~60 MB live file: dropping a column via SQLite's `ALTER TABLE` still requires rewriting every row that has any column after the dropped one repacked (SQLite implements it by rebuilding the table when there are secondary indexes/triggers/etc. touching it in general, and at minimum it is not a metadata-only operation the way adding a column is) — on a file this size, opened during app launch, on the user's only copy of this data, that is exactly the kind of "irreversible schema change on live data" this task told me not to ship. It also isn't free even in the best case: it holds `SQLITE_OPEN_READWRITE` for the duration, which on a menu-bar app whose event store opens at launch is user-visible latency if it ever stalls (WAL contents, sidecar files, etc. all need to agree afterward).
- **Recommendation**: don't drop it via a live `ALTER TABLE`. Instead: stop treating it as unused-and-harmless (fix the drift gate above, which this PR does) and decide #459 Stage 2's naming collision by **not reusing the name** — call the real column something else (`request_task_id`, `hop_task_id`, whatever #459 prefers) so `task_id` is simply left behind as inert, never written, and its presence/absence stops mattering to correctness. It already costs zero bytes worth caring about relative to the 56 MB table. If a future full-table rewrite happens anyway for an unrelated reason (a `VACUUM INTO` migration, a version-bump reformat, etc.), drop it then, as a side effect of a rewrite that was going to touch every row regardless — not as a dedicated migration whose entire purpose is removing one all-NULL column.
- **What would make the opposite choice right**: if `task_id` turns out to be exactly what #459 Stage 2 wants (same semantics, just needs backfilling) — then the right move is to adopt it, not drop it, and the schema-drift test in this PR becomes the regression gate that proves the adoption actually reaches every machine, upgraded or fresh. I did not evaluate whether the semantics match; that's the actual Stage 2 design question and out of scope here.

### `events_host_at`: recommend **leave it**, revisit only alongside #459 Stage 3

- **What the measurements say**: `events_host_at` (1.83 MiB, the largest secondary index on the table) serves exactly one path — `duo events --host`'s exact match — and cannot serve the window's `host:` filter chip (leading-wildcard `LIKE`, confirmed by `EXPLAIN QUERY PLAN` above: the window query uses `events_kind_at` instead and never touches `events_host_at`). So today it is not dead, but it is narrowly used relative to its size.
- **What dropping it would cost**: `duo events --host` would fall back to a full scan filtered by `host = ?` with no index to narrow it — on a ~41,800-row table that's not going to be slow in absolute terms, but it is a real regression for a command whose entire purpose is being a fast diagnostic. And per this task's own constraint, `DROP INDEX` on the live store is exactly the kind of change I was told not to ship regardless of how it measures.
- **Recommendation**: leave it as-is. It is small in absolute terms (1.83 MiB out of a ~60 MB file), it serves a real (if narrow) path, and neither of the two things that would touch it — dropping it, or replacing it with something `LIKE`-friendly (e.g., a normalized reverse-host column, or FTS) — is proportionate to a 1.83 MiB line item. The more relevant fact from these measurements is #459 Stage 3's actual need: fair per-app eviction wants `(app_id, at)`, which does not exist at all (item 3, `events_app_at`) — that is where index effort should go next, not here.
- **What would make the opposite choice right**: if `duo events --host` usage data (not measured here) showed it is effectively never used relative to the window's `host:` chip, the 1.83 MiB might be worth reclaiming — but that is a usage-frequency question I have no data for, not a query-plan question, and 未验证 accordingly.

## What I could not measure (未验证)

- Whether `task_id`'s semantics (as it existed historically) match what #459 Stage 2 wants for a real `taskID` column — that's a design question for #459, not something measurable from this store.
- Real-world usage frequency of `duo events --host` vs. the window's `host:` chip — I have query-plan evidence for *what each path can use*, not telemetry on *how often each path runs*.

