### PR TITLE
Heading emission: don't let a fenced heading discard a pending one; record Mac Mouse Fix's channel-signal measurement

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -391,6 +391,21 @@ public enum GitHubMarkdownParser {
                 // `## Notes` / `- <bullet>` rendered as
                 // `[n(…) H(Notes) n(…)]` — the first group silently lost its
                 // label while the second kept one, an asymmetry inside one entry.
+                //
+                // ⚠️ Residual, stated rather than hidden: an UNBALANCED fence
+                // leaves `inFencedBlock` true for the rest of the body, and a
+                // heading after it then cannot replace a still-pending one — so a
+                // later bullet could be labelled with the wrong heading, which is
+                // worse in kind than the missing label this guard fixes. Two
+                // things bound it. `qualifyingHeadings`' own scan already tracks
+                // fences and so already loses every candidate after a stray one,
+                // which usually drops the body below the two-heading threshold
+                // and styles nothing at all; and the arrangement needed to
+                // actually mislabel (two qualifying headings before the stray
+                // fence, the second not yet flushed, a heading and then a bullet
+                // after it) needs an unbalanced fence to begin with — measured
+                // across the last 30 releases of all ten repos this parser
+                // serves, 0 of 284 bodies have one.
                 if !inFencedBlock {
                     pendingHeading = (!inSkippedSection && qualifying.contains(raw))
                         ? .heading(raw) : nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubMarkdownParser.swift
@@ -354,25 +354,47 @@ public enum GitHubMarkdownParser {
         var pendingHeading: Changelog.Entry.Block?
         var inSkippedSection = false
         var inCodeBlock = false
+        var inFencedBlock = false
 
         for line in lines {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
-            // Fenced code block (lenient only): skip its contents so a release's
-            // SHA256 table or example snippet isn't mistaken for change items.
-            if lenient, trimmed.hasPrefix("```") {
-                inCodeBlock.toggle()
-                continue
+            // Fenced code block: `inCodeBlock` stays LENIENT-ONLY — it decides
+            // whether a line can become an item, and the strict pass has always
+            // read fenced bullets as items. `inFencedBlock` is tracked in both
+            // passes and read only by the heading branch below, which is new
+            // state, so switching it on for the strict pass changes no item.
+            if trimmed.hasPrefix("```") {
+                inFencedBlock.toggle()
+                if lenient {
+                    inCodeBlock.toggle()
+                    continue
+                }
             }
             if inCodeBlock { continue }
 
             // Section heading: ## Title or ### Title
             if let raw = headingRawText(of: trimmed) {
                 let heading = raw.lowercased()
+                // Computed for a fenced heading too, exactly as before this guard
+                // existed: in the strict pass a fenced `## New Contributors` has
+                // always opened a skipped section, and which lines become items is
+                // not what this fix is about.
                 inSkippedSection = skipKeywords.contains(where: { heading.contains($0) })
                     || isSkipped(heading, by: skipSections)
-                pendingHeading = (!inSkippedSection && qualifying.contains(raw))
-                    ? .heading(raw) : nil
+                // But a heading INSIDE a fence must not touch `pendingHeading`.
+                // `qualifyingHeadings` skips fenced lines, so such a heading can
+                // never be in `qualifying` — the reassignment could therefore only
+                // ever clear a real heading that was still waiting for its first
+                // note, discarding it. Measured before this guard:
+                // `## Improvements` / fence / `## Added` / fence / `- <bullet>` /
+                // `## Notes` / `- <bullet>` rendered as
+                // `[n(…) H(Notes) n(…)]` — the first group silently lost its
+                // label while the second kept one, an asymmetry inside one entry.
+                if !inFencedBlock {
+                    pendingHeading = (!inSkippedSection && qualifying.contains(raw))
+                        ? .heading(raw) : nil
+                }
                 continue
             }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacMouseFixChannel.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/MacMouseFixChannel.swift
@@ -61,6 +61,21 @@ import Foundation
 ///     once the marketing strings tie. Both call sites lean on the same fact:
 ///     `CFBundleVersion` here is a real, monotonically increasing build id.
 ///
+/// ⚠️ **This file is the ONLY thing on disk that can tell a beta copy from a
+/// stable one**, which is why the binding has to exist rather than leaving the
+/// app to `ReleaseChannel.detect()`. Measured 2026-09-12 against the real
+/// detector: `detect(version: "3.1.0 Beta 1")` answers `.stable`. Its
+/// version-suffix signal reads the `-beta.1` shape, not a space-separated
+/// `Beta 1`, and the bundle id, app name and bundle filename are identical on
+/// both tracks — so nothing else has anything to go on. The practical
+/// consequence to keep in mind when touching `readCheckForPrereleases`: a
+/// config file we cannot read resolves to an AUTHORITATIVE `.stable` (see
+/// `AppScanner`, where a non-nil binding sets `channelIsAuthoritative`), and no
+/// `detect()` signal is being suppressed when that happens — there was never one
+/// to suppress. That is what makes false-on-failure safe HERE and is not a
+/// licence to copy it into a resolver whose app does mark its betas; CotEditor's
+/// maps false to nil for exactly the opposite reason.
+///
 /// Team ID is unchanged across channels: the downloaded 3.1.0 Beta 1 bundle is
 /// signed `Developer ID Application: Noah Nuebling (LM5Z78756B)`, matching the
 /// installed stable copy — so a one-click install does not cross signing

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChannelResolverTests.swift
@@ -385,3 +385,20 @@ import Foundation
     #expect(ChannelBinding.resolve(bundleID: "com.tinyapp.TablePlus") != nil)
     #expect(ChannelBinding.resolve(bundleID: "COM.DanPristupov.FORK") != nil)
 }
+
+/// Pins the measurement `MacMouseFixChannel`'s doc comment rests on: nothing on
+/// disk except that config file distinguishes a Mac Mouse Fix beta, because the
+/// detector cannot read the vendor's space-separated `Beta 1` as a channel
+/// token. If this ever starts answering `.beta`, the doc comment's claim — and
+/// the reasoning that makes false-on-unreadable-config safe for this app — stops
+/// being true and both need revisiting.
+///
+/// Mutation: teach `ReleaseChannel.detect` to read a space-separated channel word
+/// out of the version string. This test goes red, which is the intended signal.
+@Test func nothingButTheConfigFileMarksAMacMouseFixBeta() {
+    let detected = ReleaseChannel.detect(
+        name: "Mac Mouse Fix", bundleID: MacMouseFixChannel.bundleID,
+        keystoneChannel: nil, version: "3.1.0 Beta 1",
+        bundleFileName: "Mac Mouse Fix.app")
+    #expect(detected == .stable)
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubMarkdownParserTests.swift
@@ -466,3 +466,58 @@ import Testing
         body: body, version: "1.0", date: nil)?.entries.first?.items)
     #expect(items == ["Fix the sidebar flicker", "Improve startup time"])
 }
+
+/// A heading line inside a fenced code block must not clear a heading that is
+/// still waiting for its first note.
+///
+/// The strict bullet pass deliberately does not track fences — it has always read
+/// a fenced bullet as an item — so a `##` line inside a fence reaches the heading
+/// branch. `qualifyingHeadings` DOES skip fenced lines, so such a heading can
+/// never be styled; before the guard, its only effect was to discard a real
+/// pending heading, and the entry rendered with one group labelled and an
+/// identical group above it bare.
+///
+/// Mutation: drop the `if !inFencedBlock` guard around the `pendingHeading`
+/// reassignment in `extractItems`. `Improvements` then disappears from `content`
+/// while `Notes` survives, and this fails.
+@Test func aFencedHeadingDoesNotDiscardThePendingRealHeading() {
+    let body = """
+    ## Improvements
+    ```
+    ## Added
+    ```
+    - Made the scrolling much smoother in long lists
+    ## Notes
+    - Another real change line here for length
+    """
+    let entry = GitHubMarkdownParser.parse(body: body, version: "1.0", date: nil)?.entries.first
+    var headings: [String] = []
+    for block in entry?.content ?? [] {
+        if case let .heading(text) = block { headings.append(text) }
+    }
+    #expect(headings == ["Improvements", "Notes"])
+}
+
+/// The companion guard: turning fence tracking on for the strict pass must not
+/// change which lines become items. `inCodeBlock` stays lenient-only and only the
+/// new `inFencedBlock` is tracked in both, so a fenced bullet is still an item in
+/// the strict pass and a fenced `## New Contributors` still opens a skipped
+/// section there — both exactly as before.
+///
+/// Mutation: gate the strict pass's item extraction on `inFencedBlock` too (i.e.
+/// make the fence skip items as well). The fenced bullet vanishes from `items`
+/// and this fails.
+@Test func fenceTrackingForHeadingsLeavesItemExtractionAlone() {
+    let body = """
+    ## Improvements
+    ```
+    - A fenced bullet the strict pass has always read as an item
+    ```
+    - Made the scrolling much smoother in long lists
+    ## Notes
+    - Another real change line here for length
+    """
+    let entry = GitHubMarkdownParser.parse(body: body, version: "1.0", date: nil)?.entries.first
+    #expect(entry?.items.count == 3)
+    #expect(entry?.items.first == "A fenced bullet the strict pass has always read as an item")
+}


### PR DESCRIPTION
Two follow-ups from the review round on #562 and #561. Both were raised there and deliberately not blocked on; neither changes what any app's notes look like today beyond the one asymmetry described below.

## 1. A fenced heading must not discard a pending one

The strict bullet pass deliberately does not track code fences — it has always read a fenced bullet as an item — so a `##` line inside a fence reaches the heading branch. `qualifyingHeadings` *does* skip fenced lines, so such a heading can never be styled. Its only remaining effect was to clear `pendingHeading`, discarding a real heading still waiting for its first note:

```
## Improvements
```<fence>
## Added
```<fence>
- <a real bullet>
## Notes
- <a real bullet>
```

rendered as `[n(…) H(Notes) n(…)]` — the first group silently lost its label while an identical group below kept one, an asymmetry inside a single entry.

The fix is deliberately narrow. `inCodeBlock` stays lenient-only, because it decides whether a line can become an *item* and the strict pass's answer there is not what this is about. The new `inFencedBlock` is tracked in both passes and read only by the heading branch. `inSkippedSection` is still computed for a fenced heading exactly as before, which is what keeps a fenced `## New Contributors` opening a skipped section in the strict pass the way it always has.

Two tests, both mutation-verified: dropping the guard reddens the first and names it; gating the strict pass's item extraction on the fence reddens the second — that second one is the half that proves item extraction was left alone, and it also reddens an existing case.

## 2. Record why Mac Mouse Fix's config file is the only channel signal

`MacMouseFixChannel` returns false — an authoritative `.stable` — when it cannot read the app's config file. Whether that is safe turns on a fact the file never stated. Measured against the real detector:

```
detect(version: "3.1.0 Beta 1")  ->  .stable
```

The version-suffix signal reads the `-beta.1` shape, not a space-separated `Beta 1`, and bundle id, app name and bundle filename are identical on both tracks. So an unreadable config suppresses no `detect()` signal here, because there was never one to suppress — which is exactly why CotEditor's resolver maps false to nil and this one does not. Without that written down, the next reader finds two resolvers answering the same question differently and nothing saying which is right.

Pinned by a test rather than left as prose: if `detect` ever learns to read a space-separated channel word, the claim stops being true and the reasoning needs revisiting.

No CHANGELOG entry: 0.3.93 already carries the heading feature this corrects, and the second commit is documentation.

`make test` green: 2777 + 280 cases, 0 failures, all seven Python gates.
