### PR TITLE
EventStore: fix the fresh-database migration order, plus Support cleanups

### DIFF
--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/DuoEvent.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/DuoEvent.swift
@@ -111,7 +111,10 @@ extension DuoEvent {
     /// is its microsecond truncation**, so a value built from a finer source is
     /// equal to itself only after a round trip.
     ///
-    /// The human-readable timestamp is the envelope's `at`, which stays ISO-8601.
+    /// The envelope's `at` is the same quantity, not a friendlier one: the `at`
+    /// column is `INTEGER` microseconds too. ISO-8601 appears only where a human
+    /// reads the bytes directly — the JSON export, and `meta` markers such as
+    /// `from_cache.backfilled`.
     static let microsecond = 1_000_000.0
 
     static func encoder() -> JSONEncoder {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/EventStore.swift
@@ -534,10 +534,10 @@ public actor EventStore {
     /// here would let a machine with a long install history exhaust the floor and
     /// stop the size pass giving up request events it should.
     private func eventCount(_ db: OpaquePointer) -> Int {
-        guard let statement = prepare(db, "SELECT count(*) FROM events WHERE kind <> 'install';"),
-              sqlite3_step(statement) == SQLITE_ROW
+        guard let statement = prepare(db, "SELECT count(*) FROM events WHERE kind <> 'install';")
         else { return 0 }
         defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { return 0 }
         return Int(sqlite3_column_int64(statement, 0))
     }
 
@@ -994,10 +994,10 @@ public actor EventStore {
     }
 
     private func installEventCount(_ db: OpaquePointer) -> Int {
-        guard let statement = prepare(db, "SELECT count(*) FROM events WHERE kind = 'install';"),
-              sqlite3_step(statement) == SQLITE_ROW
+        guard let statement = prepare(db, "SELECT count(*) FROM events WHERE kind = 'install';")
         else { return 0 }
         defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { return 0 }
         return Int(sqlite3_column_int64(statement, 0))
     }
 
@@ -1148,14 +1148,38 @@ public actor EventStore {
         // new index, and whoever updates the test's expected set should update this
         // paragraph in the same commit, not leave it asserting an absence that just
         // became false.
-        addColumnIfMissing(db, table: "events", column: "app_id", type: "TEXT")
-        // Denormalised because the summary asks about it on every row, on every
-        // refresh, and asking the payload meant a JSON parse per row that no
-        // index can serve: 0.29 s over 40,760 rows, repeated every two seconds
-        // for as long as the window is open, on the same actor that has to
-        // service event writes.
-        addColumnIfMissing(db, table: "events", column: "from_cache", type: "INTEGER")
-        backfillFromCache(db)
+        //
+        // The repairs are for a table that already exists, so they are skipped
+        // when it does not. A brand-new database used to run them anyway, against
+        // a file with no `events` and no `meta` in it: four `no such table`
+        // errors in the log, two notices claiming a column had been added that
+        // had not, and `backfillFromCache`'s `UPDATE` failing — which left the
+        // `from_cache.backfilled` marker unwritten, so the *second* launch of a
+        // fresh install ran a full-table `UPDATE events` that a store with
+        // nothing in it can never need. Guarding here rather than reordering:
+        // the ordering above is the thing that has to stay true, and moving the
+        // batch in front of the repairs would put the #462 bug back.
+        //
+        // Of those, only the marker had a consequence that outlived the launch,
+        // and it is fixed by moving `backfillFromCache` below the batch rather
+        // than by this guard — measured 2026-09-13: with that move in place,
+        // replacing this condition with `true` leaves all five
+        // `EventStoreSchemaDriftTests` green. **So this condition is log hygiene
+        // and intent, not a pinned guard**, and it is recorded that way rather
+        // than left to look like something a test is watching. What the tests do
+        // pin is either side of it: `freshInstallRecordsBackfillMarkerOnFirstOpen`
+        // (the marker is written on the first open) and
+        // `preColumnStoreIsMigratedAndBackfilled` (the repairs still run, and the
+        // backfill still copies, on a database that predates both columns).
+        if tableExists(db, "events") {
+            addColumnIfMissing(db, table: "events", column: "app_id", type: "TEXT")
+            // Denormalised because the summary asks about it on every row, on every
+            // refresh, and asking the payload meant a JSON parse per row that no
+            // index can serve: 0.29 s over 40,760 rows, repeated every two seconds
+            // for as long as the window is open, on the same actor that has to
+            // service event writes.
+            addColumnIfMissing(db, table: "events", column: "from_cache", type: "INTEGER")
+        }
         exec(db, """
             CREATE TABLE IF NOT EXISTS events (
               id        TEXT PRIMARY KEY,
@@ -1192,6 +1216,12 @@ public actor EventStore {
 
             CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
             """)
+        // After the batch, not before it: the backfill reads `meta` and writes
+        // `events.from_cache`, and on a fresh database neither exists until the
+        // batch has run. It is not part of the batch, so this does not reopen the
+        // ordering hazard documented above — an upgraded database reaches it with
+        // the columns already added by the repairs.
+        backfillFromCache(db)
         if let statement = prepare(db, "INSERT OR IGNORE INTO meta VALUES ('schema', ?);") {
             bind(statement, 1, String(DuoEvent.schemaVersion))
             step(db, statement)
@@ -1224,7 +1254,13 @@ public actor EventStore {
     /// directly, so a row left NULL would silently count as "not from cache"
     /// and the figures would disagree with the log they sit above. The value
     /// was always there — `fetchType` is a payload field from the first
-    /// version — so this is a copy, not a guess. Once, guarded by a marker.
+    /// version — so this is a copy, not a guess.
+    ///
+    /// Once, guarded by a marker — including on a fresh install, where the
+    /// `UPDATE` matches nothing and the marker is the only thing worth writing.
+    /// Called from `createSchema` **after** its `CREATE TABLE` batch, because
+    /// both the table it updates and the `meta` table holding the marker have to
+    /// exist first.
     private func backfillFromCache(_ db: OpaquePointer) {
         // `metaValue`, not `metaMarker`: this runs inside schema setup, and
         // `metaMarker` opens the database, which re-enters schema setup and
@@ -1239,18 +1275,43 @@ public actor EventStore {
         setMeta(db, "from_cache.backfilled", ISO8601DateFormatter.duoEvent.string(from: now()))
     }
 
+    /// Whether `table` is already in this database. `PRAGMA table_info` on a
+    /// table that is not there is not an error — it returns no rows — so this
+    /// asks `sqlite_master`, where absence and emptiness are the same answer.
+    private func tableExists(_ db: OpaquePointer, _ table: String) -> Bool {
+        guard let statement = prepare(
+            db, "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?;")
+        else { return false }
+        defer { sqlite3_finalize(statement) }
+        bind(statement, 1, table)
+        return sqlite3_step(statement) == SQLITE_ROW
+    }
+
+    /// - Returns: whether this call added the column. False both when it was
+    ///   already there and when the `ALTER` failed — the notice below is the only
+    ///   thing that distinguishes them, and it must not claim the second.
+    @discardableResult
     private func addColumnIfMissing(
         _ db: OpaquePointer, table: String, column: String, type: String
-    ) {
-        guard let statement = prepare(db, "PRAGMA table_info(\(table));") else { return }
+    ) -> Bool {
+        guard let statement = prepare(db, "PRAGMA table_info(\(table));") else { return false }
         var present = false
         while sqlite3_step(statement) == SQLITE_ROW {
             if text(statement, 1) == column { present = true; break }
         }
         sqlite3_finalize(statement)
-        guard !present else { return }
-        exec(db, "ALTER TABLE \(table) ADD COLUMN \(column) \(type);")
+        guard !present else { return false }
+        guard exec(db, "ALTER TABLE \(table) ADD COLUMN \(column) \(type);") else { return false }
         Log.app.notice("events: added the \(column, privacy: .public) column")
+        return true
+    }
+
+    /// Test seam for `addColumnIfMissing`'s return value. Internal because the
+    /// honesty of that value has no other observable: the only other thing the
+    /// failing branch produces is a log line, and this package has no log seam.
+    func addColumnForTesting(table: String, column: String) -> Bool {
+        guard let db = open() else { return false }
+        return addColumnIfMissing(db, table: table, column: column, type: "TEXT")
     }
 
     @discardableResult
@@ -1295,19 +1356,22 @@ public actor EventStore {
 
     private func changes(_ db: OpaquePointer) -> Int { Int(sqlite3_changes(db)) }
 
+    // `defer` before the `step`, not after it, in these four readers and in
+    // `coverage()`. Folding the `step` into the same `guard` as the `prepare`
+    // reads well but leaks the statement on every path where the `prepare`
+    // succeeded and the `step` did not — `SQLITE_BUSY` most of all, which is
+    // exactly the case a store shared by the menu-bar app and `duo` hits.
     private func intPragma(_ db: OpaquePointer, _ name: String) -> Int? {
-        guard let statement = prepare(db, "PRAGMA \(name);"),
-              sqlite3_step(statement) == SQLITE_ROW
-        else { return nil }
+        guard let statement = prepare(db, "PRAGMA \(name);") else { return nil }
         defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
         return Int(sqlite3_column_int64(statement, 0))
     }
 
     private func text(pragma name: String, _ db: OpaquePointer) -> String? {
-        guard let statement = prepare(db, "PRAGMA \(name);"),
-              sqlite3_step(statement) == SQLITE_ROW
-        else { return nil }
+        guard let statement = prepare(db, "PRAGMA \(name);") else { return nil }
         defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
         return text(statement, 0)
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/RequestEvent.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/RequestEvent.swift
@@ -12,7 +12,7 @@ import Foundation
 /// Every field here is copied straight off the platform's own measurement. None
 /// of it is summarised, bucketed or rounded at write time — that is the whole
 /// point of keeping events (see ``DuoEvent``). The derived rollups live in
-/// ``RequestLedger`` and can be rebuilt from these.
+/// ``RequestTotal`` (``EventStore/totals()``) and can be rebuilt from these.
 public struct RequestEvent: Codable, Sendable, Hashable {
 
     // MARK: What was asked, and why

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/RequestQuery.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Events/RequestQuery.swift
@@ -497,9 +497,9 @@ public struct RequestQuery: Sendable, Equatable {
     }
 
     /// Cache hits carry no status of their own, so "no status" alone would read
-    /// every cache hit as a failure. Asked of the payload rather than of a column
-    /// because it has to hold for rows written before this view existed.
-    /// Reads the denormalised column rather than the payload.
+    /// every cache hit as a failure. Reads the denormalised column rather than
+    /// the payload, falling back to the payload for a row the migration has not
+    /// reached.
     ///
     /// It was `json_extract(payload, '$.fetchType') <> 'localCache'`, which no
     /// index can serve and which the summary asks of every row on every

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
@@ -290,7 +290,17 @@ public actor BrewFormulaReleaseService {
         request.setValue("DuoUpdater/0.1", forHTTPHeaderField: "User-Agent")
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
 
-        let (data, response) = try await session.countedData(for: request, purpose: .catalog)
+        // `.changelog`, not `.catalog`. This is one formula's release notes, read
+        // to render them in the changelog pane — exactly what `.changelog`
+        // documents. `.catalog` means the Homebrew index specifically: the
+        // Requests window prints it as "Homebrew catalog" and `RequestQuery`
+        // matches the search token `brew` to it, so tagging a per-formula
+        // `api.github.com` fetch that way labelled it as something it is not.
+        // Visible effect: these hops move from the Catalog row to the Changelog
+        // row in the traffic breakdown. Hops recorded before this keep the label
+        // they were written with — the purpose is stored per event — so the two
+        // rows disagree with their own history across this version.
+        let (data, response) = try await session.countedData(for: request, purpose: .changelog)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             return nil  // 404 = tag has no GitHub release; treat as "no structured notes"
         }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/GzipDecode.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/GzipDecode.swift
@@ -15,6 +15,21 @@ import Compression
 /// nil, never a throw.
 enum GzipDecode {
 
+    /// Ceiling on the scratch buffer `inflate` allocates, whatever a caller or a
+    /// gzip trailer asks for. See `inflate` for why capping it is free.
+    static let maxChunkBytes = 64 * 1024 * 1024
+
+    /// The scratch-buffer size `inflate` will actually allocate for a hint.
+    ///
+    /// Split out as a pure function so the ceiling can be asserted without
+    /// allocating what it refuses to allocate: the end-to-end test below it can
+    /// only show that a hostile ISIZE still decodes correctly, which a missing
+    /// ceiling also does — on a machine where a 4 GiB reservation happens to
+    /// succeed.
+    static func chunkSize(hint: Int) -> Int {
+        min(max(hint, 64 * 1024), maxChunkBytes)
+    }
+
     /// Decompress a complete gzip member. Returns nil on any malformation.
     static func decompress(_ data: Data) -> Data? {
         let bytes = [UInt8](data)
@@ -52,7 +67,9 @@ enum GzipDecode {
 
         // ISIZE (last 4 bytes, little-endian) is the uncompressed size mod 2^32 —
         // a good initial buffer hint. Clamp to a sane floor so a zero/tiny ISIZE
-        // doesn't starve the loop.
+        // doesn't starve the loop, and to a ceiling in `inflate` because nothing
+        // here has verified the trailer: it is the tail of a vendor response, and
+        // `0xFFFFFFFF` is a four-byte request for a 4 GiB allocation.
         let isize = Int(bytes[bytes.count - 4])
             | (Int(bytes[bytes.count - 3]) << 8)
             | (Int(bytes[bytes.count - 2]) << 16)
@@ -96,8 +113,14 @@ enum GzipDecode {
 
     /// Stream raw DEFLATE bytes through `compression_stream` until done.
     private static func inflate(_ deflate: [UInt8], hint: Int) -> Data? {
+        // Both pointers are placeholders that `compression_stream_init` requires
+        // to be non-null and never reads: the real `src_ptr`/`dst_ptr` are set
+        // inside the loop below, before the first `_process`. `dst_ptr` used to
+        // be an `allocate(capacity: 0)` that nothing ever deallocated — a leak on
+        // every call, however small. A dangling non-null address costs nothing
+        // and cannot be forgotten, which is what `src_ptr` was already doing.
         var stream = compression_stream(
-            dst_ptr: UnsafeMutablePointer<UInt8>.allocate(capacity: 0),
+            dst_ptr: UnsafeMutablePointer<UInt8>(bitPattern: 1)!,
             dst_size: 0,
             src_ptr: UnsafePointer<UInt8>(bitPattern: 1)!,
             src_size: 0,
@@ -107,7 +130,14 @@ enum GzipDecode {
         else { return nil }
         defer { compression_stream_destroy(&stream) }
 
-        let chunk = max(hint, 64 * 1024)
+        // The hint is a *hint*: this is a reusable scratch buffer the loop drains
+        // and refills until the stream ends, so a hint smaller than the output
+        // costs iterations, never correctness. That makes the ceiling free — and
+        // necessary, because `decompress` derives its hint from gzip's ISIZE
+        // trailer, four bytes of attacker-supplied data that can ask for 4 GiB.
+        // A vendor changelog is not 64 MiB; a page that claims to be gets decoded
+        // 64 MiB at a time instead of reserving the claim up front.
+        let chunk = chunkSize(hint: hint)
         let dstBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: chunk)
         defer { dstBuffer.deallocate() }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Redactor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/Redactor.swift
@@ -82,16 +82,10 @@ public enum Redactor {
     public static func text(_ input: String, limit: Int? = nil) -> String {
         var out = input
 
-        // `key=…` / `token: …` inside a URL, a query string, or a log line. Stops
-        // at the delimiters that end a value in any of those contexts.
-        let assignment = "(?i)\\b(" + sensitiveParameterNames
-            .map { NSRegularExpression.escapedPattern(for: $0) }
-            .joined(separator: "|")
-            + ")([A-Za-z_-]*)\\s*[=:]\\s*[^&\\s\"'<>,}]+"
-        out = replace(out, pattern: assignment, with: "$1$2=\(placeholder)")
+        out = replace(out, regex: assignmentRegex, with: "$1$2=\(placeholder)")
 
-        for pattern in secretPatterns {
-            out = replace(out, pattern: pattern, with: placeholder)
+        for regex in secretRegexes {
+            out = replace(out, regex: regex, with: placeholder)
         }
 
         if let limit, out.count > limit {
@@ -105,8 +99,29 @@ public enum Redactor {
         return sensitiveParameterNames.contains { lowered.contains($0) }
     }
 
-    private static func replace(_ input: String, pattern: String, with template: String) -> String {
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return input }
+    /// `key=…` / `token: …` inside a URL, a query string, or a log line. Stops
+    /// at the delimiters that end a value in any of those contexts.
+    ///
+    /// Compiled once, like `RecordedPath`'s patterns. Both this and
+    /// ``secretRegexes`` used to be built per call, and `text(_:limit:)` is not
+    /// a cold path: `Finding.redacted` runs it over every warning and every body
+    /// sample of every finding a sweep produces, so a `duo verify` run paid for
+    /// six `NSRegularExpression` compilations — one of them a twenty-name
+    /// alternation — several hundred times over. The inputs are constants, so
+    /// there was never a per-call pattern to build.
+    private static let assignmentRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: "(?i)\\b(" + sensitiveParameterNames
+            .map { NSRegularExpression.escapedPattern(for: $0) }
+            .joined(separator: "|")
+            + ")([A-Za-z_-]*)\\s*[=:]\\s*[^&\\s\"'<>,}]+")
+
+    private static let secretRegexes: [NSRegularExpression] =
+        secretPatterns.compactMap { try? NSRegularExpression(pattern: $0) }
+
+    private static func replace(
+        _ input: String, regex: NSRegularExpression?, with template: String
+    ) -> String {
+        guard let regex else { return input }
         return regex.stringByReplacingMatches(
             in: input, range: NSRange(input.startIndex..., in: input), withTemplate: template)
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/SystemProxyEnvironment.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/SystemProxyEnvironment.swift
@@ -26,6 +26,25 @@ enum SystemProxyEnvironment {
     /// Never overwrites a variable the caller already has: if the app *was*
     /// launched from a shell that exported `https_proxy`, that explicit choice
     /// wins over the system pane.
+    ///
+    /// **"Already has" folds case, and for one variable that has a consequence.**
+    /// `man curl`, ENVIRONMENT: "The environment variables can be specified in
+    /// lower case or upper case. The lower case version has precedence.
+    /// `http_proxy` is an exception as it is only available in lower case."
+    /// (read 2026-09-13 against the curl shipped on this machine). So an
+    /// inherited `HTTPS_PROXY` or `ALL_PROXY` is honoured by curl and skipping
+    /// the lowercase key is exactly right — but an inherited `HTTP_PROXY` is
+    /// read by nobody: curl ignores it, and this skips `http_proxy` because the
+    /// name is taken. That environment gets no HTTP proxy at all.
+    ///
+    /// Left that way on purpose. The alternative is to fill `http_proxy` from
+    /// the system pane while an explicit `HTTP_PROXY` names a different host,
+    /// which trades a visible gap for a silent redirect to a proxy the user did
+    /// not ask for — and this type's whole contract is that an explicit export
+    /// wins. Pinned by `upperCaseHTTPProxyBlocksTheLowerCaseKey`, which exists to
+    /// make the decision visible rather than to call it obviously right: an
+    /// `HTTP_PROXY`-only environment is the one shape where this rule costs
+    /// something, and whoever wants to revisit it should start from that test.
     static func applied(
         to env: [String: String],
         settings: [String: Any]? = currentSettings()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+GatewayRetry.swift
@@ -61,7 +61,7 @@ public extension URLSession {
     /// reproducing an origin's own exception) that a body shape does not change.
     /// A success status is what makes this a *disguised* outage rather than a
     /// stated one.
-    /// `purpose` only labels the request in ``RequestLedger``; it changes nothing
+    /// `purpose` only labels the request in ``RequestTotal``; it changes nothing
     /// about the fetch. It defaults to `.versionCheck` because that is what a
     /// version feed is — the one caller that is something else (`ChangelogService`
     /// fetching a release-notes feed through this same retry) passes its own.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+Updates.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/URLSession+Updates.swift
@@ -43,13 +43,13 @@ public extension URLSession {
     ///   particular. Raising the limit avoids connection queuing on hosts that
     ///   *don't* support HTTP/2 multiplexing.
     ///
-    /// - **Private, memory-only URL cache** (16 MB). Update sources rely on
+    /// - **Private, memory-only URL cache** (64 MB). Update sources rely on
     ///   standard HTTP caching (`ETag`/`If-None-Match`, `Cache-Control:
     ///   max-age`) — Sparkle appcast feeds and GitHub's `/releases/latest`
     ///   endpoint all send reuse-friendly headers. Caveat: cache *freshness* is
     ///   never trusted for a version feed — every source sets
     ///   ``URLRequest/versionFeedCachePolicy`` (see it for why). `ChangelogService`
-    ///   also uses this session, and 16 MB keeps several pages resident without
+    ///   also uses this session, and 64 MB keeps several pages resident without
     ///   evicting update-check responses. A private cache prevents eviction by
     ///   unrelated `.shared` activity.
     ///

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -2409,6 +2409,26 @@ private let typelessFixture = """
     #expect(json.contains("Ten paragraph"))
 }
 
+/// gzip's ISIZE trailer is four bytes of whoever served the response, and
+/// `decompress` hands it to the inflater as a buffer hint. Unclamped, a vendor
+/// page (or anything that can answer for one) could ask for a 4 GiB allocation
+/// by writing `FF FF FF FF` at the end of a 500-byte member.
+///
+/// Two assertions because either one alone is vacuous: the ceiling is what
+/// stops the allocation, and the round trip is what proves the ceiling did not
+/// buy that by breaking the decode — the buffer is scratch the loop refills, so
+/// a hint below the real output size only costs iterations.
+@Test func gzipDecodeClampsAHostileISIZETrailer() throws {
+    #expect(GzipDecode.chunkSize(hint: 0xFFFF_FFFF) == GzipDecode.maxChunkBytes)
+
+    let honest = try #require(Data(base64Encoded: typelessB64))
+    let expected = try #require(GzipDecode.decompress(honest))
+
+    var hostile = honest
+    hostile.replaceSubrange(hostile.count - 4..<hostile.count, with: [0xFF, 0xFF, 0xFF, 0xFF])
+    #expect(GzipDecode.decompress(hostile) == expected)
+}
+
 @Test func decodesTypelessSortedNewestFirstWithImages() throws {
     let changelog = try #require(StructuredChangelogDecoder.decode(
         typelessFixture, format: .typelessReleaseNotes, channel: nil, maxEntries: 12))

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreSchemaDriftTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/EventStoreSchemaDriftTests.swift
@@ -133,6 +133,73 @@ struct EventStoreSchemaDriftTests {
         }
     }
 
+    /// A table shaped like a machine that predates **both** denormalised
+    /// columns: no `app_id`, no `from_cache`, no `from_cache.backfilled` marker.
+    /// This is the shape `addColumnIfMissing` ×2 plus `backfillFromCache` were
+    /// written for, and the only shape that exercises all three at once.
+    ///
+    /// Seeded with one `request` row whose payload says it came from the local
+    /// cache, so the backfill has something to copy: a test that only checks the
+    /// marker cannot tell "the backfill ran" from "the backfill was skipped and
+    /// the marker written anyway".
+    private static func makePreColumnSchema(at url: URL) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &db,
+                              SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK,
+              let db else { throw URLError(.cannotCreateFile) }
+        defer { sqlite3_close_v2(db) }
+        let sql = """
+            PRAGMA auto_vacuum=INCREMENTAL;
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE events (
+              id        TEXT PRIMARY KEY,
+              at        INTEGER NOT NULL,
+              client    TEXT    NOT NULL,
+              kind      TEXT    NOT NULL,
+              purpose   TEXT,
+              host      TEXT,
+              status    INTEGER,
+              bytes_in  INTEGER,
+              bytes_out INTEGER,
+              payload   TEXT    NOT NULL
+            );
+            CREATE INDEX events_at ON events(at);
+            CREATE TABLE totals (
+              client TEXT NOT NULL, purpose TEXT NOT NULL, host TEXT NOT NULL,
+              requests INTEGER NOT NULL DEFAULT 0, cached INTEGER NOT NULL DEFAULT 0,
+              not_modified INTEGER NOT NULL DEFAULT 0, failures INTEGER NOT NULL DEFAULT 0,
+              bytes_sent INTEGER NOT NULL DEFAULT 0, bytes_received INTEGER NOT NULL DEFAULT 0,
+              first_seen INTEGER NOT NULL, last_seen INTEGER NOT NULL,
+              PRIMARY KEY (client, purpose, host));
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO events (id, at, client, kind, purpose, host, payload)
+            VALUES ('cached-row', 1, 'cli', 'request', 'versionCheck',
+                    'zzfixture.example', '{"fetchType":"localCache"}');
+            """
+        guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+            throw URLError(.cannotCreateFile)
+        }
+    }
+
+    /// `from_cache` for one event id, read on an independent connection.
+    /// `.some(nil)` is "the row is there and the column is NULL", which is what a
+    /// skipped backfill leaves behind; `nil` is "no such row".
+    private static func fromCache(id: String, at url: URL) throws -> Int?? {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK,
+              let db else { throw URLError(.cannotOpenFile) }
+        defer { sqlite3_close_v2(db) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            db, "SELECT from_cache FROM events WHERE id = ?;", -1, &statement, nil
+        ) == SQLITE_OK, let statement else { throw URLError(.cannotOpenFile) }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, id, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        if sqlite3_column_type(statement, 0) == SQLITE_NULL { return .some(nil) }
+        return Int(sqlite3_column_int64(statement, 0))
+    }
+
     // MARK: - Tests
 
     /// A fresh install's `events` table must be exactly the twelve columns and
@@ -224,5 +291,79 @@ struct EventStoreSchemaDriftTests {
             """) {
             #expect(upgradedColumns == freshColumns)
         }
+    }
+
+    /// The migration steps have to survive a database that does not exist yet.
+    ///
+    /// `createSchema` runs the repairs **before** the `CREATE TABLE IF NOT EXISTS`
+    /// batch, and that order is load-bearing on an upgraded database (see the
+    /// comment on `createSchema`). On a brand-new one it used to mean the repairs
+    /// ran against a database with no `events` and no `meta` table at all: four
+    /// `no such table` errors in the log, two notices claiming a column had been
+    /// added that had not, and — the part with a lasting consequence —
+    /// `backfillFromCache`'s `UPDATE` failing, so the `from_cache.backfilled`
+    /// marker was never written. The next launch therefore re-ran a full-table
+    /// `UPDATE events` that a fresh store can never need, and `backfillFromCache`'s
+    /// own doc comment ("Once, guarded by a marker") was false on exactly the
+    /// machines where the marker was cheapest to write.
+    ///
+    /// The marker is the assertion because it is the only durable trace: there is
+    /// no log seam in this package to assert the absent errors directly, and the
+    /// marker is what the errors cost.
+    @Test("A fresh install records the backfill marker on its first open")
+    func freshInstallRecordsBackfillMarkerOnFirstOpen() async throws {
+        let url = Self.tempURL()
+        defer { Self.remove(url) }
+        let store = Self.store(fileURL: url)
+        _ = await store.schemaProblems() // forces open() -> createSchema()
+
+        #expect(await store.metaMarker("from_cache.backfilled") != nil)
+        // Both columns still have to be there — the repairs being skipped on a
+        // fresh database is only correct because the `CREATE TABLE` declares them.
+        let columns = try Self.columnNames(table: "events", at: url)
+        #expect(columns.contains("app_id"))
+        #expect(columns.contains("from_cache"))
+    }
+
+    /// The other half of the same fix: skipping the repairs on a fresh database
+    /// must not skip them on a database that actually needs them.
+    ///
+    /// Starts from a store that predates both columns and holds one cache-hit row,
+    /// then asserts all three effects the migration owes it — `app_id` added,
+    /// `from_cache` added, and the row's flag copied out of the payload rather
+    /// than left NULL to be misread as "not from cache" by
+    /// `RequestQuery.notCached`.
+    @Test("A pre-column store gets both columns and a real backfill")
+    func preColumnStoreIsMigratedAndBackfilled() async throws {
+        let url = Self.tempURL()
+        defer { Self.remove(url) }
+        try Self.makePreColumnSchema(at: url)
+
+        let store = Self.store(fileURL: url)
+        _ = await store.schemaProblems()
+
+        let columns = try Self.columnNames(table: "events", at: url)
+        #expect(columns.contains("app_id"))
+        #expect(columns.contains("from_cache"))
+        #expect(await store.metaMarker("from_cache.backfilled") != nil)
+        // `.some(1)`, not `.some(nil)`: the backfill copied `$.fetchType`.
+        #expect(try Self.fromCache(id: "cached-row", at: url) == .some(1))
+    }
+
+    /// `addColumnIfMissing` reports whether the column is now there, and it has to
+    /// tell the truth: it used to log "added the … column" unconditionally, right
+    /// after an `ALTER TABLE` that could have failed, which is how a fresh
+    /// database produced two notices for columns nothing had added.
+    ///
+    /// Asked of a table that does not exist because that is the cheapest way to
+    /// make the `ALTER` fail on purpose.
+    @Test("addColumnIfMissing reports failure when the table is not there")
+    func addColumnIfMissingReportsFailureOnMissingTable() async throws {
+        let url = Self.tempURL()
+        defer { Self.remove(url) }
+        let store = Self.store(fileURL: url)
+        #expect(await store.addColumnForTesting(table: "zzfixture_absent", column: "c") == false)
+        #expect(await store.addColumnForTesting(table: "events", column: "app_id") == false,
+                "app_id is already declared, so there is nothing to add")
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SystemProxyEnvironmentTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SystemProxyEnvironmentTests.swift
@@ -74,6 +74,33 @@ import Foundation
         #expect(env["PATH"] == "/usr/bin")
     }
 
+    /// The one shape where "an explicit export wins" costs something, pinned so
+    /// the cost is visible rather than discovered.
+    ///
+    /// `applied` compares names case-insensitively, and `man curl` (ENVIRONMENT)
+    /// says `http_proxy` "is an exception as it is only available in lower case"
+    /// while every other proxy variable is read in either case. So an inherited
+    /// `HTTPS_PROXY` genuinely is the user's choice and rightly blocks ours — but
+    /// an inherited `HTTP_PROXY` is read by nobody, and blocking `http_proxy`
+    /// leaves curl with no HTTP proxy at all.
+    ///
+    /// Asserted, not fixed: see `applied`'s doc comment for why filling the
+    /// lowercase key from the system pane is the worse trade. If that decision is
+    /// ever revisited, this is the test that changes.
+    @Test func upperCaseHTTPProxyBlocksTheLowerCaseKey() {
+        let env = SystemProxyEnvironment.applied(
+            to: ["HTTP_PROXY": "http://shell.example:8080"], settings: httpSettings)
+        #expect(env["HTTP_PROXY"] == "http://shell.example:8080")
+        #expect(env["http_proxy"] == nil)
+        // The same fold on a variable curl *does* read in either case is simply
+        // correct, which is why the rule is not wrong in general.
+        let https = SystemProxyEnvironment.applied(
+            to: ["HTTPS_PROXY": "http://shell.example:8080"], settings: httpSettings)
+        #expect(https["https_proxy"] == nil)
+        // And an untaken name is still filled in both cases.
+        #expect(env["https_proxy"] == "http://127.0.0.1:6152")
+    }
+
     @Test func leavesEnvironmentUntouchedWhenSettingsAreUnreadable() {
         let env = SystemProxyEnvironment.applied(to: ["PATH": "/usr/bin"], settings: nil)
         #expect(env == ["PATH": "/usr/bin"])


### PR DESCRIPTION
## Findings addressed

From the 2026-09-13 review, the EventStore + Support cluster.

| Finding | Path | Status |
|---|---|---|
| L15 · fresh-DB migration order | `Events/EventStore.swift:1151-1158` | fixed |
| 注释≠代码 · backfill "Once, guarded by a marker" | `Events/EventStore.swift:1227` | fixed |
| P9 · statement leaks | `Events/EventStore.swift:535-540, 998-1002, 1298-1311` | fixed |
| P8 · Redactor compiles 6 regexes per call | `Support/Redactor.swift:87-111` | fixed |
| L15 · gzip ISIZE allocation + placeholder leak | `Support/GzipDecode.swift:56-62, 99-112` | fixed |
| L15 · uppercase `HTTP_PROXY` blocks the lowercase key | `Support/SystemProxyEnvironment.swift:35-51` | documented + pinned, behaviour unchanged (rationale below) |
| 注释≠代码 · 16 MB → 64 MB | `Support/URLSession+Updates.swift:46, 52` | fixed |
| 注释≠代码 · ``RequestLedger`` does not exist | `Events/RequestEvent.swift:15`, `Support/URLSession+GatewayRetry.swift:64` | fixed |
| 注释≠代码 · stale first sentences | `Events/RequestQuery.swift:499-502` | fixed |
| 注释≠代码 · `at` "stays ISO-8601" | `Events/DuoEvent.swift:114` | fixed |
| purpose label on a release-notes fetch | `Install/BrewFormulaReleaseService.swift:293` | fixed → `.changelog` |

`grep -rn` for every sentence touched: `RequestLedger` had exactly the two
copies above (both in this PR); `16 MB`, `Asked of the payload`, `stays
ISO-8601` and `guarded by a marker` had one each. No other copies exist.

## The EventStore fix, and why not by reordering

The comment at `createSchema` explains that the repairs must precede the
`CREATE TABLE IF NOT EXISTS` batch: `sqlite3_exec` abandons a batch at the
first error, so a statement naming a column an upgraded database does not yet
have takes every statement after it down with it (#462's real historical
failure). Putting the batch first would reopen exactly that.

So instead: the repairs are guarded on the table existing, and
`backfillFromCache` moves **below** the batch. It is not part of the batch, so
this does not touch the ordering invariant, and below the batch both the
`events` table it updates and the `meta` table holding its marker exist on
either path.

⚠️ **Honest note on the `tableExists` guard itself.** After the other two
changes, the only thing it still prevents is two spurious `.error` log lines on
the very first launch of a fresh install. Measured: replacing the condition with
`true` leaves all five `EventStoreSchemaDriftTests` green. So it is log hygiene
and stated intent, **not a pinned guard**, and both the code comment and this
paragraph say so rather than letting a future reader assume a test is watching
it. The two halves that do have consequences are both mutation-verified below.

## Red → green

```
$ swift test --filter EventStoreSchemaDriftTests     # before the fix
✘ Test "A fresh install records the backfill marker on its first open" recorded an issue
  at EventStoreSchemaDriftTests.swift:320:9: Expectation failed:
  await store.metaMarker("from_cache.backfilled") != nil
✘ Test "addColumnIfMissing reports failure when the table is not there" recorded an issue
  at EventStoreSchemaDriftTests.swift:365:9: Expectation failed:
  await store.addColumnForTesting(table: "zzfixture_absent", column: "c") == false
✘ Test run with 5 tests in 1 suite failed with 3 issues (including 1 known issue)

$ swift test --filter EventStoreSchemaDriftTests     # after
━ Test run with 5 tests in 1 suite passed after 0.051 seconds with 1 known issue.
```

The one known issue is pre-existing: #462's `task_id` orphan column, already
wrapped in `withKnownIssue` on main.

`preColumnStoreIsMigratedAndBackfilled` passed before the fix and after it —
that is its job: it is the guard that the fresh-DB change did not also skip the
machines that genuinely need the repairs.

## Mutation checks (each reverted immediately after)

1. **`backfillFromCache` back above the batch** →
   `✘ "A fresh install records the backfill marker on its first open" … Expectation failed: await store.metaMarker("from_cache.backfilled") != nil`
2. **`addColumnIfMissing` logs/returns unconditionally again** →
   `✘ "addColumnIfMissing reports failure when the table is not there" … Expectation failed: … == false`
3. **`backfillFromCache`'s `UPDATE` replaced by `SELECT 1` (marker still written)** →
   `✘ "A pre-column store gets both columns and a real backfill" … Expectation failed: try Self.fromCache(id: "cached-row", at: url) == .some(1)`
4. **`tableExists(db, "events")` → `true`** → all 5 green. Recorded as the
   negative result it is, not hidden.
5. **gzip ceiling removed (`min(…, maxChunkBytes)` → `max(hint, 64 * 1024)`)** →
   `✘ gzipDecodeClampsAHostileISIZETrailer() … Expectation failed: GzipDecode.chunkSize(hint: 0xFFFF_FFFF) == GzipDecode.maxChunkBytes`
6. **proxy case-fold removed (`Set(env.keys.map { $0.lowercased() })` → `Set(env.keys)`)** →
   `✘ upperCaseHTTPProxyBlocksTheLowerCaseKey() … env["http_proxy"] == nil` and
   `… https["https_proxy"] == nil`

The gzip test asserts two things because either alone is vacuous: the ceiling is
what stops the allocation, and the round trip (patched ISIZE `FF FF FF FF`,
output byte-identical to the honest member) is what proves the ceiling did not
buy that by breaking the decode. A round trip alone would also pass with no
ceiling, on any machine where a 4 GiB reservation happens to succeed.

## SystemProxyEnvironment: documented, not changed

Verified against `man curl` on this machine (2026-09-13), ENVIRONMENT:

> The environment variables can be specified in lower case or upper case. The
> lower case version has precedence. `http_proxy` is an exception as it is only
> available in lower case.

So the gap is real but narrow — `HTTPS_PROXY` / `ALL_PROXY` inherited in
uppercase *are* honoured by curl, and skipping the lowercase key for them is
correct. Only `HTTP_PROXY` is read by nobody while still taking the name.

Declined to "fix" it by filling `http_proxy` from the system pane: that fills it
with the **pane's** host, not the user's, so an explicit `HTTP_PROXY` naming a
different proxy would be silently redirected — trading a visible gap for an
invisible one, against this type's own stated contract that an explicit export
wins. The consequence is now written into `applied`'s doc comment with the
source quoted, and `upperCaseHTTPProxyBlocksTheLowerCaseKey` pins it so the
decision is visible to whoever wants to revisit it.

## Behaviour a user could notice

1. **First launch of a fresh install** no longer logs four `no such table`
   errors and two false "added the … column" notices; the second launch no
   longer runs a full-table `UPDATE events`.
2. **Traffic breakdown / Requests window**: Homebrew formula release-notes
   fetches (`api.github.com/repos/…/releases/tags/…`) move from the **Catalog**
   row to the **Changelog** row, and stop showing the orange "Homebrew catalog"
   badge. `RequestPurpose` is stored per event, so hops recorded before this
   version keep their old label and the two rows disagree with their own history
   across the upgrade. No test asserted the old label.

Everything else is output-identical: `RedactionTests` (unchanged) passes against
the hoisted regexes, and the statement-leak restructure changes no return value.

## make test

```
$ make test > /tmp/mt-eventstore.log 2>&1; echo exit=$?
exit=0
```

```
━ Test run with 2782 tests in 228 suites passed after 21.381 seconds with 2 known issues.
✔ Test run with 280 tests in 34 suites passed after 0.254 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 261 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
✓ app audits consistent — 121 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 531 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 26) match the initializers
✓ no machine-population claims in code comments — 531 files
```

Both known issues are pre-existing on main (#462's `task_id`, and
`ankiZeroPaddedTagComparesEqualToInstalled`).

No recipe or parser rule changed, so no `duo verify` run. No `App/Sources` row
drawing changed, so no `make gallery` run.
