### PR TITLE
Sync TestFlight's store when a round can see it has fallen behind

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2106,11 +2106,16 @@ final class AppListModel {
     /// log date rather than anything we persist.
     @ObservationIgnored private var testFlightSyncLedger = TestFlightSyncPolicy.Ledger()
 
-    /// Whether an automatic sync is still running. The round that starts one does not
-    /// wait for it, so without this a round beginning moments later would read a
-    /// store nothing has written yet and start a second hidden TestFlight against the
-    /// same evidence. `Ledger.begin` covers the floor; this covers the overlap.
-    @ObservationIgnored private var testFlightSyncInFlight = false
+    /// The sync running right now, automatic or the button's — **one for the app**,
+    /// not one per round.
+    ///
+    /// An automatic sync outlives the round that started it, so without a gate that
+    /// both paths share, a round beginning moments later would read a store nothing
+    /// has written yet and start a second hidden TestFlight against the same
+    /// evidence, and a click would start a third beside them. `Ledger.begin` covers
+    /// the floor's arithmetic; this covers the overlap. The button *joins* whatever
+    /// is here; an automatic round steps aside for it.
+    @ObservationIgnored private var testFlightSyncTask: Task<TestFlightRefresh.Outcome, Never>?
 
     /// Start a sync the user did not ask for, **without holding the round**.
     ///
@@ -2123,20 +2128,20 @@ final class AppListModel {
     /// through `recheckTestFlightRows`, the same path a Full Disk Access grant
     /// mid-session already uses.
     private func startAutomaticTestFlightSync(for evidence: [TestFlightSyncPolicy.Evidence]) {
-        testFlightSyncInFlight = true
+        let started = Task.detached(priority: .utility) { await TestFlightRefresh().run() }
+        testFlightSyncTask = started
         testFlightSyncLedger.begin(at: .now)
         Task { @MainActor [weak self] in
             // Bounded, and the bound is not `run`'s own: `run` is bounded internally
             // by `defaultDeadline`, but the launch it awaits first is not, so a
-            // LaunchServices that never answers would leave `testFlightSyncInFlight`
-            // true for the rest of the session and silently retire automatic syncs
-            // altogether. Comfortably past the deadline, so this only ever catches a
-            // stuck launch and never a slow store.
+            // LaunchServices that never answers would leave the gate above closed for
+            // the rest of the session and silently retire automatic syncs altogether.
+            // Comfortably past the deadline, so this only ever catches a stuck launch
+            // and never a slow store.
             let outcome = await Self.firstResult(
-                of: Task.detached(priority: .utility) { await TestFlightRefresh().run() },
-                within: TestFlightRefresh.defaultDeadline + .seconds(30))
+                of: started, within: TestFlightRefresh.defaultDeadline + .seconds(30))
             guard let self else { return }
-            self.testFlightSyncInFlight = false
+            if self.testFlightSyncTask == started { self.testFlightSyncTask = nil }
             guard let outcome else {
                 Log.app.error("TestFlight sync: the attempt never returned — automatic syncs stay armed")
                 return
@@ -2144,6 +2149,21 @@ final class AppListModel {
             self.testFlightSyncLedger.finish(evidence, ran: outcome.testFlightRan, at: .now)
             Log.app.notice("TestFlight sync: \(String(describing: outcome), privacy: .public) (automatic)")
             guard outcome.storeChanged else { return }
+            // Let any round in flight publish FIRST. Launching TestFlight rebuilds
+            // its store, and for a few seconds the tester query answers nothing
+            // (#518: 89 → 0 → 89 over about 6.9s). A round that read the store inside
+            // that window is carrying "not testing this beta" for every row and has no
+            // post-sync re-check of its own, since the gate above kept it from
+            // starting one. Repairing before it publishes loses the repair:
+            // `CheckRoundWriteBack.publishing(changedSince:)` protects rows that
+            // differ from the round's baseline, and a repair that restores a row to
+            // exactly its baseline value is not a difference.
+            //
+            // Awaited here rather than inside `recheckTestFlightRows`, which is shared
+            // with the Full Disk Access path and is reached from callers that must not
+            // wait on a round. This task is never the round itself — the round starts
+            // it and moves on — so there is nothing to deadlock against.
+            if let round = self.refreshTask { await round.value }
             await self.recheckTestFlightRows()
         }
     }
@@ -2285,13 +2305,42 @@ final class AppListModel {
         // re-check after the sync, some fourteen seconds later. Bounded like the
         // round's own wait on that read, so a read that never returns cannot hold
         // the sync, and with it the round, hostage.
-        let testFlightSync: Task<TestFlightRefresh.Outcome, Never>? =
-            intent.refreshesTestFlight && mayReadTestFlight
-            ? Task.detached(priority: .utility) { [tfLoader] in
-                if let tfLoader { _ = await Self.firstResult(of: tfLoader, within: .seconds(2)) }
-                return await TestFlightRefresh().run()
+        //
+        // One sync at a time for the whole app, not one per round. An automatic sync
+        // outlives the round that started it (it is deliberately not awaited), so a
+        // click landing seconds later would otherwise start a SECOND hidden
+        // TestFlight beside it — two instances launched with
+        // `createsNewApplicationInstance`, writing one Core Data store, each one's
+        // settle detection watching the other's writes. The button joins the running
+        // attempt instead: it is the same operation against the same store, so
+        // waiting on it gives the user the same answer sooner than a fresh launch
+        // would.
+        let testFlightSync: Task<TestFlightRefresh.Outcome, Never>?
+        if intent.refreshesTestFlight, mayReadTestFlight {
+            if let inFlight = testFlightSyncTask {
+                Log.app.notice("TestFlight sync: joining the attempt already running")
+                testFlightSync = inFlight
+            } else {
+                let started = Task.detached(priority: .utility) { [tfLoader] in
+                    if let tfLoader { _ = await Self.firstResult(of: tfLoader, within: .seconds(2)) }
+                    return await TestFlightRefresh().run()
+                }
+                testFlightSyncTask = started
+                testFlightSync = started
+                // Bounded for the reason `startAutomaticTestFlightSync` is: `run`
+                // bounds its polling but not the launch it awaits first, and a gate
+                // left closed by a stuck launch would silently switch automatic syncs
+                // off for the whole session. The round below still awaits `started`
+                // itself — this only frees the gate.
+                Task { @MainActor [weak self] in
+                    _ = await Self.firstResult(
+                        of: started, within: TestFlightRefresh.defaultDeadline + .seconds(30))
+                    if self?.testFlightSyncTask == started { self?.testFlightSyncTask = nil }
+                }
             }
-            : nil
+        } else {
+            testFlightSync = nil
+        }
 
         // First scan with no TestFlight data → the list appears instantly, with no
         // wait on the prompt.
@@ -2440,7 +2489,7 @@ final class AppListModel {
         // written it in `TestFlightSyncPolicy.floorInterval` (#539). It cannot be
         // started early, because its evidence IS the check's output; and it is
         // deliberately not awaited here, so it cannot delay this round's rows.
-        if testFlightSync == nil, allowTestFlight, testflight.accessible, !testFlightSyncInFlight {
+        if testFlightSync == nil, allowTestFlight, testflight.accessible, testFlightSyncTask == nil {
             let evidence = TestFlightSyncPolicy.evidence(
                 in: checkable, inventory: testflight, announcements: announcements)
             if let reason = TestFlightSyncPolicy.reason(
@@ -2449,7 +2498,11 @@ final class AppListModel {
                 ledger: testFlightSyncLedger,
                 now: .now
             ) {
-                Log.app.notice("TestFlight sync: starting one — \(Self.describe(reason), privacy: .public)")
+                // "due", not "starting one": `run` returns before spawning anything
+                // when there is no account to fetch for or no TestFlight to launch,
+                // and a line claiming a hidden TestFlight was started is exactly the
+                // diagnostic someone would read to decide whether that happens.
+                Log.app.notice("TestFlight sync: due — \(Self.describe(reason), privacy: .public)")
                 startAutomaticTestFlightSync(for: evidence)
             }
         }

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2100,6 +2100,68 @@ final class AppListModel {
         Log.app.notice("permissions: Full Disk Access \(mayRead ? "granted" : "missing", privacy: .public) while running — re-checked \(rechecked.count, privacy: .public) TestFlight rows")
     }
 
+    /// What earlier rounds in this process already spent a TestFlight sync on
+    /// (#539). Per-process by design — see `TestFlightSyncPolicy.Ledger`, which
+    /// explains why the durable half of the question is TestFlight's own write-ahead
+    /// log date rather than anything we persist.
+    @ObservationIgnored private var testFlightSyncLedger = TestFlightSyncPolicy.Ledger()
+
+    /// Whether an automatic sync is still running. The round that starts one does not
+    /// wait for it, so without this a round beginning moments later would read a
+    /// store nothing has written yet and start a second hidden TestFlight against the
+    /// same evidence. `Ledger.begin` covers the floor; this covers the overlap.
+    @ObservationIgnored private var testFlightSyncInFlight = false
+
+    /// Start a sync the user did not ask for, **without holding the round**.
+    ///
+    /// The button's sync is awaited because the user is watching for that answer, and
+    /// it is started before the scan so it overlaps one. An automatic one is neither:
+    /// it is decided from the check's own output, so awaiting it would add its whole
+    /// wait — up to `TestFlightRefresh.defaultDeadline` — to the moment every app's
+    /// verdict is published, TestFlight rows and everything else alike. Instead the
+    /// round publishes on time and the beta rows correct themselves afterwards
+    /// through `recheckTestFlightRows`, the same path a Full Disk Access grant
+    /// mid-session already uses.
+    private func startAutomaticTestFlightSync(for evidence: [TestFlightSyncPolicy.Evidence]) {
+        testFlightSyncInFlight = true
+        testFlightSyncLedger.begin(at: .now)
+        Task { @MainActor [weak self] in
+            // Bounded, and the bound is not `run`'s own: `run` is bounded internally
+            // by `defaultDeadline`, but the launch it awaits first is not, so a
+            // LaunchServices that never answers would leave `testFlightSyncInFlight`
+            // true for the rest of the session and silently retire automatic syncs
+            // altogether. Comfortably past the deadline, so this only ever catches a
+            // stuck launch and never a slow store.
+            let outcome = await Self.firstResult(
+                of: Task.detached(priority: .utility) { await TestFlightRefresh().run() },
+                within: TestFlightRefresh.defaultDeadline + .seconds(30))
+            guard let self else { return }
+            self.testFlightSyncInFlight = false
+            guard let outcome else {
+                Log.app.error("TestFlight sync: the attempt never returned — automatic syncs stay armed")
+                return
+            }
+            self.testFlightSyncLedger.finish(evidence, ran: outcome.testFlightRan, at: .now)
+            Log.app.notice("TestFlight sync: \(String(describing: outcome), privacy: .public) (automatic)")
+            guard outcome.storeChanged else { return }
+            await self.recheckTestFlightRows()
+        }
+    }
+
+    /// One log line for why a round is about to start a hidden TestFlight. Names the
+    /// apps for `staleStore`, because "the store is behind" without saying behind
+    /// what is the kind of line that reads as noise the next time someone is
+    /// debugging this.
+    private static func describe(_ reason: TestFlightSyncPolicy.Reason) -> String {
+        switch reason {
+        case .staleStore(let evidence):
+            let named = evidence.map { "\($0.bundleID) @\($0.installedBuild)" }.joined(separator: ", ")
+            return "the store cannot bound \(evidence.count) row(s): \(named)"
+        case .floor:
+            return "nothing has written the store in \(Int(TestFlightSyncPolicy.floorInterval / 3600))h"
+        }
+    }
+
     @ObservationIgnored private var didRecoverSwaps = false
 
     /// Run the interrupted-swap recovery sweep once per session, off the main thread.
@@ -2205,8 +2267,10 @@ final class AppListModel {
             allowTestFlight ? Task.detached(priority: .utility) { TestFlightInventory() } : nil
         if allowTestFlight { testFlightReadThisSession = true }
 
-        // The refresh button, and only the button, also asks TestFlight to sync —
-        // in a hidden instance of our own; see `TestFlightRefresh`. Started here,
+        // The refresh button is the one intent that asks TestFlight to sync
+        // unconditionally — in a hidden instance of our own; see `TestFlightRefresh`.
+        // A round of any intent can still earn one further down, from what the check
+        // saw (`TestFlightSyncPolicy`). Started here,
         // before the scan, and awaited only after the network check, because its
         // wait is long and unrelated to everything else here: a store that never
         // moves holds it for the whole `TestFlightRefresh.defaultDeadline`. Awaited
@@ -2371,6 +2435,24 @@ final class AppListModel {
         // exactly those betas carry neither yet. The
         // re-read is bounded like the first one, for the same reason — a read that
         // has not returned is a prompt that is still up.
+        // A round that was not given a sync up front can still earn one from what the
+        // check just saw — the store is provably behind for some row, or nothing has
+        // written it in `TestFlightSyncPolicy.floorInterval` (#539). It cannot be
+        // started early, because its evidence IS the check's output; and it is
+        // deliberately not awaited here, so it cannot delay this round's rows.
+        if testFlightSync == nil, allowTestFlight, testflight.accessible, !testFlightSyncInFlight {
+            let evidence = TestFlightSyncPolicy.evidence(
+                in: checkable, inventory: testflight, announcements: announcements)
+            if let reason = TestFlightSyncPolicy.reason(
+                evidence: evidence,
+                storeStamp: TestFlightRefresh.storeStamp(),
+                ledger: testFlightSyncLedger,
+                now: .now
+            ) {
+                Log.app.notice("TestFlight sync: starting one — \(Self.describe(reason), privacy: .public)")
+                startAutomaticTestFlightSync(for: evidence)
+            }
+        }
         if let testFlightSync {
             let outcome = await testFlightSync.value
             Log.app.notice("TestFlight sync: \(String(describing: outcome), privacy: .public)")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ release note is debugging our code:
 
 Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
+## 0.3.93
+
+**TestFlight betas no longer wait for you to press Refresh.** When TestFlight installed a beta in the background, its row showed a question mark until the next manual refresh — and a build TestFlight had not installed yet could go unnoticed while the row said the beta was up to date. Duo Updater now checks with TestFlight on its own when a row needs it.
+
 ## 0.3.92
 
 **Some self-updating apps no longer look up to date while a newer version is out.** For apps whose update information sits behind a slow-to-refresh download server, Duo Updater could keep seeing an older version for days after a release.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RefreshIntent.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/RefreshIntent.swift
@@ -107,11 +107,18 @@ public enum RefreshIntent: Sendable, Equatable {
     /// Whether this refresh asks TestFlight to sync its store first, by starting
     /// a hidden instance of TestFlight of our own (`TestFlightRefresh`).
     ///
-    /// The button only. That starts an app the user did not start, and the
-    /// system deliberately declines this work while the Mac is in use — so it
-    /// happens when the user asks for a fresh answer and at no other time.
-    /// Opening the menu is not asking: it would start TestFlight in the
-    /// background on every glance at the list.
+    /// The button only — meaning the only intent that syncs *unconditionally*.
+    /// That starts an app the user did not start, and the system deliberately
+    /// declines this work while the Mac is in use, so no intent gets it for free:
+    /// opening the menu is not asking, and would start TestFlight on every glance
+    /// at the list.
+    ///
+    /// ⚠️ **This is no longer the whole answer to "when does a round sync".** Since
+    /// #539 a round of any intent may also earn one from what it saw —
+    /// `TestFlightSyncPolicy`, decided after the check because its evidence is the
+    /// check's own output. This flag is the unconditional half; that type is the
+    /// rationed half. A reader who stops here will conclude a background round
+    /// never syncs, which was true and is not.
     public var refreshesTestFlight: Bool {
         switch self {
         case .userRequested: true

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker+TestFlightVerdict.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker+TestFlightVerdict.swift
@@ -38,3 +38,34 @@ extension UpdateChecker {
             : .upToDate
     }
 }
+
+extension UpdateChecker {
+    /// Which of TestFlight's rows may answer for this app — decided HERE, not
+    /// inside the inventory, and the two buckets are mutually exclusive on purpose.
+    /// A wrapped iPhone/iPad bundle's builds are filed under the iOS platform and it
+    /// can never install a mac build; a native Mac app can hold iOS rows of its own
+    /// and must never be offered one. Measured 2026-09-09 on one machine: Paste is
+    /// on the mac track at 29808607 with an iOS track at 29814462, and Claudo — a
+    /// wrapped bundle — had 0.3.384 (1300) installed with 1301 offered, both iOS
+    /// rows, which the mac-only lookup could not see at all (#476).
+    ///
+    /// ⚠️ This also lets a wrapped bundle reach `.upToDate`, which it could not
+    /// before: with no mac rows it always landed on `.testFlightManaged` and claimed
+    /// nothing. That immunity was an accident of the bug, not a safeguard — but it
+    /// did mean these rows could never inherit the staleness this database has
+    /// (measured six weeks old on one machine while pushes kept arriving). What
+    /// closes that is the freshness gate in #478, for every TestFlight row at once,
+    /// not a special case here.
+    ///
+    /// One function because there are two callers now: `check`'s TestFlight branch,
+    /// and `TestFlightSyncPolicy.evidence`, which asks the same question of the same
+    /// store in order to decide whether that store is worth re-syncing. Two copies
+    /// of a platform split would be two places to get a wrapped bundle wrong.
+    public static func testFlightLatest(
+        for app: InstalledApp, in inventory: TestFlightInventory
+    ) -> TestFlightInventory.App? {
+        app.isiOSAppOnMac
+            ? inventory.latestIOS(forBundleID: app.bundleID)
+            : inventory.latest(forBundleID: app.bundleID)
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -254,26 +254,11 @@ public struct UpdateChecker: Sendable {
                 return UpdateResult(app: app, remote: nil, status: .testFlightManaged)
             }
 
-            // Which platform's rows may answer for this bundle is decided HERE, not
-            // inside the inventory, and the two are mutually exclusive on purpose.
-            // A wrapped iPhone/iPad bundle's builds are filed under the iOS
-            // platform and it can never install a mac build; a native Mac app can
-            // hold iOS rows of its own and must never be offered one. Measured
-            // 2026-09-09 on one machine: Paste is on the mac track at 29808607
-            // with an iOS track at 29814462, and Claudo — a wrapped bundle —
-            // had 0.3.384 (1300) installed with 1301 offered, both iOS rows, which
-            // the mac-only lookup could not see at all (#476).
-            //
-            // ⚠️ This also lets a wrapped bundle reach `.upToDate`, which it could
-            // not before: with no mac rows it always landed on `.testFlightManaged`
-            // and claimed nothing. That immunity was an accident of the bug, not a
-            // safeguard — but it did mean these rows could never inherit the
-            // staleness this database has (measured six weeks old on one machine
-            // while pushes kept arriving). What closes that is the freshness gate
-            // in #478, for every TestFlight row at once, not a special case here.
-            let known = app.isiOSAppOnMac
-                ? testflight?.latestIOS(forBundleID: app.bundleID)
-                : testflight?.latest(forBundleID: app.bundleID)
+            // Which platform's rows may answer for this bundle: `testFlightLatest`,
+            // shared with the staleness scan that decides whether to ask TestFlight
+            // to sync (`TestFlightSyncPolicy`). See there for why the split lives in
+            // this type rather than in the inventory.
+            let known = testflight.flatMap { Self.testFlightLatest(for: app, in: $0) }
             if let latest = known {
                 let installedBuild = app.buildVersion ?? ""
                 // An installed build NEWER than anything the database holds says

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
@@ -55,13 +55,43 @@ import Foundation
 /// of those 210 were claimed while this was measured. Say "may queue", never
 /// "will install".
 ///
-/// ⚠️ **This is an explicit, user-initiated action.** It starts an app the user did
-/// not start. Do not put it on a periodic check: the system deliberately declines
-/// to do this work while the device is in use, and doing it for the system on a
-/// timer would be overriding that decision on the user's behalf. Its callers are
-/// the two places a user asks for exactly this — `duo check --refresh-testflight`
-/// and the menu's refresh button (`RefreshIntent.userRequested`) — and not the
-/// menu opening, which is not asking.
+/// ⚠️ **And those 210 did not accumulate — they were enqueue attempts, which
+/// `appstored` dedups.** Measured 2026-09-12: its install queue is a real table
+/// (`app_install` in `~/Library/Caches/com.apple.appstoreagent/storeSystem.db`)
+/// carrying a `cancel_if_duplicate` column and a `DetectDuplicateRequestTask`, with
+/// log paths for `Skipped duplicate job`, `Skipping duplicate install`, and
+/// `Queue check found duplicate items in the queue`. The dedup fired on all seven of
+/// that day's real TestFlight installs (`Ignoring duplicate resumption request`), and
+/// the table held 0 rows before and after each of four back-to-back hidden launches.
+/// The `TestFlightExtensionSyncActivity` registration behaves the same way — it is
+/// keyed by identifier, and the binary's own string for re-registering it is
+/// "Resetting activity for TestFlight extension due to changed intervals".
+///
+/// So the cost of repeating this is **the fetch, not a backlog**: 694–705 KB in and
+/// 29–34 KB out per launch across those four, with no caching between them (one ran
+/// two minutes after the previous and fetched 704 KB anyway). That is what
+/// `TestFlightSyncPolicy` rations.
+///
+/// ⚠️ **This starts an app the user did not start, so no caller may run it on a
+/// bare timer.** The system deliberately declines this work while the device is in
+/// use, and doing it for the system every few minutes would be overriding that
+/// decision on the user's behalf — at the 5-minute default, 288 launches a day.
+///
+/// What that ruled out was a *timer*, and for a while it was read as ruling out
+/// everything but the button. #539 measured the cost of that reading: 20 hours
+/// after the last sync, 3 of this Mac's 8 TestFlight rows could not be bounded by
+/// the store, and a build published but not yet installed reads as "up to date"
+/// with nothing local able to witness it. So there are now three callers, and the
+/// two automatic ones are rationed by `TestFlightSyncPolicy` rather than by a
+/// clock:
+///
+/// - `duo check --refresh-testflight` and the menu's refresh button
+///   (`RefreshIntent.userRequested`) — the user asking, unconditionally.
+/// - A round that saw the store fall provably behind, once per `(bundle, build)`.
+/// - A round that finds nothing has written the store in six hours.
+///
+/// Read `TestFlightSyncPolicy` before adding a fourth. What must not come back is a
+/// call that runs every round.
 public struct TestFlightRefresh: Sendable {
 
     /// What one attempt did. Every case is a thing the caller may want to say out
@@ -300,6 +330,20 @@ extension TestFlightRefresh.Outcome {
         switch self {
         case .refreshed, .changedWithoutSettling: true
         case .noChange, .notSignedIn, .accountTestsNothing, .notInstalled, .launchFailed: false
+        }
+    }
+
+    /// Whether an instance of TestFlight was actually started.
+    ///
+    /// Distinct from ``storeChanged``: `noChange` means it ran and wrote nothing,
+    /// which is a real answer about the store, while the four below mean the
+    /// question was never put to TestFlight at all. `TestFlightSyncPolicy.Ledger`
+    /// needs this one — retiring a row's evidence on an attempt that never spawned
+    /// would silence it on the strength of nothing.
+    public var testFlightRan: Bool {
+        switch self {
+        case .refreshed, .changedWithoutSettling, .noChange: true
+        case .notSignedIn, .accountTestsNothing, .notInstalled, .launchFailed: false
         }
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightSyncPolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightSyncPolicy.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+/// When a round may ask TestFlight to sync its store, beyond the refresh button.
+///
+/// `TestFlightRefresh` is the only thing that makes that store move, and until
+/// #539 its only caller inside the app was `RefreshIntent.userRequested` — the
+/// button. The reason was, and still is, that a sync starts an app the user did
+/// not start. What #539 measured is what that costs on a Mac nobody clicks:
+///
+/// - 2026-09-12, 20h13m after the last sync, **3 of 8** TestFlight rows could not
+///   be bounded by the store (`Amp` 75 vs 81 on disk, `Mithka` 1153 vs 1155,
+///   `Paste` 29814462 vs 29818681). One sync, 8.0s, answered all eight. The three
+///   were exactly the three TestFlight had background-installed in that window.
+/// - The same store, for an app whose build is published but **not yet
+///   installed**, holds `latest == installed` and the row reads `.upToDate`. That
+///   one is a confident wrong answer rather than a question mark, and nothing
+///   local can witness it: TestFlight's notifications are all *post-install*
+///   ("is Now Up to Date"; 5 of 5 here, and four builds published the same day
+///   produced e-mail and no notification at all — see `TestFlightAnnouncements`),
+///   and the user can switch those notifications off anyway.
+///
+/// So there are two gaps and they need two different triggers, which is what this
+/// type decides:
+///
+/// - **Evidence** (``Reason/staleStore(_:)``) closes the first. The store is
+///   *provably* behind for some app, and the proof is the comparison
+///   `UpdateChecker` already runs. Self-limiting: a sync that works makes the
+///   proof go away.
+/// - **A floor** (``Reason/floor``) closes the second. There is nothing to
+///   witness, so the only remaining variable is time.
+///
+/// ⚠️ **What this deliberately does not do is sync on every tick.** At the 5-minute
+/// default that is 288 hidden TestFlight launches a day, and on 2026-09-12 exactly 3
+/// of those 288 would have had anything to do. The cost that scales with them is
+/// bandwidth: measured over four launches that day, each pulled **694–705 KB in and
+/// 29–34 KB out**, burned 1.56–1.75s of CPU, and settled after 7.5–9.1s. There is no
+/// caching between launches — the third ran about two minutes after the second and
+/// fetched 704 KB anyway — so 288 a day is roughly 207 MB a day, against 17 MB at
+/// the hourly floor below.
+///
+/// ⚠️ **What is NOT a reason, though it was written here first:** that repeated syncs
+/// pile up TestFlight's auto-update jobs. They do not. `appstored` keeps its install
+/// queue in a real table (`app_install` in `storeSystem.db`) with a
+/// `cancel_if_duplicate` column, a `DetectDuplicateRequestTask`, and log paths for
+/// `Skipped duplicate job` and `Dropping update request from group because it is a
+/// duplicate of an existing install`. Measured 2026-09-12: that dedup fired on all
+/// seven of the day's TestFlight installs (`Ignoring duplicate resumption request`),
+/// and the queue held 0 rows before and after each of the four launches above. The
+/// earlier note of "42 activations → 210 jobs" counted enqueue *attempts* in the log,
+/// not work that accumulated. Do not reinstate that argument.
+public enum TestFlightSyncPolicy {
+
+    /// One app whose store rows cannot bound the copy on disk, and the build that
+    /// makes that true. The build is half the identity because it is what makes a
+    /// repeat *new*: a second background install is a second thing to learn, while
+    /// the same build asking twice is the same question.
+    public struct Evidence: Sendable, Hashable {
+        public let bundleID: String
+        /// `InstalledApp.buildVersion`, or "" — the same string the verdict compared.
+        public let installedBuild: String
+
+        public init(bundleID: String, installedBuild: String) {
+            self.bundleID = bundleID
+            self.installedBuild = installedBuild
+        }
+    }
+
+    /// Why a round is about to start a hidden TestFlight. Every case is logged: a
+    /// sync is a visible-enough act that "it just happened" is not an acceptable
+    /// account of it.
+    public enum Reason: Sendable, Equatable {
+        /// The store is provably behind for these apps.
+        case staleStore([Evidence])
+        /// Nothing has synced it in ``floorInterval`` — neither us nor the user
+        /// opening TestFlight themselves.
+        case floor
+    }
+
+    /// How long the store may go unsynced before a round syncs it with no evidence
+    /// at all.
+    ///
+    /// One hour is **24 hidden launches a day** — about 17 MB against the 207 MB the
+    /// 5-minute tick would cost at the per-launch figures above, and 1 launch for the
+    /// button on a day nobody clicks it. It is not fitted to a measurement: there is
+    /// nothing to fit, because the gap it covers is the one with no local witness
+    /// (see the type doc — TestFlight announces only what it has already installed,
+    /// so a build merely waiting is invisible until something asks). So it is set by
+    /// what it costs, and the price it buys is that a published-but-uninstalled build
+    /// can read as "up to date" for up to an hour.
+    ///
+    /// ⚠️ Do not read this as the freshness of a TestFlight row in general. Anything
+    /// TestFlight has actually installed is caught by ``Reason/staleStore(_:)`` at the
+    /// next round instead, which is a check interval away, not an hour.
+    public static let floorInterval: TimeInterval = 60 * 60
+
+    /// Apps whose TestFlight rows the store cannot bound — the same comparison
+    /// `UpdateChecker.check` runs, asked of the whole round at once.
+    ///
+    /// Three shapes count, and they are the three a sync could actually fix:
+    ///
+    /// 1. The installed build outruns the store's latest
+    ///    (`UpdateChecker.testFlightVerdict` → `.testFlightManaged`). This is the
+    ///    one #539 measured three of.
+    /// 2. The store holds no rows for the bundle at all. A beta installed while the
+    ///    store was stale looks like this, and so does one whose testing ended —
+    ///    the ledger's per-build guard is what keeps the second from asking twice.
+    /// 3. TestFlight announced a build id past everything the store holds
+    ///    (`TestFlightAnnouncements.isBehind`). One-directional, like the witness
+    ///    itself: it can only ever add evidence.
+    ///
+    /// **Not** a bundle the signed-in account is not testing. Its rows are
+    /// placeholders by design rather than a store that fell behind
+    /// (`TestFlightInventory.readTesters`), and a sync has nothing to add — this is
+    /// the same gate, in the same order, that `UpdateChecker` applies before it
+    /// looks anything up.
+    ///
+    /// Only ever called with an inventory that was actually read: an inaccessible
+    /// one holds nothing, which would read as shape 2 for every beta on the Mac.
+    public static func evidence(
+        in apps: [InstalledApp],
+        inventory: TestFlightInventory,
+        announcements: TestFlightAnnouncements?
+    ) -> [Evidence] {
+        guard inventory.accessible else { return [] }
+        return apps.compactMap { app in
+            guard app.isTestFlightApp, let bundleID = app.bundleID else { return nil }
+            if inventory.isTesting(bundleID: bundleID) == false { return nil }
+            let found = Evidence(bundleID: bundleID, installedBuild: app.buildVersion ?? "")
+            guard let latest = UpdateChecker.testFlightLatest(for: app, in: inventory) else {
+                return found  // shape 2
+            }
+            let verdict = UpdateChecker.testFlightVerdict(
+                installed: app, latestShortVersion: latest.latestShortVersion,
+                latestBuild: latest.latestBuild)
+            if verdict == .testFlightManaged { return found }  // shape 1
+            if announcements?.isBehind(inventory.frontier(forBundleID: bundleID)) == true {
+                return found  // shape 3
+            }
+            return nil
+        }
+    }
+
+    /// Whether to sync, given what this round saw and what earlier rounds already
+    /// spent a sync on.
+    ///
+    /// `storeStamp` is the store's own write-ahead log date
+    /// (`TestFlightRefresh.storeStamp`) — the real "when did TestFlight last write
+    /// this", which counts the user opening TestFlight themselves and not just our
+    /// own attempts. The floor waits on whichever of that and our last attempt is
+    /// more recent, so a store that never writes cannot turn the floor into a
+    /// per-tick launcher.
+    ///
+    /// Evidence outranks the floor: it names something to learn, the floor only
+    /// says time has passed.
+    public static func reason(
+        evidence: [Evidence], storeStamp: Date?, ledger: Ledger, now: Date
+    ) -> Reason? {
+        let fresh = evidence.filter { ledger.syncedFor[$0.bundleID] != $0.installedBuild }
+        if !fresh.isEmpty { return .staleStore(fresh) }
+        let lastTouched = [storeStamp, ledger.lastAttemptAt].compactMap { $0 }.max()
+        guard let lastTouched else { return .floor }
+        return now.timeIntervalSince(lastTouched) >= floorInterval ? .floor : nil
+    }
+
+    /// What earlier rounds already spent a sync on. **Lives for one process**, and
+    /// that is enough because the durable half of the question is already on disk:
+    /// `storeStamp` is TestFlight's own write-ahead log date, so a relaunch inherits
+    /// a true "when was this store last written" without us recording anything.
+    /// What a relaunch does forget is `syncedFor`, which costs at most one extra
+    /// sync per launch for a row a sync cannot fix — bounded by how often
+    /// DuoUpdater restarts, not by the tick.
+    ///
+    /// ⚠️ `syncedFor` is what stops evidence from degenerating into a timer. A build
+    /// that **expires out of** the store stays on disk, so shape 1's inequality
+    /// stays true after a perfectly successful sync — `TestFlightAnnouncements`
+    /// records that shape — and without this map every round from then on would
+    /// start a TestFlight that cannot help. One sync per `(bundle, build)`: a real
+    /// new install brings a new build and asks again, an unfixable row asks once.
+    public struct Ledger: Sendable, Equatable {
+        /// When we last *started* an attempt — not when one succeeded. The floor is
+        /// a bound on how often we launch TestFlight, so it has to count the
+        /// launches that achieved nothing too.
+        public var lastAttemptAt: Date?
+        /// bundleID → the installed build a sync was already spent on.
+        public var syncedFor: [String: String]
+
+        public init(lastAttemptAt: Date? = nil, syncedFor: [String: String] = [:]) {
+            self.lastAttemptAt = lastAttemptAt
+            self.syncedFor = syncedFor
+        }
+
+        /// Stamp an attempt as *started*. Separate from ``finish(_:ran:at:)`` because
+        /// the caller does not wait for the attempt: a round two seconds later must
+        /// already see the floor as satisfied, or it will start a second TestFlight
+        /// against the same store.
+        public mutating func begin(at now: Date) { lastAttemptAt = now }
+
+        /// Close an attempt out. `ran` is whether TestFlight was actually started —
+        /// `TestFlightRefresh` returns before spawning when there is no account to
+        /// fetch for, and marking those bundles done would retire the evidence on
+        /// the strength of an attempt that never happened.
+        ///
+        /// `lastAttemptAt` moves either way: the cheap early returns still cost a
+        /// sign-in read and a store open, and the floor is what bounds how often a
+        /// round pays them.
+        public mutating func finish(_ evidence: [Evidence], ran: Bool, at now: Date) {
+            lastAttemptAt = now
+            guard ran else { return }
+            for item in evidence { syncedFor[item.bundleID] = item.installedBuild }
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightSyncPolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightSyncPolicy.swift
@@ -152,14 +152,35 @@ public enum TestFlightSyncPolicy {
     ///
     /// Evidence outranks the floor: it names something to learn, the floor only
     /// says time has passed.
+    ///
+    /// ⚠️ **Except after an attempt that never reached TestFlight.** Evidence is not
+    /// retired by one of those (see ``Ledger/finish(_:ran:at:)``), so on a Mac where
+    /// TestFlight can never be reached — signed out of the App Store, or TestFlight
+    /// deleted with a beta still installed — the evidence branch would otherwise
+    /// return `.staleStore` on every single round, forever. `run` returns before
+    /// spawning in those cases, so nothing is launched, but each round still pays an
+    /// accounts-database read and writes two log lines: the per-tick degeneration
+    /// this type exists to prevent, reached through a different door than the
+    /// expired-build one. So after such an attempt everything waits for the floor,
+    /// and the retry that follows still carries its evidence.
     public static func reason(
         evidence: [Evidence], storeStamp: Date?, ledger: Ledger, now: Date
     ) -> Reason? {
         let fresh = evidence.filter { ledger.syncedFor[$0.bundleID] != $0.installedBuild }
-        if !fresh.isEmpty { return .staleStore(fresh) }
+        if !fresh.isEmpty, ledger.lastAttemptReachedTestFlight { return .staleStore(fresh) }
         let lastTouched = [storeStamp, ledger.lastAttemptAt].compactMap { $0 }.max()
-        guard let lastTouched else { return .floor }
-        return now.timeIntervalSince(lastTouched) >= floorInterval ? .floor : nil
+        // A stamp in the FUTURE is not a freshly written store, it is a clock that
+        // moved — an NTP correction, a restored VM, a timezone bug — and reading it
+        // as "just synced" would park the floor until real time caught up with it,
+        // which for a backwards jump of a day is a day. Out-of-range reads as no
+        // information at all, which is the same answer as having no stamp.
+        // `CheckSchedule.nextWait` clamps the mirror image of this arithmetic with
+        // `max(0, due.timeIntervalSince(now))`.
+        let age = lastTouched.map { now.timeIntervalSince($0) }
+        guard let age, age >= 0, age < floorInterval else {
+            return fresh.isEmpty ? .floor : .staleStore(fresh)
+        }
+        return nil
     }
 
     /// What earlier rounds already spent a sync on. **Lives for one process**, and
@@ -183,10 +204,20 @@ public enum TestFlightSyncPolicy {
         public var lastAttemptAt: Date?
         /// bundleID → the installed build a sync was already spent on.
         public var syncedFor: [String: String]
+        /// Whether the last attempt actually started TestFlight. False parks the
+        /// evidence branch behind the floor — see ``TestFlightSyncPolicy/reason(evidence:storeStamp:ledger:now:)``
+        /// for the Mac that made this necessary. True before any attempt, so the
+        /// first round with evidence does not wait.
+        public var lastAttemptReachedTestFlight: Bool
 
-        public init(lastAttemptAt: Date? = nil, syncedFor: [String: String] = [:]) {
+        public init(
+            lastAttemptAt: Date? = nil,
+            syncedFor: [String: String] = [:],
+            lastAttemptReachedTestFlight: Bool = true
+        ) {
             self.lastAttemptAt = lastAttemptAt
             self.syncedFor = syncedFor
+            self.lastAttemptReachedTestFlight = lastAttemptReachedTestFlight
         }
 
         /// Stamp an attempt as *started*. Separate from ``finish(_:ran:at:)`` because
@@ -205,6 +236,7 @@ public enum TestFlightSyncPolicy {
         /// round pays them.
         public mutating func finish(_ evidence: [Evidence], ran: Bool, at now: Date) {
             lastAttemptAt = now
+            lastAttemptReachedTestFlight = ran
             guard ran else { return }
             for item in evidence { syncedFor[item.bundleID] = item.installedBuild }
         }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightSyncPolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightSyncPolicyTests.swift
@@ -214,19 +214,58 @@ struct TestFlightSyncPolicyTests {
             == .floor)
     }
 
+    /// A stamp in the future is a clock that moved, not a store that was just
+    /// written. Mutation: drop the `age >= 0` clause — a backwards clock jump parks
+    /// the floor for as long as the jump lasted, silently, and nothing on the Mac
+    /// says why TestFlight stopped being synced.
+    @Test func aStampFromTheFutureIsNotFreshness() {
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: [], storeStamp: now.addingTimeInterval(86_400),
+            ledger: .init(), now: now)
+            == .floor)
+    }
+
     // MARK: - ledger
 
-    /// Mutation: drop the `ran` guard in `finish` — an attempt that returned before
-    /// spawning anything (signed out, TestFlight not installed) retires the evidence,
-    /// so signing back in never produces the sync that would pick the store up.
-    @Test func anAttemptThatNeverStartedTestFlightRetiresNothing() {
+    /// An attempt that returned before spawning anything (signed out, TestFlight not
+    /// installed) must not retire the evidence — but it must not re-fire on the very
+    /// next round either, or a Mac where TestFlight can never be reached pays an
+    /// accounts read and two log lines every tick, forever.
+    ///
+    /// Two mutations, one per half. Drop the `ran` guard in `finish`: the evidence is
+    /// retired, and signing back in never produces the sync that would pick the store
+    /// up. Drop `lastAttemptReachedTestFlight` from `reason`'s first branch: the
+    /// immediate re-fire comes back.
+    @Test func anAttemptThatNeverStartedTestFlightIsParkedNotRetired() {
         var ledger = TestFlightSyncPolicy.Ledger()
         let evidence = [TestFlightSyncPolicy.Evidence(bundleID: "zz.a", installedBuild: "81")]
         ledger.finish(evidence, ran: false, at: now)
         #expect(ledger.syncedFor.isEmpty)
         #expect(ledger.lastAttemptAt == now)
+        // Parked: the next round does not try again.
         #expect(TestFlightSyncPolicy.reason(
-            evidence: evidence, storeStamp: nil, ledger: ledger, now: now) == .staleStore(evidence))
+            evidence: evidence, storeStamp: nil, ledger: ledger, now: now) == nil)
+        // Not retired: once the floor comes round, it is still evidence, and it is
+        // reported as such rather than as a bare `.floor`.
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: evidence, storeStamp: nil, ledger: ledger,
+            now: now.addingTimeInterval(TestFlightSyncPolicy.floorInterval))
+            == .staleStore(evidence))
+    }
+
+    /// The other side of that gate: an attempt that DID reach TestFlight leaves the
+    /// evidence branch armed, so a background install landing a minute later is acted
+    /// on at the next round rather than waiting out the floor. Mutation: leave
+    /// `lastAttemptReachedTestFlight` false in `finish` regardless of `ran` — every
+    /// new build waits up to an hour, which is the freshness this whole change buys.
+    @Test func anAttemptThatRanLeavesTheEvidenceBranchArmed() {
+        var ledger = TestFlightSyncPolicy.Ledger()
+        ledger.finish([], ran: true, at: now)
+        let newBuild = [TestFlightSyncPolicy.Evidence(bundleID: "zz.a", installedBuild: "82")]
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: newBuild, storeStamp: now, ledger: ledger,
+            now: now.addingTimeInterval(60))
+            == .staleStore(newBuild))
     }
 
     /// The other side of the same line. Mutation: record nothing at all — `finish`

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightSyncPolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightSyncPolicyTests.swift
@@ -1,0 +1,265 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// #539: when a round may start a hidden TestFlight of its own, beyond the button.
+///
+/// Every case names the mutation it kills, and each was run against this suite.
+/// Fixture paths are invented and the helper below refuses a real one — a path that
+/// exists on the machine running the tests puts the file system into the equation
+/// (`UpdatePolicy.runtimeBundlePath` resolves symlinks, which is the identity
+/// transform only for paths that do not exist).
+@Suite("TestFlightSyncPolicy")
+struct TestFlightSyncPolicyTests {
+
+    private func beta(
+        _ bundleID: String, short: String?, build: String?, wrapped: Bool = false,
+        testFlight: Bool = true
+    ) -> InstalledApp {
+        let path = URL(fileURLWithPath: "/Applications/ZZFixture-\(bundleID).app")
+        #expect(!FileManager.default.fileExists(atPath: path.path))
+        return InstalledApp(
+            name: bundleID, bundleID: bundleID, shortVersion: short, buildVersion: build,
+            path: path, isMASApp: false, isiOSAppOnMac: wrapped,
+            isTestFlightApp: testFlight, sparkleFeedURL: nil)
+    }
+
+    private func inventory(
+        mac: [(bundleID: String, shortVersion: String, build: String)] = [],
+        ios: [(bundleID: String, shortVersion: String, build: String)] = [],
+        frontiers: [String: TestFlightInventory.Frontier] = [:],
+        testers: Set<String>? = nil,
+        accessible: Bool = true
+    ) -> TestFlightInventory {
+        TestFlightInventory(
+            macRows: mac, installedIOSRows: ios, frontiers: frontiers, testers: testers,
+            accessible: accessible)
+    }
+
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    // MARK: - evidence
+
+    /// The shape #539 measured three of: TestFlight installed a build in the
+    /// background and its own store never learned. Mutation: drop the
+    /// `.testFlightManaged` branch — the three rows that started this issue produce
+    /// no evidence and nothing ever syncs.
+    @Test func aCopyAheadOfTheStoreIsEvidence() {
+        let app = beta("zz.ahead", short: "1.0", build: "81")
+        let found = TestFlightSyncPolicy.evidence(
+            in: [app],
+            inventory: inventory(mac: [("zz.ahead", "1.0", "75")]),
+            announcements: nil)
+        #expect(found == [.init(bundleID: "zz.ahead", installedBuild: "81")])
+    }
+
+    /// A beta the store holds no rows for at all. Mutation: return nil instead of
+    /// evidence when the lookup misses — a beta installed while the store was stale
+    /// can never prompt the sync that would explain it.
+    @Test func aBundleTheStoreHasNoRowsForIsEvidence() {
+        let found = TestFlightSyncPolicy.evidence(
+            in: [beta("zz.unknown", short: "2.0", build: "9")],
+            inventory: inventory(mac: [("zz.other", "1.0", "1")]),
+            announcements: nil)
+        #expect(found == [.init(bundleID: "zz.unknown", installedBuild: "9")])
+    }
+
+    /// The announcement witness, in the one direction it is allowed to speak.
+    /// Mutation: drop the `isBehind` branch — a build TestFlight has already told
+    /// the user about, past everything the store holds, buys no sync.
+    @Test func anAnnouncementPastTheFrontierIsEvidence() {
+        let inv = inventory(
+            mac: [("zz.announced", "1.0", "10")],
+            frontiers: ["zz.announced": .init(adamID: 42, maxBuildID: 100)])
+        let found = TestFlightSyncPolicy.evidence(
+            in: [beta("zz.announced", short: "1.0", build: "10")],
+            inventory: inv,
+            announcements: TestFlightAnnouncements(
+                announcements: [.init(appAdamID: 42, buildID: 101)]))
+        #expect(found == [.init(bundleID: "zz.announced", installedBuild: "10")])
+    }
+
+    /// A store that agrees with the disk says nothing, and neither does one that is
+    /// simply offering an update — that row is already correct and needs no sync.
+    /// Mutation: return evidence unconditionally — every round on every Mac starts a
+    /// TestFlight, which is the 288-a-day outcome this policy exists to avoid.
+    @Test func aBoundedRowIsNotEvidence() {
+        let inv = inventory(mac: [("zz.current", "1.0", "10"), ("zz.offered", "1.0", "12")])
+        let found = TestFlightSyncPolicy.evidence(
+            in: [beta("zz.current", short: "1.0", build: "10"),
+                 beta("zz.offered", short: "1.0", build: "11")],
+            inventory: inv, announcements: nil)
+        #expect(found.isEmpty)
+    }
+
+    /// A bundle the signed-in account is not testing has placeholder rows by design,
+    /// not a store that fell behind. Mutation: drop the `isTesting` gate — signing
+    /// out turns every installed beta into evidence, and each round then starts a
+    /// TestFlight that can only ask the user to sign in.
+    @Test func aBetaTheAccountIsNotTestingIsNotEvidence() {
+        let found = TestFlightSyncPolicy.evidence(
+            in: [beta("zz.stopped", short: "1.0", build: "81")],
+            inventory: inventory(mac: [("zz.stopped", "1.0", "75")], testers: ["zz.other"]),
+            announcements: nil)
+        #expect(found.isEmpty)
+    }
+
+    /// Mutation: drop the `accessible` guard — a store that was never opened holds
+    /// no rows, so every beta reads as "no rows for this bundle" and a Mac without
+    /// Full Disk Access syncs on every round.
+    @Test func anInaccessibleStoreIsNotEvidenceAboutAnything() {
+        let found = TestFlightSyncPolicy.evidence(
+            in: [beta("zz.blind", short: "1.0", build: "81")],
+            inventory: inventory(accessible: false),
+            announcements: nil)
+        #expect(found.isEmpty)
+    }
+
+    /// A wrapped iPhone/iPad bundle is answered from the iOS rows, the same split
+    /// `UpdateChecker` applies (#476). Mutation: call `latest(forBundleID:)` instead
+    /// of `UpdateChecker.testFlightLatest` — a current wrapped beta has no mac rows,
+    /// reads as "no rows", and syncs forever.
+    @Test func aWrappedBundleIsBoundedByItsIOSRows() {
+        let found = TestFlightSyncPolicy.evidence(
+            in: [beta("zz.wrapped", short: "1.0", build: "1300", wrapped: true)],
+            inventory: inventory(ios: [("zz.wrapped", "1.0", "1300")]),
+            announcements: nil)
+        #expect(found.isEmpty)
+    }
+
+    // MARK: - reason
+
+    /// Evidence does not wait for the floor. Mutation: gate it behind the floor
+    /// (`guard lastTouched == nil || now - lastTouched >= floorInterval else
+    /// { return nil }`) — the three rows #539 opened on wait out six hours, on a
+    /// store TestFlight itself wrote a minute earlier.
+    ///
+    /// ⚠️ This does **not** pin which reason wins when both hold — nothing can,
+    /// because nothing observes it: the caller syncs and records the same evidence
+    /// either way, so the two differ only in one log line. Reordering the two
+    /// branches was tried as a mutation and survived, correctly.
+    @Test func evidenceSyncsEvenWhenTheStoreWasJustWritten() {
+        let evidence = [TestFlightSyncPolicy.Evidence(bundleID: "zz.a", installedBuild: "81")]
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: evidence, storeStamp: now.addingTimeInterval(-60),
+            ledger: .init(lastAttemptAt: now.addingTimeInterval(-60)), now: now)
+            == .staleStore(evidence))
+    }
+
+    /// The guard that keeps evidence from becoming a timer: a build that expires out
+    /// of the store leaves the inequality true forever. Mutation: drop the
+    /// `syncedFor` filter — that row starts a TestFlight on every single round.
+    @Test func aBuildAlreadySyncedForDoesNotAskAgain() {
+        let evidence = [TestFlightSyncPolicy.Evidence(bundleID: "zz.a", installedBuild: "81")]
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: evidence, storeStamp: now.addingTimeInterval(-60),
+            ledger: .init(lastAttemptAt: now.addingTimeInterval(-60), syncedFor: ["zz.a": "81"]),
+            now: now)
+            == nil)
+    }
+
+    /// …but a genuinely new install is a new thing to learn. Mutation: key the
+    /// ledger on the bundle id alone — the second and every later background install
+    /// of the same app is swallowed, which on this machine's Amp is nine of ten
+    /// builds a day.
+    @Test func aNewBuildForTheSameBundleAsksAgain() {
+        let evidence = [TestFlightSyncPolicy.Evidence(bundleID: "zz.a", installedBuild: "82")]
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: evidence, storeStamp: now.addingTimeInterval(-60),
+            ledger: .init(lastAttemptAt: now.addingTimeInterval(-60), syncedFor: ["zz.a": "81"]),
+            now: now)
+            == .staleStore(evidence))
+    }
+
+    /// The user opened TestFlight themselves, well inside the floor. Mutation: read
+    /// only `lastAttemptAt` — the floor ignores the store's own freshness and syncs on
+    /// top of a store somebody just synced.
+    ///
+    /// The age is derived from `floorInterval` rather than written out: a literal here
+    /// was an hour, and changing the floor to an hour turned "recent" into "exactly
+    /// due" and failed this case for a reason that had nothing to do with what it
+    /// tests.
+    @Test func aRecentlyWrittenStoreHoldsTheFloorOff() {
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: [], storeStamp: now.addingTimeInterval(-TestFlightSyncPolicy.floorInterval / 2),
+            ledger: .init(), now: now)
+            == nil)
+    }
+
+    /// We tried inside the floor and TestFlight wrote nothing. Mutation: read only
+    /// `storeStamp` — a store that never moves makes every later round attempt again,
+    /// turning the floor into the per-tick launcher this whole type exists to prevent.
+    /// Age derived from the constant, for the reason given just above.
+    @Test func aRecentAttemptThatWroteNothingHoldsTheFloorOff() {
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: [], storeStamp: nil,
+            ledger: .init(lastAttemptAt: now.addingTimeInterval(-TestFlightSyncPolicy.floorInterval / 2)),
+            now: now)
+            == nil)
+    }
+
+    /// Mutation: return nil when nothing is known — a Mac whose store has never been
+    /// written (and which therefore needs this most) never syncs at all.
+    @Test func nothingKnownAboutTheStoreIsTheFloor() {
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: [], storeStamp: nil, ledger: .init(), now: now) == .floor)
+    }
+
+    /// Mutation: use `>` rather than `>=`, or widen the interval — a store last
+    /// written six hours ago is exactly what the floor is for.
+    @Test func aStaleStoreWithNoEvidenceIsTheFloor() {
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: [], storeStamp: now.addingTimeInterval(-TestFlightSyncPolicy.floorInterval),
+            ledger: .init(), now: now)
+            == .floor)
+    }
+
+    // MARK: - ledger
+
+    /// Mutation: drop the `ran` guard in `finish` — an attempt that returned before
+    /// spawning anything (signed out, TestFlight not installed) retires the evidence,
+    /// so signing back in never produces the sync that would pick the store up.
+    @Test func anAttemptThatNeverStartedTestFlightRetiresNothing() {
+        var ledger = TestFlightSyncPolicy.Ledger()
+        let evidence = [TestFlightSyncPolicy.Evidence(bundleID: "zz.a", installedBuild: "81")]
+        ledger.finish(evidence, ran: false, at: now)
+        #expect(ledger.syncedFor.isEmpty)
+        #expect(ledger.lastAttemptAt == now)
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: evidence, storeStamp: nil, ledger: ledger, now: now) == .staleStore(evidence))
+    }
+
+    /// The other side of the same line. Mutation: record nothing at all — `finish`
+    /// stops being the thing that ends a repeat and the guard case above passes for
+    /// the wrong reason.
+    @Test func anAttemptThatRanRetiresTheBuildItRanFor() {
+        var ledger = TestFlightSyncPolicy.Ledger()
+        let evidence = [TestFlightSyncPolicy.Evidence(bundleID: "zz.a", installedBuild: "81")]
+        ledger.finish(evidence, ran: true, at: now)
+        #expect(ledger.syncedFor == ["zz.a": "81"])
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: evidence, storeStamp: now, ledger: ledger, now: now) == nil)
+    }
+
+    /// `noChange` means TestFlight ran and wrote nothing — a real answer about the
+    /// store. Mutation: fold it in with the four that never spawned — a store that is
+    /// genuinely current keeps producing evidence-driven launches.
+    @Test func noChangeCountsAsHavingRun() {
+        #expect(TestFlightRefresh.Outcome.noChange.testFlightRan)
+        #expect(!TestFlightRefresh.Outcome.notSignedIn.testFlightRan)
+        #expect(!TestFlightRefresh.Outcome.launchFailed.testFlightRan)
+        #expect(!TestFlightRefresh.Outcome.notInstalled.testFlightRan)
+        #expect(!TestFlightRefresh.Outcome.accountTestsNothing.testFlightRan)
+    }
+
+    /// An attempt that is still running already counts against the floor. Mutation:
+    /// make `begin` a no-op — the round that starts a sync does not wait for it, so
+    /// the next round reads a store nothing has written yet, sees the floor as still
+    /// due, and starts a second hidden TestFlight on top of the first.
+    @Test func anAttemptInFlightAlreadySatisfiesTheFloor() {
+        var ledger = TestFlightSyncPolicy.Ledger()
+        ledger.begin(at: now)
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: [], storeStamp: nil, ledger: ledger, now: now.addingTimeInterval(30)) == nil)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ outside our own container:
 - **Your App Store sign-in** — whenever TestFlight's data is read, the system
   accounts database is read for one thing: whether the active App Store account's
   media types include the App Store. It decides whether a TestFlight beta can be
-  offered to you right now, and keeps the refresh button from starting TestFlight
-  just to ask you to sign in. Nothing else is read from it — no Apple ID, no name,
+  offered to you right now, and keeps DuoUpdater from starting TestFlight in the
+  background just to ask you to sign in. Nothing else is read from it — no Apple ID, no name,
   no identifier — and nothing read there leaves the Mac.
 
 Credentials you enter yourself (a GitHub token, an Alcove licence) are stored in


### PR DESCRIPTION
Closes #539.

`TestFlightRefresh` only ever ran from the refresh button, so on a Mac nobody clicks, TestFlight's store went stale and the rows honestly said they could not bound their betas.

## What it does

Two rationed triggers beside the button, decided in `TestFlightSyncPolicy` (Core):

- **evidence** — the store is provably behind for some row, by the comparison `UpdateChecker` already runs. Self-limiting: a sync that works removes the proof. Guarded per `(bundle, build)`, so a build that *expires out of* the store cannot turn this into a timer.
- **floor** — nothing has written the store in an hour, measured against `max(TestFlight's own -wal date, our last attempt)`, so the user opening TestFlight themselves counts and a store that never writes cannot make every round try again.

Not on the tick itself. Each sync fetches 694–705 KB with no caching between launches, so the 5-minute cadence would cost ~207 MB/day to catch what was three events; the hourly floor is ~17 MB/day.

The automatic sync is **not awaited by the round that starts it** — awaiting it would add up to `defaultDeadline` to the moment *every* app's verdict is published, not just TestFlight's. The rows correct themselves through `recheckTestFlightRows`.

## Measurements behind it

**The problem**, 2026-09-12, 20h13m after the last sync — 3 of 8 rows unbounded, all three background-installed in that window:

```
Amp     store 75       vs 81       on disk — cannot bound
Mithka  store 1153     vs 1155     on disk — cannot bound
Paste   store 29814462 vs 29818681 on disk — cannot bound
```

**Per-launch cost**, four hidden launches that day (one ~2 min after the previous, so: no caching):

| | net in | net out | CPU | settle | `app_install` rows |
|---|---|---|---|---|---|
| 1 | 695.7 KB | 29.0 KB | 1.75 s | 7.5 s | 0 → 0 |
| 2 | 694.3 KB | 29.4 KB | 1.71 s | 7.5 s | 0 → 0 |
| 3 | 704.7 KB | 31.8 KB | 1.67 s | 9.1 s | 0 → 0 |
| 4 | 704.7 KB | 33.7 KB | 1.56 s | 9.0 s | 0 → 0 |

**A retraction.** Both comments used to argue that repeated syncs pile up TestFlight's auto-update jobs, from a recorded "42 activations enqueued 210 jobs". They don't: `appstored`'s install queue is a real table (`app_install` in `storeSystem.db`) with a `cancel_if_duplicate` column and a `DetectDuplicateRequestTask`; the dedup fired on all seven of that day's real TestFlight installs (`Ignoring duplicate resumption request`), and the table held 0 rows throughout. Those 210 were enqueue *attempts*. The original count is kept and corrected in place rather than deleted.

## Verification

`make test` green — 2694 Core + 267 CLI + 23 App cases.

**19 mutations applied and run**, each turning exactly the named case red. One deliberate exception is documented in the test: reordering the two branches of `reason()` is behaviour-preserving (the caller syncs and records the same evidence either way), so that case pins the real defect — evidence gated behind the floor — instead.

**Real path, on the installed build.** Aged the store's `-wal` mtime to make the floor due (mtime only; SQLite reads contents, and TestFlight rewrote it seconds later), then let a scheduled tick run:

```
13:12:45.308  TestFlight sync: starting one — nothing has written the store in 6h
13:12:54.884  TestFlight sync: refreshed(after: 2.5 seconds) (automatic)
13:12:54.913  re-checked 8 TestFlight rows
```

A scheduled tick, not the button, and the round was not held. An earlier run confirmed it fires once and the following ticks stay quiet.

**Not verified live: the evidence trigger.** Every TestFlight row is currently bounded, so there is nothing to trigger on, and I did not fabricate store state to force it. It is unit-tested with mutations and shares all of the wiring with the floor path — but that is the honest boundary.

## Four copies of a claim this makes false

`RefreshIntent.refreshesTestFlight` ("at no other time"), `TestFlightRefresh`'s "do not put it on a periodic check", the comment above the button's own sync, and the README sentence naming the button. All four updated — a reader stopping at any one of them would have concluded a background round never syncs.

## Follow-up, not in here

A user-facing **TestFlight detection** setting (off / on-when-I-ask / on-keep-it-fresh), defaulting to on for anyone who already granted Full Disk Access and off otherwise. Worth knowing for that design, measured while reviewing this:

- The notification store moved into `~/Library/Group Containers/group.com.apple.usernoted/db2/db` and is TCC-protected, so **there is no permission-free fallback** — no Full Disk Access means neither the store nor the notifications.
- And notifications could not carry one anyway: **13 of 13** TestFlight notifications on this Mac are post-install "is Now Up to Date". A build merely waiting produces email, not a notification. The structured payload holds `{adamID, TestFlight build id}` and no comparable version — the `(81)` exists only in the localized sentence.
