### PR TITLE
Version comparisons: stop five decisions collapsing a version pair to one string

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1568,7 +1568,7 @@ final class AppListModel {
 
     /// Log every release in `checked` that arrived with a trustworthy vendor
     /// date into the release timeline, then refresh the UI snapshot. The store
-    /// dedupes by (app, version), so re-checks are cheap; only a genuinely new
+    /// dedupes by (app, version, vendor date), so re-checks are cheap; only a genuinely new
     /// release or changed display metadata writes the timeline file. Results
     /// with neither a `publishedAt` nor a `vendorDay` (vendor probes, MAS,
     /// Homebrew) use the observation path below rather than this path.
@@ -1590,7 +1590,9 @@ final class AppListModel {
             }
             // …plus any prior releases the source surfaced (Sparkle appcast items,
             // a GitHub releases list), so an app's history backfills in one shot.
-            // The store dedupes by version, so the latest overlapping here is free.
+            // The store dedupes on version + vendor date, and the latest release's
+            // date comes from the same feed item as its entry here, so the overlap
+            // is free.
             for entry in remote.releaseHistory {
                 await releaseTimelineStore.record(
                     appID: result.app.id,
@@ -6576,8 +6578,13 @@ final class AppListModel {
         let actionable = results.filter(isActionableUpdate)
         // The version we'd announce for each app; key by `key(for:)` to match how
         // ignore/skip identify an app (survives the app moving on disk).
+        //
+        // Build-aware: `displayVersion` is marketing-first and a vendor may leave
+        // that string alone across any number of builds, which made every build
+        // after the first read as already-announced. See `NotifiedUpdateVersions`,
+        // where the rule and its baseline migration are executed.
         func version(_ r: UpdateResult) -> String {
-            r.remote?.displayVersion ?? r.remote?.shortVersion ?? ""
+            NotifiedUpdateVersions.announceKey(r.remote?.versionSide)
         }
         var baseline = prefs.notifiedVersions
 
@@ -6593,10 +6600,14 @@ final class AppListModel {
 
         // Consult the legacy key too: a baseline recorded before the switch to
         // per-path keys lives under the old bundle-id key, and we don't want that
-        // migration to re-announce everything once as "new".
+        // migration to re-announce everything once as "new". The same is true of a
+        // baseline recorded before the key became build-aware, which
+        // `wasAnnounced` handles by also accepting a stored marketing-only value.
         func wasNotified(_ r: UpdateResult) -> Bool {
-            baseline[prefs.key(for: r.app)] == version(r)
-                || baseline[prefs.legacyKey(for: r.app)] == version(r)
+            NotifiedUpdateVersions.wasAnnounced(
+                r.remote?.versionSide,
+                under: [prefs.key(for: r.app), prefs.legacyKey(for: r.app)],
+                in: baseline)
         }
         let newly = actionable.filter { !wasNotified($0) }
 

--- a/App/Sources/Preferences.swift
+++ b/App/Sources/Preferences.swift
@@ -327,7 +327,9 @@ final class Preferences {
     }
 
     /// Per-app version we've already posted a "new update available" notification
-    /// for (key → the offered version). Persisted so the banner fires regardless
+    /// for (key → the offered version, as `NotifiedUpdateVersions.announceKey`
+    /// spells it: build-aware, so a vendor that freezes its marketing string can
+    /// still announce its next build). Persisted so the banner fires regardless
     /// of *which* refresh path first surfaces the update — manual menu-open or
     /// scheduled background — instead of the in-memory list silently becoming the
     /// baseline; and so the same version isn't re-announced across relaunches.

--- a/App/Sources/ReleaseLogView.swift
+++ b/App/Sources/ReleaseLogView.swift
@@ -137,7 +137,23 @@ struct ReleaseLogView: View {
         let appID: String
         let appName: String
         let event: ReleaseEvent
-        var id: String { appID + "|" + event.version }
+
+        /// The version is NOT unique within an app, so it cannot be the id on its
+        /// own: `ReleaseTimelineStore.record` dedupes on the version PLUS the
+        /// vendor date, because several releases can ship under one marketing
+        /// version (Surge has shipped four called "6.9.0"). Two rows with the same
+        /// `Identifiable` id is SwiftUI's undefined-behaviour case, and this id
+        /// also decides which row hides its separator (`feed`).
+        ///
+        /// So the id is exactly the store's dedupe key with the app in front of
+        /// it, which makes it unique by construction rather than by luck: a dated
+        /// release cannot repeat that triple, and an estimated release (both date
+        /// fields nil) is still deduped on the version alone.
+        var id: String {
+            let published = event.publishedAt?.timeIntervalSince1970 ?? -1
+            let day = event.vendorDay?.timeIntervalSince1970 ?? -1
+            return "\(appID)|\(event.version)|\(published)|\(day)"
+        }
     }
 
     private struct DayGroup {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/NotifiedUpdateVersions.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/NotifiedUpdateVersions.swift
@@ -38,10 +38,12 @@ public enum NotifiedUpdateVersions {
     /// A stored value equal to the offer's MARKETING half alone also counts as
     /// announced. That is the migration from the marketing-keyed baseline: without
     /// it, the first run after an upgrade re-announces every pending update at
-    /// once. It costs at most one suppressed announcement per app — the very next
-    /// pass rewrites that entry build-aware, after which only a genuinely
-    /// unannounced build can match — and it is deliberately not time-limited,
-    /// because an app that stops being actionable keeps its old entry indefinitely.
+    /// once. It costs at most one PASS per app, not one announcement: the pass
+    /// that sees the stale entry rewrites it build-aware, so only builds offered
+    /// during that single pass are swallowed — two builds shipped between two
+    /// passes are both swallowed, and after it only a genuinely unannounced build
+    /// can match. Deliberately not time-limited, because an app that stops being
+    /// actionable keeps its old entry indefinitely.
     public static func wasAnnounced(
         _ offered: VersionSide?, under keys: [String], in baseline: [String: String]
     ) -> Bool {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/NotifiedUpdateVersions.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/NotifiedUpdateVersions.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// The "have we already told the user about this update?" decision behind the
+/// **new updates available** banner, keyed on BOTH halves of the offered version.
+///
+/// Pulled out of `AppListModel.notifyNewUpdates` so it can be executed: the model
+/// itself is not constructible in a test (its `init` registers notification
+/// permissions, starts timers and installs FS watchers), and this is the part
+/// that can be wrong.
+///
+/// **Why not the marketing string.** The baseline used to store
+/// `remote.displayVersion`, which is `shortVersion ?? version` — a marketing
+/// string a vendor is free to leave alone across any number of builds. Amp
+/// shipped ten builds called "1.0" on 2026-08-28: the first was announced, the
+/// baseline recorded "1.0", and the remaining nine were `isActionableUpdate` —
+/// row lit, badge lit — with `wasNotified` permanently true. Quiet becoming
+/// silence, the same defect `StagedNudgeLedger` documents itself as avoiding, on
+/// a different ledger. `scripts/check_staged_version_use.py` does not see this
+/// shape: it hunts `shortVersion ?? buildVersion` spellings, and this one went
+/// through a computed property.
+public enum NotifiedUpdateVersions {
+
+    /// What to store for an offered update: "1.7.3 (194)", "1.7.3" or "194",
+    /// whichever the pair supports. Empty when the offer names no version at all —
+    /// which is what the marketing-keyed version stored for those rows too, so an
+    /// existing baseline entry keeps matching.
+    public static func announceKey(_ offered: VersionSide?) -> String {
+        guard let offered, !offered.isEmpty else { return "" }
+        return offered.text(withBuild: true)
+    }
+
+    /// Whether any of `keys` already holds an announcement for this offer.
+    ///
+    /// `keys` is plural for the same reason `notifyNewUpdates` consults two: a
+    /// baseline written before the switch to per-path keys lives under the old
+    /// bundle-id key.
+    ///
+    /// A stored value equal to the offer's MARKETING half alone also counts as
+    /// announced. That is the migration from the marketing-keyed baseline: without
+    /// it, the first run after an upgrade re-announces every pending update at
+    /// once. It costs at most one suppressed announcement per app — the very next
+    /// pass rewrites that entry build-aware, after which only a genuinely
+    /// unannounced build can match — and it is deliberately not time-limited,
+    /// because an app that stops being actionable keeps its old entry indefinitely.
+    public static func wasAnnounced(
+        _ offered: VersionSide?, under keys: [String], in baseline: [String: String]
+    ) -> Bool {
+        let key = announceKey(offered)
+        let legacyKey = offered?.marketing
+        return keys.contains { name in
+            guard let stored = baseline[name] else { return false }
+            return stored == key || stored == legacyKey
+        }
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -618,8 +618,22 @@ public struct UpdateChecker: Sendable {
         // is the one to fail in — it offers the vendor's currently published
         // package to a copy that is ahead of it, which is visible and recoverable,
         // where the other direction hid real updates silently.
-        if let build = installed.buildVersion,
-           !build.isEmpty, !build.contains("."), !isv.hasSuffix(build) {
+        // Equality is still not enough on its own when the installed build is a
+        // small hand-stamped constant. Anki stamps `CFBundleVersion` as a literal
+        // "1" for every build, so short "26.8" + build "1" folds to exactly
+        // "26.8.1" and the vendor's real 26.8.1 patch matched the folded form —
+        // the same hidden hotfix in miniature.
+        //
+        // So: a floor. A vendor folds its build into the version string BECAUSE
+        // the build is a large monotonic counter (Oray's 30757); a one- or
+        // two-digit `CFBundleVersion` is a constant somebody typed, not something
+        // anyone folds. Three digits is a judgment call, not a measured universal
+        // — it is chosen to clear Anki's "1" and every constant of that kind while
+        // leaving real counters alone, and a vendor who genuinely folds a 99 would
+        // be offered a re-install of the version it is already on, which is the
+        // harmless direction.
+        if let build = installed.buildVersion, !build.contains("."), !isv.hasSuffix(build),
+           let counter = Int(build), counter >= 100 {
             let combined = "\(isv).\(build)"
             if VersionComparator.compare(rs, combined) == .orderedSame {
                 return .upToDate

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -596,16 +596,32 @@ public struct UpdateChecker: Sendable {
         // The remote looks newer by marketing version alone — but some vendors
         // fold the build INTO the version string: Oray reports "16.5.0.30757"
         // while the installed bundle splits it into short "16.5.0" + build
-        // "30757". Re-check against the installed short+build; if that isn't older
-        // than the remote, the app is actually current — otherwise the row would
-        // show a perpetual "update" even right after a successful install. Guarded
-        // to a plain-numeric build tail not already part of the short version, so
-        // normal apps (whose build duplicates/dot-extends the short version) are
-        // unaffected — they never reach here unless genuinely behind.
+        // "30757". Those two name the SAME release, so recognise that one shape
+        // and settle the row to current; otherwise it shows a perpetual "update"
+        // even right after a successful install.
+        //
+        // The test is equality with the folded form, not "the remote is no newer
+        // than it". The looser test read the fabricated `short + "." + build` tail
+        // as a version component, and a build number is a large integer: installed
+        // short "12.10" + build "282987" fabricates "12.10.282987", which outranks
+        // every real "12.10.x" the vendor can ship. Every source that reports no
+        // separate build (Homebrew, GitHub, the App Store, Electron, most vendor
+        // probes) reaches this line, so every app whose marketing version has
+        // fewer components than its build has digits had its hotfixes swallowed —
+        // an ordinary shape, not a rare one. Equality cannot do that: it fires only
+        // when the remote IS the folded pair.
+        //
+        // The two shapes are not otherwise separable: "12.10" + "282987" against
+        // "12.10.1" and "16.5.0" + "30757" against "16.5.0.29000" are the same
+        // string problem, so a folded remote naming an OLDER build than the one on
+        // disk now reads as an update instead of being suppressed. That direction
+        // is the one to fail in — it offers the vendor's currently published
+        // package to a copy that is ahead of it, which is visible and recoverable,
+        // where the other direction hid real updates silently.
         if let build = installed.buildVersion,
            !build.isEmpty, !build.contains("."), !isv.hasSuffix(build) {
             let combined = "\(isv).\(build)"
-            if !VersionComparator.isNewer(rs, than: combined) {
+            if VersionComparator.compare(rs, combined) == .orderedSame {
                 return .upToDate
             }
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdateChecker.swift
@@ -631,9 +631,10 @@ public struct UpdateChecker: Sendable {
         // — it is chosen to clear Anki's "1" and every constant of that kind while
         // leaving real counters alone, and a vendor who genuinely folds a 99 would
         // be offered a re-install of the version it is already on, which is the
-        // harmless direction.
+        // harmless direction. `buildIsFoldableCounter` measures that by string, so
+        // a build too wide for `Int64` stays foldable.
         if let build = installed.buildVersion, !build.contains("."), !isv.hasSuffix(build),
-           let counter = Int(build), counter >= 100 {
+           Self.buildIsFoldableCounter(build) {
             let combined = "\(isv).\(build)"
             if VersionComparator.compare(rs, combined) == .orderedSame {
                 return .upToDate
@@ -641,6 +642,21 @@ public struct UpdateChecker: Sendable {
         }
 
         return .updateAvailable(latest: remote.displayVersion ?? rs)
+    }
+
+    /// Whether a build number is big enough to be the kind of counter a vendor
+    /// folds into its version string: ASCII digits only, and at least three of
+    /// them once leading zeros are off.
+    ///
+    /// Measured by string, not by `Int(build)`, for the same reason
+    /// `VersionComparator`'s tokenizer keeps digit runs as strings: an epoch-ms
+    /// or concatenated build overflows `Int64`, and `Int(build)` answering nil
+    /// there would silently switch fold recognition OFF for exactly the vendors
+    /// whose builds are largest. Stripping leading zeros first matches that
+    /// tokenizer's own normalisation, so "007" is the counter 7, not a 3-digit one.
+    static func buildIsFoldableCounter(_ build: String) -> Bool {
+        guard !build.isEmpty, build.allSatisfy({ $0.isASCII && $0.isNumber }) else { return false }
+        return build.drop(while: { $0 == "0" }).count >= 3
     }
 
     /// Drop a leading product-code run like "IU-"/"AI-" from a build number so a

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -621,9 +621,22 @@ public enum UpdatePolicy {
         // to catch trailing builds would otherwise let such leftovers block installs
         // forever, which is worse than the collision this prevents. Trailing-but-
         // different still blocks: that one has not been applied and will be.
-        let stagedV = staged.buildVersion ?? staged.version
-        if let installedV = result.app.buildVersion ?? result.app.shortVersion,
-           stagedV == installedV { return nil }
+        //
+        // Compared as PAIRS. Picking one string per side compares whatever the two
+        // `??`s happen to land on, and they do not have to land in the same
+        // namespace: Spotify's staged update carries no build number at all
+        // (`SelfUpdaterStaging` builds it with `buildVersion: nil`, because
+        // `update.json` states only a marketing `version_to`), so that pick put the
+        // staged MARKETING string against the installed BUILD number — never equal,
+        // so an applied-and-not-yet-swept staging directory went on blocking
+        // installs. `isSame` compares only the fields both sides carry, and
+        // `buildIsDerived` covers the scanner's substituted builds (Xcode, 豆包),
+        // whose build is not `CFBundleVersion` and cannot be compared to a staged
+        // bundle's at all.
+        if VersionComparator.isSame(
+            result.app.versionSide, as: staged.versionSide,
+            buildIsDerived: AppScanner.buildVersionIsOverridden(bundleID: result.app.bundleID)
+        ) { return nil }
         // Nothing to protect on routes we do not swap ourselves — Homebrew, the App
         // Store and Toolbox hand the install to something that owns the bundle, so a
         // stale staging directory belonging to a different mechanism must not block

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -296,7 +296,9 @@ public struct RemoteVersion: Sendable, Hashable {
     /// Past releases the source surfaced alongside the latest — every dated entry
     /// in a Sparkle appcast / GitHub releases list, so the timeline can backfill
     /// an app's whole visible history at once (the latest is included too; the
-    /// store dedupes by version). Empty for sources that only resolve one release.
+    /// store dedupes on version + vendor date, and both paths read that date from
+    /// the same item, so the overlap costs nothing). Empty for sources that only
+    /// resolve one release.
     public let releaseHistory: [ReleaseHistoryEntry]
 
     /// The channel of the rule that produced this answer.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimeline.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimeline.swift
@@ -29,8 +29,14 @@ import Foundation
 /// reflects our polling cadence and the user's machine being awake, so it's never
 /// used as a release time on its own.
 public struct ReleaseEvent: Codable, Sendable, Hashable {
-    /// The version string we keyed on (the remote's `displayVersion`). Also the
-    /// dedupe key within an app — we record each version exactly once.
+    /// The version string we keyed on (the remote's `displayVersion`).
+    ///
+    /// NOT the dedupe key on its own. A dated release is deduped on this string
+    /// PLUS the vendor date, because several releases can ship under one marketing
+    /// version (Surge has shipped four called "6.9.0"); an estimated release is
+    /// deduped on this string alone, which its caller already builds build-aware
+    /// ("6.9.0 (2381)"). So one app can hold more than one event naming the same
+    /// version, and anything looking a release up must match the date too.
     public let version: String
     /// The vendor's published timestamp, to the minute — set only for the
     /// trustworthy tier. nil for vendor-day and estimated (detection-only) events.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
@@ -203,6 +203,19 @@ public actor ReleaseTimelineStore {
 
         // Don't double-record a version already known (e.g. a trustworthy event
         // landed for it earlier, or a beta flapped back).
+        //
+        // Deliberately still the version ALONE, even though `record` above no
+        // longer treats "same version" as "same release". The two tiers key on
+        // different strings and neither reading is weakened here:
+        //
+        //  - Within this tier the version already IS the full discriminator. The
+        //    caller passes `side.text(withBuild: true)`, so a frozen-marketing
+        //    vendor's next build arrives as a different string ("6.9.0 (2382)")
+        //    and is not suppressed. Adding a date here would key on OUR polling
+        //    clock, which changes every check and would defeat the guard entirely.
+        //  - Across tiers, suppressing is the right answer: this path only runs
+        //    when the source stated no date at all, so an estimated window for a
+        //    version some source already dated is strictly worse information.
         guard !timeline.events.contains(where: { $0.version == version }) else {
             return false
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Releases/ReleaseTimelineStore.swift
@@ -61,10 +61,11 @@ public actor ReleaseTimelineStore {
 
     /// Record one observed release. No-op when both `publishedAt` and `vendorDay`
     /// are nil (the source gave no trustworthy date at all) or when we've already
-    /// recorded this version for this app — each version is logged exactly once,
-    /// at first sighting, so re-checks don't pile up duplicates or drift the
-    /// recorded `detectedAt`. Duplicate sightings may still refresh the
-    /// timeline's display metadata.
+    /// recorded this (version, vendor date) for this app — each release is logged
+    /// exactly once, at first sighting, so re-checks don't pile up duplicates or
+    /// drift the recorded `detectedAt`. Two releases the vendor dated differently
+    /// are two releases even when they share a marketing version. Duplicate
+    /// sightings may still refresh the timeline's display metadata.
     ///
     /// `publishedAt` and `vendorDay` are alternatives, never both real for the
     /// same call: a source names one precision for a given release, and passing
@@ -97,8 +98,24 @@ public actor ReleaseTimelineStore {
         timeline.appName = appName
         timeline.bundleID = bundleID
 
-        // Already logged this version? Nothing to do — first sighting wins.
-        guard !timeline.events.contains(where: { $0.version == version }) else {
+        // Already logged this release? Nothing to do — first sighting wins.
+        //
+        // Keyed on the version AND the vendor date, because several releases can
+        // ship under one marketing version: Surge has put out four called "6.9.0",
+        // Amp shipped ten builds as "1.0" in a day. On the version alone the first
+        // of them was logged and the rest read as already-recorded, so the timeline
+        // under-counted exactly the vendors whose marketing string has stopped
+        // carrying information. The date is the discriminator available HERE (a
+        // `ReleaseHistoryEntry` carries no build number) and a sound one: this path
+        // refuses to record at all without one, and two releases the vendor dated
+        // differently are two releases.
+        //
+        // Same-release re-checks still dedupe: both call sites read one item's date
+        // through `ReleaseDate.publishedFields`, so the latest release and its own
+        // entry in `releaseHistory` produce byte-identical dates.
+        guard !timeline.events.contains(where: {
+            $0.version == version && $0.publishedAt == publishedAt && $0.vendorDay == vendorDay
+        }) else {
             // Persist the refreshed name/bundle even when no event was added.
             timelines[appID] = timeline
             if displayFieldsChanged { timelinesDirty = true }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -2019,20 +2019,27 @@ public enum GitHubReleaseRegistry {
         // `SUFeedURL` are deliberately absent: `SparkleAppcastSource` already covers
         // them with no rule at all.
         //
-        // One shared caveat, repeated on the two rules it reaches. When an app's
-        // `CFBundleShortVersionString` has no patch component AND its
-        // `CFBundleVersion` is a small dotless counter, `UpdateChecker.evaluate`'s
-        // "the vendor folded the build into the version" fallback rebuilds the
-        // installed side as short + "." + build — "3.5" + "1" = "3.5.1" — and can
-        // read a genuine x.y.1 release as already installed. Of the artifacts
-        // inspected for this batch only Anki and noTunes have that shape. The others
-        // are safe for one of two DIFFERENT reasons, worth keeping straight: a dotted
-        // `CFBundleVersion` skips the fallback outright (that is the only thing the
-        // guard tests), while a three-component short version still RUNS it — the
-        // rebuilt string is simply four components, which is very unlikely to match
-        // a real release. The second group is practically safe, not structurally
-        // immune: four-component versions do exist in this batch (OpenLens reports
-        // 6.5.2-366), and there it is the dotted build that keeps it off this path.
+        // One shared caveat, repeated on the two rules it reaches — CLOSED for the
+        // shape described here, kept because the reasoning still decides which
+        // rules are safe. When an app's `CFBundleShortVersionString` has no patch
+        // component AND its `CFBundleVersion` is a small dotless counter,
+        // `UpdateChecker.evaluate`'s "the vendor folded the build into the version"
+        // fallback rebuilds the installed side as short + "." + build — "3.5" + "1"
+        // = "3.5.1" — and used to read a genuine x.y.1 release as already
+        // installed. Of the artifacts inspected for this batch only Anki and
+        // noTunes have that shape.
+        //
+        // The fallback now requires the remote to EQUAL the rebuilt string and the
+        // build to be a counter of at least 100, so a hand-stamped "1" no longer
+        // reaches it at all. What is left exposed is narrower: a constant build of
+        // 100 or more under a two-component marketing version. The other rules are
+        // safe for one of two DIFFERENT reasons, worth keeping straight: a dotted
+        // `CFBundleVersion` skips the fallback outright, while a three-component
+        // short version still RUNS it — the rebuilt string is simply four
+        // components, which is very unlikely to match a real release. The second
+        // group is practically safe, not structurally immune: four-component
+        // versions do exist in this batch (OpenLens reports 6.5.2-366), and there
+        // it is the dotted build that keeps it off this path.
 
         // CC Switch — Claude Code / Codex profile switcher, no Sparkle, ships one
         // macOS dmg per release (`CC-Switch-v<ver>-macOS.dmg`, beside a .zip and a
@@ -2606,12 +2613,13 @@ public enum GitHubReleaseRegistry {
         // noTunes — tags are `vX.Y` (two components), which the default pattern
         // handles. One-click: digital.twisted.noTunes, Team JP6WW46Y42, notarized.
         //
-        // Carries the same latent shape as Anki (see the batch header): the app
-        // reports `CFBundleShortVersionString` 3.5 with `CFBundleVersion` 1, so if
-        // upstream ever tags a three-component `v3.5.1`, `evaluate`'s folded-build
-        // fallback would rebuild the installed side as "3.5.1" and call it current.
-        // Not reachable today — every tag this repo has published (v1.0 through
-        // v3.5) is two-component — but it is the same trap, not a different one.
+        // Carried the same latent shape as Anki (see the batch header): the app
+        // reports `CFBundleShortVersionString` 3.5 with `CFBundleVersion` 1, so a
+        // three-component `v3.5.1` tag would have had `evaluate`'s folded-build
+        // fallback rebuild the installed side as "3.5.1" and call it current. That
+        // is closed with Anki's: a build of 1 is below the fallback's counter
+        // floor, so this rule is no longer waiting on upstream to keep tagging two
+        // components.
         GitHubReleaseRule(
             bundleID: "digital.twisted.noTunes",
             owner: "tombonez", repo: "noTunes",
@@ -2794,15 +2802,21 @@ public enum GitHubReleaseRegistry {
         // token-free `-mac-apple` wins on Apple silicon. Team ZL66D3NMZM and
         // notarization verified on BOTH dmgs.
         //
-        // KNOWN GAP (verified on this machine 2026-08-16, not a rule bug): Anki
-        // stamps `CFBundleVersion` as a literal "1" for every build. When the
-        // installed short version has no patch component (26.08 → app reports
+        // CLOSED GAP (was verified on this machine 2026-08-16, and was never a rule
+        // bug): Anki stamps `CFBundleVersion` as a literal "1" for every build. When
+        // the installed short version has no patch component (26.08 → app reports
         // "26.8"), `UpdateChecker.evaluate`'s "vendor folded the build into the
-        // version" fallback rebuilds it as "26.8" + "1" = "26.8.1" and concludes the
-        // app is already current — hiding exactly the x.y → x.y.1 patch. Every other
-        // step (26.8.1 → 26.9) reports normally. Fixing it means tightening that
-        // fallback (it exists for Oray-style 5-digit builds), which is a change to
-        // shared logic, not to this rule.
+        // version" fallback rebuilt it as "26.8" + "1" = "26.8.1" and concluded the
+        // app was already current — hiding exactly the x.y → x.y.1 patch. Every
+        // other step (26.8.1 → 26.9) always reported normally.
+        //
+        // Fixed in the shared logic rather than here, as this note said it would
+        // have to be: that fallback now demands the remote EQUAL the rebuilt string
+        // and the installed build be a counter of at least 100 — a vendor folds a
+        // build in because it is a large counter (Oray's 30757), so a hand-stamped
+        // "1" is evidence against the folded reading. Pinned by
+        // `evaluateFoldingIgnoresBuildsTooSmallToBeFoldedCounters`, whose first case
+        // is this one.
         // One-click: net.ankiweb.anki, Team ZL66D3NMZM, notarized.
         GitHubReleaseRule(
             bundleID: "net.ankiweb.anki",

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SelfUpdaterStaging.swift
@@ -127,10 +127,17 @@ public enum SelfUpdaterStaging {
             // strictly-newer filter belongs here, matching the two branches below.
             // Offering Relaunch for an older staged build would be offering a
             // downgrade, which is exactly the ChatGPT case.
+            //
+            // Pair comparison, not `buildIdentity`: both sides here carry a
+            // marketing string AND a build, and collapsing each to one string
+            // compares the builds alone. A vendor whose builds run monotonically
+            // across two trains then hands a staged 1.2.0 (build 2001) over an
+            // installed 1.3.0 (build 1990) and this offers Relaunch for a
+            // downgrade. Marketing settles direction; the build breaks its ties,
+            // which is the whole point of ``StagedSelfUpdate/versionSide``.
             if requireNewerThanInstalled {
-                let stagedV = staged.buildIdentity
-                guard let installedV = app.buildVersion ?? app.shortVersion,
-                      VersionComparator.isNewer(stagedV, than: installedV) else { return nil }
+                guard VersionComparator.isNewer(staged.versionSide, than: app.versionSide)
+                else { return nil }
             }
             return staged
         }
@@ -162,14 +169,15 @@ public enum SelfUpdaterStaging {
         else { return nil }
         let stagedBuild = infoDict["CFBundleVersion"] as? String
 
-        // Compare the staged build against what's installed, mirroring
-        // `computeRestartInfo`'s build-then-short preference. Only a strictly newer
+        // Compare the staged bundle against what's installed as a PAIR — same
+        // reasoning as the Sparkle branch above: each side carries both strings, and
+        // picking one per side compares the builds alone, which reads a trailing
+        // release carrying a leading build as an update. Only a strictly newer
         // staged version counts — a leftover state file whose staged bundle equals
         // (or trails) what's on disk has already been applied.
         if requireNewerThanInstalled {
-            let stagedV = stagedBuild ?? stagedShort
-            guard let installedV = app.buildVersion ?? app.shortVersion,
-                  VersionComparator.isNewer(stagedV, than: installedV) else { return nil }
+            let stagedSide = VersionSide(marketing: stagedShort, build: stagedBuild)
+            guard VersionComparator.isNewer(stagedSide, than: app.versionSide) else { return nil }
         }
 
         return StagedSelfUpdate(

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -55,7 +55,8 @@ public struct SparkleAppcastSource: UpdateSource {
         // Every in-channel item that carries a date — the appcast usually keeps the
         // last N releases, so this backfills the app's whole visible history into
         // the release timeline in one shot (not just the newest). Keyed on the same
-        // version string the timeline dedupes by.
+        // version string, and read through the same `publishedFields` call, that the
+        // timeline dedupes by — so the newest item does not double-record.
         let history = Self.releaseHistory(from: usable)
         let bestFields = ReleaseDate.publishedFields(from: best.pubDate)
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubReleaseRuleTests.swift
@@ -973,10 +973,12 @@ private func matches(
     #expect(matches("anki-26.08.1-mac-apple.dmg", "net.ankiweb.anki"))
     #expect(matches("anki-26.08.1-mac-intel.dmg", "net.ankiweb.anki"))
     #expect(!matches("anki-26.08.1-windows-qt6.exe", "net.ankiweb.anki"))
-    // Pins the known gap so it can't be mistaken for a rule bug later: Anki stamps
-    // CFBundleVersion "1" on every build, and evaluate()'s folded-build fallback
-    // turns installed 26.8 + build 1 into "26.8.1", which equals the real 26.08.1
-    // release — so that one patch step reads as up-to-date. Documented on the rule.
+    // Was a known gap, now closed, and pinned here because this rule is where it
+    // showed: Anki stamps CFBundleVersion "1" on every build, and evaluate()'s
+    // folded-build fallback turned installed 26.8 + build 1 into "26.8.1", which
+    // equals the real 26.08.1 release — so that one patch step read as up-to-date.
+    // The fallback now requires the installed build to be a counter of at least
+    // 100, which a hand-stamped "1" is not.
     let installed = InstalledApp(
         name: "Anki", bundleID: "net.ankiweb.anki",
         shortVersion: "26.8", buildVersion: "1",
@@ -985,14 +987,13 @@ private func matches(
     let remote = RemoteVersion(
         shortVersion: "26.08.1", version: nil, downloadURL: nil,
         sourceName: "GitHub", requiresManualInstaller: false)
-    // Recorded as a KNOWN issue, so the day someone tightens the fallback this test
-    // reports "known issue was not recorded" — a prompt to delete the wrapper and
-    // the note on the rule, rather than a failure blaming the fix.
-    withKnownIssue("evaluate()'s folded-build fallback reads installed 26.8 + build 1 as 26.8.1, hiding the real 26.08.1 release") {
-        guard case .updateAvailable = UpdateChecker.evaluate(installed: installed, remote: remote) else {
-            Issue.record("26.08.1 not offered over installed 26.8")
-            return
-        }
+    // This was wrapped in `withKnownIssue` while the gap was open, precisely so
+    // that tightening the fallback would report "known issue was not recorded" and
+    // prompt for the wrapper's removal. That is what happened, so the assertion is
+    // now made straight.
+    guard case .updateAvailable = UpdateChecker.evaluate(installed: installed, remote: remote) else {
+        Issue.record("26.08.1 not offered over installed 26.8")
+        return
     }
 }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotifiedUpdateVersionsTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/NotifiedUpdateVersionsTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// The announce-once ledger behind the "new updates available" banner. The one
+/// property that matters is that it can still discriminate for an app whose
+/// marketing string never moves — Amp shipped ten builds as "1.0" in a day, and
+/// the marketing-keyed version announced the first and silently swallowed nine.
+struct NotifiedUpdateVersionsTests {
+
+    private let key = "/ZZFixture-Frozen.app"
+    private let legacy = "zz.fixture.frozen"
+
+    @Test func fixturePathsAreInvented() {
+        #expect(!FileManager.default.fileExists(atPath: key))
+    }
+
+    /// The regression: same marketing version, new build, already-announced entry.
+    @Test func aNewBuildUnderAFrozenMarketingVersionIsNotYetAnnounced() {
+        let baseline = [key: NotifiedUpdateVersions.announceKey(
+            VersionSide(marketing: "1.0", build: "2001"))]
+        #expect(!NotifiedUpdateVersions.wasAnnounced(
+            VersionSide(marketing: "1.0", build: "2002"), under: [key, legacy], in: baseline))
+        // …and the build that WAS announced still reads as announced.
+        #expect(NotifiedUpdateVersions.wasAnnounced(
+            VersionSide(marketing: "1.0", build: "2001"), under: [key, legacy], in: baseline))
+    }
+
+    /// A baseline written by an older build stored the bare marketing string. It
+    /// must not re-announce everything once — including under the legacy app key.
+    @Test func aMarketingOnlyBaselineEntryStillCountsAsAnnounced() {
+        #expect(NotifiedUpdateVersions.wasAnnounced(
+            VersionSide(marketing: "1.0", build: "2001"),
+            under: [key, legacy], in: [key: "1.0"]))
+        #expect(NotifiedUpdateVersions.wasAnnounced(
+            VersionSide(marketing: "1.0", build: "2001"),
+            under: [key, legacy], in: [legacy: "1.0"]))
+        // A different marketing version is a different update either way.
+        #expect(!NotifiedUpdateVersions.wasAnnounced(
+            VersionSide(marketing: "1.1", build: "2001"),
+            under: [key, legacy], in: [key: "1.0"]))
+    }
+
+    /// Nothing recorded at all is never "announced", and a row whose offer names
+    /// no version keeps the empty-string key the marketing-keyed ledger stored.
+    @Test func anUnrecordedAppIsNotAnnouncedAndAVersionlessOfferKeepsItsKey() {
+        #expect(!NotifiedUpdateVersions.wasAnnounced(
+            VersionSide(marketing: "1.0", build: "2001"), under: [key, legacy], in: [:]))
+        #expect(NotifiedUpdateVersions.announceKey(nil) == "")
+        #expect(NotifiedUpdateVersions.announceKey(VersionSide()) == "")
+        #expect(NotifiedUpdateVersions.wasAnnounced(nil, under: [key], in: [key: ""]))
+    }
+
+    /// A build equal to the marketing string is not repeated, so an app that
+    /// stamps both fields identically keeps the key it always had.
+    @Test func anIdenticalBuildIsNotAppendedToTheKey() {
+        #expect(NotifiedUpdateVersions.announceKey(
+            VersionSide(marketing: "1.2.3", build: "1.2.3")) == "1.2.3")
+        #expect(NotifiedUpdateVersions.announceKey(
+            VersionSide(marketing: "1.2.3", build: nil)) == "1.2.3")
+        #expect(NotifiedUpdateVersions.announceKey(
+            VersionSide(marketing: nil, build: "194")) == "194")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
@@ -81,6 +81,14 @@ private let d3 = Date(timeIntervalSince1970: 1_720_000_000)
     #expect(!(await store.record(appID: id, appName: "ZZFixtureFrozen", bundleID: nil,
         version: "6.9.0", sourceName: "Sparkle", publishedAt: d1)))
     #expect(await store.timeline(forAppID: id)?.events.count == 3)
+    // The invariant `ReleaseLogView.Row.id` is built on: (version, publishedAt,
+    // vendorDay) does not repeat within one app. Two rows sharing an
+    // `Identifiable` id is SwiftUI's undefined-behaviour case, and the version
+    // alone stopped being unique the moment this dedupe changed.
+    let keys = (await store.timeline(forAppID: id)?.events ?? []).map {
+        "\($0.version)|\($0.publishedAt?.timeIntervalSince1970 ?? -1)|\($0.vendorDay?.timeIntervalSince1970 ?? -1)"
+    }
+    #expect(Set(keys).count == keys.count)
     #expect(!FileManager.default.fileExists(atPath: "/ZZFixture-Frozen.app"))
 }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ReleaseTimelineStoreTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import DuoUpdaterCore
 
 /// `ReleaseTimelineStore` is the persistent log of every release we've seen a
-/// source announce. The fragile parts are: it records each version exactly once
+/// source announce. The fragile parts are: it records each dated release exactly once
 /// (re-checks don't pile up), it silently drops releases with no trustworthy
 /// vendor date, and the JSON round-trips so history survives a relaunch.
 
@@ -54,6 +54,34 @@ private let d3 = Date(timeIntervalSince1970: 1_720_000_000)
     let tl = await store.timeline(forAppID: id)
     #expect(tl?.events.count == 1)
     #expect(tl?.events.first?.detectedAt == d1)   // first sighting wins
+}
+
+/// Several releases can ship under ONE marketing version — Surge has shipped
+/// four called "6.9.0", Amp shipped ten builds as "1.0" in a day. Dedupe keyed on
+/// the version string alone logged the first of them and read the rest as
+/// already-recorded, so the timeline under-counted exactly the vendors whose
+/// marketing string has stopped carrying information. A vendor date is what this
+/// path is FOR (it refuses to record without one), so the date is what separates
+/// them.
+@Test func recordsEachDatedReleaseSharingOneMarketingVersion() async {
+    let store = ReleaseTimelineStore(fileURL: tempFileURL())
+    let id = "/ZZFixture-Frozen.app"
+    let first = await store.record(appID: id, appName: "ZZFixtureFrozen", bundleID: nil,
+        version: "6.9.0", sourceName: "Sparkle", publishedAt: d1)
+    let second = await store.record(appID: id, appName: "ZZFixtureFrozen", bundleID: nil,
+        version: "6.9.0", sourceName: "Sparkle", publishedAt: d2)
+    let third = await store.record(appID: id, appName: "ZZFixtureFrozen", bundleID: nil,
+        version: "6.9.0", sourceName: "Sparkle", publishedAt: nil, vendorDay: d3)
+    #expect(first)
+    #expect(second)
+    #expect(third)
+    let tl = await store.timeline(forAppID: id)
+    #expect(tl?.events.count == 3)
+    // Re-checking any of them is still a no-op.
+    #expect(!(await store.record(appID: id, appName: "ZZFixtureFrozen", bundleID: nil,
+        version: "6.9.0", sourceName: "Sparkle", publishedAt: d1)))
+    #expect(await store.timeline(forAppID: id)?.events.count == 3)
+    #expect(!FileManager.default.fileExists(atPath: "/ZZFixture-Frozen.app"))
 }
 
 @Test func appendsDistinctVersionsSortedByPublishDate() async {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SelfUpdaterStagingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SelfUpdaterStagingTests.swift
@@ -118,6 +118,27 @@ struct SelfUpdaterStagingTests {
         }
     }
 
+    /// Same shape as the Sparkle branch's own test: a ShipIt state naming a build
+    /// that is numerically newer but a marketing release OLDER must not be offered
+    /// as an update. `buildVersion ?? shortVersion` on each side collapsed the pair
+    /// to one string and compared the builds, which reads a downgrade as an update.
+    @Test func ignoresStagedBuildWhoseMarketingVersionTrails() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            try FileManager.default.createDirectory(at: caches, withIntermediateDirectories: true)
+            let installed = root.appendingPathComponent("Squirrel.app")
+            try makeApp(at: installed, short: "1.3.0", build: "1990")
+            let stagedApp = caches.appendingPathComponent("\(bundleID).ShipIt/update.xyz/Squirrel.app")
+            try makeApp(at: stagedApp, short: "1.2.0", build: "2001")
+            try writeShipItState(in: caches, target: installed, update: stagedApp)
+
+            let result = SelfUpdaterStaging.staged(
+                for: app(at: installed, short: "1.3.0", build: "1990"),
+                cachesDirectory: caches)
+            #expect(result == nil)
+        }
+    }
+
     @Test func ignoresStateTargetingADifferentBundle() throws {
         try withScratch { root in
             let caches = root.appendingPathComponent("Caches")

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SparkleStagingTests.swift
@@ -251,6 +251,29 @@ struct SparkleStagingTests {
         }
     }
 
+    /// A vendor whose builds run monotonically ACROSS trains stages a build that
+    /// is numerically newer and a release OLDER. Deciding this on the build alone
+    /// reads that as an update and offers Relaunch for a downgrade. Marketing
+    /// settles direction; the build only breaks a marketing tie.
+    @Test func aStagedBuildWhoseMarketingVersionTrailsIsNotReportedAsAnUpdate() throws {
+        try withScratch { root in
+            let caches = root.appendingPathComponent("Caches")
+            _ = try stage(in: caches, short: "1.2.0", build: "2001")
+            let installed = root.appendingPathComponent("Sparkly.app")
+            try makeApp(at: installed, identifier: bundleID, short: "1.3.0", build: "1990")
+            let app = sparkleApp(at: installed, short: "1.3.0", build: "1990")
+
+            let parked = [parkedInstaller(in: caches)]
+            #expect(SelfUpdaterStaging.staged(
+                for: app, cachesDirectory: caches,
+                parkedInstallerBundleURLs: parked) == nil)
+            // The restart check still has to see it — that is the collision case.
+            #expect(SelfUpdaterStaging.sparkleStagedBundle(
+                for: app, cachesDirectory: caches,
+                parkedInstallerBundleURLs: parked)?.version == "1.2.0")
+        }
+    }
+
     /// The candidate pre-filter has to let Sparkle apps through, or none of the
     /// above is ever asked. It must keep saying no to an app with neither.
     @Test func theCandidateFilterAdmitsSparkleApps() {

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedBlocksInstallTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/StagedBlocksInstallTests.swift
@@ -104,6 +104,36 @@ extension StagedBlocksInstallTests {
 
 extension StagedBlocksInstallTests {
 
+    /// Spotify's staging carries no `CFBundleVersion` at all — `SelfUpdaterStaging`
+    /// constructs it with `buildVersion: nil`, because `update.json` reports only a
+    /// marketing `version_to`. Picking `buildVersion ?? version` on each side
+    /// independently then compared the staged MARKETING string against the installed
+    /// BUILD number: two namespaces, never equal, so a leftover staging directory
+    /// went on blocking installs for as long as it sat there. (Measured 2026-09-13:
+    /// this Mac's Spotify copy happens to carry identical short and build strings,
+    /// which hides it — the pick is wrong whether or not today's data exposes it.)
+    @Test func anAppliedStagedUpdateWithNoBuildNumberDoesNotBlock() {
+        let app = InstalledApp(
+            name: "ZZFixtureStage", bundleID: "zz.fixture.stage",
+            shortVersion: "1.2.60", buildVersion: "108000456",
+            path: URL(fileURLWithPath: "/ZZFixture-Stage.app"),
+            isMASApp: false, sparkleFeedURL: nil, hasSelfUpdater: true)
+        let r = UpdateResult(
+            app: app,
+            remote: RemoteVersion(
+                shortVersion: "1.2.61", version: nil,
+                downloadURL: URL(string: "https://example.com/a.zip"), sourceName: "Vendor"),
+            status: .updateAvailable(latest: "1.2.61"))
+        // Staged marketing == installed marketing: already applied, must not block.
+        #expect(UpdatePolicy.stagedBlocksInstall(r, staged: staged("1.2.60", build: nil)) == nil)
+        // A different staged marketing version has NOT been applied and still blocks.
+        #expect(UpdatePolicy.stagedBlocksInstall(r, staged: staged("1.2.61", build: nil)) != nil)
+        #expect(!FileManager.default.fileExists(atPath: "/ZZFixture-Stage.app"))
+    }
+}
+
+extension StagedBlocksInstallTests {
+
     /// `actionableStaged` gates the **Relaunch** button, so it must never point at a
     /// build older than what is installed — relaunching into that applies a
     /// DOWNGRADE, and `relaunchStagedUpdate` waits for the on-disk version to move

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
@@ -154,6 +154,15 @@ import Foundation
     // The Oray shape itself still settles to current.
     #expect(UpdateChecker.evaluate(installed: app(short: "16.5.0", build: "30757"),
                                    remote: remote("16.5.0.30757")) == .upToDate)
+    // The accepted risk, pinned so that a later "improvement" back toward
+    // `!isNewer(rs, combined)` is caught: a fold-shaped remote naming an OLDER
+    // build than the installed one now reads as an update rather than being
+    // suppressed. The two shapes are not separable from the strings, and offering
+    // the vendor's published package to a copy ahead of it is visible and
+    // recoverable, where suppressing hid real updates silently.
+    #expect(UpdateChecker.evaluate(installed: app(short: "16.5.0", build: "30757"),
+                                   remote: remote("16.5.0.29000"))
+        == .updateAvailable(latest: "16.5.0.29000"))
     #expect(!FileManager.default.fileExists(atPath: "/ZZFixture-Fold.app"))
 }
 
@@ -186,6 +195,18 @@ import Foundation
         == .updateAvailable(latest: "1.5.99"))
     #expect(UpdateChecker.evaluate(installed: app(short: "1.5", build: "100"), remote: remote("1.5.100"))
         == .upToDate)
+    // Zero padding is not width: "007" is the counter 7, the same normalisation
+    // `VersionComparator`'s tokenizer applies.
+    #expect(UpdateChecker.evaluate(installed: app(short: "1.5", build: "007"), remote: remote("1.5.007"))
+        == .updateAvailable(latest: "1.5.007"))
+    // The floor must be measured by string: a build far too wide for Int64 is the
+    // MOST counter-like shape there is (epoch-ms, concatenated counters), and
+    // `Int(build)` returning nil there would switch fold recognition off for
+    // exactly those vendors.
+    let wide = "1234567890123456789012345"  // 25 digits
+    #expect(Int(wide) == nil)
+    #expect(UpdateChecker.evaluate(installed: app(short: "1.5", build: wide),
+                                   remote: remote("1.5.\(wide)")) == .upToDate)
     // And the shape the fallback exists for is untouched.
     #expect(UpdateChecker.evaluate(installed: app(short: "16.5.0", build: "30757"),
                                    remote: remote("16.5.0.30757")) == .upToDate)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import DuoUpdaterCore
 
 @Test func basicOrdering() {
@@ -116,6 +117,44 @@ import Testing
     // Older marketing version → still detected.
     #expect(UpdateChecker.evaluate(installed: aweSun(short: "16.3.0", build: "29530"), remote: remote)
         == .updateAvailable(latest: "16.5.0.30757"))
+}
+
+/// The build-folding fallback must only fire for the shape it was written for —
+/// a remote string that IS the folded form of installed short+build. A remote
+/// that is simply one component longer than the installed marketing version is
+/// not that shape, and reading it as one hid real updates from every source that
+/// reports no separate build (Homebrew, GitHub, MAS, Electron, most vendor
+/// probes): the fabricated `short + "." + build` tail is a large integer, so the
+/// genuinely-newer remote compared as OLDER.
+@Test func evaluateFoldingDoesNotSwallowAnExtraMarketingComponent() {
+    func app(short: String, build: String) -> InstalledApp {
+        InstalledApp(
+            name: "ZZFixtureFold", bundleID: "zz.fixture.fold",
+            shortVersion: short, buildVersion: build,
+            path: .init(fileURLWithPath: "/ZZFixture-Fold.app"), isMASApp: false,
+            sparkleFeedURL: nil)
+    }
+    func remote(_ short: String) -> RemoteVersion {
+        RemoteVersion(shortVersion: short, version: nil, downloadURL: nil, sourceName: "Vendor")
+    }
+
+    // Two-component marketing plus a small integer build: the hotfix must show.
+    #expect(UpdateChecker.evaluate(installed: app(short: "2.0", build: "15"), remote: remote("2.0.3"))
+        == .updateAvailable(latest: "2.0.3"))
+    // The shape this Mac's Telegram copy carries (short "12.10", build "282987",
+    // read from its Info.plist on 2026-09-13): the fabricated "12.10.282987"
+    // outranked every real "12.10.x" release. The fixture is the shape, not the
+    // app — nothing here reads the copy.
+    #expect(UpdateChecker.evaluate(installed: app(short: "12.10", build: "282987"), remote: remote("12.10.1"))
+        == .updateAvailable(latest: "12.10.1"))
+    // Three-component marketing with an integer build — already worked, pinned so
+    // a future rewrite cannot regress it.
+    #expect(UpdateChecker.evaluate(installed: app(short: "1.2.3", build: "500"), remote: remote("1.2.4"))
+        == .updateAvailable(latest: "1.2.4"))
+    // The Oray shape itself still settles to current.
+    #expect(UpdateChecker.evaluate(installed: app(short: "16.5.0", build: "30757"),
+                                   remote: remote("16.5.0.30757")) == .upToDate)
+    #expect(!FileManager.default.fileExists(atPath: "/ZZFixture-Fold.app"))
 }
 
 /// The build-folding fallback must NOT make a genuinely-behind normal app (whose

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VersionComparatorTests.swift
@@ -157,6 +157,41 @@ import Foundation
     #expect(!FileManager.default.fileExists(atPath: "/ZZFixture-Fold.app"))
 }
 
+/// Equality alone still swallows a hotfix when the installed build is a small
+/// hand-stamped constant: Anki stamps `CFBundleVersion` as a literal "1" for
+/// every build, so short "26.8" + build "1" folds to exactly "26.8.1" and the
+/// real 26.8.1 patch matched the folded form. A vendor folds a build into its
+/// version string because the build is a large counter, so a one- or two-digit
+/// build is evidence against the folded reading — hence the floor.
+@Test func evaluateFoldingIgnoresBuildsTooSmallToBeFoldedCounters() {
+    func app(short: String, build: String) -> InstalledApp {
+        InstalledApp(
+            name: "ZZFixtureFloor", bundleID: "zz.fixture.floor",
+            shortVersion: short, buildVersion: build,
+            path: .init(fileURLWithPath: "/ZZFixture-Floor.app"), isMASApp: false,
+            sparkleFeedURL: nil)
+    }
+    func remote(_ short: String) -> RemoteVersion {
+        RemoteVersion(shortVersion: short, version: nil, downloadURL: nil, sourceName: "Vendor")
+    }
+
+    // Anki's shape — the counter-example the floor exists for.
+    #expect(UpdateChecker.evaluate(installed: app(short: "26.8", build: "1"), remote: remote("26.8.1"))
+        == .updateAvailable(latest: "26.8.1"))
+    // A single-digit build under a two-component marketing version, same shape.
+    #expect(UpdateChecker.evaluate(installed: app(short: "1.5", build: "6"), remote: remote("1.5.6"))
+        == .updateAvailable(latest: "1.5.6"))
+    // The boundary itself, both sides of it.
+    #expect(UpdateChecker.evaluate(installed: app(short: "1.5", build: "99"), remote: remote("1.5.99"))
+        == .updateAvailable(latest: "1.5.99"))
+    #expect(UpdateChecker.evaluate(installed: app(short: "1.5", build: "100"), remote: remote("1.5.100"))
+        == .upToDate)
+    // And the shape the fallback exists for is untouched.
+    #expect(UpdateChecker.evaluate(installed: app(short: "16.5.0", build: "30757"),
+                                   remote: remote("16.5.0.30757")) == .upToDate)
+    #expect(!FileManager.default.fileExists(atPath: "/ZZFixture-Floor.app"))
+}
+
 /// The build-folding fallback must NOT make a genuinely-behind normal app (whose
 /// short version is simply older) look current.
 @Test func evaluateBuildFoldingDoesNotMaskRealUpdate() {


### PR DESCRIPTION
Fixes five review findings that share one shape: a decision made on a single
version string where the two sides each carry a marketing version AND a build.

## Findings addressed

| # | Site | Change |
|---|---|---|
| L1 | `DuoUpdaterCore/.../Engine/UpdateChecker.swift:605-611` | folded-build fallback now requires the remote to BE the folded pair |
| L2 | `App/Sources/AppListModel.swift:6579-6600` | notification baseline keyed on the full `VersionSide`; rule extracted to Core as `NotifiedUpdateVersions` and tested |
| L14 | `DuoUpdaterCore/.../Sources/SelfUpdaterStaging.swift:130-133, 169-172` | both strictly-newer gates compare `VersionSide` pairs |
| L15 (timeline) | `DuoUpdaterCore/.../Releases/ReleaseTimelineStore.swift:101` | `record` dedupes on version + vendor date |
| extra | `DuoUpdaterCore/.../Engine/UpdatePolicy.swift:624-626` | `stagedBlocksInstall` uses `VersionComparator.isSame` on `VersionSide`s |

Nothing declined. Two notes on how two of them were implemented differ from the
brief's suggested mechanism — see "Deviations".

## L1 — the folded-build fallback

`if !VersionComparator.isNewer(rs, than: "\(isv).\(build)") { return .upToDate }`
fabricates a version component out of a build number. A build number is a large
integer, so any installed marketing version with fewer components than the build
has digits outranks every real release the vendor can ship on that line.

Measured on this Mac 2026-09-13, from Telegram's own `Info.plist`:
```
$ defaults read /Applications/Telegram.app/Contents/Info.plist CFBundleShortVersionString  → 12.10
$ defaults read /Applications/Telegram.app/Contents/Info.plist CFBundleVersion             → 282987
```
so a vendor `12.10.1` compared against the fabricated `12.10.282987` and the row
read `.upToDate`. Every source that reports no separate build (Homebrew, GitHub,
the App Store, Electron, most vendor probes) reaches this line.

The fallback now fires only on `compare(rs, combined) == .orderedSame`. Known
consequence, written into the comment: a folded remote naming an OLDER build than
what is on disk now reads as an update instead of being suppressed — the two
shapes are not separable from the strings, and offering the vendor's currently
published package to a copy ahead of it is visible and recoverable, where the old
direction hid real updates silently.

Not fixed, and still correctly described where it is documented: the Anki gap in
`GitHubReleasesSource.swift:2797` (short `26.8` + build `1` folds to exactly
`26.8.1`, so equality still matches it). Tightening that needs a rule about how
build-like a tail has to be, which I have no measurement for.

## L15 / `record` — deviation from the brief's mechanism

The brief asked for `record` to be build-aware "the same way the observe path is"
(`side.text(withBuild: true)`). `record`'s two call sites cannot both supply a
build: `ReleaseHistoryEntry` has no build field (`Models/UpdateResult.swift:108`),
and giving it one means changing the model, both producers, and — because the
stored `version` string IS the dedupe key — re-recording whole backfilled appcast
histories under new keys beside the ones already persisted.

Deduping on version + vendor date needs none of that and is sound for this tier
specifically: `record` refuses to log anything without a date, and two releases
the vendor dated differently are two releases. Same-release re-checks still
dedupe because the latest release and its own entry in `releaseHistory` read that
date from the same item through the same `ReleaseDate.publishedFields` call
(`SparkleAppcastSource.swift:60` / `:128`, `GitHubReleasesSource.swift:1246` /
`:1290`). Surge's four `6.9.0` releases now get four events.

## L2 — deviation on where the migration lives

Extracted to `Engine/NotifiedUpdateVersions.swift` (Core, pure, executed by
tests) rather than reasoned about in `AppListModel`. Legacy migration is the
"treat a stored marketing-only value as matching" option, not a rewrite-on-read:
it is two lines, it costs at most one suppressed announcement per app, and the
next pass rewrites every actionable app's entry build-aware, so it expires by
itself. A rewrite-on-read would have to decide what build an old bare `"1.0"`
meant, which is not recoverable.

## `stagedBlocksInstall` — the finding holds, with a caveat

`staged.buildVersion ?? staged.version` against
`app.buildVersion ?? app.shortVersion` can land in two namespaces: Spotify's
staged update is built with `buildVersion: nil` by construction
(`SelfUpdaterStaging.swift:233`), so the staged MARKETING string is compared with
the installed BUILD number and can never be equal — an applied-but-unswept
staging directory blocks installs. Caveat, measured 2026-09-13: this Mac's
Spotify copy carries `CFBundleVersion` == `CFBundleShortVersionString` ==
`1.2.99.317`, so on this copy the wrong pick lands right by luck. The
discriminator is wrong whether or not today's data exposes it, so it is fixed.
`buildIsDerived:` is passed for the scanner-substituted builds (Xcode, 豆包),
matching `VersionComparator.isSame`'s own documented rule.

## Red → green

Before the fixes (`swift test --filter …`):
```
✘ evaluateFoldingDoesNotSwallowAnExtraMarketingComponent() … Expectation failed: evaluate(installed: app(short: "2.0", build: "15"), remote: remote("2.0.3")) == .updateAvailable(latest: "2.0.3")
✘ evaluateFoldingDoesNotSwallowAnExtraMarketingComponent() … Expectation failed: evaluate(installed: app(short: "12.10", build: "282987"), remote: remote("12.10.1")) == .updateAvailable(latest: "12.10.1")
✘ aStagedBuildWhoseMarketingVersionTrailsIsNotReportedAsAnUpdate() failed after 0.010 seconds with 1 issue.
✘ ignoresStagedBuildWhoseMarketingVersionTrails() failed after 0.012 seconds with 1 issue.
✘ recordsEachDatedReleaseSharingOneMarketingVersion() … tl?.events.count → 1  (expected 3)
✘ anAppliedStagedUpdateWithNoBuildNumberDoesNotBlock() failed after 0.011 seconds with 1 issue.
✘ Test run with 5 tests in 3 suites failed after 0.012 seconds with 9 issues.
```
After:
```
✔ Test run with 10 tests in 4 suites passed after 0.030 seconds.
```
(The pre-fix code IS the mutation for those five: each test was written first and
observed red against it.)

`NotifiedUpdateVersions` could not be red before it existed, so it was mutated
explicitly, one property at a time:

1. `announceKey` → `offered.marketing ?? offered.build ?? ""`
```
✘ aNewBuildUnderAFrozenMarketingVersionIsNotYetAnnounced() … Expectation failed: !wasAnnounced(VersionSide(marketing: "1.0", build: "2002"), …)
✔ (the other four passed)
```
2. `wasAnnounced` → `return stored == key` (drop the legacy acceptance)
```
✘ aMarketingOnlyBaselineEntryStillCountsAsAnnounced() … 2 issues (per-path key and legacy key)
✔ (the other four passed)
```
Both restored; full suite green.

## Verification

```
$ make test > /tmp/mt-fix-vcfb2.log 2>&1; echo exit=$?
exit=0
```
tail:
```
━ Test run with 2787 tests in 229 suites passed after 21.560 seconds with 2 known issues.
✔ Test run with 280 tests in 34 suites passed after 0.150 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 262 files, 2 ledger call(s) keyed on the build, 9 marketing-first pick(s), all display-only
✓ app audits consistent — 121 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 533 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 26) match the initializers
✓ no machine-population claims in code comments — 533 files
```

No `make gallery`: nothing under `App/Sources` that draws a row was touched
(`AppListModel.notifyNewUpdates`, two comments, one `Preferences` doc). No
`duo verify`: no recipe or parser rule changed.

## What a user could notice

- Updates that were previously invisible for apps whose marketing version is
  shorter than their build number now appear.
- An app that ships several builds under one marketing name gets a banner for
  each build instead of only the first, and a Release Log entry for each dated
  release instead of only the first.
- Relaunch is no longer offered for a staged build that trails the installed
  release.
- The first run after upgrading suppresses at most one announcement per app
  (the marketing-keyed baseline migration); nothing is re-announced.
