### PR TITLE
docs: move AppListModel's channel-switch-recheck archaeology to docs/engine-notes (#409)

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -6111,11 +6111,12 @@ final class AppListModel {
         // flush is one rename, not a multi-second bundle swap, and the whole point
         // of this stream is to put the row into its checking state before the user
         // can act on a verdict their flip has just invalidated — every millisecond
-        // of debounce is time that row spends live and wrong. It used to be 1s,
-        // which was the bulk of the measured 2.4s a flip took to settle. Cutting it
-        // is only safe now that `recheckChannelSwitches` supersedes its own passes:
-        // a burst that fires several times just cancels itself down to the last
-        // one, where before each extra event was work we could not take back.
+        // of debounce is time that row spends live and wrong. Cutting it from the
+        // original 1s is only safe now that `recheckChannelSwitches` supersedes its
+        // own passes (see `docs/engine-notes/app-list-model.md` §3 for the settle
+        // time that debounce used to be most of): a burst that fires several times
+        // just cancels itself down to the last one, where before each extra event
+        // was work we could not take back.
         let prefPaths = ChannelBinding.preferenceWatchPaths
         if !prefPaths.isEmpty {
             let prefsWatcher = AppDirectoryWatcher(paths: prefPaths, debounce: 0.25) { [weak self] in
@@ -6718,28 +6719,21 @@ final class AppListModel {
     /// flow). Coalesced against overlapping calls.
     private func recheckChannelSwitches(trigger: String) async {
         guard !results.isEmpty else { return }
-        // Latest wins. A pass already on the network was started from a choice the
-        // user has since left, so its verdict is not merely late — it is wrong, and
+        // Latest wins: a pass already on the network was started from a choice the
+        // user has since left, so its verdict is not merely late but wrong, and
         // letting it finish would write the superseded track into the row. Cancel it
-        // and start over rather than queueing behind it. Dropping the new trigger
-        // instead (what the old `channelSwitchRecheckRunning` guard did) was worse
-        // still: the flip was forgotten entirely, and because the fingerprints had
-        // already been booked, nothing compared them again — a row kept offering a
-        // prerelease to someone who had just opted out, for up to the watcher's
-        // 900s re-arm. See issue #74.
+        // and start over rather than queueing behind it or dropping the new trigger —
+        // see `docs/engine-notes/app-list-model.md` §3 for what the dropped-trigger
+        // design did instead, and why (issue #74).
         let previous = channelRecheckTask
         previous?.cancel()
         let task = Task { @MainActor [weak self] in
-            // Cancelling only raises a flag. The superseded pass keeps running until
-            // its `recheck` returns — `recheckMany` scans on a DETACHED task, which
-            // cancellation cannot reach at all — and for that whole time it still
-            // holds `installing[id] = .checking` on the rows it claimed. Starting the
-            // new pass on top of that made it skip those very rows, because its claim
-            // filter is `installing[id] == nil`: it rechecked nothing, the dying pass
-            // rechecked nothing either, and the flip was acted on by neither. That is
-            // issue #74 moved rather than fixed — two flips half a second apart, or
-            // one flip plus any unrelated write to the machine-wide
-            // `~/Library/Preferences` during the pass, were enough to hit it.
+            // `Task.cancel()` only raises a flag: the superseded pass keeps running
+            // (and holding `installing[id] = .checking` on its claimed rows) until its
+            // `recheck` returns, so starting a new claim pass on top of it just skips
+            // those same rows. See `docs/engine-notes/app-list-model.md` §3 for the
+            // race that let a flip go un-rechecked by either pass, and how narrow it
+            // turned out to be (issue #74).
             //
             // So wait the old pass out. It happens HERE, inside the new task, so that
             // `channelRecheckTask` below is still assigned synchronously: a third
@@ -6784,8 +6778,9 @@ final class AppListModel {
         // Mark every target busy BEFORE the first network call, not one at a time as
         // we reach it. The row's action button is replaced by the checking state, so
         // this is what stops a click landing on a verdict the flip has already
-        // invalidated — the window between the toggle and the new answer is ~2.4s,
-        // and only the marked part of it is safe.
+        // invalidated — the window between the toggle and the new answer used to
+        // measure ~2.4s (`docs/engine-notes/app-list-model.md` §3; not re-measured
+        // since the debounce above was cut), and only the marked part of it is safe.
         var claimed: [UpdateResult] = []
         for result in targets where installing[result.id] == nil {
             installing[result.id] = .checking

--- a/docs/engine-notes/README.md
+++ b/docs/engine-notes/README.md
@@ -63,4 +63,4 @@ what to do when the number has already drifted once.
 
 - [`app-store-page-cache.md`](app-store-page-cache.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift`
 - [`pre-install-gate.md`](pre-install-gate.md) — `DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PreInstallGate.swift`
-- [`app-list-model.md`](app-list-model.md) — `App/Sources/AppListModel.swift`, migrated in slices: §1 the install path (`install` / `runInstall` / `GateHandle` / `performInstall`), §2 running-app detection (`armRunningAppsMonitor` / `refreshRunningApps` / `retry`)
+- [`app-list-model.md`](app-list-model.md) — `App/Sources/AppListModel.swift`, migrated in slices: §1 the install path (`install` / `runInstall` / `GateHandle` / `performInstall`), §2 running-app detection (`armRunningAppsMonitor` / `refreshRunningApps` / `retry`), §3 channel-switch recheck (`recheckChannelSwitches` / `runChannelSwitchRecheck`)

--- a/docs/engine-notes/app-list-model.md
+++ b/docs/engine-notes/app-list-model.md
@@ -120,6 +120,82 @@ it replaced.
 
 ---
 
+**§3** (below) is the third slice: channel-switch detection
+(`recheckChannelSwitches` / `runChannelSwitchRecheck` /
+`fingerprints(forBoundIDs:)`, under the `// MARK: - Channel-switch recheck`
+heading), the scheduling around a `ChannelBinding` app's own in-app channel
+toggle that issue #74 found broken and that got revised twice in the same
+evening. The current contract — cancel-and-restart beats both "drop the new
+trigger" and "let both run", and the cancelling task must wait the superseded
+one out before its own claim pass starts — stays next to the code; what
+follows is why those two alternatives were tried and rejected.
+
+## §3 Why a channel-switch recheck cancels and waits, rather than dropping or racing (issue #74)
+
+The watcher that notices a flip at all — a filesystem stream on the vendor
+preference files a bound app's channel lives in, debounced and coalesced
+through a fingerprint compare — predates this section, and its own genesis
+(the Surge timeline: a launch event reading `KDDefaults.plist` before Surge
+had finished writing it) already has an authoritative home,
+`ChannelBinding.preferenceWatchPaths`'s own doc comment — not repeated here.
+What follows is two bugs found in the recheck *scheduling* around that
+watcher, both from 2026-08-26.
+
+**The original bug** (issue #74, filed and fixed 2026-08-26). Before commit
+`3d19c1f8` ("supersede an in-flight channel recheck instead of dropping the
+new one"), a trigger that arrived while a recheck was already on the network
+was dropped by a `channelSwitchRecheckRunning` guard — and because
+`lastSeenChannelFingerprints` was booked *before* the per-row rechecks ran,
+nothing ever compared that state again. Observed on this machine, flipping
+BetterDisplay's prerelease toggle back and forth: "a single flip settles in
+~2.4s every time (1s FSEvents debounce + fingerprint pass + networked
+recheck)" (quoted from the issue), and a flip landing inside another flip's
+~2.4s window was forgotten until an unrelated event — another bound app's
+launch/quit, the watcher's 900s re-arm, wake, or the next full check —
+happened to trigger a fresh pass; worst case, ~15 minutes on the wrong track.
+Fixed by cancelling the in-flight pass and starting over instead of dropping
+the new trigger, with fingerprints booked per id only once that id's own
+recheck finishes (`ChannelSwitchDetector.booked`).
+
+**The bug that fix introduced** (found by reading, the same evening — see the
+caveat below on how it was found; fixed by commit `7e7b89d0`, ~75 minutes
+after `3d19c1f8`).
+`Task.cancel()` only raises a flag: the cancelled pass kept running —
+`recheckMany` scans on a detached task, which cancellation cannot reach — and
+kept holding `installing[id] = .checking` on the rows it had claimed. The new
+pass's claim filter is `installing[id] == nil`, so it skipped exactly those
+rows: neither pass rechecked them, and a flip could go un-acted-on by both.
+Fixed by making the new task explicitly await the superseded one's
+completion before running its own claim pass, chained inside the new task so
+`channelRecheckTask` is already reassigned by the time a third trigger
+arrives.
+
+⚠️ **How likely that second bug was, in the fixing commit's own words, is more
+qualified than the source comment (before this pass) put it.** `7e7b89d0`
+measured the claim window at roughly 0.3s inside a ~0.72s settle, and ran
+twenty flips with deliberately dense extra triggers — a bound app
+launching/quitting, an unrelated `~/Library/Preferences` write, each within
+300ms of the flip — without reproducing it once, closing with "this is a
+defect found by reading... not a bug anyone has reported." The source
+comment in `recheckChannelSwitches`, before this pass, described the same
+double-trigger shape as "enough to hit it," with no such caveat. Both
+statements describe a real, narrow window that the fix correctly closes —
+the difference is confidence, not mechanism — so this is flagged as
+overstated rather than rewritten as false, and the source now points here
+instead of repeating either framing.
+
+Not independently re-verified this pass (2026-09-12): whether the 2.4s /
+0.72s / 0.3s timings above still hold — the preference-watcher debounce they
+were measured against has since been cut from 1s to 0.25s (same MARK
+section, `armLocalRescan`), which should shorten all three, and none of them
+has been re-measured since. What *was* re-checked: `recheckChannelSwitches`
+still cancels-and-waits rather than dropping or racing, and
+`runChannelSwitchRecheck` still books per completed id via
+`ChannelSwitchDetector.booked` — the architecture both 2026-08-26 fixes
+produced has not drifted.
+
+---
+
 Tests: `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/` has no dedicated test for
 the host-gate release point itself (it's exercised indirectly by
 `AppListModel`'s own concurrency, which the app-layer test target does not
@@ -134,3 +210,17 @@ is the cache `refreshRunningApps` calls into — eviction on a process quit,
 re-resolution on reappearance, the staging-name normalisation `retry()`'s
 correctness depends on — everything downstream of "here is this event's
 snapshot of running bundle URLs", not the KVO delivery itself.
+
+Same absence for §3: nothing constructs `AppListModel` to exercise
+`recheckChannelSwitches`'s cancel-and-wait scheduling itself — the two
+2026-08-26 races were both found by reading, not by a failing test, and
+neither has one today. What IS tested, in
+`DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift`,
+is `ChannelSwitchDetector.changes`/`.booked` — the per-id fingerprint compare
+and the "leave an unfinished id looking changed" bookkeeping the first fix
+depends on — not the `Task`-cancellation race the second fix closes. That
+test file's own `/// The regression behind issue #74, as a sequence.` comment
+(line 220) is a second retelling of the first bug, written to justify its own
+fixture rather than to be a design record; left as is, per this directory's
+own guidance that a test's incident retelling documents the test, not the
+class.


### PR DESCRIPTION
Third slice of AppListModel.swift for #409 (first: install path, #439; second: running-app detection, #541).

## Region chosen, and what I rejected

**Chosen:** `recheckChannelSwitches` / `runChannelSwitchRecheck` / `fingerprints(forBoundIDs:)`, under the `// MARK: - Channel-switch recheck` heading — the scheduling around a `ChannelBinding` app's own in-app channel toggle (Tailscale, Fork, Surge, …) that issue #74 found broken and that got revised twice on 2026-08-26. This block is self-contained (its own `// MARK:` section, its own two properties, no overlap with §1's install path or §2's running-app detection) and its two incidents — a dropped-trigger bug and the narrower race its own fix introduced — have no authoritative home anywhere else in the repo.

I also trimmed one adjacent comment in `armLocalRescan`'s preference-watcher setup (not under the same `MARK:`, but it quotes the exact same 2.4s measurement from issue #74 while explaining a debounce value) and one in `runChannelSwitchRecheck`'s "mark busy" comment that quoted the same number — both now point at §3 instead of repeating a number I couldn't re-verify.

**Considered and rejected:**
- Moving the Surge-timeline story (why the preference watcher exists at all) — it already has an authoritative home, `ChannelBinding.preferenceWatchPaths`'s own doc comment, so it stays a pointer, not a second copy.
- Widening the slice to all of `armLocalRescan` — the function's first half (the app-directory watcher for local rescans) is an unrelated subsystem; only the preference-watcher paragraph that shares this slice's incident got touched.
- Grepped for other copies of "issue #74" / `channelSwitchRecheckRunning` / the 2.4s figure across `.swift` and `.md` files. Found one: `ChannelSwitchDetectorTests.swift:220`'s own `/// The regression behind issue #74, as a sequence.` — left alone per this directory's own guidance (a test's incident retelling documents the test, not the class), and noted in the doc's Tests section.

## Where each migrated block went

| source block | destination |
|---|---|
| `recheckChannelSwitches`'s "Latest wins" comment (the dropped-trigger design, issue #74's original bug) | `docs/engine-notes/app-list-model.md` §3, "The original bug" |
| the `Task { @MainActor }` closure's "Cancelling only raises a flag" comment (the race that fix introduced) | §3, "The bug that fix introduced" |
| `armLocalRescan`'s "It used to be 1s, which was the bulk of the measured 2.4s" | §3 (pointer added; number moved, current-contract debounce reasoning kept in source) |
| `runChannelSwitchRecheck`'s "~2.4s" busy-window justification | §3 (pointer added, hedged as "used to measure" since unverified) |
| README.md Index line | extended to list §3 |

## Claims re-checked

| claim | status |
|---|---|
| issue #74's original bug: dropped-trigger guard (`channelSwitchRecheckRunning`) let a flip go un-rechecked until an unrelated event, up to 900s | still-true — confirmed against issue #74's own body and fix commit `3d19c1f8`; matches current code's rationale for cancel-and-restart |
| BetterDisplay flip settles "~2.4s every time (1s FSEvents debounce + fingerprint pass + networked recheck)" | quoted from issue #74, not re-measured this pass — flagged as such (debounce has since dropped 1s→0.25s, so this number is now stale by construction, just not independently re-measured to a new value) |
| second bug: `Task.cancel()` only raises a flag, superseded pass keeps holding `installing[id] = .checking`, starving the new pass's claim filter | still-true — confirmed against fixing commit `7e7b89d0`'s own description; matches current code (the `await previous?.value` wait) |
| source comment's framing that two flips "half a second apart... were enough to hit it" | **no longer accurately framed** — `7e7b89d0` measured the window at ~0.3s inside a ~0.72s settle and explicitly did NOT reproduce it in 20 dense-trigger attempts, calling it "a defect found by reading... not a bug anyone has reported." The source comment presented it as a demonstrated failure mode with no such caveat. Not a reversed-mechanism false claim like slice two's `retry()` finding — both descriptions agree on the mechanism — but overstated relative to how the fix's own author characterized it. Flagged in §3, not silently rewritten to match either framing. |
| Surge-timeline genesis of the preference watcher (Surge relaunching before `KDDefaults.plist` finished writing) | still-true, and already has its own authoritative home in `ChannelBinding.preferenceWatchPaths` — left as a pointer, not moved |
| `ChannelSwitchDetectorTests.swift:220`'s own issue-#74 retelling | a second copy, left alone (documents the test's own fixture, not the class) |
| current architecture (cancel-and-wait, not drop-or-race; per-id booking via `ChannelSwitchDetector.booked`) | re-checked against today's code (2026-09-12) — has not drifted |

## Most important finding

Not a reversed-mechanism false claim like slice two's `retry()` (which asserted the literal opposite of the current mechanism). This one is subtler: the source comment for the second, harder-to-hit bug asserted a specific failure condition ("two flips half a second apart... were enough to hit it") as if demonstrated, while the commit that actually fixed it (`7e7b89d0`) explicitly said the opposite about confidence — it measured a ~0.3s window inside a ~0.72s settle, ran 20 deliberately dense attempts, reproduced nothing, and called it "a defect found by reading... not a bug anyone has reported." Both descriptions agree on the mechanism; the source overstated how likely its own fixing commit considered it. Written up in §3 rather than quietly rewritten to sound more certain or more hedged than either original source.

## No behavior change

`git diff` touches only `App/Sources/AppListModel.swift` (comments) and `docs/engine-notes/`. Every changed line in the `.swift` file starts with `//`:

```
$ git diff origin/main -- App/Sources/AppListModel.swift | grep -E '^[+-][^+-]' | sed -E 's/^[+-][[:space:]]*//' | grep -vE '^//'
(no output)
```

## Verification

- `python3 scripts/check_engine_notes.py` → `✓ engine-notes pointers resolve — 523 Swift files scanned, 3 doc(s) indexed`
- `python3 scripts/check_prose_claims.py` → `✓ no machine-population claims in code comments — 523 files`
- `swift build --package-path DuoUpdaterCore` → `Build complete!` (proves nothing about `App/Sources`, run anyway per instructions)
- `xcrun swiftc -parse App/Sources/AppListModel.swift` → exits 0, no output (**parse check only, not a build**)
- Did NOT run `make test` — full suite left for pre-merge, per instructions.
