### PR TITLE
verify/reconcile: make baseline complaints reportable, bound the CLI scan, stop killing other worktrees

### DIFF
--- a/App/Sources/Preferences.swift
+++ b/App/Sources/Preferences.swift
@@ -566,7 +566,6 @@ final class Preferences {
     /// This build's marketing version — the namespace `SettingsSpotlight` states
     /// its versions in. Marketing-only is correct here and only here: this is our
     /// own app, and every release bumps this string.
-    // version-lint:allow-marketing-first — our own release version, never a vendor's
     static var currentVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
     }

--- a/CLI/Sources/DuoKit/Baseline.swift
+++ b/CLI/Sources/DuoKit/Baseline.swift
@@ -6,8 +6,9 @@ import DuoUpdaterCore
 ///
 /// One file doing three jobs, deliberately:
 ///
-///  1. **Monotonicity baseline** — the last version each recipe successfully
-///     read. A recipe that goes *backwards* has almost certainly started
+///  1. **Monotonicity baseline** — the last version each recipe read that this
+///     file believes (a read that went backwards is complained about and not
+///     recorded). A recipe that goes *backwards* has almost certainly started
 ///     matching something else on the page; nothing else detects that.
 ///  2. **Flap suppressor** — `consecutiveActionable`, so a single bad sweep
 ///     never files anything. Vendors have five-minute outages; issues are
@@ -25,8 +26,10 @@ public struct Baseline: Codable, Sendable {
     public struct Entry: Codable, Sendable {
         public var lastGoodVersion: String?
         public var lastGoodAt: Date?
-        /// Entries the last sweep that got an answer extracted from this
-        /// recipe's page. Changelog recipes only — nil everywhere else, and nil
+        /// Entries the last sweep that got a BELIEVABLE answer extracted from
+        /// this recipe's page — a count that collapsed to one is complained
+        /// about and not recorded, so this stays the yardstick the next sweep
+        /// measures against. Changelog recipes only — nil everywhere else, and nil
         /// on a row written before this field existed, which is why the
         /// collapse check needs a previous value and cannot fire on the first
         /// sweep after an upgrade.
@@ -52,6 +55,17 @@ public struct Baseline: Codable, Sendable {
         /// A *change* in this is new information and worth speaking up about
         /// immediately, where a repeat is not.
         public var lastSignature: String?
+        /// What was wrong the sweep BEFORE that, and the only field
+        /// `Reconcile` can compare against.
+        ///
+        /// `duo verify` writes the baseline and `duo reconcile` reads it back, in
+        /// that order, so by the time reconciliation runs `lastSignature` is
+        /// already this sweep's own signature — comparing it against the finding
+        /// asks whether a value equals itself. "The failure changed shape" was
+        /// therefore unreachable: a recipe that went from `versionPatternNoMatch`
+        /// to `httpStatus404` between sweeps was reported, if at all, as "still
+        /// failing the same way".
+        public var previousSignature: String?
         /// Set by the reconcile step, read by it on the next run.
         public var issueNumber: Int?
         public var closedAt: Date?
@@ -152,6 +166,7 @@ public struct Baseline: Codable, Sendable {
             consecutiveInfra = try c.decodeIfPresent(Int.self, forKey: .consecutiveInfra) ?? 0
             infraSince = try c.decodeIfPresent(Date.self, forKey: .infraSince)
             lastSignature = try c.decodeIfPresent(String.self, forKey: .lastSignature)
+            previousSignature = try c.decodeIfPresent(String.self, forKey: .previousSignature)
             issueNumber = try c.decodeIfPresent(Int.self, forKey: .issueNumber)
             closedAt = try c.decodeIfPresent(Date.self, forKey: .closedAt)
             sweepsSinceComment =
@@ -280,9 +295,16 @@ public struct Baseline: Codable, Sendable {
                 complaints.append("version went BACKWARDS since the last sweep "
                     + "(\(previous) → \(version)) — the pattern may have started "
                     + "matching a different element")
+                // The regressed value deliberately does NOT become the new
+                // baseline. Recording it would make the next sweep compare 4.7
+                // against 4.7, find nothing wrong, and go silent on a recipe that
+                // is still reading the wrong element — one sweep's exit code, then
+                // nothing. Holding the last version we trust is also what lets the
+                // streak below reach `actionableThreshold`.
+            } else {
+                entry.lastGoodVersion = version
+                entry.lastGoodAt = Date()
             }
-            entry.lastGoodVersion = version
-            entry.lastGoodAt = Date()
         }
 
         // The changelog sweep's own blind spot, and the reason `version` alone
@@ -310,13 +332,29 @@ public struct Baseline: Codable, Sendable {
                     + "(\(previous) → 1) — an entry pattern whose terminator stopped "
                     + "matching leaves the first entry carrying the whole page, with its "
                     + "version still parsing correctly off the heading")
+                // Same reason as the version above: recording the 1 would leave
+                // the next sweep comparing 1 against 1, which is the shape this
+                // check reads as healthy. The collapse would then be reported by
+                // exactly one sweep and never again — and one sweep is below
+                // `actionableThreshold`, so it would reach nobody.
+            } else {
+                entry.lastGoodEntryCount = count
             }
-            entry.lastGoodEntryCount = count
         }
 
         // The installer URL's transient run is tracked on every status, because the
         // finding it rides on stays `.ok` — there is no other place it would age.
-        if finding.warnings.contains(ProbeWarning.installURLTransient(status: nil).kind) {
+        //
+        // `hasPrefix`, not `contains(_:)` on the element, for the same reason
+        // `Verify.classify` and `Finding.signature` use it: a warning is published
+        // as `kind: detail`, so the Telegram 502 this field's doc is written about
+        // arrives as `installURLTransient: HTTP 502` and never equalled the bare
+        // kind. An exact match read every one of those as a sweep that RESOLVED
+        // the URL, reset the run on each sweep, and made
+        // `isInstallTransientReportable` unreachable for any transient that
+        // carried a status — which is to say almost all of them.
+        let transientKind = ProbeWarning.installURLTransient(status: nil).kind
+        if finding.warnings.contains(where: { $0.hasPrefix(transientKind) }) {
             entry.consecutiveInstallTransient += 1
             if entry.installTransientSince == nil { entry.installTransientSince = Date() }
         } else if finding.status != .skipped {
@@ -334,16 +372,29 @@ public struct Baseline: Codable, Sendable {
             entry.infraSince = nil
         }
 
-        switch finding.status {
+        // From here on, the finding as the REPORT will carry it. `Verify` folds
+        // every complaint back in with `adding(warning:)`, which promotes `ok` to
+        // `warn` — so switching on the status as it arrived recorded a sweep the
+        // report calls degraded as a clean one: the streak was reset by the very
+        // complaint that should have raised it, and no baseline complaint could
+        // ever clear `actionableThreshold` or reach `Reconcile`. The signature has
+        // to come from the promoted finding too, or the row says "unknown" while
+        // `report.json` says what is actually wrong, and `Reconcile` reads the two
+        // as a failure that changes shape every sweep.
+        let promoted = complaints.reduce(finding) { $0.adding(warning: $1) }
+
+        switch promoted.status {
         case .ok:
             entry.consecutiveActionable = 0
             entry.lastSignature = nil
+            entry.previousSignature = nil
             entry.sweepsSinceComment = 0
             entry.lastCommentedAt = nil
 
         case .broken, .warn:
             entry.consecutiveActionable += 1
-            entry.lastSignature = finding.signature
+            entry.previousSignature = entry.lastSignature
+            entry.lastSignature = promoted.signature
             entry.sweepsSinceComment += 1
 
         case .infra:

--- a/CLI/Sources/DuoKit/BoundedScan.swift
+++ b/CLI/Sources/DuoKit/BoundedScan.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// A blocking call run under a wall-clock bound, for the one shape in this
+/// package that cannot be cancelled: `AppScanner().scan()`.
+///
+/// **Why anything bounds it.** `AppScanner` reads TestFlight's SQLite database,
+/// which lives behind macOS's app-data privacy gate. On a machine with someone at
+/// the keyboard that surfaces a consent prompt; on a headless runner nothing ever
+/// answers it and the `open()` syscall simply never returns. The first CI sweep
+/// sat in `guarded_open_np` until the job timed out.
+///
+/// **Why a `Thread` and not a task group.** The blocked thread cannot be
+/// cancelled — it is stuck in a syscall — so this abandons it rather than waiting
+/// on it. A group looks like it would work (race the scan against a sleep, take
+/// whichever lands first) but `withTaskGroup` does not return until *every* child
+/// has finished, and `cancelAll()` cannot touch a thread parked in
+/// `guarded_open_np`. Both call sites shipped that version: the warning printed on
+/// time and the command hung anyway — 2026-08-15 the sweep sat there for ten
+/// minutes at 0.03s of CPU.
+///
+/// **Why the wait is off the cooperative pool.** A blocking wait there occupies
+/// one of about as many threads as the machine has cores, and the pool does not
+/// grow to compensate; that is how #351 stopped a whole test process.
+///
+/// One implementation, because there were two and they had already drifted — one
+/// converted the sub-second part of its `Duration`, the other silently floored it,
+/// so the same argument meant different things depending on which copy you
+/// reached.
+enum BoundedScan {
+
+    /// How long to wait for a local app scan before giving up on it.
+    ///
+    /// A scan that takes this long is a permission wall, not a slow disk. Both
+    /// callers treat the result as a bonus signal — the sweep loses one class of
+    /// finding, `duo list` shows nothing — and both would otherwise lose the whole
+    /// run.
+    static let timeout = Duration.seconds(20)
+
+    /// Run `body` on a detached thread, returning its value, or nil if `timeout`
+    /// elapsed first. A nil is "we gave up", never "it answered with nothing":
+    /// the caller decides what to say about that.
+    static func result<T: Sendable>(
+        within timeout: Duration, _ body: @escaping @Sendable () -> T
+    ) async -> T? {
+        let box = Box<T>()
+        let done = DispatchSemaphore(value: 0)
+        let worker = Thread {
+            box.set(body())
+            done.signal()
+        }
+        worker.start()
+
+        let timedOut = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global().async {
+                cont.resume(returning: done.wait(timeout: .now() + seconds(timeout)) == .timedOut)
+            }
+        }
+        guard !timedOut else { return nil }
+        return box.take()
+    }
+
+    /// A `Duration` as seconds, for `DispatchTime`.
+    ///
+    /// Both components, because one of the two copies this replaced took only
+    /// `components.seconds` — which floors any sub-second `Duration` to zero and
+    /// turns the bound into "do not wait at all". Neither production caller
+    /// passes one, so nothing would have caught it there; a test that wants a
+    /// timeout it can actually reach passes milliseconds.
+    static func seconds(_ duration: Duration) -> Double {
+        Double(duration.components.seconds)
+            + Double(duration.components.attoseconds) / 1e18
+    }
+
+    /// A slot the worker thread fills and the caller reads, for the case where the
+    /// caller has already given up on it.
+    private final class Box<T: Sendable>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: T?
+        func set(_ v: T) {
+            lock.lock(); defer { lock.unlock() }
+            value = v
+        }
+        func take() -> T? {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+    }
+}

--- a/CLI/Sources/DuoKit/Inventory.swift
+++ b/CLI/Sources/DuoKit/Inventory.swift
@@ -4,13 +4,6 @@ import DuoUpdaterCore
 /// Scanning and checking, shared by `duo list` and `duo check`.
 public enum Inventory {
 
-    /// `AppScanner` reads TestFlight's SQLite database, which lives behind the
-    /// Sequoia app-data TCC gate. With nobody at the keyboard to answer the
-    /// prompt the `open()` never returns — the first CI sweep hung until the job
-    /// timed out. A scan that takes this long is a permission wall, not a slow
-    /// disk, so it is abandoned rather than waited on.
-    static let scanTimeout = Duration.seconds(20)
-
     /// TestFlight's store, or the sentinel that stands for "not read", according to
     /// the user's setting. One function so the scan and the checker cannot disagree
     /// about it within a single run — a scan that read it would tag wrapped
@@ -24,9 +17,9 @@ public enum Inventory {
 
     public static func scan(_ settings: Settings) async -> [InstalledApp] {
         let extraLocations = settings.customScanPaths.map { URL(fileURLWithPath: $0) }
-        return await scan(timeout: scanTimeout) {
+        return await scan(timeout: BoundedScan.timeout) {
             // ⚠️ `testFlightStore` opens the database, and that open is the thing
-            // `scanTimeout` exists to race — so it has to be INSIDE this closure.
+            // the timeout exists to race — so it has to be INSIDE this closure.
             // It used to be, invisibly: `AppScanner`'s `testflight:` default was
             // evaluated at the call site. Naming it explicitly one line further
             // out reads identically and quietly moves the one blocking call out
@@ -36,39 +29,14 @@ public enum Inventory {
         }
     }
 
-    /// The bounded scan itself, with the scanner passed in so a test can wedge it.
-    ///
-    /// The scan runs on a plain `Thread`, not in a task group. A group looks like
-    /// it would work — race the scan against a sleep, take whichever lands first —
-    /// but `withTaskGroup` does not return until *every* child has finished, and
-    /// `cancelAll()` cannot touch a thread parked in `guarded_open_np`. That is
-    /// what this used to do, and the doc above already claimed the scan was
-    /// abandoned: the warning printed on time and the command hung anyway. The
-    /// sweep hit the identical bug and fixed it this way first — see
-    /// `Verify.installedVersions`.
-    ///
-    /// The wait itself is taken off the cooperative pool, because a blocking wait
-    /// there occupies one of about as many threads as the machine has cores and
-    /// the pool does not grow to compensate.
+    /// The bounded scan, with the scanner passed in so a test can wedge it.
+    /// `BoundedScan` holds the thread-and-timeout half and the reasons for it;
+    /// what belongs here is only what `duo` should say when the scan is given up
+    /// on, which is not what the sweep says about the same event.
     static func scan(
         timeout: Duration, _ body: @escaping @Sendable () -> [InstalledApp]
     ) async -> [InstalledApp] {
-        let box = ScanBox()
-        let done = DispatchSemaphore(value: 0)
-        let worker = Thread {
-            box.set(body())
-            done.signal()
-        }
-        worker.start()
-
-        let timedOut = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
-            DispatchQueue.global().async {
-                let seconds = Double(timeout.components.seconds)
-                    + Double(timeout.components.attoseconds) / 1e18
-                cont.resume(returning: done.wait(timeout: .now() + seconds) == .timedOut)
-            }
-        }
-        guard !timedOut, let scanned = box.take() else {
+        guard let scanned = await BoundedScan.result(within: timeout, body) else {
             FileHandle.standardError.write(Data("""
                 duo: the app scan did not finish within \(timeout). This is almost always \
                 the TestFlight database waiting on an "access data from other apps" \
@@ -77,21 +45,6 @@ public enum Inventory {
             return []
         }
         return scanned
-    }
-
-    /// A slot the scan thread fills and the caller reads, for the case where the
-    /// caller has already given up on it.
-    private final class ScanBox: @unchecked Sendable {
-        private let lock = NSLock()
-        private var value: [InstalledApp]?
-        func set(_ v: [InstalledApp]) {
-            lock.lock(); defer { lock.unlock() }
-            value = v
-        }
-        func take() -> [InstalledApp]? {
-            lock.lock(); defer { lock.unlock() }
-            return value
-        }
     }
 
     /// Build the checker the same way the menu-bar app does, so a version

--- a/CLI/Sources/DuoKit/Inventory.swift
+++ b/CLI/Sources/DuoKit/Inventory.swift
@@ -24,29 +24,73 @@ public enum Inventory {
 
     public static func scan(_ settings: Settings) async -> [InstalledApp] {
         let extraLocations = settings.customScanPaths.map { URL(fileURLWithPath: $0) }
-        return await withTaskGroup(of: [InstalledApp]?.self) { group in
+        return await scan(timeout: scanTimeout) {
             // ⚠️ `testFlightStore` opens the database, and that open is the thing
-            // `scanTimeout` exists to race — so it has to be INSIDE this task. It
-            // used to be, invisibly: `AppScanner`'s `testflight:` default was
-            // evaluated here, at the call site. Naming it explicitly on the line
-            // above `withTaskGroup` reads identically and quietly moved the one
-            // blocking call out from under the only thing bounding it.
-            group.addTask { AppScanner(
-                extraLocations: extraLocations, testflight: testFlightStore(settings)).scan() }
-            group.addTask {
-                try? await Task.sleep(for: scanTimeout)
-                return nil
+            // `scanTimeout` exists to race — so it has to be INSIDE this closure.
+            // It used to be, invisibly: `AppScanner`'s `testflight:` default was
+            // evaluated at the call site. Naming it explicitly one line further
+            // out reads identically and quietly moves the one blocking call out
+            // from under the only thing bounding it.
+            AppScanner(
+                extraLocations: extraLocations, testflight: testFlightStore(settings)).scan()
+        }
+    }
+
+    /// The bounded scan itself, with the scanner passed in so a test can wedge it.
+    ///
+    /// The scan runs on a plain `Thread`, not in a task group. A group looks like
+    /// it would work — race the scan against a sleep, take whichever lands first —
+    /// but `withTaskGroup` does not return until *every* child has finished, and
+    /// `cancelAll()` cannot touch a thread parked in `guarded_open_np`. That is
+    /// what this used to do, and the doc above already claimed the scan was
+    /// abandoned: the warning printed on time and the command hung anyway. The
+    /// sweep hit the identical bug and fixed it this way first — see
+    /// `Verify.installedVersions`.
+    ///
+    /// The wait itself is taken off the cooperative pool, because a blocking wait
+    /// there occupies one of about as many threads as the machine has cores and
+    /// the pool does not grow to compensate.
+    static func scan(
+        timeout: Duration, _ body: @escaping @Sendable () -> [InstalledApp]
+    ) async -> [InstalledApp] {
+        let box = ScanBox()
+        let done = DispatchSemaphore(value: 0)
+        let worker = Thread {
+            box.set(body())
+            done.signal()
+        }
+        worker.start()
+
+        let timedOut = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global().async {
+                let seconds = Double(timeout.components.seconds)
+                    + Double(timeout.components.attoseconds) / 1e18
+                cont.resume(returning: done.wait(timeout: .now() + seconds) == .timedOut)
             }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            if first == nil {
-                FileHandle.standardError.write(Data("""
-                    duo: the app scan did not finish within 20s. This is almost always \
-                    the TestFlight database waiting on an "access data from other apps" \
-                    prompt — grant it once in System Settings ▸ Privacy & Security.\n
-                    """.utf8))
-            }
-            return first ?? []
+        }
+        guard !timedOut, let scanned = box.take() else {
+            FileHandle.standardError.write(Data("""
+                duo: the app scan did not finish within \(timeout). This is almost always \
+                the TestFlight database waiting on an "access data from other apps" \
+                prompt — grant it once in System Settings ▸ Privacy & Security.\n
+                """.utf8))
+            return []
+        }
+        return scanned
+    }
+
+    /// A slot the scan thread fills and the caller reads, for the case where the
+    /// caller has already given up on it.
+    private final class ScanBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: [InstalledApp]?
+        func set(_ v: [InstalledApp]) {
+            lock.lock(); defer { lock.unlock() }
+            value = v
+        }
+        func take() -> [InstalledApp]? {
+            lock.lock(); defer { lock.unlock() }
+            return value
         }
     }
 

--- a/CLI/Sources/DuoKit/Reconcile.swift
+++ b/CLI/Sources/DuoKit/Reconcile.swift
@@ -178,11 +178,20 @@ public enum Reconcile {
 
         // Open issue, still broken. Speak up only if something changed, or if
         // enough sweeps have passed that a nudge is warranted.
-        if entry.lastSignature != finding.signature {
+        //
+        // Against `previousSignature`, never `lastSignature`: `duo verify` writes
+        // the baseline and this step reads it back, so `lastSignature` is already
+        // THIS finding's signature and the comparison asks whether a value equals
+        // itself — it was dead in both directions. A nil previous (a row written
+        // before the field existed, or one whose streak started on an infra sweep)
+        // is "nothing to compare", not "changed": announcing a shape change
+        // against `unknown` would fire once on every open issue the day this
+        // shipped, which is the noise this whole file is built to avoid.
+        if let previous = entry.previousSignature, previous != finding.signature {
             return .comment(
                 issue: issue,
                 body: "The failure changed shape on \(Self.day(now)) — was "
-                    + "`\(entry.lastSignature ?? "unknown")`, now "
+                    + "`\(previous)`, now "
                     + "`\(finding.signature)`.\n\n\(body(for: finding, entry: entry, suggestion: suggestion))")
         }
         // A suggestion the issue doesn't have yet is genuinely new information,
@@ -296,14 +305,17 @@ public enum Reconcile {
         // here is the whole diagnosis: the page collapsed into one entry and the
         // heading it kept still parses.
         //
-        // Just the count, never "(was N)". `entry` came from the file `duo
-        // verify` wrote minutes ago, and that write already folded THIS sweep's
-        // count into it — so `lastGoodEntryCount` equals what is printed here,
-        // always, and a "was" that can never differ reads as "nothing changed"
-        // on exactly the issue that exists because something did. The transition
-        // is in the warning below, where it comes from the sweep that saw both
-        // numbers. (`| last good |` above has the same property, for the same
-        // reason.)
+        // Just the count, never "(was N)". The transition belongs in the warning
+        // below, which comes from the sweep that saw both numbers and says which
+        // way it moved; a second, separately-derived "was" beside it could only
+        // agree with it or contradict it.
+        //
+        // (`entry` is the row `duo verify` wrote minutes ago. Its
+        // `lastGoodEntryCount` is the last count the sweep TRUSTED, which on a
+        // collapse is deliberately not this sweep's — see `Baseline.reconcile`,
+        // where recording the collapsed value would leave the next sweep with
+        // nothing to notice. `| last good |` above is the same field for
+        // versions.)
         if let entries = finding.entryCount {
             out += "| entries parsed | \(entries) |\n"
         }

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -18,7 +18,8 @@ import DuoUpdaterCore
 public struct VerifyOptions: Sendable {
     public init() {}
     /// Restrict the sweep to recipes whose bundle id or recipe id contains one
-    /// of these. Spot-checking one app shouldn't cost 150 requests.
+    /// of these — see `Verify.filtered`. Spot-checking one app shouldn't cost 150
+    /// requests.
     public var only: [String] = []
     public var registries: Set<Registry> = Set(Registry.allCases)
     public var hostConcurrency = 4
@@ -46,6 +47,20 @@ struct InstalledVersion: Sendable {
     let vendorBuild: String?
 }
 
+/// What `--only` may name. The two ids every registry entry carries, so
+/// `Verify.filtered` has one definition of "matches" instead of one per call
+/// site — see that function for which half was missing.
+protocol VerifySelectable {
+    var bundleID: String { get }
+    var recipeID: String { get }
+}
+
+extension VendorProbeRecipe: VerifySelectable {}
+extension GitHubReleaseRule: VerifySelectable {}
+extension ChangelogRecipe: VerifySelectable {}
+extension MacAppStoreProbeCase: VerifySelectable {}
+extension SparkleFeedCatalog.VerificationCase: VerifySelectable {}
+
 public enum Verify {
 
     public static func run(_ options: VerifyOptions) async -> Int32 {
@@ -59,11 +74,11 @@ public enum Verify {
             print("\n  ⚠︎ \(reason).\n    Sweeping anyway because --allow-stale-binary was passed.\n")
         }
 
-        let vendor = filtered(VendorProbeRegistry.recipes, options) { $0.bundleID }
-        let github = filtered(GitHubReleaseRegistry.rules, options) { $0.bundleID }
-        let changelog = filtered(ChangelogRecipeRegistry.recipes, options) { $0.bundleID }
-        let appStore = filtered(MacAppStoreProbeRegistry.cases, options) { $0.bundleID }
-        let feeds = filtered(SparkleFeedCatalog.verificationCases, options) { $0.bundleID }
+        let vendor = filtered(VendorProbeRegistry.recipes, options)
+        let github = filtered(GitHubReleaseRegistry.rules, options)
+        let changelog = filtered(ChangelogRecipeRegistry.recipes, options)
+        let appStore = filtered(MacAppStoreProbeRegistry.cases, options)
+        let feeds = filtered(SparkleFeedCatalog.verificationCases, options)
 
         // The pkg install specs the pkgarch sweep reads. Counted here like every
         // other registry: without it `duo verify --pkgarch` computes a total of
@@ -265,12 +280,25 @@ public enum Verify {
         return versions["\(recipe.bundleID):\(channel.rawValue)"]
     }
 
-    private static func filtered<T>(
-        _ items: [T], _ options: VerifyOptions, id: (T) -> String
+    /// Both ids, not one: `--only` is documented as matching a bundle id OR a
+    /// recipe id, and it matched the bundle id alone. For four of the five
+    /// registries the recipe id contains the bundle id, so that looked like it
+    /// worked; the GitHub rules are keyed on the repository slug, so no `--only`
+    /// could ever name one by its recipe id — and nothing anywhere could select by
+    /// channel, which is the other half of every recipe id.
+    ///
+    /// Taken from a protocol rather than a per-call-site closure because the
+    /// closure is exactly the part that was wrong, and five of them are five
+    /// chances to be wrong again in a way no test of this function would see.
+    static func filtered<T: VerifySelectable>(
+        _ items: [T], _ options: VerifyOptions
     ) -> [T] {
         guard !options.only.isEmpty else { return items }
         return items.filter { item in
-            options.only.contains { id(item).localizedCaseInsensitiveContains($0) }
+            options.only.contains { needle in
+                item.bundleID.localizedCaseInsensitiveContains(needle)
+                    || item.recipeID.localizedCaseInsensitiveContains(needle)
+            }
         }
     }
 
@@ -1287,8 +1315,11 @@ extension Finding {
     /// persisted report schema and a new field would have to be threaded
     /// through every construction site.
     ///
-    /// It survives `Baseline.signature`, which keys on the first 40 characters,
-    /// so a note stays one stable signature rather than a new one per sweep.
+    /// It never reaches `Finding.signature` at all: that is computed over
+    /// `publicWarnings`, which is defined as the warnings that do NOT carry this
+    /// prefix. So a note can say something different every sweep — it names this
+    /// machine's state — without the signature moving, which is the property the
+    /// nudge rate limit depends on.
     public static let machineNotePrefix = "machine-note: "
 
     /// Attach a note without touching the status — see `machineNotePrefix`. A
@@ -1302,7 +1333,12 @@ extension Finding {
             failureKind: failureKind, failureDetail: failureDetail,
             warnings: warnings + [note], endpointHost: endpointHost, pattern: pattern,
             attempts: attempts, gatewayRetries: gatewayRetries,
-            elapsedMs: elapsedMs, bodySample: bodySample)
+            // Every field forwarded, for the reason spelled out on
+            // `adding(warning:)` below — and this one shipped without
+            // `entryCount`, so a finding that picked up a machine note lost
+            // "entries parsed" from `report.json`. Silently: every argument here
+            // has a default.
+            entryCount: entryCount, elapsedMs: elapsedMs, bodySample: bodySample)
     }
 
     /// Attach a warning discovered after the fact (the baseline's history checks

--- a/CLI/Sources/DuoKit/Verify.swift
+++ b/CLI/Sources/DuoKit/Verify.swift
@@ -1211,42 +1211,22 @@ public enum Verify {
         return make(actionable.isEmpty ? .ok : .warn, version: version, warnings: warnings)
     }
 
-    /// How long to wait for the local scan before deciding the cross-check isn't
-    /// worth the run.
-    static let scanTimeout = Duration.seconds(20)
-
     /// Index the locally installed apps by the recipe id they'd be checked
     /// under, so a recipe can find its own installed copy without re-deriving
     /// the channel gate.
     ///
-    /// **Bounded, because this scan can block forever.** `AppScanner` reads
-    /// TestFlight's SQLite database, which lives behind macOS's app-data
-    /// privacy gate. On a machine with someone at the keyboard that surfaces a
-    /// consent prompt; on a headless runner nothing ever answers it and the
-    /// `open()` syscall simply never returns. The first CI run sat in
-    /// `guarded_open_np` until the job timed out.
-    ///
-    /// The blocked thread can't be cancelled — it is stuck in a syscall — so
-    /// this abandons it instead and moves on. The cross-check is a bonus signal;
+    /// **Bounded, because this scan can block forever** — `BoundedScan` holds the
+    /// mechanism and every reason for it. The cross-check is a bonus signal:
     /// losing it costs one class of finding, while waiting for it costs the
     /// entire sweep.
     ///
-    /// The scan runs on a plain `Thread`, not in a task group. A group looks
-    /// like it would work — race the scan against a sleep, take whichever lands
-    /// first — but `withTaskGroup` does not return until *every* child has
-    /// finished, and `cancelAll()` cannot touch a thread parked in
-    /// `guarded_open_np`. The warning printed on time and the sweep hung anyway;
-    /// 2026-08-15 it sat there for ten minutes at 0.03s of CPU.
-    ///
-    /// `TestFlightInventory` now bounds that open itself, so this should no
-    /// longer be reachable through TestFlight. It stays because it is the last
-    /// guard around everything *else* `scan()` touches — other apps' containers,
-    /// network volumes, a stalled automount.
+    /// `TestFlightInventory` now bounds its own open, so this should no longer be
+    /// reachable through TestFlight. It stays because it is the last guard around
+    /// everything *else* `scan()` touches — other apps' containers, network
+    /// volumes, a stalled automount.
     static func installedVersions() async -> [String: InstalledVersion] {
-        let box = ScanBox()
-        let done = DispatchSemaphore(value: 0)
         let proofs = ResolvedChannelStore.Snapshot()
-        let worker = Thread {
+        let scanned = await BoundedScan.result(within: BoundedScan.timeout) {
             var out: [String: InstalledVersion] = [:]
             for app in AppScanner().scan() {
                 guard let bundleID = app.bundleID else { continue }
@@ -1269,21 +1249,11 @@ public enum Verify {
                     marketing: app.shortVersion, build: app.buildVersion,
                     vendorBuild: app.vendorBuildVersion)
             }
-            box.set(out)
-            done.signal()
+            return out
         }
-        worker.start()
-
-        // Wait off the cooperative pool so a stuck scan can never starve it.
-        let timedOut = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
-            DispatchQueue.global().async {
-                let seconds = Double(scanTimeout.components.seconds)
-                cont.resume(returning: done.wait(timeout: .now() + seconds) == .timedOut)
-            }
-        }
-        guard !timedOut, let scanned = box.take() else {
+        guard let scanned else {
             FileHandle.standardError.write(Data("""
-                ⚠︎ the local app scan did not finish within \(scanTimeout) — continuing \
+                ⚠︎ the local app scan did not finish within \(BoundedScan.timeout) — continuing \
                 without the installed-copy cross-check.
                   Usually means a privacy prompt nobody can answer (TestFlight's \
                 database is behind the app-data gate).\n
@@ -1291,21 +1261,6 @@ public enum Verify {
             return [:]
         }
         return scanned
-    }
-
-    /// A slot the scan thread fills and the caller reads, for the case where the
-    /// caller has already given up.
-    private final class ScanBox: @unchecked Sendable {
-        private let lock = NSLock()
-        private var value: [String: InstalledVersion]?
-        func set(_ v: [String: InstalledVersion]) {
-            lock.lock(); defer { lock.unlock() }
-            value = v
-        }
-        func take() -> [String: InstalledVersion]? {
-            lock.lock(); defer { lock.unlock() }
-            return value
-        }
     }
 }
 

--- a/CLI/Sources/duo/main.swift
+++ b/CLI/Sources/duo/main.swift
@@ -161,7 +161,8 @@ events options:
   installed separately from the app and is often the older of the two.
 
 verify options:
-  --only <text>       Restrict to recipes whose bundle id contains <text>.
+  --only <text>       Restrict to recipes whose bundle id or recipe id contains
+                      <text> (so `--only beta` selects every beta channel).
                       Comma-separated for several. Without it all six
                       registries are swept (~150 requests, about 3 minutes).
   --vendor            Sweep only the vendor probe recipes.
@@ -230,7 +231,10 @@ reconcile options:
 exit codes:
   0  no recipe-level problems
   1  at least one recipe is degraded, broken for 2+ consecutive sweeps, or
-     pointed at an endpoint that has been unreachable for 5+ consecutive sweeps
+     pointed at an endpoint that has been unreachable on 3+ consecutive sweeps
+     spanning at least 5 days (see Baseline.isInfraReportable — the wall-clock
+     half is the one that matters; the sweep count only keeps a runner that was
+     off for a week from retiring a host on two observations)
   2  usage error
 """
 

--- a/CLI/Tests/DuoKitTests/BaselineTests.swift
+++ b/CLI/Tests/DuoKitTests/BaselineTests.swift
@@ -217,6 +217,26 @@ import DuoUpdaterCore
         #expect(complaints.first?.contains("4.7.9") == true)
     }
 
+    /// The same half `aCollapseAccumulatesAStreakAndKeepsTheGoodCount` pins for
+    /// the entry count: a regression is a `.warn` in the report, so it has to be a
+    /// `.warn` in the file too. Counted on the finding as it arrives (`.ok`) the
+    /// streak was RESET by the very sweep that complained, and the regressed
+    /// version became the yardstick — so the second sweep saw no regression at
+    /// all and the complaint could never reach `Reconcile`.
+    @Test func aVersionRegressionAccumulatesAStreakAndKeepsTheGoodVersion() {
+        var baseline = Baseline()
+        let id = "vendor:com.example.app:stable"
+        _ = baseline.reconcile(finding(status: .ok, version: "4.7.9"))
+
+        #expect(baseline.reconcile(finding(status: .ok, version: "4.7")).count == 1)
+        #expect(baseline.streak(id) == 1)
+        #expect(baseline.entries[id]?.lastGoodVersion == "4.7.9")
+
+        #expect(baseline.reconcile(finding(status: .ok, version: "4.7")).count == 1)
+        #expect(baseline.streak(id) == 2)
+        #expect(baseline.isReportable(id))
+    }
+
     @Test func movingForwardOrStandingStillIsNotFlagged() {
         var baseline = Baseline()
         _ = baseline.reconcile(finding(status: .ok, version: "4.7.9"))

--- a/CLI/Tests/DuoKitTests/CheckScopeTests.swift
+++ b/CLI/Tests/DuoKitTests/CheckScopeTests.swift
@@ -72,3 +72,41 @@ import DuoUpdaterCore
         #expect(scope.map(\.name) == ["Ignored"])
     }
 }
+
+/// `--only` is documented as matching a bundle id *or* a recipe id, and it is the
+/// flag that keeps a spot-check from costing 150 requests. It matched the bundle
+/// id alone, which is indistinguishable from working for four of the five
+/// registries — their recipe ids contain the bundle id — and completely broken
+/// for the GitHub rules, whose recipe id is keyed on the repository slug.
+@Suite struct VerifyOnlyFilterTests {
+
+    private func options(_ only: [String]) -> VerifyOptions {
+        var o = VerifyOptions()
+        o.only = only
+        return o
+    }
+
+    /// Mutation: drop the `recipeID` half of `Verify.filtered`'s match.
+    @Test func aGitHubRuleCanBeNamedByItsRecipeID() throws {
+        let rule = try #require(GitHubReleaseRegistry.rules.first)
+        #expect(!rule.recipeID.contains(rule.bundleID),
+                "fixture guard: a slug-keyed recipe id is the whole point here")
+        let selected = Verify.filtered(
+            GitHubReleaseRegistry.rules, options([rule.recipeID]))
+        #expect(selected.map(\.recipeID) == [rule.recipeID])
+    }
+
+    /// …and the bundle id keeps working, because that is what everything types.
+    @Test func aBundleIDStillSelects() throws {
+        let recipe = try #require(VendorProbeRegistry.recipes.first)
+        let selected = Verify.filtered(
+            VendorProbeRegistry.recipes, options([recipe.bundleID]))
+        #expect(selected.allSatisfy { $0.bundleID == recipe.bundleID })
+        #expect(!selected.isEmpty)
+    }
+
+    @Test func anEmptyFilterSelectsEverything() {
+        let selected = Verify.filtered(VendorProbeRegistry.recipes, options([]))
+        #expect(selected.count == VendorProbeRegistry.recipes.count)
+    }
+}

--- a/CLI/Tests/DuoKitTests/EntryCountCollapseTests.swift
+++ b/CLI/Tests/DuoKitTests/EntryCountCollapseTests.swift
@@ -173,6 +173,51 @@ import DuoUpdaterCore
         #expect(second.reconcile(changelog(entries: 1)).count == 1)
     }
 
+    /// A complaint only reaches a human through `Reconcile`, and `Reconcile` only
+    /// ever sees the baseline — so a complaint that does not move the baseline is
+    /// visible in exactly one sweep's exit code and nowhere else.
+    ///
+    /// Both halves are load-bearing and both were wrong:
+    ///
+    ///  * the streak was counted on the finding as it arrived (`.ok`), so a
+    ///    collapse RESET `consecutiveActionable` instead of raising it and could
+    ///    never clear `actionableThreshold`;
+    ///  * `lastGoodEntryCount` was overwritten with the collapsed value, so the
+    ///    second sweep had 1 to compare against, produced no complaint at all,
+    ///    and the page stayed collapsed in silence forever after.
+    ///
+    /// Mutation: either half — switch on `finding.status` instead of the promoted
+    /// one, or move the `entry.lastGoodEntryCount = count` assignment back out of
+    /// the `else`.
+    @Test func aCollapseAccumulatesAStreakAndKeepsTheGoodCount() {
+        var baseline = Baseline()
+        let id = "changelog:com.example.app:-"
+        _ = baseline.reconcile(changelog(entries: 20))
+
+        #expect(baseline.reconcile(changelog(entries: 1)).count == 1)
+        #expect(baseline.streak(id) == 1)
+        #expect(baseline.entries[id]?.lastGoodEntryCount == 20,
+                "the collapsed count must not become the yardstick the next sweep uses")
+
+        #expect(baseline.reconcile(changelog(entries: 1)).count == 1,
+                "still collapsed against the last good count")
+        #expect(baseline.streak(id) == 2)
+        #expect(baseline.isReportable(id),
+                "two consecutive collapses is what `actionableThreshold` is for")
+        #expect(baseline.entries[id]?.lastGoodEntryCount == 20)
+    }
+
+    /// …and the page healing clears it, the same way any other recovery does.
+    @Test func aPageThatRecoversClearsTheCollapseStreak() {
+        var baseline = Baseline()
+        let id = "changelog:com.example.app:-"
+        _ = baseline.reconcile(changelog(entries: 20))
+        _ = baseline.reconcile(changelog(entries: 1))
+        _ = baseline.reconcile(changelog(entries: 20))
+        #expect(baseline.streak(id) == 0)
+        #expect(baseline.entries[id]?.lastGoodEntryCount == 20)
+    }
+
     /// The count has to survive the rebuild `adding(warning:)` performs, or it
     /// is dropped from `report.json` for exactly the findings that carry a
     /// complaint — the ones most worth reading, and the ones whose issue body

--- a/CLI/Tests/DuoKitTests/GatewayRetryReportingTests.swift
+++ b/CLI/Tests/DuoKitTests/GatewayRetryReportingTests.swift
@@ -32,6 +32,24 @@ struct GatewayRetryReportingTests {
         #expect(base.adding(warning: "w").attempts == 3)
     }
 
+    /// …and the same for the changelog entry count, which is the field that was
+    /// actually dropped. `adding(warning:)` forwards it and carries a comment
+    /// saying why; `observing` did not, so a machine note — the one-click
+    /// candidate note the vendor sweep attaches — silently deleted "entries
+    /// parsed" from `report.json` for that finding, and it is the number the
+    /// collapse check exists to show.
+    ///
+    /// Mutation: drop `entryCount:` from `observing`'s initializer call. It
+    /// compiles, because every argument there has a default.
+    @Test func annotatingAFindingKeepsItsEntryCount() {
+        let counted = Finding(
+            recipeID: "changelog:com.example.app:-", registry: .changelog,
+            bundleID: "com.example.app", channel: "-", status: .ok,
+            endpointHost: "example.com", entryCount: 17)
+        #expect(counted.observing("\(Finding.machineNotePrefix)note").entryCount == 17)
+        #expect(counted.adding(warning: "w").entryCount == 17)
+    }
+
     /// `report.json` files written before this field existed are still read by
     /// `Reconcile` and `Triage`. Decoding must not start failing on them, and a
     /// missing key must not be reported as a confident zero.

--- a/CLI/Tests/DuoKitTests/InstallTransientAgingTests.swift
+++ b/CLI/Tests/DuoKitTests/InstallTransientAgingTests.swift
@@ -1,15 +1,30 @@
 import Testing
 import Foundation
 @testable import DuoKit
+import DuoUpdaterCore
 
 /// Splitting a vendor 5xx on the installer URL out of `installURLUnresolved` was
 /// right — it stopped a working recipe filing issues against itself. But "not
 /// actionable" was implemented as "never actionable", which recreated the failure
 /// this whole sweep exists to end: an installer URL that 5xxs forever reported
 /// `.ok` on every run and could never be seen by anyone. These pin both halves.
+/// What the sweep actually writes into `Finding.warnings`: `ProbeWarning`
+/// publishes `kind: detail`, and the detail is the status when there is one.
+/// Building the fixtures from the production value rather than from the bare
+/// kind is the whole point — the aging counter was matched with an exact element
+/// comparison, so every 5xx (the Telegram case this exists for) was counted as a
+/// sweep that RESOLVED the URL, and the run could never age.
+private let transientShapes = [
+    ProbeWarning.installURLTransient(status: 502).display,
+    // The one shape that IS the bare kind: the request failed outright, so there
+    // is no status to name.
+    ProbeWarning.installURLTransient(status: nil).display,
+]
+
 struct InstallTransientAgingTests {
 
     private let transientKind = "installURLTransient"
+
 
     private func entry(sweeps: Int, daysAgo: Double?, issue: Int? = nil) -> Baseline.Entry {
         var e = Baseline.Entry()
@@ -65,10 +80,17 @@ struct InstallTransientAgingTests {
         #expect(!action.isWrite)
     }
 
-    @Test func aResolvedInstallURLEndsTheRun() {
+    /// ⚠️ Runs over the shapes the sweep really produces, including the one with
+    /// a status. `installURLTransient: HTTP 502` is what `td.telegram.org`'s
+    /// bursts write, and an exact-element match against the bare kind counted
+    /// every one of them as a sweep that RESOLVED the URL — so the run reset on
+    /// each sweep, `consecutiveInstallTransient` never left 1, and the endpoint
+    /// this counter exists for could 502 forever without ever being reportable.
+    @Test(arguments: transientShapes)
+    func aResolvedInstallURLEndsTheRun(shape: String) {
         var baseline = Baseline()
         let id = "vendor:com.example.app:stable"
-        for _ in 1...5 { _ = baseline.reconcile(finding(warnings: [transientKind])) }
+        for _ in 1...5 { _ = baseline.reconcile(finding(warnings: [shape])) }
         #expect(baseline.entries[id]?.consecutiveInstallTransient == 5)
         #expect(baseline.entries[id]?.installTransientSince != nil)
 
@@ -76,6 +98,20 @@ struct InstallTransientAgingTests {
         #expect(baseline.entries[id]?.consecutiveInstallTransient == 0)
         #expect(baseline.entries[id]?.installTransientSince == nil,
                 "one good resolution means it was transient after all")
+    }
+
+    /// The end-to-end shape of the bug, on the exact warning the field's own doc
+    /// names: five sweeps of 502 past the window must be reportable.
+    @Test func aStatusCarryingTransientAgesIntoAReport() {
+        var baseline = Baseline()
+        let id = "vendor:com.example.app:stable"
+        let warning = ProbeWarning.installURLTransient(status: 502).display
+        #expect(warning == "installURLTransient: HTTP 502")
+        for _ in 1...5 { _ = baseline.reconcile(finding(warnings: [warning])) }
+
+        let entry = baseline.entries[id] ?? Baseline.Entry()
+        #expect(entry.isInstallTransientReportable(
+            now: Date().addingTimeInterval(Baseline.infraWindow + 60)))
     }
 
     @Test func theGateIsWallClockNotSweepCount() {

--- a/CLI/Tests/DuoKitTests/InventoryTests.swift
+++ b/CLI/Tests/DuoKitTests/InventoryTests.swift
@@ -99,6 +99,47 @@ private let installed = [
     }
 }
 
+/// The scan's timeout is the only thing standing between `duo list/check/install/
+/// restart/backups/doctor/ignore` and a permission wall nobody can answer: the
+/// `open()` behind macOS's app-data gate never returns on a headless runner.
+///
+/// ⚠️ Written as a real wedge — a scan that never returns — because the shape of
+/// the bug was that the timeout PRINTED on time and the command hung anyway.
+/// `withTaskGroup` does not return until every child finishes and `cancelAll()`
+/// cannot touch a thread parked in a syscall, so racing the scan against a sleep
+/// inside a group measures nothing. A fixture whose scan eventually returns would
+/// pass against either implementation.
+@Suite struct InventoryScanTimeoutTests {
+
+    /// Mutation: put the body back in a `withTaskGroup` racing a sleep. This test
+    /// then sits on the blocked scan until the suite's own timeout kills it.
+    @Test func aScanThatNeverReturnsIsAbandonedAtTheTimeout() async {
+        // Released in the `defer` so the thread cannot outlive the test.
+        let release = DispatchSemaphore(value: 0)
+        defer { release.signal() }
+
+        let started = Date()
+        let scanned = await Inventory.scan(timeout: .milliseconds(200)) {
+            release.wait()
+            return []
+        }
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(scanned.isEmpty)
+        // Generous: the assertion is "it came back", not a wall-clock bound —
+        // a 3-core runner is not a stopwatch. The unfixed code never returns at
+        // all, so any finite time distinguishes it.
+        #expect(elapsed < 20, "returned after \(elapsed)s — the timeout did not abandon the scan")
+    }
+
+    /// …and the ordinary case still hands back what the scan found, rather than
+    /// the empty list the timeout produces.
+    @Test func aScanThatFinishesIsReturned() async {
+        let scanned = await Inventory.scan(timeout: .seconds(20)) { installed }
+        #expect(scanned.map(\.name) == installed.map(\.name))
+    }
+}
+
 @Suite struct CheckRowTests {
 
     private func row(hasUpdate: Bool, hidden: Bool) -> Check.Row {

--- a/CLI/Tests/DuoKitTests/InventoryTests.swift
+++ b/CLI/Tests/DuoKitTests/InventoryTests.swift
@@ -135,8 +135,24 @@ private let installed = [
     /// …and the ordinary case still hands back what the scan found, rather than
     /// the empty list the timeout produces.
     @Test func aScanThatFinishesIsReturned() async {
-        let scanned = await Inventory.scan(timeout: .seconds(20)) { installed }
+        let scanned = await Inventory.scan(timeout: BoundedScan.timeout) { installed }
         #expect(scanned.map(\.name) == installed.map(\.name))
+    }
+
+    /// The sweep's copy of this primitive read only `components.seconds`, which
+    /// floors any sub-second bound to "do not wait at all". Both callers pass
+    /// whole seconds, so nothing in production would ever have shown it — but the
+    /// two copies meant the same argument did different things depending on which
+    /// one you reached, and now there is only one.
+    ///
+    /// Asserted as arithmetic rather than as elapsed time on purpose: a wall-clock
+    /// bound in a parallel suite on a 3-core runner is not a measurement.
+    ///
+    /// Mutation: drop the attoseconds term.
+    @Test func aSubSecondBoundIsNotFlooredToZero() {
+        #expect(BoundedScan.seconds(.milliseconds(200)) == 0.2)
+        #expect(BoundedScan.seconds(.seconds(20)) == 20)
+        #expect(BoundedScan.seconds(BoundedScan.timeout) == 20)
     }
 }
 

--- a/CLI/Tests/DuoKitTests/ReconcileTests.swift
+++ b/CLI/Tests/DuoKitTests/ReconcileTests.swift
@@ -21,6 +21,7 @@ import Foundation
 
     private func entry(
         issue: Int? = nil, streak: Int = 0, signature: String? = nil,
+        previousSignature: String? = nil,
         closedAt: Date? = nil, sweepsSinceComment: Int = 0, commentedDaysAgo: Double? = nil,
         lastGood: String? = nil,
         infra: Int = 0, infraDays: Double? = nil
@@ -29,6 +30,7 @@ import Foundation
         e.issueNumber = issue
         e.consecutiveActionable = streak
         e.lastSignature = signature
+        e.previousSignature = previousSignature
         e.closedAt = closedAt
         e.sweepsSinceComment = sweepsSinceComment
         e.lastCommentedAt = commentedDaysAgo.map { Date(timeIntervalSinceNow: -$0 * 86_400) }
@@ -233,10 +235,17 @@ import Foundation
     /// A failure that changes shape is new information and shouldn't wait for the
     /// nudge cycle — "the regex stopped matching" becoming "the endpoint 404s"
     /// changes what the fix is.
+    ///
+    /// ⚠️ The entry is the one `duo verify` leaves behind, which is why
+    /// `lastSignature` is THIS sweep's signature and the comparison is against
+    /// `previousSignature`. Written the other way round (`lastSignature:
+    /// "versionPatternNoMatch"`) this test passed against a branch that can never
+    /// be reached in production — see the end-to-end case below.
     @Test func aFailureChangingShapeIsReportedImmediately() {
         let action = Reconcile.decide(
             finding(status: .broken, failureKind: "httpStatus404"),
-            entry: entry(issue: 7, streak: 3, signature: "versionPatternNoMatch",
+            entry: entry(issue: 7, streak: 3, signature: "httpStatus404",
+                         previousSignature: "versionPatternNoMatch",
                          sweepsSinceComment: 1),
             reportable: true)
         guard case .comment(_, let body) = action else {
@@ -246,6 +255,49 @@ import Foundation
         #expect(body.contains("changed shape"))
         #expect(body.contains("versionPatternNoMatch"))
         #expect(body.contains("httpStatus404"))
+    }
+
+    /// The same rule through the real pipeline: `duo verify` folds each sweep into
+    /// the baseline and writes it, then `duo reconcile` reads that file back. The
+    /// hand-built case above cannot see that ordering, and the ordering is what
+    /// broke the rule — verify had already written this sweep's signature into
+    /// `lastSignature`, so the comparison `Reconcile` made was between a value and
+    /// itself and "changed shape" was unreachable for every recipe.
+    ///
+    /// Mutation: compare `entry.lastSignature` instead. The third sweep then
+    /// reports a 404 following a pattern failure as "still failing the same way".
+    @Test func aShapeChangeSurvivesTheVerifyThenReconcileRoundTrip() throws {
+        var baseline = Baseline()
+        let id = "vendor:com.example.app:stable"
+        // Two sweeps of one failure, which is what opens the issue.
+        for _ in 1...2 {
+            _ = baseline.reconcile(finding(status: .broken, failureKind: "versionPatternNoMatch"))
+        }
+        baseline.entries[id]?.issueNumber = 7
+        baseline.entries[id]?.lastCommentedAt = Date()
+
+        // The sweep where it changes shape.
+        let changed = finding(status: .broken, failureKind: "httpStatus404")
+        _ = baseline.reconcile(changed)
+
+        let action = Reconcile.decide(
+            changed, entry: try #require(baseline.entries[id]),
+            reportable: baseline.isReportable(id))
+        guard case .comment(_, let body) = action else {
+            Issue.record("expected an immediate comment, got \(action)")
+            return
+        }
+        #expect(body.contains("changed shape"))
+        #expect(body.contains("versionPatternNoMatch"))
+        #expect(body.contains("httpStatus404"))
+
+        // …and a sweep that repeats the new shape is not news again. The weekly
+        // rate limit is what must hold it, not a second "changed shape".
+        _ = baseline.reconcile(changed)
+        let repeated = Reconcile.decide(
+            changed, entry: try #require(baseline.entries[id]),
+            reportable: baseline.isReportable(id))
+        #expect(!repeated.isWrite, "got \(repeated)")
     }
 
     // MARK: - healing

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ install:
 cli:
 	@scripts/build-cli.sh
 
-# Core package build + tests (some tests hit the network).
+# Compile the Core package. Nothing is executed — `make test` is the one that
+# runs anything, and it runs more than this package.
 build:
 	cd DuoUpdaterCore && swift build
 

--- a/application-test/Sources/channel-verify/main.swift
+++ b/application-test/Sources/channel-verify/main.swift
@@ -79,10 +79,24 @@ if argv[1] == "--scan" {
     let remote = try? await VendorProbeSource().latestVersion(for: app)
     if let remote {
         let latest = remote.displayVersion ?? "<nil>"
-        let inst = remote.shortVersion != nil ? app.shortVersion : app.buildVersion
-        let newer = (remote.shortVersion ?? remote.version).map {
-            VersionComparator.isNewer($0, than: inst ?? "") } ?? false
-        print("    VendorProbe → \(latest) · \(newer ? "UPDATE \(inst ?? "?") → \(latest)" : "up to date (not newer)")")
+        // The production gate, for the reason path mode's comment spells out: a
+        // re-implemented comparison disagrees with the engine for every
+        // `versionIsBuild` recipe, because those carry both a build to compare and
+        // a marketing string to display. This one picked whichever side the remote
+        // happened to fill in, which is the marketing-first shape that answers
+        // "1.0 is not newer than 1.0" for an app that freezes its marketing string
+        // — the harness certifying exactly what it was built to catch.
+        let verdict: String
+        switch UpdateChecker.evaluate(installed: app, remote: remote) {
+        case .updateAvailable(let to):
+            let from = app.buildVersion(in: remote.buildNamespace) ?? app.shortVersion
+            verdict = "UPDATE \(from ?? "?") → \(to)"
+        case .upToDate:
+            verdict = "up to date (not newer)"
+        case let other:
+            verdict = "\(other)"
+        }
+        print("    VendorProbe → \(latest) · \(verdict)")
     } else {
         print("    VendorProbe → no version (channel \(app.releaseChannel.rawValue) recipe miss)")
     }

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -19,7 +19,14 @@ set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_DIR="$REPO/App"
-DD="${DERIVED_DATA:-/tmp/duo-cli-dd}"
+# Per checkout, and the dead ones reclaimed — see scripts/derived_data_path.py,
+# which install.sh, app-tests.sh and row-state-gallery.sh already go through.
+# This used to be a fixed /tmp/duo-cli-dd shared by every worktree open at once,
+# which is a couple of dozen here: two concurrent builds collide on one
+# derived-data directory's SQLite lock, and the failure reads as a broken build
+# rather than as contention. Two runs in the SAME checkout still share it — the
+# one collision left, and not worth a lock. `DERIVED_DATA` overrides.
+DD="${DERIVED_DATA:-$(python3 "$REPO/scripts/derived_data_path.py" cli "$REPO")}"
 PRODUCT="$DD/Build/Products/Release/duo-cli"
 LIBEXEC="$HOME/.local/libexec"
 BIN="$HOME/.local/bin"

--- a/scripts/check_staged_version_use.py
+++ b/scripts/check_staged_version_use.py
@@ -72,10 +72,47 @@ DISPLAY_VERSION_AS_MARKETING = re.compile(
 # directly above it. A marker beats
 # an allowlist of line numbers: it travels with the code when the line moves, and
 # it makes the reason visible where the next reader is already looking.
+# It also expires — see `dead_allow_markers`, which fails the build on a marker
+# that no longer has a pick under it.
 ALLOW = "version-lint:allow-marketing-first"
 # Enough lines to cover the reason written above the site — the marker is only
 # useful if it can sit at the top of the paragraph that explains it.
 ALLOW_LOOKBACK = 6
+
+
+def allow_markers(lines):
+    """1-based line numbers carrying the opt-out marker."""
+    return [n for n, line in enumerate(lines, 1) if ALLOW in line]
+
+
+def markers_covering(lines, n):
+    """The markers that exempt a marketing-first pick on 1-based line `n`.
+
+    One definition, used both to decide whether a hit is allowed and to decide
+    whether a marker is still exempting anything. Two spellings of this window
+    would drift, and the direction they drift in is "the marker stops being
+    reported as dead while still silencing the rule".
+    """
+    return [m for m in allow_markers(lines) if n - ALLOW_LOOKBACK <= m <= n]
+
+
+def dead_allow_markers(lines):
+    """Markers with no marketing-first pick in range.
+
+    An exemption that no longer matches anything is a standing pass for whatever
+    is written there next: the line moves, the pick it was written about goes
+    away, and the marker stays behind silencing the next one nobody read. This
+    is the same rule `check_prose_claims.py` applies to its own marker, and the
+    reason `make gallery` fails on a stale `mayLookAlike` — CLAUDE.md records
+    (#271) what happened to the one gate that skipped it.
+    """
+    alive = set()
+    for n, line in enumerate(lines, 1):
+        if MARKETING_FIRST.search(line):
+            alive.update(markers_covering(lines, n))
+    return [m for m in allow_markers(lines) if m not in alive]
+
+
 # What makes a marketing-first pick dangerous is a comparison in the same
 # STATEMENT — which in Swift is routinely two or three lines away, because
 # `if let a = ..., \n   cond` is the idiom these sites are written in. Looking at
@@ -190,6 +227,7 @@ def main() -> int:
     package_restart_hits = []
     prune_staged_hits = []
     banned_landed_hits: list[str] = []
+    dead_allow_hits: list[str] = []
     ledger_seen = 0
     marketing_seen = 0
     package_restart_seen = 0
@@ -200,6 +238,8 @@ def main() -> int:
         rel = path.relative_to(ROOT)
         lines = path.read_text(encoding="utf-8").splitlines()
         source = "\n".join(lines)
+        for marker in dead_allow_markers(lines):
+            dead_allow_hits.append(f"{rel}:{marker}")
         for match in DISPLAY_VERSION_AS_MARKETING.finditer(source):
             line = source.count("\n", 0, match.start()) + 1
             display_marketing_hits.append(
@@ -217,9 +257,7 @@ def main() -> int:
                     ledger_hits.append(f"{rel}:{n}: {line.strip()}")
             if MARKETING_FIRST.search(line):
                 marketing_seen += 1
-                allowed = ALLOW in line or any(
-                    ALLOW in lines[i]
-                    for i in range(max(0, n - 1 - ALLOW_LOOKBACK), n - 1))
+                allowed = bool(markers_covering(lines, n))
                 if compares_near(lines, n - 1) and not allowed:
                     compare_hits.append(f"{rel}:{n}: {line.strip()}")
             if SHORT_READ.search(line) and compares_near(lines, n - 1):
@@ -323,9 +361,16 @@ def main() -> int:
               "so a scanner-substituted build is not compared with a staged package's.")
         for hit in prune_staged_hits:
             print(f"    {hit}")
+    if dead_allow_hits:
+        print(f"\u2717 {len(dead_allow_hits)} `{ALLOW}` marker(s) no longer "
+              "exempt anything.")
+        print("  The pick they were written about is gone, so the marker is now a "
+              "standing pass for whatever is written there next — delete it.")
+        for hit in dead_allow_hits:
+            print(f"    {hit}")
     if (display_hits or ledger_hits or compare_hits or display_marketing_hits
             or read_hits or package_restart_hits or prune_staged_hits
-            or banned_landed_hits):
+            or banned_landed_hits or dead_allow_hits):
         return 1
 
     print(f"✓ version comparisons discriminate — {len(files)} files, "

--- a/scripts/run-with-hang-report.sh
+++ b/scripts/run-with-hang-report.sh
@@ -25,6 +25,18 @@ set -uo pipefail
 budget="${1:?usage: run-with-hang-report.sh <seconds> <command> [args...]}"
 shift
 
+# Every pid in the tree rooted at $1, deepest first, so a kill loop takes the
+# leaves before their parent. Recursive because `pgrep -P` only reports direct
+# children, and the chain that holds the SwiftPM lock is three deep
+# (sh → swift-test → swiftpm-testing-helper).
+descendants_of() {
+    local pid="$1" kid
+    for kid in $(pgrep -P "$pid" 2>/dev/null); do
+        descendants_of "$kid"
+    done
+    printf '%s\n' "$pid"
+}
+
 "$@" &
 child=$!
 
@@ -89,11 +101,24 @@ while kill -0 "$child" 2>/dev/null; do
         done
         rm -f "$report"
         echo "=== killing the tree =========================================" >&2
-        # The whole tree. Killing only the top leaves orphans holding the SwiftPM
-        # lock, which turns the next run into a different and more confusing hang.
-        pkill -P "$child" 2>/dev/null
-        kill -9 "$child" 2>/dev/null
-        pkill -9 -f "$sample_targets" 2>/dev/null
+        # The whole tree, by parentage. Killing only the top leaves orphans
+        # holding the SwiftPM lock, which turns the next run into a different and
+        # more confusing hang.
+        #
+        # ⚠️ NOT `pkill -9 -f "$sample_targets"`, which is what this did before:
+        # that pattern is MACHINE-WIDE. This repo routinely has a couple of dozen
+        # worktrees open, so one run overshooting its budget killed every other
+        # checkout's `swift test` and `xcodebuild` too — and those die looking
+        # like their own failure, with nothing in their output naming this.
+        #
+        # Collected before anything is killed, and leaves first: once the parent
+        # is gone its children are reparented and `pgrep -P` can no longer find
+        # them.
+        victims="$(descendants_of "$child")"
+        echo "    killing: $(echo "$victims" | tr '\n' ' ')" >&2
+        for pid in $victims; do
+            kill -9 "$pid" 2>/dev/null
+        done
         wait "$child" 2>/dev/null
         exit 124
     fi

--- a/scripts/test_check_staged_version_use.py
+++ b/scripts/test_check_staged_version_use.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Regression tests for `check_staged_version_use.py`'s `DISPLAY_VERSION_AS_MARKETING` rule.
+"""Regression tests for `check_staged_version_use.py`'s `DISPLAY_VERSION_AS_MARKETING`
+rule and for the expiry on its opt-out marker.
 
 #286: the rule PR #250 added used `[\\w.]*` between `marketing:` and
 `displayVersion`, which excludes `?` — so it missed the standard way this
@@ -84,6 +85,40 @@ class MutationGuard(unittest.TestCase):
         self.assertNotEqual(
             csvu.DISPLAY_VERSION_AS_MARKETING.pattern, self.PRE_286_PATTERN.pattern)
 
+class DeadAllowMarkers(unittest.TestCase):
+    """The opt-out marker had no expiry. A marker whose marketing-first pick has
+    been rewritten or moved away stays in the file silencing rule 3 for whatever
+    is written there next — the standing-pass failure `check_prose_claims.py`
+    fails on for its own marker, and the one `make gallery`'s `mayBeBlank` was
+    allowed to skip (#271)."""
+
+    PICK = "guard let v = app.shortVersion ?? app.buildVersion else { return }"
+
+    def lines(self, text):
+        return text.splitlines()
+
+    def test_a_marker_with_no_pick_below_it_is_dead(self):
+        lines = self.lines(f"// {csvu.ALLOW} — reason\nlet x = 1\n")
+        self.assertEqual(csvu.dead_allow_markers(lines), [1])
+
+    def test_a_marker_on_the_same_line_as_a_pick_is_alive(self):
+        lines = self.lines(f"{self.PICK}  // {csvu.ALLOW} — reason\n")
+        self.assertEqual(csvu.dead_allow_markers(lines), [])
+
+    def test_a_marker_within_the_lookback_is_alive(self):
+        body = f"// {csvu.ALLOW} — reason\n" + "// filler\n" * (csvu.ALLOW_LOOKBACK - 1)
+        lines = self.lines(body + self.PICK + "\n")
+        self.assertEqual(csvu.dead_allow_markers(lines), [])
+
+    def test_a_marker_beyond_the_lookback_is_dead(self):
+        """The same file one line further apart. This is what pins the two halves
+        to ONE window: a marker that no longer exempts the pick must be reported,
+        or the check would have to be read as "some marker somewhere below"."""
+        body = f"// {csvu.ALLOW} — reason\n" + "// filler\n" * csvu.ALLOW_LOOKBACK
+        lines = self.lines(body + self.PICK + "\n")
+        self.assertEqual(csvu.dead_allow_markers(lines), [1])
+        # …and the pick it no longer covers is not exempt either.
+        self.assertEqual(csvu.markers_covering(lines, len(lines)), [])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes L7, L8, L9, the `scripts/build-cli.sh` item from P9, and six comment/usage
mismatches from the 2026-09-13 review.

## What was wrong

**L7 — `Baseline.swift:319`.** The install-URL transient run was matched with an
exact element comparison against the bare warning kind. A warning is published as
`kind: detail`, so the `td.telegram.org` 502 the field's own doc is written about
arrives as `installURLTransient: HTTP 502` and was read as a sweep that RESOLVED
the URL: the run reset every sweep, `consecutiveInstallTransient` never left 1,
and `isInstallTransientReportable` could not become true for any transient
carrying a status. `hasPrefix`, as `Verify.classify` and `Finding.signature`
already do.

**L8 — `Baseline.reconcile` + `Reconcile.decide`.** Three linked defects:

- `reconcile` switched on the finding as it arrived (`.ok`), while `Verify`
  promotes it to `.warn` with `adding(warning:)`. A version regression or entry
  collapse therefore RESET the actionable streak instead of raising it.
- the complained-about value was still written to `lastGoodVersion` /
  `lastGoodEntryCount`, so the next sweep compared 1 against 1 and found nothing
  wrong. Both complaints were visible in exactly one sweep's exit code and never
  reached an issue.
- `Reconcile`'s "the failure changed shape" compared `entry.lastSignature` with
  `finding.signature`, but verify writes the baseline and reconcile reads it
  back — a value compared with itself, dead in both directions. Added
  `previousSignature` (decoder updated too, per the ⚠️ on `Entry.init(from:)`).
  A nil previous means "nothing to compare", not "changed", so rows written
  before this field existed do not all fire a comment on the first run.

**L9 — `Inventory.scan`.** Documented as "abandoned rather than waited on", and
implemented as a `withTaskGroup` race, which does not return until every child
finishes; `cancelAll()` cannot touch a thread parked in a syscall. The warning
printed on time and `list`/`check`/`install`/`restart`/`backups`/`doctor`/
`ignore` hung anyway. Ported the detached-`Thread` + off-pool-semaphore shape
`Verify.installedVersions` already uses, with the scanner passed in as a seam.

**`scripts/run-with-hang-report.sh`.** `pkill -9 -f '<sample_targets>'` is
machine-wide: one run overshooting its budget killed every other worktree's
`swift test` and `xcodebuild`. Now collects the tree rooted at `$child` via
`pgrep -P` (recursively, before killing anything, since a dead parent's children
are reparented) and kills those pids leaves-first. This also makes the "The whole
tree" comment true, which the review flagged separately.

**`scripts/build-cli.sh`.** Last script on a fixed `/tmp/duo-cli-dd`; now goes
through `scripts/derived_data_path.py` like `install.sh` / `app-tests.sh` /
`row-state-gallery.sh`.

**`scripts/check_staged_version_use.py`.** `version-lint:allow-marketing-first`
had no expiry. Added a dead-exemption failure (shape copied from
`check_prose_claims.py`), with the window defined once so the "is this hit
exempt" and "is this marker dead" halves cannot drift. Removed the one dead
marker it found, `App/Sources/Preferences.swift:569` — it sat above a plain
`CFBundleShortVersionString` read that rule 3 never matched.

**`application-test/.../channel-verify --scan`.** Re-implemented the version gate
marketing-first; now calls `UpdateChecker.evaluate`, like the same file's path
mode (whose comment already explains why).

**Comment/usage fixes.** `duo/main.swift` exit-code rule (`consecutiveInfra >= 3`
AND ≥ 5 days) and `--only` help text; `Verify.machineNotePrefix` (notes never
enter `signature` at all — it is computed over `publicWarnings`); `observing`
now forwards `entryCount` (code fix, not a doc fix); `Makefile`'s `build:`
comment; `Reconcile.body`'s note about `lastGoodEntryCount`, which is no longer
this sweep's count on a collapse.

`--only` was fixed rather than documented down: it now matches bundle id OR
recipe id, taken from a `VerifySelectable` protocol instead of a closure repeated
at five call sites — the closure being the part that was wrong, and five of them
five chances to be wrong again in a way no test of `filtered` would see.

## Red → green

Every test below was written first and run against the unfixed code.

L7 (`swift test --package-path CLI --filter InstallTransientAging`), before:

```
✘ Test aStatusCarryingTransientAgesIntoAReport() recorded an issue at
  InstallTransientAgingTests.swift:113:9: Expectation failed:
  entry.isInstallTransientReportable(...) → false
✘ Test run with 7 tests in 1 suite failed after 0.008 seconds with 3 issues.
```

after:

```
✔ Test aStatusCarryingTransientAgesIntoAReport() passed after 0.002 seconds.
✔ Test aResolvedInstallURLEndsTheRun(shape:) with 2 test cases passed after 0.002 seconds.
✔ Test run with 7 tests in 1 suite passed after 0.003 seconds.
```

L8, before (`--filter "EntryCountCollapse|BaselineTests"`):

```
✘ aCollapseAccumulatesAStreakAndKeepsTheGoodCount(): baseline.streak(id) == 1
✘ aCollapseAccumulatesAStreakAndKeepsTheGoodCount(): baseline.entries[id]?.lastGoodEntryCount == 20
✘ aCollapseAccumulatesAStreakAndKeepsTheGoodCount(): baseline.reconcile(changelog(entries: 1)).count == 1
✘ aVersionRegressionAccumulatesAStreakAndKeepsTheGoodVersion(): baseline.streak(id) == 1
✘ Test run with 44 tests in 4 suites failed after 0.006 seconds with 11 issues.
```

after: `✔ Test run with 291 tests in 36 suites passed`.

L9: red by wedge rather than by assertion — see the mutation below; the fixed
code gives `✔ aScanThatNeverReturnsIsAbandonedAtTheTimeout() passed after 0.207
seconds` plus the timeout warning on stderr.

`observing`'s dropped `entryCount`, before:

```
✘ annotatingAFindingKeepsItsEntryCount(): counted.observing("machine-note: note").entryCount == 17
```

Dead version-lint marker, before the marker was deleted:

```
✗ 1 `version-lint:allow-marketing-first` marker(s) no longer exempt anything.
    App/Sources/Preferences.swift:569
```

## Mutation checks

- **L8**, `switch promoted.status` → `switch finding.status`: both new tests go
  red and name the streak (`baseline.streak(id) == 1`, `== 2`, `isReportable`).
  Restored; full suite green.
- **L9**, the implementation put back as a `withTaskGroup` race: the suite
  produced no test output at all and was still wedged after ~2 minutes
  (`swiftpm-testing-helper` alive, no lines printed). Killed and restored.
- **`--only`**, drop the `recipeID` half of the match:
  `✘ aGitHubRuleCanBeNamedByItsRecipeID(): selected.map(\.recipeID) == [rule.recipeID]`.
- **hang-report kill**, old `pkill -9 -f` restored, run against a throwaway
  nested tree (`bash -c 'sleep 300 & sleep 300 & wait'`) plus a decoy
  `/bin/sh -c 'exec -a swift-test sleep 600'` standing in for another worktree:

  ```
  fixed:   exit=124 elapsed=88s / survivors: none / decoy: alive
           killing: 52391 52392 52389
  mutated: exit=124 elapsed=91s / survivors: none / decoy: KILLED
  ```
- **dead-marker gate**, a marker re-added above a line the rule does not match:
  `✗ 1 … marker(s) no longer exempt anything … App/Sources/Preferences.swift:569`,
  exit 1. Four unit cases in `scripts/test_check_staged_version_use.py` pin the
  window from both sides (same line, inside the lookback, one line past it).

## Verification

```
$ make test > /tmp/mt-fix.log 2>&1; echo exit=$?
exit=0
$ tail -12 /tmp/mt-fix.log
✔ Test run with 291 tests in 36 suites passed after 0.236 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 261 files, 2 ledger call(s) keyed on the build,
  8 marketing-first pick(s), all display-only
Ran 11 tests in 0.000s
OK
✓ app audits consistent — 121 docs …
✓ engine-notes pointers resolve — 531 Swift files scanned …
✓ skill docs consistent …
✓ no machine-population claims in code comments — 531 files
```

Also `swift build --package-path application-test` (Build complete) for
channel-verify, and `bash -n` on both scripts.

`make cli` was NOT run (it replaces a machine-global binary other sessions
depend on). `scripts/build-cli.sh` is verified by `bash -n` plus running the
derivation standalone: `python3 scripts/derived_data_path.py cli <repo>` →
`/tmp/duo-cli-d1a251e3`. No recipe or parser rule changed, so no `duo verify`.

## Behaviour a user could notice

- `duo verify` now exits 1 on a recipe whose version regressed or whose
  changelog collapsed to one entry for two consecutive sweeps, and `duo
  reconcile` will open an issue for it. That is the intent of both checks; until
  now neither could reach the threshold.
- The first `reconcile` run after this merges may open issues for recipes that
  have been quietly regressed for a while. That is the backlog, not a new
  failure.
- `duo verify --only <recipe-id>` and `--only beta` now select something.
- `baseline.json` gains a `previousSignature` key per row.
