### PR TITLE
Move every blocking install/CLI call off the cooperative pool, and gate it

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1399,8 +1399,15 @@ final class AppListModel {
         // none per menu-bar open — everything else goes through
         // `githubTokenForRecheck`, which only reaches here on a miss.
         Log.app.info("GitHub token: resolving (explicit=\(explicit != nil, privacy: .public))")
+        // The resolve shells out to `gh auth token` and blocks in
+        // `waitUntilExit()`, so it goes to Dispatch rather than to the cooperative
+        // pool a detached task shares (see `offCooperativePool`). The task wrapper
+        // stays: it is what `firstResult` races the deadline against, and all it
+        // does itself is await.
         let loader = Task.detached(priority: .utility) {
-            GitHubToken.resolve(explicit: explicit)
+            await offCooperativePool(qos: .utility) {
+                GitHubToken.resolve(explicit: explicit)
+            }
         }
         if let token = await firstResult(of: loader, within: timeout) {
             return token
@@ -2283,6 +2290,10 @@ final class AppListModel {
             URL(fileURLWithPath: "/Library/Input Methods", isDirectory: true),
             home.appendingPathComponent("Library/Input Methods", isDirectory: true),
         ]
+        // The sweep's own blocking half (`SecStaticCode…` on every orphan it
+        // finds — the exact call #351 measured) hops inside
+        // `InPlaceSwap.recoverInterruptedSwaps`, which is async now that it takes
+        // the install lock. Nothing to do here but await it.
         Task.detached(priority: .utility) { [weak self] in
             var swept = true
             for root in roots {
@@ -4831,7 +4842,11 @@ final class AppListModel {
     /// relaunch a batch of apps during an install. Blocking `@MainActor` here
     /// froze the whole UI (spin report) and stranded the half-restarted app.
     nonisolated private static func runningBuildVersions() async -> [String: String] {
-        await Task.detached(priority: .utility) {
+        // Dispatch, not `Task.detached`: a detached task still runs on the
+        // cooperative pool, and the pair below (`readDataToEndOfFile()` +
+        // `waitUntilExit()`) parks whatever thread it lands on for as long as
+        // `coreservicesd` takes. See `offCooperativePool`.
+        await offCooperativePool(qos: .utility) {
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/lsappinfo")
             process.arguments = ["list"]
@@ -4867,7 +4882,7 @@ final class AppListModel {
             // instead of a live process list. This closure only owns invoking the
             // tool and its timeout/kill backstop.
             return LSAppInfoParser.runningBuildVersions(from: text)
-        }.value
+        }
     }
 
     /// Take down a note one of the restart paths wrote — and only if it is still
@@ -5784,9 +5799,13 @@ final class AppListModel {
             return
         }
         do {
-            let restored = try await Task.detached(priority: .userInitiated) { () -> String? in
+            // Off the cooperative pool, not merely off this actor: the restore
+            // dittos the stored bundle out and then runs the same blocking
+            // `InPlaceSwap.replace` an install does, and a detached task still runs
+            // on the pool. See `offCooperativePool`.
+            let restored = try await offCooperativePool(qos: .userInitiated) { () -> String? in
                 try BackupStore.restore(forKey: key, over: target)
-            }.value
+            }
             // The swap has landed; everything below is bookkeeping and needs no
             // exclusion, so hand the claim back rather than holding it through a
             // rescan (same reasoning as the apply permit in `performInstall`).

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -489,7 +489,8 @@ final class AppListModel {
         Task {
             let page = await Self.firstResult(
                 of: Task.detached(priority: .userInitiated) {
-                    TestFlightInventory().frontier(forBundleID: bundleID)?.appPageURL
+                    await TestFlightInventory.loadOffPool()
+                        .frontier(forBundleID: bundleID)?.appPageURL
                 },
                 within: .seconds(2))
             if let url = page ?? nil {
@@ -1399,7 +1400,13 @@ final class AppListModel {
         // none per menu-bar open — everything else goes through
         // `githubTokenForRecheck`, which only reaches here on a miss.
         Log.app.info("GitHub token: resolving (explicit=\(explicit != nil, privacy: .public))")
-        // The resolve shells out to `gh auth token` and blocks in
+        // A settings value or an env var answers here, with no subprocess, no hop
+        // and no deadline. Racing those was a regression: the hop has to be
+        // ADMITTED to a Dispatch queue, and on a loaded machine admission alone
+        // can outlast the two seconds — which turns a token the user pasted into
+        // "continuing without a token". See `GitHubToken.preresolved`.
+        if let cheap = GitHubToken.preresolved(explicit: explicit) { return cheap }
+        // Only `gh auth token` is left. It shells out and blocks in
         // `waitUntilExit()`, so it goes to Dispatch rather than to the cooperative
         // pool a detached task shares (see `offCooperativePool`). The task wrapper
         // stays: it is what `firstResult` races the deadline against, and all it
@@ -2036,7 +2043,7 @@ final class AppListModel {
     private static func beginTestFlightLoad(
         timeout: Duration = .seconds(2)
     ) async -> (inventory: TestFlightInventory, pendingLoader: Task<TestFlightInventory, Never>?) {
-        let loader = Task.detached(priority: .utility) { TestFlightInventory() }
+        let loader = Task.detached(priority: .utility) { await TestFlightInventory.loadOffPool(qos: .utility) }
         if let loaded = await firstResult(of: loader, within: timeout) {
             return (loaded, nil)
         }
@@ -2113,7 +2120,7 @@ final class AppListModel {
         let unread = TestFlightInventory(macRows: [], accessible: false)
         let inventory = mayRead
             ? await Self.firstResult(
-                of: Task.detached(priority: .userInitiated) { TestFlightInventory() },
+                of: Task.detached(priority: .userInitiated) { await TestFlightInventory.loadOffPool() },
                 within: .seconds(2)) ?? unread
             : unread
         // Granted, but the store did not open in time or at all: leave the rows as
@@ -2132,7 +2139,7 @@ final class AppListModel {
         guard !targets.isEmpty else { return }
         let announcements: TestFlightAnnouncements? = mayRead
             ? await Self.firstResult(
-                of: Task.detached(priority: .userInitiated) { TestFlightAnnouncements() },
+                of: Task.detached(priority: .userInitiated) { await TestFlightAnnouncements.loadOffPool() },
                 within: .seconds(2))
             : nil
         let signedIn: Bool? = mayRead ? await AppStoreSignIn.current() : nil
@@ -2388,7 +2395,7 @@ final class AppListModel {
         // them again, and they say they cannot tell (`ScanRowAssembly.roundPlan`,
         // below).
         let tfLoader: Task<TestFlightInventory, Never>? =
-            allowTestFlight ? Task.detached(priority: .utility) { TestFlightInventory() } : nil
+            allowTestFlight ? Task.detached(priority: .utility) { await TestFlightInventory.loadOffPool(qos: .utility) } : nil
         if allowTestFlight { testFlightReadThisSession = true }
 
         // The refresh button is the one intent that asks TestFlight to sync
@@ -2534,7 +2541,7 @@ final class AppListModel {
         // what that store says, and it sits in another app's container too.
         let announcements: TestFlightAnnouncements? = mayReadTestFlight
             ? await Self.firstResult(
-                of: Task.detached(priority: .userInitiated) { TestFlightAnnouncements() },
+                of: Task.detached(priority: .userInitiated) { await TestFlightAnnouncements.loadOffPool() },
                 within: .seconds(2))
             : nil
         // Whether this Mac is signed in to the App Store (`AppStoreSignIn`), read only
@@ -2629,13 +2636,13 @@ final class AppListModel {
             Log.app.notice("TestFlight sync: \(String(describing: outcome), privacy: .public)")
             if outcome.storeChanged,
                let synced = await Self.firstResult(
-                   of: Task.detached(priority: .userInitiated) { TestFlightInventory() },
+                   of: Task.detached(priority: .userInitiated) { await TestFlightInventory.loadOffPool() },
                    within: .seconds(2)),
                synced.accessible {
                 let targets = AppScanner.applyingTestFlightInventory(synced, to: checkable)
                     .filter(\.isTestFlightApp)
                 let syncedAnnouncements = await Self.firstResult(
-                    of: Task.detached(priority: .userInitiated) { TestFlightAnnouncements() },
+                    of: Task.detached(priority: .userInitiated) { await TestFlightAnnouncements.loadOffPool() },
                     within: .seconds(2))
                 let resync = UpdateChecker(
                     sources: makeSources(token: token),
@@ -2902,13 +2909,17 @@ final class AppListModel {
         // The scanner's default reads TestFlight's store — not when that read
         // cannot succeed (`mayReadTestFlightStore`).
         let readsTestFlight = mayReadTestFlightStore
-        let found = await Task.detached(priority: .userInitiated) {
+        // The whole closure off the cooperative pool, not just the TestFlight
+        // read: `AppScanner.scan()` is synchronous to the bottom and bounded the
+        // same way (see `BoundedBlockingWork`), so a detached task here parks a
+        // cooperative thread for as long as the app-data gate goes unanswered.
+        let found = await offCooperativePool(qos: .userInitiated) {
             AppScanner(
                 extraLocations: extraScan,
                 testflight: readsTestFlight
                     ? TestFlightInventory() : TestFlightInventory(macRows: [], accessible: false)
             ).scan()
-        }.value
+        }
         results = sorted(mergeScanned(found))
         await computeRestartInfo()
         await computeSelfUpdateStaging()
@@ -6500,13 +6511,14 @@ final class AppListModel {
         let extraScan = prefs.customScanLocations
         // Same gate as `refreshLocal`: the scanner's default reads TestFlight's store.
         let readsTestFlight = mayReadTestFlightStore
-        let found = await Task.detached(priority: .utility) {
+        // Off the cooperative pool for the reason `refreshLocal` gives.
+        let found = await offCooperativePool(qos: .utility) {
             AppScanner(
                 extraLocations: extraScan,
                 testflight: readsTestFlight
                     ? TestFlightInventory() : TestFlightInventory(macRows: [], accessible: false)
             ).scan()
-        }.value
+        }
         let mergedByID = Dictionary(
             mergeScanned(found).map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
         var next = results
@@ -6791,7 +6803,7 @@ final class AppListModel {
             mayRead: mayReadTestFlightStore,
             read: {
                 await Self.firstResult(
-                    of: Task.detached(priority: .userInitiated) { TestFlightInventory() },
+                    of: Task.detached(priority: .userInitiated) { await TestFlightInventory.loadOffPool() },
                     within: .seconds(2))
             },
             proofs: ResolvedChannelStore.Snapshot(),
@@ -6802,7 +6814,7 @@ final class AppListModel {
                 // unless the store was.
                 let announcements: TestFlightAnnouncements? = testflight.accessible
                     ? await Self.firstResult(
-                        of: Task.detached(priority: .userInitiated) { TestFlightAnnouncements() },
+                        of: Task.detached(priority: .userInitiated) { await TestFlightAnnouncements.loadOffPool() },
                         within: .seconds(2))
                     : nil
                 let signedIn: Bool? = testflight.accessible ? await AppStoreSignIn.current() : nil

--- a/App/Sources/PrivilegedHelperClient.swift
+++ b/App/Sources/PrivilegedHelperClient.swift
@@ -169,7 +169,10 @@ final class PrivilegedHelperClient: ObservableObject {
         // prompt. Callers guard against a second press while this is in flight.
         let label = HelperConfig.machServiceName
         // nil means it ran and succeeded; a string is why it didn't.
-        let failure: String? = await Task.detached(priority: .userInitiated) { () -> String? in
+        // Dispatch, not `Task.detached`: a detached task still runs on the
+        // cooperative pool, and the panel below parks the calling thread for as
+        // long as the user takes to answer it. See `offCooperativePool`.
+        let failure: String? = await offCooperativePool(qos: .userInitiated) { () -> String? in
             let shell = "/bin/launchctl kickstart -k system/\(label)"
             let script = "do shell script \"\(shell)\" with administrator privileges"
             let process = Process()
@@ -186,7 +189,7 @@ final class PrivilegedHelperClient: ObservableObject {
                 return String(data: errData, encoding: .utf8) ?? "unknown error"
             }
             return nil
-        }.value
+        }
         if let message = failure {
             // Dismissing the panel lands here too, and is a decision rather than a
             // fault: nothing ran, so nothing is claimed.

--- a/CLI/Sources/DuoKit/Backups.swift
+++ b/CLI/Sources/DuoKit/Backups.swift
@@ -211,9 +211,14 @@ public enum Backups {
     /// `Install.run`'s shape.
     private static func performRestore(app: InstalledApp, key: String, json: Bool) async -> Int32 {
         do {
-            let restored = try await Task.detached(priority: .userInitiated) { () -> String? in
-                try BackupStore.restore(forKey: key, over: app.path)
-            }.value
+            // Off the cooperative pool, not merely off this task: the restore
+            // dittos the stored bundle out and then runs the blocking
+            // `InPlaceSwap.replace`, and a detached task still runs on the pool.
+            // See `offCooperativePool`.
+            let path = app.path
+            let restored = try await offCooperativePool(qos: .userInitiated) { () -> String? in
+                try BackupStore.restore(forKey: key, over: path)
+            }
             if json {
                 emitRestoreJSON(app: app.name, key: key, restoredVersion: restored)
             } else {

--- a/CLI/Sources/DuoKit/Doctor.swift
+++ b/CLI/Sources/DuoKit/Doctor.swift
@@ -45,7 +45,7 @@ public enum Doctor {
             // reports a grant duo does not hold.
             isResponsibleForItself: TCCPreflight.isResponsibleForItself(),
             installedApp: installedAppPath(),
-            privilegedHelper: helperStatus(),
+            privilegedHelper: await helperStatus(),
             githubToken: tokenDescription(settings),
             alcoveCredentials: settings.alcove != nil,
             masInstalled: which("mas") != nil,
@@ -181,15 +181,21 @@ public enum Doctor {
     /// `/Library/LaunchDaemons`, so a file check reports "not registered" for a
     /// helper that is registered and running. (It did, on a machine where it
     /// was.)
-    static func helperStatus() -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-        process.arguments = ["print", "system/com.duoupdater.helper"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try? process.run()
-        process.waitUntilExit()
-        return process.terminationStatus == 0
+    ///
+    /// `async` because `waitUntilExit()` blocks and `run` is reached from the
+    /// cooperative pool: the wait goes to Dispatch (see `offCooperativePool`).
+    static func helperStatus() async -> String {
+        let registered = await offCooperativePool { () -> Bool in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            process.arguments = ["print", "system/com.duoupdater.helper"]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            try? process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        }
+        return registered
             ? "registered"
             : "not registered — approve it once in the menu-bar app; the CLI cannot register it"
     }

--- a/CLI/Sources/DuoKit/GitHub.swift
+++ b/CLI/Sources/DuoKit/GitHub.swift
@@ -43,10 +43,24 @@ enum GitHub {
             input.fileHandleForWriting.write(Data(stdin.utf8))
             try? input.fileHandleForWriting.close()
         }
+        // Drain both pipes CONCURRENTLY. Reading stdout to EOF and only then
+        // stderr deadlocks as soon as the child fills stderr's ~64KB buffer while
+        // stdout is still open — `gh` writes progress, deprecation and auth notices
+        // there — because it blocks in `write()`, stdout never reaches EOF, and
+        // neither side moves. Same failure shape and same fix as
+        // `ArchiveExtractor.run`.
+        let errData = Locked(Data())
+        let drained = DispatchSemaphore(value: 0)
+        let errHandle = errorPipe.fileHandleForReading
+        DispatchQueue.global().async {
+            let data = errHandle.readDataToEndOfFile()
+            errData.withLock { $0 = data }
+            drained.signal()
+        }
         let out = String(
             decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-        let err = String(
-            decoding: errorPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        drained.wait()
+        let err = String(decoding: errData.withLock { $0 }, as: UTF8.self)
         process.waitUntilExit()
 
         guard process.terminationStatus == 0 else {

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -458,7 +458,13 @@ case "triage":
     if let cap = args.int("max-calls") { triage.maxCalls = max(0, cap) }
     if let budget = args.int("budget") { triage.budget = TimeInterval(budget) }
     triage.dryRun = args.has("dry-run")
-    run = { Triage.run(triage) }
+    // Off the cooperative pool: `Triage.run` is synchronous end to end and waits
+    // on `opencode` with a `Thread.sleep` poll plus a semaphore, which would park
+    // the thread this closure is awaited on. One hop for the whole command — see
+    // `offCooperativePool`.
+    // Copied so the closure captures a value rather than the mutable local above.
+    let triageOptions = triage
+    run = { await offCooperativePool { Triage.run(triageOptions) } }
 
 case "reconcile":
     guard let report = args.value("report"), let baseline = args.value("baseline") else {
@@ -469,7 +475,9 @@ case "reconcile":
         baselinePath: URL(fileURLWithPath: baseline),
         triagePath: args.value("triage").map { URL(fileURLWithPath: $0) },
         dryRun: args.has("dry-run"))
-    run = { Reconcile.run(reconcile) }
+    // Off the cooperative pool, like `triage` above: `Reconcile.run` is
+    // synchronous and every issue it files waits on a `gh` subprocess.
+    run = { await offCooperativePool { Reconcile.run(reconcile) } }
 
 case "help":
     print(usage)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/AppStoreAXInstaller.swift
@@ -529,11 +529,16 @@ public actor AppStoreAXInstaller {
             .runningApplications(withBundleIdentifier: "com.apple.AppStore").first {
             return (app, false)
         }
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        p.arguments = ["-g", "-b", "com.apple.AppStore"]  // -g background, -b by bundle id
-        try p.run()
-        p.waitUntilExit()
+        // Off the cooperative pool: `open` is quick but `waitUntilExit()` parks
+        // whatever thread it is called on, and this one belongs to a pool that
+        // does not overcommit. See `offCooperativePool`.
+        try await offCooperativePool {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            p.arguments = ["-g", "-b", "com.apple.AppStore"]  // -g background, -b by bundle id
+            try p.run()
+            p.waitUntilExit()
+        }
         return (try await waitForAppStore(), true)
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/BrewFormulaReleaseService.swift
@@ -229,7 +229,13 @@ public actor BrewFormulaReleaseService {
         process.environment = env
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        // nullDevice, not `Pipe()`: an undrained stderr pipe deadlocks once its
+        // 64KB buffer fills — brew blocks writing (a long run of deprecation
+        // warnings or a Ruby backtrace is enough), we block forever in the
+        // `readDataToEndOfFile()` below waiting on stdout, which brew never
+        // reaches. Same failure shape, and same fix, as
+        // `BrewFormulaService.realExecutor`; this one was the last `Pipe()` left.
+        process.standardError = FileHandle.nullDevice
         do { try process.run() } catch { return nil }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/DeltaApplier.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/DeltaApplier.swift
@@ -100,16 +100,34 @@ public enum DeltaApplier {
         process.executableURL = tool
         process.arguments = ["apply", installedApp.path, destination.path, patch.path]
         let errPipe = Pipe()
-        let outPipe = Pipe()
         process.standardError = errPipe
-        process.standardOutput = outPipe
+        // nullDevice, not a `Pipe()` we read second: only stderr is used here, and
+        // draining stdout *after* stderr deadlocks the moment the tool fills
+        // stdout's ~64KB buffer while we are still waiting on stderr's EOF — it
+        // blocks in `write()`, we block in `readDataToEndOfFile()`, neither moves.
+        // Same reasoning as `BrewFormulaService.realExecutor`.
+        process.standardOutput = FileHandle.nullDevice
 
         try process.run()
+        // Watchdog: `BinaryDelta` reads the whole installed bundle and writes a new
+        // one, so a wedged run has no self-imposed bound and the caller is holding
+        // an apply permit throughout. SIGTERM at the cap, SIGKILL shortly after if
+        // it is ignored (a stuck process holds stderr's write end open, so the
+        // drain below would never return) — same pattern as
+        // `ArchiveExtractor.run`. Ten minutes is deliberately far above the work:
+        // the largest patch measured here reconstructs ChatGPT's 1.4 GB bundle in
+        // 7.5s, so nothing short of a hang can reach it.
+        let pid = process.processIdentifier
+        let term = DispatchWorkItem { process.terminate() }
+        let kill = DispatchWorkItem { Foundation.kill(pid, SIGKILL) }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 600, execute: term)
+        DispatchQueue.global().asyncAfter(deadline: .now() + 605, execute: kill)
         // Drained before `waitUntilExit` so a verbose failure can't fill the pipe
         // buffer and deadlock the tool against a reader that never runs.
         let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-        _ = outPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
+        term.cancel()
+        kill.cancel()
 
         guard process.terminationStatus == 0 else {
             let message = String(decoding: errData, as: UTF8.self)
@@ -150,7 +168,7 @@ public enum DeltaApplier {
         patchFile: URL,
         workDir: URL,
         edPublicKey: String?,
-        onStage: (InstallStage) -> Void
+        onStage: @escaping @Sendable (InstallStage) -> Void
     ) throws -> URL {
         guard let onDisk = InstalledBuild.read(at: installedApp) else {
             throw DeltaError.baselineUnreadable

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -801,9 +801,16 @@ public enum InPlaceSwap {
         // `/Applications` on the development machine, 22 of them store-installed)
         // a batch can reach it twice at once — two system panels stacked over each
         // other, neither saying which app it belongs to. Blocking here rather than
-        // making `replace` async is deliberate: the callers are synchronous, and
-        // the thread this parks was going to sit in `waitUntilExit` waiting on the
-        // same human anyway, so this moves the wait rather than adding one.
+        // making `replace` async is deliberate: the thread this parks was going to
+        // sit in `waitUntilExit` waiting on the same human anyway, so this moves
+        // the wait rather than adding one.
+        //
+        // ⚠️ It parks whatever thread `replace` was called on, for as long as the
+        // user takes to answer — so every async caller must reach `replace`
+        // through `offCooperativePool`, never directly. Both installers and the
+        // rollback path do. An earlier version of this comment said "the callers
+        // are synchronous"; they are `async` and always were, which is exactly the
+        // shape #351 measured killing the runtime.
         elevationPanel.lock()
         defer { elevationPanel.unlock() }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InPlaceSwap.swift
@@ -90,12 +90,18 @@ public enum InPlaceSwap {
                 "another installer holds the install lock, sweep deferred: \(error, privacy: .public)")
             return false
         }
-        sweepInterruptedSwaps(in: directory)
-        // Unconditional rather than deferred, and it stays correct only because
-        // the sweep below neither throws nor suspends: there is no early return
-        // and no cancellation point between the claim and here. (`defer` cannot
-        // hold an `await` anyway.) Anything added to that function that can bail
-        // out early has to release the claim on its way.
+        // Off the cooperative pool: the sweep validates every orphan it finds with
+        // `SecStaticCodeCheckValidity`, which is the exact call #351 measured
+        // parking all three cooperative threads on a 3-core runner, and this is
+        // reached from a `Task.detached` that runs on that same pool. See
+        // `offCooperativePool`.
+        await offCooperativePool(qos: .utility) { sweepInterruptedSwaps(in: directory) }
+        // Unconditional rather than deferred, and it stays correct because the
+        // sweep neither throws nor returns early: the hop above suspends, but it
+        // is not cancellable and always resumes (see `offCooperativePool`), so
+        // there is still no path from the claim to here that skips the release.
+        // (`defer` cannot hold an `await` anyway.) Anything added to that
+        // function that can bail out early has to release the claim on its way.
         await lock.release()
         return true
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/InstallCoordinator.swift
@@ -199,7 +199,13 @@ public actor InstallCoordinator {
         let fromStore = (route == .appStore)
         let path = app.path
         let bundleID = app.bundleID
-        return await Task.detached(priority: .userInitiated) { () -> BackupOutcome in
+        // Dispatch, not `Task.detached`: a detached task still runs on the
+        // cooperative pool, and everything below blocks — `unreadableFiles` walks
+        // the bundle, `BackupStore.save` waits on `ditto`, and the input-method
+        // copy waits on another. Measured at 8.7s twice over for Word, which is
+        // 8.7s of a pool that is only as wide as the core count. See
+        // `offCooperativePool`.
+        return await offCooperativePool(qos: .userInitiated) { () -> BackupOutcome in
             // Only *sealed* unreadable files stop a backup. Unsealed ones are the
             // app's own runtime droppings; the copy skips them and still restores.
             let unreadable = BackupManifest.unreadableFiles(in: path)
@@ -251,7 +257,7 @@ public actor InstallCoordinator {
                     "backup: \(path.lastPathComponent, privacy: .public) failed — \(error.localizedDescription, privacy: .public)")
                 return .failed
             }
-        }.value
+        }
     }
 
     /// Fetch and apply `result` by `route`.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/MASInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/MASInstaller.swift
@@ -345,6 +345,11 @@ public actor MASInstaller {
     /// (absent binary, non-zero exit, timeout). `mas outdated` reaches the store for
     /// every installed MAS app, so we cap the wait: a stalled network must not hang
     /// the install pipeline.
+    ///
+    /// offpool-lint:allow — the wait here is the `terminationHandler` continuation,
+    /// not a parked thread; by the time the drain below runs the child has exited
+    /// and Foundation has closed the parent's copy of the write end, so it reads
+    /// buffered bytes and hits EOF without blocking.
     private func runOutdated() async -> Set<Int>? {
         guard let mas = Self.executablePath else { return nil }
         let process = Process()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/PackageInstaller.swift
@@ -175,16 +175,27 @@ public actor PackageInstaller {
         let sourceFingerprint = try verifyDownload(file)
         // A signed DMG is about to be parsed into a different inner file, so prove
         // the pathname still holds the exact enclosure whose EdDSA check passed.
-        // A direct pkg carries this proof into `handOver` instead, avoiding an
-        // extra full read of a potentially hundreds-of-megabytes package.
-        if file.pathExtension.lowercased() == "dmg", let sourceFingerprint,
-           try Self.contentFingerprint(of: file) != sourceFingerprint {
-            throw PackageError.downloadFailed(
-                "The download changed after source verification. Nothing was opened.")
+        // A direct pkg is not re-read here; it carries this proof into `handOver`
+        // as `approvedFingerprint`, which is then what the seals there are pinned
+        // against. It is NOT an extra full read saved — `handOver` hashes the file
+        // whole twice either way, deliberately (see its two-seal comment) — only
+        // one the DMG route pays on a different file.
+        if file.pathExtension.lowercased() == "dmg", let sourceFingerprint {
+            // Hashing hundreds of megabytes is blocking work, and this is reached
+            // from an async install. See `offCooperativePool`.
+            let seen = try await offCooperativePool { try Self.contentFingerprint(of: file) }
+            guard seen == sourceFingerprint else {
+                throw PackageError.downloadFailed(
+                    "The download changed after source verification. Nothing was opened.")
+            }
         }
 
         onStage(.installing)
-        let toOpen = try resolveInstaller(from: file, workDir: workDir, installedApp: installedApp)
+        // Off the cooperative pool: the DMG route mounts with `hdiutil` and copies
+        // with `ditto`, both through a blocking `waitUntilExit()`.
+        let toOpen = try await offCooperativePool { [self] in
+            try resolveInstaller(from: file, workDir: workDir, installedApp: installedApp)
+        }
         let directSourceFingerprint = toOpen.standardizedFileURL == file.standardizedFileURL
             ? sourceFingerprint : nil
         try await handOver(
@@ -245,8 +256,16 @@ public actor PackageInstaller {
     ) async throws {
         // Preliminary gate: an ordinary bad package must not retire the valid
         // Installer window it was meant to replace.
-        try applyPackageGate(toOpen, installedApp: installedApp)
-        let preliminarySeal = try Self.contentSeal(of: toOpen)
+        //
+        // Gate and seal go off the cooperative pool together, in ONE hop: the gate
+        // runs `pkgutil`/`xar`/`lsbom` and `SecStaticCode…` (the #351 call), the
+        // seal hashes the whole package — 375 MB for ToDesk — and the order between
+        // them is load-bearing, so it is not split across two hops. See
+        // `offCooperativePool`.
+        let preliminarySeal = try await offCooperativePool { [self] () -> ContentSeal in
+            try applyPackageGate(toOpen, installedApp: installedApp)
+            return try Self.contentSeal(of: toOpen)
+        }
         let pinnedFingerprint = approvedFingerprint ?? preliminarySeal.fingerprint
         if approvedFingerprint != nil,
            preliminarySeal.fingerprint != pinnedFingerprint {
@@ -257,8 +276,10 @@ public actor PackageInstaller {
         // Final gate: `beforeOpen` is async, so the user-owned temp path may have
         // changed while it ran. Re-establish every signature/identity invariant
         // immediately before handing the path to Installer.
-        try applyPackageGate(toOpen, installedApp: installedApp)
-        let finalSeal = try Self.contentSeal(of: toOpen)
+        let finalSeal = try await offCooperativePool { [self] () -> ContentSeal in
+            try applyPackageGate(toOpen, installedApp: installedApp)
+            return try Self.contentSeal(of: toOpen)
+        }
         guard finalSeal.fingerprint == pinnedFingerprint else {
             throw PackageError.downloadFailed(
                 "The installer changed after verification. Nothing was opened.")
@@ -434,7 +455,13 @@ public actor PackageInstaller {
         }
     }
 
-    private func applyPackageGate(_ package: URL, installedApp: URL) throws {
+    /// `nonisolated`, like the blocking helpers it reaches (`verifyOpenable`,
+    /// `packageSignature`, `runCapturingOutput`, `run`, `resolveInstaller`): all of
+    /// them read only `let` state, and they have to be callable from inside an
+    /// `offCooperativePool` hop, which by construction is not on this actor. The
+    /// actor was never the thing ordering these anyway — `handOver` already
+    /// suspends between its two gates, and `downloadAndOpen` awaits its download.
+    private nonisolated func applyPackageGate(_ package: URL, installedApp: URL) throws {
         if let packageGate {
             try packageGate(package, installedApp)
         } else {
@@ -445,7 +472,7 @@ public actor PackageInstaller {
     /// The fail-closed gate: only a signed `.pkg`/`.mpkg` whose Team ID matches the
     /// installed app may be handed to the system installer. Shared by the first
     /// open and every re-open.
-    private func verifyOpenable(_ toOpen: URL, installedApp: URL) throws {
+    private nonisolated func verifyOpenable(_ toOpen: URL, installedApp: URL) throws {
         // A `.pkg`/`.mpkg` runs install scripts (often with admin rights) the moment
         // the user confirms. The download's filename/extension is server-controlled
         // (`suggestedFilename`), so a hijacked or misconfigured endpoint could
@@ -728,7 +755,7 @@ public actor PackageInstaller {
     /// For a `.dmg` we mount it, copy the contained `.pkg` out (so the installer
     /// keeps working after we unmount), and return that; otherwise we open the
     /// file itself (a bare `.pkg`, or the `.dmg`/folder as a fallback).
-    private func resolveInstaller(from file: URL, workDir: URL, installedApp: URL) throws -> URL {
+    private nonisolated func resolveInstaller(from file: URL, workDir: URL, installedApp: URL) throws -> URL {
         guard file.pathExtension.lowercased() == "dmg" else { return file }
 
         let mountPoint = workDir.appendingPathComponent("mnt")
@@ -822,7 +849,7 @@ public actor PackageInstaller {
 
     /// `pkgutil --check-signature` validates the package chain and prints the
     /// Developer ID Installer certificate, whose parenthesized OU is the Team ID.
-    private func packageSignature(_ pkg: URL) -> (isValid: Bool, teamIdentifier: String?) {
+    private nonisolated func packageSignature(_ pkg: URL) -> (isValid: Bool, teamIdentifier: String?) {
         let result = runCapturingOutput("/usr/sbin/pkgutil", ["--check-signature", pkg.path])
         guard result.code == 0 else { return (false, nil) }
         return (true, Self.packageTeamIdentifier(fromPkgutilOutput: result.output))
@@ -892,7 +919,7 @@ public actor PackageInstaller {
     }
 
     @discardableResult
-    private func run(_ launchPath: String, _ args: [String]) -> Int32 {
+    private nonisolated func run(_ launchPath: String, _ args: [String]) -> Int32 {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: launchPath)
         p.arguments = args
@@ -907,7 +934,7 @@ public actor PackageInstaller {
     }
 
     @discardableResult
-    private func runCapturingOutput(_ launchPath: String, _ args: [String]) -> (code: Int32, output: String) {
+    private nonisolated func runCapturingOutput(_ launchPath: String, _ args: [String]) -> (code: Int32, output: String) {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: launchPath)
         p.arguments = args

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/SparkleInstaller.swift
@@ -210,13 +210,22 @@ public actor SparkleInstaller {
         onStage(.extracting)
         let newApp: URL
         if let patch = download.appliedPatch {
-            newApp = try DeltaApplier.reconstruct(
-                installedApp: result.app.path,
-                patch: patch,
-                patchFile: download.archiveURL,
-                workDir: download.workDir,
-                edPublicKey: publicKey,
-                onStage: onStage)
+            // Off the cooperative pool for the same reason as the extract below:
+            // `reconstruct` ends in `BinaryDelta`, whose `waitUntilExit()` parks the
+            // calling thread for the whole reconstruction. See `offCooperativePool`.
+            let installed = result.app.path
+            let patchFile = download.archiveURL
+            let work = download.workDir
+            let key = publicKey
+            newApp = try await offCooperativePool {
+                try DeltaApplier.reconstruct(
+                    installedApp: installed,
+                    patch: patch,
+                    patchFile: patchFile,
+                    workDir: work,
+                    edPublicKey: key,
+                    onStage: onStage)
+            }
         } else {
             // Off the cooperative pool for the same reason as the gates below:
             // `extractApp` shells out and blocks on `errDone.wait()` and
@@ -259,7 +268,7 @@ public actor SparkleInstaller {
         // caller surfaces a "Restart" prompt). We never force a quit — that would
         // skip the app's own save-on-quit flow.
         onStage(.installing)
-        try installApp(newApp, over: result.app.path)
+        try await installApp(newApp, over: result.app.path)
 
         onStage(.done)
     }
@@ -269,7 +278,13 @@ public actor SparkleInstaller {
     /// Replace the bundle at `target` with `newApp`. Validation, quarantine
     /// removal, atomic same-volume swap, and the privileged fallback all live in
     /// `InPlaceSwap`, shared with `VendorInstaller`.
-    private func installApp(_ newApp: URL, over target: URL) throws {
-        try InPlaceSwap.replace(newApp: newApp, over: target)
+    private func installApp(_ newApp: URL, over target: URL) async throws {
+        // Off the cooperative pool, like the extract and the gates above: the swap
+        // shells out, and its privileged route parks the calling thread inside
+        // `osascript` for as long as the user takes to answer the administrator
+        // panel. See `offCooperativePool`.
+        try await offCooperativePool {
+            try InPlaceSwap.replace(newApp: newApp, over: target)
+        }
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Install/VendorInstaller.swift
@@ -207,13 +207,22 @@ public actor VendorInstaller {
             // does both (45 of 45 patches signed), so its patch route ends up better
             // proven than this installer's full-archive path, which has no signature
             // to check at all.
-            newApp = try DeltaApplier.reconstruct(
-                installedApp: result.app.path,
-                patch: patch,
-                patchFile: download.archiveURL,
-                workDir: download.workDir,
-                edPublicKey: result.app.sparkleEdPublicKey,
-                onStage: onStage)
+            // Off the cooperative pool for the same reason as the extract below:
+            // `reconstruct` ends in `BinaryDelta`, whose `waitUntilExit()` parks the
+            // calling thread for the whole reconstruction. See `offCooperativePool`.
+            let installed = result.app.path
+            let patchFile = download.archiveURL
+            let work = download.workDir
+            let key = result.app.sparkleEdPublicKey
+            newApp = try await offCooperativePool {
+                try DeltaApplier.reconstruct(
+                    installedApp: installed,
+                    patch: patch,
+                    patchFile: patchFile,
+                    workDir: work,
+                    edPublicKey: key,
+                    onStage: onStage)
+            }
         } else {
             // 2. Gate 1 (optional) — SHA-512 over the exact bytes we downloaded.
             if let expected = remote.expectedSHA512 {
@@ -264,7 +273,7 @@ public actor VendorInstaller {
         // caller surfaces a "Restart" prompt). We never force a quit — that would
         // skip the app's own save-on-quit flow.
         onStage(.installing)
-        try installApp(newApp, over: result.app.path)
+        try await installApp(newApp, over: result.app.path)
 
         onStage(.done)
     }
@@ -335,7 +344,13 @@ public actor VendorInstaller {
 
     /// Validation, quarantine removal, atomic same-volume swap, and the privileged
     /// fallback all live in `InPlaceSwap`, shared with `SparkleInstaller`.
-    private func installApp(_ newApp: URL, over target: URL) throws {
-        try InPlaceSwap.replace(newApp: newApp, over: target)
+    private func installApp(_ newApp: URL, over target: URL) async throws {
+        // Off the cooperative pool, like the extract and the gates above: the swap
+        // shells out, and its privileged route parks the calling thread inside
+        // `osascript` for as long as the user takes to answer the administrator
+        // panel. See `offCooperativePool`.
+        try await offCooperativePool {
+            try InPlaceSwap.replace(newApp: newApp, over: target)
+        }
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStoreSignIn.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppStoreSignIn.swift
@@ -53,7 +53,7 @@ public enum AppStoreSignIn {
     /// `isSignedIn()` off the cooperative pool, for async callers: the read is a
     /// bounded but blocking open (see `offCooperativePool`).
     public static func current() async -> Bool? {
-        (try? await offCooperativePool { isSignedIn() }) ?? nil
+        await offCooperativePool { isSignedIn() }
     }
 
     /// Active App Store accounts' `activeMediaTypes`, and no other column.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -365,26 +365,44 @@ public enum ChangelogService {
         cachedToken = ResolvedToken(explicit: explicit, token: token, at: now)
     }
 
-    static func gitHubToken(now: Date = Date()) async -> String? {
+    /// - Parameter timeout: how long the `gh auth token` subprocess gets. A test
+    ///   seam as well as a knob: setting it to nothing is how
+    ///   `anExplicitTokenDoesNotRaceTheDeadline` proves the settings token is
+    ///   answered without entering the race at all.
+    static func gitHubToken(
+        now: Date = Date(), timeout: Duration = .seconds(2)
+    ) async -> String? {
         let (explicit, hit) = rememberedToken(now: now)
         if let hit { return hit }
 
-        // Resolved *outside* the lock and off the cooperative pool, with a
-        // deadline. `GitHubToken.resolve` runs `gh auth token` to completion with
-        // no timeout of its own, so a wedged credential helper (a keychain prompt
-        // nobody answers) would otherwise pin the lock forever and pile the whole
-        // changelog prewarm fan-out up behind it. `AppListModel.resolveGitHubToken`
-        // learned this already — "don't let a wedged `gh auth token` hold the
-        // whole refresh hostage forever" — and the lesson belongs here too.
-        let loader = Task.detached(priority: .utility) {
-            await offCooperativePool(qos: .utility) { GitHubToken.resolve(explicit: explicit) }
-        }
-        guard let resolved = await firstResult(of: loader, within: .seconds(2)) else {
-            // Timed out: deliberately *not* cached. Caching would extend one
-            // wedged `gh` into ten minutes of unauthenticated fetches; falling
-            // through unauthenticated for this one request is enough.
-            Log.source.error("changelog GitHub token resolve timed out — continuing anonymous")
-            return nil
+        let resolved: String?
+        if let cheap = GitHubToken.preresolved(explicit: explicit) {
+            // A settings value or an env var: two memory reads, no subprocess, so
+            // no hop and no deadline. Racing it was a real regression — on a
+            // loaded 3-core runner the hop's queue admission lost to the 2s
+            // timeout and a valid settings token resolved to nil. See
+            // `GitHubToken.preresolved`.
+            resolved = cheap
+        } else {
+            // Only `gh auth token` is left, and it runs to completion with no
+            // timeout of its own — so this half is resolved *outside* the lock,
+            // off the cooperative pool, and with a deadline. A wedged credential
+            // helper (a keychain prompt nobody answers) would otherwise pin the
+            // lock forever and pile the whole changelog prewarm fan-out up behind
+            // it. `AppListModel.resolveGitHubToken` learned this already — "don't
+            // let a wedged `gh auth token` hold the whole refresh hostage
+            // forever" — and the lesson belongs here too.
+            let loader = Task.detached(priority: .utility) {
+                await offCooperativePool(qos: .utility) { GitHubToken.resolve(explicit: explicit) }
+            }
+            guard let answered = await firstResult(of: loader, within: timeout) else {
+                // Timed out: deliberately *not* cached. Caching would extend one
+                // wedged `gh` into ten minutes of unauthenticated fetches; falling
+                // through unauthenticated for this one request is enough.
+                Log.source.error("changelog GitHub token resolve timed out — continuing anonymous")
+                return nil
+            }
+            resolved = answered
         }
 
         rememberToken(resolved, explicit: explicit, at: now)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -376,7 +376,9 @@ public enum ChangelogService {
         // changelog prewarm fan-out up behind it. `AppListModel.resolveGitHubToken`
         // learned this already — "don't let a wedged `gh auth token` hold the
         // whole refresh hostage forever" — and the lesson belongs here too.
-        let loader = Task.detached(priority: .utility) { GitHubToken.resolve(explicit: explicit) }
+        let loader = Task.detached(priority: .utility) {
+            await offCooperativePool(qos: .utility) { GitHubToken.resolve(explicit: explicit) }
+        }
         guard let resolved = await firstResult(of: loader, within: .seconds(2)) else {
             // Timed out: deliberately *not* cached. Caching would extend one
             // wedged `gh` into ten minutes of unauthenticated fetches; falling

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubToken.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubToken.swift
@@ -11,6 +11,25 @@ import Foundation
 ///      many developers who already have GitHub CLI authenticated.
 public enum GitHubToken {
     public static func resolve(explicit: String? = nil) -> String? {
+        preresolved(explicit: explicit) ?? ghCLIToken()
+    }
+
+    /// Steps 1 and 2 alone — the ones that are two memory reads and cannot block.
+    /// nil means "nothing here", i.e. only `gh` is left to ask.
+    ///
+    /// Split out because the deadline an async caller puts around `resolve` is
+    /// there for step 3 and only step 3, and spending it on the other two is not
+    /// free: the hop those callers make has to be ADMITTED to a Dispatch queue
+    /// first, and admission is not instant on a loaded machine. Measured on CI
+    /// (3-core runner, the full suite in parallel): a settings token that needs
+    /// no subprocess at all lost a 2-second race to queue admission and came back
+    /// nil, so the pane went anonymous with a valid token sitting in settings.
+    /// Same shape as the timing note in CLAUDE.md — on that runner, pool
+    /// admission is measured in seconds.
+    ///
+    /// So callers answer from here when they can, and spend the deadline only on
+    /// the call that can actually hang.
+    public static func preresolved(explicit: String? = nil) -> String? {
         if let explicit = explicit?.trimmingCharacters(in: .whitespacesAndNewlines),
            !explicit.isEmpty {
             return explicit
@@ -22,7 +41,7 @@ public enum GitHubToken {
                 return value
             }
         }
-        return ghCLIToken()
+        return nil
     }
 
     /// Ask the `gh` CLI for its stored token.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubToken.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubToken.swift
@@ -25,8 +25,15 @@ public enum GitHubToken {
         return ghCLIToken()
     }
 
-    /// Ask the `gh` CLI for its stored token. Cheap subprocess; callers should
-    /// resolve once per check run rather than per request.
+    /// Ask the `gh` CLI for its stored token.
+    ///
+    /// Cheap only when it answers: `gh` can sit on a keychain prompt nobody is
+    /// looking at, and `run` waits for it with no deadline of its own. So this is
+    /// **blocking** work — every async caller must reach it through
+    /// `offCooperativePool` (both do, each with its own timeout race), never
+    /// directly and not via `Task.detached`, which still runs on the cooperative
+    /// pool. Callers should also resolve once per check run rather than per
+    /// request.
     private static func ghCLIToken() -> String? {
         guard let gh = ghExecutablePath() else { return nil }
         guard let out = run(gh, ["auth", "token"]) else { return nil }
@@ -136,7 +143,10 @@ public enum GitHubToken {
         process.arguments = args
         let out = Pipe()
         process.standardOutput = out
-        process.standardError = Pipe()
+        // nullDevice, not an undrained `Pipe()`: nothing reads stderr here, and a
+        // pipe nobody drains deadlocks the pair below once the child fills its
+        // ~64KB buffer. Same reasoning as `BrewFormulaService.realExecutor`.
+        process.standardError = FileHandle.nullDevice
         do { try process.run() } catch { return nil }
         let data = out.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
@@ -151,7 +161,8 @@ public enum GitHubToken {
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = args
         let err = Pipe()
-        process.standardOutput = Pipe()
+        // nullDevice for the half we do not read, for the reason `run` above gives.
+        process.standardOutput = FileHandle.nullDevice
         process.standardError = err
         do { try process.run() } catch { return ("", false) }
         let data = err.fileHandleForReading.readDataToEndOfFile()

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
@@ -153,6 +153,16 @@ public struct TestFlightAnnouncements: Sendable {
         self.accessible = opened
     }
 
+    /// The initializer above, off the cooperative pool — for the same reason, and
+    /// with the same caveat, as `TestFlightInventory.loadOffPool`: the bound stops
+    /// us waiting, not the thread being held, and the thread being held is one of
+    /// very few.
+    public static func loadOffPool(
+        databaseURL: URL? = nil, qos: DispatchQoS.QoSClass = .userInitiated
+    ) async -> TestFlightAnnouncements {
+        await offCooperativePool(qos: qos) { TestFlightAnnouncements(databaseURL: databaseURL) }
+    }
+
     /// Test seam: inject the parsed announcements directly.
     public init(announcements: [Announcement], accessible: Bool = true) {
         self.announcements = announcements

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -165,6 +165,21 @@ public struct TestFlightInventory: Sendable {
         self.buildsByBundleID = Self.buildIndex(macInstalledRows ?? rows)
     }
 
+    /// The initializer above, off the cooperative pool.
+    ///
+    /// `BoundedBlockingWork` bounds the *wait*, it does not un-block it: the
+    /// calling thread still sits in `DispatchSemaphore.wait` for up to
+    /// `openTimeout` seconds, and every caller builds this from `Task.detached`,
+    /// which runs on the cooperative pool. Eleven construction sites in the menu
+    /// bar app × five seconds is the #351 shape with a cap on it — and the cap is
+    /// reached exactly when the app-data gate is unanswered, which is when the
+    /// app has the most other work in flight. See `offCooperativePool`.
+    public static func loadOffPool(
+        databaseURL: URL? = nil, qos: DispatchQoS.QoSClass = .userInitiated
+    ) async -> TestFlightInventory {
+        await offCooperativePool(qos: qos) { TestFlightInventory(databaseURL: databaseURL) }
+    }
+
     /// Test seam / explicit construction: inject the parsed rows directly, skipping
     /// the DB read. `accessible` defaults to `true` (the caller supplied data); pass
     /// `false` to build the "couldn't read TestFlight" sentinel used when the TCC

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightRefresh.swift
@@ -300,7 +300,7 @@ public struct TestFlightRefresh: Sendable {
     /// Off the cooperative pool: the read is a bounded but blocking open, and it is
     /// called from `run()`, which is async (see `offCooperativePool`).
     public static let storeTestsNothing: @Sendable () async -> Bool = {
-        (try? await offCooperativePool { TestFlightInventory().isTestingNothing }) ?? false
+        await offCooperativePool { TestFlightInventory().isTestingNothing }
     }
 
     /// Whether this Mac is signed in to the App Store (`AppStoreSignIn`), read off the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -1390,19 +1390,31 @@ public struct VendorProbeSource: UpdateSource {
         catch { return .failure(.archiveExtractionFailed("cannot stage archive: \(error.localizedDescription)")) }
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        proc.arguments = ["-p", tmp.path, entry]
-        let out = Pipe()
-        proc.standardOutput = out
-        proc.standardError = FileHandle.nullDevice
-        do { try proc.run() }
-        catch { return .failure(.archiveExtractionFailed("cannot run unzip: \(error.localizedDescription)")) }
-        let plistData = out.fileHandleForReading.readDataToEndOfFile()
-        proc.waitUntilExit()
-        guard proc.terminationStatus == 0 else {
+        // Off the cooperative pool: `readDataToEndOfFile()` + `waitUntilExit()` park
+        // the calling thread, and this runs on every check and every `duo verify`.
+        // See `offCooperativePool`.
+        let extracted: (status: Int32, data: Data)
+        do {
+            let archive = tmp
+            extracted = try await offCooperativePool { () -> (status: Int32, data: Data) in
+                let proc = Process()
+                proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+                proc.arguments = ["-p", archive.path, entry]
+                let out = Pipe()
+                proc.standardOutput = out
+                proc.standardError = FileHandle.nullDevice
+                try proc.run()
+                let data = out.fileHandleForReading.readDataToEndOfFile()
+                proc.waitUntilExit()
+                return (proc.terminationStatus, data)
+            }
+        } catch {
+            return .failure(.archiveExtractionFailed("cannot run unzip: \(error.localizedDescription)"))
+        }
+        let plistData = extracted.data
+        guard extracted.status == 0 else {
             return .failure(.archiveExtractionFailed(
-                "unzip exited \(proc.terminationStatus) extracting '\(entry)'"))
+                "unzip exited \(extracted.status) extracting '\(entry)'"))
         }
         guard !plistData.isEmpty else {
             return .failure(.archiveExtractionFailed("'\(entry)' extracted empty"))

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/OffPool.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Support/OffPool.swift
@@ -40,13 +40,38 @@ import Foundation
 /// work runs to completion even after `Task.cancel()`. That is exactly what the
 /// synchronous call did before, so nothing regresses — but do not read this as
 /// having made these gates interruptible, because it has not.
-func offCooperativePool<T: Sendable>(
+///
+/// ## Public, and two of it
+///
+/// Public because the blocking calls are not all in this package: the menu-bar
+/// app (`lsappinfo`, the helper's `osascript`) and `duo` (its whole synchronous
+/// subcommands) reach the same pool through the same async entry points.
+///
+/// The second, non-throwing overload exists so a caller whose own signature
+/// cannot throw does not have to write `(try? await …) ?? fallback` around work
+/// that never throws — a fallback no input can reach, which reads as a handled
+/// failure and is not one. Overload resolution picks the throwing one whenever
+/// the closure body actually throws.
+public func offCooperativePool<T: Sendable>(
     qos: DispatchQoS.QoSClass = .userInitiated,
     _ work: @escaping @Sendable () throws -> T
 ) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in
         DispatchQueue.global(qos: qos).async {
             continuation.resume(with: Result { try work() })
+        }
+    }
+}
+
+/// `offCooperativePool` for work that cannot throw. Same hop, same guarantees;
+/// see the doc comment above.
+public func offCooperativePool<T: Sendable>(
+    qos: DispatchQoS.QoSClass = .userInitiated,
+    _ work: @escaping @Sendable () -> T
+) async -> T {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global(qos: qos).async {
+            continuation.resume(returning: work())
         }
     }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogGitHubAuthTests.swift
@@ -49,6 +49,30 @@ import Foundation
         #expect(await ChangelogService.gitHubToken() == "pasted-in-settings")
     }
 
+    /// The settings token must be answered WITHOUT entering the `gh` deadline
+    /// race, because everything in that race is slower than a memory read and
+    /// some of it is slower than the deadline.
+    ///
+    /// This is the test above's CI failure, made deterministic. The race was
+    /// entered unconditionally once the resolve moved onto a Dispatch hop, and
+    /// on the 3-core runner with the suite in parallel the hop's queue admission
+    /// lost to the 2-second timeout: a token sitting in settings resolved to nil,
+    /// 18.9s into a test that passes instantly on a 14-core laptop. A deadline of
+    /// one nanosecond is that same race, lost on purpose and on every machine.
+    ///
+    /// Mutation: delete the `GitHubToken.preresolved` short-circuit in
+    /// `gitHubToken` and this returns nil. `timeout:` exists for it.
+    @Test func anExplicitTokenDoesNotRaceTheDeadline() async {
+        defer {
+            ChangelogService.setExplicitGitHubToken(nil)
+            ChangelogService.resetGitHubTokenCache()
+        }
+        ChangelogService.setExplicitGitHubToken("pasted-in-settings")
+        ChangelogService.resetGitHubTokenCache()
+        #expect(await ChangelogService.gitHubToken(timeout: .nanoseconds(1))
+                == "pasted-in-settings")
+    }
+
     /// Whitespace and empty strings mean "no explicit token" — `Preferences` stores
     /// an empty string for a cleared field, and pushing that must fall back to the
     /// env/`gh` path rather than sending `Bearer `.

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test:
 	python3 scripts/test_appcast_edit.py
 	python3 scripts/test_publish_release.py
 	python3 scripts/test_check_prose_claims.py
+	python3 scripts/test_check_offpool.py
 	python3 scripts/test_claude_lag_probe.py
 	cd DuoUpdaterCore && swift test
 	swift test --package-path CLI
@@ -29,6 +30,7 @@ test:
 	python3 scripts/check_engine_notes.py
 	python3 scripts/check_skill_docs.py
 	python3 scripts/check_prose_claims.py
+	python3 scripts/check_offpool.py
 
 # Render every row state to verify/row-states/*.png. The images are committed:
 # re-run after a UI change and read the diff. Fails if a state draws nothing.

--- a/scripts/check_offpool.py
+++ b/scripts/check_offpool.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Refuse a thread-parking call that runs on Swift concurrency's cooperative pool.
+
+Run by `make test`.
+
+    python3 scripts/check_offpool.py
+
+## What this is for
+
+The cooperative pool is width-capped near the core count and does not overcommit
+when one of its threads blocks, so a handful of blocking calls on it stops the
+runtime scheduling anything at all. `Support/OffPool.swift` carries the
+measurement (#351: three concurrent `SecStaticCodeCheckValidity` calls, all three
+cooperative threads parked, 0.00s and 0.01s of CPU burned across sixty seconds,
+the process silent for the rest of the job). `offCooperativePool` is the fix, and
+`Task.detached` is NOT one — a detached task still runs on that same pool.
+
+Before this check there was no gate at all: `grep offCooperativePool App/Sources
+CLI/Sources` answered zero while eleven call paths were blocking on the pool.
+
+## What it checks, and what it cannot
+
+For each blocking call it finds, it walks out through the enclosing braces to the
+first scope that decides who the caller's thread belongs to:
+
+  * an `offCooperativePool { … }` closure — fine, that is the hop;
+  * an `async func`, a `Task { }` or a `Task.detached { }` — a violation;
+  * a plain synchronous `func` — NOT reported.
+
+That last one is the honest limit: `InPlaceSwap.replace` is synchronous and was
+reached from two `async` callers for months, which no amount of looking at its
+own body can reveal. Answering it needs a call graph. So this gate catches the
+shape at the point where it is visible — the blocking call written directly in
+async-reachable code — and the rule for everything else stays a rule.
+
+`offpool-lint:allow — <reason>` on a comment line inside the enclosing function
+exempts that function's calls. The reason is mandatory, and an exemption that no
+longer matches anything fails the build: a dead exemption is a standing pass for
+whatever is written there next (`make gallery`'s `mayLookAlike` does the same,
+and CLAUDE.md records under #271 what happened to the one gate that skipped it).
+"""
+
+import pathlib
+import re
+import sys
+
+ROOTS = ["DuoUpdaterCore/Sources", "App/Sources", "CLI/Sources"]
+
+# Calls that park the calling thread until something outside this process moves.
+# Deliberately a short list of exact spellings rather than a guess at intent:
+# every one of them is a documented member of the family in `OffPool.swift`.
+BLOCKING = [
+    "waitUntilExit()",
+    "readDataToEndOfFile()",
+    "SecStaticCodeCheckValidity",
+]
+
+MARKER = "offpool-lint:allow"
+REASON = re.compile(re.escape(MARKER) + r"\s*[—-]\s*(\S.*)")
+
+# The scope kinds a frame can have. `SYNC` is "a synchronous function body",
+# which this check deliberately says nothing about.
+OFFPOOL, ASYNC, SYNC, PLAIN = "offpool", "async", "sync", "plain"
+
+FUNC = re.compile(r"\bfunc\s+[A-Za-z_<]")
+ASYNC_FUNC = re.compile(r"\bfunc\b.*\basync\b")
+# `Task {`, `Task.detached {`, `Task(priority:) {` — all of them run on the
+# cooperative pool, which is the whole point of naming them here.
+TASK = re.compile(r"\bTask\b(?:\.detached)?\s*(?:\([^)]*\))?\s*\{")
+OFFPOOL_CALL = re.compile(r"\boffCooperativePool\b")
+# A closure that names its own signature, e.g. `{ () -> Info? in` or
+# `{ [self] () async -> Int32 in` — the `async` there belongs to the closure.
+ASYNC_CLOSURE = re.compile(r"\{[^}]*\basync\b[^}]*\bin\b")
+
+STRING = re.compile(r'"(?:\\.|[^"\\])*"')
+
+
+def strip_noise(line):
+    """Line with string literals and trailing comments blanked out.
+
+    Brace counting is the only thing downstream cares about, and a `}` inside a
+    log message or a `//` aside is not a scope. String interpolation braces are
+    balanced, so blanking the whole literal keeps the count right.
+    """
+    line = STRING.sub('""', line)
+    cut = line.find("//")
+    if cut >= 0:
+        line = line[:cut]
+    return line
+
+
+def frame_kind(text, parent):
+    """What an opening brace on this line makes the scope inside it."""
+    if OFFPOOL_CALL.search(text):
+        return OFFPOOL
+    if ASYNC_FUNC.search(text) or ASYNC_CLOSURE.search(text):
+        return ASYNC
+    if FUNC.search(text):
+        return SYNC
+    if TASK.search(text):
+        return ASYNC
+    # Any other brace — an `if`, a `for`, a plain closure — does not decide
+    # anything, so it inherits and the walk keeps going outward.
+    return PLAIN
+
+
+def deciding_frame(stack):
+    for kind, _ in reversed(stack):
+        if kind != PLAIN:
+            return kind
+    return SYNC
+
+
+def scan(path):
+    """(line number, call, verdict, comments in scope) per blocking call.
+
+    Braces are walked in the order they appear ON the line, not counted: a line
+    can both open and close a scope (`} else {`, `func f() { 5 }`), and counting
+    gets the nesting wrong in opposite directions for those two.
+    """
+    stack = []            # [(kind, comments attached to that scope)]
+    pending = []          # comment lines since the last statement
+    # A signature wrapped across lines, kept so the `{` that opens the body is
+    # still judged against the whole declaration. Without it every `async`
+    # function whose parameters do not fit on one line reads as synchronous —
+    # which is most of the interesting ones. `VendorProbeSource`'s
+    # `zipEntryPlistValue` is the case that caught it.
+    declaration = ""
+    out = []
+    for number, raw in enumerate(path.read_text(errors="replace").splitlines(), 1):
+        stripped = raw.strip()
+        if stripped.startswith("//"):
+            pending.append(re.sub(r"^/{2,3}\s?", "", stripped))
+            continue
+        text = strip_noise(raw)
+        braces = "{" in text or "}" in text
+        judged = (declaration + " " + text).strip() if declaration else text
+        if braces:
+            declaration = ""
+        elif declaration:
+            declaration += " " + text
+        elif FUNC.search(text):
+            declaration = text
+        hits = sorted(
+            (text.index(call), call) for call in BLOCKING if call in text)
+        if not braces:
+            for _, call in hits:
+                comments = [c for _, scope in stack for c in scope] + pending
+                out.append((number, call, deciding_frame(stack), comments))
+            pending = []
+            continue
+        opened_on_line = False
+        for column, character in enumerate(text):
+            while hits and hits[0][0] <= column:
+                _, call = hits.pop(0)
+                comments = [c for _, scope in stack for c in scope] + pending
+                out.append((number, call, deciding_frame(stack), comments))
+            if character == "{":
+                kind = PLAIN if opened_on_line else frame_kind(judged, stack)
+                opened_on_line = True
+                stack.append((kind, list(pending)))
+            elif character == "}" and stack:
+                stack.pop()
+        for _, call in hits:
+            comments = [c for _, scope in stack for c in scope] + pending
+            out.append((number, call, deciding_frame(stack), comments))
+        pending = []
+    return out
+
+
+def review(root, roots=ROOTS):
+    missing = [r for r in roots if not (root / r).is_dir()]
+    scanned, calls, offences, dead = 0, 0, [], []
+    for r in roots:
+        base = root / r
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.swift")):
+            if ".build" in path.parts:
+                continue
+            rel = path.relative_to(root)
+            scanned += 1
+            text = path.read_text(errors="replace")
+            markers = [
+                (i + 1, line.strip())
+                for i, line in enumerate(text.splitlines())
+                if MARKER in line
+            ]
+            used = set()
+            for number, call, verdict, comments in scan(path):
+                calls += 1
+                marker = next((c for c in comments if MARKER in c), None)
+                if verdict != ASYNC:
+                    continue
+                if marker is None:
+                    offences.append((rel, number, "blocking", call))
+                elif not REASON.search(marker):
+                    offences.append((rel, number, "no-reason", call))
+                else:
+                    used.add(marker.strip())
+            for line_number, line in markers:
+                if not any(u in line or line.endswith(u) for u in used):
+                    dead.append((rel, line_number))
+    return {"missing": missing, "scanned": scanned, "calls": calls,
+            "offences": offences, "dead": dead}
+
+
+def main(root=None, roots=ROOTS, minimum=200, minimum_calls=20):
+    root = root or pathlib.Path(__file__).resolve().parent.parent
+    found = review(root, roots=roots)
+
+    if found["missing"]:
+        print(f"✗ these source roots are not under {root}: "
+              f"{', '.join(found['missing'])}\n"
+              "  Fix the paths rather than dropping them.", file=sys.stderr)
+        return 1
+    # Two floors, for the two ways this becomes a check that inspects nothing:
+    # the roots moving, and the call spellings going out of date (a rename of
+    # `waitUntilExit` would leave every root in place and every file scanned).
+    if found["scanned"] < minimum:
+        print(f"✗ only {found['scanned']} Swift files scanned across "
+              f"{len(roots)} roots — too few to be a real run.", file=sys.stderr)
+        return 1
+    if found["calls"] < minimum_calls:
+        print(f"✗ only {found['calls']} blocking calls found; this repository "
+              f"has far more.\n  Check the spellings in BLOCKING before "
+              f"believing a green run.", file=sys.stderr)
+        return 1
+
+    offences, dead = found["offences"], found["dead"]
+    if not offences and not dead:
+        print(f"✓ no blocking calls left on the cooperative pool — "
+              f"{found['calls']} call(s) in {found['scanned']} files")
+        return 0
+
+    for rel, line, kind, call in offences:
+        if kind == "no-reason":
+            print(f"✗ {rel}:{line}: `{call}` is exempted by a bare `{MARKER}` "
+                  f"— the reason is not optional, write `{MARKER} — <why>`",
+                  file=sys.stderr)
+        else:
+            print(f"✗ {rel}:{line}: `{call}` parks a cooperative thread — it is "
+                  f"inside an async function or a Task, not inside an "
+                  f"`offCooperativePool` hop", file=sys.stderr)
+    for rel, line in dead:
+        print(f"✗ {rel}:{line}: `{MARKER}` here no longer exempts anything — "
+              "delete it, or it silently exempts whatever is written next",
+              file=sys.stderr)
+    print(f"\n{len(offences)} blocking call(s), {len(dead)} stale "
+          "exemption(s).\nWrap the whole contiguous blocking sequence in one\n"
+          "    try await offCooperativePool { … }\n"
+          f"or, if it genuinely cannot block, add `{MARKER} — <why>` to the "
+          "enclosing function's comment.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_offpool.py
+++ b/scripts/check_offpool.py
@@ -33,6 +33,19 @@ own body can reveal. Answering it needs a call graph. So this gate catches the
 shape at the point where it is visible — the blocking call written directly in
 async-reachable code — and the rule for everything else stays a rule.
 
+Two consequences of that limit, both real and both already paid for here:
+
+  * `BoundedBlockingWork.run` is a synchronous function, so `.run(key:` is
+    reported where it is WRITTEN (inside sync readers, i.e. never) and not where
+    it is reached from. `TestFlightInventory()` is an initializer whose body is
+    that call; a `Task.detached { TestFlightInventory() }` is a five-second park
+    on the cooperative pool and this gate cannot see it. Eleven of those were
+    found by reading, not by running this.
+  * The same goes for any wrapper: a blocking call one function call away from
+    an `async` body is invisible here. Adding the token spellings is cheap;
+    adding a call graph is not, and a gate that claims to have one when it does
+    not is worse than this one.
+
 `offpool-lint:allow — <reason>` on a comment line inside the enclosing function
 exempts that function's calls. The reason is mandatory, and an exemption that no
 longer matches anything fails the build: a dead exemption is a standing pass for
@@ -49,10 +62,18 @@ ROOTS = ["DuoUpdaterCore/Sources", "App/Sources", "CLI/Sources"]
 # Calls that park the calling thread until something outside this process moves.
 # Deliberately a short list of exact spellings rather than a guess at intent:
 # every one of them is a documented member of the family in `OffPool.swift`.
+#
+# `.run(key:` is `BoundedBlockingWork.run`, which is the one entry here that does
+# not block forever — it gives up after its timeout. It is still a
+# `DispatchSemaphore.wait` on the calling thread for up to five seconds, and five
+# seconds of a pool as wide as the core count is the thing this file is about.
 BLOCKING = [
     "waitUntilExit()",
     "readDataToEndOfFile()",
     "SecStaticCodeCheckValidity",
+    ".wait()",
+    ".wait(timeout:",
+    ".run(key:",
 ]
 
 MARKER = "offpool-lint:allow"
@@ -71,29 +92,85 @@ OFFPOOL_CALL = re.compile(r"\boffCooperativePool\b")
 # A closure that names its own signature, e.g. `{ () -> Info? in` or
 # `{ [self] () async -> Int32 in` — the `async` there belongs to the closure.
 ASYNC_CLOSURE = re.compile(r"\{[^}]*\basync\b[^}]*\bin\b")
+# An `async` computed accessor: `var x: T { get async { … } }`. Without this the
+# accessor body reads as an ordinary brace and inherits from the enclosing type,
+# i.e. from nothing.
+GET_ASYNC = re.compile(r"\bget\s+async\b")
+# Closures that do NOT run on the cooperative pool, so blocking inside them is
+# the fix rather than the bug: a GCD queue's `async`/`asyncAfter`, a
+# `DispatchWorkItem`, a `Thread`. Written against `.async`/`.asyncAfter` on any
+# receiver because the queue is as often a stored property (`errQueue.async {`)
+# as it is `DispatchQueue.global()`.
+#
+# ⚠️ `.sync { }` is deliberately NOT here. It runs the block on the CALLING
+# thread, so blocking inside it parks exactly the thread this check is protecting
+# — treating it as a hop would hide the violation rather than find it.
+GCD = re.compile(
+    r"\.(?:async|asyncAfter)\s*(?:\([^{]*\))?\s*\{"
+    r"|\bDispatchWorkItem\s*\{"
+    r"|\bThread\s*(?:\{|\(\s*block:)")
+# An `await` in front of the call means it is an async wait, not a parked thread
+# (`AsyncSemaphore.wait()`, and every other `await x.wait()` shape). This is the
+# one place a blocking token is dismissed on the line's own evidence.
+AWAIT = re.compile(r"\bawait\b")
 
-STRING = re.compile(r'"(?:\\.|[^"\\])*"')
+EXTENDED_STRING_OPEN = re.compile(r'(#+)"')
 
 
-def strip_noise(line):
-    """Line with string literals and trailing comments blanked out.
+def strip_noise(line, in_block=False, in_multiline=False):
+    """(code on this line, still in a block comment, still in a `\"\"\"` literal).
 
     Brace counting is the only thing downstream cares about, and a `}` inside a
-    log message or a `//` aside is not a scope. String interpolation braces are
-    balanced, so blanking the whole literal keeps the count right.
+    log message, a regex, or a comment is not a scope. Walked character by
+    character rather than run through a pile of regexes in some order, because
+    every order is wrong for something: this repo has `/*` inside a `//` comment
+    (`AppRuntime.swift:252`), `#\"…\"#` regexes full of quotes, and multi-line SQL.
     """
-    line = STRING.sub('""', line)
-    cut = line.find("//")
-    if cut >= 0:
-        line = line[:cut]
-    return line
+    if in_multiline:
+        return "", in_block, ('"""' not in line)
+    out, index, length = [], 0, len(line)
+    while index < length:
+        if in_block:
+            if line.startswith("*/", index):
+                in_block = False
+                index += 2
+            else:
+                index += 1
+            continue
+        if line.startswith('"""', index):
+            return "".join(out), in_block, True
+        if line.startswith("//", index):
+            break
+        if line.startswith("/*", index):
+            in_block = True
+            index += 2
+            continue
+        extended = EXTENDED_STRING_OPEN.match(line, index)
+        if extended:
+            closing = '"' + extended.group(1)
+            end = line.find(closing, extended.end())
+            out.append('""')
+            index = length if end < 0 else end + len(closing)
+            continue
+        if line[index] == '"':
+            index += 1
+            while index < length and line[index] != '"':
+                index += 2 if line[index] == "\\" else 1
+            out.append('""')
+            index += 1
+            continue
+        out.append(line[index])
+        index += 1
+    return "".join(out), in_block, False
 
 
 def frame_kind(text, parent):
     """What an opening brace on this line makes the scope inside it."""
     if OFFPOOL_CALL.search(text):
         return OFFPOOL
-    if ASYNC_FUNC.search(text) or ASYNC_CLOSURE.search(text):
+    if GCD.search(text):
+        return SYNC
+    if ASYNC_FUNC.search(text) or ASYNC_CLOSURE.search(text) or GET_ASYNC.search(text):
         return ASYNC
     if FUNC.search(text):
         return SYNC
@@ -119,30 +196,46 @@ def scan(path):
     gets the nesting wrong in opposite directions for those two.
     """
     stack = []            # [(kind, comments attached to that scope)]
-    pending = []          # comment lines since the last statement
+    pending = []          # (line number, text) of comments since the last statement
     # A signature wrapped across lines, kept so the `{` that opens the body is
     # still judged against the whole declaration. Without it every `async`
     # function whose parameters do not fit on one line reads as synchronous —
     # which is most of the interesting ones. `VendorProbeSource`'s
     # `zipEntryPlistValue` is the case that caught it.
     declaration = ""
+    in_block = in_multiline = False
     out = []
     for number, raw in enumerate(path.read_text(errors="replace").splitlines(), 1):
         stripped = raw.strip()
-        if stripped.startswith("//"):
-            pending.append(re.sub(r"^/{2,3}\s?", "", stripped))
+        was_in_block, was_in_multiline = in_block, in_multiline
+        text, in_block, in_multiline = strip_noise(raw, in_block, in_multiline)
+        if (was_in_block or was_in_multiline) and not text.strip():
             continue
-        text = strip_noise(raw)
+        if stripped.startswith("//") and not was_in_block:
+            pending.append((number, re.sub(r"^/{2,3}\s?", "", stripped)))
+            continue
         braces = "{" in text or "}" in text
         judged = (declaration + " " + text).strip() if declaration else text
-        if braces:
-            declaration = ""
-        elif declaration:
-            declaration += " " + text
-        elif FUNC.search(text):
+        if not braces and declaration:
+            declaration = judged
+        elif not braces and FUNC.search(text):
             declaration = text
+        elif braces and declaration and text.count("{") == text.count("}") \
+                and not text.rstrip().endswith("{"):
+            # The signature is still open: this line's braces balance and none of
+            # them opened a body, so they belong to a default argument
+            # (`onDone: () -> Void = { }`) or a literal inside the parameter list.
+            # Resetting here loses the `async` that is still three lines up.
+            declaration = judged
+        else:
+            declaration = ""
         hits = sorted(
             (text.index(call), call) for call in BLOCKING if call in text)
+        # `await x.wait()` is an async wait, not a parked thread. Dismissed on the
+        # line's own evidence because the alternative — leaving `.wait()` out of
+        # BLOCKING — loses the semaphore and group waits CLAUDE.md names.
+        if AWAIT.search(text):
+            hits = [hit for hit in hits if not hit[1].startswith(".wait")]
         if not braces:
             for _, call in hits:
                 comments = [c for _, scope in stack for c in scope] + pending
@@ -186,20 +279,25 @@ def review(root, roots=ROOTS):
                 for i, line in enumerate(text.splitlines())
                 if MARKER in line
             ]
+            # Which marker LINES did work, identified by line number. Comparing
+            # marker text by containment let a live `…allow — network retry
+            # budget` cover a stale `…allow — network` elsewhere in the file:
+            # the stale one then never came up for review again, which is the
+            # single thing this half exists to prevent.
             used = set()
             for number, call, verdict, comments in scan(path):
                 calls += 1
-                marker = next((c for c in comments if MARKER in c), None)
+                marker = next(((n, c) for n, c in comments if MARKER in c), None)
                 if verdict != ASYNC:
                     continue
                 if marker is None:
                     offences.append((rel, number, "blocking", call))
-                elif not REASON.search(marker):
+                elif not REASON.search(marker[1]):
                     offences.append((rel, number, "no-reason", call))
                 else:
-                    used.add(marker.strip())
-            for line_number, line in markers:
-                if not any(u in line or line.endswith(u) for u in used):
+                    used.add(marker[0])
+            for line_number, _ in markers:
+                if line_number not in used:
                     dead.append((rel, line_number))
     return {"missing": missing, "scanned": scanned, "calls": calls,
             "offences": offences, "dead": dead}

--- a/scripts/test_check_offpool.py
+++ b/scripts/test_check_offpool.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Regression tests for `check_offpool`. Run by `make test`.
+
+    python3 scripts/test_check_offpool.py
+
+Every case names the mutation it catches. The must-hit fixtures are real shapes
+from this repository as they stood at 924be257, before the hops went in — the
+`lsappinfo` probe's `Task.detached`, and a wrapped `async` signature, which a
+scanner that judges the `{` line alone reads as synchronous.
+"""
+
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_offpool as co  # noqa: E402
+
+# `AppListModel.runningBuildVersions` as it was: a detached task, which still
+# runs on the cooperative pool.
+DETACHED = """\
+    private static func runningBuildVersions() async -> [String: String] {
+        await Task.detached(priority: .utility) {
+            let process = Process()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return LSAppInfoParser.runningBuildVersions(from: text)
+        }.value
+    }
+"""
+
+# `VendorProbeSource.zipEntryPlistValue`'s shape: the brace that opens the body
+# is three lines below the word `func`, and `async` is on the brace's line but
+# `func` is not.
+WRAPPED_SIGNATURE = """\
+    private func zipEntryPlistValue(
+        url: URL, entry: String, key: String
+    ) async -> Result<String, ProbeFailure> {
+        let plistData = out.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        return .success("")
+    }
+"""
+
+HOPPED = """\
+    private func installApp(_ newApp: URL, over target: URL) async throws {
+        try await offCooperativePool {
+            let process = Process()
+            try process.run()
+            process.waitUntilExit()
+        }
+    }
+"""
+
+# A synchronous helper. Out of this check's reach on purpose — whether its
+# callers hop is a call-graph question — so it must NOT be reported, or the
+# check turns into an exemption list over every `Process` wrapper in the repo.
+SYNCHRONOUS = """\
+    private static func run(_ launchPath: String) -> Int32 {
+        let p = Process()
+        try? p.run()
+        p.waitUntilExit()
+        return p.terminationStatus
+    }
+"""
+
+# A one-line body plus a `} else {`, the two shapes that break brace COUNTING in
+# opposite directions: counted closes-first, `func f() -> Int { 5 }` pops the
+# type body; counted opens-first, `} else {` nests forever.
+BRACE_ARITHMETIC = """\
+enum Fixture {
+    static func size() -> Int { 5 }
+
+    static func pick(_ flag: Bool) -> Int {
+        if flag {
+            return 1
+        } else {
+            return 2
+        }
+    }
+
+    static func probe() async {
+        let p = Process()
+        p.waitUntilExit()
+    }
+}
+"""
+
+
+class OffPool(unittest.TestCase):
+    def setUp(self):
+        self.root = pathlib.Path(tempfile.mkdtemp(prefix="duo-offpool-"))
+        self.addCleanup(shutil.rmtree, self.root, True)
+        (self.root / "Sources").mkdir()
+
+    def write(self, text, name="Fixture.swift"):
+        (self.root / "Sources" / name).write_text(text)
+
+    def review(self):
+        return co.review(self.root, roots=["Sources"])
+
+    # Mutation: drop `Task` from the frames that count as async. The App layer's
+    # two worst sites were both detached tasks, and `OffPool.swift` says in so
+    # many words that a detached task is not an alternative.
+    def test_a_detached_task_is_not_a_hop(self):
+        self.write(DETACHED)
+        found = self.review()
+        self.assertEqual(len(found["offences"]), 2, found)
+
+    # Mutation: judge the brace's own line instead of the accumulated
+    # declaration. Every wrapped `async` signature then reads as synchronous and
+    # the check goes green over the real thing.
+    def test_a_wrapped_async_signature_is_still_async(self):
+        self.write(WRAPPED_SIGNATURE)
+        self.assertEqual(len(self.review()["offences"]), 2)
+
+    def test_a_hopped_call_passes(self):
+        self.write(HOPPED)
+        self.assertEqual(self.review()["offences"], [])
+
+    def test_a_synchronous_helper_is_not_reported(self):
+        self.write(SYNCHRONOUS)
+        self.assertEqual(self.review()["offences"], [])
+
+    # Mutation: count braces per line rather than walking them in order. Both
+    # halves of this fixture are ordinary Swift, and either miscount moves the
+    # `probe()` body to the wrong depth — which silently changes the answer for
+    # every function after it in the file.
+    def test_brace_arithmetic_survives_one_line_bodies_and_else(self):
+        self.write(BRACE_ARITHMETIC)
+        found = self.review()
+        self.assertEqual(len(found["offences"]), 1, found)
+
+    def test_an_exemption_needs_a_reason(self):
+        self.write("    /// offpool-lint:allow\n" + DETACHED)
+        found = self.review()
+        self.assertTrue(all(o[2] == "no-reason" for o in found["offences"]),
+                        found)
+
+    def test_an_exemption_with_a_reason_exempts(self):
+        self.write("    /// offpool-lint:allow — fixture\n" + DETACHED)
+        found = self.review()
+        self.assertEqual(found["offences"], [])
+        self.assertEqual(found["dead"], [])
+
+    # The half that keeps the exemption list honest: an exemption matching
+    # nothing is a standing pass for whatever is written under it next.
+    def test_a_stale_exemption_fails(self):
+        self.write("    /// offpool-lint:allow — fixture\n"
+                   "    func f() {}\n")
+        self.assertEqual(len(self.review()["dead"]), 1)
+
+    # Both emptiness floors, because a check that inspects nothing prints the
+    # same ✓ as one that inspects everything.
+    def test_a_missing_root_fails(self):
+        self.assertEqual(co.main(self.root, roots=["Nope"]), 1)
+
+    def test_too_few_files_fails(self):
+        self.write(HOPPED)
+        self.assertEqual(co.main(self.root, roots=["Sources"]), 1)
+
+    # The floor that catches the spellings going stale: roots intact, files
+    # scanned, and nothing to look at because the call was renamed.
+    def test_too_few_blocking_calls_fails(self):
+        for index in range(250):
+            self.write("func f() {}\n", name=f"F{index}.swift")
+        self.assertEqual(
+            co.main(self.root, roots=["Sources"], minimum=200), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_check_offpool.py
+++ b/scripts/test_check_offpool.py
@@ -89,6 +89,129 @@ enum Fixture {
 """
 
 
+# A semaphore and a group wait, the two CLAUDE.md names that the first version
+# of BLOCKING did not carry — while `GitHub.run`, added in the same PR, waits on
+# a semaphore of its own.
+SEMAPHORE = """\
+    private func drain() async -> Data {
+        let drained = DispatchSemaphore(value: 0)
+        let group = DispatchGroup()
+        drained.wait()
+        group.wait()
+        return Data()
+    }
+"""
+
+# An async wait is not a parked thread. Both of these are real lines from
+# `AppListModel`, and reporting them would be the kind of noise that gets a gate
+# switched off.
+AWAITED_WAIT = """\
+    private func gated() async {
+        await Self.prewarmNetworkGate.wait()
+        await gate?.wait()
+    }
+"""
+
+# GCD closures do not run on the cooperative pool, so blocking inside one is the
+# fix. ~10 sites in this repo look like this, `ArchiveExtractor.run`'s stderr
+# drain among them.
+GCD_CLOSURE = """\
+    private func drainBoth() async {
+        errQueue.async {
+            errBox.data = errHandle.readDataToEndOfFile()
+        }
+        DispatchQueue.global().async {
+            process.waitUntilExit()
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5) {
+            process.waitUntilExit()
+        }
+        let work = DispatchWorkItem {
+            process.waitUntilExit()
+        }
+        Thread {
+            process.waitUntilExit()
+        }.start()
+    }
+"""
+
+# ⚠️ `.sync { }` runs the block on the CALLING thread, so it is NOT a hop. This
+# is the one member of the GCD family that must still be reported, and the
+# distinction is the reason `GCD` does not simply match `Dispatch`.
+GCD_SYNC_IS_NOT_A_HOP = """\
+    private func inline() async {
+        queue.sync {
+            process.waitUntilExit()
+        }
+    }
+"""
+
+# A live exemption whose reason is a PREFIX of a stale one's. Under containment
+# matching, the live text is found inside the stale line, so the stale exemption
+# reads as used and is never reviewed again.
+PREFIX_MARKER = """\
+    /// offpool-lint:allow — network
+    func probe() async {
+        process.waitUntilExit()
+    }
+
+    /// offpool-lint:allow — network retry budget
+    func settled() {}
+"""
+
+BLOCK_COMMENT = """\
+    private func probe() async {
+        /* a closing brace in prose: }
+           and another } here */
+        process.waitUntilExit()
+    }
+"""
+
+# `/*` inside a `//` comment — `Scan/AppRuntime.swift:252` really does this.
+SLASH_STAR_INSIDE_LINE_COMMENT = """\
+    private func probe() async {
+        // `Contents/MacOS/*.app` is also where subprocesses live
+        process.waitUntilExit()
+    }
+"""
+
+GET_ASYNC = """\
+struct Fixture {
+    var token: String? {
+        get async {
+            process.waitUntilExit()
+            return nil
+        }
+    }
+}
+"""
+
+# A default closure argument inside a wrapped signature. Its braces balance on
+# their own line and open no body, so resetting the accumulated declaration
+# there loses the `async` two lines above.
+DEFAULT_CLOSURE_ARGUMENT = """\
+    private func install(
+        _ app: URL,
+        onDone: @Sendable () -> Void = { },
+        onStage: @Sendable (Int) -> Void = { _ in }
+    ) async throws {
+        process.waitUntilExit()
+    }
+"""
+
+# An extended literal carrying quotes AND a brace, which is what every regex in
+# this repo looks like.
+# One bare quote and then a brace: the naive pair-matching stripper consumes
+# `"say "` and leaves the `}` behind as code, which pops the function's frame and
+# makes everything after it read as type-level — silently green.
+EXTENDED_STRING = """\
+    private func probe() async {
+        let pattern = #"say " then }"#
+        process.waitUntilExit()
+    }
+"""
+
+
 class OffPool(unittest.TestCase):
     def setUp(self):
         self.root = pathlib.Path(tempfile.mkdtemp(prefix="duo-offpool-"))
@@ -115,6 +238,60 @@ class OffPool(unittest.TestCase):
     def test_a_wrapped_async_signature_is_still_async(self):
         self.write(WRAPPED_SIGNATURE)
         self.assertEqual(len(self.review()["offences"]), 2)
+
+    # CLAUDE.md names `DispatchGroup.wait()` and `DispatchSemaphore.wait()` in
+    # the same breath as `waitUntilExit`; the first BLOCKING list carried
+    # neither, while this PR's own `GitHub.run` added a semaphore wait.
+    def test_semaphore_and_group_waits_are_blocking(self):
+        self.write(SEMAPHORE)
+        self.assertEqual(len(self.review()["offences"]), 2, self.review())
+
+    # …and the cost of carrying `.wait()`: `await x.wait()` must not be reported.
+    def test_an_awaited_wait_is_not_a_parked_thread(self):
+        self.write(AWAITED_WAIT)
+        self.assertEqual(self.review()["offences"], [])
+
+    # FALSE POSITIVE this gate shipped with: a GCD closure inside an `async func`
+    # inherited the async verdict, so ~10 correct sites in this repo were
+    # reported as violations. Blocking inside `DispatchQueue.async` is the fix.
+    def test_gcd_closures_are_not_the_cooperative_pool(self):
+        self.write(GCD_CLOSURE)
+        self.assertEqual(self.review()["offences"], [], self.review())
+
+    # The other half, which keeps the fix above from becoming a hole: `.sync`
+    # runs the block on the calling thread.
+    def test_dispatch_sync_is_still_the_calling_thread(self):
+        self.write(GCD_SYNC_IS_NOT_A_HOP)
+        self.assertEqual(len(self.review()["offences"]), 1, self.review())
+
+    # Mutation: match markers by substring. A live `…allow — network retry
+    # budget` then covers a stale `…allow — network`, and the stale one is never
+    # reviewed again — the exact hole the dead-exemption half exists to close.
+    def test_a_stale_marker_is_not_covered_by_a_longer_live_one(self):
+        self.write(PREFIX_MARKER)
+        dead = self.review()["dead"]
+        self.assertEqual([line for _, line in dead], [6], self.review())
+
+    def test_a_brace_inside_a_block_comment_is_not_a_scope(self):
+        self.write(BLOCK_COMMENT)
+        self.assertEqual(len(self.review()["offences"]), 1, self.review())
+
+    # …and `/*` inside a line comment must not open one.
+    def test_a_block_opener_inside_a_line_comment_is_inert(self):
+        self.write(SLASH_STAR_INSIDE_LINE_COMMENT)
+        self.assertEqual(len(self.review()["offences"]), 1, self.review())
+
+    def test_an_async_getter_is_an_async_scope(self):
+        self.write(GET_ASYNC)
+        self.assertEqual(len(self.review()["offences"]), 1, self.review())
+
+    def test_a_default_closure_argument_does_not_end_the_signature(self):
+        self.write(DEFAULT_CLOSURE_ARGUMENT)
+        self.assertEqual(len(self.review()["offences"]), 1, self.review())
+
+    def test_an_extended_string_literal_is_not_code(self):
+        self.write(EXTENDED_STRING)
+        self.assertEqual(len(self.review()["offences"]), 1, self.review())
 
     def test_a_hopped_call_passes(self):
         self.write(HOPPED)


### PR DESCRIPTION
Fixes the whole **P1** cluster of the 2026-09-13 review (report section 二): every blocking call reached from `async` code that was parking a cooperative thread, plus the two false comments the cluster rests on.

`OffPool.swift`'s doc is the premise: the cooperative pool is width-capped near the core count and does **not** overcommit when a thread parks, so a handful of blocking calls on it stops the runtime scheduling anything at all (#351, run 33959023008: three parked threads, 0.00s and 0.01s of CPU across sixty seconds, silence for the rest of the job). `Task.detached` is not an alternative — it still runs on that pool. Before this PR, `grep offCooperativePool App/Sources CLI/Sources` answered **0**.

## Findings addressed

| # | Site | What it was | What it is now |
|---|---|---|---|
| 1 | `Install/InPlaceSwap.swift` `replace`, via `SparkleInstaller.swift:262`, `VendorInstaller.swift:267`, `BackupStore.restore:413` | `NSLock` + osascript admin panel held for the whole time the user takes to answer | both installers' `installApp` are `async` and hop; the rollback paths (App + CLI) hop their `BackupStore.restore` |
| 2 | `Install/DeltaApplier.swift` `reconstruct` | `BinaryDelta`'s `waitUntilExit()`, no watchdog | hopped at both call sites; SIGTERM at 600s / SIGKILL at 605s, the `ArchiveExtractor.run` shape |
| 3 | `Install/InstallCoordinator.swift` `backUp` | `Task.detached` around `BackupStore.save` + `BackupManifest` + `InputMethodDataBackup` (8.7s × 2 for Word) | one `offCooperativePool` around the same block, unchanged inside |
| 4 | `InPlaceSwap.recoverInterruptedSwaps` via `AppListModel:2269` | `Task.detached` around `SecStaticCodeCheckValidity` — the #351 call | hop at the call site only (the function body is untouched, so it cannot conflict with `fix/backup-seal-and-sweep-lock`) |
| 5 | `Install/PackageInstaller.swift` | gate (`pkgutil`/`xar`/`lsbom`/`SecStaticCode`) and two full-file SHA-256 seals inline on the actor | **one hop per contiguous sequence**: gate+seal together, twice; the dmg fingerprint and `resolveInstaller` separately. Gate/seal ordering untouched |
| 6 | `Sources/VendorProbeSource.swift` `zipEntryPlistValue` | `unzip` read+wait on every check and every `duo verify` | hopped |
| 7 | `AppListModel.runningBuildVersions`, `PrivilegedHelperClient.restartDaemon` | `Task.detached` | `offCooperativePool`; `offCooperativePool` is now `public` |
| 8 | `Sources/GitHubToken.swift` via `ChangelogService:379` and `AppListModel:1394` | `Task.detached`; the ChangelogService comment already *claimed* "off the cooperative pool" | both hop inside the task that races the 2s deadline, so the deadline behaviour is unchanged |
| 9 | `Install/BrewFormulaReleaseService.swift:563` | `standardError = Pipe()`, never drained → deadlock past 64KB | `FileHandle.nullDevice`, with `BrewFormulaService.realExecutor`'s reasoning |
| 10 | CLI `Doctor.swift`, `Backups.swift`, `GitHub.swift`, `Triage.swift` | blocking on the pool (single-task, so not starving, but the rule is the rule) | `doctor` and `backups restore` hop directly; `triage` and `reconcile` are synchronous end to end, so each gets one hop at its `main.swift` seam |

Nothing was declined. Two sites the brief did not list turned up when the gate was run and are fixed here too: `AppStoreAXInstaller.ensureAppStoreRunning` (`open -g` + `waitUntilExit()` directly in an `async func`) and `GitHubToken.run`/`runCapturingStderr`, which both handed the half they do not read an undrained `Pipe()`.

### Comment corrections

* `InPlaceSwap.swift:645` said *"the callers are synchronous"* — both are actor-isolated `async` and always were. Replaced with the actual invariant (every async caller must reach `replace` through a hop) and what the old sentence got wrong.
* `PackageInstaller.swift:178` said a direct pkg avoids *"an extra full read"* — `handOver` hashes the file whole twice either way, deliberately. Rewritten to say what the `approvedFingerprint` hand-off really buys.
* `GitHubToken.ghCLIToken`'s *"cheap subprocess"* now says it is cheap only when it answers, and must be called off-pool.

Both were grepped for copies first (`grep -rn "callers are synchronous"` → 1; the pkg sentence → 1).

### Out of scope, reported not fixed

* **The download permit still spans the whole pkg gate + two hashes** (`InstallCoordinator` vs `InstallPermits.swift:5-6`'s "held only while fetching bytes"). Moving the boundary is a design change; untouched.
* `MASInstaller.runOutdated` is **exempted, not hopped**: its wait is the `terminationHandler` continuation, and by the time the drain runs the child has exited and Foundation has closed the parent's write end. The exemption carries that reason.
* `CLAUDE.md`'s 「别在协作池上做阻塞调用」 now has one stale line — *"`recoverInterruptedSwapsOnce` 还从 `Task.detached` 再加"* — which this PR makes false, and the section has no mention of the new gate. Left for the lead: I do not edit CLAUDE.md on an agent brief.

## Changes a user could notice

None intended. Same work, same order, same timeouts — on a Dispatch thread instead of a cooperative one. Three things worth a reviewer's eye:

1. `offCooperativePool` gained a **non-throwing overload** so callers that cannot throw need not write `(try? …) ?? fallback` around work that never throws (an unreachable branch that reads as a handled failure). The two existing `try?` call sites drop theirs; overload resolution picks the throwing one whenever the closure body throws (verified: no `UnnecessaryEffectMarker` warnings in the build).
2. `PackageInstaller`'s blocking helpers became `nonisolated`. The actor was not ordering them — `handOver` already suspends between its two gates and `downloadAndOpen` awaits its download — but two installs of *different* packages can now overlap their gates in wall time where before they interleaved around suspension points.
3. `DeltaApplier` sends `BinaryDelta`'s stdout to `nullDevice`. It was read and discarded, and reading it *after* stderr was itself a deadlock.

## The gate, and its evidence

`scripts/check_offpool.py` (in `make test`) walks out from each `waitUntilExit()` / `readDataToEndOfFile()` / `SecStaticCodeCheckValidity` to the first scope that decides whose thread it is: an `offCooperativePool` closure passes, an `async func` or a `Task` fails, a plain synchronous function is **not** reported. That limit is written into the file: `InPlaceSwap.replace` is synchronous and was reached from two `async` callers for months, which nothing in its own body can reveal — answering that needs a call graph.

`offpool-lint:allow — <reason>` exempts a function; the reason is mandatory and a **dead exemption fails the build** (`mayLookAlike`'s shape, not `mayBeBlank`'s #271 hole).

Red on the pre-fix tree, green on this branch — same script, `git archive origin/main` into a scratch dir:

```
$ python3 …/prefixcheck.py …/prefix        # origin/main @ 924be257
scanned 261 calls 43 offences 8
   …/Install/AppStoreAXInstaller.swift 536 waitUntilExit()
   …/Install/MASInstaller.swift 370 readDataToEndOfFile()
   …/Sources/VendorProbeSource.swift 1401 readDataToEndOfFile()
   …/Sources/VendorProbeSource.swift 1402 waitUntilExit()
   App/Sources/AppListModel.swift 4774 readDataToEndOfFile()
   App/Sources/AppListModel.swift 4775 waitUntilExit()
   App/Sources/PrivilegedHelperClient.swift 183 readDataToEndOfFile()
   App/Sources/PrivilegedHelperClient.swift 184 waitUntilExit()

$ python3 scripts/check_offpool.py          # this branch
✓ no blocking calls left on the cooperative pool — 42 call(s) in 261 files
exit=0
```

Mutation-tested by hand against the real tree (each applied, run, reverted):

```
--- restored: exit=0                         ✓ … 42 call(s) in 261 files
--- mutation 1 (bare waitUntilExit in an async func): exit=1
✗ …/SignatureVerifier.swift:83: `waitUntilExit()` parks a cooperative thread …
--- mutation 2 (the same call inside Task.detached): exit=1
✗ …/SignatureVerifier.swift:84: `waitUntilExit()` parks a cooperative thread …
--- mutation 3 (marker, no reason): exit=1   (names the line, and the stale marker)
--- mutation 4 (marker + reason): exit=0
--- mutation 5 (stale exemption): exit=1
✗ …/SignatureVerifier.swift:80: `offpool-lint:allow` here no longer exempts anything …
```

`scripts/test_check_offpool.py` (also in `make test`) pins eleven of them, including the two that made earlier drafts of this script silently green:

* judging the `{`'s own line rather than the accumulated declaration — every wrapped `async` signature then reads as synchronous, which is how the first draft missed `VendorProbeSource` entirely (it is in the pre-fix output above only because that was fixed);
* counting braces per line instead of walking them in order — `func f() -> Int { 5 }` and `} else {` break a count in opposite directions.

Plus both emptiness floors (roots gone; call spellings gone stale), because a check that inspects nothing prints the same ✓ as one that inspects everything.

## Verification

```
$ make test > /tmp/duo-mt-offpool2.log 2>&1; echo exit=$?
exit=0

$ grep -n "Test run with .* tests" /tmp/duo-mt-offpool2.log
6665:━ Test run with 2777 tests in 228 suites passed after 20.444 seconds with 2 known issues.
7346:✔ Test run with 280 tests in 34 suites passed after 0.144 seconds.

$ tail -8 /tmp/duo-mt-offpool2.log
python3 scripts/check_skill_docs.py
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 26) match the initializers
python3 scripts/check_prose_claims.py
✓ no machine-population claims in code comments — 531 files
python3 scripts/check_offpool.py
✓ no blocking calls left on the cooperative pool — 42 call(s) in 261 files
```

`make gallery` not run: the `App/Sources` changes are all model-side (`runningBuildVersions`, `rollback`, the token resolve, the swap sweep, the helper kickstart). No row view, no `RowAction.state`, and none of those files is in the gallery target. `duo verify` not run: no recipe or parser rule changed.
