### PR TITLE
Downloader: name a createFile failure clearly (does not close #419)

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
@@ -45,6 +45,15 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
         /// than the server itself declared as the object's length. Transient when
         /// short — the next attempt resumes from where this one stopped.
         case lengthMismatch(received: Int64, expected: Int64)
+        /// `startFresh` could not (re)create the partial file on disk — its
+        /// scratch directory is gone, unwritable, or out of space. Investigated
+        /// as a candidate for #419 and found NOT to be that mechanism (see
+        /// `Downloader.swift`'s `startFresh` doc comment); kept because
+        /// `FileManager.createFile`'s `Bool` was previously discarded, so this
+        /// failure used to surface only indirectly, as whatever error the next
+        /// `FileHandle(forWritingTo:)` happened to throw. Not retried: the same
+        /// directory problem would recur.
+        case cannotCreatePartialFile(String)
         var errorDescription: String? {
             switch self {
             case .httpStatus(let code):
@@ -55,6 +64,8 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
                 return "The server sent a partial response that cannot be used: \(reason)."
             case .lengthMismatch(let received, let expected):
                 return "The server closed the connection after \(received) of \(expected) bytes."
+            case .cannotCreatePartialFile(let path):
+                return "Couldn't create a fresh download file at \(path)."
             }
         }
     }
@@ -594,9 +605,31 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     /// Start the partial file over from byte zero for a response that carries the
     /// whole object, and adopt that response's validator for later resumes: the
     /// old one described bytes that are being thrown away.
+    ///
+    /// This is the only place mid-download that removes the partial, and it was
+    /// investigated as the mechanism behind #419 (a local-only flake in
+    /// `installPipelineDryRun`, theorized as a race between this `removeItem`
+    /// and `finalizePartial`'s `moveItem`). It isn't one: `download`'s data
+    /// tasks run one at a time on one serial delegate queue, and the previous
+    /// attempt's `fileHandle` is already closed (in `didCompleteWithError`,
+    /// before the next attempt's response can reach here) — there is no second
+    /// writer for a `removeItem` to race. A deterministic replay of the exact
+    /// suspected shape (a truncated first response, then a resume answered
+    /// `200` instead of `206`) passes reliably; see
+    /// `downloaderRestartsWhenRangeIsAnsweredAs200`.
+    ///
+    /// `createFile`'s `Bool` WAS being discarded, though: if it fails (its
+    /// directory vanished, filled up, or lost write permission), the `try
+    /// FileHandle(forWritingTo:)` right below still throws — just with
+    /// whatever generic "no such file" error `FileHandle` happens to produce,
+    /// not one that names `startFresh` as the place it went wrong. Checking it
+    /// only makes that existing failure legible; it does not change whether
+    /// this throws.
     private func startFresh(from http: HTTPURLResponse?) throws {
         try? FileManager.default.removeItem(at: partialURL!)
-        FileManager.default.createFile(atPath: partialURL!.path, contents: nil)
+        guard FileManager.default.createFile(atPath: partialURL!.path, contents: nil) else {
+            throw DownloadError.cannotCreatePartialFile(partialURL!.path)
+        }
         fileHandle = try FileHandle(forWritingTo: partialURL!)
         writtenOffset = 0
         resumeValidator = Self.strongValidator(http)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DownloaderTrafficTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DownloaderTrafficTests.swift
@@ -791,4 +791,52 @@ struct DownloaderTrafficTests {
         _ = try await downloader.download(src)
         #expect(downloader.bytesDownloaded == Int64(body.count))
     }
+
+    // MARK: - #419: `startFresh` must not swallow a failed `createFile`
+
+    /// #419 theorized `startFresh`'s `removeItem`/`createFile` racing
+    /// `finalizePartial`'s `moveItem` on the retry-to-200 path. That theory did
+    /// not hold up (see `startFresh`'s doc comment and
+    /// `downloaderRestartsWhenRangeIsAnsweredAs200`, which replays exactly that
+    /// shape and passes), but chasing it surfaced a real, narrower gap:
+    /// `FileManager.createFile`'s `Bool` was discarded, so a failed create
+    /// silently fell through to whatever the next line, `FileHandle(forWritingTo:)`,
+    /// happened to throw — never `Downloader.DownloadError`.
+    ///
+    /// Deterministic and timing-free: making the scratch directory read-only
+    /// up front means the very first `startFresh` (attempt 1 is a "200" too —
+    /// no partial exists yet) hits a `createFile` that is guaranteed to fail,
+    /// no server choreography or retry needed. Read+execute permission is left
+    /// in place so `FileManager` can still resolve `destinationDir` itself;
+    /// only creating an entry inside it is blocked.
+    @Test func downloaderNamesTheFailureWhenStartFreshCannotCreateThePartial() async throws {
+        let body = Data((0..<4096).map { UInt8($0 & 0xFF) })
+        let server = try OneShotHTTPServer(body: body)
+        defer { server.stop() }
+        let workDir = try makeWorkDir("readonly-scratch")
+        defer {
+            // Restore write permission before cleanup — `removeItem` on a
+            // read-only directory's contents would otherwise fail too.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: workDir.path)
+            try? FileManager.default.removeItem(at: workDir)
+        }
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o500], ofItemAtPath: workDir.path)
+
+        let url = URL(string: "http://127.0.0.1:\(server.port)/blob.bin")!
+        let downloader = Downloader(destinationDir: workDir) { _ in }
+        do {
+            _ = try await downloader.download(url)
+            Issue.record("expected download to fail when its scratch directory can't be written to")
+        } catch let error as Downloader.DownloadError {
+            guard case .cannotCreatePartialFile = error else {
+                Issue.record("unexpected DownloadError: \(error)"); return
+            }
+        } catch {
+            let message = "createFile's failure surfaced as \(type(of: error)) (\(error)) "
+                + "instead of Downloader.DownloadError.cannotCreatePartialFile"
+            Issue.record("\(message)")
+        }
+    }
 }


### PR DESCRIPTION
## What this is (and isn't)

Investigating #419 to find and fix the real mechanism. **It does not close #419.** None of the three theories on the table — the issue body's, the issue comment's, or the one I was asked to test — turned out to explain the reported flake. What follows is the evidence for that, plus one real (but different, narrower) bug the investigation surfaced and fixed.

## The three theories, and what the evidence showed

1. **Issue body: scratch-directory lifecycle race.** Already established wrong by the issue's own follow-up comment, and the real instance of that shape (two concurrent `installPipelineDryRun` runs sharing an unsuffixed scratch dir name) was already fixed separately in #420. Not re-touched here.

2. **Issue comment: `startFresh`'s `removeItem`→`createFile` racing `finalizePartial`'s `moveItem`, on the retry-to-200 path.** This is the one the comment calls out specifically. It does not hold up:
   - `Downloader.download` runs one `URLSessionDataTask` at a time, and all its delegate callbacks are serialized on one delegate queue. The previous attempt's `fileHandle` is explicitly closed in `didCompleteWithError`, and that happens-before the next attempt's `runAttempt`/`didReceive response:` can call `startFresh` again. There is no second writer for `removeItem` to race — a race needs two things touching the file concurrently, and this is strictly one-at-a-time.
   - A deterministic replay of the *exact* suspected shape already exists in the suite: `downloaderRestartsWhenRangeIsAnsweredAs200` truncates the first response, then answers the resumed (ranged) request with a plain `200` and the whole body — precisely the "resume gets 200 instead of 206" path the comment describes. Run 30 times back-to-back: **30/30 pass**. Run 20 more times as part of the full `DownloaderTrafficTests` suite: **20/20 pass** (18 tests each, 0 failures).
   - The issue comment itself flagged this as unverified: "没有任何一条日志显示失败那次真的发生了重试" (no log shows a retry actually happened). That gap stands — I could not find or force evidence that a real resume-to-200 event happened in the failing runs.

3. **My hypothesis (unchecked `createFile` Bool / a handle outliving `removeItem`).** Also not the mechanism for *this* symptom:
   - The stale-handle half doesn't apply, for the same serialization reason as (2) — there's no live handle at the moment any `removeItem` runs.
   - The unchecked-`Bool` half is real as a *code smell*, but tracing it shows it can't produce the reported symptom: if `createFile` fails, the very next line, `FileHandle(forWritingTo:)`, throws immediately — the download fails right there, before ever reaching `finalizePartial`'s `moveItem`. I confirmed this by making the scratch directory read-only and observing today's actual thrown error: `NSCocoaErrorDomain Code=4 "The file ... doesn't exist."` — an early, distinct failure, not a later `moveItem` failure.

## What I could not reproduce

Real downloads through the same local HTTP/HTTPS proxy the issue names, including **Helium**, the exact app in the report:
- Default `installPipelineDryRun` (single candidate, "Amp" today): **13/13 pass**.
- Full `DUO_INSTALL_SMOKE=all` sweep (6 candidates including Helium, 120 MB dmg): **6/6 pass**, one full run.

That's 19 clean real-network runs through the proxy, but the original report was ~2/7 (≈71% pass rate) — 19 clean runs doesn't statistically rule out a rarer failure. **I did not reach a high-confidence pass rate for the actual reported flake**, because I could not force the one condition the comment's theory depends on (a resume answered `200` instead of `206` by a *real* vendor CDN through a *real* proxy) to happen on demand. The author's own suggested experiment — hitting `updates.helium.computer` bypassing the proxy vs. through it, N times each — would settle whether the proxy ever actually produces that condition; I did not run it (budget: that's real vendor bandwidth, and the theory it would test is already looking unlikely given the deterministic replay above).

**#419 should stay open.** I have no fix to offer for it, only a stronger case that the mechanism proposed for it isn't real, plus one narrower thing I did find and fix (below).

## What I did fix

Chasing hypothesis 3 surfaced a real, independent gap: `startFresh` discarded `FileManager.createFile`'s `Bool` return. If that create ever genuinely fails (directory vanished, disk full, permissions), execution didn't stop there — it fell through to whatever generic, unlabeled error the next line's `FileHandle(forWritingTo:)` happened to throw, never a typed `Downloader.DownloadError`. Harmless today (the download still fails, just with a confusing message), but exactly the kind of silent-failure gap this repo's CLAUDE.md asks to close on sight.

Fix: check the `Bool`, throw a new `DownloadError.cannotCreatePartialFile` when it's false. Both the enum case and `startFresh`'s doc comment record that this was investigated as an #419 candidate and ruled out, so the next person doesn't have to redo this trace.

### Regression test: red → green

`downloaderNamesTheFailureWhenStartFreshCannotCreateThePartial` — makes the scratch directory read+execute-only (no write), so the very first `startFresh` call is guaranteed to hit a failing `createFile`. Deterministic, no server choreography or timing dependency.

**Red** (behavior reverted, enum case kept so it still compiles — i.e. testing the actual behavior change, not just a missing symbol):
```
✘ Test downloaderNamesTheFailureWhenStartFreshCannotCreateThePartial() recorded an issue at DownloaderTrafficTests.swift:839:25: Issue recorded
↳ createFile's failure surfaced as NSError (Error Domain=NSCocoaErrorDomain Code=4 "The file “.duo-download-B1330B21-C1F0-4D27-8513-EEAF7CF1891D.partial” doesn’t exist." UserInfo={NSFilePath=/var/folders/.../dl-readonly-scratch-.../.duo-download-....partial, NSUnderlyingError=0x7a114ae310 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}) instead of Downloader.DownloadError.cannotCreatePartialFile
✘ Test downloaderNamesTheFailureWhenStartFreshCannotCreateThePartial() failed after 0.051 seconds with 1 issue.
```

**Green** (fix restored):
```
✔ Test downloaderNamesTheFailureWhenStartFreshCannotCreateThePartial() passed after 0.017 seconds.
```

## Measured pass rates

| What | Runs | Result |
| --- | --- | --- |
| New test alone, tight loop | 1 (plus the red/green pair above) | pass |
| `downloaderRestartsWhenRangeIsAnsweredAs200` alone, tight loop | 30 | **30/30** |
| Full `DownloaderTrafficTests` suite (18 tests incl. both above) | 20 | **20/20**, 0 failures |
| Real `installPipelineDryRun`, default (1 candidate), through the local proxy | 13 | **13/13** |
| Real `installPipelineDryRun`, `DUO_INSTALL_SMOKE=all` (6 candidates incl. Helium), through the local proxy | 1 sweep (6 downloads) | **6/6** |

Per `swift test --filter DownloaderTrafficTests` output, the loop's own summary line: `DownloaderTrafficTests suite: pass=20 fail=0`.

## What remains unverified

- Whether a real vendor CDN, through this proxy, ever actually answers a ranged resume with `200` instead of `206` — the one condition the comment's theory needs, and the one thing no log has shown actually happening. Not driven on demand in this PR.
- #419's original ~2/7 local failure rate is therefore still unexplained. It may need capturing verbose `Log.install` output (`.notice`) from an actual failing run — those retry/resume log lines exist in production code but the smoke test's own `log()` closure doesn't capture them, so a failing run today would show *whether* a retry happened, which no evidence so far does.

## Test plan

- [x] `swift test --package-path DuoUpdaterCore --filter downloaderNamesTheFailureWhenStartFreshCannotCreateThePartial` — red before the fix, green after (shown above)
- [x] `swift test --package-path DuoUpdaterCore --filter DownloaderTrafficTests` — 20/20 clean runs
- [x] `swift test --package-path DuoUpdaterCore --filter installPipelineDryRun` (default + `DUO_INSTALL_SMOKE=all`) — 19/19 real downloads through the proxy, no repro
- [ ] Did not run full `make test` (per instructions — the requester runs that before merge)
