### PR TITLE
Sparkle appcast: read release notes in the reader's own language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 ## 0.3.93
 
+**Release notes now show up in your own language when an app publishes them in several.** Some apps ship their notes translated alongside each release; Duo Updater used to take whichever translation the app happened to list first or last, so one app's notes read in German for everyone and another's changed language from one release to the next.
+
 **Apps that added a Mac version no longer show as "not supported on this Mac."** An iPhone or iPad app you run on Apple silicon was mistakenly flagged the moment its developer shipped a real Mac build — the one change that makes the update more available, not less.
 
 **An App Store app you also beta-test is no longer mistaken for a TestFlight build.** When a developer promoted a beta unchanged, the two carried the same build number and your purchased copy was handed to TestFlight — so the App Store could never offer it an update.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -593,18 +593,23 @@ struct SparkleAppcastItem {
     /// terms. Absent for the vast majority of feeds.
     var minimumAutoupdateVersion: String?
     /// Inline release notes — the `<description>` body, usually CDATA-wrapped HTML.
+    /// One language's worth: a feed repeating the element per `xml:lang` is
+    /// narrowed to the reader's by `preferredVariant`.
     var descriptionHTML: String?
     /// Inline release notes shipped as Markdown via `<markdownDescription>` — some
     /// feeds (e.g. Surge) publish only this and no HTML `<description>`. Parsed
     /// into a structured changelog so the notes render natively instead of falling
-    /// back to a web view.
+    /// back to a web view. Localized the same way `descriptionHTML` is.
     var markdownDescription: String?
     /// `<pubDate>` — the item's publish date, verbatim. RSS spells this many ways
     /// (RFC822, ISO8601, or a bare Unix epoch as Surge does); kept raw and
     /// normalized only when we build a changelog entry.
     var pubDate: String?
     /// `<sparkle:releaseNotesLink>` — an external notes page, when the feed links
-    /// out instead of (or in addition to) inlining them.
+    /// out instead of (or in addition to) inlining them. Localized the same way
+    /// `descriptionHTML` is, and this is the field where it bites hardest: the
+    /// link is one page per language, so picking the wrong variant means fetching
+    /// and rendering a whole page of notes nobody asked for.
     var releaseNotesLink: URL?
 
     /// Prefer the build version (Sparkle's canonical key); fall back to short.
@@ -635,9 +640,13 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
     /// space to `%20` in the enclosure string before parsing. Nothing we read
     /// needs that yet, and doing it here would quietly start accepting items this
     /// has always dropped.
-    static func parse(_ data: Data, relativeTo base: URL? = nil) -> [SparkleAppcastItem] {
+    static func parse(
+        _ data: Data,
+        relativeTo base: URL? = nil,
+        preferredLanguages: [String] = Locale.preferredLanguages
+    ) -> [SparkleAppcastItem] {
         let parser = XMLParser(data: data)
-        let delegate = SparkleAppcastParser(base: base)
+        let delegate = SparkleAppcastParser(base: base, preferredLanguages: preferredLanguages)
         parser.delegate = delegate
         parser.parse()
         return delegate.items
@@ -646,8 +655,15 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
     /// The appcast's own URL, for resolving the relative URLs inside it.
     private let base: URL?
 
-    init(base: URL? = nil) {
+    /// The reader's language preferences, most-preferred first. Injected rather
+    /// than read from the process inside `preferredVariant` so a test can state
+    /// which reader it is describing instead of inheriting whatever language the
+    /// host Mac — or a CI runner — happens to be set to.
+    private let preferredLanguages: [String]
+
+    init(base: URL? = nil, preferredLanguages: [String] = Locale.preferredLanguages) {
         self.base = base
+        self.preferredLanguages = preferredLanguages
         super.init()
     }
 
@@ -657,6 +673,117 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
     /// and a relative `URL` would print as `assets/…` in a log or a report.
     private func resolve(_ string: String) -> URL? {
         URL(string: string, relativeTo: base)?.absoluteURL
+    }
+
+    // MARK: - Localized children
+
+    /// One `<item>` child element repeated per language, in document order.
+    ///
+    /// Sparkle lets a vendor ship the SAME child of `<item>` several times, each
+    /// tagged with `xml:lang`, and picks the one matching the reader
+    /// (https://sparkle-project.org/documentation/publishing/). Two feeds we track
+    /// do exactly that, in the two different shapes the format allows, and until
+    /// this existed we read BOTH of them by position — which is to say, at random
+    /// from the user's point of view (issue #399):
+    ///
+    ///  * Mac Mouse Fix links out: 12 `<sparkle:releaseNotesLink xml:lang>` per
+    ///    item (de, es, fr, pt-BR, vi, tr, cs, ru, zh-Hans, zh-Hant, zh-HK, ko) and
+    ///    no untagged one at all. `releaseNotesLink` was first-wins, so every
+    ///    reader on earth got `…/3.0.8/de.html`.
+    ///  * Mole inlines: 10 CDATA `<description xml:lang>` per item. `descriptionHTML`
+    ///    was last-wins, so every reader got the language the vendor happened to
+    ///    list last.
+    ///
+    /// Collected per item and resolved at `</item>` rather than assigned as each
+    /// element closes, because the choice cannot be made until every variant has
+    /// been seen.
+    private var localizedChildren: [String: [(language: String?, text: String)]] = [:]
+
+    /// The `xml:lang` of the element currently being read, or nil when it carries
+    /// none. Set on every `didStartElement` exactly like `textBuffer` is cleared
+    /// there, which is sound for the three elements below because all of them are
+    /// leaves — their content arrives as characters or CDATA, never as child
+    /// elements that would overwrite this mid-read.
+    private var currentLanguage: String?
+
+    /// Record one language variant of a localizable `<item>` child.
+    ///
+    /// Guarded on `current` for the same reason `<description>` always was: a feed
+    /// may carry a channel-level copy of these elements outside any `<item>`, and
+    /// attaching those to the first item that comes along would be worse than
+    /// dropping them.
+    private func recordLocalized(_ name: String, _ text: String) {
+        guard current != nil, !text.isEmpty else { return }
+        localizedChildren[name, default: []].append((currentLanguage, text))
+    }
+
+    /// Pick the variant to use, following Sparkle's `-[SUAppcast bestNodeInNodes:]`
+    /// exactly (Sparkle 2.x, `Sparkle/SUAppcast.m`):
+    ///
+    ///  1. A lone variant wins outright — its `xml:lang` is never even read. This
+    ///     is what keeps every single-variant feed we already parse byte-for-byte
+    ///     unchanged, including one whose only `<description>` is tagged `de`.
+    ///  2. Otherwise an untagged variant counts as `"en"` (Sparkle logs an error
+    ///     and assumes the same), and `preferredLocalizations` picks the winner.
+    ///  3. A reader matching nothing gets the FIRST variant.
+    ///
+    /// ⚠️ Step 3 is not a corner case, and it is not the `else` below doing it:
+    /// `Bundle.preferredLocalizations(from:forPreferences:)` itself answers with
+    /// the array's first element when nothing matches (measured 2026-09-12 on
+    /// macOS 27 — `["de","es",…,"ko"]` against `["en-US"]` and against `["ja-JP"]`
+    /// both come back `["de"]`). So an English reader still sees German for Mac
+    /// Mouse Fix, whose feed lists no `en` variant even though `…/3.0.8/en.html`
+    /// is published and reachable. That is the vendor's omission — Sparkle's own
+    /// updater shows German there too — and deviating would mean guessing at URLs
+    /// the feed does not offer.
+    ///
+    /// The `else` is therefore belt-and-braces rather than the mechanism, and it
+    /// is stated that way because it cannot be tested: no input reaches it. The
+    /// API returned a non-empty array present in the input for every adversarial
+    /// list tried (`""`, `"EN"`, `"en_US"`, `"Deutsch"`, `"🙂"`), and a lone
+    /// variant has already returned above. Sparkle carries the same unreachable
+    /// fallback (it logs an error beside it), and a future OS could make it live.
+    static func preferredVariant(
+        _ variants: [(language: String?, text: String)],
+        preferredLanguages: [String]
+    ) -> String? {
+        guard variants.count > 1 else { return variants.first?.text }
+        let languages = variants.map { $0.language.flatMap { $0.isEmpty ? nil : $0 } ?? "en" }
+        guard
+            let choice = Bundle.preferredLocalizations(
+                from: languages, forPreferences: preferredLanguages).first,
+            let index = languages.firstIndex(of: choice)
+        else { return variants.first?.text }
+        return variants[index].text
+    }
+
+    /// Resolve every collected variant onto the item that is closing.
+    ///
+    /// The table is emptied when an item OPENS rather than here, so "these
+    /// variants belong to the item currently being read" holds because of where
+    /// the reset lives and not because the feed closed its tags. `</item>` is the
+    /// vendor's to get wrong; `<item>` is what actually creates `current`.
+    ///
+    /// ⚠️ A chosen `<sparkle:releaseNotesLink>` that does not resolve leaves the
+    /// field nil, where the old first-wins guard (`releaseNotesLink == nil`) would
+    /// have gone on to try the next element in the item. That fall-through was an
+    /// accident of the guard, not a design: the next element is a different
+    /// LANGUAGE, so what it rescued was a reader silently getting notes they
+    /// cannot read. `resolve` only fails on a string `URL(string:)` refuses — a
+    /// literal space is the realistic one, since this parser deliberately skips
+    /// Sparkle's space→%20 rewrite (see `parse`) — and no notes URL is better than
+    /// the wrong language's.
+    private func applyLocalizedChildren() {
+        func best(_ name: String) -> String? {
+            localizedChildren[name].flatMap {
+                Self.preferredVariant($0, preferredLanguages: preferredLanguages)
+            }
+        }
+        if let text = best("description") { current?.descriptionHTML = text }
+        if let text = best("markdownDescription") { current?.markdownDescription = text }
+        if let text = best("sparkle:releaseNotesLink") {
+            current?.releaseNotesLink = resolve(text)
+        }
     }
 
     private var items: [SparkleAppcastItem] = []
@@ -680,9 +807,13 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
         attributes attributeDict: [String: String]
     ) {
         textBuffer = ""
+        currentLanguage = attributeDict["xml:lang"]
         switch elementName {
         case "item":
             current = SparkleAppcastItem()
+            // Whatever is still in the table belongs to an item that is over. See
+            // `applyLocalizedChildren` for why the reset lives here.
+            localizedChildren.removeAll(keepingCapacity: true)
         case "sparkle:deltas":
             deltasDepth += 1
         case "enclosure":
@@ -771,19 +902,30 @@ final class SparkleAppcastParser: NSObject, XMLParserDelegate {
             }
         case "description":
             // Only inside an <item>; the channel-level <description> has no
-            // `current` to attach to, so it's harmlessly dropped.
-            if !text.isEmpty { current?.descriptionHTML = text }
+            // `current` to attach to, so it's harmlessly dropped (see
+            // `recordLocalized`).
+            //
+            // ⚠️ This was last-non-empty-wins, and for a localized feed that was
+            // the bug. For an item repeating <description> with NO xml:lang on any
+            // of them — vendor duplication rather than translation — every copy now
+            // reads as "en" and the FIRST one wins instead of the last. That is
+            // Sparkle's behaviour, and the two feeds known to repeat a localizable
+            // child at all — Mac Mouse Fix's and Mole's, both fetchable by anyone —
+            // tag every duplicate with xml:lang, so neither takes this branch.
+            recordLocalized("description", text)
         case "markdownDescription", "sparkle:markdownDescription":
-            if current?.markdownDescription == nil, !text.isEmpty {
-                current?.markdownDescription = text
-            }
+            // Both spellings share one key, so a feed mixing them compares its
+            // variants against each other rather than letting whichever spelling
+            // came first win outright.
+            recordLocalized("markdownDescription", text)
         case "pubDate":
             if current?.pubDate == nil, !text.isEmpty { current?.pubDate = text }
         case "sparkle:releaseNotesLink":
-            if current?.releaseNotesLink == nil, !text.isEmpty {
-                current?.releaseNotesLink = resolve(text)
-            }
+            recordLocalized("sparkle:releaseNotesLink", text)
         case "item":
+            // Before appending: the localized children can only be resolved once
+            // every variant in this item has been seen.
+            applyLocalizedChildren()
             if let item = current { items.append(item) }
             current = nil
         default:

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleLocalizedNotesTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleLocalizedNotesTests.swift
@@ -1,0 +1,197 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+// Sparkle lets a vendor repeat an <item> child once per language, tagged with
+// `xml:lang`, and picks the one matching the reader. We used to ignore the
+// attribute entirely and take a variant by POSITION — first-wins for
+// <sparkle:releaseNotesLink>, last-wins for <description> — so the language a
+// reader got was whatever the vendor happened to list at that end of the list.
+// Issue #399 reported both halves: Mac Mouse Fix's notes came out German for
+// everyone, Mole's came out in whichever language its feed listed last.
+//
+// Every case below states the reader's language preferences explicitly rather
+// than letting `Locale.preferredLanguages` supply them. A test that read the
+// host's would be asserting something about this Mac, not about the parser, and
+// would answer differently on a CI runner set to another language.
+
+/// Two langs on `<description>`, Mole's shape (CDATA bodies, `en` listed first
+/// and the reader's language in the middle). Mutation: drop the language
+/// selection and take the last non-empty `<description>` as before — the reader
+/// gets `pt-BR` and this fails.
+@Test func descriptionPicksTheReadersLanguage() {
+    let items = SparkleAppcastParser.parse(Data(moleShapedFeed.utf8),
+                                           preferredLanguages: ["zh-Hans-CN", "en-US"])
+    #expect(items.count == 1)
+    #expect(items.first?.descriptionHTML == "<ol><li>软件更新</li></ol>")
+}
+
+/// The same feed read by an English Mac: the `en` variant, not the first or last
+/// one in the document.
+@Test func descriptionFollowsADifferentReaderToADifferentLanguage() {
+    let items = SparkleAppcastParser.parse(Data(moleShapedFeed.utf8),
+                                           preferredLanguages: ["en-US"])
+    #expect(items.first?.descriptionHTML == "<ol><li>Software updates</li></ol>")
+}
+
+/// Mac Mouse Fix's shape: the notes are LINKED, one URL per language, and the
+/// first one listed is German. Mutation: restore the `releaseNotesLink == nil`
+/// first-wins guard — every reader gets `de.html` and this fails.
+@Test func releaseNotesLinkPicksTheReadersLanguage() {
+    let items = SparkleAppcastParser.parse(
+        Data(macMouseFixShapedFeed.utf8),
+        relativeTo: URL(string: "https://example.com/appcast.xml")!,
+        preferredLanguages: ["zh-Hans-CN", "en-US"])
+    #expect(items.first?.releaseNotesLink?.lastPathComponent == "zh-Hans.html")
+}
+
+/// What an English reader gets from that same feed, which lists no `en` variant
+/// at all: the FIRST one, German.
+///
+/// This is not a shrug: `Bundle.preferredLocalizations(from:forPreferences:)`
+/// answers with the input array's first element when nothing matches, and
+/// Sparkle's own `bestNodeInNodes:` rides on the same call — so Mac Mouse Fix
+/// reading German to an English Mac is the vendor omitting `en` from its feed
+/// (`…/3.0.8/en.html` is published and reachable, just never listed), not us
+/// choosing badly. Pinned because the tempting "fix" is to invent a URL the feed
+/// does not offer.
+///
+/// What this case does NOT cover is `preferredVariant`'s own `else` arm; the
+/// fallback above happens inside Foundation, one level up from it. Removing that
+/// arm leaves every test here green, which is exactly what its doc comment says
+/// to expect.
+@Test func aReaderWithNoMatchingVariantGetsTheFirstOne() {
+    let items = SparkleAppcastParser.parse(
+        Data(macMouseFixShapedFeed.utf8),
+        relativeTo: URL(string: "https://example.com/appcast.xml")!,
+        preferredLanguages: ["ja-JP"])
+    #expect(items.first?.releaseNotesLink?.lastPathComponent == "de.html")
+}
+
+/// A lone variant is used whatever its `xml:lang` claims — Sparkle never even
+/// reads the attribute when there is nothing to choose between. This is what
+/// keeps every single-variant feed we already parse unchanged; without it a
+/// vendor who tags their one `<description>` `de` would lose its notes entirely
+/// for most readers.
+@Test func aLoneVariantIsUsedWhateverLanguageItClaims() {
+    let xml = feed(items: ["<description xml:lang=\"de\"><![CDATA[Nur Deutsch]]></description>"])
+    let items = SparkleAppcastParser.parse(Data(xml.utf8), preferredLanguages: ["en-US"])
+    #expect(items.first?.descriptionHTML == "Nur Deutsch")
+}
+
+/// An untagged variant among tagged ones counts as English — Sparkle assumes the
+/// same (it logs an error and defaults to `en`). Mutation: treat untagged as
+/// unknown and skip it, and the English reader falls through to `zh-Hans`.
+@Test func anUntaggedVariantCountsAsEnglish() {
+    let xml = feed(items: [
+        "<description xml:lang=\"zh-Hans\"><![CDATA[中文]]></description>",
+        "<description><![CDATA[English]]></description>",
+    ])
+    let items = SparkleAppcastParser.parse(Data(xml.utf8), preferredLanguages: ["en-US"])
+    #expect(items.first?.descriptionHTML == "English")
+}
+
+/// A channel-level `<description>` sits outside every `<item>` and has always
+/// been dropped. Mutation: drop the `current != nil` guard in `recordLocalized`
+/// and the channel blurb becomes a variant of the first item's notes — on an
+/// English Mac it would even win, because it carries no `xml:lang`.
+@Test func channelLevelNotesDoNotLeakIntoTheFirstItem() {
+    let xml = """
+    <?xml version="1.0" standalone="yes"?>
+    <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+      <title>Example feed</title>
+      <description>Most recent changes with links to updates.</description>
+      <item>
+        <sparkle:shortVersionString>1.0</sparkle:shortVersionString>
+        <description xml:lang="zh-Hans"><![CDATA[中文]]></description>
+        <description xml:lang="ja"><![CDATA[日本語]]></description>
+        <enclosure url="https://example.com/App-1.0.zip" length="1" type="application/octet-stream"/>
+      </item>
+    </channel>
+    </rss>
+    """
+    let items = SparkleAppcastParser.parse(Data(xml.utf8), preferredLanguages: ["en-US"])
+    #expect(items.count == 1)
+    #expect(items.first?.descriptionHTML == "中文")
+}
+
+/// One item's variants must not survive into the next. Mutation: drop the
+/// `localizedChildren.removeAll()` that runs when an `<item>` opens, and 1.0's
+/// two-language table is still standing while 0.9 is read — 0.9's own single
+/// untagged note then competes with 1.0's stale `en` one, loses on position, and
+/// this fails.
+@Test func variantsDoNotLeakFromOneItemToTheNext() {
+    let xml = """
+    <?xml version="1.0" standalone="yes"?>
+    <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+      <item>
+        <sparkle:shortVersionString>1.0</sparkle:shortVersionString>
+        <description xml:lang="en"><![CDATA[Newest, English]]></description>
+        <description xml:lang="zh-Hans"><![CDATA[最新]]></description>
+        <enclosure url="https://example.com/App-1.0.zip" length="1" type="application/octet-stream"/>
+      </item>
+      <item>
+        <sparkle:shortVersionString>0.9</sparkle:shortVersionString>
+        <description><![CDATA[Older, untagged]]></description>
+        <enclosure url="https://example.com/App-0.9.zip" length="1" type="application/octet-stream"/>
+      </item>
+    </channel>
+    </rss>
+    """
+    let items = SparkleAppcastParser.parse(Data(xml.utf8), preferredLanguages: ["en-US"])
+    #expect(items.count == 2)
+    #expect(items.first?.descriptionHTML == "Newest, English")
+    #expect(items.last?.descriptionHTML == "Older, untagged")
+}
+
+/// `<markdownDescription>` is localizable the same way, and the two spellings
+/// share one table — a feed mixing them compares its variants against each other
+/// rather than letting whichever spelling came first win outright.
+@Test func markdownDescriptionIsLocalizedAcrossBothSpellings() {
+    // The reader's language sits on the `sparkle:` spelling and the other one on
+    // the plain spelling, so a table keyed per spelling cannot answer "New": it
+    // would only ever see one of the two and hand back "Neu".
+    let xml = feed(items: [
+        "<markdownDescription xml:lang=\"de\">Neu</markdownDescription>",
+        "<sparkle:markdownDescription xml:lang=\"en\">New</sparkle:markdownDescription>",
+    ])
+    let items = SparkleAppcastParser.parse(Data(xml.utf8), preferredLanguages: ["en-US"])
+    #expect(items.first?.markdownDescription == "New")
+}
+
+// MARK: - Fixtures
+
+/// Wrap `items` — the localizable children under test — in the smallest feed the
+/// parser will yield an item for.
+private func feed(items children: [String]) -> String {
+    """
+    <?xml version="1.0" standalone="yes"?>
+    <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+      <item>
+        <sparkle:shortVersionString>1.0</sparkle:shortVersionString>
+        \(children.joined(separator: "\n    "))
+        <enclosure url="https://example.com/App-1.0.zip" length="1" type="application/octet-stream"/>
+      </item>
+    </channel>
+    </rss>
+    """
+}
+
+/// Mole's shape, trimmed: inline CDATA notes, `en` first and `pt-BR` last —
+/// the two ends a positional reader would have landed on.
+private let moleShapedFeed = feed(items: [
+    "<description xml:lang=\"en\"><![CDATA[<ol><li>Software updates</li></ol>]]></description>",
+    "<description xml:lang=\"zh-Hans\"><![CDATA[<ol><li>软件更新</li></ol>]]></description>",
+    "<description xml:lang=\"pt-BR\"><![CDATA[<ol><li>Atualizações</li></ol>]]></description>",
+])
+
+/// Mac Mouse Fix's shape, trimmed: linked notes, one URL per language, German
+/// first and no `en` variant anywhere.
+private let macMouseFixShapedFeed = feed(items: [
+    "<sparkle:releaseNotesLink xml:lang=\"de\">notes/3.0.8/de.html</sparkle:releaseNotesLink>",
+    "<sparkle:releaseNotesLink xml:lang=\"zh-Hans\">notes/3.0.8/zh-Hans.html</sparkle:releaseNotesLink>",
+    "<sparkle:releaseNotesLink xml:lang=\"ko\">notes/3.0.8/ko.html</sparkle:releaseNotesLink>",
+])


### PR DESCRIPTION
Half of #399 — the language half. The Keep a Changelog heading half is not in here (see below).

A vendor may repeat an `<item>` child once per language, tagged with `xml:lang`, and Sparkle picks the one matching the reader. We ignored the attribute and took a variant by position — first-wins for `<sparkle:releaseNotesLink>`, last-wins for `<description>` — so the language a reader got was whatever the vendor happened to list at that end of the list. Both reported cases are that one bug in its two shapes:

| feed | shape | before | after, on a Mac preferring en then zh-Hans |
|---|---|---|---|
| Mac Mouse Fix | 12 `releaseNotesLink xml:lang` per item, **no `en` variant** | `…/3.0.8/de.html` for everyone | `…/3.0.8/zh-Hans.html` |
| Mole | 10 CDATA `description xml:lang` per item | whichever language the feed listed last | English |

They differ because the rule is the same: Mole publishes an `en` variant so the first preference hits; Mac Mouse Fix publishes none, so the second one does.

## How it selects

Rule for rule from Sparkle's own `-[SUAppcast bestNodeInNodes:]` (2.x, `Sparkle/SUAppcast.m`):

1. a lone variant wins outright, its `xml:lang` never read — which is what keeps every single-variant feed parsing byte-for-byte as before;
2. an untagged variant counts as `"en"`;
3. `Bundle.preferredLocalizations` picks among the rest.

Covers `<description>`, `<markdownDescription>` (both spellings share one table) and `<sparkle:releaseNotesLink>`.

The reader's preferences are a parameter defaulted to `Locale.preferredLanguages`, not something the selector reads for itself: a case that asked the process would be asserting something about the host Mac rather than about the parser, and would answer differently on a runner set to another language.

**An English reader still sees German for Mac Mouse Fix, and that is correct.** `Bundle.preferredLocalizations(from:forPreferences:)` answers with the array's first element when nothing matches, so Sparkle's own updater shows German there too. The vendor publishes `…/3.0.8/en.html` — reachable, HTTP 200 — but never lists it in the feed. Deviating would mean guessing at URLs the feed does not offer.

**No `parserGeneration` bump.** Nothing on this path reaches either cross-launch changelog cache: `ChangelogDiskCache` is written from one call site, the recipe-backed `ChangelogService.load`, and a Sparkle-derived changelog travels on `RemoteVersion`, which is not `Codable`.

## Verification

Both apps installed, both `SUFeedURL`s confirmed to be the feeds measured, and the before/after above read out of `SparkleAppcastSource.latestVersion` itself over the live network — not out of the parser in isolation. Then confirmed in the installed app: Mac Mouse Fix's pane renders the Chinese notes page, Mole's renders English in the native multi-version view.

`make test` green — 2736 + 280 cases, 0 failures, all seven Python gates.

Nine new cases, each naming the mutation it exists to catch. Eight mutations run: seven go red and name the case. The eighth is documented as uncatchable rather than papered over — the no-match fallback happens inside Foundation, one level above the `else` arm that looks like it implements it, so removing that arm leaves every case green.

`/code-review` raised four, all addressed in the diff: the variant table now clears when an `<item>` opens rather than when one closes (so the invariant does not depend on the vendor closing its tags), a comment about Markdown spellings moved back onto the case it describes, the last-wins→first-wins change for *untagged* duplicate `<description>` elements is now written down, and so is the loss of the accidental fall-through when a chosen notes URL fails to resolve.

## Not in here

- **Keep a Changelog headings** — the other half of #399. `Changelog.Entry.items` is a flat `[String]`, so `### Fixed` is only ever a boundary. Doing it properly means a `.heading` case on `Entry.Block` plus a renderer style; it is a separate change and it needs a generation bump, which this one does not.
- **Mac Mouse Fix's notes are a web view, not the native view.** Its feed inlines nothing, so there is no structured changelog to render. A recipe would re-freeze the language — `sourceTemplate` understands `{version}` and `{major}`, and has no language token — so the fix for that is not "add a recipe".
