### PR TITLE
docs: move AppListModel's running-app-detection comments' archaeology to docs/engine-notes (#409)

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -6233,21 +6233,9 @@ final class AppListModel {
     /// AppKit's own header prescribes: "Instead of polling, use key-value observing
     /// to be notified of changes to this array property" (`NSRunningApplication.h`).
     /// The launch/terminate notifications are kept as a second, independent
-    /// delivery path — they cost one no-op recompute each when both fire.
-    ///
-    /// **Why not the notifications alone** (issue #247). They are posted per app by
-    /// LaunchServices and are, measured on this machine, simply missing for some
-    /// apps in both directions, while the array — which cannot fail to lose an
-    /// entry when a process exits — always moved. One process, all four observers
-    /// plus a 200 ms poll as ground truth, 2026-09-02:
-    ///
-    ///     Alcove, 4 quits + 4 relaunches   notifications 0/8   KVO 8/8
-    ///     UURemote quit (+UURemoteServer)  no didTerminate     KVO caught both
-    ///     AppCleaner (control)             both fire           KVO 512 ms earlier
-    ///
-    /// KVO also beat the 200 ms poll by 26–180 ms on every transition, so the
-    /// ~2 s reconcile timer the issue proposed is not needed: there is nothing for
-    /// it to catch that this misses sooner.
+    /// delivery path — they cost one no-op recompute each when both fire. See
+    /// `docs/engine-notes/app-list-model.md` §2 for why (issue #247's measurement
+    /// of where the notifications alone fell short).
     ///
     /// **What it does not change.** The property "will only change when the main
     /// run loop is run in a common mode" (same header) — exactly the condition the
@@ -6258,11 +6246,9 @@ final class AppListModel {
     /// snapshot (~140 entries, ~130 with a bundle URL and ~105 of those distinct),
     /// a bundle-id set, and a `realpath` for each bundle path *not seen in the
     /// previous snapshot* — for most events, none; for a launch, the app and
-    /// whatever XPC services came up with it. `RunningBundlePathCache` is what
-    /// keeps it to that: this used to resolve every running bundle's symlinks on
-    /// every event, measured at 1.16 ms against 0.10 ms now (release build, live
-    /// snapshot), per launch/quit anywhere on the machine, all day, under a
-    /// comment that called it an in-memory walk.
+    /// whatever XPC services came up with it. See `RunningBundlePathCache`'s own
+    /// doc comment for what keeping that resolution buys and what it used to cost
+    /// without it.
     private func armRunningAppsMonitor() {
         // Seed before observing rather than passing `.initial`: the seed must set
         // the baseline the first real change is diffed against, without running the
@@ -6861,14 +6847,14 @@ final class AppListModel {
     /// app without paying for a whole sweep.
     ///
     /// It re-derives the running set first, so it also corrects a row whose
-    /// *running* state has gone stale. `NSWorkspace`'s launch/terminate
-    /// notifications are the only thing maintaining that set, and some apps never
-    /// post one of them — measured: Alcove posts no `didLaunch`, UURemote no
-    /// `didTerminate` (issue #247) — which leaves the dot lit for an app that has
-    /// quit, or dark for one that is open. That recompute is whole-set and, since
-    /// the resolutions are memoized, 0.095 ms; it happens before the network check
-    /// rather than after, so the dot is right the moment the row starts checking
-    /// instead of when the source answers.
+    /// *running* state has gone stale. `armRunningAppsMonitor` keeps that set
+    /// live off KVO on `runningApplications`, measured to catch what the
+    /// launch/terminate notifications miss (issue #247) — but this call is a
+    /// floor under that live path, not a substitute for it, the same reasoning
+    /// `performRefresh` and `performLocalRescan` take it for. That recompute is
+    /// whole-set and, since the resolutions are memoized, 0.095 ms; it happens
+    /// before the network check rather than after, so the dot is right the
+    /// moment the row starts checking instead of when the source answers.
     ///
     /// Reuses the install-stage spinner to show "Checking" on just that row, and
     /// bails if the row is already busy (installing or mid-recheck).

--- a/docs/engine-notes/README.md
+++ b/docs/engine-notes/README.md
@@ -63,4 +63,4 @@ what to do when the number has already drifted once.
 
 - [`app-store-page-cache.md`](app-store-page-cache.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift`
 - [`pre-install-gate.md`](pre-install-gate.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift`
-- [`app-list-model.md`](app-list-model.md) — `App/Sources/AppListModel.swift`'s install path (`install` / `runInstall` / `GateHandle` / `performInstall`)
+- [`app-list-model.md`](app-list-model.md) — `App/Sources/AppListModel.swift`, migrated in slices: §1 the install path (`install` / `runInstall` / `GateHandle` / `performInstall`), §2 running-app detection (`armRunningAppsMonitor` / `refreshRunningApps` / `retry`)

--- a/docs/engine-notes/app-list-model.md
+++ b/docs/engine-notes/app-list-model.md
@@ -1,13 +1,19 @@
-# AppListModel install path: design history
+# AppListModel: design history
 
-Companion to the install path in `App/Sources/AppListModel.swift`
-(`install` → `runInstall` → `GateHandle` → `performInstall`). The source file
-keeps the current contract; this file keeps *why it looks that way* where that
-reasoning is a rejected prior design rather than something still true today.
-Written for issue #409, which asked this file to be done in slices rather than
-all at once — this is the first slice, the install path.
+Companion to `App/Sources/AppListModel.swift`. The source file keeps the
+current contract; this file keeps *why it looks that way* where that
+reasoning is a rejected prior design, an incident timeline, or a measurement
+rather than something still true today. Written for issue #409, which asked
+this file to be migrated in slices rather than all at once — each `§` below
+is one slice's content, introduced by a short paragraph naming which part of
+`AppListModel.swift` that slice covers. This is not one-file-per-subsystem
+the way `docs/engine-notes/README.md`'s
+naming rule reads at a glance; it is one file per *source* file, exactly as
+the README states, and `AppListModel.swift` is the one source file large
+enough that its own migration spans several unrelated subsystems.
 
-This slice is deliberately short. Most of the install path's comments describe
+**§1** (below) is the first slice, the install path. This slice is
+deliberately short. Most of the install path's comments describe
 a **current** contract or a non-obvious constraint (why `offered` and not the
 re-check's own result decides `.answerRegressed`, why `refreshRunningApps()`
 takes a fresh snapshot before deferring to a self-updater, why `GateHandle`
@@ -58,9 +64,73 @@ double-signaling the semaphore on the paths that do.
 
 ---
 
+**§2** (below) is the second slice: running-app detection
+(`armRunningAppsMonitor` / `refreshRunningApps` / `handleRunningAppsChange`,
+and `retry()` as one of the callers that leans on it), the path issue #247
+rewrote. The current contract — KVO is the source of truth, the
+notifications are kept as a redundant second path, a snapshot needs a live
+run loop to stay current — stays next to the code; what follows is the
+measurement issue #247 was filed and closed on, which nothing else in the
+source points at.
+
+## §2 Why running-app detection trusts KVO over the launch/terminate notifications (issue #247)
+
+Before commit `03dd3d46` ("App: drive the running set from KVO, not the
+launch/terminate notifications", 2026-09-02), `runningAppPaths` was kept
+live off `NSWorkspace.didLaunchApplicationNotification` /
+`didTerminateApplicationNotification` alone. Those notifications are posted
+per app by LaunchServices and, per that commit's own measurement, were
+simply missing for some apps in both directions — while
+`runningApplications` (the array KVO observes) cannot fail to lose an entry
+when a process exits, so it always moved. One process observing both
+notifications and KVO, against a 200 ms poll as ground truth, 2026-09-02:
+
+    Alcove, 4 quits + 4 relaunches    notifications 0/8    KVO 8/8
+    UURemote quit (+ UURemoteServer)  no didTerminate      KVO caught both
+    AppCleaner (control)              both fired           KVO 512 ms earlier
+
+KVO also beat the 200 ms poll by 26–180 ms on every transition it caught,
+which is why the ~2 s reconcile timer issue #247 originally proposed as a
+backstop was dropped rather than added: there was nothing left for a
+periodic reconcile to catch that KVO didn't already report sooner.
+
+⚠️ One-time measurement on one machine, not a tracked benchmark — see this
+directory's README on the difference. It has not been re-run for this pass:
+whether the specific notification gaps above (Alcove's, UURemote's) are a
+stable LaunchServices property, or an artifact of that machine/OS build on
+2026-09-02, is unverified either way. What *was* re-checked for this pass
+(2026-09-12): `armRunningAppsMonitor` still observes
+`NSWorkspace.runningApplications` via KVO as its primary path, with the two
+notifications kept as a secondary one, matching the source comment — the
+architecture this measurement justified has not drifted.
+
+**A false claim this pass found, not just an old one it moved.** `retry()`'s
+own doc comment read: "`NSWorkspace`'s launch/terminate notifications are
+the only thing maintaining that set." That was true of the code when it was
+written — commit `3841dfb8`, the same day, 13 minutes *before* `03dd3d46`
+landed — but was never updated once KVO shipped, and has said the opposite
+of the running mechanism ever since: KVO has been the source of truth since
+2026-09-02, and `retry()`'s explicit re-derivation is a defensive floor
+under that live path (the same role `performRefresh` and
+`performLocalRescan`'s own comments describe it playing at their call
+sites), not the only thing keeping the set current. Fixed in the same edit
+that added this section's pointer, on the reasoning that a comment
+contradicting the section it now points at is worse than the long version
+it replaced.
+
+---
+
 Tests: `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/` has no dedicated test for
 the host-gate release point itself (it's exercised indirectly by
 `AppListModel`'s own concurrency, which the app-layer test target does not
 construct — see `CLAUDE.md`'s "App 层的测试 target" section for why). The
 per-host/App-Store gate split itself is `hostInstallGate(for:)` and
-`Self.appStoreInstallGate` in `AppListModel.swift`, upstream of this section.
+`Self.appStoreInstallGate` in `AppListModel.swift`, upstream of §1.
+
+Same absence for §2: nothing constructs `AppListModel` to exercise
+`armRunningAppsMonitor`'s KVO wiring itself. What IS tested, in
+`DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RunningBundlePathCacheTests.swift`,
+is the cache `refreshRunningApps` calls into — eviction on a process quit,
+re-resolution on reappearance, the staging-name normalisation `retry()`'s
+correctness depends on — everything downstream of "here is this event's
+snapshot of running bundle URLs", not the KVO delivery itself.


### PR DESCRIPTION
## Scope

Second slice of `App/Sources/AppListModel.swift` for #409 (the issue's own ordering: small files first — `AppStorePageCache.swift` (#431) and `PreInstallGate.swift` (#438) are already done — then `AppListModel.swift` in slices; the first slice was the install path, #439). This is one narrow slice, matched to #439's size, **not** the rest of the file.

**Region chosen and why**: `armRunningAppsMonitor` / `refreshRunningApps` / `handleRunningAppsChange` — the running-app-detection path issue #247 rewrote — plus `retry()`, one of its callers. Considered and rejected other candidates in the same file (the Amp/Surge marketing-vs-build measurement around L4779, the TestFlight-tester-query timing around L2232, the App-Store-page-cache TTL/measurement duplicate around L1192) because each of those either interleaves with subsystems a future slice would need to touch on its own, or is comment-light contract rather than archaeology. This region is self-contained (one incident, one commit that resolved it, one later comment that drifted from that resolution) and every comment in it is genuinely incident/measurement material, not contract a future editor needs in front of them.

## What moved, and where

| block | destination |
|---|---|
| `armRunningAppsMonitor`'s "Why not the notifications alone" paragraph — issue #247's Alcove/UURemote/AppCleaner measurement table and the 200ms-poll comparison | `docs/engine-notes/app-list-model.md` §2 |
| `armRunningAppsMonitor`'s `RunningBundlePathCache` before/after numbers (1.16ms → 0.10ms) | trimmed to a pointer — `RunningBundlePathCache.swift`'s own doc comment already carries the authoritative, more precise version (1.164ms / 0.095ms / 0.047ms, 129 URLs / 106 distinct) of the same measurement. This was a second copy, not a place with nothing else pointing at it. |
| `retry()`'s framing of why it re-derives the running set | rewritten in place (see below), not moved — it's current contract about that call site, restated to match the (already-current) framing at `performRefresh` and `performLocalRescan` |

`docs/engine-notes/app-list-model.md`'s title and intro were broadened from "install path" to the whole file, since it now covers two unrelated subsystems across its two slices; `README.md`'s Index line was updated to match (grepped for other copies of "install path" scoping this file — those two were the only ones).

## Historical claims re-checked (2026-09-12)

- **KVO is still the primary path**: still true. `armRunningAppsMonitor` still observes `NSWorkspace.runningApplications` via `.observe(\.runningApplications)`, with the two notifications kept as a secondary path, matching the source comment.
- **Issue #247's Alcove/UURemote/AppCleaner measurement table**: could not verify — it's a one-time, dated (2026-09-02) live-process observation on one machine; re-running it would need those exact apps running and quitting again. Marked as such in the doc, per this directory's own convention for this shape of claim.
- **`RunningBundlePathCache`'s numbers as restated in `AppListModel.swift`** (1.16ms/0.10ms): consistent with, and a rounded duplicate of, that struct's own doc comment (1.164ms/0.095ms) — not contradictory, just a third copy waiting to drift. Trimmed to a pointer instead of moved.
- **`retry()`'s "NSWorkspace's launch/terminate notifications are the only thing maintaining that set"**: **no longer true — this is the finding, not just tidying.** Confirmed by commit timestamps: this sentence was introduced in `3841dfb8` at 14:23:40 on 2026-09-02; `03dd3d46`, which made KVO (not the notifications) the source of truth, landed 13 minutes later at 14:36:40 the same day. The sentence was never revisited and has asserted the opposite of the running mechanism for the entire time since. Fixed in place to match the accurate framing `performRefresh` and `performLocalRescan` already use for the same call pattern ("a floor under the live path, not a substitute for it").

## Duplicate check

`grep -rn` for the moved measurement text (`"Alcove, 4 quits"`, `"AppCleaner (control)"`, `"are the only thing maintaining"`) across the repo, including `.claude/skills` and `.agents`: no other copies found. The only other mentions of issue #247 are at call sites that already cite it correctly (`performRefresh`, `performLocalRescan`, `handleRunningAppsChange`'s debug-log comment, and one line each in `MenuContentView.swift` / `WorkbenchWindowView.swift`) — none of those needed changing.

## Verification

- `python3 scripts/check_engine_notes.py` (foreground):
  ```
  ✓ engine-notes pointers resolve — 523 Swift files scanned, 3 doc(s) indexed
  ```
- `swift build --package-path DuoUpdaterCore` (foreground): builds clean (pre-existing unrelated warning about two test fixture JSON files, unchanged by this PR).
- `App/Sources` isn't covered by that build. Two cheap proxies used instead, since `make test`/`app-tests.sh` weren't run per instructions:
  1. `git diff App/Sources/AppListModel.swift` — every added/removed line starts with `//` or `///`; mechanically, no non-comment line was touched.
  2. `swiftc -parse App/Sources/AppListModel.swift` — exits 0. Syntax-only (doesn't resolve the project's type graph), but it does catch a broken doc-comment or brace from the edit, which is the actual risk in a comment-only change.
  I did not run the full app build/`app-tests.sh` — the full suite will catch anything these two miss.

**No behavior change.** The diff is comments and `docs/` only: no non-comment line in any `.swift` file changed (confirmed above), and no new/removed declarations, calls, or control flow.

Do not merge / no auto-merge — for review.