### PR TITLE
App Store and TestFlight: stop answering wide questions with narrow facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.93
 
+**Apps that added a Mac version no longer show as "not supported on this Mac."** An iPhone or iPad app you run on Apple silicon was mistakenly flagged the moment its developer shipped a real Mac build — the one change that makes the update more available, not less.
+
+**An App Store app you also beta-test is no longer mistaken for a TestFlight build.** When a developer promoted a beta unchanged, the two carried the same build number and your purchased copy was handed to TestFlight — so the App Store could never offer it an update.
+
 **The Requests window now shows how far back its log actually reaches, and marks date ranges it can't fully cover.** Before, picking "Last 30 days" on a log that only went back a few hours looked exactly like picking "Last 24 hours," with nothing on screen explaining why.
 
 ## 0.3.92

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,14 +214,28 @@ xcodebuild 的 SQLite 锁**,症状是 `database is locked` 或者干脆卡住—
 
 - **「转引一条实测」也是断言,而且是最容易漏的那种。** 引用一句带日期、带数字的实测,
   等于你自己也说了一遍——现有规矩只管「写新断言前先量」,不管「引用旧断言算不算」。
-  2026-09-06 实测过一次代价:`UpdateChecker` 里一句「measured 2026-08-29, Keka is a store
-  copy carrying `SUFeedURL`, 1 of the 22 store apps on this machine」写下来那天就是错的
-  (Keka 是 Developer ID 签的、没有 `_MASReceipt`,而 `isMAS` 的推导那天和今天逐字相同),
-  它却是「不给 `SparkleAppcastSource` 加商店闸」的**唯一记录理由**,撑了一周,并且被
-  转抄进另外三个文件——其中一次是我,而我当时的行为在旧规矩下完全合规。
+  `UpdateChecker` 里一句「measured 2026-08-29, Keka is a store copy carrying
+  `SUFeedURL`, 1 of the 22 store apps on this machine」是「不给 `SparkleAppcastSource`
+  加商店闸」的**唯一记录理由**,撑了一周,并且被转抄进另外三个文件。
   要么复测,要么写明「转引自 X,未复测」。
+
+- ⚠️ **这一条自己也栽在下一条上,2026-09-12 实测。** 上面这段原先接着写:
+  「(Keka 是 Developer ID 签的、没有 `_MASReceipt`,而 `isMAS` 的推导那天和今天逐字相同)」
+  ——那个**更正本身是错的**,而且错法和它要纠正的那句一模一样。
+  两台机器同为 Keka 1.6.7:一台 `/Applications/Keka.app/Contents/_MASReceipt/receipt`
+  在(2026-07-01)、`Authority=Apple Mac OS Application Signing`、且
+  `SUFeedURL = https://u.keka.io`;另一台是 `Developer ID Application`、无 receipt。
+  **原句在一台上是真的,更正在另一台上是真的,两句都被写成了关于这个 app 的事实。**
+
+- **「这份拷贝是什么」不是「这个 app 是什么」。** 上面那对错误的共同根因。Keka、WhatsApp、
+  CotEditor 都同时以商店和 Developer ID 两种方式分发,所以任何「app X 是/不是商店副本」
+  的句子,**别人在别的机器上复核只会得到相反的结论**,而这恰好是最像"已经量过了"的那种句子。
+  要写就写成 per-copy:「我这台的 X 是…」,或者干脆别靠它论证——
+  `SourceStorePolicyTests` 那种从 registry 推导的检查谁都能重跑。
+
 - **复合断言拆开写证据。** 那句话是 `Keka 带 SUFeedURL`(真从 plist 读的)∧
-  `Keka 是商店副本`(推的),合取继承了实测那半边的可信度。**写到"推断"两个字的时候就会暴露。**
+  `Keka 是商店副本`(**当时是推的,后来实测在一台机器上成立**),合取继承了实测那半边的可信度。
+  **写到"推断"两个字的时候就会暴露。**
 - **有一道闸,但只管一小片。** `scripts/check_prose_claims.py`(挂在 `make test` 里)拒绝
   「以本机 app 群体为分母的计数」——那种断言 CI、subagent、以后的读者都无法复现或证伪。
   它**管不了断言真不真**,只管它住在哪、长什么形状;换个说法就绕过去了,这是设计如此。

--- a/CLI/Sources/DuoKit/AppStoreVerify.swift
+++ b/CLI/Sources/DuoKit/AppStoreVerify.swift
@@ -187,7 +187,7 @@ extension Verify {
     ///  1. `single.kind`/`single.trackId` match what the registry declared.
     ///  2/3. `pageShape` — the product page the declared route depends on
     ///     still carries the JSON shape `extractMacVersionInfo`/
-    ///     `extractMacCompatible` parses.
+    ///     `extractMacCompatibility` parses.
     ///  4. (native-Mac cases only) `trackViewCheck` — `trackViewUrl` is still
     ///     an `https://apps.apple.com` URL reachable with zero redirects.
     ///  5. `batchEntry` — a batched lookup agrees with the single lookup on
@@ -235,8 +235,10 @@ extension Verify {
                             + "mostRecentVersion shelf — the parser and the live page have drifted apart")
                 case .wrappedIOS:
                     warnings.append(
-                        "compatFlagNotFound: page fetched fine, but extractMacCompatible found no "
-                            + "isIOSBinaryMacOSCompatible flag")
+                        "compatSignalsNotFound: page fetched fine, but extractMacCompatibility "
+                            + "did not find BOTH isIOSBinaryMacOSCompatible and appPlatforms — "
+                            + "either one drifting away silently narrows what the Mac-compat "
+                            + "verdict can tell apart")
                 }
             }
         case .unreachable(let code):

--- a/CLI/Tests/DuoKitTests/AppStoreVerifyClassificationTests.swift
+++ b/CLI/Tests/DuoKitTests/AppStoreVerifyClassificationTests.swift
@@ -97,7 +97,7 @@ import Foundation
     /// Mutation: the page fetched (2xx) but the production parser
     /// (`extractMacVersionInfo`) found nothing — A2's main silent-failure
     /// mode. Message differs by route (`versionShelfNotFound` vs.
-    /// `compatFlagNotFound`), so this is run for all three routes.
+    /// `compatSignalsNotFound`), so this is run for all three routes.
     @Test func pageFetchedButShapeNotFoundIsBroken() throws {
         for probeCase in [try nativeMacCase(), try iosOnMacCase(), try wrappedIOSCase()] {
             var observation = passingObservation(for: probeCase)
@@ -106,7 +106,7 @@ import Foundation
                 trackViewCheck: observation.trackViewCheck, batchEntry: observation.batchEntry)
             let verdict = Verify.classifyAppStore(probeCase, observation)
             #expect(verdict.status == .broken, "\(probeCase.bundleID)")
-            let expectedPrefix = probeCase.route == .wrappedIOS ? "compatFlagNotFound:" : "versionShelfNotFound:"
+            let expectedPrefix = probeCase.route == .wrappedIOS ? "compatSignalsNotFound:" : "versionShelfNotFound:"
             #expect(verdict.warnings.contains { $0.hasPrefix(expectedPrefix) }, "\(probeCase.bundleID)")
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -428,11 +428,30 @@ public struct UpdateChecker: Sendable {
         //
         // It used to be an inventory of which sources happened to carry
         // `guard !app.isMASApp`, kept accurate by hand and re-checked whenever a
-        // source was added. It was wrong twice: once by naming one source when
-        // three could run, and then, in the commit that fixed that, by citing
-        // Keka as a store copy carrying a `SUFeedURL` — Keka is Developer
-        // ID-signed with no `_MASReceipt`, so `isMASApp` was false for it under
-        // the very same derivation both then and now.
+        // source was added. It was wrong three times, and the third time is the
+        // instructive one.
+        //
+        //  1. It named one source when three could run.
+        //  2. The commit that fixed that cited "Keka is a store copy carrying a
+        //     `SUFeedURL`" as the worked example.
+        //  3. The commit that "corrected" THAT replaced it with "Keka is
+        //     Developer ID-signed with no `_MASReceipt`, so `isMASApp` was false
+        //     for it under the very same derivation both then and now."
+        //
+        // Measured 2026-09-12, two Macs, same app at the same version 1.6.7:
+        // one has `/Applications/Keka.app/Contents/_MASReceipt/receipt` (dated
+        // 2026-07-01, `Authority=Apple Mac OS Application Signing`) AND
+        // `SUFeedURL = https://u.keka.io`; the other is
+        // `Authority=Developer ID Application: Jorge Garcia Armero` with no
+        // receipt. So (2) was true of one machine and (3) of the other, and each
+        // was written down as a fact about the app.
+        //
+        // Whether a given copy is a store copy is not a property of the app.
+        // Keka, WhatsApp and CotEditor all ship both ways, so no sentence of the
+        // form "app X is/isn't a store copy" can be checked by anyone but the
+        // person running it — which is exactly why this paragraph no longer rests
+        // on one. `SourceStorePolicyTests.exactlyOneSourceAnswersStoreCopies`
+        // does, and it is derived from the registry rather than from a machine.
         //
         // TestFlight returns before the loop and never gets here at all.
         if let lastError, !app.isToolboxManaged {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -10,10 +10,16 @@ public struct AppStoreAvailability: Sendable, Hashable {
     public let homeRegion: String?
 
     /// For an iPhone/iPad app run on Apple Silicon: whether the *latest* App Store
-    /// build still runs on Macs (Apple's `isIOSBinaryMacOSCompatible` flag).
-    /// Vendors can drop Mac support in a newer release, so the newest version may
-    /// be real but uninstallable here — the App Store shows "Not compatible with
-    /// this device". nil = native Mac app / not checked (assume compatible).
+    /// build can be installed on a Mac at all. Vendors can drop Mac support in a
+    /// newer release, so the newest version may be real but uninstallable here —
+    /// the App Store shows "Not compatible with this device". nil = native Mac
+    /// app / not checked / couldn't tell (assume compatible).
+    ///
+    /// ⚠️ NOT a straight copy of Apple's `isIOSBinaryMacOSCompatible` flag, which
+    /// answers the narrower "does the *iOS binary* run on macOS" and therefore
+    /// reads `false` for every app that ships its own native Mac build. See
+    /// `MacAppStoreSource.MacCompatibilityReading` for the measurements and for
+    /// the second signal (`appPlatforms`) it takes to tell those two apart.
     public let latestMacCompatible: Bool?
 
     /// The store's own listing title, e.g. "DingDing: Redefine Work in AI" for the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -563,10 +563,16 @@ public struct AppScanner: Sendable {
         //
         // Deliberately NOT extended to the bundle's own `SUFeedURL` read above.
         // That read records what the bundle says — a fact, not a decision — and
-        // the decision now lives in one place, the gate. (The earlier version of
-        // this comment justified the split with "Keka is a store copy carrying
-        // one". It is not: Developer ID-signed, no `_MASReceipt`. Verified before
-        // repeating it would have taken one `ls`.)
+        // the decision now lives in one place, the gate.
+        //
+        // (Two earlier versions of this comment argued the split from Keka — first
+        // "Keka is a store copy carrying one", then "It is not: Developer
+        // ID-signed, no `_MASReceipt`". Both are true, of different machines:
+        // measured 2026-09-12, one Mac's Keka 1.6.7 has a 2026-07-01
+        // `_MASReceipt` and `SUFeedURL = https://u.keka.io`, another's is
+        // Developer ID with no receipt. An `ls` settles which copy is in front of
+        // you and nothing more, which is the whole point — a store copy carrying
+        // a feed is a real arrangement, so this branch has to be right for both.)
         if feedURL == nil, !isMAS { feedURL = SparkleFeedCatalog.feed(forBundleID: bundleID) }
         // The narrower gap: the bundle DOES name a feed, and the vendor stopped
         // publishing to it. Matched on the dead address itself, not on the bundle

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Scan/AppScanner.swift
@@ -497,10 +497,16 @@ public struct AppScanner: Sendable {
         // cached DB, this is local and never stale — it still recognizes a
         // TestFlight install whose build has OUTRUN the DB (Paste on 18771 while the
         // DB still lists 18655 → the old DB-only check fell through to the MAS path
-        // and got compared against the App Store stable track). It also cleanly
-        // distinguishes a TestFlight copy from an App Store copy of an app the user
-        // merely has TestFlight access to. Fall back to the DB match when the type
-        // is unreadable (e.g. Spotlight indexing off).
+        // and got compared against the App Store stable track). Fall back to the DB
+        // match when the type is unreadable (e.g. Spotlight indexing off).
+        //
+        // ⚠️ This clause distinguishes a TestFlight copy from a store copy of an app
+        // the user merely has TestFlight access to — but only on its own. It cannot
+        // do so from inside this `||`: a "Production" receipt makes THIS term false
+        // and every later term is still free to make the whole thing true. This
+        // comment used to claim the distinction as a property of the result, and it
+        // is not one. `cam.thescreen`, measured 2026-09-12, is what that cost — see
+        // `TestFlightInventory.isManaged`, which is the term that fired.
         //
         // The two `isiOSAppOnMac` clauses exist because NEITHER of the other two
         // can answer for a wrapped bundle: there is no receipt to read (measured —
@@ -514,10 +520,18 @@ public struct AppScanner: Sendable {
         // is local but privately formatted, the DB is documented by its own schema
         // but sits behind the app-data privacy gate and lags real installs.
         //
-        // The DB clause asks whether TestFlight says this build is installed HERE,
-        // not merely whether the user has access to it — so it cannot promote a
-        // store copy of an app the user also happens to beta-test, even when the
-        // two carry the same build number. See `hasInstalledIOSBuild`.
+        // Both DB clauses ask whether TestFlight says this build is installed HERE
+        // (`ZINSTALLSTATUSRAW = 1`), not merely whether the user has access to it —
+        // so neither promotes a store copy of an app the user also happens to
+        // beta-test, even when the two carry the same build number. See
+        // `hasInstalledIOSBuild` and `isManaged`.
+        //
+        // ⚠️ That was true of the iOS clause only until 2026-09-12. The mac clause
+        // (`isManaged`) read a table of every mac row the DB held, installed or
+        // not, while this comment — singular, "The DB clause" — pointed at the iOS
+        // one as if it spoke for both. On a schema with no `ZINSTALLSTATUSRAW` the
+        // mac clause still fails open to that older behaviour by design, so the
+        // sentence above is a statement about the common case, not a guarantee.
         let isTestFlight =
             (hasReceipt && Self.appStoreReceiptType(bundleURL) == "ProductionSandbox")
             || (isiOSAppOnMac && Self.wrappedBundleIsTestFlight(bundleURL))

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStorePageCache.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 /// TTL-memoized cache for the two things `MacAppStoreSource` scrapes off an App
-/// Store product page: the Mac-track version (+ "What's New" notes) and the
-/// `isIOSBinaryMacOSCompatible` flag.
+/// Store product page: the Mac-track version (+ "What's New" notes) and whether
+/// the latest build can be installed on a Mac at all
+/// (`MacAppStoreSource.MacCompatibilityReading`).
 ///
 /// **All of the value is across scans, none of it within one.** `resolve()` is
 /// a three-way dispatch with early returns, so exactly one of
@@ -22,7 +23,7 @@ import Foundation
 /// is based on and the wrong assumption an earlier version of this comment
 /// made.
 ///
-/// Deliberately caches a *parse failure* (2xx response, no version/flag found)
+/// Deliberately caches a *parse failure* (2xx response, no version/verdict found)
 /// the same as a *parse success* — an unparseable page costs full price again
 /// only once per TTL window, not once per check, which is the failure mode this
 /// exists to fix (skipping the scrape entirely would instead make the two

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreProbeRegistry.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreProbeRegistry.swift
@@ -22,8 +22,8 @@ public struct MacAppStoreProbeCase: Sendable {
         case iosOnMac
         /// `kind == "software"`, installed as the wrapped iOS binary →
         /// `remoteVersion(checkMacCompat: true)`: reads
-        /// `isIOSBinaryMacOSCompatible` off the plain (non `platform=mac`)
-        /// product page.
+        /// `isIOSBinaryMacOSCompatible` *and* `appPlatforms` off the plain
+        /// (non `platform=mac`) product page.
         case wrappedIOS
     }
 
@@ -68,7 +68,7 @@ public struct MacAppStoreProbeCase: Sendable {
 /// only unit-test coverage against captured fixtures.
 ///
 /// The failure mode this exists to catch is SILENT. If Apple reshapes the
-/// embedded JSON `extractMacVersionInfo`/`extractMacCompatible` parse:
+/// embedded JSON `extractMacVersionInfo`/`extractMacCompatibility` parse:
 ///   - `nativeMacVersion` quietly falls back to the (possibly stale) lookup
 ///     version — no error, no red row, just an answer that stopped being the
 ///     freshest one.
@@ -142,10 +142,20 @@ public enum MacAppStoreProbeRegistry {
         // Discord — `kind == "software"`, installable on Apple Silicon Macs
         // as the wrapped iOS binary. Exercises
         // `remoteVersion(checkMacCompat: true)`, which reads
-        // `isIOSBinaryMacOSCompatible` off the plain (non `?platform=mac`)
-        // product page. Confirmed live 2026-09-04: flag present (false —
-        // Discord ships a native build now, which is itself evidence the
-        // flag is still read correctly, not evidence the parse failed).
+        // `isIOSBinaryMacOSCompatible` and `appPlatforms` off the plain (non
+        // `?platform=mac`) product page. Confirmed live 2026-09-04: flag
+        // present. Re-measured 2026-09-12: flag false, `appPlatforms`
+        // `["phone", "pad"]`, and the page's Compatibility section names no
+        // Mac at all — a true negative, which is what keeps this case a
+        // useful probe of the `false` verdict.
+        //
+        // The 2026-09-04 note here used to explain the `false` as "Discord
+        // ships a native build now". That reading was wrong twice over: the
+        // App Store listing publishes no Mac binary (Discord's Mac app is a
+        // direct download, off-store), and had it been true the verdict would
+        // have been backwards — a native Mac build is precisely the shape that
+        // makes `isIOSBinaryMacOSCompatible == false` mean "supported", which
+        // is the bug `MacCompatibilityReading` exists to fix.
         MacAppStoreProbeCase(
             bundleID: "com.hammerandchisel.discord", trackId: 985746746,
             expectedKind: "software", route: .wrappedIOS),

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -476,13 +476,69 @@ public struct MacAppStoreSource: UpdateSource {
 
     // MARK: - Mac compatibility (wrapped iOS apps)
 
-    /// Reads Apple's `isIOSBinaryMacOSCompatible` flag for the latest build from
-    /// the product page's inline amp-api JSON. nil when the page/flag can't be
-    /// read — callers treat nil as "assume compatible" so a scrape failure never
-    /// hides a real update. Memoized through `pageCache`, same contract as
-    /// `cachedMacVersion` above: a non-2xx/undecodable response is `.unavailable`
-    /// (not cached, nil returned exactly as before this cache existed); a 2xx
-    /// response with no readable flag is `.success(nil)` (cached).
+    /// What one product page says about running the LATEST build on a Mac.
+    ///
+    /// Two readings, because `isIOSBinaryMacOSCompatible` on its own answers a
+    /// narrower question than its name suggests: it says whether the *iOS
+    /// binary* runs on macOS — i.e. whether this listing is installable on
+    /// Apple Silicon as a wrapped iPhone/iPad app. A listing that ships its own
+    /// **Mac** binary answers `false` there and is nevertheless fully supported
+    /// on Macs; the Mac build, not the wrapper, is what a Mac installs. So the
+    /// flag flips to `false` on the day a developer ADDS Mac support natively,
+    /// which reads exactly like the day one drops it.
+    ///
+    /// `appPlatforms` is the other half: the platforms the listing publishes
+    /// binaries for. `"mac"` in it means a real Mac build exists.
+    ///
+    /// Measured 2026-09-12 against 18 live listings (`us` storefront, Aqara Home
+    /// also `cn`): the page's own "Compatibility" section names Mac exactly when
+    /// `isIOSBinaryMacOSCompatible == true || appPlatforms.contains("mac")`, with
+    /// no exception in either direction.
+    ///   - flag `true`, no `"mac"` platform, Mac listed: Overcast, Aqara Home.
+    ///   - flag `false`, `"mac"` platform, Mac listed: nowdex, GoodNotes,
+    ///     WhatsApp, Kindle, CARROT Weather, Home Assistant, Bear, Things 3,
+    ///     Day One, Todoist, Microsoft To Do.
+    ///   - flag `false`, no `"mac"` platform, Mac NOT listed: Instagram,
+    ///     Discord, Facebook, Scriptable, ChatGPT, Telegram, Fantastical,
+    ///     Microsoft Edge.
+    struct MacCompatibilityReading {
+        /// `data[0].data.lockup.isIOSBinaryMacOSCompatible`.
+        var iosBinaryRunsOnMac: Bool?
+        /// `data[0].data.appPlatforms`.
+        var appPlatforms: [String]?
+
+        /// Both shapes were found. Only `verifyMacCompatPageShape` cares: the
+        /// verdict below stays useful when either one alone survives, so a
+        /// half-drifted page would still answer correctly — and silently — if
+        /// the sweep settled for `macSupported != nil`.
+        var readBothSignals: Bool { iosBinaryRunsOnMac != nil && appPlatforms != nil }
+
+        /// Whether the latest build is installable on a Mac at all. `nil` means
+        /// "couldn't tell" and callers treat it as compatible, so a scrape
+        /// failure never hides a real update.
+        ///
+        /// Fails open in one more place than the shape of the data strictly
+        /// forces: a `false` verdict needs BOTH readings, because a lone
+        /// `isIOSBinaryMacOSCompatible == false` is the majority shape above and
+        /// says nothing on its own. If Apple renames `appPlatforms`, every app
+        /// with a native Mac build lands here as `nil` (offer the update, maybe
+        /// wrongly) rather than as `false` (refuse it, definitely wrongly).
+        var macSupported: Bool? {
+            if iosBinaryRunsOnMac == true { return true }
+            guard let appPlatforms else { return nil }
+            if appPlatforms.contains("mac") { return true }
+            return iosBinaryRunsOnMac == false ? false : nil
+        }
+    }
+
+    /// Reads the two signals above off the product page's inline amp-api JSON
+    /// and reduces them to one verdict. nil when the page can't be read, or
+    /// when what it carries doesn't settle the question — callers treat nil as
+    /// "assume compatible" so a scrape failure never hides a real update.
+    /// Memoized through `pageCache`, same contract as `cachedMacVersion` above:
+    /// a non-2xx/undecodable response is `.unavailable` (not cached, nil
+    /// returned exactly as before this cache existed); a 2xx response with
+    /// nothing readable is `.success(nil)` (cached).
     private func cachedMacCompatibility(trackId: Int, region: String) async throws -> Bool? {
         if let cached = await pageCache.cachedCompatibility(trackId: trackId, region: region) {
             return cached
@@ -491,7 +547,8 @@ public struct MacAppStoreSource: UpdateSource {
             return nil  // malformed URL never happens for a real trackId/region; nothing to cache
         }
         switch try await fetchMacCompatibility(url: url) {
-        case .success(let compat):
+        case .success(let reading):
+            let compat = reading.macSupported
             await pageCache.storeCompatibility(compat, trackId: trackId, region: region)
             return compat
         case .unavailable:
@@ -499,7 +556,7 @@ public struct MacAppStoreSource: UpdateSource {
         }
     }
 
-    private func fetchMacCompatibility(url: URL) async throws -> PageFetchOutcome<Bool?> {
+    private func fetchMacCompatibility(url: URL) async throws -> PageFetchOutcome<MacCompatibilityReading> {
         var request = URLRequest(url: url)
         request.timeoutInterval = 15
         request.cachePolicy = URLRequest.versionFeedCachePolicy
@@ -515,12 +572,20 @@ public struct MacAppStoreSource: UpdateSource {
         guard let html = String(data: data, encoding: .utf8) else {
             return .unavailable
         }
-        return .success(extractMacCompatible(from: html))
+        return .success(extractMacCompatibility(from: html))
     }
 
-    /// Finds `data[0].data.lockup.isIOSBinaryMacOSCompatible` in the page's
-    /// `<script type="application/json">` blobs. Internal for offline tests.
-    func extractMacCompatible(from html: String) -> Bool? {
+    /// Finds `data[0].data.lockup.isIOSBinaryMacOSCompatible` and
+    /// `data[0].data.appPlatforms` in the page's `<script type="application/json">`
+    /// blobs. Internal for offline tests and for `verifyMacCompatPageShape`,
+    /// which asserts both shapes are still there.
+    ///
+    /// The pages carry more than one lockup — `moreByDeveloper` items have the
+    /// same flag, for other apps entirely — so the path is anchored at
+    /// `data[0].data`, which is this listing's own. (Measured on nowdex's page,
+    /// 2026-09-12: four `isIOSBinaryMacOSCompatible` occurrences, three of them
+    /// the developer's other apps.)
+    func extractMacCompatibility(from html: String) -> MacCompatibilityReading {
         var searchRange = html.startIndex..<html.endIndex
         let open = "<script type=\"application/json\""
         let close = "</script>"
@@ -533,14 +598,22 @@ public struct MacAppStoreSource: UpdateSource {
             if let jsonData = jsonSlice.data(using: .utf8),
                let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
                let dataArr = root["data"] as? [[String: Any]],
-               let inner   = dataArr.first?["data"] as? [String: Any],
-               let lockup  = inner["lockup"] as? [String: Any],
-               let compat  = lockup["isIOSBinaryMacOSCompatible"] as? Bool {
-                return compat
+               let inner   = dataArr.first?["data"] as? [String: Any] {
+                let reading = MacCompatibilityReading(
+                    iosBinaryRunsOnMac: (inner["lockup"] as? [String: Any])?["isIOSBinaryMacOSCompatible"] as? Bool,
+                    appPlatforms: inner["appPlatforms"] as? [String])
+                // Keep scanning when this blob carried neither — an earlier blob
+                // on the page can be some other payload entirely.
+                if reading.iosBinaryRunsOnMac != nil || reading.appPlatforms != nil { return reading }
             }
             searchRange = bodyEnd.upperBound..<html.endIndex
         }
-        return nil
+        return MacCompatibilityReading()
+    }
+
+    /// The verdict alone, for the one production caller. Internal for offline tests.
+    func extractMacCompatible(from html: String) -> Bool? {
+        extractMacCompatibility(from: html).macSupported
     }
 
     // MARK: -
@@ -924,14 +997,19 @@ extension MacAppStoreSource {
         }
     }
 
-    /// Un-cached fetch + parse of the `isIOSBinaryMacOSCompatible` flag at
-    /// `trackId`'s plain (non `?platform=mac`) product page — the page
+    /// Un-cached fetch + parse of both Mac-compatibility signals at `trackId`'s
+    /// plain (non `?platform=mac`) product page — the page
     /// `remoteVersion(checkMacCompat: true)` scrapes, bypassing `pageCache`.
+    ///
+    /// `found` requires BOTH, not just a usable verdict: either signal drifting
+    /// away on its own still leaves `macSupported` answering — the remaining one
+    /// covers most listings — so a sweep that asked only for a non-nil verdict
+    /// would go quiet on exactly the half-drift it exists to catch.
     public func verifyMacCompatPageShape(trackId: Int, region: String) async throws -> AppStorePageShapeCheck {
         guard let url = URL(string: "https://apps.apple.com/\(region)/app/id\(trackId)")
         else { return .unreachable(httpStatus: nil) }
         switch try await fetchMacCompatibility(url: url) {
-        case .success(let compat): return .reachable(found: compat != nil)
+        case .success(let reading): return .reachable(found: reading.readBothSignals)
         case .unavailable: return .unreachable(httpStatus: nil)
         }
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacAppStoreSource.swift
@@ -611,10 +611,6 @@ public struct MacAppStoreSource: UpdateSource {
         return MacCompatibilityReading()
     }
 
-    /// The verdict alone, for the one production caller. Internal for offline tests.
-    func extractMacCompatible(from html: String) -> Bool? {
-        extractMacCompatibility(from: html).macSupported
-    }
 
     // MARK: -
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -18,6 +18,10 @@ import SQLite3
 ///     app can hold iOS rows of its own, so a merged table would offer it an
 ///     iPhone build as its next Mac update.
 ///   - `ZINSTALLSTATUSRAW` 1 == a build TestFlight installed on this machine.
+///     Read on BOTH platform branches. It used to gate only the iOS one, which
+///     left `isManaged(bundleID:installedBuild:)` answering membership out of a
+///     table of everything merely AVAILABLE — see that method for the App Store
+///     purchase it mistagged.
 ///   - `ZTFAPPMODEL.ZISTESTER` 1, reached through a build row's `ZAPP` == the signed-in
 ///     account is testing that app. Read by its own query; see `readTesters`.
 ///     Measured 2026-09-08: 6 of 110 rows carry it, no nulls, values only 0/1, and
@@ -68,8 +72,15 @@ public struct TestFlightInventory: Sendable {
     /// newest available build plus the full set of build numbers, so we can both
     /// offer an update and recognize that an on-disk build is a TestFlight install.
     private let appsByBundleID: [String: App]
-    /// Every (bundleID, build) macOS pair seen — used to confirm a given on-disk
-    /// app really is the TestFlight install (its build appears here).
+    /// The (bundleID, build) macOS pairs `ZINSTALLSTATUSRAW` marks as installed
+    /// HERE — used to confirm a given on-disk app really is the TestFlight
+    /// install. The mirror of `iosBuildsByBundleID` below, and separate from
+    /// `appsByBundleID` above for the same reason: that one answers "what is
+    /// available", this one answers "is this copy TestFlight's".
+    ///
+    /// ⚠️ Falls back to EVERY mac row when the status column could not be read
+    /// (`macRowsOnlySQL`, or a fixture built without `installedMacRows`) — see
+    /// `isManaged(bundleID:installedBuild:)` for why unknown fails open here.
     private let buildsByBundleID: [String: Set<String>]
     /// The same, for the iOS rows TestFlight marks as installed here, and
     /// deliberately a separate map rather than more entries in the one above.
@@ -139,17 +150,19 @@ public struct TestFlightInventory: Sendable {
 
     public init(databaseURL: URL? = nil) {
         let url = databaseURL ?? Self.defaultDatabaseURL
-        let (rows, iosRows, iosAvailableRows, frontiers, testers, opened) = Self.readRows(at: url)
+        let (rows, macInstalledRows, iosRows, iosAvailableRows, frontiers, testers, opened) =
+            Self.readRows(at: url)
         self.accessible = opened
         self.frontierByBundleID = frontiers
         self.testerBundleIDs = testers
         self.iosBuildsByBundleID = Self.buildIndex(iosRows)
         self.iosLatestByBundleID = Self.newestByBundleID(iosAvailableRows)
 
-        var builds: [String: Set<String>] = [:]
-        for row in rows { builds[row.bundleID, default: []].insert(row.build) }
         self.appsByBundleID = Self.newestByBundleID(rows)
-        self.buildsByBundleID = builds
+        // `?? rows` is the fail-open: a schema without `ZINSTALLSTATUSRAW` costs
+        // the precision, not the signal, so every native-Mac TestFlight app keeps
+        // its tag rather than silently losing it.
+        self.buildsByBundleID = Self.buildIndex(macInstalledRows ?? rows)
     }
 
     /// Test seam / explicit construction: inject the parsed rows directly, skipping
@@ -165,6 +178,12 @@ public struct TestFlightInventory: Sendable {
     /// such precondition — every mac row is kept, installed or not, because
     /// ``latest(forBundleID:)`` is asking what is available.
     ///
+    /// ⚠️ `installedMacRows` is the mac mirror of `installedIOSRows`, and omitting
+    /// it means "this fixture does not say which mac builds TestFlight installed",
+    /// NOT "it installed none" — ``isManaged(bundleID:installedBuild:)`` then falls
+    /// back to `macRows`, which is what it did before the status column was read here. A case about a copy
+    /// TestFlight did NOT install has to pass it (`[]`, or the other builds).
+    ///
     /// `availableIOSRows` is the other iOS bucket and carries the opposite
     /// precondition: it is NOT filtered by install status, because
     /// ``latestIOS(forBundleID:)`` is asking what TestFlight offers. Passing only
@@ -173,6 +192,7 @@ public struct TestFlightInventory: Sendable {
     /// to use for a case about an update being available.
     public init(
         macRows: [(bundleID: String, shortVersion: String, build: String)],
+        installedMacRows: [(bundleID: String, shortVersion: String, build: String)]? = nil,
         installedIOSRows: [(bundleID: String, shortVersion: String, build: String)] = [],
         availableIOSRows: [(bundleID: String, shortVersion: String, build: String)]? = nil,
         frontiers: [String: Frontier] = [:],
@@ -187,16 +207,35 @@ public struct TestFlightInventory: Sendable {
         // available ones, so a fixture that names only the installed rows gets the
         // same shape rather than an inventory that says "installed but not offered".
         self.iosLatestByBundleID = Self.newestByBundleID(availableIOSRows ?? installedIOSRows)
-        var builds: [String: Set<String>] = [:]
-        for row in macRows { builds[row.bundleID, default: []].insert(row.build) }
         self.appsByBundleID = Self.newestByBundleID(macRows)
-        self.buildsByBundleID = builds
+        self.buildsByBundleID = Self.buildIndex(installedMacRows ?? macRows)
     }
 
-    /// Whether an on-disk app is a TestFlight install: its bundle id has macOS
-    /// rows in the DB and the installed build is one of them. Matching the build
-    /// (not just the bundle id) avoids mistaking an App Store copy of an app the
-    /// user merely *has access to* on TestFlight for a TestFlight install.
+    /// Whether an on-disk app is a TestFlight install: TestFlight marks a macOS
+    /// build as installed here (`ZINSTALLSTATUSRAW = 1`) and that is the build on
+    /// disk. The mac counterpart of ``hasInstalledIOSBuild(bundleID:installedBuild:)``,
+    /// and it requires both the same way and for the same reasons.
+    ///
+    /// ⚠️ Matching the build alone is NOT enough, and the comment here used to say
+    /// it was ("avoids mistaking an App Store copy of an app the user merely *has
+    /// access to*"). Measured 2026-09-12 on a machine where it did exactly that:
+    /// `cam.thescreen` is an App Store purchase — `Contents/_MASReceipt` present,
+    /// `kMDItemAppStoreReceiptType = Production`, `Authority=Apple Mac OS
+    /// Application Signing` — while the DB held
+    /// `cam.thescreen | 1.3.1 | 20260903024310 | platform 3 | ZINSTALLSTATUSRAW 0`,
+    /// i.e. a beta the user has access to that happens to carry the same
+    /// `CFBundleVersion` as the shipping build. Build match alone said "TestFlight
+    /// install", `AppScanner`'s `isTestFlight` is an `||` so the Production receipt
+    /// could not veto it, and `UpdateChecker` then returned from the TestFlight
+    /// branch before any source ran — the App Store could never answer for that row.
+    ///
+    /// A vendor shipping the same build to both channels is not exotic; it is what
+    /// happens whenever a beta is promoted unchanged.
+    ///
+    /// Fails OPEN when the status is unknown — `macRowsOnlySQL` (a schema with no
+    /// `ZINSTALLSTATUSRAW`), or a fixture built without `installedMacRows` — by
+    /// falling back to every mac row, because losing the column must cost the
+    /// precision and not the signal.
     public func isManaged(bundleID: String?, installedBuild: String?) -> Bool {
         guard let bundleID, let installedBuild,
               let builds = buildsByBundleID[bundleID] else { return false }
@@ -360,8 +399,11 @@ public struct TestFlightInventory: Sendable {
     typealias Row = (bundleID: String, shortVersion: String, build: String)
     /// What one read of the database yields: the two platform buckets, plus
     /// whether we got in at all.
+    /// `macInstalledRows` is nil — not empty — when the query could not name
+    /// `ZINSTALLSTATUSRAW`. Empty would say "TestFlight installed nothing here",
+    /// which is a claim that read never made.
     typealias Reading = (
-        rows: [Row], iosRows: [Row], iosAvailableRows: [Row],
+        rows: [Row], macInstalledRows: [Row]?, iosRows: [Row], iosAvailableRows: [Row],
         frontiers: [String: Frontier], testers: Set<String>?, opened: Bool)
 
     /// How long to wait for the database to open before treating it as
@@ -397,7 +439,7 @@ public struct TestFlightInventory: Sendable {
     /// Observed 2026-08-15: a nightly sweep sat in `guarded_open_np` for ten
     /// minutes at 0.03s of CPU before it was killed.
     private static func readRows(at url: URL) -> Reading {
-        guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], [], [:], nil, false) }
+        guard FileManager.default.fileExists(atPath: url.path) else { return ([], nil, [], [], [:], nil, false) }
         // nil covers both give-up modes — this open timed out, or an earlier one
         // for this path is still stranded — and both mean the same thing to the
         // caller: we never got in, so `opened` is false rather than "read it,
@@ -407,7 +449,8 @@ public struct TestFlightInventory: Sendable {
         // tuple type and `Reading`, and the compiler rejects it.
         return bounded.run(key: url.path, timeout: openTimeout) {
             openAndRead(at: url)
-        } ?? (rows: [], iosRows: [], iosAvailableRows: [], frontiers: [:], testers: nil, opened: false)
+        } ?? (rows: [], macInstalledRows: nil, iosRows: [], iosAvailableRows: [],
+              frontiers: [:], testers: nil, opened: false)
     }
 
     /// The actual read. Only ever called from `readRows(at:)`'s worker thread.
@@ -418,18 +461,20 @@ public struct TestFlightInventory: Sendable {
         guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
             sqlite3_close(db)
             Log.scan.error("TestFlight DB open failed at \(url.path, privacy: .public)")
-            return ([], [], [], [:], nil, false)
+            return ([], nil, [], [], [:], nil, false)
         }
         defer { sqlite3_close(db) }
 
         // Two queries, tried in order, because a prepare failure is total: it
         // returns an empty inventory that still reports `opened`, so every
         // TestFlight app silently loses its build and no native-Mac beta is
-        // offered an update again. `ZINSTALLSTATUSRAW` only feeds the wrapped-bundle
-        // signal, so a schema that no longer has that column must cost that signal
-        // and nothing else — not the macOS rows this file has read since before it
-        // existed. Naming a column in a SELECT is what makes its absence fatal, so
-        // the fallback names one fewer.
+        // offered an update again. `ZINSTALLSTATUSRAW` now feeds the mac
+        // membership signal too, so a schema that no longer has that column costs
+        // `isManaged` its precision — it falls back to every mac row, the answer
+        // it gave before the column was read — and still costs nothing else, not
+        // the macOS rows this file has read since before it existed. Naming a
+        // column in a SELECT is what makes its absence fatal, so the fallback
+        // names one fewer.
         if var reading = runRowQuery(db, sql: Self.rowsWithInstallStatusSQL, hasInstallStatus: true) {
             reading.frontiers = readFrontiers(db)
             reading.testers = readTesters(db)
@@ -450,7 +495,7 @@ public struct TestFlightInventory: Sendable {
         // one cannot prepare — and the whole reason the frontier got its own query is
         // that each signal fails on its own. Returning here without trying made the
         // implication run backwards.
-        return ([], [], [], readFrontiers(db), readTesters(db), true)  // we opened it; the schema just didn't match
+        return ([], nil, [], [], readFrontiers(db), readTesters(db), true)  // we opened it; the schema just didn't match
     }
 
     /// Both platforms, sorted into two buckets by the reader rather than merged.
@@ -559,13 +604,16 @@ public struct TestFlightInventory: Sendable {
     /// Runs one of the two queries above. `nil` means it would not prepare, which
     /// is the caller's cue to try the next one.
     ///
-    /// ⚠️ `hasInstallStatus` cannot change the outcome today — the fallback query
-    /// selects `ZPLATFORMRAW = 3`, so no iOS row ever reaches the branch that reads
-    /// it (measured: inverting the flag leaves the suite green). It stays because
-    /// of what it guards, not what it currently decides: column 4 does not exist in
+    /// `hasInstallStatus` now decides a real outcome: it gates BOTH platform
+    /// branches' membership buckets, and it is what makes `macInstalledRows` nil
+    /// ("unknown") rather than empty ("installed nothing") on the fallback query.
+    /// It previously could not change anything — the fallback selects
+    /// `ZPLATFORMRAW = 3`, so no iOS row ever reached the only branch that read
+    /// it, and inverting the flag left the suite green.
+    ///
+    /// What it has always also done, and still does: column 4 does not exist in
     /// the fallback's result set, and `&&` short-circuiting is what keeps
-    /// `sqlite3_column_int64(stmt, 4)` from being an out-of-range read the day
-    /// someone widens that query the way the primary one is widened.
+    /// `sqlite3_column_int64(stmt, 4)` from being an out-of-range read.
     private static func runRowQuery(
         _ db: OpaquePointer?, sql: String, hasInstallStatus: Bool
     ) -> Reading? {
@@ -577,6 +625,7 @@ public struct TestFlightInventory: Sendable {
         defer { sqlite3_finalize(stmt) }
 
         var rows: [Row] = []
+        var macInstalledRows: [Row] = []
         var iosRows: [Row] = []
         var iosAvailableRows: [Row] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
@@ -598,6 +647,14 @@ public struct TestFlightInventory: Sendable {
                 // Every mac row, installed or not: `latest(forBundleID:)` is
                 // asking which builds are AVAILABLE.
                 rows.append((bundleID, short, build))
+                // …and, separately, the one TestFlight says it installed here —
+                // the same split the iOS branch below has always made. Without
+                // it `isManaged` answered a membership question out of the
+                // availability table, and a store purchase of an app the user
+                // also beta-tests read as a TestFlight install.
+                if hasInstallStatus, sqlite3_column_int64(stmt, 4) == Self.installedHere {
+                    macInstalledRows.append((bundleID, short, build))
+                }
             case Self.iOSPlatform:
                 // Every iOS row is what TestFlight OFFERS for this bundle, which is
                 // the only bucket an update can come out of.
@@ -614,7 +671,10 @@ public struct TestFlightInventory: Sendable {
             }
         }
         // Frontiers are filled in by `openAndRead`, from its own query.
-        return (rows, iosRows, iosAvailableRows, [:], nil, true)
+        // `hasInstallStatus == false` means the status column was never selected,
+        // so "installed here" is unknown for mac rows, not empty.
+        return (rows, hasInstallStatus ? macInstalledRows : nil,
+                iosRows, iosAvailableRows, [:], nil, true)
     }
 
     /// `ZPLATFORMRAW` values, both named because both are now matched positively.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -181,8 +181,9 @@ public struct TestFlightInventory: Sendable {
     /// ⚠️ `installedMacRows` is the mac mirror of `installedIOSRows`, and omitting
     /// it means "this fixture does not say which mac builds TestFlight installed",
     /// NOT "it installed none" — ``isManaged(bundleID:installedBuild:)`` then falls
-    /// back to `macRows`, which is what it did before the status column was read here. A case about a copy
-    /// TestFlight did NOT install has to pass it (`[]`, or the other builds).
+    /// back to `macRows` — what it did before the status column was read here. A
+    /// case about a copy TestFlight did NOT install has to pass it (`[]`, or the
+    /// other builds).
     ///
     /// `availableIOSRows` is the other iOS bucket and carries the opposite
     /// precondition: it is NOT filtered by install status, because

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/AppScannerStoreCopyTests.swift
@@ -115,8 +115,12 @@ struct AppScannerStoreCopyTests {
     /// not any more. `UpdateChecker`'s gate declines every non-store source for a
     /// store row, so the address recorded here has no consumer. The earlier
     /// version of this comment justified the split with "Keka is a real store
-    /// copy carrying `SUFeedURL`", which was never true: Developer ID-signed, no
-    /// `_MASReceipt`.
+    /// copy carrying `SUFeedURL`"; the version after that called it "never true:
+    /// Developer ID-signed, no `_MASReceipt`". Measured 2026-09-12, both spellings
+    /// exist — one Mac's Keka 1.6.7 carries a 2026-07-01 `_MASReceipt` and
+    /// `SUFeedURL` together, another's carries neither. The arrangement this case
+    /// scans for is real; which copy a given Mac has is not the point, which is
+    /// why the fixture below is invented rather than named after Keka.
     ///
     /// Mutation: extend the guard to the `SUFeedURL` read and this goes nil.
     @Test func aStoreCopyKeepsTheFeedItsOwnBundleStates() throws {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStoreNotesTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStoreNotesTests.swift
@@ -61,10 +61,10 @@ import Foundation
         """)
     let missing = page("{}")
 
-    #expect(src.extractMacCompatible(from: noMacAtAll) == false)
-    #expect(src.extractMacCompatible(from: nativeMacBuild) == true)
-    #expect(src.extractMacCompatible(from: wrappedOnMac) == true)
-    #expect(src.extractMacCompatible(from: missing) == nil)  // unknown ⇒ assume compatible
+    #expect(src.extractMacCompatibility(from: noMacAtAll).macSupported == false)
+    #expect(src.extractMacCompatibility(from: nativeMacBuild).macSupported == true)
+    #expect(src.extractMacCompatibility(from: wrappedOnMac).macSupported == true)
+    #expect(src.extractMacCompatibility(from: missing).macSupported == nil)  // unknown ⇒ assume compatible
 }
 
 /// A `false` verdict takes both signals. With `appPlatforms` gone — Apple
@@ -78,7 +78,7 @@ import Foundation
     {"data":[{"data":{"lockup":{"isIOSBinaryMacOSCompatible":false}}}]}
     </script></html>
     """
-    #expect(src.extractMacCompatible(from: flagOnly) == nil)
+    #expect(src.extractMacCompatibility(from: flagOnly).macSupported == nil)
     #expect(src.extractMacCompatibility(from: flagOnly).readBothSignals == false)
 }
 
@@ -102,7 +102,7 @@ import Foundation
 
     #expect(src.extractMacCompatibility(from: both).readBothSignals)
     // Still a verdict, but no longer a shape the sweep should call healthy.
-    #expect(src.extractMacCompatible(from: platformsOnly) == true)
+    #expect(src.extractMacCompatibility(from: platformsOnly).macSupported == true)
     #expect(src.extractMacCompatibility(from: platformsOnly).readBothSignals == false)
 }
 
@@ -125,7 +125,7 @@ import Foundation
     }}]}
     </script></html>
     """
-    #expect(src.extractMacCompatible(from: html) == false)
+    #expect(src.extractMacCompatibility(from: html).macSupported == false)
 }
 
 /// The product-page scrape for an iOS-on-Mac app reads the latest Mac build's

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStoreNotesTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacAppStoreNotesTests.swift
@@ -20,22 +20,112 @@ import Foundation
     #expect(result.releaseNotes == "Bug fixes:\n• Fixed a crash\n• Faster launch")
 }
 
-/// The product-page scrape reads Apple's `isIOSBinaryMacOSCompatible` flag for a
-/// wrapped iPhone/iPad app, so we can warn when the latest build dropped Mac
-/// support (e.g. Aqara Home: a newer version exists but won't install here).
-@Test func extractsMacCompatibilityFlag() {
+/// The product-page scrape decides whether a wrapped iPhone/iPad app's latest
+/// build can be installed on a Mac at all, so we can warn when one really did
+/// drop Mac support instead of offering an update the store will refuse.
+///
+/// The three payloads below are the three live shapes measured 2026-09-12 (see
+/// `MacAppStoreSource.MacCompatibilityReading` for the full 18-listing table);
+/// each is the real `data[0].data` key layout, trimmed to the two fields the
+/// parser reads.
+///
+/// The middle one is the regression: `isIOSBinaryMacOSCompatible` answers "does
+/// the *iOS binary* run on macOS", so a developer who ADDS a native Mac build
+/// flips it to `false` — indistinguishable, on that field alone, from one who
+/// drops Mac support. Reading the flag by itself told a nowdex 1.1.0 user their
+/// 1.1.2 update was impossible, on the day the vendor shipped the Mac build that
+/// made it possible.
+@Test func extractsMacCompatibilityVerdict() {
     let src = MacAppStoreSource()
-    let incompatible = """
+    func page(_ inner: String) -> String {
+        """
+        <html><script type="application/json" id="shoebox">
+        {"data":[{"data":\(inner)}]}
+        </script></html>
+        """
+    }
+    // Discord, us: no Mac binary, and the iOS binary is opted out of Mac.
+    let noMacAtAll = page(
+        """
+        {"appPlatforms":["phone","pad"],"lockup":{"isIOSBinaryMacOSCompatible":false}}
+        """)
+    // nowdex, cn: ships its own Mac build, so the wrapper flag reads false.
+    let nativeMacBuild = page(
+        """
+        {"appPlatforms":["mac","phone","pad"],"lockup":{"isIOSBinaryMacOSCompatible":false}}
+        """)
+    // Overcast, us: no Mac binary, but the iOS binary runs on Apple Silicon.
+    let wrappedOnMac = page(
+        """
+        {"appPlatforms":["watch","phone","pad"],"lockup":{"isIOSBinaryMacOSCompatible":true}}
+        """)
+    let missing = page("{}")
+
+    #expect(src.extractMacCompatible(from: noMacAtAll) == false)
+    #expect(src.extractMacCompatible(from: nativeMacBuild) == true)
+    #expect(src.extractMacCompatible(from: wrappedOnMac) == true)
+    #expect(src.extractMacCompatible(from: missing) == nil)  // unknown ⇒ assume compatible
+}
+
+/// A `false` verdict takes both signals. With `appPlatforms` gone — Apple
+/// renaming it, or a page shape we haven't seen — the flag alone is the majority
+/// shape of Mac-SUPPORTED listings, so concluding "incompatible" from it would
+/// hide real updates for every app that ships a native Mac build. Fail open.
+@Test func aLoneIncompatibleFlagIsNotEnoughToRefuseAnUpdate() {
+    let src = MacAppStoreSource()
+    let flagOnly = """
     <html><script type="application/json" id="shoebox">
     {"data":[{"data":{"lockup":{"isIOSBinaryMacOSCompatible":false}}}]}
     </script></html>
     """
-    let compatible = incompatible.replacingOccurrences(of: "false", with: "true")
-    let missing = "<html><script type=\"application/json\">{\"data\":[{\"data\":{}}]}</script></html>"
+    #expect(src.extractMacCompatible(from: flagOnly) == nil)
+    #expect(src.extractMacCompatibility(from: flagOnly).readBothSignals == false)
+}
 
-    #expect(src.extractMacCompatible(from: incompatible) == false)
-    #expect(src.extractMacCompatible(from: compatible) == true)
-    #expect(src.extractMacCompatible(from: missing) == nil)  // unknown ⇒ assume compatible
+/// `duo verify`'s wrapped-iOS sweep asks for BOTH shapes, not merely a usable
+/// verdict. Either signal surviving alone still answers most listings, so a
+/// sweep that settled for `macSupported != nil` would stay green through exactly
+/// the half-drift it exists to catch.
+@Test func theSweepDemandsBothCompatibilitySignals() {
+    let src = MacAppStoreSource()
+    func page(_ inner: String) -> String {
+        "<html><script type=\"application/json\">{\"data\":[{\"data\":\(inner)}]}</script></html>"
+    }
+    let both = page(
+        """
+        {"appPlatforms":["mac","phone","pad"],"lockup":{"isIOSBinaryMacOSCompatible":false}}
+        """)
+    let platformsOnly = page(
+        """
+        {"appPlatforms":["mac","phone","pad"]}
+        """)
+
+    #expect(src.extractMacCompatibility(from: both).readBothSignals)
+    // Still a verdict, but no longer a shape the sweep should call healthy.
+    #expect(src.extractMacCompatible(from: platformsOnly) == true)
+    #expect(src.extractMacCompatibility(from: platformsOnly).readBothSignals == false)
+}
+
+/// A product page carries more than one lockup: `moreByDeveloper` items have the
+/// same flag, for other apps entirely. Measured on nowdex's page 2026-09-12 —
+/// four occurrences, three of them the developer's three other apps, all `true`
+/// while nowdex's own is `false`. Anchoring at `data[0].data` is what keeps the
+/// verdict about the app being checked; a looser search would read a neighbour.
+@Test func readsThisListingsLockupNotTheDevelopersOtherApps() {
+    let src = MacAppStoreSource()
+    let html = """
+    <html><script type="application/json" id="shoebox">
+    {"data":[{"data":{
+      "appPlatforms":["phone","pad"],
+      "lockup":{"adamId":"1","isIOSBinaryMacOSCompatible":false},
+      "shelfMapping":{"moreByDeveloper":{"items":[
+        {"adamId":"2","isIOSBinaryMacOSCompatible":true},
+        {"adamId":"3","isIOSBinaryMacOSCompatible":true}
+      ]}}
+    }}]}
+    </script></html>
+    """
+    #expect(src.extractMacCompatible(from: html) == false)
 }
 
 /// The product-page scrape for an iOS-on-Mac app reads the latest Mac build's

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SourceStorePolicyTests.swift
@@ -14,12 +14,23 @@ import Foundation
 /// because each fix went where the bite was.
 ///
 /// The prose left behind was an inventory of who carried the guard, and it went
-/// wrong twice. Most recently it justified `SparkleAppcastSource`'s exemption
-/// with "Keka is a store copy carrying a `SUFeedURL`" — measured, dated, and
-/// false on the day it was written: `/Applications/Keka.app` is Developer
-/// ID-signed with no `Contents/_MASReceipt`, and `AppScanner`'s `isMAS`
-/// derivation is byte-identical then and now. That single sentence was the only
-/// recorded reason not to close the hole, and it held for a week.
+/// wrong three times. It justified `SparkleAppcastSource`'s exemption with "Keka
+/// is a store copy carrying a `SUFeedURL`"; that was then "corrected" to "Keka is
+/// Developer ID-signed with no `Contents/_MASReceipt`, and `AppScanner`'s `isMAS`
+/// derivation is byte-identical then and now" — and the correction is the third
+/// error. Measured 2026-09-12, two Macs, Keka 1.6.7 on both: one has a
+/// 2026-07-01 `_MASReceipt` and `Authority=Apple Mac OS Application Signing`
+/// alongside `SUFeedURL = https://u.keka.io`; the other is Developer ID with no
+/// receipt.
+///
+/// Both sentences were true of the machine their author was sitting at, and both
+/// were written as facts about the app. A store copy carrying its own feed is a
+/// real arrangement — so the hole the original sentence described is real, and
+/// the "correction" argued it away on the strength of a different laptop.
+///
+/// That is the whole reason this file exists: a per-source reason checked against
+/// what the type declares can be re-run by anyone, and a sentence about what is
+/// installed on one Mac cannot.
 ///
 /// So: a registered reason per source, checked against what the type actually
 /// declares, plus a behavioural case that runs the real `UpdateChecker`.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightInventoryTests.swift
@@ -123,6 +123,47 @@ final class TestFlightInventoryTests: XCTestCase {
         XCTAssertFalse(tf.isManaged(bundleID: "com.wiheads.paste", installedBuild: nil))
     }
 
+    /// The mac membership question is `ZINSTALLSTATUSRAW = 1`, not "a row exists".
+    ///
+    /// Replays the shape measured 2026-09-12: a store purchase whose shipping
+    /// build carries the same `CFBundleVersion` as a beta the user has access to
+    /// but never installed. Build match alone answers "TestFlight install" for it,
+    /// which is what let `AppScanner`'s `||` override a Production receipt and
+    /// take the whole row away from the App Store.
+    ///
+    /// The paths and ids here are invented on purpose — a case that named the real
+    /// app would be measuring this machine's TestFlight library, not this rule.
+    func testIsManagedIgnoresBuildsTestFlightDidNotInstallHere() {
+        let tf = TestFlightInventory(
+            macRows: [
+                // Available to this tester: the promoted build, and a newer beta.
+                ("zz.fixture.promoted", "1.3.1", "2026090300"),
+                ("zz.fixture.promoted", "1.4.0", "2026091000"),
+                // A second app TestFlight really did install here.
+                ("zz.fixture.beta", "2.0", "900")
+            ],
+            installedMacRows: [("zz.fixture.beta", "2.0", "900")])
+
+        // The store copy sits at the promoted build. A row exists for it; an
+        // install does not.
+        XCTAssertFalse(tf.isManaged(bundleID: "zz.fixture.promoted", installedBuild: "2026090300"))
+        XCTAssertFalse(tf.isManaged(bundleID: "zz.fixture.promoted", installedBuild: "2026091000"))
+        XCTAssertTrue(tf.isManaged(bundleID: "zz.fixture.beta", installedBuild: "900"))
+
+        // `latest(forBundleID:)` is the other question and must still see every
+        // available row — including the app TestFlight did not install here.
+        XCTAssertEqual(tf.latest(forBundleID: "zz.fixture.promoted")?.latestBuild, "2026091000")
+    }
+
+    /// Unknown ≠ none. A schema with no `ZINSTALLSTATUSRAW` (and a fixture that
+    /// does not say) must cost the precision, not the signal — otherwise every
+    /// native-Mac TestFlight app silently loses its tag and stops being offered
+    /// beta updates, which is a worse failure than the one above.
+    func testIsManagedFailsOpenWhenInstallStatusIsUnknown() {
+        let tf = TestFlightInventory(macRows: [("zz.fixture.beta", "2.0", "900")])
+        XCTAssertTrue(tf.isManaged(bundleID: "zz.fixture.beta", installedBuild: "900"))
+    }
+
     func testCheckerOffersBetaUpdateWhenNewerBuildExists() async {
         let tf = inventory()
         let checker = UpdateChecker(sources: [], testflight: tf)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UpdateCheckerTerminalStatusTests.swift
@@ -215,10 +215,13 @@ import Foundation
     /// they get when the store is quietly keeping the app current.
     ///
     /// ⚠️ This paragraph used to be a hand-kept inventory of which sources
-    /// carried `guard !app.isMASApp`, and it was wrong twice — the second time
-    /// citing Keka as a store copy carrying a `SUFeedURL`, which was false on the
-    /// day it was written (Developer ID, no `_MASReceipt`). Do not reintroduce an
-    /// inventory here; the gate and its table are the answer.
+    /// carried `guard !app.isMASApp`, and it was wrong three times — twice about
+    /// the sources, and once about Keka, which two successive comments called a
+    /// store copy and then not one. Both were measured, on different Macs, and
+    /// both were wrong to be written as facts about the app (see
+    /// `SourceStorePolicyTests`). Do not reintroduce an inventory here, and do not
+    /// settle a policy question with what is installed on the machine you happen
+    /// to be on; the gate and its table are the answer.
     ///
     /// If a later change makes this `.appStoreManaged`, that is a decision to
     /// argue for here, not a tidy-up of an inconsistency.

--- a/docs/app-audits/com-coteditor-CotEditor.md
+++ b/docs/app-audits/com-coteditor-CotEditor.md
@@ -173,8 +173,12 @@ installed=7.0.9/843        box=on   → 7.1.0-beta.6  CotEditor_7.1.0-beta.6.dmg
 - **`AppScanner` 填 `SparkleFeedCatalog` 时不看 `isMASApp`**（#368 的第二半）已修，
   fill-in 和 superseded 两个入口都加了 `!isMAS`；随后 `UpdateChecker` 又加了统一的商店闸，
   商店副本根本到不了 `SparkleAppcastSource`。CotEditor 不走那条路，本来就不受影响。
-  （这条原先写着"Keka 是真实的商店副本自带 feed"——不是，Keka 是 Developer ID 签的、
-  没有 `_MASReceipt`。那句话我是从 `UpdateChecker` 的注释里转引的，没有复核。）
+  （这条先写着"Keka 是真实的商店副本自带 feed"，后来被"更正"成"不是，Keka 是
+  Developer ID 签的、没有 `_MASReceipt`"。2026-09-12 两台机器实测：同为 Keka 1.6.7，
+  一台带 2026-07-01 的 `_MASReceipt` + `Authority=Apple Mac OS Application Signing`
+  + `SUFeedURL = https://u.keka.io`，另一台是 Developer ID、无 receipt。
+  **两句都是各自机器上的真话，也都被写成了关于这个 app 的事实。**
+  「商店副本自带 feed」这个组合是真实存在的，别再拿某一台的 `ls` 结果去否掉它。）
 
 ## Changelog
 


### PR DESCRIPTION
Two apps on two of my Macs were being told the wrong thing about themselves, in the same shape: **a narrow fact standing in for a wide question, where the two opposite truths look identical in that fact.**

## 1. Nowdex showed "Not supported on this Mac" the day it gained Mac support

`isIOSBinaryMacOSCompatible` answers "does the *iOS binary* run on macOS", not "does this app support Mac". A listing that ships its own Mac binary answers `false` and is fully supported — so the flag flips the day a developer **adds** Mac support natively, identically to the day one drops it.

Measured 2026-09-12 across 18 live listings (`us`, Aqara Home also `cn`): the page's own Compatibility section names Mac exactly when `isIOSBinaryMacOSCompatible == true || appPlatforms.contains("mac")`, no exception either way.

- flag `true`, no `"mac"` platform, Mac listed: Overcast, Aqara Home
- flag `false`, `"mac"` platform, Mac listed: nowdex, GoodNotes, WhatsApp, Kindle, CARROT Weather, Home Assistant, Bear, Things 3, Day One, Todoist, Microsoft To Do
- flag `false`, no `"mac"` platform, Mac NOT listed: Instagram, Discord, Facebook, Scriptable, ChatGPT, Telegram, Fantastical, Microsoft Edge

A `false` verdict now needs **both** readings. A lone `isIOSBinaryMacOSCompatible == false` is the majority shape among Mac-supported listings, so it is unsound on its own: if Apple renames `appPlatforms`, every app with a native Mac build lands on `nil` (offer the update, maybe wrongly) rather than `false` (refuse it, definitely wrongly).

Red→green on the machine that reported it, binary as the only change:

```
old: {"name":"Nowdex","installedVersion":"1.1.0","latestVersion":"1.1.2","route":"manual"}
new: {"name":"Nowdex","installedVersion":"1.1.0","latestVersion":"1.1.2","route":"in-place"}
```

## 2. An App Store purchase was handed to TestFlight

`isManaged` answered a membership question out of the table of every mac row the DB holds — the *availability* table. The iOS branch has always filtered on `ZINSTALLSTATUSRAW = 1`; the mac branch never did.

`cam.thescreen` is an App Store purchase (`_MASReceipt` present, `kMDItemAppStoreReceiptType = Production`, `Authority=Apple Mac OS Application Signing`) while the DB held `cam.thescreen | 1.3.1 | 20260903024310 | platform 3 | ZINSTALLSTATUSRAW 0` — a beta the user has access to carrying the same `CFBundleVersion` as the shipping build, which is what happens whenever a beta is promoted unchanged. Build match alone said "TestFlight install"; `AppScanner`'s `isTestFlight` is an `||` so the Production receipt could not veto it; `UpdateChecker` then returned from the TestFlight branch before any source ran, and the App Store could never answer for that row.

Fails **open** when the status is unknown (a schema without the column, or a fixture that does not say): losing the column must cost the precision, not the signal. `macInstalledRows` is `[Row]?` for exactly that — nil is "unknown", not "installed none".

Red→green, and verified against the live database rather than through `AppScanner`'s `||`, because all four genuine TestFlight installs on this Mac are already tagged by an earlier term and would have masked a broken `isManaged`:

```
lettera 4266 → true    mithka 1155 → true    notability 7133 → true
paste 29818681 → true (and still offered 29819872)
cam.thescreen 20260903024310 → false, while latest() still sees the row
```

## 3. "Is it a store copy" is a fact about the copy, not the app

Seven places argued from Keka. First "Keka is a store copy carrying a `SUFeedURL`", then a commit "corrected" it to "Developer ID-signed with no `_MASReceipt`, and the `isMAS` derivation is byte-identical then and now". **The correction is the second error, and it is the same error.** Two Macs, Keka 1.6.7 on both: one has a 2026-07-01 `_MASReceipt` with `Authority=Apple Mac OS Application Signing` *and* `SUFeedURL = https://u.keka.io`; the other is Developer ID with no receipt.

That matters beyond wording — "a store copy carrying its own feed" is a real arrangement, so the hole the original sentence described is real, and the correction argued it away on the strength of a different laptop. `CLAUDE.md` used this correction as the worked example for 「转引一条实测也是断言」, so it is updated rather than deleted, and gains the rule it was missing.

`grep -rn Keka` first: seven sites, not the five a first pass found.

## Verification

- `make test` green (`2682 tests / 226 suites` + `280 tests / 34 suites`, exit 0)
- Five mutations, each reddening only its own case: reverting to the flag alone; weakening `readBothSignals` to `macSupported != nil`; searching the whole payload instead of anchoring at `data[0].data`; taking the unfiltered mac rows; treating unknown install status as none
- `duo verify --only com.hammerandchisel.discord` green live against the stricter sweep gate
- Both fixes deployed and confirmed on the two machines they were found on

## Deliberately out of scope

[#545](https://github.com/jizhi0v0/duo-updater/issues/545) — `resolve()` still routes on `Wrapper/` when the listing already answers it. Note the fix must carry a lookup fallback or it turns working rows blank.
[#546](https://github.com/jizhi0v0/duo-updater/issues/546) — neither App Store install route has an OS-floor judge.
