### PR TITLE
Stop the row views re-deriving per-row facts on every repaint

### DIFF
--- a/App/RowStateGallery/Cases.swift
+++ b/App/RowStateGallery/Cases.swift
@@ -105,7 +105,7 @@ enum RowStateGalleryCases {
             return AnyView(
                 PopoverRowAction(
                     state: state, result: result,
-                    downloadReadout: popoverDownloadReadoutOverrides[name] ?? .barAndPercent,
+                    downloadReadout: { popoverDownloadReadoutOverrides[name] ?? .barAndPercent },
                     showsStageLabel: popoverShowsStageLabelOverrides[name] ?? { _ in true },
                     testFlightUnboundedReason: testFlightUnboundedReasonOverrides[name] ?? .storeSilent)
                 .frame(width: tileWidth, height: tileHeight, alignment: .trailing))

--- a/App/RowStateGallery/main.swift
+++ b/App/RowStateGallery/main.swift
@@ -6,8 +6,9 @@ import DuoUpdaterCore
 /// is drawn shows up as an image diff instead of being noticed in use — or not.
 ///
 /// This exists because the two windows' row rendering has no other executable
-/// check. `App/project.yml` has no test target, so nothing runs `App/Sources`; the
-/// Core tests cover which state a row IS (`RowActionStateTests`) but not what that
+/// check. `DuoUpdaterAppTests` compiles only the files it names in
+/// `App/project.yml`, and the row views are not among them; the Core tests cover
+/// which state a row IS (`RowActionStateTests`) but not what that
 /// state looks like, and the failure mode that motivated all of this was a state
 /// rendering as *nothing at all* — invisible to any assertion about the state
 /// itself.

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -40,6 +40,7 @@ final class AppListModel {
         // cycle, the same window every other derived fact in this model lives in.
         didSet {
             elevationPathsCache = nil
+            runtimeKeysCache = nil
             pruneSettledInstallErrors()
             pruneRetractedNotes()
         }
@@ -1253,7 +1254,8 @@ final class AppListModel {
         // approved in Login Items (no second click). The menu's `.task` calls this on
         // appear, so App Store rows reflect the helper without opening Settings.
         helperClient.refreshStatus()
-        helperEnabled = helperClient.isEnabled
+        // The mirror it just wrote, not another live query — see the doc above.
+        helperEnabled = helperClient.status == .enabled
 
         logPermissionsOnce()
     }
@@ -2685,8 +2687,35 @@ final class AppListModel {
             runningAppPaths: runningAppPaths,
             stagedSelfUpdates: pendingSelfUpdate,
             elevationRequiredPaths: elevationRequiredPaths,
-            runningBundleIDs: runningBundleIDs)
+            runningBundleIDs: runningBundleIDs,
+            runtimeKeys: runtimeKeys)
     }
+
+    /// The comparable path for every install in the list, resolved once per scan.
+    ///
+    /// Same shape and the same reason as `elevationRequiredPaths` above, for the
+    /// other filesystem call on this path: `UpdatePolicy.runtimeBundlePath` opens
+    /// with `resolvingSymlinksInPath()`, a `realpath`. `isRunning` asks for it on
+    /// every row — twice per popover row, since `nameLineWidth` measures the name
+    /// with the running dot and then `nameLine` draws it — and the workbench
+    /// sidebar once more, all on the main actor, all re-run on every download
+    /// tick. The answer cannot change without the list changing, so it is resolved
+    /// with the list and looked up after that.
+    private var runtimeKeys: [URL: String] {
+        if let cache = runtimeKeysCache { return cache }
+        var value: [URL: String] = [:]
+        value.reserveCapacity(results.count)
+        for result in results {
+            value[result.app.path] = UpdatePolicy.runtimeBundlePath(result.app.path)
+        }
+        runtimeKeysCache = value
+        return value
+    }
+
+    /// Memo for `runtimeKeys`, invalidated by `results.didSet` — see
+    /// `elevationPathsCache` for why that is sufficient and why it must be
+    /// `@ObservationIgnored`.
+    @ObservationIgnored private var runtimeKeysCache: [URL: String]?
 
     /// The install paths that need an administrator prompt to replace.
     ///
@@ -2946,19 +2975,28 @@ final class AppListModel {
     /// screenful of outdated formulae can't burn the 60/hr unauthenticated budget —
     /// the disk cache still makes every re-select and relaunch instant.
     private func prewarmFormulaReleases() {
-        let explicitToken = explicitGitHubToken()
-        let tokenTask = Task {
-            await Self.resolveGitHubToken(explicit: explicitToken)
+        // Cheap synchronous skip for what we already hold at this exact version.
+        // NOT the authoritative guard — that is the `claim` below, and it has to
+        // stay there so we never hold a slot we might not fill. This only keeps
+        // a refresh from spawning a task and a disk read per formula for work
+        // that is already done: `refreshBrewFormulae` runs on every menu-bar
+        // open, not just after an upgrade.
+        let pending = brewFormulae.filter { formula in
+            formula.hasUpdate && formulaReleases.state(
+                name: formula.name,
+                version: formula.availableVersion ?? formula.installedVersion) == nil
         }
-        for formula in brewFormulae where formula.hasUpdate {
+        // Decided BEFORE the token, which is the point: resolving one is a
+        // `gh auth token` subprocess in the zero-config case, and this runs on
+        // every menu-bar open for every brew user. Nothing to warm must cost
+        // nothing — it used to cost a subprocess with zero outdated formulae.
+        guard !pending.isEmpty else { return }
+        // One task for the whole pass, through the recheck cache: the resolution is
+        // shared by every formula below (a per-formula resolve would be N
+        // subprocesses), and a later pass reuses what this one recorded.
+        let tokenTask = Task { [weak self] in await self?.githubTokenForRecheck() ?? nil }
+        for formula in pending {
             let version = formula.availableVersion ?? formula.installedVersion
-            // Cheap synchronous skip for what we already hold at this exact version.
-            // NOT the authoritative guard — that is the `claim` below, and it has to
-            // stay there so we never hold a slot we might not fill. This only keeps
-            // a refresh from spawning a task and a disk read per formula for work
-            // that is already done: `refreshBrewFormulae` runs on every menu-bar
-            // open, not just after an upgrade.
-            guard formulaReleases.state(name: formula.name, version: version) == nil else { continue }
             Task { [weak self] in
                 guard let self else { return }
                 // Decide whether we will load BEFORE claiming, never the other way
@@ -3101,9 +3139,10 @@ final class AppListModel {
     /// for a version it is no longer displaying.
     func ensureFormulaReleaseLoading(name: String, version: String) {
         guard formulaReleases.claim(name: name, version: version) else { return }
-        let explicitToken = explicitGitHubToken()
         Task {
-            let token = await Self.resolveGitHubToken(explicit: explicitToken)
+            // Through the cache, like the prewarm pass: selecting formula after
+            // formula used to resolve a token — a subprocess — every single time.
+            let token = await githubTokenForRecheck()
             let release = await formulaReleaseService.release(for: name, version: version, token: token)
             formulaReleases.finish(name: name, version: version, release: release)
         }
@@ -3137,17 +3176,31 @@ final class AppListModel {
     /// Flash an "Updated ✓" confirmation on a just-completed row, then let it go.
     /// The row keeps showing in `visible` while its id is here; after a short beat we
     /// drop it, at which point the (now up-to-date) app filters out of the list
-    /// normally. Idempotent re-entry just restarts the window.
+    /// normally. Idempotent re-entry restarts the window.
+    ///
+    /// Restarting it is what the cancellation below buys. Without it a second call
+    /// left the FIRST call's timer running, so the window ended at the earlier
+    /// deadline — a row updated twice inside two seconds (an App Store hand-off
+    /// landing on top of our own install) could flash its confirmation for a few
+    /// milliseconds and vanish, and the row-order freeze lifted early with it.
     private func markJustUpdated(_ id: String) {
         justUpdated.insert(id)
-        Task { @MainActor [weak self] in
+        justUpdatedTimers[id]?.cancel()
+        justUpdatedTimers[id] = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(2))
-            self?.justUpdated.remove(id)
+            // A replacement window is already running; it owns the clearing.
+            guard !Task.isCancelled, let self else { return }
+            self.justUpdatedTimers[id] = nil
+            self.justUpdated.remove(id)
             // Usually the last thing to clear after an install, so this is where the
             // frozen order normally lifts.
-            self?.releaseRowOrder()
+            self.releaseRowOrder()
         }
     }
+
+    /// The in-flight "Updated ✓" window per row id, so re-entry can restart it.
+    /// Entries remove themselves when the window ends.
+    @ObservationIgnored private var justUpdatedTimers: [String: Task<Void, Never>] = [:]
 
     /// Install an update, routing to the right installer for its source. `notify`
     /// is false for the batch path so "Update All" posts one summary banner

--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1205,7 +1205,11 @@ final class AppListModel {
     /// Refresh the mirrored permission states once, and auto-dismiss a drag-panel whose
     /// grant just landed. Cheap: `AXIsProcessTrusted()`, a `TCCAccessPreflight` call, and
     /// four file opens — measured 2026-09-10 at about 20–70 µs for the four, granted or
-    /// refused.
+    /// refused. It also reads `SMAppService.status`, which the "Cheap" above used to
+    /// leave out — ONCE, via `helperClient.refreshStatus()`. It was twice until
+    /// 2026-09-13: `helperClient.isEnabled` is deliberately a live query, so asking
+    /// it right after `refreshStatus()` re-asked the same question, and the Welcome
+    /// and Settings panes poll this every 1.5 s.
     ///
     /// Caveat we can't engineer around for *Accessibility*: TCC reflects a *grant* to a
     /// running process live, but a *revocation* is cached — `AXIsProcessTrusted()` keeps
@@ -1391,7 +1395,9 @@ final class AppListModel {
     ) async -> String? {
         // Logged so a resolve is visible in `log stream`: without an explicit or env
         // token each one is a `gh auth token` subprocess, and this line is how to
-        // count them per action (one per full check; none per Update click).
+        // count them per action. One per full check; none per Update click, and
+        // none per menu-bar open — everything else goes through
+        // `githubTokenForRecheck`, which only reaches here on a miss.
         Log.app.info("GitHub token: resolving (explicit=\(explicit != nil, privacy: .public))")
         let loader = Task.detached(priority: .utility) {
             GitHubToken.resolve(explicit: explicit)
@@ -2198,11 +2204,13 @@ final class AppListModel {
         testFlightSyncLedger.begin(at: .now)
         Task { @MainActor [weak self] in
             // Bounded, and the bound is not `run`'s own: `run` is bounded internally
-            // by `defaultDeadline`, but the launch it awaits first is not, so a
-            // LaunchServices that never answers would leave the gate above closed for
-            // the rest of the session and silently retire automatic syncs altogether.
-            // Comfortably past the deadline, so this only ever catches a stuck launch
-            // and never a slow store.
+            // by `defaultDeadline`, and the launch it awaits first is bounded too
+            // (`AppRestarter.launchTimeout`, 60 s) — but those are two bounds in
+            // series, not one, and neither covers everything `run` does between
+            // them. A gate left closed by an attempt that never returns would
+            // silently retire automatic syncs for the rest of the session, so the
+            // whole thing gets one outer bound. Comfortably past the deadline, so
+            // this only ever catches a stuck attempt and never a slow store.
             let outcome = await Self.firstResult(
                 of: started, within: TestFlightRefresh.defaultDeadline + .seconds(30))
             guard let self else { return }
@@ -2400,10 +2408,12 @@ final class AppListModel {
                 testFlightSyncTask = started
                 testFlightSync = started
                 // Bounded for the reason `startAutomaticTestFlightSync` is: `run`
-                // bounds its polling but not the launch it awaits first, and a gate
-                // left closed by a stuck launch would silently switch automatic syncs
-                // off for the whole session. The round below still awaits `started`
-                // itself — this only frees the gate.
+                // bounds its polling and `AppRestarter.launchTimeout` bounds the
+                // launch it awaits first, but those are bounds in series rather than
+                // one bound over the attempt, and a gate left closed by an attempt
+                // that never returns would silently switch automatic syncs off for
+                // the whole session. The round below still awaits `started` itself —
+                // this only frees the gate.
                 Task { @MainActor [weak self] in
                     _ = await Self.firstResult(
                         of: started, within: TestFlightRefresh.defaultDeadline + .seconds(30))
@@ -6213,14 +6223,17 @@ final class AppListModel {
         // latest, i.e. this very version), so it must not outlive the skip.
         //
         // Cleared, NOT withdrawn — unlike ignoring. The skip is recorded against the
-        // offered `displayVersion`, while the gate that has to hold afterwards
-        // (`VisibilityRules.isVersionSkipped`, through `nudgeableStaged`) is asked
-        // about `staged.version`, and it compares strings exactly where
-        // `actionableStaged` compares versions. Where those two strings differ — a
-        // build suffix, "1.2" against "1.2.0" — forgetting the ledger entry would
-        // let the very next staging pass post a banner for the version the user just
-        // skipped. The entry is the belt behind those braces. The cost is that
-        // un-skipping doesn't bring the banner back; the row and the badge do.
+        // offered `remote.versionSide` (as `VisibilityRules.skipKey`, a
+        // marketing+build pair — NOT the display string), while the gate that has to
+        // hold afterwards (`VisibilityRules.isVersionSkipped`, through
+        // `nudgeableStaged`) is asked about `staged.versionSide`. Two different
+        // values, and `isVersionSkipped` compares their keys exactly where
+        // `actionableStaged` compares versions. Where those keys differ — a build
+        // the offer carried and the staged copy does not, "1.2" against "1.2.0" —
+        // forgetting the ledger entry would let the very next staging pass post a
+        // banner for the version the user just skipped. The entry is the belt behind
+        // those braces. The cost is that un-skipping doesn't bring the banner back;
+        // the row and the badge do.
         UpdateNotifier.clearSelfDownloaded(appID: result.id)
         Log.app.info("skip \(VisibilityRules.skipKey(version), privacy: .public): \(result.app.name, privacy: .public)")
     }

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -75,7 +75,10 @@ struct MenuContentView: View {
     /// `"Café".localizedCaseInsensitiveContains("cafe")` is **false** and
     /// `"Café".localizedStandardContains("cafe")` is true. That is the one
     /// user-facing difference: typing "cafe" now finds an app spelled "Café".
-    /// Same predicate `SettingsSection.matches` searches its pages with.
+    /// Same folding (case + diacritics) `SettingsSection.matches` searches its
+    /// pages with — NOT the same predicate: that one is
+    /// `range(of:options: [.caseInsensitive, .diacriticInsensitive])` with no
+    /// locale, while this one passes `Locale.current`.
     private func matches(_ result: UpdateResult, _ query: String) -> Bool {
         if result.app.name.localizedStandardContains(query) { return true }
         if let bundleID = result.app.bundleID,

--- a/App/Sources/MenuContentView.swift
+++ b/App/Sources/MenuContentView.swift
@@ -68,10 +68,18 @@ struct MenuContentView: View {
 
     /// Match the query against an app's name and bundle id (so "com.google" finds
     /// Chrome), case- and diacritic-insensitively.
+    ///
+    /// `localizedStandardContains`, not `localizedCaseInsensitiveContains`: only
+    /// the first of the two folds diacritics, and the sentence above claims the
+    /// folding — measured 2026-09-13 on this machine,
+    /// `"Café".localizedCaseInsensitiveContains("cafe")` is **false** and
+    /// `"Café".localizedStandardContains("cafe")` is true. That is the one
+    /// user-facing difference: typing "cafe" now finds an app spelled "Café".
+    /// Same predicate `SettingsSection.matches` searches its pages with.
     private func matches(_ result: UpdateResult, _ query: String) -> Bool {
-        if result.app.name.localizedCaseInsensitiveContains(query) { return true }
+        if result.app.name.localizedStandardContains(query) { return true }
         if let bundleID = result.app.bundleID,
-           bundleID.localizedCaseInsensitiveContains(query) { return true }
+           bundleID.localizedStandardContains(query) { return true }
         return false
     }
 
@@ -1027,7 +1035,7 @@ private struct AppRow: View {
                         }),
                     runningVersion: model.runningVersion(result.id),
                     helperEnabled: model.helperEnabled,
-                    downloadReadout: downloadReadout,
+                    downloadReadout: { downloadReadout },
                     showsStageLabel: showsStageLabel,
                     testFlightUnboundedReason: model.testFlightUnboundedReason)
                     .frame(minWidth: trailingSlot, alignment: .trailing)

--- a/App/Sources/PopoverRowAction.swift
+++ b/App/Sources/PopoverRowAction.swift
@@ -5,7 +5,7 @@ import DuoUpdaterCore
 /// The popover's row action — the trailing edge of every row in the menu bar.
 ///
 /// Model-free by construction: it takes the shared `RowActionState`, the row, and
-/// plain closures. That is what lets `RowStateGallery` draw all 30 states without
+/// plain closures. That is what lets `RowStateGallery` draw every state without
 /// an `AppListModel` (whose `init` registers notification permission, arms timers
 /// and starts FS watchers — not things a screenshot tool should do).
 ///

--- a/App/Sources/PopoverRowAction.swift
+++ b/App/Sources/PopoverRowAction.swift
@@ -23,7 +23,16 @@ struct PopoverRowAction: View {
     var helperEnabled: Bool = true
     /// How much of the download readout fits. Measured by the ROW, which knows the
     /// name's width, and handed down — this view draws what it is told to.
-    var downloadReadout: DownloadReadout = .barAndPercent
+    ///
+    /// A closure, like `showsStageLabel` beside it, because measuring it is not
+    /// free: it walks `DownloadReadout.allCases` and each candidate lays out the
+    /// name, the channel tag and both version strings with AppKit — up to a dozen
+    /// text measurements. Only `.installing(.downloading)` reads it, and a row is
+    /// downloading for a few seconds of its life, while EVERY row's body re-runs
+    /// on every progress tick (they all read `model.installing`). Passing the
+    /// value made every row in the list pay, on every tick, for the one row that
+    /// was downloading. Same lesson as `RowActionFacts.route`.
+    var downloadReadout: () -> DownloadReadout = { .barAndPercent }
     /// Whether a stage word fits beside the spinner, same reasoning.
     var showsStageLabel: (InstallStage) -> Bool = { _ in true }
     /// Why a TestFlight row cannot bound its beta — decides which mark it carries
@@ -182,7 +191,7 @@ struct PopoverRowAction: View {
     /// losing the number leaves the row saying only "something is happening".
     @ViewBuilder
     private func downloadProgress(_ f: Double) -> some View {
-        switch downloadReadout {
+        switch downloadReadout() {
         case .barAndPercent:
             HStack(spacing: 4) {
                 ProgressView(value: f).frame(width: 50).controlSize(.small)

--- a/App/Sources/RequestLogPane.swift
+++ b/App/Sources/RequestLogPane.swift
@@ -12,8 +12,9 @@ import DuoUpdaterCore
 ///
 /// Nothing is decided in this file. Every figure comes off ``RequestLogSummary``,
 /// every filter is a ``RequestQuery``, and even the field's colouring comes from
-/// ``RequestQuery/highlights(_:)`` — all in Core, because `App/project.yml` has
-/// no test target, so a rule written into a `body` is a rule nothing executes.
+/// ``RequestQuery/highlights(_:)`` — all in Core, because `DuoUpdaterAppTests`
+/// compiles only the files `App/project.yml` names and this one is not among
+/// them, so a rule written into a `body` is a rule nothing executes.
 ///
 /// The filter chips are not a second filtering path: each one is literally a
 /// token appended to the field, so a question asked by clicking and the same

--- a/App/Sources/RequestLogPane.swift
+++ b/App/Sources/RequestLogPane.swift
@@ -200,14 +200,18 @@ struct RequestLogPane: View {
         // process's own commits, so ``EventStore/changeToken()`` folds our own
         // write count in. Two seconds is a pragma read and an integer compare,
         // not a query.
-        .task {
+        //
+        // Keyed on the active state so the guard below reads it LIVE: a `.task`
+        // with no id runs once and captures the view as it was then, so a window
+        // that went behind another kept polling on the state it had on appear.
+        .task(id: activeState) {
+            // Behind another window, or on the Downloads tab (which destroys
+            // this pane), nobody is watching the log — so nothing polls it.
+            // The catch-up happens when the window comes forward again.
+            guard activeState != .inactive else { return }
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2))
                 guard !Task.isCancelled else { return }
-                // Behind another window, or on the Downloads tab (which destroys
-                // this pane), nobody is watching the log — so nothing polls it.
-                // The catch-up happens when the window comes forward again.
-                guard activeState != .inactive else { continue }
                 let token = await onChangeToken()
                 guard token != lastToken else { continue }
                 lastToken = token

--- a/App/Sources/RowActionViews.swift
+++ b/App/Sources/RowActionViews.swift
@@ -147,6 +147,7 @@ struct WorkbenchRowAction: View {
             HStack(spacing: 6) {
                 ProgressView().controlSize(.small)
                 Text("Relaunching…").font(.callout).foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
 
         case .pendingBatchRestart:
@@ -338,6 +339,13 @@ struct WorkbenchRowAction: View {
             // License-boundary warning lives in the popover; don't one-click it here.
             Label("Major update", systemImage: "exclamationmark.triangle.fill")
                 .font(.callout).foregroundStyle(.orange)
+                // Same overflow protection its `.macIncompatible` /
+                // `.needsNewerMacOS` / `.region` siblings carry — it had none, and
+                // the catalog's longest translation of it is es "Actualización
+                // importante" (24 characters, drawn at `.callout`). UNMEASURED
+                // against a real row: this is the protection every sibling label
+                // has, not a fix for a width somebody measured overflowing.
+                .lineLimit(1).minimumScaleFactor(0.7)
                 .help("Major version upgrade — review and install it from the menu-bar popover")
 
         case .autoInstall:
@@ -462,6 +470,7 @@ struct WorkbenchRowAction: View {
             } else {
                 ProgressView().controlSize(.small)
                 Text(installStageLabel(stage)).font(.callout).foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
         }
     }

--- a/App/Sources/RowActionViews.swift
+++ b/App/Sources/RowActionViews.swift
@@ -471,9 +471,14 @@ struct WorkbenchRowAction: View {
 /// The readouts a downloading row can wear, WIDEST FIRST — `AppRow` walks
 /// `allCases` in order and takes the first one the app's name leaves room for, so
 /// the declaration order is the algorithm. Reorder these and every downloading row
-/// silently degrades to the narrowest option: no compile error, no test (there is
-/// no test target over `App/Sources`), and no gallery tile, since the gallery draws
-/// only the default.
+/// silently degrades to the narrowest option, with no compile error — and the
+/// algorithm itself is in `AppRow`, which `DuoUpdaterAppTests` does not compile
+/// (that target builds only the files `App/project.yml` names). What holds the
+/// order is the gallery: tiles 35 and 36 draw `.ringAndPercent` and `.ringOnly`
+/// (via `RowStateGalleryCases.popoverDownloadReadoutOverrides`), and
+/// `RowStateGalleryCases.downloadReadoutOrderIsIntact()` fails the build outright
+/// if this declaration order changes — because an image diff is a symptom, not an
+/// assertion.
 ///
 /// The widths are what the group actually lays out to: the indicator, the 4pt
 /// HStack spacing, and the percentage's fixed 32pt slot.

--- a/App/Sources/TrafficLedgerPane.swift
+++ b/App/Sources/TrafficLedgerPane.swift
@@ -251,8 +251,11 @@ struct TrafficLedgerPane: View {
         ScrollView {
             LazyVStack(spacing: 0) {
                 let present = sorted(model.trafficPresent)
+                // Hoisted: it scans the whole ledger for a maximum, and read from
+                // inside the `ForEach` it did that once per ROW.
+                let scale = maxBytes
                 ForEach(Array(present.enumerated()), id: \.element.id) { index, stat in
-                    TrafficRow(stat: stat, maxBytes: maxBytes,
+                    TrafficRow(stat: stat, maxBytes: scale,
                                isExpanded: expanded.contains(stat.id),
                                isRemoved: false,
                                toggle: { toggle(stat.id) })
@@ -264,7 +267,7 @@ struct TrafficLedgerPane: View {
                     // The group header carries only a background tint, so the rule
                     // that separates it from the list has to be drawn here.
                     Divider()
-                    removedGroup
+                    removedGroup(scale: scale)
                 }
             }
         }
@@ -303,7 +306,7 @@ struct TrafficLedgerPane: View {
     /// because next to the app's current entry they read as a duplicate rather
     /// than as history.
     @ViewBuilder
-    private var removedGroup: some View {
+    private func removedGroup(scale: Int64) -> some View {
         Button {
             withAnimation(.easeOut(duration: 0.15)) { showRemoved.toggle() }
         } label: {
@@ -331,7 +334,7 @@ struct TrafficLedgerPane: View {
         if showRemoved {
             ForEach(sorted(model.trafficRemoved)) { stat in
                 Divider()
-                TrafficRow(stat: stat, maxBytes: maxBytes,
+                TrafficRow(stat: stat, maxBytes: scale,
                            isExpanded: expanded.contains(stat.id),
                            isRemoved: true,
                            toggle: { toggle(stat.id) })

--- a/App/Sources/TrafficLedgerPane.swift
+++ b/App/Sources/TrafficLedgerPane.swift
@@ -564,8 +564,9 @@ private struct TrafficRow: View {
 /// source onto a second line instead of clipping it away — the split has to stay
 /// fully visible to be checkable against the total.
 ///
-/// Shared with the workbench's Network Activity panel, whose purpose legend has
-/// the same requirement for the same reason; hence not `private`.
+/// Shared with the Requests tab's legends and the query field's token row
+/// (`RequestLogPane`, `QueryTokenField`), which have the same requirement for the
+/// same reason; hence not `private`.
 struct FlowLayout: Layout {
     var spacing: CGFloat = 8
 

--- a/App/Sources/Vendor/PermissionFlow/SettingsWindowTracker.swift
+++ b/App/Sources/Vendor/PermissionFlow/SettingsWindowTracker.swift
@@ -318,9 +318,10 @@ final class SettingsWindowTracker {
 
     /// Converts a global top-left-origin rectangle from CG/AX space into
     /// AppKit screen coordinates by matching the rect to its containing screen.
-    /// The `+ 28` vertical offset is an intentional visual compensation used
+    /// The `- 3` on the converted `y` is an intentional visual compensation used
     /// by this package so the floating helper panel sits closer to the visible
-    /// bottom edge of the System Settings window.
+    /// bottom edge of the System Settings window. (It used to read `+ 28` here,
+    /// a number that has never appeared in this function.)
     private func appKitFrame(fromGlobalTopLeftFrame frame: CGRect) -> CGRect {
         let screens = NSScreen.screens.compactMap { screen -> (frame: CGRect, cgBounds: CGRect)? in
             guard

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -5,12 +5,12 @@ import DuoUpdaterCore
 
 /// The unified workbench window — one roomy home for everything the menu-bar
 /// popover can't hold. App-centric: the left column lists every scanned app; the
-/// right pane shows the selected app through one of two lenses, toggled in the
-/// toolbar:
-///   • Release Notes — its changelog (recipe → structured → inline HTML → web page).
-///   • Traffic       — the exact bytes we've downloaded for it, event by event.
-/// A toolbar gear opens Settings as a sheet, so all three former windows
-/// (Changelog, Traffic, Settings) now live in this single window.
+/// right pane shows the selected app's changelog (recipe → structured → inline
+/// HTML → web page).
+///
+/// There is no lens switcher any more: download traffic has its own window
+/// (`NetworkWindowView`), so the detail pane is always Release Notes. The toolbar
+/// gear opens Settings in its own window too (`openWindow`), not as a sheet.
 struct WorkbenchWindowView: View {
     static let windowID = "workbench"
 
@@ -79,10 +79,8 @@ struct WorkbenchWindowView: View {
     /// match the model's own backstop cadence rather than out-polling it 12×.
     private let refreshTimer = Timer.publish(every: 180, on: .main, in: .common).autoconnect()
 
-    /// The sidebar app list. One stable order regardless of the active lens —
-    /// pending updates float to the top, everything else alphabetical — so
-    /// flipping between Release Notes and Traffic never reshuffles the list under
-    /// the user. The lens only changes each row's trailing detail, not its place.
+    /// The sidebar app list. One stable order — pending updates float to the top,
+    /// everything else alphabetical.
     ///
     /// Brew-managed casks are excluded here: they live under the Brew tree instead
     /// (the "cask 只在此面板" rule), so they never appear in both places.
@@ -120,15 +118,6 @@ struct WorkbenchWindowView: View {
                 return model.rollbackIsDistinct(result)
             }
             .sorted { $0.app.name.localizedCaseInsensitiveCompare($1.app.name) == .orderedAscending }
-    }
-
-    /// Whether to show the Rollback section at all — hidden when nothing is restorable.
-    private var hasRollback: Bool { !rollbackableApps.isEmpty }
-
-    /// Content-fitting height for the (bottom-pinned) Rollback list, capped so a long
-    /// list scrolls internally instead of crowding out the Apps tree above it.
-    private var rollbackListHeight: CGFloat {
-        min(CGFloat(rollbackableApps.count) * 34 + 12, 240)
     }
 
     /// `apps` narrowed by the search field. A blank query passes everything through;
@@ -640,8 +629,6 @@ private struct SplitViewAutosave: NSViewRepresentable {
     }
 }
 
-// MARK: - Mode switcher
-
 // MARK: - Sidebar row
 
 private struct WorkbenchSidebarRow: View {
@@ -822,6 +809,11 @@ private struct WorkbenchSidebarRow: View {
                     // White over the blue highlight when selected; blue tint otherwise.
                     .foregroundStyle(isSelected ? AnyShapeStyle(.white) : AnyShapeStyle(.tint))
                     .lineLimit(1)
+                    // Its `.stagedRelaunch` / `.restart` siblings scale; this one is
+                    // the longest of the four (two versions, both possibly with a
+                    // build in parentheses) and had only the line limit, so it
+                    // truncated where they shrank.
+                    .minimumScaleFactor(0.75)
             } else {
                 Text("v\(result.installedDisplay ?? "?")")
                     .font(.caption).foregroundStyle(.secondary).lineLimit(1)
@@ -1625,8 +1617,6 @@ private struct ChangelogVersionList: View {
         return entry.version.isEmpty ? "—" : entry.version
     }
 }
-
-// MARK: - Traffic pane
 
 // MARK: - One changelog entry
 

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -1176,9 +1176,11 @@ private struct DetailHeader: View {
                 let to = bump.map { "\(latest) (\($0.remote))" } ?? latest
                 Text("\(from)  →  \(to)")
                     .font(.callout).foregroundStyle(.tint)
+                    .lineLimit(1).minimumScaleFactor(0.75)
             } else {
                 Text("v\(result.installedDisplay ?? "?") · up to date")
                     .font(.callout).foregroundStyle(.secondary)
+                    .lineLimit(1).minimumScaleFactor(0.75)
             }
         }
     }

--- a/App/Sources/WorkbenchWindowView.swift
+++ b/App/Sources/WorkbenchWindowView.swift
@@ -138,11 +138,38 @@ struct WorkbenchWindowView: View {
         let query = searchText.trimmingCharacters(in: .whitespaces)
         guard !query.isEmpty else { return apps }
         return apps.filter { result in
-            if result.app.name.localizedCaseInsensitiveContains(query) { return true }
+            if result.app.name.localizedStandardContains(query) { return true }
             if let bundleID = result.app.bundleID,
-               bundleID.localizedCaseInsensitiveContains(query) { return true }
+               bundleID.localizedStandardContains(query) { return true }
             return false
         }
+    }
+
+    /// The three derived lists the sidebar draws, built ONCE per body pass and
+    /// handed down.
+    ///
+    /// They used to be computed properties read from the view builders that need
+    /// them — `filteredApps` from three (`appsHeader`, the list, its empty
+    /// overlay), `rollbackableApps` from four, `brewCasks` from three — so one
+    /// pass re-ran every `filter` and every `sort(localizedCaseInsensitiveCompare)`
+    /// three or four times over. And the pass is not rare: the body reads
+    /// `model.installing`, so every download tick re-runs all of it.
+    struct SidebarLists {
+        let filteredApps: [UpdateResult]
+        let brewCasks: [UpdateResult]
+        let rollbackable: [UpdateResult]
+
+        /// Whether to show the Rollback section at all — hidden when nothing is
+        /// restorable.
+        var hasRollback: Bool { !rollbackable.isEmpty }
+        /// Content-fitting height for the (bottom-pinned) Rollback list, capped so a
+        /// long list scrolls internally instead of crowding out the Apps tree above it.
+        var rollbackListHeight: CGFloat { min(CGFloat(rollbackable.count) * 34 + 12, 240) }
+    }
+
+    private var sidebarLists: SidebarLists {
+        SidebarLists(filteredApps: filteredApps, brewCasks: brewCasks,
+                     rollbackable: rollbackableApps)
     }
 
     /// The app the detail pane shows — keyed off the debounced `detailSelection`,
@@ -161,8 +188,9 @@ struct WorkbenchWindowView: View {
     }
 
     var body: some View {
-        NavigationSplitView {
-            sidebar
+        let lists = sidebarLists
+        return NavigationSplitView {
+            sidebar(lists)
                 .navigationSplitViewColumnWidth(min: 260, ideal: 280, max: 340)
         } detail: {
             if let selected {
@@ -366,17 +394,17 @@ struct WorkbenchWindowView: View {
 
     /// Whether there's anything brew-managed to show a Brew tree for. Non-brew users
     /// see only the Apps tree (no empty Brew header).
-    private var hasBrew: Bool {
-        !brewCasks.isEmpty || !model.brewFormulae.isEmpty
+    private func hasBrew(_ lists: SidebarLists) -> Bool {
+        !lists.brewCasks.isEmpty || !model.brewFormulae.isEmpty
     }
 
     /// Total brew items, for the Brew header's count pill and its list height.
-    private var brewItemCount: Int {
-        brewCasks.count + model.brewFormulae.count
+    private func brewItemCount(_ lists: SidebarLists) -> Int {
+        lists.brewCasks.count + model.brewFormulae.count
     }
 
     @ViewBuilder
-    private var sidebar: some View {
+    private func sidebar(_ lists: SidebarLists) -> some View {
         VStack(spacing: 0) {
             AppSearchField(text: $searchText)
                 .padding(.horizontal, 12)
@@ -385,44 +413,44 @@ struct WorkbenchWindowView: View {
             // Fill the middle and top-align: without this, when both trees are
             // collapsed (no list filling the space) the outer VStack would center the
             // headers vertically, floating them in the middle with empty space above.
-            splitRegion
+            splitRegion(lists)
                 .frame(maxHeight: .infinity, alignment: .top)
 
             // Rollback pinned to the bottom, below the Apps/Brew split (so it never
             // disturbs that draggable divider). Only shown when something is
             // restorable; the always-visible header is the discovery surface for
             // apps that have already updated and dropped out of the lists above.
-            if hasRollback {
+            if lists.hasRollback {
                 Divider()
-                rollbackHeader
-                if rollbackExpanded { rollbackListView }
+                rollbackHeader(lists)
+                if rollbackExpanded { rollbackListView(lists) }
             }
         }
     }
 
-    private var appsHeader: some View {
+    private func appsHeader(_ lists: SidebarLists) -> some View {
         sectionHeader(String(localized: "Apps"), systemImage: "square.grid.2x2.fill",
-                      count: filteredApps.count, expanded: $appsExpanded)
+                      count: lists.filteredApps.count, expanded: $appsExpanded)
     }
 
-    private var brewHeader: some View {
+    private func brewHeader(_ lists: SidebarLists) -> some View {
         sectionHeader(String(localized: "Brew"), systemImage: "mug.fill",
-                      count: brewItemCount, expanded: $brewExpanded) {
+                      count: brewItemCount(lists), expanded: $brewExpanded) {
             brewBulkUpgrade
         }
     }
 
-    private var rollbackHeader: some View {
+    private func rollbackHeader(_ lists: SidebarLists) -> some View {
         sectionHeader(String(localized: "Rollback"), systemImage: "arrow.uturn.backward",
-                      count: rollbackableApps.count, expanded: $rollbackExpanded)
+                      count: lists.rollbackable.count, expanded: $rollbackExpanded)
     }
 
     /// The Rollback list: every app with a backup we can restore, each with an inline
     /// "Roll back to vX" action. Reuses `$selection`, so clicking a row also opens that
     /// app's changelog in the detail pane — useful context before undoing an update.
-    private var rollbackListView: some View {
+    private func rollbackListView(_ lists: SidebarLists) -> some View {
         List(selection: $selection) {
-            ForEach(rollbackableApps) { result in
+            ForEach(lists.rollbackable) { result in
                 WorkbenchRollbackRow(
                     result: result,
                     target: model.backupVersion(result.id) ?? "previous",
@@ -431,7 +459,7 @@ struct WorkbenchWindowView: View {
             }
         }
         .listStyle(.sidebar)
-        .frame(height: rollbackListHeight)
+        .frame(height: lists.rollbackListHeight)
     }
 
     /// Bulk "Upgrade All" for the Brew tree — runs `brew upgrade --formula` (all
@@ -469,17 +497,17 @@ struct WorkbenchWindowView: View {
     /// NSSplitView's heavy splitter bar rendering as a black line against a 34pt
     /// collapsed pane.
     @ViewBuilder
-    private var splitRegion: some View {
-        if hasBrew && appsExpanded && brewExpanded {
+    private func splitRegion(_ lists: SidebarLists) -> some View {
+        if hasBrew(lists) && appsExpanded && brewExpanded {
             VSplitView {
                 // VSplitView gives each pane's sidebar list a ~10pt top inset that the
                 // collapsed (plain-VStack) layout doesn't, so the list sat 10pt lower
                 // under its header only while the split was engaged (measured: the rows
                 // shifted down exactly 20px @2x). Pull each list back up by that inset so
                 // both layouts hug the header identically.
-                VStack(spacing: 0) { appsHeader; appsListView.padding(.top, Self.splitPaneListInset) }
+                VStack(spacing: 0) { appsHeader(lists); appsListView(lists).padding(.top, Self.splitPaneListInset) }
                     .frame(minHeight: 120)
-                VStack(spacing: 0) { brewHeader; brewListView.padding(.top, Self.splitPaneListInset) }
+                VStack(spacing: 0) { brewHeader(lists); brewListView(lists).padding(.top, Self.splitPaneListInset) }
                     .frame(minHeight: 100)
             }
             // Persist the divider position across launches. VSplitView exposes no
@@ -488,12 +516,12 @@ struct WorkbenchWindowView: View {
             .background(SplitViewAutosave(name: "duo.workbench.sidebarSplit"))
         } else {
             VStack(spacing: 0) {
-                appsHeader
-                if appsExpanded { appsListView.frame(maxHeight: .infinity) }
-                if hasBrew {
+                appsHeader(lists)
+                if appsExpanded { appsListView(lists).frame(maxHeight: .infinity) }
+                if hasBrew(lists) {
                     Divider()
-                    brewHeader
-                    if brewExpanded { brewListView.frame(maxHeight: .infinity) }
+                    brewHeader(lists)
+                    if brewExpanded { brewListView(lists).frame(maxHeight: .infinity) }
                 }
             }
         }
@@ -501,9 +529,9 @@ struct WorkbenchWindowView: View {
 
     /// The Apps tree's scrolling list (extracted so the split layout above stays
     /// readable).
-    private var appsListView: some View {
+    private func appsListView(_ lists: SidebarLists) -> some View {
         List(selection: $selection) {
-            ForEach(filteredApps) { result in
+            ForEach(lists.filteredApps) { result in
                 WorkbenchSidebarRow(
                     result: result,
                     checkAgain: { Task { await model.retry(result) } },
@@ -526,7 +554,7 @@ struct WorkbenchWindowView: View {
         .listStyle(.sidebar)
         .focused($appsListFocused)
         .overlay {
-            if filteredApps.isEmpty {
+            if lists.filteredApps.isEmpty {
                 ContentUnavailableView.search(text: searchText)
             }
         }
@@ -534,9 +562,9 @@ struct WorkbenchWindowView: View {
 
     /// The Brew tree's scrolling list: brew-managed casks (reusing the app row + its
     /// existing install path) above outdated CLI formulae (their own inline action).
-    private var brewListView: some View {
+    private func brewListView(_ lists: SidebarLists) -> some View {
         List(selection: $selection) {
-            ForEach(brewCasks) { result in
+            ForEach(lists.brewCasks) { result in
                 WorkbenchSidebarRow(
                     result: result,
                     checkAgain: { Task { await model.retry(result) } },

--- a/App/project.yml
+++ b/App/project.yml
@@ -76,10 +76,11 @@ targets:
 
   # A developer tool, not part of the shipped app: renders every `RowActionState`
   # to `verify/row-states/*.png` so a change to how a row is drawn shows up as an
-  # image diff. It exists because there is no test target over `App/Sources` (see
-  # below), so nothing else executes the row rendering — and the failure that
-  # created the need was a state drawing NOTHING, which no assertion about the
-  # state itself can catch. Run with `make gallery`.
+  # image diff. It exists because the test target above compiles only the files it
+  # names, and the row views are not among them (see below), so nothing else
+  # executes the row rendering — and the failure that created the need was a state
+  # drawing NOTHING, which no assertion about the state itself can catch. Run with
+  # `make gallery`.
   #
   # The sources it links are deliberately free of `AppListModel`: the views take a
   # state plus plain closures, so the gallery needs no scanning, no network and no

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartReconciler.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/PackageRestartReconciler.swift
@@ -45,12 +45,17 @@ public enum PackageRestartReconciler {
     ///   - onDisk: the apps THIS scan found, by row id. An id missing here is a
     ///     blind pass, not a deletion.
     ///   - launchDates: launch dates of running copies, by resolved bundle path.
+    ///     An autoclosure, and deliberately: nothing staged is the overwhelmingly
+    ///     common case and it returns below without reading this, while producing
+    ///     the value means walking every running process on the machine and
+    ///     `realpath`-ing its bundle on the main actor. Same lesson as
+    ///     `RowActionFacts.route`. Evaluated exactly once, past the guard.
     ///   - previouslyPending: the badge state going in.
     ///   - previouslyNotified: the notify-once guard going in.
     public static func reconcile(
         staged: [String: StagedPackageFacts],
         onDisk: [String: InstalledApp],
-        launchDates: [String: [Date]],
+        launchDates: @autoclosure () -> [String: [Date]],
         previouslyPending: Set<String>,
         previouslyNotified: Set<String>
     ) -> PackageRestartReconciliation {
@@ -60,6 +65,7 @@ public enum PackageRestartReconciler {
             return PackageRestartReconciliation(
                 pending: [], settled: [], toNotify: [], notified: [])
         }
+        let launchDates = launchDates()
 
         var pending: Set<String> = []
         var settled: [String] = []

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/UpdatePolicy.swift
@@ -37,19 +37,43 @@ public struct InstallEnvironment: Sendable {
     /// a running wrapped app and every path-keyed "is it running?" answers no.
     /// The identifier is unaffected (`com.lumiunited.pre.homekit` either way).
     public var runningBundleIDs: Set<String>
+    /// `InstalledApp.path` → what `UpdatePolicy.runtimeBundlePath` returns for
+    /// it, precomputed by the host for the installs it is about to ask about. A
+    /// pure memo: an entry MUST be what that function would have answered, and a
+    /// missing one simply costs the call.
+    ///
+    /// It exists because `runtimeBundlePath` starts with
+    /// `resolvingSymlinksInPath()` — a `realpath`, a filesystem walk — and the two
+    /// row-level questions that use it (`isRunning`, `requiresElevatedInstall`) are
+    /// asked once or twice PER ROW PER REDRAW, while the answer can only change
+    /// when the scan does. The running side has had `RunningBundlePathCache` for
+    /// this since the same measurement; this is the row side of it.
+    ///
+    /// Keyed by the URL rather than by its `path`: a lookup here happens per row
+    /// per redraw, and `URL.path` bridges to `NSURL` — the exact cost the
+    /// `elevationRequiredPaths` memo was rewritten to stop paying.
+    public var runtimeKeys: [URL: String]
 
     public init(
         isHelperEnabled: Bool,
         runningAppPaths: Set<String>,
         stagedSelfUpdates: [String: StagedSelfUpdate],
         elevationRequiredPaths: Set<String> = [],
-        runningBundleIDs: Set<String> = []
+        runningBundleIDs: Set<String> = [],
+        runtimeKeys: [URL: String] = [:]
     ) {
         self.isHelperEnabled = isHelperEnabled
         self.runningAppPaths = runningAppPaths
         self.stagedSelfUpdates = stagedSelfUpdates
         self.elevationRequiredPaths = elevationRequiredPaths
         self.runningBundleIDs = runningBundleIDs
+        self.runtimeKeys = runtimeKeys
+    }
+
+    /// The comparable path for one install — from `runtimeKeys` when the host
+    /// precomputed it, otherwise resolved here.
+    func runtimeKey(for url: URL) -> String {
+        runtimeKeys[url] ?? UpdatePolicy.runtimeBundlePath(url)
     }
 }
 
@@ -206,7 +230,7 @@ public enum UpdatePolicy {
         _ result: UpdateResult,
         environment: InstallEnvironment
     ) -> Bool {
-        environment.elevationRequiredPaths.contains(runtimeBundlePath(result.app.path))
+        environment.elevationRequiredPaths.contains(environment.runtimeKey(for: result.app.path))
     }
 
     /// The declined leg of the tri-state: this install needs an administrator
@@ -417,7 +441,7 @@ public enum UpdatePolicy {
         if result.app.isiOSAppOnMac, let bundleID = result.app.bundleID {
             return environment.runningBundleIDs.contains(bundleID)
         }
-        return environment.runningAppPaths.contains(runtimeBundlePath(result.app.path))
+        return environment.runningAppPaths.contains(environment.runtimeKey(for: result.app.path))
     }
 
     /// The vendor's advertised version when it is strictly *older* than what is

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallEnvironmentRuntimeKeyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/InstallEnvironmentRuntimeKeyTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `InstallEnvironment.runtimeKeys` — the precomputed answer the row-level
+/// questions use instead of resolving a path per row per redraw.
+///
+/// **How the seam works.** `UpdatePolicy.runtimeBundlePath` opens with
+/// `resolvingSymlinksInPath()`, a filesystem call, and nothing in these tests can
+/// count a `realpath`. So the map is used the way `RunningBundlePathCache`'s
+/// injectable `resolver` is: it is given an answer the resolver provably would
+/// never produce for that path, and the question is which of the two came out.
+/// A map entry that lies is not a state production can reach — the host builds
+/// the map by calling that very function — it is how the call is observed.
+///
+/// Every path here is invented and asserted absent: `resolvingSymlinksInPath` is
+/// existence-sensitive, so a fixture that happened to exist on the host would put
+/// the filesystem into the answer (CLAUDE.md, "测试不能问宿主「你装了什么」").
+struct InstallEnvironmentRuntimeKeyTests {
+
+    /// A path no machine has, and the sentinel a resolver could not invent for it.
+    private static let rawPath = "/ZZFixture-RuntimeKey/Raw.app"
+    private static let precomputed = "/ZZFixture-RuntimeKey/Precomputed.app"
+
+    private func app(path: String) -> InstalledApp {
+        #expect(!FileManager.default.fileExists(atPath: path),
+                "fixture paths must not exist, or the resolver's answer becomes a fact about this Mac")
+        return InstalledApp(
+            name: "Fixture", bundleID: "com.example.zzfixture",
+            shortVersion: "1.0", buildVersion: "1",
+            path: URL(fileURLWithPath: path),
+            isMASApp: false, sparkleFeedURL: nil)
+    }
+
+    private func result(path: String) -> UpdateResult {
+        UpdateResult(app: app(path: path), remote: nil, status: .upToDate)
+    }
+
+    /// The point of the whole change: `isRunning` answers from the map, so a
+    /// redraw costs a dictionary lookup rather than a `realpath`.
+    ///
+    /// Mutation: put `runtimeBundlePath(result.app.path)` back into `isRunning`
+    /// and this fails — the raw path is what gets compared, and it is not in
+    /// `runningAppPaths`.
+    @Test func isRunningAnswersFromThePrecomputedKey() {
+        let row = result(path: Self.rawPath)
+        let environment = InstallEnvironment(
+            isHelperEnabled: false,
+            runningAppPaths: [Self.precomputed],
+            stagedSelfUpdates: [:],
+            runtimeKeys: [URL(fileURLWithPath: Self.rawPath): Self.precomputed])
+
+        #expect(UpdatePolicy.isRunning(row, environment: environment))
+        #expect(UpdatePolicy.runtimeBundlePath(row.app.path) != Self.precomputed,
+                "the seam only proves anything while the resolver disagrees with the map")
+    }
+
+    /// The same for the elevation question, which shares the call.
+    @Test func requiresElevatedInstallAnswersFromThePrecomputedKey() {
+        let row = result(path: Self.rawPath)
+        let environment = InstallEnvironment(
+            isHelperEnabled: false,
+            runningAppPaths: [],
+            stagedSelfUpdates: [:],
+            elevationRequiredPaths: [Self.precomputed],
+            runtimeKeys: [URL(fileURLWithPath: Self.rawPath): Self.precomputed])
+
+        #expect(UpdatePolicy.requiresElevatedInstall(row, environment: environment))
+    }
+
+    /// A host that precomputes nothing — every CLI call site — must be unchanged:
+    /// the resolver still runs, including its staging-name rewrite, which is the
+    /// half of `runtimeBundlePath` that is not optional.
+    ///
+    /// Mutation: drop the `?? UpdatePolicy.runtimeBundlePath(url)` fallback and
+    /// this fails; the staged path would never match the live one.
+    @Test func anEmptyMapStillResolves() {
+        let staged = "/ZZFixture-RuntimeKey/.duoupdater-staged-Live.app"
+        let live = "/ZZFixture-RuntimeKey/Live.app"
+        let row = result(path: staged)
+        let environment = InstallEnvironment(
+            isHelperEnabled: false,
+            runningAppPaths: [live],
+            stagedSelfUpdates: [:])
+
+        #expect(UpdatePolicy.isRunning(row, environment: environment))
+    }
+
+    /// And a map that covers OTHER rows must not answer for this one.
+    @Test func aMissEntryFallsBackRatherThanReadingAnotherRowsKey() {
+        let row = result(path: Self.rawPath)
+        let environment = InstallEnvironment(
+            isHelperEnabled: false,
+            runningAppPaths: [Self.precomputed],
+            stagedSelfUpdates: [:],
+            runtimeKeys: [URL(fileURLWithPath: "/ZZFixture-RuntimeKey/Other.app"): Self.precomputed])
+
+        #expect(!UpdatePolicy.isRunning(row, environment: environment))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartReconcilerTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/PackageRestartReconcilerTests.swift
@@ -57,6 +57,41 @@ struct PackageRestartReconcilerTests {
             previouslyPending: pending, previouslyNotified: notified)
     }
 
+    // MARK: laziness
+
+    /// `launchDates` is not produced for the pass that cannot read it.
+    ///
+    /// Producing it means walking every running process on the machine and
+    /// `realpath`-ing its bundle, on the main actor; and "nothing staged" is
+    /// almost every pass, since `reconcilePackageRestarts` runs on every rescan.
+    /// Same shape as `routeIsDeferred` in `RowActionStateTests`, and the same
+    /// positive pole: deferral alone would stay green if the parameter stopped
+    /// being read at all, so the loaded pass asserts it IS evaluated — exactly
+    /// once, since the loop reads it per id.
+    ///
+    /// Mutation: drop `@autoclosure` from `reconcile` and the first count is 1.
+    @Test("launch dates are not gathered for a pass with nothing staged")
+    func launchDatesAreDeferred() {
+        final class Counter: @unchecked Sendable { var n = 0 }
+        let calls = Counter()
+
+        _ = PackageRestartReconciler.reconcile(
+            staged: [:],
+            onDisk: [Self.path: app("2.0")],
+            launchDates: { calls.n += 1; return [Self.path: Self.staleLaunch] }(),
+            previouslyPending: [Self.path], previouslyNotified: [])
+        #expect(calls.n == 0)
+
+        let out = PackageRestartReconciler.reconcile(
+            staged: [Self.path: staged("2.0"), Self.otherPath: staged("2.0")],
+            onDisk: [Self.path: app("2.0"),
+                     Self.otherPath: app("2.0", path: Self.otherPath)],
+            launchDates: { calls.n += 1; return [Self.path: Self.staleLaunch] }(),
+            previouslyPending: [], previouslyNotified: [])
+        #expect(calls.n == 1, "two staged ids must share one gathering, not one each")
+        #expect(out.pending == [Self.path])
+    }
+
     // MARK: the three states
 
     /// Landed, and a copy that predates the hand-off is still running: light the


### PR DESCRIPTION
Review findings P2–P5, the small perf ones, the App-side comment mismatches from
section 三, and the row-text parity finding (section 二, finding 7).

Three commits: perf (+ its two Core tests) / comments / row-label parity.

## What it addresses

| Finding | Where | Done |
|---|---|---|
| **P2** popover evaluates `downloadReadout` per row per tick | `MenuContentView.swift:938-943, 1030` | `PopoverRowAction.downloadReadout` is now `() -> DownloadReadout`, like `showsStageLabel` beside it. Gallery and `popoverDownloadReadoutOverrides` updated. |
| **P3** `isRunning` / `requiresElevatedInstall` `realpath` per row per render | `Engine/UpdatePolicy.swift:420, 209` | `InstallEnvironment.runtimeKeys` (option **b**, memo in the host — see below). |
| **P3** `runningLaunchDatesByPath` computed for a pass that discards it | `AppListModel.swift:4079-4093`, `PackageRestartReconciler.reconcile` | `launchDates` is an `@autoclosure`, evaluated once past the `staged.isEmpty` guard. |
| **P4** Workbench re-filters/re-sorts 3–4× per body | `WorkbenchWindowView.swift:89-146, 405, 506, 529` | One `SidebarLists` value per body pass, threaded into the sidebar builders. Ordering and filtering semantics unchanged. |
| **P5** `gh auth token` subprocess on every popover open | `AppListModel.swift:2948-2952, 3104, 1390-1392` | `prewarmFormulaReleases` decides there is something to warm *before* resolving, and both it and `ensureFormulaReleaseLoading` go through `githubTokenForRecheck()`. Log-line comment fixed. |
| small | `TrafficLedgerPane.swift:253-258, 332-337` | `maxBytes` hoisted out of the `ForEach` (it scanned the whole ledger per row) and passed into `removedGroup`. |
| small | `RequestLogPane.swift:203-223` | poll is now `.task(id: activeState)`, so the "nobody is watching" guard reads the live value instead of the one captured on appear. |
| comments 三 | `MenuContentView.swift:69-76`, `WorkbenchWindowView.swift:41-42, 134-146` | **Code changed to match the comment**: `localizedStandardContains`. |
| comments 三 | `SettingsWindowTracker.swift:319-323`, `RowActionViews.swift:471-476`, `RequestLogPane.swift:15-16`, `RowStateGallery/main.swift:9`, `App/project.yml:79`, `WorkbenchWindowView.swift:6-13, 82-88, 615, 1601`, `TrafficLedgerPane.swift:564-565`, `PopoverRowAction.swift:8`, `AppListModel.swift:2196-2203, 2400-2404, 6162-6170, 3140-3149, 1204-1207` | All corrected. `markJustUpdated` and `refreshPermissionStatus` were fixed in the **code** (the brief's preference), not the doc. |
| parity 二/7 | `RowActionViews.swift:339-341, 149, 464`, `WorkbenchWindowView.swift:1157-1158, 792-796` | `.lineLimit(1)` / `.minimumScaleFactor` added to match siblings. |

### Nothing declined, but two judgement calls

**P3, why option (b) and not (a).** (a) — a runtime key stored on `InstalledApp` at
scan time — is the semantically pure version, but `InstalledApp` is `Hashable` with
synthesised conformance over all stored properties and is constructed in 157 places,
so a new field changes `==`/`hash` for every fixture in the suite. (b) as written is
narrower still than "memoise in `AppListModel`": the memo lives on
`InstallEnvironment` (`runtimeKeys`, default `[:]`), so `UpdatePolicy` keeps its
signature, every CLI call site behaves exactly as before, and `AppListModel` builds
the map with the *same* function, invalidated by `results.didSet` — the identical
shape the neighbouring `elevationPathsCache` already uses, for the identical reason.
`elevationRequiredPaths` still inserts with `runtimeBundlePath`, so the two sides
cannot disagree.

**`localizedStandardContains` is a user-visible behaviour change** (the only one in
this PR): typing "cafe" in either search field now finds an app spelled "Café". That
is what both docs have always said the search does.

## Red → green, and the mutation check

Two new Core tests. `isRunning` cannot be observed counting a `realpath`, so
`runtimeKeys` is the seam — the same role `RunningBundlePathCache(resolver:)` plays
for the running side: it is given an answer the resolver provably would not produce
and the question is which one came out. All fixture paths are invented
(`/ZZFixture-RuntimeKey/…`) and asserted absent, per CLAUDE.md's rule about tests
asking the host what it has installed.

Green with the fix:

```
$ cd DuoUpdaterCore && swift test --filter 'InstallEnvironmentRuntimeKeyTests|launchDatesAreDeferred'
✔ Test isRunningAnswersFromThePrecomputedKey() passed after 0.001 seconds.
✔ Test requiresElevatedInstallAnswersFromThePrecomputedKey() passed after 0.001 seconds.
✔ Test "launch dates are not gathered for a pass with nothing staged" passed after 0.001 seconds.
✔ Test anEmptyMapStillResolves() passed after 0.001 seconds.
✔ Test aMissEntryFallsBackRatherThanReadingAnotherRowsKey() passed after 0.001 seconds.
✔ Test run with 5 tests in 2 suites passed after 0.001 seconds.
```

Mutation — both fixes reverted in place (`isRunning`/`requiresElevatedInstall` back
to `runtimeBundlePath(result.app.path)`, `@autoclosure` dropped from `reconcile`):

```
✘ Test "launch dates are not gathered for a pass with nothing staged" recorded an issue at PackageRestartReconcilerTests.swift:83:9: Expectation failed: calls.n == 0
✘ Test "launch dates are not gathered for a pass with nothing staged" recorded an issue at PackageRestartReconcilerTests.swift:91:9: Expectation failed: calls.n == 1
✘ Test requiresElevatedInstallAnswersFromThePrecomputedKey() recorded an issue at InstallEnvironmentRuntimeKeyTests.swift:68:9: Expectation failed: UpdatePolicy.requiresElevatedInstall(row, environment: environment)
✘ Test isRunningAnswersFromThePrecomputedKey() recorded an issue at InstallEnvironmentRuntimeKeyTests.swift:53:9: Expectation failed: UpdatePolicy.isRunning(row, environment: environment)
✘ Test run with 5 tests in 2 suites failed after 0.009 seconds with 4 issues.
```

Each names its own case; the two control tests (`anEmptyMapStillResolves`,
`aMissEntryFallsBackRatherThanReadingAnotherRowsKey`) stayed green under the
mutation, which is what keeps them from being the same assertion twice. Fixes
restored, re-run green (above).

## Full verification

```
$ make test > /tmp/mt-commit.log 2>&1; echo "exit=$?"
exit=0

━ Test run with 2782 tests in 229 suites passed after 20.140 seconds with 2 known issues.
✔ Test run with 280 tests in 34 suites passed after 0.234 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 261 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
✓ app audits consistent — 121 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 532 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 26) match the initializers
✓ no machine-population claims in code comments — 532 files
```

```
$ make gallery                      # run after every edit that touches a row
rendered 88 states → verify/row-states
DownloadReadout order intact (barAndPercent, ringAndPercent, ringOnly)
no state renders blank
no unregistered ImageRenderer placeholder pixels
no two states draw the same tile
9 mayLookAlike pair(s) claiming a tooltip differentiator checked — every one actually has a different tooltip on each side

$ git status --short verify/row-states
                                    # empty
```

**No PNG diff**, which is the load-bearing result twice over: it proves the
`downloadReadout` closure draws exactly what the value drew (tiles 35/36 exercise
the two non-default readouts), and that the four added `lineLimit`/
`minimumScaleFactor` modifiers change nothing for the English strings the gallery
renders. Nothing under `verify/` is committed here.

No recipe or parser rule changed, so `duo verify` was not run (and `make cli` /
`make install` were deliberately not run — machine-global binaries).

## Noticed, not fixed (outside this brief)

1. `grep -rn "no test target"` finds more present-tense copies than the review
   counted — `AppListModel.swift:177, 449, 889` and seven Core files
   (`RelaunchProgress`, `RefreshIntent`, `ListActivity`, `RowActionState`,
   `RequestEvent`, `EventStore`, `SelfChangelogLocalization`). I left them: they
   argue about `AppListModel` and about view bodies, which the narrow target
   genuinely does not compile, so the sentence is awkward rather than false. Worth
   a deliberate decision rather than a drive-by.
2. `PrivilegedHelperClient.isEnabled` is a live `SMAppService.status` query and is
   called twice more in `AppListModel` around :4106-4119 (three queries in two
   adjacent lines). Not on a 1.5 s path, so left alone.
3. `WorkbenchWindowView.apps` / `rollbackableApps` / `brewCasks` still sort with
   `localizedCaseInsensitiveCompare` while the *search* now folds diacritics. That
   is consistent with how it behaved before and no doc claims otherwise, but the
   two predicates being different is now visible in one file.
