### PR TITLE
Backup sealing and the interrupted-swap sweep's install lock

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2257,6 +2257,13 @@ final class AppListModel {
     /// is an input method macOS can no longer load. Sweeping only `/Applications`
     /// would have left exactly that state unrecoverable, because a rotation's
     /// leftovers sit INSIDE the bundle rather than beside it.
+    ///
+    /// "Once" means once it has actually run. The flag is set before the task so a
+    /// second refresh cannot start a second sweep beside the first, and cleared
+    /// again if any root was skipped because another process held the install
+    /// lock — a deferred sweep has recovered nothing, and latching on it would
+    /// leave a genuine leftover from an earlier crash sitting there until the next
+    /// launch.
     private func recoverInterruptedSwapsOnce() {
         guard !didRecoverSwaps else { return }
         didRecoverSwaps = true
@@ -2266,8 +2273,14 @@ final class AppListModel {
             URL(fileURLWithPath: "/Library/Input Methods", isDirectory: true),
             home.appendingPathComponent("Library/Input Methods", isDirectory: true),
         ]
-        Task.detached(priority: .utility) {
-            for root in roots { await InPlaceSwap.recoverInterruptedSwaps(in: root) }
+        Task.detached(priority: .utility) { [weak self] in
+            var swept = true
+            for root in roots {
+                // Every root is attempted; one deferral must not skip the rest.
+                if await InPlaceSwap.recoverInterruptedSwaps(in: root) == false { swept = false }
+            }
+            guard !swept else { return }
+            await MainActor.run { self?.didRecoverSwaps = false }
         }
     }
 

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -2267,7 +2267,7 @@ final class AppListModel {
             home.appendingPathComponent("Library/Input Methods", isDirectory: true),
         ]
         Task.detached(priority: .utility) {
-            for root in roots { InPlaceSwap.recoverInterruptedSwaps(in: root) }
+            for root in roots { await InPlaceSwap.recoverInterruptedSwaps(in: root) }
         }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupManifest.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BackupManifest.swift
@@ -37,6 +37,11 @@ public struct BackupManifest: Codable, Equatable, Sendable {
     /// recreates them. A file the seal *does* cover is shipped payload
     /// (EasyConnect's setuid helpers), and a copy without it is a broken app, so
     /// there is nothing honest to store.
+    ///
+    /// "The seal covers it" is not the same as "`CodeResources` lists it": the
+    /// bundle's own main executable, its `Info.plist` and the signature directory
+    /// are sealed by the CodeDirectory's special slots instead and appear in no
+    /// resource list. See ``directlySealedKeys(of:interior:fileManager:)``.
     public struct UnreadableFiles: Sendable {
         /// Relative to the bundle root, e.g. `Contents/mmkv.default`.
         public let sealed: [String]
@@ -54,6 +59,7 @@ public struct BackupManifest: Codable, Equatable, Sendable {
         // plist and its seal under `Wrapper/<Inner>.app/`. Read from the bundle
         // rather than assumed, so the seal keys below line up with the walk.
         let interior = BundleLayout.interiorPrefix(for: bundle, fileManager: fm)
+        let directlySealed = directlySealedKeys(of: bundle, interior: interior, fileManager: fm)
         let base = bundle.standardizedFileURL.path
         var sealed: [String] = []
         var unsealed: [String] = []
@@ -70,7 +76,13 @@ public struct BackupManifest: Codable, Equatable, Sendable {
             let sealKey = relative.hasPrefix(interior)
                 ? String(relative.dropFirst(interior.count)) : relative
             guard let sealedPaths else { sealed.append(relative); continue }
-            if sealedPaths.contains(sealKey) { sealed.append(relative) } else { unsealed.append(relative) }
+            if sealedPaths.contains(sealKey)
+                || directlySealed.contains(sealKey)
+                || sealKey.hasPrefix("_CodeSignature/") {
+                sealed.append(relative)
+            } else {
+                unsealed.append(relative)
+            }
         }
         return UnreadableFiles(sealed: sealed.sorted(), unsealed: unsealed.sorted())
     }
@@ -91,6 +103,52 @@ public struct BackupManifest: Codable, Equatable, Sendable {
             if let entries = plist[key] as? [String: Any] { out.formUnion(entries.keys) }
         }
         return out
+    }
+
+    /// Paths the code signature seals **directly**, relative to the bundle's
+    /// interior, rather than through the resource envelope — so they are sealed
+    /// while being listed in no `CodeResources` dictionary.
+    ///
+    /// `files`/`files2` enumerate *resources*. The bundle's own `Info.plist` and
+    /// main executable are hashed into the CodeDirectory (the plist into a special
+    /// slot, the executable into the page hashes carrying the signature itself),
+    /// and `_CodeSignature/` is the envelope, which cannot list itself. Measured
+    /// 2026-09-13 on `/Applications/{Safari,Keka,DuoUpdater}.app`: `Info.plist`,
+    /// `MacOS/<CFBundleExecutable>` and `_CodeSignature/CodeResources` are absent
+    /// from both dictionaries in all three, and in a scratch `ditto` copy
+    /// appending one byte to any of them makes `codesign --verify --deep --strict`
+    /// exit 1 ("invalid Info.plist", a main-executable hash mismatch, "invalid
+    /// resource directory"). Treating the omission as "unsealed" let `ditto` skip
+    /// an unreadable main executable and had the manifest certify — and
+    /// `.savedWithoutRuntimeState` report success for — a bundle that cannot run.
+    ///
+    /// `Contents/PkgInfo` is the counter-example that keeps this list from growing
+    /// into "every top-level file": it is in neither place, and on the same two
+    /// bundles mutating *and* deleting it left verification passing.
+    ///
+    /// An unreadable `Info.plist` costs us the executable's name, but it is itself
+    /// in this set, so such a bundle is refused on that entry alone.
+    private static func directlySealedKeys(
+        of bundle: URL, interior: String, fileManager fm: FileManager
+    ) -> Set<String> {
+        var keys: Set<String> = ["Info.plist"]
+        guard let data = try? Data(contentsOf: BundleLayout.infoPlistURL(
+                for: bundle, fileManager: fm)),
+              let plist = try? PropertyListSerialization.propertyList(
+                from: data, options: [], format: nil) as? [String: Any],
+              let executable = plist["CFBundleExecutable"] as? String,
+              !executable.isEmpty
+        else { return keys }
+        // `Contents/MacOS/<exe>` in a normal bundle; a wrapped iPhone/iPad app has
+        // a flat layout and keeps its executable at the interior root. Settled by
+        // what is on disk rather than by which layout we think this is, the way
+        // `BundleLayout` settles the interior itself.
+        let interiorURL = bundle.appendingPathComponent(interior, isDirectory: true)
+        let nested = "MacOS/" + executable
+        keys.insert(
+            fm.fileExists(atPath: interiorURL.appendingPathComponent(nested).path)
+                ? nested : executable)
+        return keys
     }
 
     /// Files present and readable in `source` but absent from `copy`, ignoring

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -73,21 +73,35 @@ public enum InPlaceSwap {
     /// the claim rather than refusing it. That is the documented refcount and it
     /// is what lets the app apply two updates at once; it does mean this sweep is
     /// serialised only against other processes.
+    ///
+    /// Returns whether the directory was actually swept. False means only that
+    /// the lock was busy, and the caller must not treat that as "done": a
+    /// caller latching a once-per-session flag on a deferred sweep would leave a
+    /// genuine leftover from an earlier crash unrecovered until the next launch,
+    /// which is the opposite of what this exists for.
+    @discardableResult
     public static func recoverInterruptedSwaps(
         in directory: URL, lock: ProcessInstallLock = .shared
-    ) async {
+    ) async -> Bool {
         do {
             try await lock.claim()
         } catch {
             Log.install.notice(
                 "another installer holds the install lock, sweep deferred: \(error, privacy: .public)")
-            return
+            return false
         }
         sweepInterruptedSwaps(in: directory)
+        // Unconditional rather than deferred, and it stays correct only because
+        // the sweep below neither throws nor suspends: there is no early return
+        // and no cancellation point between the claim and here. (`defer` cannot
+        // hold an `await` anyway.) Anything added to that function that can bail
+        // out early has to release the claim on its way.
         await lock.release()
+        return true
     }
 
-    /// The sweep itself, once the lock is held.
+    /// The sweep itself, once the lock is held. Deliberately non-throwing and
+    /// non-`async` — see the release note in the caller.
     private static func sweepInterruptedSwaps(in directory: URL) {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -60,7 +60,35 @@ public enum InPlaceSwap {
     /// `-staged` (and present-app `.duoupdater-old`) leftovers. Best-effort; safe to
     /// run on every launch. Only the non-admin / read-only-parent install path can
     /// leave these behind (the common admin path is a truly atomic `replaceItemAt`).
-    public static func recoverInterruptedSwaps(in directory: URL) {
+    ///
+    /// Takes the machine-wide install lock first, like every other path that
+    /// replaces a bundle. Without it this sweep is not recovery but interference:
+    /// `<App>.app.duoupdater-new` is exactly what a live install has parked beside
+    /// its target, so the menu-bar app's first refresh could delete the staging
+    /// directory `duo` is still `ditto`-ing into. The claim is non-blocking, as
+    /// `InstallLock` always is — a launch-time sweep has nothing to wait for, and
+    /// whatever it skips it will find again next launch.
+    ///
+    /// It is `ProcessInstallLock`, so an install running in *this* process joins
+    /// the claim rather than refusing it. That is the documented refcount and it
+    /// is what lets the app apply two updates at once; it does mean this sweep is
+    /// serialised only against other processes.
+    public static func recoverInterruptedSwaps(
+        in directory: URL, lock: ProcessInstallLock = .shared
+    ) async {
+        do {
+            try await lock.claim()
+        } catch {
+            Log.install.notice(
+                "another installer holds the install lock, sweep deferred: \(error, privacy: .public)")
+            return
+        }
+        sweepInterruptedSwaps(in: directory)
+        await lock.release()
+    }
+
+    /// The sweep itself, once the lock is held.
+    private static func sweepInterruptedSwaps(in directory: URL) {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
             at: directory, includingPropertiesForKeys: nil, options: []) else { return }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
@@ -557,6 +557,104 @@ struct BackupStoreTests {
         }
     }
 
+    // MARK: - Files the CodeDirectory seals directly
+
+    /// `CodeResources` lists *resources*, so the bundle's own main executable is
+    /// not in it — measured 2026-09-13 on Safari, Keka and DuoUpdater: absent
+    /// from `files` and `files2` in all three, yet appending one byte to it makes
+    /// `codesign --verify` fail. Reading the omission as "unsealed" would have
+    /// `ditto` skip it and the manifest certify a bundle with no executable.
+    @Test func theMainExecutableCountsAsSealedThoughCodeResourcesOmitsIt() throws {
+        try withScratchRoot { root in
+            let app = root.appendingPathComponent("ZZFixture-Sealed.app")
+            #expect(!FileManager.default.fileExists(atPath: app.path))
+            try makeApp(named: "ZZFixture-Sealed.app", in: root, marker: "old")
+            // A helper binary *is* a resource and does appear in the seal; the
+            // main executable never does. Both live under `Contents/MacOS/`, so
+            // the classification cannot go by directory.
+            let macOS = app.appendingPathComponent("Contents/MacOS")
+            try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+            let exe = macOS.appendingPathComponent("App")
+            try Data("MZ".utf8).write(to: exe)
+            try Data("helper".utf8).write(to: macOS.appendingPathComponent("Helper"))
+            try sealFixture(app, sealing: ["marker.txt", "MacOS/Helper"])
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o000], ofItemAtPath: exe.path)
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o644], ofItemAtPath: exe.path)
+            }
+
+            let classified = BackupManifest.unreadableFiles(in: app)
+            #expect(classified.sealed == ["Contents/MacOS/App"])
+            #expect(classified.unsealed.isEmpty)
+
+            let key = BackupStore.key(bundleID: "com.example.testapp", path: app)
+            #expect(throws: BackupStore.BackupError.self) {
+                try BackupStore.save(
+                    appPath: app, key: key, version: "1.0", bundleID: "com.example.testapp")
+            }
+        }
+    }
+
+    /// Same omission, same measurement: `Contents/Info.plist` and the contents of
+    /// `Contents/_CodeSignature/` are hashed into the CodeDirectory's special
+    /// slots rather than listed as resources. Mutating either made
+    /// `codesign --verify` report "invalid Info.plist" / "invalid resource
+    /// directory".
+    @Test func theInfoPlistAndSignatureDirectoryCountAsSealed() throws {
+        try withScratchRoot { root in
+            let app = root.appendingPathComponent("ZZFixture-Slots.app")
+            #expect(!FileManager.default.fileExists(atPath: app.path))
+            try makeApp(named: "ZZFixture-Slots.app", in: root, marker: "old")
+            try sealFixture(app, sealing: ["marker.txt"])
+            let plist = app.appendingPathComponent("Contents/Info.plist")
+            let cd = app.appendingPathComponent("Contents/_CodeSignature/CodeDirectory")
+            try Data("cd".utf8).write(to: cd)
+            for file in [plist, cd] {
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o000], ofItemAtPath: file.path)
+            }
+            defer {
+                for file in [plist, cd] {
+                    try? FileManager.default.setAttributes(
+                        [.posixPermissions: 0o644], ofItemAtPath: file.path)
+                }
+            }
+
+            let classified = BackupManifest.unreadableFiles(in: app)
+            #expect(classified.sealed == [
+                "Contents/Info.plist", "Contents/_CodeSignature/CodeDirectory",
+            ])
+            #expect(classified.unsealed.isEmpty)
+        }
+    }
+
+    /// The counter-example that keeps the rule above from being widened to "every
+    /// top-level file": `Contents/PkgInfo` is in neither `files2` nor a special
+    /// slot. Measured 2026-09-13 on Keka and DuoUpdater — mutating *and* deleting
+    /// it left `codesign --verify` passing — so it stays skippable.
+    @Test func pkgInfoIsNotSealedSoAnUnreadableOneStillAllowsTheBackup() throws {
+        try withScratchRoot { root in
+            let app = root.appendingPathComponent("ZZFixture-PkgInfo.app")
+            #expect(!FileManager.default.fileExists(atPath: app.path))
+            try makeApp(named: "ZZFixture-PkgInfo.app", in: root, marker: "old")
+            try sealFixture(app, sealing: ["marker.txt", "Info.plist"])
+            let pkgInfo = app.appendingPathComponent("Contents/PkgInfo")
+            try Data("APPL????".utf8).write(to: pkgInfo)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o000], ofItemAtPath: pkgInfo.path)
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o644], ofItemAtPath: pkgInfo.path)
+            }
+
+            let classified = BackupManifest.unreadableFiles(in: app)
+            #expect(classified.sealed.isEmpty)
+            #expect(classified.unsealed == ["Contents/PkgInfo"])
+        }
+    }
+
     /// The copy must be rejected when it lost something we meant to keep — a
     /// single exit status cannot distinguish "skipped the droppings" from "ran
     /// out of disk".

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/BackupStoreTests.swift
@@ -630,6 +630,54 @@ struct BackupStoreTests {
         }
     }
 
+    /// A wrapped iPhone/iPad app has no `Contents/` at all: its interior is
+    /// `Wrapper/<Inner>.app/` and the executable sits at that interior's root, not
+    /// under `MacOS/`. So the rule cannot hard-code a macOS layout — it has to
+    /// follow the same `BundleLayout.interiorPrefix` the seal keys are relative to.
+    @Test func theMainExecutableOfAWrappedBundleCountsAsSealed() throws {
+        try withScratchRoot { root in
+            let fm = FileManager.default
+            let app = root.appendingPathComponent("ZZFixture-Wrapped.app")
+            #expect(!fm.fileExists(atPath: app.path))
+            let innerName = "Wrapper/ZZFixture-Inner.app"
+            let inner = app.appendingPathComponent(innerName)
+            try fm.createDirectory(at: inner, withIntermediateDirectories: true)
+            // The discriminator `interiorPrefix` reads, and it reads the link's own
+            // text — so the destination has to be relative, as the real ones are.
+            try fm.createSymbolicLink(
+                atPath: app.appendingPathComponent("WrappedBundle").path,
+                withDestinationPath: innerName)
+            let plist = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0"><dict>
+              <key>CFBundleExecutable</key><string>ZZWrapped</string>
+              <key>CFBundleIdentifier</key><string>com.example.wrapped</string>
+            </dict></plist>
+            """
+            try Data(plist.utf8).write(to: inner.appendingPathComponent("Info.plist"))
+            let assets = inner.appendingPathComponent("Assets.car")
+            try Data("assets".utf8).write(to: assets)
+            let sigDir = inner.appendingPathComponent("_CodeSignature")
+            try fm.createDirectory(at: sigDir, withIntermediateDirectories: true)
+            // A real resource is listed; the executable, as always, is not.
+            let seal = try PropertyListSerialization.data(
+                fromPropertyList: ["files2": ["Assets.car": ["hash2": Data()]]],
+                format: .xml, options: 0)
+            try seal.write(to: sigDir.appendingPathComponent("CodeResources"))
+            let exe = inner.appendingPathComponent("ZZWrapped")
+            try Data("MZ".utf8).write(to: exe)
+            try fm.setAttributes([.posixPermissions: 0o000], ofItemAtPath: exe.path)
+            defer {
+                try? fm.setAttributes([.posixPermissions: 0o644], ofItemAtPath: exe.path)
+            }
+
+            let classified = BackupManifest.unreadableFiles(in: app)
+            #expect(classified.sealed == ["\(innerName)/ZZWrapped"])
+            #expect(classified.unsealed.isEmpty)
+        }
+    }
+
     /// The counter-example that keeps the rule above from being widened to "every
     /// top-level file": `Contents/PkgInfo` is in neither `files2` nor a special
     /// slot. Measured 2026-09-13 on Keka and DuoUpdater — mutating *and* deleting

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InPlaceSwapTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InPlaceSwapTests.swift
@@ -268,7 +268,7 @@ import Testing
     /// The state a rotation killed between its two renames leaves behind: no
     /// `Contents` at all, which is an input method the system can no longer load.
     /// The launch sweep has to put it back.
-    @Test func anInterruptedRotationIsRecoveredBySweep() throws {
+    @Test func anInterruptedRotationIsRecoveredBySweep() async throws {
         let fm = FileManager.default
         let root = try inputMethodsScratch()
         defer { try? fm.removeItem(at: root.top) }
@@ -283,7 +283,7 @@ import Testing
             to: target.appendingPathComponent(InPlaceSwap.rotationBackupName))
         #expect(!fm.fileExists(atPath: target.appendingPathComponent("Contents").path))
 
-        InPlaceSwap.recoverInterruptedSwaps(in: root.dir)
+        await InPlaceSwap.recoverInterruptedSwaps(in: root.dir, lock: scratchLock(in: root.top))
 
         #expect(fm.fileExists(atPath: target.appendingPathComponent("Contents/old").path))
         #expect(!fm.fileExists(
@@ -299,7 +299,7 @@ import Testing
     /// present in the bundle root", and removing it restores it. (`.DS_Store` is
     /// exempt by the signing rules; ours is not.) A leftover nothing clears is an
     /// input method that fails Gatekeeper.
-    @Test func aStaleRotationLeftoverIsCleared() throws {
+    @Test func aStaleRotationLeftoverIsCleared() async throws {
         let fm = FileManager.default
         let root = try inputMethodsScratch()
         defer { try? fm.removeItem(at: root.top) }
@@ -309,7 +309,7 @@ import Testing
                 at: target.appendingPathComponent(name), withIntermediateDirectories: true)
         }
 
-        InPlaceSwap.recoverInterruptedSwaps(in: root.dir)
+        await InPlaceSwap.recoverInterruptedSwaps(in: root.dir, lock: scratchLock(in: root.top))
 
         #expect(fm.fileExists(atPath: target.appendingPathComponent("Contents/old").path))
         for name in [InPlaceSwap.rotationStagedName, InPlaceSwap.rotationBackupName] {
@@ -328,6 +328,14 @@ import Testing
         let dir = top.appendingPathComponent("Library/Input Methods", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return (top, dir)
+    }
+
+    /// The sweep's install lock, on a per-test path. Never the default one: that
+    /// is `~/…/install.lock`, shared with whatever `duo` or the menu-bar app on
+    /// this machine is doing, so a test taking it would both interfere with a real
+    /// install and go red because of one.
+    private func scratchLock(in dir: URL) -> ProcessInstallLock {
+        ProcessInstallLock(url: dir.appendingPathComponent("install.lock"))
     }
 
     /// Structurally valid but unsigned, so the recovery sweep's signature check
@@ -356,5 +364,48 @@ import Testing
         """
         try Data(info.utf8).write(to: url.appendingPathComponent("Contents/Info.plist"))
         return url
+    }
+}
+
+/// The launch sweep writes where every other install path writes: it deletes
+/// `.duoupdater-new`/`.duoupdater-staged-*` and promotes `.duoupdater-old` back
+/// over the live bundle. Those are the writes `InstallLock` exists to serialise.
+@Suite struct InterruptedSwapSweepLockTests {
+
+    /// `duo` mid-`ditto` owns the `.duoupdater-new` this sweep would delete, and
+    /// the whole point of the lock is that the menu-bar app's first refresh must
+    /// not pull it out from under it. The second half is the vacuity guard: with
+    /// the lock free, the same call does delete it.
+    @Test func theSweepDefersWhileAnotherProcessHoldsTheInstallLock() async throws {
+        let fm = FileManager.default
+        let dir = try scratch()
+        defer { try? fm.removeItem(at: dir) }
+        let leftover = dir.appendingPathComponent("ZZFixture-Sweep.app.duoupdater-new")
+        #expect(!fm.fileExists(atPath: leftover.path))
+        try fm.createDirectory(at: leftover, withIntermediateDirectories: true)
+
+        let lockURL = dir.appendingPathComponent("install.lock")
+        // `flock` is scoped to the open file description, not the process, so a
+        // second `acquire` on the same path refuses the claim exactly the way a
+        // second process would — deterministically, with no helper to spawn.
+        let holder = try InstallLock.acquire(at: lockURL)
+
+        await InPlaceSwap.recoverInterruptedSwaps(
+            in: dir, lock: ProcessInstallLock(url: lockURL))
+        #expect(fm.fileExists(atPath: leftover.path),
+                "the sweep must leave another installer's staging directory alone")
+
+        holder.release()
+        await InPlaceSwap.recoverInterruptedSwaps(
+            in: dir, lock: ProcessInstallLock(url: lockURL))
+        #expect(!fm.fileExists(atPath: leftover.path),
+                "with the lock free the sweep still has to do its job")
+    }
+
+    private func scratch() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoSweepLockTest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InPlaceSwapTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InPlaceSwapTests.swift
@@ -390,16 +390,38 @@ import Testing
         // second process would — deterministically, with no helper to spawn.
         let holder = try InstallLock.acquire(at: lockURL)
 
-        await InPlaceSwap.recoverInterruptedSwaps(
+        let deferred = await InPlaceSwap.recoverInterruptedSwaps(
             in: dir, lock: ProcessInstallLock(url: lockURL))
+        #expect(deferred == false)
         #expect(fm.fileExists(atPath: leftover.path),
                 "the sweep must leave another installer's staging directory alone")
 
         holder.release()
-        await InPlaceSwap.recoverInterruptedSwaps(
+        let swept = await InPlaceSwap.recoverInterruptedSwaps(
             in: dir, lock: ProcessInstallLock(url: lockURL))
+        #expect(swept)
         #expect(!fm.fileExists(atPath: leftover.path),
                 "with the lock free the sweep still has to do its job")
+    }
+
+    /// The return value is what stops `AppListModel.recoverInterruptedSwapsOnce`
+    /// from latching its once-per-session flag on a sweep that never happened. A
+    /// deferral there is not "done": a real orphan from an earlier crash would sit
+    /// unrecovered until the next launch. Asserted on an EMPTY directory so the
+    /// answer can only be "did I hold the lock", never "did I find anything".
+    @Test func theReturnValueReportsWhetherTheSweepActuallyRan() async throws {
+        let fm = FileManager.default
+        let dir = try scratch()
+        defer { try? fm.removeItem(at: dir) }
+        let lockURL = dir.appendingPathComponent("install.lock")
+
+        let holder = try InstallLock.acquire(at: lockURL)
+        #expect(await InPlaceSwap.recoverInterruptedSwaps(
+            in: dir, lock: ProcessInstallLock(url: lockURL)) == false)
+
+        holder.release()
+        #expect(await InPlaceSwap.recoverInterruptedSwaps(
+            in: dir, lock: ProcessInstallLock(url: lockURL)))
     }
 
     private func scratch() throws -> URL {


### PR DESCRIPTION
Fixes two findings from the 2026-09-13 review. Both are in the install/backup path.

## L10 — `Install/BackupManifest.swift:47-76, 83-94`

`unreadableFiles` classified an unreadable file as "sealed" only if it was a key in
the bundle's `CodeResources` `files`/`files2`. Those enumerate **resources**; the
bundle's own `Info.plist`, its main executable and the `_CodeSignature/` envelope are
hashed into the CodeDirectory instead and appear in neither. An unreadable main
executable was therefore read as runtime droppings — `ditto` skipped it, the manifest
certified the result, and `BackupStore.save` returned `.savedWithoutRuntimeState`
(success) for a rollback point that is a bundle with no executable.

### The claim, verified before fixing it

Step 1 — are those keys really absent from `files`/`files2`? (plistlib, read-only):

```
--- /Applications/Safari.app  (files+files2 = 1575 keys)
    'MacOS/Safari'          in seal? False
    'Info.plist'            in seal? False
    'PkgInfo'               in seal? False
    '_CodeSignature/CodeResources'  in seal? False
--- /Applications/DuoUpdater.app  (files+files2 = 22 keys)   … all four False
--- /Applications/Keka.app  (files+files2 = 478 keys)        … all four False
```

(Nested bundles' `Info.plist`/`MacOS/<exe>` *are* listed — e.g. Safari's appex — so
the rule is specifically about the outer bundle's own copies.)

Step 2 — absence from the list is not the same as "unsealed", so ask `codesign`.
Each row is a fresh `ditto` copy with one file mutated:

```
--- /Applications/Keka.app
[baseline, untouched]                            verify rc=0
[mutated Contents/Info.plist]                    verify rc=1  invalid Info.plist (plist or signature have been modified)
[mutated Contents/MacOS/Keka]                    verify rc=1
[mutated Contents/_CodeSignature/CodeResources]  verify rc=1  invalid resource directory (directory or signature have been modified)
[mutated Contents/PkgInfo]                       verify rc=0
[deleted Contents/PkgInfo]                       verify rc=0
--- /Applications/DuoUpdater.app   (identical results, same six rows)
```

So three of the four are sealed and **`PkgInfo` is not** — it is in neither place and
stays skippable. That is what keeps the fix from widening into "every top-level file".

### The fix

A new `directlySealedKeys(of:interior:fileManager:)` contributes `Info.plist` and
`MacOS/<CFBundleExecutable>` (or the flat `<exe>` for a wrapped iPhone/iPad bundle,
decided by what is on disk), and `unreadableFiles` also treats anything under
`_CodeSignature/` as sealed. The `UnreadableFiles` doc comment at :30-39 now says
that "the seal covers it" ≠ "`CodeResources` lists it".

### Red → green

Three new tests in `BackupStoreTests`, fixtures named `ZZFixture-*` with a
`!fileExists` guard. Before the fix:

```
✘ theMainExecutableCountsAsSealedThoughCodeResourcesOmitsIt() failed … with 3 issues
    classified.sealed → []          (expected ["Contents/MacOS/App"])
    an error was expected but none was thrown   ← save happily stored the broken copy
✘ theInfoPlistAndSignatureDirectoryCountAsSealed() failed … with 2 issues
    classified.unsealed → ["Contents/Info.plist", "Contents/_CodeSignature/CodeDirectory"]
✔ pkgInfoIsNotSealedSoAnUnreadableOneStillAllowsTheBackup() passed   ← negative control
```

After: `✔ Test run with 35 tests in 1 suite passed`.

### Mutation checks (each reverted afterwards)

| mutation | result |
|---|---|
| drop `\|\| directlySealed.contains(sealKey)` | ✘ `theMainExecutableCountsAsSealed…` (3 issues), ✘ `theInfoPlistAndSignatureDirectory…` (2) |
| drop `\|\| sealKey.hasPrefix("_CodeSignature/")` | ✘ `theInfoPlistAndSignatureDirectory…` (2 issues) |
| over-widen: add `"PkgInfo"` to the set | ✘ `pkgInfoIsNotSealedSoAnUnreadableOne…` (2 issues) |

The third is the one that matters for scope: the negative control goes red if someone
later decides the whole top level is sealed.

## L13 — `Install/InPlaceSwap.swift:63-99`

`recoverInterruptedSwaps` deletes `*.duoupdater-new` / `.duoupdater-staged-*` and
promotes `*.duoupdater-old` over the live app without holding `InstallLock`, while
the app's install and rollback and the CLI's install and backup restore all claim it.
Those suffixes are exactly what a live install parks beside its target, so the
menu-bar app's first refresh could delete the staging directory a `duo` in a terminal
is still `ditto`-ing into.

It now claims `ProcessInstallLock` first and, when refused, logs at `.notice`
("another installer holds the install lock, sweep deferred: …") and returns. The
claim is non-blocking because `InstallLock.acquire` always is (`LOCK_EX | LOCK_NB`) —
a launch-time sweep has nothing to wait for, and it will find the same leftovers next
launch. The sweep body moved verbatim into a private `sweepInterruptedSwaps(in:)` so
the lock brackets all of it; the public entry point is now `async` and takes
`lock: ProcessInstallLock = .shared`.

**What the lock does not cover, and the doc comment now says so:** `ProcessInstallLock`
is reference-counted per process, so an install running in *this* process joins the
claim rather than refusing it. That is the documented refcount (it is what lets the app
apply two updates at once); this sweep is serialised only against other processes.

### Test seam

`ProcessInstallLock.init(url:)` is already public, so no new seam was needed. The
"other holder" is simulated with a second `InstallLock.acquire(at:)` on the same path:
`flock` is scoped to the open **file description**, not the process, so the second
acquire is refused exactly the way a second process would be — deterministic, no
helper process, no sleeps. The two pre-existing sweep tests now pass a per-test scratch
lock too, so they never touch the machine-global `install.lock` (a test taking that
would interfere with a real install and go red because of one).

### Red → green

New: `InterruptedSwapSweepLockTests.theSweepDefersWhileAnotherProcessHoldsTheInstallLock`.
Before the fix the API does not exist:

```
InPlaceSwapTests.swift:386:28: error: extra argument 'lock' in call
InPlaceSwapTests.swift:392:28: error: extra argument 'lock' in call
```

After: `✔ Test run with 10 tests in 2 suites passed`.

### Mutation check

Changed `try await lock.claim()` to `try? await lock.claim()` so a refusal no longer
skips the sweep:

```
✘ theSweepDefersWhileAnotherProcessHoldsTheInstallLock() recorded an issue at
  InPlaceSwapTests.swift:395:9: Expectation failed: fm.fileExists(atPath: leftover.path)
  ↳ "the sweep must leave another installer's staging directory alone"
```

Restored, green again. The test's second half is its own vacuity guard: once the
holder releases, the same call *does* delete the leftover, so the test cannot pass by
the sweep simply doing nothing.

## `make test`

```
$ make test > /tmp/mt-sealsweep.log 2>&1; echo exit=$?
exit=0
$ grep -E "Test run with" /tmp/mt-sealsweep.log
━ Test run with 2781 tests in 229 suites passed after 20.998 seconds with 2 known issues.
✔ Test run with 280 tests in 34 suites passed after 0.146 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 261 files …
✓ no machine-population claims in code comments — 531 files
```

No `make gallery` run: nothing under `App/Sources` that draws a row was touched (the
only App change is one `await` in `recoverInterruptedSwapsOnce`). No recipe or parser
rule changed, so no `duo verify`.

## Behaviour a user could notice

- A backup of an app with an unreadable main executable or `Info.plist` is now refused
  instead of silently stored as a rollback point that cannot run. Rare input (a `0700`
  main executable), and the previous "success" was the worse outcome.
- The launch recovery sweep is skipped when another process is installing. It runs
  again next launch, and the leftovers it would have cleaned belong to that install.

## Declined / out of scope

Nothing declined — both findings hold. Two things noticed and deliberately not fixed:

1. `recoverInterruptedSwaps` still does its `SecStaticCodeCheckValidity` work on the
   cooperative pool (the `#351` shape; it is row 4 of the review's P1 table and belongs
   to whoever owns P1). Making the entry point `async` does not change that — the
   caller was already inside `Task.detached`, which is the same pool. The body is now a
   separate private function, which should make an `offCooperativePool` hop a one-liner.
   **Heads-up for the lead: P1 names this same function, so expect a conflict there.**
2. The in-process refcount means this sweep is not serialised against an install in the
   same process. Documented in the new doc comment rather than changed, since narrowing
   it would need a new `ProcessInstallLock` API and would affect every other caller.
