### PR TITLE
Sparkle: 2.9.3 -> 2.9.6

### DIFF
--- a/App/project.yml
+++ b/App/project.yml
@@ -32,7 +32,7 @@ packages:
     path: ../CLI
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
-    exactVersion: 2.9.3
+    exactVersion: 2.9.6
 
 targets:
   # The first test target over `App/Sources`. Before it, those ~20k lines were

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/DeltaApplier.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/DeltaApplier.swift
@@ -2,10 +2,17 @@ import Foundation
 
 /// Applies a Sparkle binary patch: installed bundle + `.delta` → the new bundle.
 ///
-/// Sparkle's format is its own (version 3 since Sparkle 2.1 — a custom container
-/// with lzma, replacing the xar/bzip2 of version 2), so the only correct reader
-/// is Sparkle's own `BinaryDelta`. We ship that executable rather than reimplement
-/// a format that has already changed once and carries no compatibility promise.
+/// Sparkle's format is its own and has now changed twice: version 2 (xar/bzip2)
+/// → version 3 (Sparkle 2.1, a custom container with lzma) → version 4 (Sparkle
+/// 2.7, and the default our bundled tool cuts today — `BinaryDelta info` on one
+/// reports `Patch version 4.2`). So the only correct reader is Sparkle's own
+/// `BinaryDelta`, and we ship that executable rather than reimplement a format
+/// that carries no compatibility promise.
+///
+/// Reading OLDER patches still works, which is what matters here: we apply what
+/// the vendor's feed happens to carry, and that was cut by whatever Sparkle the
+/// vendor builds with. Measured on 2.9.6 (2026-09-13): patches created at
+/// `--version=2`, `3` and `4` each reconstructed the target bundle byte for byte.
 ///
 /// A patch saves download, not disk. Applying one reads the installed bundle and
 /// writes a complete replacement into the scratch directory, so the I/O is

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Useful overrides:
 
 | Component | Where | Licence |
 | --- | --- | --- |
-| [Sparkle](https://github.com/sparkle-project/Sparkle) 2.9.3 | SPM dependency, used to install other apps' Sparkle updates and to update this app | MIT |
+| [Sparkle](https://github.com/sparkle-project/Sparkle) 2.9.6 | SPM dependency, used to install other apps' Sparkle updates and to update this app | MIT |
 | [`mas`](https://github.com/mas-cli/mas) | `App/Resources/mas`, a prebuilt universal binary invoked for Mac App Store installs | MIT |
 | PermissionFlow | `App/Sources/Vendor/PermissionFlow/` (vendored source) | MIT — see the `LICENSE` and `NOTICE.md` in that directory |
 


### PR DESCRIPTION
Bumps the Sparkle package pin from 2.9.3 to 2.9.6, and corrects a stale version
number in the comment that explains why we ship Sparkle's patch tool instead of
reimplementing its format.

`mas` was checked in the same pass and needs nothing: the bundled binary reports
7.0.0, and v7.0.0 is upstream's latest.

## Why this is not just release tooling

Two of the three things we take from the Sparkle package run on the user's
machine:

| use | where it runs | affected by this bump |
| --- | --- | --- |
| `Sparkle.framework`, our own self-update | user's Mac, runtime | yes |
| `BinaryDelta`, patching third-party apps | user's Mac, install path | yes |
| `generate_appcast`, building our appcast | release machine only | version moves, no fixes here |

`BinaryDelta` is on the main install path, not a fallback: `DeltaApplier` is
called from `SparkleInstaller.swift:81` and `VendorInstaller.swift:112`, and
`isAvailable` decides patch-vs-full-download by whether the executable is there.

## What is in 2.9.4 - 2.9.6

| release | change | self-update | third-party patching |
| --- | --- | --- | --- |
| 2.9.5 #2891 | symlink hardening in delta patching | yes | **yes** |
| 2.9.6 #2898 | installer archive move hardening | yes | - |
| 2.9.6 #2897 | no progress tool copy for root (privilege escalation) | yes | - |
| 2.9.6 #2895 | reject pkg installs when signature validation failed | yes | - |
| 2.9.4 #2890 | window activation for backgrounded apps | yes | - |

#2891 is the only one that reaches both: its sources live under `Autoupdate/`,
which compiles into the standalone `BinaryDelta` as well as the framework's
installer. Mapping taken from each PR's changed-file list, not from the prose.

## Verification

`make test` green — 2774 cases in 228 suites, plus 280 app-test cases (34 of 34
executed) and every Python gate. `make install` green; the installed bundle's
`Sparkle.framework` reads 2.9.6, `workspace-state.json` resolves sparkle to
2.9.6, and exactly one `BinaryDelta` exists under the resolved artifact bundle
(so the build script's `find ... | head -1` has nothing to pick wrong).

That was not enough on its own. The code 2.9.5 changed is the code we execute,
and `DeltaApplierTests` only invokes the tool on the failure path — a corrupt
patch must fail — so a green suite says nothing about patches that should
succeed. Measured directly instead, over a fixture bundle carrying a Mach-O, a
200 KB binary, a symlink and a file only the new side has, comparing with
`diff -r --no-dereference`:

| patch | applied by | result |
| --- | --- | --- |
| cut by 2.9.3 | 2.9.6 | identical to target |
| cut by 2.9.6 | 2.9.6 | identical |
| cut by 2.9.6 | 2.9.3 | identical |
| `--version=2` (2.5) | 2.9.6 | identical |
| `--version=3` (3.3) | 2.9.6 | identical |
| `--version=4` (4.2) | 2.9.6 | identical |

The last three are the property the product actually leans on: we apply whatever
a vendor's feed carries, and that was cut by whatever Sparkle the vendor builds
with.

## The comment fix

`DeltaApplier`'s header said the format was "version 3 since Sparkle 2.1". True
when written; version 4 landed in Sparkle 2.7 and became the default there, so
the bundled tool cuts 4.2 today. The comment's argument is unchanged — the
format has no compatibility promise, so ship their reader — but the number is
how the next reader concludes we parse something we do not. Only one copy of the
claim in the repo (grepped).

## Deliberately not included

No `CHANGELOG.md` entry. Nothing here is perceptible to a user: no behavior
change, no new capability, and the security fixes are in code paths whose
observable outcome is the same as before. Say the word and I will add an
"Under the hood" line to 0.3.93.
