### PR TITLE
Mac Mouse Fix: detect and offer its beta channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Cline now gets updates, on both its release and beta builds, and shows its release notes.** Until now it sat with a question mark instead of a version — it ships no update feed of the kind Duo Updater could read, and there is no Homebrew package for it. Duo Updater now asks the same address Cline's own updater asks, so the update offered is the one Cline would have installed itself, and the beta build stays on the beta track.
 
+**Mac Mouse Fix now offers its beta releases if you've turned on "Get Beta Versions" in its own General settings.** Before, Duo Updater could only see Mac Mouse Fix's regular releases, so a beta build sat unnoticed until the next regular version shipped.
+
 ## 0.3.92
 
 **Some self-updating apps no longer look up to date while a newer version is out.** For apps whose update information sits behind a slow-to-refresh download server, Duo Updater could keep seeing an older version for days after a release.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelArtifactProof.swift
@@ -504,6 +504,12 @@ public enum ChannelProofRegistry {
             .recipeAnchor(#"appcast-signed-beta\.xml"#, in: ["feedOverride"]),
         ChannelProofKey("com.colliderli.iina", .beta):
             .recipeAnchor(#"appcast-beta\.xml"#, in: ["feedOverride"]),
+        // Mac Mouse Fix: same feed-swap shape as IINA, and the same reasoning —
+        // stable and beta share host, path prefix and repo, differing only in
+        // the trailing filename (`appcast.xml` vs `appcast-pre.xml`), which is
+        // exactly what the anchor targets.
+        ChannelProofKey("com.nuebling.mac-mouse-fix", .beta):
+            .recipeAnchor(#"appcast-pre\.xml"#, in: ["feedOverride"]),
         // TablePlus is the sharpest case in the population and the only
         // header-keyed one. Stable and beta share ONE feed URL; the server decides
         // which builds to return from a request header, and the VALUE is

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -130,6 +130,8 @@ public struct ResolvedChannel: Sendable, Equatable {
 ///   * CapCut   → `~/Movies/CapCut/User Data/Config/updateInfo` (`joinBeta` in an INI)
 ///   * CotEditor→ `UserDefaults[checksUpdatesForBeta]`, in its sandbox CONTAINER
 ///                                     (Bool: true→beta; false→nil, see the type)
+///   * Mac Mouse Fix→ `…/Application Support/com.nuebling.mac-mouse-fix/config.plist`
+///                                     → `General.checkForPrereleases` (Bool: true→beta)
 ///
 /// So there is no generic reader. `ChannelBinding` is the single authority the
 /// scanner consults; an app with no resolver returns nil and the generic
@@ -170,6 +172,7 @@ public enum ChannelBinding {
         CotEditorChannel.bundleID.lowercased(),
         WindscribeChannel.bundleID.lowercased(),
         SuperconductorChannel.bundleID.lowercased(),
+        MacMouseFixChannel.bundleID.lowercased(),
     ]
 
     /// The directories holding every preference a resolver above reads, for a
@@ -240,6 +243,12 @@ public enum ChannelBinding {
         // is what makes flipping "Update to prereleases when available" show up
         // without waiting for a relaunch.
         roots.append(CotEditorChannel.preferencesDirectoryURL)
+        // Mac Mouse Fix is the second app (after Surge) that keeps its channel
+        // choice in its own Application Support file rather than in
+        // `~/Library/Preferences` — `General.checkForPrereleases` lives in
+        // `config.plist`, not in a CFPreferences domain, so neither of the two
+        // roots above would ever see it change.
+        roots.append(MacMouseFixChannel.configFileURL.deletingLastPathComponent())
         // Windscribe deliberately adds nothing: it is not sandboxed and its
         // QSettings scope (`Windscribe`/`Windscribe2`) lands on
         // `~/Library/Preferences/com.windscribe.Windscribe2.plist`, already
@@ -380,6 +389,8 @@ public enum ChannelBinding {
         case SuperconductorChannel.bundleID.lowercased():
             return SuperconductorChannel.resolveCurrent
         case CodeEditChannel.bundleID.lowercased(): return CodeEditChannel.resolveCurrent
+        case MacMouseFixChannel.bundleID.lowercased():
+            return MacMouseFixChannel.resolveCurrent
         default:                       return nil
         }
     }
@@ -428,6 +439,8 @@ public enum ChannelBinding {
         (TablePlusChannel.bundleID, TablePlusChannel.resolve(receiveBeta: true)),
         (IINAChannel.bundleID, IINAChannel.resolve(receiveBeta: false)),
         (IINAChannel.bundleID, IINAChannel.resolve(receiveBeta: true)),
+        (MacMouseFixChannel.bundleID, MacMouseFixChannel.resolve(checkForPrereleases: false)),
+        (MacMouseFixChannel.bundleID, MacMouseFixChannel.resolve(checkForPrereleases: true)),
         // Both toggles, because "internal" subsumes "pre" — a user with both on is
         // opted into two tags at once and must be offered whichever is newer.
         (BetterDisplayChannel.bundleID,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacMouseFixChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacMouseFixChannel.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// Mac Mouse Fix (`com.nuebling.mac-mouse-fix`) — a feed-swap Sparkle app, same
+/// shape as IINA: the shipped Info.plist `SUFeedURL` is always the STABLE feed,
+/// and the user's own in-app toggle swaps in a second feed at runtime.
+///
+/// Read from the open-source repo rather than inferred (issue #555 / #556):
+/// `App/Update/SparkleUpdaterController.m`'s `+enablePrereleaseChannel:` does
+/// exactly this —
+/// ```
+/// SUUpdater.sharedUpdater.feedURL =
+///     pre ? "<repo>/update-feed/appcast-pre.xml" : "<repo>/update-feed/appcast.xml"
+/// ```
+/// where `<repo>` is `kMFUpdateFeedRepoAddressRaw`
+/// (`https://raw.githubusercontent.com/noah-nuebling/mac-mouse-fix/update-feed`,
+/// `Shared/Constants.h`). The toggle itself (`betaToggle` in
+/// `App/UI/Main/Tabs/GeneralTabController.swift`) writes a Bool at the config
+/// path `General.checkForPrereleases` — NOT UserDefaults/CFPreferences. Mac
+/// Mouse Fix keeps its own config file instead (`Shared/Locator/Locator.m`):
+/// `~/Library/Application Support/com.nuebling.mac-mouse-fix/config.plist`, a
+/// dict whose `"General"` entry is itself a dict holding `"checkForPrereleases"`
+/// (confirmed against the bundle's own `Contents/Resources/default_config.plist`,
+/// which ships that shape with the key defaulting to `false`).
+///
+/// `generate_releases.py` (the script that WRITES both feeds, read on the
+/// `update-feed` branch) is the authority on how the two tracks are built, and
+/// two things follow from reading it rather than guessing:
+///   * `is_prerelease = r['prerelease']` comes straight from the GitHub release
+///     API flag. The stable feed (`appcast_items`) only ever gets
+///     `not is_prerelease` releases; the preview feed (`appcast_pre_items`) gets
+///     EVERY release, prerelease or not — so it is a superset of stable, not a
+///     separate track, and both lists preserve the GitHub API's own
+///     newest-first order (no re-sort in the script).
+///   * `sparkle:shortVersionString` is `r['name']` — the release's literal
+///     GitHub display name, e.g. the verified newest preview item's
+///     `"3.1.0 Beta 1"` (space, capital B) — while `sparkle:version` is the
+///     REAL `CFBundleVersion` read out of the actual downloaded, unzipped
+///     bundle. Downloading that exact asset (build 24830, 2026-09-12) confirms
+///     both fields land on the installed copy unchanged: its own
+///     `CFBundleShortVersionString` is the literal `3.1.0 Beta 1` and its
+///     `CFBundleVersion` is `24830` — so there is no feed-vs-bundle mismatch
+///     here the way Mozilla's suffix-stripping is (`ReleaseChannel.detect`'s
+///     own warning). `RemoteVersion.marketingMatchesBundle: true` is correct.
+///
+/// Comparator behaviour actually run against `"3.1.0 Beta 1"` (not assumed):
+///   * `VersionComparator.comparableMarketingVersion` rejects any string
+///     containing whitespace, so `"3.1.0 Beta 1"` fails it. `isMarketingDowngrade`
+///     therefore answers "cannot tell" (→ not a downgrade) for a pair on either
+///     side of it — the safe direction, since callers use that guard only to
+///     WITHHOLD an offer, never to raise one.
+///   * `UpdateChecker.evaluate` reaches its build-number branch first: with both
+///     sides carrying `sparkle:version`, `24830` vs. an installed `24310`
+///     compares as strictly newer under `VersionComparator.isNewer`, and the
+///     marketing-downgrade guard above declines to override that verdict — so
+///     the beta is correctly offered. This is not an accident of this one pair:
+///     Mac Mouse Fix's OWN Sparkle delegate (`CoolSUComparator.m`) resolves the
+///     exact same ambiguity the same way — it strips a version string down to
+///     its leading digits-and-periods run before comparing (so `"3.1.0"` and
+///     `"3.1.0 Beta 1"` compare EQUAL), then breaks the tie on the build number
+///     — i.e. the vendor's own client also treats the build as authoritative
+///     once the marketing strings tie. Both call sites lean on the same fact:
+///     `CFBundleVersion` here is a real, monotonically increasing build id.
+///
+/// Team ID is unchanged across channels: the downloaded 3.1.0 Beta 1 bundle is
+/// signed `Developer ID Application: Noah Nuebling (LM5Z78756B)`, matching the
+/// installed stable copy — so a one-click install does not cross signing
+/// identities.
+enum MacMouseFixChannel {
+    static let bundleID = "com.nuebling.mac-mouse-fix"
+
+    static let stableFeed = URL(
+        string: "https://raw.githubusercontent.com/noah-nuebling/mac-mouse-fix/update-feed/appcast.xml")!
+    static let betaFeed = URL(
+        string: "https://raw.githubusercontent.com/noah-nuebling/mac-mouse-fix/update-feed/appcast-pre.xml")!
+
+    /// Map Mac Mouse Fix's `General.checkForPrereleases` flag to a resolution.
+    /// Pure and tested. `stableFeed` is named explicitly (even though it is also
+    /// the bundle's own signed `SUFeedURL`) so a stable resolution never
+    /// depends on that plist value staying what it is today — the same choice
+    /// `IINAChannel` makes for the same reason.
+    static func resolve(checkForPrereleases: Bool) -> ResolvedChannel {
+        checkForPrereleases
+            ? ResolvedChannel(channel: .beta, feedOverride: betaFeed)
+            : ResolvedChannel(channel: .stable, feedOverride: stableFeed)
+    }
+
+    static func resolveCurrent() -> ResolvedChannel {
+        resolve(checkForPrereleases: readCheckForPrereleases())
+    }
+
+    /// The file `readCheckForPrereleases` reads. Exposed for the same reason
+    /// `SurgeChannel.defaultsFileURL` is: `ChannelBinding.preferenceWatchCandidates`
+    /// has to sit on exactly this path, and a watcher aimed anywhere else would
+    /// look healthy while never firing.
+    static var configFileURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent(bundleID, isDirectory: true)
+            .appendingPathComponent("config.plist", isDirectory: false)
+    }
+
+    /// Read `General.checkForPrereleases` from Mac Mouse Fix's own config file.
+    /// Returns false (stable) if the file, the `General` dict, or the key is
+    /// missing — the conservative default, same stance `SurgeChannel` takes.
+    static func readCheckForPrereleases() -> Bool {
+        guard
+            let data = try? Data(contentsOf: configFileURL),
+            let plist = try? PropertyListSerialization.propertyList(
+                from: data, format: nil) as? [String: Any]
+        else { return false }
+        return checkForPrereleases(fromConfig: plist)
+    }
+
+    /// The typed half of the read, split out so the nested-dict lookup can be
+    /// tested without touching the real config file — same discipline
+    /// `ForkChannel.channelPref(from:)` uses for its own preference read.
+    ///
+    /// The key is nested (`plist["General"]["checkForPrereleases"]`), not a
+    /// dotted top-level key — confirmed against the bundle's own
+    /// `default_config.plist`, which ships exactly this shape. The dotted
+    /// string `"General.checkForPrereleases"` seen in `AppDelegate.m` is Mac
+    /// Mouse Fix's OWN config accessor's path syntax, not the on-disk key.
+    static func checkForPrereleases(fromConfig plist: [String: Any]?) -> Bool {
+        guard let general = plist?["General"] as? [String: Any] else { return false }
+        return (general["checkForPrereleases"] as? NSNumber)?.boolValue ?? false
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BindingChannelProofTests.swift
@@ -28,6 +28,7 @@ import Foundation
             ChannelProofKey("com.nssurge.surge-mac", .beta),
             ChannelProofKey("com.tinyapp.tableplus", .beta),
             ChannelProofKey("com.colliderli.iina", .beta),
+            ChannelProofKey("com.nuebling.mac-mouse-fix", .beta),
             ChannelProofKey("pro.betterdisplay.BetterDisplay", .beta),
             ChannelProofKey("pro.betterdisplay.BetterDisplay", .unstable),
         ]), "the binding population changed: \(needing.map(\.description).sorted())")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
@@ -150,6 +150,66 @@ import Foundation
     #expect(r.feedOverride == IINAChannel.stableFeed)
 }
 
+// MARK: - Mac Mouse Fix (`General.checkForPrereleases` Bool, own config.plist → feed swap)
+
+@Test func macMouseFixCheckForPrereleasesTrueRetargetsToBetaFeed() {
+    let r = MacMouseFixChannel.resolve(checkForPrereleases: true)
+    #expect(r.channel == .beta)
+    #expect(r.feedOverride == MacMouseFixChannel.betaFeed)
+}
+
+@Test func macMouseFixCheckForPrereleasesFalseStaysOnStableFeed() {
+    let r = MacMouseFixChannel.resolve(checkForPrereleases: false)
+    #expect(r.channel == .stable)
+    #expect(r.feedOverride == MacMouseFixChannel.stableFeed)
+}
+
+/// The nested-dict lookup (`plist["General"]["checkForPrereleases"]`), tested
+/// directly against constructed dictionaries rather than a real config file —
+/// mirrors `ForkChannel.channelPref(from:)`'s split for the same reason.
+///
+/// Mutation this guards against: collapsing the lookup to a flat top-level key
+/// (`plist["checkForPrereleases"]` or `plist["General.checkForPrereleases"]`,
+/// mistaking the dotted string seen in `AppDelegate.m` for the on-disk shape
+/// rather than Mac Mouse Fix's own config-accessor syntax). Run by hand against
+/// a flat-key rewrite of `checkForPrereleases(fromConfig:)`: every case below
+/// that expects `true` from the nested shape reads `false` instead, and
+/// `wrongTypeAtTheNestedKeyIsFalse`'s NSNumber probe stops exercising the
+/// nested branch at all — both are exactly the silent "beta toggle is on but we
+/// never see it" failure this recipe exists to avoid.
+@Test func realConfigShapeNestedGeneralDictReadsTrue() {
+    let plist: [String: Any] = ["General": ["checkForPrereleases": true]]
+    #expect(MacMouseFixChannel.checkForPrereleases(fromConfig: plist))
+}
+
+@Test func realConfigShapeNestedGeneralDictReadsFalse() {
+    let plist: [String: Any] = ["General": ["checkForPrereleases": false]]
+    #expect(!MacMouseFixChannel.checkForPrereleases(fromConfig: plist))
+}
+
+@Test func missingGeneralDictIsFalse() {
+    #expect(!MacMouseFixChannel.checkForPrereleases(fromConfig: [:]))
+    #expect(!MacMouseFixChannel.checkForPrereleases(fromConfig: nil))
+}
+
+@Test func generalDictWithoutTheKeyIsFalse() {
+    let plist: [String: Any] = ["General": ["buttonKillSwitch": false]]
+    #expect(!MacMouseFixChannel.checkForPrereleases(fromConfig: plist))
+}
+
+/// A flat top-level key (the shape a flat-key mutation would read) must NOT be
+/// mistaken for the real nested one — pins the "nested, not dotted-flat" half
+/// of the mutation described above from the other direction.
+@Test func flatTopLevelKeyIsNotTheRealShapeAndReadsFalse() {
+    let plist: [String: Any] = ["General.checkForPrereleases": true, "checkForPrereleases": true]
+    #expect(!MacMouseFixChannel.checkForPrereleases(fromConfig: plist))
+}
+
+@Test func wrongTypeAtTheNestedKeyIsFalse() {
+    let plist: [String: Any] = ["General": ["checkForPrereleases": "not a bool"]]
+    #expect(!MacMouseFixChannel.checkForPrereleases(fromConfig: plist))
+}
+
 // MARK: - CapCut (`joinBeta` in an INI outside the sandbox container)
 
 @Test func capCutJoinBetaMapsToTheBetaTrack() {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelSwitchDetectorTests.swift
@@ -186,6 +186,13 @@ import Foundation
             isWatched(file.standardizedFileURL.path),
             "CapCut's \(file.lastPathComponent) — a file its resolver reads — is not under any watched root")
     }
+    // Mac Mouse Fix keeps `General.checkForPrereleases` in its own
+    // Application Support config.plist, like Surge — not in
+    // `~/Library/Preferences`, so the generic CFPreferences assertion below
+    // would not exercise this path at all.
+    #expect(
+        isWatched(MacMouseFixChannel.configFileURL.standardizedFileURL.path),
+        "Mac Mouse Fix's config.plist — the file its resolver reads — is not under any watched root")
 
     // Everyone else resolves through `CFPreferencesCopyAppValue`, backed by
     // `~/Library/Preferences/<domain>.plist` for an unsandboxed app.

--- a/docs/app-audits/README.md
+++ b/docs/app-audits/README.md
@@ -30,6 +30,7 @@ Per-app audit checklist. Run `/app-audit <App>` for each, then check off.
 - [x] [**CapCut**](com-lemon-lvoverseas.md) · `com.lemon.lvoverseas` — P(stable/beta) B · 2 channels, shared ID + ChannelBinding（`joinBeta` 在容器外的 INI）· **全 channel 一键 ✓**（Team 22MMUN2RN5，两轨真实 dmg 挂载核对）· **两轨版本字段是反的**（beta 的 short=`9.3.4531` / version=`9.4.0-beta4`，故 beta `versionIsBuild:true`）· 同 id 有 MAS 副本（19.2.0），靠 `_MASReceipt` 分流 · 2026-08-27
 - [x] [**Termius**](com-termius-dmg-mac.md) · 三个独立 bundle id：`com.termius.mac`（MAS，`MacAppStoreSource` 通用覆盖，无 registry）/ `com.termius-dmg.mac`（官网 dmg，P stable，既有）/ `com.termius-beta.mac`（P beta，本次新增）— **全 channel 一键 ✓**（beta 用 universal dmg，Team 6KN952WR85）· stable 既有 recipe 的 arm64-only 一键是刻意的 arm64-pin（DuoUpdater 自身 arm64-only），不是 bug；真正待修的是 `changelogURL` 404，已拆分为独立任务 · issue #91、#102 · 2026-08-27
 - [x] [**UTM**](com-utmapp-UTM.md) · `com.utmapp.UTM` — G(stable+beta，一键) C + MAS/TestFlight 通用托管 · 包内无 channel 标记；用观测版本的 exact GitHub release `prerelease` 位判轨（判"这份拷贝是什么"），候选则按 `max(装机大版本线, 最新正式版)` 取 —— **UTM 的预览是每条线的前半段、会转正，不是平行轨** · 双渠道 changelog 隔离，beta 侧含转正条目 · 真实 v5.0.5 DMG 签名/公证验证 ✓ · 2026-09-03
+- [x] [**Mac Mouse Fix**](com-nuebling-mac-mouse-fix.md) · `com.nuebling.mac-mouse-fix` — B(stable/beta) · 2 channels, shared ID + feed-swap ChannelBinding · **stable 端到端本机验证 ✓**（`channel-verify --check` 走生产 AppScanner→ChannelBinding→Sparkle，实时命中 stable feed，判定 up to date）· beta 侧 resolver 映射与真实 preview bundle 已核对，未在本机翻转该 app 自身的偏好文件 · 2026-09-12
 
 ## Microsoft Office family
 

--- a/docs/app-audits/com-nuebling-mac-mouse-fix.md
+++ b/docs/app-audits/com-nuebling-mac-mouse-fix.md
@@ -1,0 +1,86 @@
+# Mac Mouse Fix
+
+> 审计日期 2026-09-12 · 模式 INVESTIGATE→接入 · 结论：**stable/beta 两 channel，ChannelBinding，Sparkle feed-swap；无 ChangelogRecipe（两条 feed 都用 `<sparkle:releaseNotesLink>`，已被 #553 覆盖）**
+
+## 基本信息
+- Bundle ID: `com.nuebling.mac-mouse-fix`（两 channel **共用**）
+- Team ID: `LM5Z78756B`
+- 观测版本: stable `3.0.8`（`CFBundleVersion` 24310）；preview 轨最新 `3.1.0 Beta 1`（`CFBundleVersion` 24830）
+- 自更新机制: Sparkle。开源仓库 `noah-nuebling/mac-mouse-fix`，`update-feed` 分支下的 `generate_releases.py` 生成两份 appcast。
+
+## 覆盖矩阵
+
+> ✓ = 已接入  ○ = 可接入(未实现)  ✗ = 已调查不可行  — = 不适用
+
+|              | Sparkle | Homebrew | MAS | GitHub | VendorProbe |
+|--------------|---------|----------|-----|--------|-------------|
+| **stable**   | ✓(feed-swap) | — | — | — | — |
+| **beta**     | ✓(feed-swap) | — | — | — | — |
+
+当前生效源: **SparkleAppcastSource**（`ChannelBinding` → `MacMouseFixChannel` 提供 `feedOverride`；应用自带 `SUFeedURL` 始终指向 stable feed，preview 是应用自己在运行时用 `SUUpdater.sharedUpdater.feedURL = …` 换掉的，plist 里看不出来）。
+
+## Channel 详情（Pattern B — 共享 bundle id，偏好切换 feed）
+
+| Channel | Bundle ID | 独立/共享 | 检测信号 | 门控方式 | 状态 |
+|---------|-----------|----------|---------|---------|------|
+| stable  | `com.nuebling.mac-mouse-fix` | 共享 | `General.checkForPrereleases = false`（或文件/键缺失）| feed-swap → `…/update-feed/appcast.xml` | ✓ |
+| beta    | `com.nuebling.mac-mouse-fix` | 共享 | `General.checkForPrereleases = true` | feed-swap → `…/update-feed/appcast-pre.xml` | ✓ |
+
+两条 feed 的完整地址：
+- stable: `https://raw.githubusercontent.com/noah-nuebling/mac-mouse-fix/update-feed/appcast.xml`
+- preview: `https://raw.githubusercontent.com/noah-nuebling/mac-mouse-fix/update-feed/appcast-pre.xml`
+
+（`kMFUpdateFeedRepoAddressRaw` + `kSUFeedURLSub`/`kSUFeedURLSubBeta`，`Shared/Constants.h`；实际换 feed 的调用点是 `App/Update/SparkleUpdaterController.m` 的 `+enablePrereleaseChannel:`。）
+
+`General.checkForPrereleases` **不在** UserDefaults/CFPreferences 里——Mac Mouse Fix 自己管一份配置文件：`~/Library/Application Support/com.nuebling.mac-mouse-fix/config.plist`，顶层 dict 的 `"General"` 键下再是一个 dict，`"checkForPrereleases"` 是其中一个 Bool（对照应用自带的 `Contents/Resources/default_config.plist` 确认了这个嵌套形状，默认值 `false`）。`MacMouseFixChannel.readCheckForPrereleases()` 直接读这份文件；文件或键缺失时回落到 stable。
+
+### `generate_releases.py` 对两条轨道的定义（读自 `update-feed` 分支的源码，非推测）
+
+- `is_prerelease = r['prerelease']` 直接取自 GitHub Releases API 的 `prerelease` 标志位。
+- stable feed（`appcast_items`）只收 `not is_prerelease` 的条目；preview feed（`appcast_pre_items`）收**全部**条目，prerelease 和正式版都在——所以 preview 是 stable 的超集,不是并列的独立轨道,且脚本没有重新排序，两条 feed 都保留 GitHub Releases API 本身的时间倒序（最新在前)。
+- `sparkle:shortVersionString` 写的是 `r['name']`——GitHub Release 的显示名原文，例如验证到的最新 preview 条目 `"3.1.0 Beta 1"`（空格、大写 B）；`sparkle:version` 写的是从**真实下载并解压后的 bundle** 里读出的 `CFBundleVersion`。下载该资产（build 24830，观测于 2026-09-12）确认这两个字段和装机后的 bundle 完全一致：其 `CFBundleShortVersionString` 就是字面的 `"3.1.0 Beta 1"`，`CFBundleVersion` 就是 `24830`——不存在 Mozilla 那种「feed 与 bundle 不一致」的坑，`RemoteVersion.marketingMatchesBundle: true` 是对的。
+- 下载到的 preview 包签名 `Developer ID Application: Noah Nuebling (LM5Z78756B)`，与已装 stable 副本一致——一键安装不会跨 Team ID。
+
+### 版本比较：真实跑过 `"3.1.0 Beta 1"`，不是假设
+
+- `VersionComparator.comparableMarketingVersion` 拒绝任何带空白的字符串，`"3.1.0 Beta 1"` 因此落在这条规则外；`isMarketingDowngrade` 对这类字符串只会答"看不出来"（即"不是降级"）——这正是安全的方向,因为调用方只用这个判断来**拦截**报价,从不用来**发起**报价。
+- `UpdateChecker.evaluate` 优先走 build 号分支：两侧都带 `sparkle:version` 时，`24830` 对已装 `24310` 用 `VersionComparator.isNewer` 判定为更新，上面的降级保护不会推翻这个结论——于是 beta 会被正确报价。这不是这一对版本号运气好：Mac Mouse Fix **自己的** Sparkle 代理（`App/Update/CoolSUComparator.m`）解决同一个歧义用的是同一个思路——先把版本串砍到只剩开头的数字和点号再比较（所以 `"3.1.0"` 和 `"3.1.0 Beta 1"` 比较结果是相等），相等时再用 build 号断胜负。两处独立实现都依赖同一个事实：这里的 `CFBundleVersion` 是真实的、单调递增的 build 号。
+
+## Changelog
+- 无 ChangelogRecipe。两条 feed 都用 `<sparkle:releaseNotesLink>`（按语言给一条链接），这个形状已经被 #553 处理，不需要新东西。
+- Recipe 状态: 不需要
+
+## 增量更新（delta / binary patch）
+
+| | 客户端能力 | 服务端实际下发 | 我们能否消费 |
+|---|---|---|---|
+| 结论 | 没查 | 没查 | 没查 |
+| 证据 | — | — | — |
+
+（超出本次 issue 范围，未投入时间验证；两条 feed 的条目里都没看到 `sparkle:deltaFrom`。）
+
+## 一键安装
+- 状态: 仅检测（本次未接一键；两轨都可以走通用 Sparkle 安装路径，未验证是否需要额外处理）
+- 格式: `.zip`（`MacMouseFixApp.zip`）
+- 读的是: 人人可手动下载的 GA —— stable 和 preview 都是 GitHub Releases 上公开挂出的资产，与厂商自己 Sparkle 更新器分发的是同一份文件，不存在"轨道最新但未分配"的问题
+- 阻塞: 无已知阻塞，只是本次未做
+
+## 已知问题
+- 无
+
+## 如何复验
+
+`channel-verify` 对**真实 bundle** 跑生产 `AppScanner` → `ChannelBinding` → `SparkleAppcastSource`（不是重实现）。原始验证 2026-09-12。
+
+stable 端到端（真实网络请求，命中当时线上的 stable feed）：
+
+```
+swift run --package-path application-test channel-verify --check com.nuebling.mac-mouse-fix --expect stable
+```
+
+结果：`detected channel → stable`，`winning source → Sparkle`，`latest → 3.0.8`，`status → up to date`——与观测版本一致。
+
+beta 侧**未在真机上翻转** `General.checkForPrereleases`（该文件在审计时不存在，需要新建才能翻转，而不是像 Surge/Fork 那样逐字节备份/还原一份已存在的文件，风险不对称，故未做）。beta 的证据链是：
+1. `MacMouseFixChannel.resolve(checkForPrereleases: true)` 的映射关系由单元测试直接钉住;
+2. `MacMouseFixChannel.checkForPrereleases(fromConfig:)` 的嵌套 key 解析由单元测试针对"拍平成顶层 key"这个具体的失效模式做了变异验证（人工引入该变异，两条相关用例按预期变红）；
+3. preview feed 最新条目对应的真实资产已下载解压，`Contents/Info.plist` 逐字段核对过（见上文）。


### PR DESCRIPTION
Closes #555.

Mac Mouse Fix has a beta track Duo Updater could not see. The registry did not name the app at all — it rode the generic Sparkle path on the stable feed only, so a user who had turned on the app's own **Get Beta Versions** checkbox was offered betas by Mac Mouse Fix and nothing by us.

It is the feed-swap shape, same as IINA: the shipped `SUFeedURL` is always stable, and the app swaps in a second feed at runtime.

## Read from the source, not inferred

The app is open source, and every load-bearing fact here came out of its repo rather than out of probing — which is the point of #556, landing alongside this:

- `SparkleUpdaterController.m`'s `+enablePrereleaseChannel:` assigns `SUUpdater.sharedUpdater.feedURL` to `appcast-pre.xml` or `appcast.xml`. Nothing in the plist shows this.
- `generate_releases.py` on the `update-feed` branch writes both feeds: `if not is_prerelease` gates the stable list, while the preview list gets **every** release. So preview is a *superset* of stable, not a parallel track.
- `sparkle:shortVersionString` is the GitHub release's display name; `sparkle:version` is the real `CFBundleVersion` read out of the downloaded bundle.
- The toggle writes to Mac Mouse Fix's **own** config file, not UserDefaults: `~/Library/Application Support/com.nuebling.mac-mouse-fix/config.plist`, where `General` is a dict holding `checkForPrereleases` — the nested shape, confirmed against the bundle's shipped `default_config.plist`. The dotted `General.checkForPrereleases` seen in the source is that app's own config-accessor syntax, not an on-disk key. Reading it flat would have been a silent "the beta toggle is on and we never see it".

That file is in Application Support rather than `~/Library/Preferences`, so it needed its own watch root — Surge is the only other app in that position.

## The version string is the trap

The preview feed's `sparkle:shortVersionString` is the literal `3.1.0 Beta 1` — spaces, capital B. Verified end-to-end against the live feeds with the installed 3.0.8 rather than reasoned about:

```
stable feed → 3.0.8 / 24310          upToDate
beta   feed → 3.1.0 Beta 1 / 24830   updateAvailable
```

`comparableMarketingVersion` rejects the string for its whitespace, so `isMarketingDowngrade` answers "cannot tell" — which only ever withholds an offer, never raises one — and `evaluate` reaches the build branch, where 24830 beats 24310. Mac Mouse Fix's own Sparkle delegate (`CoolSUComparator.m`) resolves the same ambiguity the same way: strip to the leading digits, then break the tie on the build. Both lean on `CFBundleVersion` being a real monotonic build id here, which the downloaded beta bundle confirms.

Team ID is `LM5Z78756B` on both tracks, so nothing crosses signing identities.

## Coverage

Five mutations run, all red and naming the right case: inverting the `resolve` ternary, dropping the watch root, dropping the proof registration, reading the config flat instead of nested, and — the one that would otherwise be silent — leaving the bundle id declared in `bindingBundleIDs` while the resolver returns nil, which the registry-derived `everyBoundIDHasAResolverBehindIt` catches.

Audit doc committed under `docs/app-audits/`. One-click install is out of scope and recorded as not-done rather than as a blocker.

`make test` green: 2759 + 280 cases, 0 failures, all seven Python gates.
