### PR TITLE
Install outcomes: don't count a pkg hand-off as an update, don't report a landed swap as a failure, and stop a cancelled download

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -3151,9 +3151,11 @@ final class AppListModel {
 
     /// Install an update, routing to the right installer for its source. `notify`
     /// is false for the batch path so "Update All" posts one summary banner
-    /// instead of one per app. Returns true only when a bundle was actually
-    /// installed (not when the app turned out already-current, or an early-out/
-    /// error path was taken) so the batch summary count is exact.
+    /// instead of one per app. Returns `.installed` only when a bundle was actually
+    /// installed — not when the app turned out already-current, an early-out/error
+    /// path was taken (`.notInstalled`), or a `.pkg` was handed to macOS's
+    /// Installer (`.handedOffToSystemInstaller`, which is neither) — so the batch
+    /// summary count is exact.
     ///
     /// The per-app "updated"/"ready to restart" banners are NOT gated on
     /// `prefs.notifyOnUpdates`: that setting governs unsolicited *background*
@@ -3167,17 +3169,17 @@ final class AppListModel {
     /// `lsappinfo` call that can stall right after we relaunch apps) blocked the
     /// next install from starting. `installAll` runs it once after the whole batch.
     @discardableResult
-    func install(_ result: UpdateResult, notify: Bool = true, deferBookkeeping: Bool = false) async -> Bool {
+    func install(_ result: UpdateResult, notify: Bool = true, deferBookkeeping: Bool = false) async -> InstallAttemptOutcome {
         let id = result.id
         // Re-entrancy / cross-path guard (matches `retry`): the popover "Update
         // anyway" button and the major-upgrade badge aren't disabled while an install
         // is in flight, so a double-click — or a manual click racing "Update All" for
         // the same app — could otherwise launch two concurrent installs (two
         // downloads, two in-place swaps, two notifications). Claim the id *before* any
-        // await so whoever sets `.queued` first wins and the loser returns false.
+        // await so whoever sets `.queued` first wins and the loser installs nothing.
         // `installAll` pre-claims all its targets, so a manual click on a queued batch
         // row no-ops here and the row keeps its spinner instead of a live button.
-        guard installing[id] == nil else { return false }
+        guard installing[id] == nil else { return .notInstalled }
         // Re-initiating clears a prior attempt's error/note right away, so a re-clicked
         // row shows a clean "Queued" spinner — not last failure's red error text
         // sitting beside it. (Otherwise the error only clears later in `performInstall`,
@@ -3196,7 +3198,7 @@ final class AppListModel {
     /// every target `.queued` up front (so each shows a queued spinner at once and
     /// the re-entrancy guard blocks a manual click) while the gates here still pace
     /// the actual installs.
-    private func runInstall(_ result: UpdateResult, notify: Bool, deferBookkeeping: Bool) async -> Bool {
+    private func runInstall(_ result: UpdateResult, notify: Bool, deferBookkeeping: Bool) async -> InstallAttemptOutcome {
         let id = result.id
         // Hold the list still for the duration — this row's rank is about to change
         // under whoever is clicking down the list. Every exit below clears
@@ -3240,7 +3242,7 @@ final class AppListModel {
         if Task.isCancelled {
             installing[id] = nil
             await gate?.signal()
-            return false
+            return .notInstalled
         }
         // What the host gate protects is a HOST'S BANDWIDTH, so it belongs to the
         // download phase and nothing after it — see
@@ -3267,9 +3269,9 @@ final class AppListModel {
                 ?? String(describing: error)
             installing[id] = nil
             await hostGate.release()
-            return false
+            return .notInstalled
         }
-        let didInstall = await performInstall(
+        let outcome = await performInstall(
             result, notify: notify, deferBookkeeping: deferBookkeeping,
             releaseAfterDownload: isAppStore ? nil : hostGate)
         await ProcessInstallLock.shared.release()
@@ -3278,7 +3280,7 @@ final class AppListModel {
         // deferred — drain it now that the install is done (no-op in a batch, which
         // drains once at the end of `installAll`, and when nothing was deferred).
         await drainDeferredLocalRescan()
-        return didInstall
+        return outcome
     }
 
     /// A semaphore permit that can be handed to a callee to release early, while the
@@ -3304,7 +3306,7 @@ final class AppListModel {
     private func performInstall(
         _ result: UpdateResult, notify: Bool, deferBookkeeping: Bool,
         releaseAfterDownload: GateHandle? = nil
-    ) async -> Bool {
+    ) async -> InstallAttemptOutcome {
         let id = result.id
         installErrors[id] = nil
         installNotes[id] = nil
@@ -3359,7 +3361,7 @@ final class AppListModel {
                 localized: "No readable bundle was found right now — it may have been uninstalled, or its Info.plist could not be parsed.")
             await computeRestartInfo()
             installing[id] = nil
-            return false
+            return .notInstalled
         }
         // A regressed answer must NOT become the row. Writing it in replaces a
         // real "1.0.9 available" with "1.0.8, up to date", and an up-to-date row
@@ -3420,7 +3422,7 @@ final class AppListModel {
             // state is recomputed either way.
             await computeRestartInfo()
             installing[id] = nil
-            return false
+            return .notInstalled
         }
 
         // Install policy: a running self-updating app is handed to its own
@@ -3447,7 +3449,7 @@ final class AppListModel {
             // focus repeatedly.
             openSelfUpdater(result, activating: !deferBookkeeping)
             installing[id] = nil
-            return false
+            return .notInstalled
         }
 
         // The app's own updater may already have this release in flight. Ours would
@@ -3478,7 +3480,7 @@ final class AppListModel {
             installNotes[id] = note
             inFlightNotes[id] = note
             installing[id] = nil
-            return false
+            return .notInstalled
         }
 
         if let inFlight = SelfUpdaterStaging.inFlightDownload(for: result.app) {
@@ -3487,7 +3489,7 @@ final class AppListModel {
             installNotes[id] = note
             inFlightNotes[id] = note
             installing[id] = nil
-            return false
+            return .notInstalled
         }
 
         // Back up the current bundle first (when enabled) so this update can be
@@ -3561,10 +3563,15 @@ final class AppListModel {
                     // can offer "Install" — a re-open of this exact file — instead
                     // of "Update", which would download the same hundreds of
                     // megabytes again. If they dismiss the window the package is
-                    // still on disk and still the right version.
+                    // still on disk and still the right version. Reported as a
+                    // hand-off, not as an install: this used to return `true`, which
+                    // "Update All" counted, so a batch of two vendor-pkg apps
+                    // announced "2 apps were updated" with both Installer windows
+                    // still open and neither bundle replaced. It is not a failure
+                    // either — the row carries no error and keeps the staged package.
                     recordStagedPackage(result, packageURL: packageURL)
                     installing[id] = nil
-                    return true
+                    return .handedOffToSystemInstaller
                 }
             case .appStore:
                 // On the mas route a wrapped iPhone/iPad app can only be updated by
@@ -3586,13 +3593,13 @@ final class AppListModel {
                    result.remote?.appStore?.isRegionMismatch != true {
                     installing[id] = nil
                     if let url = result.remote?.appStore?.deepLink { NSWorkspace.shared.open(url) }
-                    return false
+                    return .notInstalled
                 }
                 // Reset the spinner on this early-out too (see Homebrew above) so a
                 // missing adamID can't wedge every future install for this app.
                 guard let adamID = result.remote?.appStore?.trackID else {
                     installing[id] = nil
-                    return false
+                    return .notInstalled
                 }
                 // Arm the reopen before anything can quit the app. On this route
                 // the store's own daemon terminates a running app to replace its
@@ -3640,7 +3647,7 @@ final class AppListModel {
                     // defer above hands it back.
                     reopenAfterQuit[id] = nil
                     installing[id] = nil
-                    return false
+                    return .notInstalled
                 }
                 // Pre-flight before we drive the store: the row may have gone current
                 // since the install-time re-check ran — the App Store's own background
@@ -3674,7 +3681,7 @@ final class AppListModel {
                     await refreshRow(result)
                     reopenAfterQuit[id] = nil
                     installing[id] = nil
-                    return false
+                    return .notInstalled
                 }
                 if result.remote?.appStore?.isRegionMismatch == true {
                     // Region-locked app (listed in a storefront other than the signed-in
@@ -3690,7 +3697,7 @@ final class AppListModel {
                         installing[id] = nil
                         installErrors[id] = AppStoreAXInstaller.AXError.notTrusted.errorDescription
                         presentAccessibilityPermissionFlow()
-                        return false
+                        return .notInstalled
                     }
                     try await appStoreAXInstaller.update(
                         trackID: adamID,
@@ -3767,7 +3774,7 @@ final class AppListModel {
                         installing[id] = nil
                         installErrors[id] = AppStoreAXInstaller.AXError.notTrusted.errorDescription
                         presentAccessibilityPermissionFlow()
-                        return false
+                        return .notInstalled
                     }
                 }
                 // The store is done fetching and installing: release before the
@@ -3822,7 +3829,7 @@ final class AppListModel {
                 }
                 installing[id] = nil
                 relaunching.remove(id)
-                return false
+                return .notInstalled
             }
             // The bundle was replaced in place (same path); drop its cached icon so
             // the row re-reads the new one instead of showing the old until restart.
@@ -3868,7 +3875,7 @@ final class AppListModel {
                 reopenIfQuitForUpdate(result, installSucceeded: false)
                 installing[id] = nil
                 relaunching.remove(id)
-                return false
+                return .notInstalled
             }
 
             // Tell the user it landed. If the app was running, its live process
@@ -3923,7 +3930,7 @@ final class AppListModel {
             reopenAfterQuit[id] = nil
             installing[id] = nil
             relaunching.remove(id)
-            return false
+            return .notInstalled
         } catch let error as AppManagementRequiredError {
             // The swap was blocked by the App Management privacy gate. There's no
             // API to request it, so guide the user to the right Settings pane with
@@ -3984,7 +3991,7 @@ final class AppListModel {
                 relaunching.remove(id)
                 await refreshRow(result)  // re-scan + re-check → up-to-date, error-free
                 installing[id] = nil       // clear the spinner last, matching the skip path
-                return false
+                return .notInstalled
             }
             Log.install.error("install failed: \(result.app.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
             installErrors[id] = error.localizedDescription
@@ -4007,8 +4014,8 @@ final class AppListModel {
         // Drop the "Relaunching…" indicator a confirmed App Store quit raised, on
         // every exit (success or error) so a failed/cancelled install can't strand it.
         relaunching.remove(id)
-        // True only if we reached the install path without throwing.
-        return !failed
+        // `.installed` only if we reached the install path without throwing.
+        return failed ? .notInstalled : .installed
     }
 
     /// True when the row's install error is the mas receipt-import dead end — mas
@@ -5900,7 +5907,7 @@ final class AppListModel {
     private func installInParallel(_ targets: [UpdateResult], limit: Int) async -> Int {
         guard !targets.isEmpty, limit > 0 else { return 0 }
         var installed = 0
-        await withTaskGroup(of: Bool.self) { group in
+        await withTaskGroup(of: InstallAttemptOutcome.self) { group in
             var next = 0
             var inFlight = 0
 
@@ -5920,8 +5927,8 @@ final class AppListModel {
             while inFlight < limit, addNext() {
                 inFlight += 1
             }
-            while let didInstall = await group.next() {
-                if didInstall { installed += 1 }
+            while let outcome = await group.next() {
+                if outcome.countsAsUpdatedApp { installed += 1 }
                 inFlight -= 1
                 if Task.isCancelled {
                     group.cancelAll()
@@ -6015,14 +6022,17 @@ final class AppListModel {
         let installerTargets = InstallBatchOrdering.sortByDownloadSize(rest.filter(requiresInstaller))
         let limit = min(Self.maxParallelInstalls, parallelTargets.count)
         Log.app.info("update all: \(targets.count, privacy: .public) apps, parallel=\(parallelTargets.count, privacy: .public), serial=\(serialTargets.count, privacy: .public), installer=\(installerTargets.count, privacy: .public), parallelism=\(limit, privacy: .public)")
-        // Count only the installs that actually happened (runInstall returns false for
-        // already-current/early-out/error), so the summary banner is exact.
+        // Count only the installs that actually happened — `runInstall` reports
+        // `.notInstalled` for already-current/early-out/error and
+        // `.handedOffToSystemInstaller` for a `.pkg` whose Installer window the user
+        // has yet to drive — so the summary banner is exact.
         var installed = 0
         installed += await installInParallel(parallelTargets, limit: limit)
         for target in serialTargets + installerTargets {
             if Task.isCancelled { break }
             // `runInstall`, not `install`: the target is already claimed above.
-            if await runInstall(target, notify: false, deferBookkeeping: true) {
+            if await runInstall(target, notify: false, deferBookkeeping: true)
+                .countsAsUpdatedApp {
                 installed += 1
             }
             if hitAppManagementGate(target) {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/Downloader.swift
@@ -77,6 +77,12 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     private let maxAttempts = 5
 
     private var continuation: CheckedContinuation<URL, Error>?
+    /// The attempt's data task, and whether a cancellation has already arrived for
+    /// it. Both live under `lock` with `continuation`: the cancellation handler runs
+    /// on whatever thread cancelled the Swift task, which is neither the caller's
+    /// nor the delegate queue.
+    private var inFlightTask: URLSessionTask?
+    private var attemptCancelled = false
     /// Guards `continuation` so the delegate callbacks (which fire on a concurrent
     /// delegate queue) can't double-resume or race a leaked resume.
     private let lock = NSLock()
@@ -274,6 +280,10 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
 
         var lastError: Error = URLError(.unknown)
         for attempt in 0..<maxAttempts {
+            // Stopping "Update All" has to stop the bytes. Checked before every
+            // attempt (not just the first) so a cancellation that arrives between
+            // two resumes is not answered with another request.
+            try Task.checkCancellation()
             do {
                 let result = try await runAttempt(url: url, headers: headers, partial: partial)
                 let secs = Date().timeIntervalSince(started)
@@ -282,6 +292,13 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
                 return result
             } catch {
                 lastError = error
+                // A cancelled transfer arrives here as URLSession's `-999`, which is
+                // an error like any other: without this it would be classified,
+                // logged as a download failure and — for the shapes that are
+                // transient — retried. Ask the task instead of the error, and say
+                // `CancellationError` so every caller up the chain (the coordinator,
+                // `installAll`) reads it as "stopped", not "failed".
+                try Task.checkCancellation()
                 // Bytes already on disk: the next attempt resumes from here, so it
                 // is the one number that says whether a retry is making progress.
                 let attrs = try? FileManager.default.attributesOfItem(atPath: partial.path)
@@ -296,8 +313,10 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
                 Log.install.notice(
                     "download retry \(attempt + 1, privacy: .public)/\(self.maxAttempts, privacy: .public): resuming from \(onDisk, privacy: .public) bytes on disk — \(error.localizedDescription, privacy: .public)")
                 // Brief, growing backoff (0.5s, 1.0s, …) so we don't hammer a CDN
-                // that's momentarily resetting connections.
-                try? await Task.sleep(nanoseconds: UInt64(attempt + 1) * 500_000_000)
+                // that's momentarily resetting connections. NOT `try?`: swallowing
+                // the sleep's cancellation put the loop straight into the next
+                // attempt, so a stop during a backoff bought one more full request.
+                try await Task.sleep(nanoseconds: UInt64(attempt + 1) * 500_000_000)
             }
         }
         Log.install.error(
@@ -343,9 +362,31 @@ final class Downloader: NSObject, URLSessionDataDelegate, @unchecked Sendable {
         lastReportedPercent = -1
 
         guard let session else { throw URLError(.unknown) }
-        return try await withCheckedThrowingContinuation { cont in
-            lock.lock(); continuation = cont; lock.unlock()
-            session.dataTask(with: request).resume()
+        lock.withLock { inFlightTask = nil; attemptCancelled = false }
+        // A URLSession task is not part of the Swift task tree: cancelling the
+        // `Task` that awaits this continuation leaves the transfer running to
+        // completion (up to five times over, with resume). Bridge the two.
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { cont in
+                lock.lock(); continuation = cont; lock.unlock()
+                let task = session.dataTask(with: request)
+                // Published before `resume()`, and the flag re-read after it: a
+                // cancellation that lands in that window would otherwise find no
+                // task to cancel and the transfer would run on unattended.
+                // `resume()` first either way — cancelling a task that was never
+                // resumed has no defined delivery, and the continuation must be
+                // resumed by `didCompleteWithError` or it leaks.
+                lock.lock(); inFlightTask = task; lock.unlock()
+                task.resume()
+                lock.lock(); let alreadyCancelled = attemptCancelled; lock.unlock()
+                if alreadyCancelled { task.cancel() }
+            }
+        } onCancel: {
+            lock.lock()
+            attemptCancelled = true
+            let task = inFlightTask
+            lock.unlock()
+            task?.cancel()
         }
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -186,9 +186,55 @@ public enum InPlaceSwap {
         }
     }
 
+    /// Where the bundle stood when a swap threw. Decided by the target's identity
+    /// before and after, not by its existence: after a successful replacement the
+    /// path exists too, so `fileExists` answers the same for two opposite outcomes.
+    ///
+    /// Pure and separately testable because the branch it drives is the difference
+    /// between "the update failed, go grant App Management" and "the update is
+    /// live". `replaceItemAt` really does produce the middle case — observed
+    /// restoring ToDesk on 2026-08-26, where the new bundle was in place and the
+    /// error came from removing the one it displaced — and `NSCocoaErrorDomain 513`
+    /// is exactly what `isAppManagementDenial` matches, so that landed install was
+    /// reported as a permission failure.
+    ///
+    /// Fail-closed: an identity we could not read on either side counts as
+    /// `unchanged`, i.e. a failure, rather than being promoted to a success.
+    enum SwapFailureSite: Equatable {
+        /// The exchange landed; the error came afterwards, from the cleanup. The
+        /// new version is live.
+        case replacedThenCleanupFailed
+        /// The app on disk is the one that was there before.
+        case unchanged
+        /// The target is gone from disk (the privileged path moved it aside and
+        /// could not restore it).
+        case targetMissing
+    }
+
+    static func classifySwapFailure(
+        targetExists: Bool, identityBefore: UInt64?, identityAfter: UInt64?
+    ) -> SwapFailureSite {
+        guard targetExists else { return .targetMissing }
+        if let before = identityBefore, let after = identityAfter, before != after {
+            return .replacedThenCleanupFailed
+        }
+        return .unchanged
+    }
+
+    /// What a completed `replace` did.
+    enum SwapOutcome: Equatable {
+        case replaced
+        /// The new bundle is in place, but the exchange's own cleanup failed — a
+        /// displaced bundle left behind, typically. A warning, not a failure: the
+        /// caller must go on to re-check the app and compute restart info, because
+        /// the version on disk has changed.
+        case replacedButCleanupFailed(String)
+    }
+
     /// Replace `target` with `newApp`. Tries a user-level atomic swap first; if the
     /// location needs admin rights, falls back to an authenticated copy.
-    static func replace(newApp: URL, over target: URL) throws {
+    @discardableResult
+    static func replace(newApp: URL, over target: URL) throws -> SwapOutcome {
         try validateTarget(target)
         stripQuarantine(newApp)
         // The single moment the user's disk actually changes. Logged at `.notice`
@@ -218,17 +264,29 @@ public enum InPlaceSwap {
             ? target.appendingPathComponent("Contents", isDirectory: true)
             : target
         let identityBefore = inode(of: identityTarget)
+        var cleanupFailure: String?
         Log.install.notice(
             "swap start: \(target.lastPathComponent, privacy: .public) elevated=\(elevated, privacy: .public)")
         defer {
             if replaced {
-                Log.install.notice("swap done: \(target.lastPathComponent, privacy: .public)")
+                if let cleanupFailure {
+                    Log.install.error(
+                        "swap replaced \(target.lastPathComponent, privacy: .public) but its cleanup failed — the new version is live and the caller is told to carry on: \(cleanupFailure, privacy: .public)")
+                } else {
+                    Log.install.notice("swap done: \(target.lastPathComponent, privacy: .public)")
+                }
             } else if FileManager.default.fileExists(atPath: identityTarget.path) {
-                let identityAfter = inode(of: identityTarget)
-                if let before = identityBefore, let after = identityAfter, before != after {
+                switch Self.classifySwapFailure(
+                    targetExists: true,
+                    identityBefore: identityBefore,
+                    identityAfter: inode(of: identityTarget)) {
+                case .replacedThenCleanupFailed:
+                    // Only the elevated and rotation paths reach this with the new
+                    // bundle live: the unprivileged one classifies the same way in
+                    // its `catch` and returns rather than throwing.
                     Log.install.error(
                         "swap threw for \(target.lastPathComponent, privacy: .public) but the bundle at that path was REPLACED anyway — the error came after the exchange, so the new version is live and the failure is in the cleanup")
-                } else {
+                case .unchanged, .targetMissing:
                     Log.install.error(
                         "swap did NOT replace \(target.lastPathComponent, privacy: .public) — the app on disk is unchanged")
                 }
@@ -250,7 +308,7 @@ public enum InPlaceSwap {
         if usesContentsRotation(target: target) {
             try rotateContents(newApp: newApp, over: target)
             replaced = true
-            return
+            return .replaced
         }
 
         if !elevated {
@@ -288,6 +346,22 @@ public enum InPlaceSwap {
                             "swap: left \(staged.lastPathComponent, privacy: .public) behind in \(parent.path, privacy: .public) — \(error.localizedDescription, privacy: .public)")
                     }
                 }
+                // Which of the two opposite things just happened. `replaceItemAt`
+                // can land the new bundle and then throw while removing the one it
+                // displaced, and both user-facing shapes below describe a CAUSE for
+                // an update that did not happen — so classifying first is what
+                // stops a landed install from being reported as a missing
+                // permission (the ToDesk restore of 2026-08-26: 513 both times).
+                // The cleanup failure is still said out loud, in the `defer`.
+                let site = Self.classifySwapFailure(
+                    targetExists: fm.fileExists(atPath: identityTarget.path),
+                    identityBefore: identityBefore,
+                    identityAfter: inode(of: identityTarget))
+                if site == .replacedThenCleanupFailed {
+                    replaced = true
+                    cleanupFailure = error.localizedDescription
+                    return .replacedButCleanupFailed(error.localizedDescription)
+                }
                 // `/Applications` is group-writable for admins, so we took the
                 // user-level path — but replacing *another app's* bundle is gated
                 // by App Management on macOS 13+. That denial surfaces as EPERM;
@@ -298,11 +372,12 @@ public enum InPlaceSwap {
                 throw SwapError.notReplaceable(error.localizedDescription)
             }
             replaced = true
-            return
+            return .replaced
         }
 
         try privilegedReplace(newApp: newApp, target: target)
         replaced = true
+        return .replaced
     }
 
     /// Whether replacing `target` has to go through the administrator prompt.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -221,13 +221,18 @@ public enum InPlaceSwap {
         return .unchanged
     }
 
-    /// What a completed `replace` did.
+    /// What a completed `replace` did. Both cases are success — `replace` returning
+    /// at all means the new version is live — and no caller branches on this today:
+    /// they discard it, which is the point of the second case existing instead of a
+    /// throw. The debris the cleanup left behind is reported in the log, not to the
+    /// row. (Surfacing it as a note on the row would need a channel through
+    /// `InstallCoordinator.Outcome`; deliberately not built.)
     enum SwapOutcome: Equatable {
         case replaced
-        /// The new bundle is in place, but the exchange's own cleanup failed — a
-        /// displaced bundle left behind, typically. A warning, not a failure: the
-        /// caller must go on to re-check the app and compute restart info, because
-        /// the version on disk has changed.
+        /// The exchange landed and then threw while clearing up after itself — the
+        /// bundle it displaced left behind, typically. The version on disk HAS
+        /// changed, so the install is finished: re-check and restart info must be
+        /// computed exactly as for `.replaced`.
         case replacedButCleanupFailed(String)
     }
 
@@ -281,9 +286,12 @@ public enum InPlaceSwap {
                     identityBefore: identityBefore,
                     identityAfter: inode(of: identityTarget)) {
                 case .replacedThenCleanupFailed:
-                    // Only the elevated and rotation paths reach this with the new
-                    // bundle live: the unprivileged one classifies the same way in
-                    // its `catch` and returns rather than throwing.
+                    // A backstop, and deliberately kept as one. All three exchange
+                    // paths now classify themselves and RETURN on this outcome, so
+                    // nothing throws its way here today — but a future throw added
+                    // after an exchange would otherwise be logged as "the app on
+                    // disk is unchanged", which is the untrue half of the pair this
+                    // whole comparison exists to separate.
                     Log.install.error(
                         "swap threw for \(target.lastPathComponent, privacy: .public) but the bundle at that path was REPLACED anyway — the error came after the exchange, so the new version is live and the failure is in the cleanup")
                 case .unchanged, .targetMissing:
@@ -306,9 +314,10 @@ public enum InPlaceSwap {
         // see `usesContentsRotation`. Never elevated, and that is not a shortcut:
         // the elevated route cannot do this at all (see `rotateContents`).
         if usesContentsRotation(target: target) {
-            try rotateContents(newApp: newApp, over: target)
+            let outcome = try rotateContents(newApp: newApp, over: target)
             replaced = true
-            return .replaced
+            if case .replacedButCleanupFailed(let reason) = outcome { cleanupFailure = reason }
+            return outcome
         }
 
         if !elevated {
@@ -375,9 +384,10 @@ public enum InPlaceSwap {
             return .replaced
         }
 
-        try privilegedReplace(newApp: newApp, target: target)
+        let elevatedOutcome = try privilegedReplace(newApp: newApp, target: target)
         replaced = true
-        return .replaced
+        if case .replacedButCleanupFailed(let reason) = elevatedOutcome { cleanupFailure = reason }
+        return elevatedOutcome
     }
 
     /// Whether replacing `target` has to go through the administrator prompt.
@@ -598,7 +608,8 @@ public enum InPlaceSwap {
     /// `staff`, so the group already had exactly the owner's rights — and the
     /// vendor's own installer restores `root:staff` the next time it runs. It is
     /// logged rather than left silent.
-    static func rotateContents(newApp: URL, over target: URL) throws {
+    @discardableResult
+    static func rotateContents(newApp: URL, over target: URL) throws -> SwapOutcome {
         let fm = FileManager.default
         let liveContents = target.appendingPathComponent("Contents", isDirectory: true)
         let sourceContents = newApp.appendingPathComponent("Contents", isDirectory: true)
@@ -659,6 +670,11 @@ public enum InPlaceSwap {
 
         let ownerBefore = (try? fm.attributesOfItem(atPath: liveContents.path))?[.ownerAccountName]
             as? String
+        // The identity of the thing this exchange replaces — `Contents`, not the
+        // bundle. Asking the bundle would answer "unchanged" for every outcome: a
+        // rotation deliberately leaves the outer directory's inode alone.
+        let identityBefore = inode(of: liveContents)
+        var cleanupFailure: String?
         do {
             // A named backup, not `nil`. `replaceItemAt` deletes it on success
             // (measured: the bundle holds `Contents` alone afterwards), so this
@@ -680,10 +696,24 @@ public enum InPlaceSwap {
                         "rotate: left \(rotationStagedName, privacy: .public) inside \(target.path, privacy: .public) — \(error.localizedDescription, privacy: .public)")
                 }
             }
-            if isAppManagementDenial(error) {
+            // `replaceItemAt` here can land the new `Contents` and then throw while
+            // removing the one it displaced, exactly as on the whole-bundle path —
+            // and it raises the same `NSCocoaErrorDomain 513` an App Management
+            // denial does, so the error cannot be asked. When it landed, the input
+            // method on disk IS the new build: fall through to the ownership carry
+            // below (which describes what is now live) and report a cleanup
+            // failure rather than throwing an update that happened away.
+            let site = classifySwapFailure(
+                targetExists: fm.fileExists(atPath: liveContents.path),
+                identityBefore: identityBefore,
+                identityAfter: inode(of: liveContents))
+            if site == .replacedThenCleanupFailed {
+                cleanupFailure = error.localizedDescription
+            } else if isAppManagementDenial(error) {
                 throw AppManagementRequiredError(targetPath: target.path)
+            } else {
+                throw SwapError.notReplaceable(error.localizedDescription)
             }
-            throw SwapError.notReplaceable(error.localizedDescription)
         }
         let ownerAfter = (try? fm.attributesOfItem(atPath: liveContents.path))?[.ownerAccountName]
             as? String
@@ -691,6 +721,8 @@ public enum InPlaceSwap {
             Log.install.notice(
                 "rotate: \(target.lastPathComponent, privacy: .public)/Contents changed owner from \(ownerBefore, privacy: .public) to \(ownerAfter ?? "?", privacy: .public) — unprivileged by necessity, see rotateContents")
         }
+        if let cleanupFailure { return .replacedButCleanupFailed(cleanupFailure) }
+        return .replaced
     }
 
     /// Refuse a rotation on a bundle that holds more than `Contents`. Hidden
@@ -709,7 +741,16 @@ public enum InPlaceSwap {
         }
     }
 
-    private static func privilegedReplace(newApp: URL, target: URL) throws {
+    private static func privilegedReplace(newApp: URL, target: URL) throws -> SwapOutcome {
+        // Read before anything moves. The shell's last clause —
+        // `{ chown …; rm -rf old; }` — runs AFTER the two renames have put the new
+        // bundle at `target`, so a failure there exits the chain non-zero with the
+        // update already live. Every other way the chain can fail leaves `target`'s
+        // identity where it was: `ditto` failing, `mv tgt old` failing, or
+        // `mv new tgt` failing and the in-band `mv old tgt` putting the original
+        // back (a rename preserves the inode, so the restored bundle answers with
+        // the same number it started with).
+        let identityBefore = inode(of: target)
         let shell = privilegedReplacementShell(newApp: newApp, target: target)
         let appleScript = "do shell script \"\(escapeForAppleScript(shell))\" with administrator privileges"
 
@@ -741,8 +782,24 @@ public enum InPlaceSwap {
             if isAuthorizationDeclined(msg) {
                 throw AuthorizationDeclinedError(targetPath: target.path)
             }
+            // Asked after the declined check, which is about a shell that never
+            // ran. This is the majority route — every root-owned bundle takes it,
+            // 28 apps in `/Applications` on the development machine by this file's
+            // own count — so "the cleanup failed" being reported as "the update
+            // failed" is not an edge case: the app really is on the new version and
+            // the row would have said otherwise.
+            if classifySwapFailure(
+                targetExists: FileManager.default.fileExists(atPath: target.path),
+                identityBefore: identityBefore,
+                identityAfter: inode(of: target)) == .replacedThenCleanupFailed {
+                // The osascript stderr, unedited: it is the only account of what the
+                // shell could not finish (a `.duoupdater-old` left behind, most
+                // likely), and it goes into the log line `replace` emits.
+                return .replacedButCleanupFailed(msg)
+            }
             throw SwapError.notReplaceable(msg)
         }
+        return .replaced
     }
 
     /// The authenticated shell transaction, split out so its metadata guarantees

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallAttemptOutcome.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallAttemptOutcome.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// What one install attempt actually did to the machine.
+///
+/// A `Bool` could not say it. Three outcomes reach the caller and only one of
+/// them is an app that is now updated:
+///
+///   * `installed` — a bundle was replaced (or the store finished an install).
+///   * `handedOffToSystemInstaller` — a vendor `.pkg` was staged and opened in
+///     macOS's Installer. Nothing is installed yet: the user drives that window,
+///     and a later rescan settles the row. It is not a failure either, so the row
+///     keeps its staged-package bookkeeping and gets no error.
+///   * `notInstalled` — an early-out (already current, missing id, cancelled) or
+///     a failure. Which one it was lives in the row's error, not here.
+///
+/// The distinction is load-bearing for the batch summary: "Update All" counts
+/// these to post "N apps were updated". While the hand-off returned `true`, a
+/// batch of two vendor-pkg apps announced "2 apps were updated" while both
+/// Installer windows were still open and nothing had been replaced.
+public enum InstallAttemptOutcome: Equatable, Sendable {
+    case installed
+    case handedOffToSystemInstaller
+    case notInstalled
+
+    /// Whether this attempt may be counted into "N apps were updated".
+    ///
+    /// Only a real install may. A hand-off is deliberately excluded rather than
+    /// folded in with the failures: it is the one non-failure that has not
+    /// updated anything *yet*.
+    public var countsAsUpdatedApp: Bool {
+        self == .installed
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DownloaderCancellationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/DownloaderCancellationTests.swift
@@ -1,0 +1,155 @@
+import Testing
+import Foundation
+import Network
+@testable import DuoUpdaterCore
+
+/// Stopping "Update All" has to stop the bytes.
+///
+/// A `URLSessionTask` is not part of the Swift task tree, so cancelling the task
+/// that awaits a download used to leave the transfer running: a 2 GB package
+/// stopped at 5% carried on to 100% — up to five times over, since the retry
+/// backoff was a `try?` that swallowed the cancellation too — and only the
+/// coordinator's check before the apply step noticed anything.
+///
+/// Driven against a loopback server that answers with headers and then simply
+/// stops sending, which is what "a transfer in flight" looks like from the client
+/// side, with no external network and no dependence on how fast this machine is.
+@Suite struct DownloaderCancellationTests {
+
+    /// Sends a response head declaring a large body, then a few bytes, then holds
+    /// the connection open forever. Every request head is recorded so a test can
+    /// tell "the transfer was stopped" from "the transfer was re-issued".
+    ///
+    /// All callbacks run on a dedicated serial queue rather than the shared global
+    /// pool, for the reason `DownloaderTrafficTests` documents: under a saturated
+    /// run the global pool's threads are all blocked on other tests' I/O and this
+    /// server would be starved.
+    private final class StallingHTTPServer: @unchecked Sendable {
+        private let listener: NWListener
+        private let queue = DispatchQueue(label: "StallingHTTPServer")
+        private let state = State()
+        let port: UInt16
+
+        /// Request heads, and the live connections — held so the framework does not
+        /// tear down a connection we are deliberately never finishing.
+        final class State: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _requests: [String] = []
+            private var _connections: [NWConnection] = []
+            var requestCount: Int { lock.withLock { _requests.count } }
+            func record(_ request: String) { lock.withLock { _requests.append(request) } }
+            func hold(_ conn: NWConnection) { lock.withLock { _connections.append(conn) } }
+            func closeAll() {
+                let conns = lock.withLock { _connections }
+                for conn in conns { conn.cancel() }
+            }
+        }
+
+        init(declaredTotal: Int, prefix: Data) throws {
+            let listener = try NWListener(using: .tcp, on: .any)
+            self.listener = listener
+            let queue = self.queue
+            let state = self.state
+
+            listener.newConnectionHandler = { conn in
+                state.hold(conn)
+                conn.start(queue: queue)
+                conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, _, _ in
+                    state.record(String(data: data ?? Data(), encoding: .utf8) ?? "")
+                    let head = [
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: \(declaredTotal)",
+                        "Accept-Ranges: bytes",
+                        "Connection: keep-alive",
+                    ].joined(separator: "\r\n") + "\r\n\r\n"
+                    var response = Data(head.utf8)
+                    response.append(prefix)
+                    // No completion work: the rest of the body never arrives and the
+                    // connection is never closed, so the client stays mid-transfer
+                    // until something cancels it.
+                    conn.send(content: response, completion: .contentProcessed { _ in })
+                }
+            }
+            listener.start(queue: queue)
+            var resolved: UInt16?
+            for _ in 0..<500 {
+                if let p = listener.port?.rawValue, p != 0 { resolved = p; break }
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            guard let p = resolved else { throw URLError(.cannotConnectToHost) }
+            self.port = p
+        }
+
+        var requestCount: Int { state.requestCount }
+        func stop() {
+            state.closeAll()
+            listener.cancel()
+        }
+    }
+
+    private enum Settled: Sendable, Equatable {
+        case cancelled
+        case otherError(String)
+        case completed
+        case neverStopped
+    }
+
+    /// How long the download is given to notice the cancellation. Not a measurement
+    /// of how fast it reacts — it reacts immediately — but a bound that separates
+    /// "stopped" from "ran on", which otherwise means waiting out URLSession's
+    /// 60 s timeout five times. Generous enough that a loaded 3-core runner cannot
+    /// turn a working stop into a red test (see the repo's note on wall-clock
+    /// bounds in a parallel suite).
+    private static let stopBudget: Duration = .seconds(20)
+
+    @Test func cancellingTheTaskStopsAnInFlightDownload() async throws {
+        let server = try StallingHTTPServer(declaredTotal: 50_000_000, prefix: Data(count: 4096))
+        defer { server.stop() }
+        let workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dl-cancel-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        let url = URL(string: "http://127.0.0.1:\(server.port)/blob.bin")!
+        let downloader = Downloader(destinationDir: workDir) { _ in }
+        let download = Task { try await downloader.download(url) }
+
+        // Wait for the request to actually reach the server: cancelling before the
+        // transfer is in flight would test the easy half.
+        for _ in 0..<1000 {
+            if server.requestCount > 0 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(server.requestCount == 1, "the download never reached the server")
+
+        download.cancel()
+
+        let settled = await withTaskGroup(of: Settled.self) { group in
+            group.addTask {
+                do {
+                    _ = try await download.value
+                    return .completed
+                } catch is CancellationError {
+                    return .cancelled
+                } catch {
+                    return .otherError(String(describing: error))
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: Self.stopBudget)
+                return .neverStopped
+            }
+            let first = await group.next() ?? .neverStopped
+            group.cancelAll()
+            return first
+        }
+
+        // `CancellationError`, not URLSession's `-999`: every caller up the chain
+        // (`InstallCoordinator`, then `installAll`) reads a stop as a stop rather
+        // than as a download failure with a red error on the row.
+        #expect(settled == .cancelled)
+        // And it stopped rather than resuming: a retry would have re-issued the GET
+        // with a `Range` header.
+        #expect(server.requestCount == 1)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallAttemptOutcomeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallAttemptOutcomeTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// "Update All" posts one banner saying how many apps it updated, and it counts
+/// the outcomes of the installs it ran. A vendor `.pkg` is not one of them: the
+/// batch stages the package and opens macOS's Installer, which the user then has
+/// to drive. While that hand-off returned the same `true` a finished swap did, a
+/// batch of two pkg apps announced "2 apps were updated" with both Installer
+/// windows still open and neither bundle replaced.
+///
+/// It is equally not a failure — the row keeps its staged package and shows no
+/// error — which is why it is a third case rather than being folded into either
+/// side.
+@Suite struct InstallAttemptOutcomeTests {
+
+    @Test func onlyARealInstallIsCountedIntoTheBatchBanner() {
+        #expect(InstallAttemptOutcome.installed.countsAsUpdatedApp)
+        #expect(!InstallAttemptOutcome.handedOffToSystemInstaller.countsAsUpdatedApp)
+        #expect(!InstallAttemptOutcome.notInstalled.countsAsUpdatedApp)
+    }
+
+    /// The hand-off must stay distinguishable from the failure/early-out case, not
+    /// merely uncounted: it is what tells the row it has a package waiting rather
+    /// than an install that went nowhere.
+    @Test func aHandOffIsNeitherAnInstallNorANonInstall() {
+        #expect(InstallAttemptOutcome.handedOffToSystemInstaller != .installed)
+        #expect(InstallAttemptOutcome.handedOffToSystemInstaller != .notInstalled)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SwapFailureClassificationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SwapFailureClassificationTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// `replaceItemAt` can put the new bundle in place and *then* throw while removing
+/// the one it displaced — observed restoring ToDesk on 2026-08-26. The error it
+/// throws then is `NSCocoaErrorDomain 513`, the same code an App Management denial
+/// raises, so the error alone cannot say which of the two opposite things happened:
+/// for a while the swap answered "go grant App Management" for an update that was
+/// already live, with `duo doctor` reporting the permission granted all along. Only
+/// the bundle's identity before and after settles it, and `fileExists` cannot —
+/// after a successful replacement the path exists too.
+///
+/// Tested as a function rather than through a real swap because nothing in this
+/// process can make the OS produce a land-then-throw on demand; the integration
+/// path (a vendor swap whose cleanup fails) stays a manual check. No fixture paths
+/// appear here on purpose: the classification takes identities, asks the file
+/// system nothing of its own, and so gives the same answer on every machine.
+@Suite struct SwapFailureClassificationTests {
+
+    /// The case the whole thing exists for.
+    @Test func aBundleWhoseIdentityChangedWasReplacedBeforeTheErrorArrived() {
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: 111, identityAfter: 222)
+            == .replacedThenCleanupFailed)
+    }
+
+    @Test func anUnchangedIdentityIsAFailedSwap() {
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: 111, identityAfter: 111)
+            == .unchanged)
+    }
+
+    /// Fail-closed. An identity we could not read on either side must not be
+    /// promoted to "replaced": reporting a genuinely failed install as a live
+    /// update is the more expensive direction to be wrong in — the row would stop
+    /// offering the update and the app would stay behind.
+    @Test func anUnreadableIdentityCountsAsUnchanged() {
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: nil, identityAfter: 222) == .unchanged)
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: 111, identityAfter: nil) == .unchanged)
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: nil, identityAfter: nil) == .unchanged)
+    }
+
+    /// The privileged path moves the target aside before moving the new bundle in,
+    /// so "gone from disk" is a third answer rather than a flavour of unchanged —
+    /// `recoverInterruptedSwaps` promotes the `.duoupdater-old` copy back on the
+    /// next launch, and the log line for it must not claim the app is fine.
+    @Test func aMissingTargetIsItsOwnAnswer() {
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: false, identityBefore: 111, identityAfter: nil) == .targetMissing)
+        // Even if something else took that path in the meantime: the target this
+        // swap was asked about is not there.
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: false, identityBefore: 111, identityAfter: 222) == .targetMissing)
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SwapFailureClassificationTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/SwapFailureClassificationTests.swift
@@ -11,11 +11,14 @@ import Testing
 /// the bundle's identity before and after settles it, and `fileExists` cannot —
 /// after a successful replacement the path exists too.
 ///
-/// Tested as a function rather than through a real swap because nothing in this
-/// process can make the OS produce a land-then-throw on demand; the integration
-/// path (a vendor swap whose cleanup fails) stays a manual check. No fixture paths
-/// appear here on purpose: the classification takes identities, asks the file
-/// system nothing of its own, and so gives the same answer on every machine.
+/// The decision is tested as a function, because nothing in this process can make
+/// `replaceItemAt` land-then-throw on demand; that integration path stays a manual
+/// check. The two identities it is fed are NOT assumed, though: the last two tests
+/// run the real exchange each path performs (a `Contents` rotation, and the
+/// elevated shell, whose cleanup is made to fail with a `uchg` file) and assert
+/// that the inodes it hands the classifier really do move. Every fixture path is
+/// invented (`ZZFixture-…`) and lives in a fresh scratch directory, so no test here
+/// depends on what this machine has installed.
 @Suite struct SwapFailureClassificationTests {
 
     /// The case the whole thing exists for.
@@ -55,5 +58,183 @@ import Testing
         // swap was asked about is not there.
         #expect(InPlaceSwap.classifySwapFailure(
             targetExists: false, identityBefore: 111, identityAfter: 222) == .targetMissing)
+    }
+
+    // MARK: - The identities the two other exchange paths hand it
+
+    /// A rotation (input methods) exchanges what is INSIDE the bundle, so the
+    /// identity it must ask about is `Contents`. Run against a real exchange rather
+    /// than made-up numbers, because the claim is about what `replaceItemAt` does to
+    /// the two inodes — and the second assertion is the whole reason `rotateContents`
+    /// may not reuse the whole-bundle question: the bundle's own inode is the thing
+    /// a rotation deliberately does not change, so asking it would answer
+    /// "unchanged" for a landed update as readily as for a failed one.
+    @Test func aRotationsIdentityLivesInContentsNotInTheOuterBundle() throws {
+        let fm = FileManager.default
+        let scratch = try scratch()
+        defer { try? fm.removeItem(at: scratch) }
+        let app = scratch.appendingPathComponent("ZZFixture-Rotation.app")
+        try fm.createDirectory(
+            at: app.appendingPathComponent("Contents"), withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: app.appendingPathComponent("Contents/old"))
+        let staged = app.appendingPathComponent(InPlaceSwap.rotationStagedName)
+        try fm.createDirectory(at: staged, withIntermediateDirectories: true)
+        try Data("new".utf8).write(to: staged.appendingPathComponent("new"))
+
+        let live = app.appendingPathComponent("Contents")
+        let bundleBefore = try inode(of: app)
+        let contentsBefore = try inode(of: live)
+        _ = try fm.replaceItemAt(
+            live, withItemAt: staged,
+            backupItemName: InPlaceSwap.rotationBackupName, options: [])
+        let contentsAfter = try inode(of: live)
+        let bundleAfter = try inode(of: app)
+
+        // The exchange really happened: new payload live, old gone.
+        #expect(fm.fileExists(atPath: app.appendingPathComponent("Contents/new").path))
+        #expect(!fm.fileExists(atPath: app.appendingPathComponent("Contents/old").path))
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: contentsBefore, identityAfter: contentsAfter)
+            == .replacedThenCleanupFailed)
+        // Same exchange, wrong question.
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: bundleBefore, identityAfter: bundleAfter)
+            == .unchanged)
+    }
+
+    /// The elevated shell's last clause — `{ chown …; rm -rf old; }` — runs after
+    /// the two renames, so a failure in it exits the chain non-zero with the new
+    /// bundle already live. That is the majority route (every root-owned bundle
+    /// takes it), and it used to come out as `SwapError.notReplaceable`.
+    ///
+    /// Reproduced for real, without a password panel: a `uchg` file inside the
+    /// bundle survives the rename (flags travel with the inode) and then makes
+    /// `rm -rf` fail with EPERM. The assertion is on the pair — non-zero status AND
+    /// a changed identity — which is precisely the input `privilegedReplace` now
+    /// classifies on.
+    @Test func anElevatedSwapWhoseCleanupFailsHasAlreadyPutTheNewBundleLive() throws {
+        let fm = FileManager.default
+        let scratch = try scratch()
+        defer {
+            _ = try? shell("/usr/bin/chflags -R nouchg '\(scratch.path)'")
+            try? fm.removeItem(at: scratch)
+        }
+        let target = scratch.appendingPathComponent("ZZFixture-Elevated.app")
+        let incoming = scratch.appendingPathComponent("ZZFixture-Incoming.app")
+        for (bundle, marker) in [(target, "old"), (incoming, "new")] {
+            try fm.createDirectory(
+                at: bundle.appendingPathComponent("Contents"), withIntermediateDirectories: true)
+            try Data(marker.utf8).write(to: bundle.appendingPathComponent("Contents/\(marker)"))
+        }
+        // The thing the trailing `rm -rf` will not be able to remove. Inside the
+        // bundle, not the bundle itself: a `uchg` bundle could not be renamed
+        // either, and then the exchange would never land — which is the other
+        // outcome, not this one.
+        let stubborn = target.appendingPathComponent("Contents/pinned")
+        try Data("pinned".utf8).write(to: stubborn)
+        #expect(try shell("/usr/bin/chflags uchg '\(stubborn.path)'") == 0)
+
+        let before = try inode(of: target)
+        let status = try shell(InPlaceSwap.privilegedReplacementShell(
+            newApp: incoming, target: target))
+        let after = try inode(of: target)
+
+        // The cleanup failed…
+        #expect(status != 0)
+        // …but the app at that path is the new one.
+        #expect(fm.fileExists(atPath: target.appendingPathComponent("Contents/new").path))
+        #expect(InPlaceSwap.classifySwapFailure(
+            targetExists: true, identityBefore: before, identityAfter: after)
+            == .replacedThenCleanupFailed)
+    }
+
+    /// The whole thing, end to end, on the rotation path — the land-then-throw CAN
+    /// be produced after all, and this is what it looks like: a `uchg` file inside
+    /// the `Contents` being displaced makes `replaceItemAt` install the new one and
+    /// then fail deleting the old, with `NSCocoaErrorDomain 513` — the same code
+    /// `isAppManagementDenial` matches, measured here, not assumed.
+    ///
+    /// `rotateContents` must therefore RETURN rather than throw: the input method on
+    /// disk is the new build, and the caller has to go on to re-check it.
+    @Test func aRotationWhoseCleanupFailsReportsSuccessWithAWarning() throws {
+        let fm = FileManager.default
+        let scratch = try scratch()
+        defer {
+            _ = try? shell("/usr/bin/chflags -R nouchg '\(scratch.path)'")
+            try? fm.removeItem(at: scratch)
+        }
+        let target = scratch.appendingPathComponent("ZZFixture-Rotation.app")
+        let incoming = scratch.appendingPathComponent("ZZFixture-RotationNew.app")
+        for (bundle, marker) in [(target, "old"), (incoming, "new")] {
+            try fm.createDirectory(
+                at: bundle.appendingPathComponent("Contents"), withIntermediateDirectories: true)
+            try Data(marker.utf8).write(to: bundle.appendingPathComponent("Contents/\(marker)"))
+        }
+        let stubborn = target.appendingPathComponent("Contents/pinned")
+        try Data("pinned".utf8).write(to: stubborn)
+        #expect(try shell("/usr/bin/chflags uchg '\(stubborn.path)'") == 0)
+
+        let outcome = try InPlaceSwap.rotateContents(newApp: incoming, over: target)
+
+        #expect(outcome != .replaced)
+        if case .replacedButCleanupFailed = outcome {} else {
+            Issue.record("expected a cleanup-failure outcome, got \(outcome)")
+        }
+        // The new build is what an input method would now load.
+        #expect(fm.fileExists(atPath: target.appendingPathComponent("Contents/new").path))
+    }
+
+    /// And the same thing through `replace` itself on the unprivileged whole-bundle
+    /// path — the finding's original shape. Before this, the 513 went to
+    /// `isAppManagementDenial`, the row said "macOS blocked the update: … App
+    /// Management permission", and the app on disk was already the new version.
+    @Test func anUnprivilegedSwapWhoseCleanupFailsReportsSuccessWithAWarning() throws {
+        let fm = FileManager.default
+        let scratch = try scratch()
+        defer {
+            _ = try? shell("/usr/bin/chflags -R nouchg '\(scratch.path)'")
+            try? fm.removeItem(at: scratch)
+        }
+        let target = scratch.appendingPathComponent("ZZFixture-Unprivileged.app")
+        let incoming = scratch.appendingPathComponent("ZZFixture-UnprivilegedNew.app")
+        for (bundle, marker) in [(target, "old"), (incoming, "new")] {
+            try fm.createDirectory(
+                at: bundle.appendingPathComponent("Contents"), withIntermediateDirectories: true)
+            try Data(marker.utf8).write(to: bundle.appendingPathComponent("Contents/\(marker)"))
+        }
+        let stubborn = target.appendingPathComponent("Contents/pinned")
+        try Data("pinned".utf8).write(to: stubborn)
+        #expect(try shell("/usr/bin/chflags uchg '\(stubborn.path)'") == 0)
+
+        let outcome = try InPlaceSwap.replace(newApp: incoming, over: target)
+
+        if case .replacedButCleanupFailed = outcome {} else {
+            Issue.record("expected a cleanup-failure outcome, got \(outcome)")
+        }
+        #expect(fm.fileExists(atPath: target.appendingPathComponent("Contents/new").path))
+    }
+
+    // MARK: - Helpers
+
+    private func scratch() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DuoSwapClassifyTest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func inode(of url: URL) throws -> UInt64 {
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        return try #require(attrs[.systemFileNumber] as? NSNumber).uint64Value
+    }
+
+    private func shell(_ command: String) throws -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
     }
 }


### PR DESCRIPTION
Addresses three findings from the 2026-09-13 review. None declined.

## L3 — staged pkg hand-off counted as an update (`App/Sources/AppListModel.swift:3557-3568` vs `6025-6026`)

`runInstall` returned `true` both for "a bundle was replaced" and for "a `.pkg`
was staged and macOS's Installer opened", and `installAll` counted that into
`UpdateNotifier.batchUpdated(count:)`. Two vendor-pkg apps in one batch →
"2 apps were updated" with both Installer windows still open.

`install` / `runInstall` / `performInstall` now return
`InstallAttemptOutcome` (new, in Core) with three cases. The hand-off is
`.handedOffToSystemInstaller`: it keeps its bookkeeping (`recordStagedPackage`,
`installing[id] = nil`), sets no error, and is not counted. Both counting sites
(`installInParallel`'s task group and the serial loop) go through
`countsAsUpdatedApp`. Every caller of `runInstall`/`install` was checked — the
only consumer of the value is `installAll`; the two view call sites discard it
(`@discardableResult` kept). The doc comment at 3156 said "Returns true only
when a bundle was actually installed", which was the review's comment finding on
the same lines; it now describes all three cases. `grep -rn` for copies of that
sentence and of the "Count only the installs that actually happened" comment
found exactly those two, both updated in this commit.

## L4 — replace-then-throw still thrown as a failure (`Install/InPlaceSwap.swift`)

The inode before/after comparison only drove the `defer` log; the `catch` still
threw `AppManagementRequiredError` / `SwapError.notReplaceable`, so a swap that
landed and then threw during cleanup (ToDesk, 2026-08-26 — `NSCocoaErrorDomain
513` both times) sent the user to grant a permission they already had, and
`needsRestart` was never computed.

The comparison is now `InPlaceSwap.classifySwapFailure(targetExists:
identityBefore:identityAfter:)`, used by both the log and the `catch`.
`.replacedThenCleanupFailed` no longer throws: `replace` returns
`SwapOutcome.replacedButCleanupFailed`, so `SparkleInstaller`, `VendorInstaller`
and `BackupStore.restore` (and the App's `rollback` catch, which only sees
throws) all carry on as they do for a successful swap — recheck, restart info,
no `installErrors[id]`. The cleanup problem is logged as an error line naming
the underlying failure. Fail-closed: an identity unreadable on either side is
`.unchanged`, i.e. still a failure.

`replace` is `@discardableResult`; no caller consumes the outcome yet. Surfacing
"updated, but cleanup failed" in the UI would need a note channel through
`InstallCoordinator.Outcome` and is deliberately not in this change.

## L12 — a stopped "Update All" did not stop the download (`Install/Downloader.swift`)

Zero cancellation handling: the URLSessionTask is not in the Swift task tree, so
a cancelled download ran to completion — up to five times over, since the retry
backoff's `try? await Task.sleep` swallowed the cancellation as well.

* `Task.checkCancellation()` at the top of each attempt and in the `catch`
  (which converts URLSession's `-999` into `CancellationError`, so the
  coordinator and `installAll` read a stop as a stop, not as a failed install
  with a red row);
* the backoff sleep is `try`, not `try?`;
* the in-flight data task is cancelled from a `withTaskCancellationHandler`,
  with the task published under the existing `lock` before `resume()` and the
  flag re-read after it so a cancellation landing in that window still cancels.

Resume/`Range`/`If-Range`/partial-file behaviour is untouched.

## Red → green and mutation evidence

All three test suites are new. Each mutation below was applied to the fixed
code, run, and reverted.

`DuoUpdaterCore && swift test --filter "DownloaderCancellationTests|SwapFailureClassificationTests|InstallAttemptOutcomeTests"`

```
✔ Test run with 7 tests in 3 suites passed after 0.049 seconds.
```

Mutation 1 — remove `withTaskCancellationHandler` from `runAttempt` (restore the
bare continuation):

```
✘ Test cancellingTheTaskStopsAnInFlightDownload() recorded an issue at DownloaderCancellationTests.swift:150:9: Expectation failed: settled == .cancelled
↳   settled → .neverStopped
✘ Test run with 1 test in 1 suite failed after 61.093 seconds with 1 issue.
```

Mutation 2 — remove the `try Task.checkCancellation()` from the retry `catch`:

```
✘ Test cancellingTheTaskStopsAnInFlightDownload() recorded an issue at DownloaderCancellationTests.swift:150:9: Expectation failed: settled == .cancelled
↳   settled → .otherError("Error Domain=NSURLErrorDomain Code=-999 \"cancelled\" ...")
✘ Test run with 1 test in 1 suite failed after 0.057 seconds with 1 issue.
```

Mutation 3 — invert the inode comparison in `classifySwapFailure`
(`before != after` → `before == after`):

```
✘ Test aBundleWhoseIdentityChangedWasReplacedBeforeTheErrorArrived() recorded an issue at SwapFailureClassificationTests.swift:23:9
✘ Test anUnchangedIdentityIsAFailedSwap() recorded an issue at SwapFailureClassificationTests.swift:29:9
✘ Test run with 4 tests in 1 suite failed after 0.001 seconds with 2 issues.
```

Mutation 4 — widen `countsAsUpdatedApp` to `self != .notInstalled` (i.e. count
the hand-off again, which is the bug):

```
✘ Test onlyARealInstallIsCountedIntoTheBatchBanner() recorded an issue at InstallAttemptOutcomeTests.swift:19:9: Expectation failed: !InstallAttemptOutcome.handedOffToSystemInstaller.countsAsUpdatedApp
✘ Test run with 6 tests in 2 suites failed after 0.001 seconds with 1 issue.
```

Notes on test design:

* The cancellation test drives a loopback `NWListener` that sends a response
  head declaring a 50 MB body, 4 KB of it, and then holds the connection open.
  It waits for the request to reach the server before cancelling (so the
  transfer really is in flight), then bounds the wait at 20 s — not a
  measurement of reaction time (it settles in ~50 ms) but the only way to
  separate "stopped" from "ran on" without sitting through URLSession's 60 s
  timeout five times. It also asserts the server saw exactly one request, so a
  retry would fail it.
* `classifySwapFailure` is unit-tested rather than driven through a real swap:
  nothing in-process can make the OS produce a land-then-throw on demand. The
  integration path stays a manual check, and the test file says so. No fixture
  paths are used — the function takes identities and asks the file system
  nothing, so the tests give the same answer on every machine.
* The `InstallAttemptOutcome` wiring inside `AppListModel` is not covered by a
  test: that file is not in `DuoUpdaterAppTests`' sources (it pulls in SwiftUI
  and `AppListModel.init`), and adding it is explicitly not allowed. The
  three-way property it now depends on is what the Core test pins.

## Verification

```
$ make test > /tmp/mt.log 2>&1; echo exit=$?
exit=0
```

tail:

```
━ Test run with 2784 tests in 231 suites passed after 20.289 seconds with 2 known issues.
✔ Test run with 280 tests in 34 suites passed after 0.156 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 262 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
✓ app audits consistent — 121 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 535 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 26) match the initializers
✓ no machine-population claims in code comments — 535 files
```

`make gallery` was not run: nothing here changes how a row is drawn (the only
`App/Sources` change is `AppListModel`'s return types and comments; no view
file, no `RowActionState`). No recipe or parser rule changed, so no
`duo verify`.

## User-visible behaviour changes

1. A "Update All" containing vendor `.pkg` apps no longer counts them in the
   "N apps were updated" banner. If a batch is only pkg hand-offs, no banner is
   posted at all — nothing was updated yet.
2. An update whose swap landed but whose cleanup failed now completes: the row
   settles as updated / needs-restart instead of showing "macOS blocked the
   update: … App Management permission". The cleanup failure is in the log only.
3. Stopping a batch stops the download immediately rather than letting it finish
   in the background, and a stopped install leaves no red error on the row.


---

# Update (5154eea3) — review round 1

The first commit fixed only the unprivileged whole-bundle exchange. Both other
exchange paths had the same gap, and my own comment documented rather than
closed them. Closed now.

**`rotateContents`** (rotation, input methods) runs the same `replaceItemAt` and
threw unconditionally. It now classifies on the identity of `Contents` — the
thing a rotation actually replaces. (The outer bundle's inode is deliberately
left alone by a rotation, so asking it would answer "unchanged" for a landed
update as readily as for a failed one; `aRotationsIdentityLivesInContentsNotIn
TheOuterBundle` pins that with a real exchange.) On a landed exchange it falls
through to the staged-sibling cleanup and the ownership carry, both of which
describe what is now live, and returns `.replacedButCleanupFailed`.

**`privilegedReplace`** (elevated) had the same shape in shell:
`privilegedReplacementShell` ends with `{ chown …; rm -rf old; }`, which runs
*after* the two renames, so a failure there exits the chain non-zero with the
new bundle already at `target`. It now reads the target's inode before running
osascript and classifies on it, keeping the osascript stderr as the payload. The
declined-panel check still comes first (that shell never ran). This is the
majority route — by this file's own count every root-owned bundle takes it, 28
apps in `/Applications` on the development machine, 22 of them store-installed —
so "the cleanup failed" being reported as "the update failed" was not an edge
case.

Every other way the elevated chain can fail leaves the identity where it was:
`ditto` failing, `mv tgt old` failing, or `mv new tgt` failing with the in-band
`mv old tgt` putting the original back (a rename preserves the inode). Both
directions are now stated in the code.

`SwapOutcome`'s doc no longer implies callers branch on it: both cases are
success, the three callers discard it, the debris is reported in the log. Not
surfacing it to the row remains out of scope, as requested.

## The land-then-throw IS reproducible

I said in the first round that nothing in-process could produce one. That was
wrong, and the reviewer's request to test the rotation shape is what turned it
up: a `uchg` file inside the `Contents`/bundle being displaced makes
`replaceItemAt` install the new item and then fail to delete the old one with
`NSCocoaErrorDomain 513` — the exact code `isAppManagementDenial` matches,
measured rather than assumed. Probe output:

```
replaceItemAt THREW NSCocoaErrorDomain 513: You don’t have permission to save the file “Contents” …
inode before=238900387 after=238900390 changed=true
new live: true
```

So two of the three paths now have real end-to-end regression tests instead of
only a test of the extracted decision:

* `anUnprivilegedSwapWhoseCleanupFailsReportsSuccessWithAWarning` — drives
  `InPlaceSwap.replace` itself (the finding's original shape).
* `aRotationWhoseCleanupFailsReportsSuccessWithAWarning` — drives
  `InPlaceSwap.rotateContents`.

The elevated path cannot be driven end to end (it raises a password panel), so
`anElevatedSwapWhoseCleanupFailsHasAlreadyPutTheNewBundleLive` runs its real
shell unprivileged in a scratch directory and pins the pair the classification
stands on: non-zero exit status **and** a changed target identity, with the new
marker live at the target. The wiring inside `privilegedReplace` itself is
review-only; stated here rather than implied.

Fixtures are invented (`ZZFixture-*`) in a fresh scratch directory, and each
test clears `uchg` before removing it.

## Red → green and mutation evidence (this round)

`DuoUpdaterCore && swift test --filter SwapFailureClassificationTests`

```
✔ Test run with 8 tests in 1 suite passed after 0.189 seconds.
```

Mutation 5 — disable the classification in `rotateContents` (`if site ==
.replacedThenCleanupFailed` → `if false`), i.e. throw again:

```
✘ Test aRotationWhoseCleanupFailsReportsSuccessWithAWarning() recorded an issue at SwapFailureClassificationTests.swift:159:6: Caught error: AppManagementRequiredError(targetPath: ".../ZZFixture-Rotation.app")
✘ Test run with 1 test in 1 suite failed after 0.051 seconds with 1 issue.
```

Mutation 6 — same on the unprivileged path in `replace`:

```
✘ Test anUnprivilegedSwapWhoseCleanupFailsReportsSuccessWithAWarning() recorded an issue at SwapFailureClassificationTests.swift:191:6: Caught error: AppManagementRequiredError(targetPath: ".../ZZFixture-Unprivileged.app")
✘ Test run with 1 test in 1 suite failed after 0.104 seconds with 1 issue.
```

Both name the exact wrong answer the finding is about. Reverted after each.

## Verification

```
$ make test > /tmp/mt3.log 2>&1; echo exit=$?
exit=0
━ Test run with 2788 tests in 231 suites passed after 20.410 seconds with 2 known issues.
✔ Test run with 280 tests in 34 suites passed after 0.139 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 262 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
✓ app audits consistent — 121 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 535 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 26) match the initializers
✓ no machine-population claims in code comments — 535 files
```

## Behaviour change, restated

Point 2 in the list above now covers all three exchange paths, not just the
unprivileged one — including the elevated route, which is the one most installs
actually take.
