### PR TITLE
Keep a Changelog: render category headings instead of flattening them

### DIFF
--- a/.agents/skills/fragile-recipe/references/changelog-recipe.md
+++ b/.agents/skills/fragile-recipe/references/changelog-recipe.md
@@ -23,10 +23,10 @@ their emoji/category prefixes (✨ 🔔 🎨) inline as the vendor wrote them.
 ## The recipe fields
 
 > ⚠️ **The initializer is the reference; this page is a tour of the common half.**
-> `ChangelogRecipe.init` currently takes **25** parameters. Beyond the ones below it
+> `ChangelogRecipe.init` currently takes **26** parameters. Beyond the ones below it
 > also carries `channel`, `includesPromotedStable`, `sourceTemplate`, `newestLast`,
-> `imagePattern`, `minimumAppVersion`, `belowAppVersion`, `structuredFormat`,
-> `httpMethod`, `requestBody`, `skipSections`, `tagPattern` and
+> `imagePattern`, `headingPattern`, `minimumAppVersion`, `belowAppVersion`,
+> `structuredFormat`, `httpMethod`, `requestBody`, `skipSections`, `tagPattern` and
 > `acknowledgedStaleEntry`. Read
 > `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift` before
 > concluding the registry can't express something.

--- a/.claude/skills/fragile-recipe/references/changelog-recipe.md
+++ b/.claude/skills/fragile-recipe/references/changelog-recipe.md
@@ -23,10 +23,10 @@ their emoji/category prefixes (✨ 🔔 🎨) inline as the vendor wrote them.
 ## The recipe fields
 
 > ⚠️ **The initializer is the reference; this page is a tour of the common half.**
-> `ChangelogRecipe.init` currently takes **25** parameters. Beyond the ones below it
+> `ChangelogRecipe.init` currently takes **26** parameters. Beyond the ones below it
 > also carries `channel`, `includesPromotedStable`, `sourceTemplate`, `newestLast`,
-> `imagePattern`, `minimumAppVersion`, `belowAppVersion`, `structuredFormat`,
-> `httpMethod`, `requestBody`, `skipSections`, `tagPattern` and
+> `imagePattern`, `headingPattern`, `minimumAppVersion`, `belowAppVersion`,
+> `structuredFormat`, `httpMethod`, `requestBody`, `skipSections`, `tagPattern` and
 > `acknowledgedStaleEntry`. Read
 > `DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift` before
 > concluding the registry can't express something.

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1638,9 +1638,12 @@ private struct ChangelogEntryView: View {
                     }
                 }
             }
-            // Rich entries (notes interleaved with images, e.g. WeChat) walk `content`
-            // so a screenshot lands between the change lines exactly as on the vendor's
-            // page. Text-only entries (the common case) just bullet `items`.
+            // Rich entries — notes interleaved with images (WeChat) or category
+            // headings (Mac Performance Monitor's Keep a Changelog file, a
+            // GitHub-sourced app whose release body had ≥2 real ones — see
+            // `Changelog.Entry.Block`) — walk `content` so a screenshot or a
+            // heading lands exactly where it does on the vendor's page. Text-only
+            // entries (the common case) just bullet `items`.
             // LAZY, not a plain VStack. An entry used to be a couple of dozen lines
             // at most, because every changelog came from a recipe. A Sparkle feed's
             // inline notes are not capped that way — TablePro's 0.67.0 carries 205
@@ -1659,6 +1662,7 @@ private struct ChangelogEntryView: View {
                         switch block {
                         case let .note(text): noteRow(text)
                         case let .image(url): noteImage(url)
+                        case let .heading(text): headingRow(text)
                         }
                     }
                 }
@@ -1710,6 +1714,18 @@ private struct ChangelogEntryView: View {
         CachedImage(url: url)
             .frame(maxWidth: 480, alignment: .leading)
             .padding(.vertical, 2)
+    }
+
+    /// A category heading (`Added`, `Fixed`, …) grouping the notes that follow it.
+    /// Deliberately smaller than the version title above and left-aligned like a
+    /// bullet, not indented — it is a sub-section of THIS entry, not a nested
+    /// entry of its own. Markdown-rendered like a bullet (`rendered(_:syntax:)`),
+    /// since a GitHub-sourced heading carries the same inline syntax an item does.
+    @ViewBuilder
+    private func headingRow(_ text: String) -> some View {
+        Text(Self.rendered(text, syntax: syntax))
+            .font(.subheadline).bold()
+            .padding(.top, 2)
     }
 
     private static func displayDate(for raw: String) -> String {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Cline now gets updates, on both its release and beta builds, and shows its release notes.** Until now it sat with a question mark instead of a version — it ships no update feed of the kind Duo Updater could read, and there is no Homebrew package for it. Duo Updater now asks the same address Cline's own updater asks, so the update offered is the one Cline would have installed itself, and the beta build stays on the beta track.
 
+**Release notes that group changes under headings like Added and Fixed now keep those headings.** Before, every group was merged into one flat list, so you couldn't tell which changes were new features and which were bug fixes.
+
 ## 0.3.92
 
 **Some self-updating apps no longer look up to date while a newer version is out.** For apps whose update information sits behind a slow-to-refresh download server, Duo Updater could keep seeing an older version for days after a release.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
@@ -37,9 +37,10 @@ public struct Changelog: Codable, Sendable, Hashable {
     ///   that's threaded into that code and changes its output just as directly —
     ///   `entryPattern`, `itemPatterns`, `skipSections`, `stripTags`,
     ///   `escapedMarkup`, `markdownSource`, `minItemLength`, `newestLast`,
-    ///   `maxEntries`, `source` itself, and so on. A recipe edit that changes what
-    ///   an EXISTING cached version's notes would parse to (not just what a *new*
-    ///   release's notes will) is exactly as invalidating as a code change; two
+    ///   `maxEntries`, `source`, `headingPattern`, and so on. A recipe edit that
+    ///   changes what an EXISTING cached version's notes would parse to (not just
+    ///   what a *new* release's notes will) is exactly as invalidating as a code
+    ///   change; two
     ///   already-merged commits prove it — `0d9d424` (Figma moved to a different
     ///   feed with a different `entryPattern`, same bundle id) and `a6ac16b`
     ///   (`skipSections` added, changing BetterDisplay's existing releases' output).
@@ -64,7 +65,17 @@ public struct Changelog: Codable, Sendable, Hashable {
     /// - 2: Ollama's recipe gained a paragraph item pattern, so a release written as
     ///   prose (no bullet list) parses to an entry instead of being dropped. Notes
     ///   already cached for 0.34.0 were stored without 0.34.0's own entry.
-    public static let parserGeneration = 2
+    /// - 3: Keep a Changelog / GitHub category headings (`### Added`, `### Fixed`,
+    ///   …) now survive as `.heading` blocks in `content` instead of being
+    ///   silently flattened into `items` — `GitHubMarkdownParser` styles a heading
+    ///   only when it has ≥2 non-boilerplate sibling headings AND contains no
+    ///   digit (a version-restating heading like UTM's `Changes (v5.0.4)` or
+    ///   Rockxy's `Rockxy 0.38.3 (build 58)` fails that second test and stays
+    ///   folded away exactly as before); `ChangelogRecipe.headingPattern` lets a
+    ///   hand-written recipe (Mac Performance Monitor) opt in unconditionally.
+    ///   Notes already cached under the old logic had every group's heading
+    ///   dropped with no way to tell which category a line belonged to.
+    public static let parserGeneration = 3
 
     public let entries: [Entry]
 
@@ -125,19 +136,29 @@ public struct Changelog: Codable, Sendable, Hashable {
         /// The individual change lines, in document order. Emoji/category prefixes
         /// (✨ 🔔 🎨 …) are kept inline as the vendor wrote them. Always the full set
         /// of text lines, even when `content` also carries them interleaved with
-        /// images — so a text-only consumer never needs to walk `content`.
+        /// images or headings — so a text-only consumer never needs to walk
+        /// `content`. A category heading (`### Added`) is NOT a change line and
+        /// never appears here, styled or not — see `Block.heading`.
         public let items: [String]
-        /// Notes and illustration images in their original document order. Empty for
-        /// the common (text-only) case, where the renderer just bullets `items`.
-        /// Populated only when a recipe sets `imagePattern` AND the entry actually
-        /// embeds an image — then the renderer walks this so a screenshot lands
-        /// between the change lines exactly as it does on the vendor's page (WeChat).
+        /// Notes, illustration images, and category headings in their original
+        /// document order. Empty for the common (flat) case, where the renderer
+        /// just bullets `items`. Populated when a recipe sets `imagePattern` AND
+        /// the entry actually embeds an image (then the renderer walks this so a
+        /// screenshot lands between the change lines exactly as it does on the
+        /// vendor's page, WeChat) OR when at least one of the entry's headings
+        /// earned a `.heading` block (see `Block.heading`) — either producer can
+        /// populate this independent of the other, so an entry can carry headings
+        /// with no images, images with no headings, or both.
         public let content: [Block]
 
-        /// One ordered piece of a rich entry: a change line, or an embedded image.
+        /// One ordered piece of a rich entry: a change line, an embedded image, or
+        /// a category heading (`### Added`, `### Fixed`, …) worth styling as its
+        /// own line rather than flattening into the notes around it. Never present
+        /// in `items` — see that property's doc comment.
         public enum Block: Codable, Sendable, Hashable {
             case note(String)
             case image(URL)
+            case heading(String)
         }
 
         public init(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
@@ -25,6 +25,7 @@ public enum ChangelogExtractor {
         let itemRegexes = recipe.itemPatterns.compactMap(compile)
         guard !itemRegexes.isEmpty else { return nil }
         let imageRegex = recipe.imagePattern.flatMap(compile)
+        let headingRegex = recipe.headingPattern.flatMap(compile)
 
         let whole = NSRange(text.startIndex..., in: text)
         var entries: [Changelog.Entry] = []
@@ -63,15 +64,18 @@ public enum ChangelogExtractor {
             guard !noteHits.isEmpty else { return }
             let items = noteHits.map(\.text)
 
-            // Interleave images with the notes by document position — but only when
-            // the recipe asks for images AND this entry has at least one. Otherwise
-            // `content` stays empty and the renderer just bullets `items` (unchanged
-            // for every text-only recipe).
+            // Interleave images and headings with the notes by document position —
+            // but only when the recipe asks for one of them AND this entry actually
+            // has at least one. Otherwise `content` stays empty and the renderer
+            // just bullets `items` (unchanged for every recipe that sets neither).
             let imageBlocks = imageRegex.map { imageHits(in: bodyText, regex: $0) } ?? []
-            let content: [Changelog.Entry.Block] = imageBlocks.isEmpty
+            let headingBlocks = headingRegex
+                .map { headingHits(in: bodyText, regex: $0, recipe: recipe) } ?? []
+            let content: [Changelog.Entry.Block] = (imageBlocks.isEmpty && headingBlocks.isEmpty)
                 ? []
                 : (noteHits.map { ($0.location, Changelog.Entry.Block.note($0.text)) }
-                    + imageBlocks.map { ($0.location, .image($0.url)) })
+                    + imageBlocks.map { ($0.location, .image($0.url)) }
+                    + headingBlocks.map { ($0.location, .heading($0.text)) })
                     .sorted { $0.0 < $1.0 }
                     .map(\.1)
 
@@ -151,6 +155,38 @@ public enum ChangelogExtractor {
             guard let url = URL(string: decoded), let scheme = url.scheme,
                   scheme == "http" || scheme == "https", seen.insert(url).inserted else { continue }
             hits.append((match.range.location, url))
+        }
+        return hits
+    }
+
+    /// Collect category headings (`### Added`, `### Fixed`, …) from an entry body,
+    /// each tagged with its match location so the caller can interleave them with
+    /// the notes they introduce. Each match yields its `heading` group (else
+    /// capture group 1, else the whole match), cleaned exactly like an item —
+    /// `recipe.markdownSource` unwraps inline code/links in the heading text the
+    /// same way it does for a bullet.
+    ///
+    /// Unlike `firstNonEmptyItemHits`, every match from `regex` counts — this is
+    /// opt-in per recipe (`ChangelogRecipe.headingPattern`), so setting it at all
+    /// is the recipe author's declaration that this vendor's headings are real
+    /// categories worth styling unconditionally, the same way `imagePattern`
+    /// declares every matched image worth showing. There's no `GitHubMarkdownParser`
+    /// -style "≥2 siblings, no digit" heuristic here because that heuristic exists
+    /// to guess at structure across dozens of vendors sharing one parser; a
+    /// hand-written recipe is already curated for one vendor's page, so the guess
+    /// is unnecessary — see `Changelog.parserGeneration`'s generation-3 entry.
+    private static func headingHits(
+        in body: String, regex: NSRegularExpression, recipe: ChangelogRecipe
+    ) -> [(location: Int, text: String)] {
+        let range = NSRange(body.startIndex..., in: body)
+        var hits: [(location: Int, text: String)] = []
+        for match in regex.matches(in: body, range: range) {
+            let raw = group(match, "heading", in: body)
+                ?? group(match, nil, in: body)
+                ?? ""
+            let cleaned = clean(raw, recipe)
+            guard !cleaned.isEmpty else { continue }
+            hits.append((match.range.location, cleaned))
         }
         return hits
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -179,6 +179,23 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// feature illustration between the change lines).
     public let imagePattern: String?
 
+    /// Optional regex run over each entry's `body` to pull out category headings
+    /// (`### Added`, `### Fixed`, …) so the renderer can show them as their own
+    /// styled line instead of silently dropping them the way a plain `itemPattern`
+    /// boundary does. Every match becomes one `.heading` block (capture group 1,
+    /// or the named `heading` group), cleaned the same way an item is — including
+    /// `markdownSource` unwrapping. nil = no headings (the common case).
+    ///
+    /// Opt-in and unconditional, unlike `GitHubMarkdownParser`'s "≥2 siblings, no
+    /// digit" heuristic (see `Changelog.parserGeneration`'s generation-3 entry):
+    /// that heuristic exists because ONE parser has to guess at structure across
+    /// dozens of GitHub-hosted vendors with no per-app tuning. A recipe that sets
+    /// this is already curated for one vendor's page — Mac Performance Monitor's
+    /// real Keep a Changelog file, where `### Added`/`### Fixed`/… are always
+    /// genuine categories — so every match renders, the same way `imagePattern`
+    /// renders every matched image without a similar guess.
+    public let headingPattern: String?
+
     /// Lowest app version this recipe's page covers, inclusive. nil → no floor.
     ///
     /// This and `belowAppVersion` are the changelog analogue of a
@@ -502,6 +519,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         sourceTemplate: String? = nil,
         newestLast: Bool = false,
         imagePattern: String? = nil,
+        headingPattern: String? = nil,
         minimumAppVersion: String? = nil,
         belowAppVersion: String? = nil,
         structuredFormat: StructuredFormat? = nil,
@@ -529,6 +547,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         self.sourceTemplate = sourceTemplate
         self.newestLast = newestLast
         self.imagePattern = imagePattern
+        self.headingPattern = headingPattern
         self.minimumAppVersion = minimumAppVersion
         self.belowAppVersion = belowAppVersion
         self.httpMethod = httpMethod
@@ -645,6 +664,7 @@ public struct ChangelogRecipe: Codable, Sendable {
         sourceTemplate = try c.decodeIfPresent(String.self, forKey: .sourceTemplate)
         newestLast = try c.decodeIfPresent(Bool.self, forKey: .newestLast) ?? false
         imagePattern = try c.decodeIfPresent(String.self, forKey: .imagePattern)
+        headingPattern = try c.decodeIfPresent(String.self, forKey: .headingPattern)
         minimumAppVersion = try c.decodeIfPresent(String.self, forKey: .minimumAppVersion)
         belowAppVersion = try c.decodeIfPresent(String.self, forKey: .belowAppVersion)
         httpMethod = try c.decodeIfPresent(HTTPMethod.self, forKey: .httpMethod) ?? .get
@@ -2953,13 +2973,25 @@ public enum ChangelogRecipeRegistry {
         // same 17 entries parse with the same item counts, and no item carries a
         // link definition any more. Unindented, so it cannot fire on a wrapped
         // continuation line, which this vendor indents by two spaces.
+        //
+        // `headingPattern` (#554, part of #399) turns the `### Added` / `###
+        // Fixed` group headings back into real `.heading` blocks instead of
+        // letting them keep serving only as the `itemPattern` boundary above —
+        // this is a genuine Keep a Changelog file, so every `###` heading it has
+        // IS a real category, unconditionally (no "≥2 siblings" guess needed the
+        // way `GitHubMarkdownParser` needs one across dozens of unrelated GitHub
+        // vendors — see `Changelog.parserGeneration`'s generation-3 entry).
+        // Bounded the same way the item pattern is, so a heading also stops at
+        // the next entry or the trailing link-reference block rather than
+        // swallowing the rest of the file.
         ChangelogRecipe(
             bundleID: "uk.co.bzwrd.macperfmonitor",
             source: URL(string: "https://raw.githubusercontent.com/Zesty0wl/mac-performance-monitor/main/CHANGELOG.md")!,
             entryPattern:
                 #"(?:^|\n)##\s+\[(?<version>[0-9][^\]]*)\]\s*-\s*(?<date>[^\n]+)\n(?<body>.*?)(?=\n##\s|\z)"#,
             itemPatterns: [#"\n-\s+(?<item>.+?)(?=\n-\s|\n###\s|\n##\s|\n\[|\z)"#],
-            markdownSource: true),
+            markdownSource: true,
+            headingPattern: #"\n###\s+(?<heading>[^\n]+)"#),
 
         // TypeWhisper — no notes in the appcast either. The official changelog
         // page is the vendor's own, and it interleaves **macOS and Windows**

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -2981,9 +2981,11 @@ public enum ChangelogRecipeRegistry {
         // IS a real category, unconditionally (no "≥2 siblings" guess needed the
         // way `GitHubMarkdownParser` needs one across dozens of unrelated GitHub
         // vendors — see `Changelog.parserGeneration`'s generation-3 entry).
-        // Bounded the same way the item pattern is, so a heading also stops at
-        // the next entry or the trailing link-reference block rather than
-        // swallowing the rest of the file.
+        // A heading is one line, so it needs none of the item pattern's lookahead
+        // boundary list above: `[^\n]+` is a negated character class, which
+        // already cannot cross the newline that ends it. Simpler than the item
+        // pattern by construction, not by omission — there is no multi-line
+        // heading to bound against here.
         ChangelogRecipe(
             bundleID: "uk.co.bzwrd.macperfmonitor",
             source: URL(string: "https://raw.githubusercontent.com/Zesty0wl/mac-performance-monitor/main/CHANGELOG.md")!,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -53,18 +53,27 @@ public enum GitHubMarkdownParser {
     /// these are matched whole — case-insensitively, after trimming — against one
     /// app's headings, so a heading that merely resembles one is untouched. Empty
     /// by default, and an empty list is byte-for-byte the old behavior.
+    ///
+    /// A category heading (`### Added`, `### Fixed`, …) survives into the returned
+    /// entry's `content` as a `.heading` block — but only when `qualifyingHeadings`
+    /// says so (see that function's doc comment for the rule and the measurement
+    /// behind it); a recipe's own `skipSections`/`skippedSectionKeywords` still
+    /// name a heading as boilerplate first, same as before. Everything else is
+    /// dropped exactly as it always was (never folded into `items` either way —
+    /// see `Changelog.Entry.items`'s doc comment). `items` itself is completely
+    /// unaffected: a heading was never one of its lines before this and still isn't.
     public static func parse(
         body: String, version: String, date: String?, skipSections: [String] = []
     ) -> Changelog? {
-        var items = extractItems(from: body, lenient: false, skipSections: skipSections)
+        var (items, content) = extractItems(from: body, lenient: false, skipSections: skipSections)
         if items.isEmpty {
-            items = extractItems(from: body, lenient: true, skipSections: skipSections)
+            (items, content) = extractItems(from: body, lenient: true, skipSections: skipSections)
         }
         if items.isEmpty {
-            items = proseItems(from: body, skipSections: skipSections)
+            (items, content) = proseItems(from: body, skipSections: skipSections)
         }
         guard !items.isEmpty else { return nil }
-        let entry = Changelog.Entry(version: version, date: date, items: items)
+        let entry = Changelog.Entry(version: version, date: date, items: items, content: content)
         // The body is Markdown and the items keep their inline syntax — say so,
         // or the renderer prints `**bold**` and `[text](url)` verbatim.
         return Changelog(entries: [entry], itemSyntax: .markdown)
@@ -76,15 +85,82 @@ public enum GitHubMarkdownParser {
         "new contributors", "contributors", "full changelog",
     ]
 
-    /// The heading text of a `## Heading` / `### Heading` line, lowercased and
-    /// trimmed — nil for any other line. One place, so the bullet passes and the
-    /// prose pass cannot drift on what counts as a heading.
-    private static func headingText(of trimmedLine: String) -> String? {
+    /// The heading text of a `## Heading` / `### Heading` line, verbatim (original
+    /// case) and trimmed — nil for any other line. One place, so every caller
+    /// (the bullet passes, the prose pass, and `qualifyingHeadings`) agrees on
+    /// what counts as a heading; each lowercases the result itself where a
+    /// case-insensitive comparison is what it needs.
+    private static func headingRawText(of trimmedLine: String) -> String? {
         guard trimmedLine.hasPrefix("#") else { return nil }
         return trimmedLine
             .drop(while: { $0 == "#" })
             .trimmingCharacters(in: .whitespaces)
-            .lowercased()
+    }
+
+    /// A heading that contains a digit reads as restating a version or build
+    /// number rather than naming a change category, and styling it draws a
+    /// second "version" next to the rail that already shows one — confusing,
+    /// not informative. Real, measured examples (fetched 2026-09-12, 30 releases
+    /// each across the 10 repos already routed through this parser): UTM's
+    /// `Changes (v5.0.4)` (a DIFFERENT release folded into this one's body),
+    /// Rockxy's `Rockxy 0.38.3 (build 58)` (this release's own version, restated),
+    /// AnythingLLM's `AnythingLLM v1.8.0 | MCP tools & a fresh new look!`, and
+    /// CotEditor's `Changes in 7.0.8 (unreleased)`. None of the ~90 distinct real
+    /// category headings the same sweep found (`Added`, `Fixed`, `Improvements`,
+    /// `Bug Fixes`, `Known Issues`, dozens of vendor-specific ones like `Model
+    /// Router: The First Consumer Hybrid AI Experience`) contain a digit, so this
+    /// single rule separates the two groups cleanly on every body sampled — see
+    /// `Changelog.parserGeneration`'s generation-3 entry.
+    private static func isVersionLikeHeading(_ heading: String) -> Bool {
+        heading.range(of: #"[0-9]"#, options: .regularExpression) != nil
+    }
+
+    /// This release body's headings worth styling as `.heading` blocks: not
+    /// boilerplate (`skippedSectionKeywords`/`extraSkipKeywords`/a recipe's own
+    /// `skipSections`), not version-like (`isVersionLikeHeading`), AND — because a
+    /// GitHub release body is not Keep a Changelog and ranges from real categories
+    /// (CotEditor's `Improvements`/`Fixes`) to one heading restating the pane
+    /// (Shotbase's "What's new", measured always exactly 0 or 1 per release across
+    /// 13 fetched) to 38 headings in one body (Headlamp, though it never reaches
+    /// this parser — its recipe reads raw JSON with its own regexes) — only when
+    /// there are at least 2 such headings in this one body. Below that threshold a
+    /// heading is exactly as invisible as it always was: dropped, never folded
+    /// into `items`, not shown at all.
+    ///
+    /// Returns the qualifying headings' raw (non-lowercased) text, since that's
+    /// what a `.heading` block displays and membership only needs a set. A
+    /// heading repeated in one body (CotEditor's beta releases list an
+    /// "unreleased" sub-range with its own `Improvements`/`Fixes`) qualifies at
+    /// every occurrence once its text is in the set — each occurrence still
+    /// counts toward the ≥2 threshold too, because this counts total headings
+    /// found, not distinct names.
+    ///
+    /// Mostly independent of the strict/lenient/prose split below: all three
+    /// encounter the same `#`-prefixed lines the same way, EXCEPT that the strict
+    /// bullet pass (`extractItems(lenient: false, …)`) never tracks fenced code
+    /// blocks at all — its own `inCodeBlock` toggle is gated on `lenient` — so a
+    /// heading-shaped line inside a fence is a heading to it. `tracksCodeFences`
+    /// mirrors that per-pass rule so this scan's candidate count and code-fence
+    /// state can never disagree with the pass that actually wins.
+    private static func qualifyingHeadings(
+        in body: String, skipSections: [String], extraSkipKeywords: [String] = [],
+        tracksCodeFences: Bool = true
+    ) -> Set<String> {
+        var candidates: [String] = []
+        var inCodeBlock = false
+        for line in body.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if tracksCodeFences, trimmed.hasPrefix("```") { inCodeBlock.toggle(); continue }
+            if tracksCodeFences, inCodeBlock { continue }
+            guard let raw = headingRawText(of: trimmed) else { continue }
+            let lowered = raw.lowercased()
+            if skippedSectionKeywords.contains(where: { lowered.contains($0) }) { continue }
+            if extraSkipKeywords.contains(where: { lowered.contains($0) }) { continue }
+            if isSkipped(lowered, by: skipSections) { continue }
+            if isVersionLikeHeading(raw) { continue }
+            candidates.append(raw)
+        }
+        return candidates.count >= 2 ? Set(candidates) : []
     }
 
     /// Whole-heading, case-insensitive match against a recipe's own `skipSections`.
@@ -134,10 +210,14 @@ public enum GitHubMarkdownParser {
     ///     falls back to the renderer that shows the body whole.
     private static let proseItemCap = 12
 
-    private static func proseItems(from body: String, skipSections: [String] = []) -> [String] {
+    private static func proseItems(
+        from body: String, skipSections: [String] = []
+    ) -> (items: [String], content: [Changelog.Entry.Block]) {
         guard body.range(of: #"(?m)^\s*\|"#, options: .regularExpression) == nil
-        else { return [] }
+        else { return ([], []) }
+        let qualifying = qualifyingHeadings(in: body, skipSections: skipSections)
         var items: [String] = []
+        var content: [Changelog.Entry.Block] = []
         var inCodeBlock = false
         var inSkippedSection = false
         for line in body.components(separatedBy: .newlines) {
@@ -146,8 +226,11 @@ public enum GitHubMarkdownParser {
             // A recipe-declared section is skipped here too, so a vendor who writes
             // their boilerplate as prose is handled the same as one who bullets it.
             // Gated on a non-empty list, so the default path is unchanged.
-            if !inCodeBlock, let heading = headingText(of: trimmed) {
-                inSkippedSection = isSkipped(heading, by: skipSections)
+            if !inCodeBlock, let raw = headingRawText(of: trimmed) {
+                inSkippedSection = isSkipped(raw.lowercased(), by: skipSections)
+                if !inSkippedSection, !qualifying.isEmpty, qualifying.contains(raw) {
+                    content.append(.heading(raw))
+                }
                 continue
             }
             if inCodeBlock || inSkippedSection || trimmed.isEmpty { continue }
@@ -156,9 +239,10 @@ public enum GitHubMarkdownParser {
                 trimmed.lowercased().hasPrefix("**\($0)")
             }) { continue }
             items.append(trimmed)
-            if items.count > proseItemCap { return [] }
+            if !qualifying.isEmpty { content.append(.note(trimmed)) }
+            if items.count > proseItemCap { return ([], []) }
         }
-        return items
+        return (items, qualifying.isEmpty ? [] : content)
     }
 
     /// A line that is nothing but a URL. Not a change description — the same
@@ -199,11 +283,15 @@ public enum GitHubMarkdownParser {
 
     private static func extractItems(
         from body: String, lenient: Bool, skipSections: [String] = []
-    ) -> [String] {
+    ) -> (items: [String], content: [Changelog.Entry.Block]) {
         let lines = body.components(separatedBy: .newlines)
         let skipKeywords = lenient ? skippedSectionKeywords + lenientExtraSkipKeywords
                                    : skippedSectionKeywords
+        let qualifying = lenient
+            ? qualifyingHeadings(in: body, skipSections: skipSections, extraSkipKeywords: lenientExtraSkipKeywords)
+            : qualifyingHeadings(in: body, skipSections: skipSections, tracksCodeFences: false)
         var items: [String] = []
+        var content: [Changelog.Entry.Block] = []
         var inSkippedSection = false
         var inCodeBlock = false
 
@@ -219,9 +307,13 @@ public enum GitHubMarkdownParser {
             if inCodeBlock { continue }
 
             // Section heading: ## Title or ### Title
-            if let heading = headingText(of: trimmed) {
+            if let raw = headingRawText(of: trimmed) {
+                let heading = raw.lowercased()
                 inSkippedSection = skipKeywords.contains(where: { heading.contains($0) })
                     || isSkipped(heading, by: skipSections)
+                if !inSkippedSection, !qualifying.isEmpty, qualifying.contains(raw) {
+                    content.append(.heading(raw))
+                }
                 continue
             }
 
@@ -233,7 +325,10 @@ public enum GitHubMarkdownParser {
                 // items for an indented line to be a duplicate sub-detail of.
                 if let raw = bulletContent(from: trimmed) ?? numberedContent(from: trimmed) {
                     let cleaned = cleanItem(raw)
-                    if cleaned.count >= 6 { items.append(cleaned) }
+                    if cleaned.count >= 6 {
+                        items.append(cleaned)
+                        if !qualifying.isEmpty { content.append(.note(cleaned)) }
+                    }
                 }
             } else {
                 // Bullet: `- text`, `* text`, `+ text`.
@@ -245,12 +340,15 @@ public enum GitHubMarkdownParser {
                 if let raw = bulletContent(from: trimmed) {
                     let cleaned = cleanItem(raw)
                     // Drop very short items (emoji-only, single-word, link-only lines).
-                    if cleaned.count >= 6 { items.append(cleaned) }
+                    if cleaned.count >= 6 {
+                        items.append(cleaned)
+                        if !qualifying.isEmpty { content.append(.note(cleaned)) }
+                    }
                 }
             }
         }
 
-        return items
+        return (items, qualifying.isEmpty ? [] : content)
     }
 
     /// A numbered-list item's text: "1. text" / "12) text" → "text". nil otherwise.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -146,23 +146,33 @@ public enum GitHubMarkdownParser {
     /// counts toward the ≥2 threshold too, because this counts total headings
     /// found, not distinct names.
     ///
-    /// Mostly independent of the strict/lenient/prose split below: all three
-    /// encounter the same `#`-prefixed lines the same way, EXCEPT that the strict
-    /// bullet pass (`extractItems(lenient: false, …)`) never tracks fenced code
-    /// blocks at all — its own `inCodeBlock` toggle is gated on `lenient` — so a
-    /// heading-shaped line inside a fence is a heading to it. `tracksCodeFences`
-    /// mirrors that per-pass rule so this scan's candidate count and code-fence
-    /// state can never disagree with the pass that actually wins.
+    /// Deliberately STRICTER than the strict bullet pass below on one point: this
+    /// scan always tracks fenced code blocks and never counts a heading-shaped
+    /// line inside one, even though `extractItems(lenient: false, …)` itself
+    /// never tracks fences at all (its own `inCodeBlock` toggle is gated on
+    /// `lenient`, so the strict pass's loop really does walk into a fence's
+    /// contents). That mismatch is safe rather than a repeat of the "scan
+    /// disagrees with the pass" mistake this function's doc used to warn against:
+    /// the only thing this scan's membership decides is whether a `.heading`
+    /// block gets emitted, never whether a bullet becomes an item or a section
+    /// gets skipped — those are the strict pass's own business and this change
+    /// touches neither. A heading whose only appearance is inside a fence simply
+    /// never enters `candidates`, so it can never be in the returned set, so the
+    /// strict pass's loop — which still walks into the fence and still sees the
+    /// line as heading-shaped — finds no match in `qualifying.contains(raw)` and
+    /// emits nothing for it, exactly as if the fence had been skipped. Verified
+    /// with a fixture reproducing the shape this fixes: two headings live only
+    /// between a pair of ``` fences, alongside two real ones outside — before,
+    /// all four rendered as `.heading` blocks; after, only the two real ones do.
     private static func qualifyingHeadings(
-        in body: String, skipSections: [String], extraSkipKeywords: [String] = [],
-        tracksCodeFences: Bool = true
+        in body: String, skipSections: [String], extraSkipKeywords: [String] = []
     ) -> Set<String> {
         var candidates: [String] = []
         var inCodeBlock = false
         for line in body.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if tracksCodeFences, trimmed.hasPrefix("```") { inCodeBlock.toggle(); continue }
-            if tracksCodeFences, inCodeBlock { continue }
+            if trimmed.hasPrefix("```") { inCodeBlock.toggle(); continue }
+            if inCodeBlock { continue }
             guard let raw = headingRawText(of: trimmed) else { continue }
             let lowered = raw.lowercased()
             if skippedSectionKeywords.contains(where: { lowered.contains($0) }) { continue }
@@ -172,6 +182,16 @@ public enum GitHubMarkdownParser {
             candidates.append(raw)
         }
         return candidates.count >= 2 ? Set(candidates) : []
+    }
+
+    /// True when at least one block is a styled heading. The dangling-heading
+    /// buffer in `extractItems`/`proseItems` can leave `content` holding nothing
+    /// but `.note`s once every pending heading in a body turned out dangling and
+    /// got dropped — `Changelog.Entry.content`'s own doc comment promises it is
+    /// populated only when there is something extra to walk, so that case must
+    /// reset to `[]` exactly like the "no headings qualified at all" case does.
+    private static func hasHeadingBlock(_ content: [Changelog.Entry.Block]) -> Bool {
+        content.contains { if case .heading = $0 { return true }; return false }
     }
 
     /// Whole-heading, case-insensitive match against a recipe's own `skipSections`.
@@ -229,6 +249,10 @@ public enum GitHubMarkdownParser {
         let qualifying = qualifyingHeadings(in: body, skipSections: skipSections)
         var items: [String] = []
         var content: [Changelog.Entry.Block] = []
+        // A heading only earns its `.heading` block once a note actually lands
+        // under it — see the doc comment on `extractItems`'s identical buffer for
+        // why (dangling headings, measured live at 22% of styled headings).
+        var pendingHeading: Changelog.Entry.Block?
         var inCodeBlock = false
         var inSkippedSection = false
         for line in body.components(separatedBy: .newlines) {
@@ -239,9 +263,12 @@ public enum GitHubMarkdownParser {
             // Gated on a non-empty list, so the default path is unchanged.
             if !inCodeBlock, let raw = headingRawText(of: trimmed) {
                 inSkippedSection = isSkipped(raw.lowercased(), by: skipSections)
-                if !inSkippedSection, !qualifying.isEmpty, qualifying.contains(raw) {
-                    content.append(.heading(raw))
-                }
+                // Unconditional reassignment: whatever was pending (if anything)
+                // never got a note under it, so it is dropped here, not carried
+                // forward — same rule whether this new heading itself qualifies,
+                // is boilerplate, or neither.
+                pendingHeading = (!inSkippedSection && qualifying.contains(raw))
+                    ? .heading(raw) : nil
                 continue
             }
             if inCodeBlock || inSkippedSection || trimmed.isEmpty { continue }
@@ -250,10 +277,18 @@ public enum GitHubMarkdownParser {
                 trimmed.lowercased().hasPrefix("**\($0)")
             }) { continue }
             items.append(trimmed)
-            if !qualifying.isEmpty { content.append(.note(trimmed)) }
+            if !qualifying.isEmpty {
+                if let heading = pendingHeading {
+                    content.append(heading)
+                    pendingHeading = nil
+                }
+                content.append(.note(trimmed))
+            }
             if items.count > proseItemCap { return ([], []) }
         }
-        return (items, qualifying.isEmpty ? [] : content)
+        // Anything still pending here is a heading with no note after it before
+        // the body ended — dropped, not appended, same as any other dangling one.
+        return (items, hasHeadingBlock(content) ? content : [])
     }
 
     /// A line that is nothing but a URL. Not a change description — the same
@@ -300,9 +335,23 @@ public enum GitHubMarkdownParser {
                                    : skippedSectionKeywords
         let qualifying = lenient
             ? qualifyingHeadings(in: body, skipSections: skipSections, extraSkipKeywords: lenientExtraSkipKeywords)
-            : qualifyingHeadings(in: body, skipSections: skipSections, tracksCodeFences: false)
+            : qualifyingHeadings(in: body, skipSections: skipSections)
         var items: [String] = []
         var content: [Changelog.Entry.Block] = []
+        // A heading is appended to `content` only once a note actually lands
+        // under it in its own section — never the instant it is seen. Without
+        // this, `## Fixed\n- None\n## Improvements\n- …` styles BOTH headings
+        // (`None` is 4 characters and dies on the 6-character floor below, so
+        // `Fixed` would otherwise sit directly on top of `Improvements` with
+        // nothing under it), and a body ending in a bare heading styles one that
+        // is never followed by anything at all. Measured live (30 releases each,
+        // the 10 repos this parser serves, a heading counting as dangling when
+        // the next block is another heading or there is none): 161 of 742 styled
+        // headings, 22%, would render this way without the buffer. Reassigned
+        // unconditionally on every heading line — whatever was pending, if
+        // anything, never got a note under it, so it is dropped rather than
+        // carried into the next section, whether or not THIS heading qualifies.
+        var pendingHeading: Changelog.Entry.Block?
         var inSkippedSection = false
         var inCodeBlock = false
 
@@ -322,9 +371,8 @@ public enum GitHubMarkdownParser {
                 let heading = raw.lowercased()
                 inSkippedSection = skipKeywords.contains(where: { heading.contains($0) })
                     || isSkipped(heading, by: skipSections)
-                if !inSkippedSection, !qualifying.isEmpty, qualifying.contains(raw) {
-                    content.append(.heading(raw))
-                }
+                pendingHeading = (!inSkippedSection && qualifying.contains(raw))
+                    ? .heading(raw) : nil
                 continue
             }
 
@@ -338,7 +386,13 @@ public enum GitHubMarkdownParser {
                     let cleaned = cleanItem(raw)
                     if cleaned.count >= 6 {
                         items.append(cleaned)
-                        if !qualifying.isEmpty { content.append(.note(cleaned)) }
+                        if !qualifying.isEmpty {
+                            if let heading = pendingHeading {
+                                content.append(heading)
+                                pendingHeading = nil
+                            }
+                            content.append(.note(cleaned))
+                        }
                     }
                 }
             } else {
@@ -353,13 +407,21 @@ public enum GitHubMarkdownParser {
                     // Drop very short items (emoji-only, single-word, link-only lines).
                     if cleaned.count >= 6 {
                         items.append(cleaned)
-                        if !qualifying.isEmpty { content.append(.note(cleaned)) }
+                        if !qualifying.isEmpty {
+                            if let heading = pendingHeading {
+                                content.append(heading)
+                                pendingHeading = nil
+                            }
+                            content.append(.note(cleaned))
+                        }
                     }
                 }
             }
         }
 
-        return (items, qualifying.isEmpty ? [] : content)
+        // Anything still pending here is a heading with no note after it before
+        // the body ended — dropped, not appended, same as any other dangling one.
+        return (items, hasHeadingBlock(content) ? content : [])
     }
 
     /// A numbered-list item's text: "1. text" / "12) text" → "text". nil otherwise.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -127,6 +127,17 @@ public enum GitHubMarkdownParser {
     /// heading is exactly as invisible as it always was: dropped, never folded
     /// into `items`, not shown at all.
     ///
+    /// That threshold has a real cost, not just a benefit: Rockxy's current
+    /// release body has exactly two headings, `Rockxy 0.38.3 (build 58)` (its own
+    /// version, restated) and `Fixed` — a genuine Keep a Changelog category on an
+    /// app in this registry. The digit filter above removes the first, leaving
+    /// one candidate, which is below the threshold, so `Fixed` renders as nothing
+    /// on that release. Lowering the threshold to 1 would fix Rockxy but re-admit
+    /// exactly the Shotbase noise (below) the threshold exists to stop, so this
+    /// is deliberate — the point of naming it here is so the next person weighing
+    /// "should this be ≥1?" starts from this measurement instead of rediscovering
+    /// Rockxy.
+    ///
     /// Returns the qualifying headings' raw (non-lowercased) text, since that's
     /// what a `.heading` block displays and membership only needs a set. A
     /// heading repeated in one body (CotEditor's beta releases list an

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
@@ -55,8 +55,18 @@ import Foundation
     /// 2 moves neither fixture: it is Ollama's paragraph fallback, which changes
     /// what a release written as prose parses to — pinned by
     /// `extractsOllamaProseReleases`, not here.
+    ///
+    /// 3 (category headings surviving as `.heading` blocks, #554) ALSO moves
+    /// neither fixture below — checked by hand, not assumed: v4.3.6's only
+    /// non-boilerplate heading is `Changes` (`Included Localizations` is
+    /// `skipSections`-excluded), 1 candidate is below the ≥2-sibling threshold;
+    /// v5.0.2 is the bullet-less prose fixture and has no headings at all; the
+    /// Figma recipe below is a hand-written regex recipe with no
+    /// `headingPattern` set. Pinned by the new heading-specific tests in
+    /// `GitHubMarkdownParserTests.swift` and
+    /// `MacPerformanceMonitorChangelogRecipeTests.swift` instead.
     @Test func pinnedGeneration() {
-        #expect(Changelog.parserGeneration == 2)
+        #expect(Changelog.parserGeneration == 3)
     }
 
     /// Stable (v4.3.6, bulleted): exercises `skipSections` — the `### Included

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogReviewRegressionTests.swift
@@ -257,6 +257,22 @@ private let hbuilderXCodeSpanFixture = #"""
     }
 }
 
+/// `headingPattern` is read only by `ChangelogExtractor` — the regex path. A
+/// `.gitHubReleases`/`.zedGitHubReleases` recipe never reaches
+/// `ChangelogExtractor` at all (it goes through `StructuredChangelogDecoder` →
+/// `GitHubMarkdownParser`, which decides which headings to style on its own —
+/// see `Changelog.parserGeneration`'s generation-3 entry), so setting
+/// `headingPattern` there is not an error, it is *nothing*: the field is set and
+/// nothing ever reads it. Same failure shape as `skipSections`/`tagPattern`
+/// above, mirrored the other way — those two are no-ops on the regex path,
+/// this one is a no-op on the structured path.
+@Test func headingPatternOnlyLandsOnAFormatThatReadsIt() {
+    for recipe in ChangelogRecipeRegistry.recipes where recipe.headingPattern != nil {
+        #expect(recipe.structuredFormat == nil,
+                "\(recipe.bundleID): headingPattern is a no-op on \(recipe.structuredFormat!.rawValue)")
+    }
+}
+
 // MARK: - Waku
 
 /// Waku's registered recipe reads GitHub releases, which carry the same bullets

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
@@ -1,6 +1,195 @@
 import Testing
 @testable import DuoUpdaterCore
 
+// MARK: - Category headings (#554, part of #399)
+//
+// Measured 2026-09-12 across the 10 repos already routed through
+// `GitHubMarkdownParser` (30 releases each, `gh api repos/<owner>/<repo>/releases`):
+// real category headings (`Added`/`Fixed`/`Improvements`/…) never carry a digit,
+// while every version-restating heading found (UTM's `Changes (v5.0.4)`,
+// Rockxy's `Rockxy 0.38.3 (build 58)`, AnythingLLM's `AnythingLLM v1.8.0 | …`,
+// CotEditor's `Changes in 7.0.8 (unreleased)`) does — see
+// `Changelog.parserGeneration`'s generation-3 entry and
+// `GitHubMarkdownParser.isVersionLikeHeading`'s doc comment.
+
+/// Two real categories: both style as `.heading` blocks, in document order,
+/// interleaved with the notes they introduce — and `items` stays exactly the
+/// flat list it always was (a heading is never one of its lines).
+///
+/// Mutations this catches: appending heading text into `items` (breaks the
+/// `items`-doesn't-change assertion); building `content` as "all headings then
+/// all notes" instead of interleaved (breaks the ordering assertion).
+@Test func twoOrMoreCategoryHeadingsStyleAsHeadingBlocksInDocumentOrder() throws {
+    let body = """
+    ## Added
+    - New feature one
+    - New feature two
+
+    ## Fixed
+    - Fixed bug one
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0.0", date: nil)?.entries.first)
+    #expect(entry.items == ["New feature one", "New feature two", "Fixed bug one"])
+    #expect(entry.content == [
+        .heading("Added"), .note("New feature one"), .note("New feature two"),
+        .heading("Fixed"), .note("Fixed bug one"),
+    ])
+    #expect(!entry.items.contains("Added"), "a heading leaked into items")
+    #expect(!entry.items.contains("Fixed"), "a heading leaked into items")
+}
+
+/// A single heading — Shotbase's real shape, "one heading restating the pane"
+/// (`### What's new` on every release) — never earns a `.heading` block: below
+/// the ≥2-sibling threshold it folds away exactly as it always did, invisible,
+/// not even as a plain item.
+///
+/// Mutation this catches: dropping (or inverting) the `candidates.count >= 2`
+/// threshold in `qualifyingHeadings` — a lone heading would start rendering.
+@Test func aLoneHeadingStaysFoldedAwayBelowTheSiblingThreshold() throws {
+    let body = """
+    ## What's new
+    - Something changed
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0.0", date: nil)?.entries.first)
+    #expect(entry.items == ["Something changed"])
+    #expect(entry.content.isEmpty, "a lone heading must not produce a .heading block")
+}
+
+/// UTM's real shape: `Highlights`/`Notes` are genuine sections, but the body
+/// also nests OTHER releases' notes under `Changes (vX.Y.Z)` headings — styling
+/// those would draw four version numbers next to the one the rail already
+/// shows. Only the non-version headings qualify; the version-shaped ones fold
+/// away, and their bullets still surface as plain (unheaded) items exactly as
+/// before this change — nothing about `items` regresses for this shape.
+///
+/// Mutation this catches: deleting `isVersionLikeHeading` from
+/// `qualifyingHeadings` (or always returning `false`) — the version headings
+/// would join `Highlights`/`Notes` as styled blocks.
+@Test func versionRestatingHeadingsDoNotQualifyEvenWithEnoughSiblings() throws {
+    let body = """
+    ## Highlights
+    - Big new feature
+
+    ## Notes
+    - Some notes
+
+    ## Changes (v5.0.4)
+    - Old changes from a previous release
+
+    ## Changes (v5.0.3)
+    - Even older changes
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "5.0.5", date: nil)?.entries.first)
+    #expect(entry.items == [
+        "Big new feature", "Some notes",
+        "Old changes from a previous release", "Even older changes",
+    ], "the version-shaped headings' bullets must still come through as plain items")
+    #expect(entry.content == [
+        .heading("Highlights"), .note("Big new feature"),
+        .heading("Notes"), .note("Some notes"),
+        .note("Old changes from a previous release"),
+        .note("Even older changes"),
+    ])
+}
+
+/// Even with three siblings, an ALL-version-shaped set of headings never
+/// qualifies — proving the digit filter is load-bearing on its own, not merely
+/// riding along with the ≥2 threshold (which three headings would otherwise
+/// clear easily).
+@Test func allVersionShapedHeadingsNeverQualifyRegardlessOfCount() throws {
+    let body = """
+    ## Changes (v5.0.4)
+    - A change
+
+    ## Changes (v5.0.3)
+    - Another change
+
+    ## Changes (v5.0.2)
+    - Yet another change
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "5.0.5", date: nil)?.entries.first)
+    #expect(entry.content.isEmpty)
+}
+
+/// A recipe-declared `skipSections` heading must not count toward the ≥2
+/// threshold for its SIBLINGS either — otherwise adding a `skipSections` entry
+/// for a boilerplate section would, as a side effect, start styling the one
+/// real heading left behind (1 real + 1 boilerplate reads as "2 siblings" if
+/// the boilerplate one isn't excluded from the count first).
+///
+/// Mutation this catches: computing the sibling count from ALL headings before
+/// filtering out `skipSections` matches, instead of after.
+@Test func aSkippedHeadingDoesNotCountTowardTheSiblingThreshold() throws {
+    let body = """
+    ## Added
+    - Real change
+
+    ## Roster
+    - Alice
+    - Bob
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0.0", date: nil, skipSections: ["Roster"])?.entries.first)
+    #expect(entry.items == ["Real change"], "the skipped section's bullets must still be dropped")
+    #expect(entry.content.isEmpty,
+            "one real heading left after excluding the skipped one is still below the threshold")
+}
+
+/// The lenient pass (indented bullets, strict pass finds nothing) wires up
+/// headings exactly the same way the strict pass does.
+@Test func headingsStyleThroughTheLenientPassToo() throws {
+    let body = """
+    ## New Stuff
+     - install from cache without network access
+    ## Bug Fixes
+     - reject version strings with disallowed characters
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "0.40.5", date: nil)?.entries.first)
+    #expect(entry.content == [
+        .heading("New Stuff"), .note("install from cache without network access"),
+        .heading("Bug Fixes"), .note("reject version strings with disallowed characters"),
+    ])
+}
+
+/// …and so does the prose pass (both bullet passes come up empty).
+@Test func headingsStyleThroughTheProsePassToo() throws {
+    let body = """
+    ## Highlights
+    A faster startup on every platform.
+
+    ## Notes
+    Nothing else changed in this release.
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0", date: nil)?.entries.first)
+    #expect(entry.content == [
+        .heading("Highlights"), .note("A faster startup on every platform."),
+        .heading("Notes"), .note("Nothing else changed in this release."),
+    ])
+}
+
+/// Backward compatibility: the existing "What's Changed" + "New Contributors"
+/// shape has exactly one non-boilerplate heading ("What's Changed" — "New
+/// Contributors" is `skippedSectionKeywords` boilerplate, excluded from the
+/// count same as `skipSections`), so it stays below the ≥2 threshold and
+/// `content` stays empty exactly as it did before this change.
+@Test func theExistingWhatsChangedShapeStaysUnstyled() {
+    let body = """
+    ## What's Changed
+    - Fix the broken thing by @bob in https://github.com/o/r/pull/1
+    - Add a useful feature (#42)
+    ## New Contributors
+    - @newbie made their first contribution
+    """
+    let cl = GitHubMarkdownParser.parse(body: body, version: "1.0.0", date: nil)
+    #expect(cl?.entries.first?.content.isEmpty == true)
+}
+
 // MARK: - Strict pass (existing behavior — must not regress)
 
 @Test func parsesTopLevelBulletsAndStripsPRNoise() {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
@@ -190,6 +190,127 @@ import Testing
     #expect(cl?.entries.first?.content.isEmpty == true)
 }
 
+// MARK: - Dangling headings (`/code-review` on #562, PR review of #554)
+//
+// Measured live (30 releases each, the 10 repos this parser serves — a heading
+// counts as dangling when the next block is another heading or there is none):
+// 161 of 742 styled headings, 22%, would render this way without the fix below
+// (`Windscribe 58/136, AnythingLLM 46/105, UTM 30/116, Zed 18/167,
+// BetterDisplay 9/42, CotEditor/Rockxy/Yaak/cline 0`).
+
+/// The reported reproduction: a heading whose only item dies on the
+/// 6-character floor ("None" is 4 characters) must not style anyway just
+/// because it was seen — a heading earns its block only once a note actually
+/// lands under it.
+///
+/// Mutation this catches: appending a heading to `content` the instant it is
+/// seen (reverting the `pendingHeading` buffer in `extractItems`) — `Fixed`
+/// would render with nothing under it, directly above `Improvements`.
+@Test func aHeadingWhoseOnlyLineFailsTheLengthFloorIsNotStyled() throws {
+    let body = """
+    ## Fixed
+    - None
+    ## Improvements
+    - Made the scrolling much smoother in long lists
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0", date: nil)?.entries.first)
+    #expect(entry.content == [
+        .heading("Improvements"),
+        .note("Made the scrolling much smoother in long lists"),
+    ])
+}
+
+/// A body ending in a bare heading with nothing after it at all — the other
+/// trigger, at the tail rather than mid-body.
+///
+/// Mutation this catches: same as above, but exercised at end-of-input, where
+/// there is no following heading to trigger the "drop the pending one" branch
+/// — only the fact that the loop ends with `pendingHeading` still set and
+/// nothing ever flushes it.
+@Test func aTrailingHeadingWithNoNoteAfterItIsNotStyled() throws {
+    let body = """
+    ## Added
+    - A real change
+
+    ## Known Issues
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0", date: nil)?.entries.first)
+    #expect(entry.content == [.heading("Added"), .note("A real change")])
+}
+
+/// The same two triggers through the lenient pass, which has its own copy of
+/// the buffer.
+@Test func danglingHeadingsAreDroppedThroughTheLenientPassToo() throws {
+    let body = """
+    ## New Stuff
+    ## Bug Fixes
+     - reject version strings with disallowed characters
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0", date: nil)?.entries.first)
+    #expect(entry.content == [
+        .heading("Bug Fixes"), .note("reject version strings with disallowed characters"),
+    ])
+}
+
+/// …and through the prose pass, which has its own copy too.
+@Test func danglingHeadingsAreDroppedThroughTheProsePassToo() throws {
+    let body = """
+    ## Highlights
+    ## Notes
+    Nothing else changed in this release.
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0", date: nil)?.entries.first)
+    #expect(entry.content == [
+        .heading("Notes"), .note("Nothing else changed in this release."),
+    ])
+}
+
+// MARK: - Headings inside a fenced code block (`/code-review` on #562)
+
+/// The strict pass's own loop never tracks fences (its toggle is gated on
+/// `lenient`), but `qualifyingHeadings` must track them anyway — a heading
+/// whose only appearance is inside a fence must never earn a `.heading` block,
+/// even though the strict pass's loop still walks into the fence's contents
+/// and still sees those lines as heading-shaped.
+///
+/// The fenced heading is followed by what LOOKS like a bullet — deliberately,
+/// so this cannot pass merely because the dangling-heading fix above already
+/// drops a heading with nothing under it. `Added` here DOES get a "note"
+/// right after it (the strict pass's own loop never tracks fences, so it
+/// reads that line as a real bullet regardless of this fix); the only thing
+/// this test isolates is whether `Added` itself gets promoted to a `.heading`
+/// block for it.
+///
+/// Mutation this catches: passing `tracksCodeFences: false` (or an
+/// equivalent) into the strict pass's call to `qualifyingHeadings` — `Added`
+/// would then count toward the sibling threshold and render as a `.heading`
+/// block despite living only inside the fence.
+@Test func headingsInsideAFencedCodeBlockAreNeverStyled() throws {
+    let body = """
+    ## Improvements
+    - A real change here
+
+    ```
+    ## Added
+    - Example config, not a real change
+    ```
+
+    ## Notes
+    - Another real change here
+    """
+    let entry = try #require(GitHubMarkdownParser.parse(
+        body: body, version: "1.0", date: nil)?.entries.first)
+    #expect(entry.content == [
+        .heading("Improvements"), .note("A real change here"),
+        .note("Example config, not a real change"),
+        .heading("Notes"), .note("Another real change here"),
+    ])
+}
+
 // MARK: - Strict pass (existing behavior — must not regress)
 
 @Test func parsesTopLevelBulletsAndStripsPRNoise() {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacPerformanceMonitorChangelogRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/MacPerformanceMonitorChangelogRecipeTests.swift
@@ -150,4 +150,35 @@ struct MacPerformanceMonitorChangelogRecipeTests {
             }
         }
     }
+
+    /// #554 (part of #399): the whole point of `headingPattern` on this recipe.
+    /// 1.7.1 has TWO groups (`Fixed`, `Changed`) — the reported case, Mac
+    /// Performance Monitor 1.7.1 — so both must survive as `.heading` blocks,
+    /// interleaved with their own bullets in document order, distinct from the
+    /// OTHER entry's `Added` group two releases later.
+    ///
+    /// Unlike `GitHubMarkdownParser`'s ≥2-siblings rule, this recipe styles every
+    /// heading unconditionally — including 1.7.0's single `Added` group — because
+    /// it is curated for one real Keep a Changelog file, where every `###` is
+    /// always a genuine category (see `ChangelogRecipe.headingPattern`'s doc
+    /// comment).
+    ///
+    /// Mutation this catches: dropping `headingPattern` from the recipe (or
+    /// reverting `ChangelogExtractor` to ignore it) — every assertion here would
+    /// fail with an empty `content`.
+    @Test func groupHeadingsSurviveAsStyledBlocksForEveryEntry() throws {
+        let parsed = try #require(ChangelogService.parse(try Self.recipe, body: Self.fixture))
+        let newest = try #require(parsed.entries.first)
+        #expect(newest.version == "1.7.1")
+        #expect(newest.content == [
+            .heading("Fixed"),
+            .note(newest.items[0]),
+            .note(newest.items[1]),
+            .heading("Changed"),
+            .note(newest.items[2]),
+        ])
+        let oldest = try #require(parsed.entries.last)
+        #expect(oldest.version == "1.7.0")
+        #expect(oldest.content == [.heading("Added"), .note(oldest.items[0])])
+    }
 }


### PR DESCRIPTION
Closes #554, and finishes the second half of #399 (the first half, localized notes, shipped in #553).

A vendor writing Keep a Changelog groups its change lines under `### Added` / `### Fixed` / …. `Changelog.Entry.items` was a flat `[String]`, so those headings only ever acted as a boundary in an `itemPattern` — the groups were flattened and the reader lost which kind of change each line was. Mac Performance Monitor 1.7.1 is the reported case.

`Changelog.Entry.Block` gains `.heading(String)`; the renderer draws it as a bold sub-head inside the entry. Two producers feed it, and they do NOT share a rule, on purpose.

## Hand-written recipes: unconditional

`ChangelogRecipe.headingPattern` is opt-in per recipe, like `imagePattern`. A recipe is already curated for one vendor's page, so every match renders — no guessing. Wired into Mac Performance Monitor, whose file is genuinely Keep a Changelog.

## The shared GitHub parser: a measured rule

`GitHubMarkdownParser` is shared by ten repos with no per-app tuning, and GitHub release bodies are not Keep a Changelog. The rule is: not boilerplate, **contains no digit**, and **at least two such headings in the same body**.

The digit half is not in the issue — it was added because the issue's candidate rule ("≥2 siblings, else fold") **fails on real data**. UTM carries 4–10 sibling headings per release, mixing genuine sections with other releases' headings folded into one body, so a bare sibling count styles both. Across 30 releases each from all ten repos, no version-restating heading lacks a digit and none of the ~90 real category headings contains one.

Verified against live bodies, not fixtures:

| repo | headings in body | styled |
|---|---|---|
| UTM | 10 | **4** — all four `Changes (v5.0.x)` dropped |
| CotEditor | 3 | 3 |
| Zed | 9 | 9 |
| AnythingLLM | 9 | 8 |
| Rockxy | 2 | **0** |

Rockxy is the rule's cost and it is documented as such in `qualifyingHeadings`: its body is `Rockxy 0.38.3 (build 58)` plus `Fixed`, the digit filter removes the first, and the single survivor falls below the threshold — so a genuine category renders as nothing. Lowering the threshold to 1 would fix Rockxy and re-admit the single-heading noise (Shotbase's `What's new`) the threshold exists to stop, so it stays, with the measurement written down so the next person weighing it argues from data.

A body with no qualifying headings produces an empty `content` and renders exactly as before.

## Invariants and caches

- `parserGeneration` → 3, with a history line. Both guard fixtures were checked by hand and shown not to move, rather than having their pinned values edited to match.
- A heading is never added to `items`; `items`' "full set of text lines" promise is unchanged, and both it and `content.isEmpty`'s meaning are restated where they are documented.
- `AppcastHTMLChangelogParser` keeps folding headings in as plain items — out of scope here.

## Coverage

Eight mutations, each introduced, confirmed red on a named test, and reverted: removing the sibling threshold, disabling the digit filter, letting a skip-listed heading count toward the threshold, leaking heading text into `items`, emitting headings out of document order, skipping the prose pass, ignoring `headingPattern` in `ChangelogExtractor`, and planting `headingPattern` on a `structuredFormat` recipe.

The strict bullet pass deliberately does not track code fences (its toggle is gated on `lenient`), so the heading scan mirrors that per-pass rather than assuming one behaviour for both — otherwise the scan's candidate count and the winning pass could disagree.

Both `fragile-recipe` skill copies updated in step, including the documented parameter count the `check_skill_docs.py` gate pins.

`make test` green: 2761 + 280 cases, 0 failures, all seven Python gates.
