### PR TITLE
docs: note duo verify --pkgarch drift sweep in README (#415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ It **respects each app's own update channel**:
   Team ID and destination checks do not inspect payload Mach-O executables, so
   an Intel-only package can pass those checks. DuoUpdater does not verify or
   automatically roll back architecture changes after the system installer runs.
+  `duo verify --pkgarch` sweeps every pkg spec's declared `hostArchitectures` for
+  drift, but that is not the same thing as an install-time gate: measured across
+  the registry, the declaration has never once said "Intel-only", and the
+  packages that actually vary by architecture are exactly the ones that declare
+  nothing — so a gate built on this field would not catch the case it exists for.
 - **Never force-quits** a running app. When an update needs the app restarted to
   take effect, the quit is a plain `terminate()` — the app runs its own save
   prompts and can refuse. One that refuses is left running and keeps a


### PR DESCRIPTION
## What

Closes the last open piece of #415 — acceptance criterion 4, the README half. Criteria 1–3 and the `PackageInstaller.swift` header comment were already done by #417 (`56d5a333`); this PR only touches `README.md`.

## Before

```
- **Package architecture limitation**: updates handed to the system installer
  (`.pkg` / `.mpkg`, including those inside disk images) do not pass DuoUpdater's
  runnable-architecture or native-to-Intel downgrade gates. Package signature,
  Team ID and destination checks do not inspect payload Mach-O executables, so
  an Intel-only package can pass those checks. DuoUpdater does not verify or
  automatically roll back architecture changes after the system installer runs.
```

## After

```
- **Package architecture limitation**: updates handed to the system installer
  (`.pkg` / `.mpkg`, including those inside disk images) do not pass DuoUpdater's
  runnable-architecture or native-to-Intel downgrade gates. Package signature,
  Team ID and destination checks do not inspect payload Mach-O executables, so
  an Intel-only package can pass those checks. DuoUpdater does not verify or
  automatically roll back architecture changes after the system installer runs.
  `duo verify --pkgarch` sweeps every pkg spec's declared `hostArchitectures` for
  drift, but that is not the same thing as an install-time gate: measured across
  the registry, the declaration has never once said "Intel-only", and the
  packages that actually vary by architecture are exactly the ones that declare
  nothing — so a gate built on this field would not catch the case it exists for.
```

**The install-time limitation itself is unchanged and still true** — `--pkgarch` is an offline drift sweep, not an install-time gate; there is still no architecture gate on the pkg install path. This PR only adds the missing "here's what does exist, and why it isn't a gate" half.

## Grep results — every home of this statement, and what was touched

```
README.md:93:  runnable-architecture or native-to-Intel downgrade gates. Package signature,
README.md:95:  an Intel-only package can pass those checks. DuoUpdater does not verify or
README.md:96:  automatically roll back architecture changes after the system installer runs.
DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift (header comment)
CLI/Sources/DuoKit/PackageArchitectureProbe.swift (header comment)
CLI/Sources/DuoKit/Verify.swift:506-529 (sweepPackageArchitecture doc comment)
CLI/Sources/duo/main.swift:172 (--pkgarch help text)
docs/app-audits/com-termius-dmg-mac.md:135 (unrelated — a single cask's arch note, not this general limitation)
```

- **Touched:** `README.md` only.
- **Not touched — already correct and up to date:** `PackageInstaller.swift`'s header already documents `duo verify --pkgarch` and the drift-vs-gate distinction (done as part of #417 for criterion 4's Swift half). `PackageArchitectureProbe.swift`, `Verify.swift`, and `main.swift` are the implementation/CLI-help copies and already describe the sweep correctly. `docs/app-audits/com-termius-dmg-mac.md` is an unrelated, app-specific note and not a copy of this statement.

## Verification

```
$ python3 scripts/check_app_audits.py
✓ app audits consistent — 119 docs, all indexed, no machine inventory, no pointers into untracked evidence
```

`scripts/check_prose_claims.py` only scans `*.swift` files (confirmed by reading it), so it does not apply to this README-only change. No Swift files were touched. Per instructions, `make test` was not run (left for merge-time).

## Test plan

- [x] Re-read `--pkgarch`'s implementation (`PackageArchitectureProbe.swift`) and CLI wiring (`Verify.swift`, `main.swift`) to confirm it is an offline HTTP-range sweep of declared `hostArchitectures`, not an install-time check.
- [x] `grep -rn` for every other copy of the package-architecture-limitation statement; confirmed none besides README need changing.
- [x] `python3 scripts/check_app_audits.py` passes.

Not merging — leaving open for review per the task.