### PR TITLE
Changelog: give every recipe its own cache slot, decode HTML entities in one pass

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -1796,7 +1796,7 @@ final class AppListModel {
         changelogRevalidated = changelogRevalidated.filter { $0.bundleID != bundleID }
         // Clear the network cache for every channel variant (Stable & ESR share this
         // bundle id but have different sources; Warp's three channels share one
-        // endpoint but get distinct channel-fragmented cache slots), since we don't
+        // endpoint but get distinct recipe-fragmented cache slots), since we don't
         // know here which channel's notes were cached.
         let recipes = ChangelogRecipeRegistry.recipes(forBundleID: bundleID)
         if !recipes.isEmpty {

--- a/CLI/Tests/DuoKitTests/TriageTests.swift
+++ b/CLI/Tests/DuoKitTests/TriageTests.swift
@@ -207,6 +207,28 @@ import DuoUpdaterCore
         let body = #"{"version":"1.2.3"}"#
         #expect(ResponseSample.condense(body, limit: 4096, pattern: nil) == body)
     }
+
+    /// `limit` is `maxSampleBytes` and the note says "bytes elided", but the head
+    /// and tail were taken with `String.prefix`/`suffix`, which count Characters.
+    /// On a CJK page that is 3 bytes each: a 1 200-byte cap kept ~3 600 bytes, and
+    /// the elided count it reported was the one it would have dropped had the cap
+    /// been honoured. Both halves of the promise are checked here — what is kept,
+    /// and what the sample claims about what is gone.
+    @Test func theSampleIsCappedInBytesAndReportsTheBytesItActuallyDropped() throws {
+        let body = String(repeating: "中", count: 5_000)  // 5 000 Characters, 15 000 bytes
+        let limit = 1_200
+        let sample = ResponseSample.condense(body, limit: limit, pattern: nil)
+
+        let note = try #require(
+            sample.range(of: #"\n…\[\d+ bytes elided\]…\n"#, options: .regularExpression))
+        let reported = try #require(Int(sample[note].filter(\.isNumber)))
+        let kept = sample.replacingCharacters(in: note, with: "")
+
+        #expect(kept.utf8.count <= limit)
+        #expect(reported == body.utf8.count - kept.utf8.count)
+        // A multi-byte character is never split down the middle.
+        #expect(kept.allSatisfy { $0 == "中" })
+    }
 }
 
 /// A suggestion in an issue is read weeks later, when the only thing that says

--- a/CLI/Tests/DuoKitTests/TriageTests.swift
+++ b/CLI/Tests/DuoKitTests/TriageTests.swift
@@ -229,6 +229,30 @@ import DuoUpdaterCore
         // A multi-byte character is never split down the middle.
         #expect(kept.allSatisfy { $0 == "中" })
     }
+
+    /// The same cap, on the branch that usually runs. `condense` only reaches the
+    /// head/tail path when the pattern's anchors are all gone; when one is still
+    /// there — the normal case — the window comes from `windowAroundAnchor`, which
+    /// was counting Characters too.
+    @Test func theAnchoredWindowIsCappedInBytesToo() {
+        let limit = 1_200
+        let body = String(repeating: "中", count: 3_000)
+            + #"<li id="codex-1">版本 4.2.0</li>"#
+            + String(repeating: "文", count: 3_000)
+        let sample = ResponseSample.condense(
+            body, limit: limit, pattern: #"<li id="codex-[^"]*">"#)
+
+        #expect(sample.contains("centred on the pattern's anchor"))
+        #expect(sample.contains(#"<li id="codex-1">版本 4.2.0</li>"#))
+        // The framing lines are the tool talking; the window it wrapped is what the
+        // cap is about.
+        let window = sample
+            .replacingOccurrences(
+                of: #"^…\[sample centred on the pattern's anchor '[^']*'\]…\n"#,
+                with: "", options: .regularExpression)
+            .replacingOccurrences(of: "\n…[truncated]…", with: "")
+        #expect(window.utf8.count <= limit)
+    }
 }
 
 /// A suggestion in an issue is read weeks later, when the only thing that says

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppcastHTMLChangelogParser.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/AppcastHTMLChangelogParser.swift
@@ -135,6 +135,12 @@ enum AppcastHTMLChangelogParser {
         cleaned.range(of: #"^release date\b"#, options: [.regularExpression, .caseInsensitive]) != nil
     }
 
+    /// Compiled once: `cleanInline` runs per `<li>`, and a long appcast
+    /// `<description>` has dozens. Same reasoning — and same thread-safety — as
+    /// `ChangelogExtractor.elementBreakRegex`.
+    private static let anchorRegex = try? NSRegularExpression(
+        pattern: #"<a\b[^>]*>([\s\S]*?)</a>"#, options: [.caseInsensitive])
+
     /// Clean one captured heading/`<li>` body for plain-text display: flatten
     /// `<a href="…">text</a>` to just `text` (no bracket/paren markup, no bare
     /// URL — `Changelog.itemSyntax` for this path is `.plain`, so anything left
@@ -143,9 +149,10 @@ enum AppcastHTMLChangelogParser {
     /// collapse whitespace. nil when nothing readable is left.
     private static func cleanInline(_ raw: String) -> String? {
         var s = raw
-        s = s.replacingOccurrences(
-            of: #"<a\b[^>]*>([\s\S]*?)</a>"#, with: "$1",
-            options: [.regularExpression, .caseInsensitive])
+        if let anchorRegex {
+            s = anchorRegex.stringByReplacingMatches(
+                in: s, range: NSRange(s.startIndex..., in: s), withTemplate: "$1")
+        }
         // Known HTML elements only — NOT a blind `<[^>]+>` sweep. TablePro's notes
         // carry `` `USE <database>` `` and `` `<unsupported: type>` `` as literal
         // text inside CDATA, and a blind sweep deletes exactly the identifier the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/Changelog.swift
@@ -75,7 +75,14 @@ public struct Changelog: Codable, Sendable, Hashable {
     ///   hand-written recipe (Mac Performance Monitor) opt in unconditionally.
     ///   Notes already cached under the old logic had every group's heading
     ///   dropped with no way to tell which category a line belonged to.
-    public static let parserGeneration = 3
+    /// - 4: HTML entity decoding is one left-to-right pass instead of a loop over a
+    ///   `Dictionary`, whose iteration order Swift randomises per process — so a
+    ///   double-escaped note (`&amp;lt;`, a vendor showing the reader a literal
+    ///   `&lt;`) decoded once on one launch and twice on the next, and whichever
+    ///   reading the cache happened to catch is now wrong half the time. Typeless's
+    ///   decoder also splits CRLF bodies correctly, so an entry cached from one kept
+    ///   only its first note.
+    public static let parserGeneration = 4
 
     public let entries: [Entry]
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCache.swift
@@ -8,9 +8,12 @@ import Foundation
 /// Entries expire after ``ttl`` seconds so the window always reflects recent
 /// releases rather than a session-long snapshot.
 ///
-/// Keyed on the recipe's canonical `source` URL so each recipe owns exactly one
-/// cache slot, regardless of the per-run resolved detail URL (index redirects
-/// don't inflate the key space). The cache stores parsed ``Changelog`` values —
+/// Keyed on the recipe's canonical `source` URL plus the recipe's own identity as
+/// a fragment (``ChangelogService/cacheKeyURL(for:resolved:)``), so each recipe
+/// owns exactly one cache slot and no two recipes share one — several recipes can
+/// read one page (Warp's three channels, Antigravity's two products). The per-run
+/// resolved detail URL stays out of it, so index redirects don't inflate the key
+/// space. The cache stores parsed ``Changelog`` values —
 /// not raw HTML — so it carries no ambiguity about what `nil` means.
 ///
 /// Concurrent callers requesting the same URL while a fetch is in-flight are

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCache.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogCache.swift
@@ -110,6 +110,21 @@ public actor ChangelogCache {
         store[url] = nil
     }
 
+    /// Drop every slot whose key carries this fragment — i.e. every slot belonging
+    /// to one recipe, whatever page it resolved to.
+    ///
+    /// One recipe is not one URL: a templated recipe (`sourceTemplate`) fetches a
+    /// different page per version, so it can own several slots at once, and the
+    /// caller after an on-disk update knows the recipe but not which versions the
+    /// user has opened. Matching on the fragment is what makes "drop this recipe's
+    /// notes" unable to miss. Compared percent-encoded, because that is how
+    /// ``ChangelogService/cacheKeyURL(for:resolved:)`` writes it.
+    public func invalidate(fragment: String) {
+        let keys = Set(store.keys).union(inflight.keys)
+            .filter { $0.fragment(percentEncoded: true) == fragment }
+        for key in keys { invalidate(key) }
+    }
+
     // MARK: - Low-level access (also used by tests)
 
     /// Return the cached ``Changelog`` for `url` if still fresh; nil otherwise.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogExtractor.swift
@@ -56,8 +56,14 @@ public enum ChangelogExtractor {
                 .flatMap { $0.isEmpty ? nil : $0 }
 
             // Items come from the `body` group when present, else the whole entry.
+            // NOT `group(match, nil, …)`, whose fallback is capture group 1: a named
+            // group is a numbered group too, so for a pattern without a `body` group
+            // that handed the item regexes the `version` capture — a version string,
+            // never any items — and the entry was dropped for having none. All 65
+            // registered entry patterns declare `body` today, so it only ever
+            // mattered for the next one written without it.
             let bodyText = group(match, "body", in: text)
-                ?? group(match, nil, in: text)
+                ?? wholeMatch(match, in: text)
                 ?? ""
 
             let noteHits = firstNonEmptyItemHits(in: bodyText, regexes: itemRegexes, recipe: recipe)
@@ -207,6 +213,13 @@ public enum ChangelogExtractor {
         return String(text[r])
     }
 
+    /// The entire matched text, capture groups ignored.
+    private static func wholeMatch(_ match: NSTextCheckingResult, in text: String) -> String? {
+        guard match.range.location != NSNotFound,
+              let r = Range(match.range, in: text) else { return nil }
+        return String(text[r])
+    }
+
     /// Strip tags (optional), decode entities (optional), collapse whitespace, trim.
     private static func clean(_ raw: String, _ recipe: ChangelogRecipe) -> String {
         var s = raw
@@ -263,9 +276,11 @@ public enum ChangelogExtractor {
             options: .regularExpression)
     }
 
+    private static let inlineCodeRegex = try? NSRegularExpression(
+        pattern: "``([^\n]*?)``|`([^`\n]+?)`")
+
     static func unwrapMarkdownInlineCode(_ s: String) -> String {
-        guard let regex = try? NSRegularExpression(pattern: "``([^\n]*?)``|`([^`\n]+?)`")
-        else { return s }
+        guard let regex = inlineCodeRegex else { return s }
         return regex.stringByReplacingMatches(
             in: s, range: NSRange(location: 0, length: (s as NSString).length),
             withTemplate: "$1$2")
@@ -288,6 +303,19 @@ public enum ChangelogExtractor {
         "var", "video",
     ]
 
+    /// Compiled once, not per call. `clean()` runs for every item, heading, title,
+    /// version and date of every entry, so a 60-release page with 20 notes each
+    /// re-compiled these thousands of times per panel open — and the element-name
+    /// alternation below re-joined its 70 names each time on top of that.
+    /// `NSRegularExpression` is immutable and thread-safe, which is what lets these
+    /// be `static let` (the same reason `RecordedPath.tokenShapes` is).
+    private static let elementBreakRegex = try? NSRegularExpression(
+        pattern: #"<\s*/?\s*(?:br|p|li|div|ul|ol|tr|td|th|h[1-6])\b[^>]*>"#,
+        options: [.caseInsensitive])
+    private static let elementRestRegex = try? NSRegularExpression(
+        pattern: #"<\s*/?\s*(?:\#(htmlElementNames.joined(separator: "|")))\b[^>]*>"#,
+        options: [.caseInsensitive])
+
     /// Strip only *known* HTML elements, turning the block-level ones into a space
     /// so adjacent text doesn't glue together, and leave every other angle-bracket
     /// run as literal text.
@@ -306,34 +334,32 @@ public enum ChangelogExtractor {
     /// `<custom-tag>`) survives as text, which is the safe direction — visible
     /// noise beats invisible deletion.
     static func stripHTMLElements(_ s: String) -> String {
-        let names = htmlElementNames.joined(separator: "|")
         var out = s
         // Block/line-breaking elements first, to a space.
-        if let breaks = try? NSRegularExpression(
-            pattern: #"<\s*/?\s*(?:br|p|li|div|ul|ol|tr|td|th|h[1-6])\b[^>]*>"#,
-            options: [.caseInsensitive]) {
+        if let breaks = elementBreakRegex {
             out = breaks.stringByReplacingMatches(
                 in: out, range: NSRange(out.startIndex..., in: out), withTemplate: " ")
         }
-        if let rest = try? NSRegularExpression(
-            pattern: #"<\s*/?\s*(?:\#(names))\b[^>]*>"#, options: [.caseInsensitive]) {
+        if let rest = elementRestRegex {
             out = rest.stringByReplacingMatches(
                 in: out, range: NSRange(out.startIndex..., in: out), withTemplate: "")
         }
         return out
     }
 
+    /// See `elementBreakRegex` for why these are hoisted.
+    private static let tagBreakRegex = try? NSRegularExpression(
+        pattern: #"<\s*/?\s*(br|p|li|div|ul|ol)\b[^>]*>"#,
+        options: [.caseInsensitive])
+    private static let anyTagRegex = try? NSRegularExpression(pattern: #"<[^>]+>"#)
+
     static func stripTags(_ s: String) -> String {
-        let breaks = try? NSRegularExpression(
-            pattern: #"<\s*/?\s*(br|p|li|div|ul|ol)\b[^>]*>"#,
-            options: [.caseInsensitive])
         var out = s
-        if let breaks {
+        if let breaks = tagBreakRegex {
             out = breaks.stringByReplacingMatches(
                 in: out, range: NSRange(out.startIndex..., in: out), withTemplate: " ")
         }
-        let anyTag = try? NSRegularExpression(pattern: #"<[^>]+>"#)
-        if let anyTag {
+        if let anyTag = anyTagRegex {
             out = anyTag.stringByReplacingMatches(
                 in: out, range: NSRange(out.startIndex..., in: out), withTemplate: "")
         }
@@ -348,54 +374,73 @@ public enum ChangelogExtractor {
         decodeJSONUnicodeEscapes(decodeHTMLEntities(s))
     }
 
-    /// The HTML half on its own: named entities plus numeric `&#NNN;` / `&#xHHH;`.
-    /// Split out from `decodeEntities` because the JSON `\uXXXX` pass that follows
-    /// it there has nothing to do with HTML — it exists for json-mode feeds whose
-    /// server escapes non-ASCII. A caller working on real markup (the Sparkle
-    /// appcast HTML parser) wants this half only: running the JSON pass over a
-    /// vendor's prose would rewrite a literal `\uXXXX` the vendor actually typed.
-    static func decodeHTMLEntities(_ s: String) -> String {
-        var out = s
-        let named: [String: String] = [
-            "&amp;": "&", "&lt;": "<", "&gt;": ">",
-            "&quot;": "\"", "&apos;": "'", "&#39;": "'",
-            "&nbsp;": " ", "&mdash;": "—", "&ndash;": "–",
-            "&hellip;": "…", "&rsquo;": "’", "&lsquo;": "‘",
-            "&ldquo;": "“", "&rdquo;": "”", "&times;": "×",
-        ]
-        for (entity, replacement) in named {
-            out = out.replacingOccurrences(of: entity, with: replacement)
-        }
-        // Numeric escapes: &#NNN; (decimal) and &#xHHH; (hex).
-        out = decodeNumericEntities(out)
-        return out
-    }
+    /// The named entities worth decoding. No `&#39;` here even though it decodes to
+    /// the same apostrophe: numeric escapes are handled by the same pass, from the
+    /// `&#…;` branch of `entityRegex`, so a second spelling of it would be dead.
+    private static let namedEntities: [String: String] = [
+        "&amp;": "&", "&lt;": "<", "&gt;": ">",
+        "&quot;": "\"", "&apos;": "'",
+        "&nbsp;": " ", "&mdash;": "—", "&ndash;": "–",
+        "&hellip;": "…", "&rsquo;": "’", "&lsquo;": "‘",
+        "&ldquo;": "“", "&rdquo;": "”", "&times;": "×",
+    ]
 
-    private static func decodeNumericEntities(_ s: String) -> String {
-        guard let regex = try? NSRegularExpression(
-            pattern: #"&#(x?[0-9a-fA-F]+);"#, options: [.caseInsensitive]) else { return s }
+    /// Every entity shape in one expression: `&#NNN;`, `&#xHHH;`, `&name;`.
+    private static let entityRegex = try? NSRegularExpression(
+        pattern: #"&(?:#([xX]?[0-9a-fA-F]+)|[a-zA-Z][a-zA-Z0-9]*);"#)
+
+    /// The HTML half of `decodeEntities` on its own: named entities plus numeric
+    /// `&#NNN;` / `&#xHHH;`. Split out from `decodeEntities` because the JSON
+    /// `\uXXXX` pass that follows it there has nothing to do with HTML — it exists
+    /// for json-mode feeds whose server escapes non-ASCII. A caller working on real
+    /// markup (the Sparkle appcast HTML parser) wants this half only: running the
+    /// JSON pass over a vendor's prose would rewrite a literal `\uXXXX` the vendor
+    /// actually typed.
+    ///
+    /// ONE left-to-right pass, which is both the correct semantics and the reason
+    /// this isn't a loop over the dictionary any more.
+    ///
+    /// It used to be `for (entity, replacement) in named` — and Swift randomises
+    /// `Dictionary` iteration order per process (a per-launch hash seed), so what a
+    /// double-escaped body decoded to changed from launch to launch: `&amp;lt;`,
+    /// which a vendor writes to show the reader a literal `&lt;`, came out as
+    /// `&lt;` when `&amp;` was substituted late and as `<` when it was substituted
+    /// early. The numeric pass was not even random — it ran unconditionally after
+    /// the named one, so `&amp;#39;` always decoded twice.
+    ///
+    /// Ordering the passes instead (numerics first, `&amp;` last) does not fix it:
+    /// `&#38;` IS an ampersand, so `&#38;lt;` would become `&lt;` and the named
+    /// pass behind it would eat that too. A single pass cannot double-decode in
+    /// either direction, because it never re-reads what it has written — each
+    /// entity present in the INPUT is decoded exactly once.
+    static func decodeHTMLEntities(_ s: String) -> String {
+        guard s.contains("&"), let regex = entityRegex else { return s }
         let ns = s as NSString
         var result = ""
         var last = 0
         for m in regex.matches(in: s, range: NSRange(location: 0, length: ns.length)) {
             result += ns.substring(with: NSRange(location: last, length: m.range.location - last))
-            let token = ns.substring(with: m.range(at: 1))
-            let scalarValue: UInt32?
-            if token.lowercased().hasPrefix("x") {
-                scalarValue = UInt32(token.dropFirst(), radix: 16)
+            let whole = ns.substring(with: m.range)
+            let decoded: String?
+            if m.range(at: 1).location != NSNotFound {
+                // Numeric: &#NNN; (decimal) and &#xHHH; (hex).
+                let token = ns.substring(with: m.range(at: 1))
+                let value = token.lowercased().hasPrefix("x")
+                    ? UInt32(token.dropFirst(), radix: 16)
+                    : UInt32(token, radix: 10)
+                decoded = value.flatMap(Unicode.Scalar.init).map { String(Character($0)) }
             } else {
-                scalarValue = UInt32(token, radix: 10)
+                decoded = namedEntities[whole]
             }
-            if let v = scalarValue, let scalar = Unicode.Scalar(v) {
-                result.append(Character(scalar))
-            } else {
-                result += ns.substring(with: m.range)  // leave it untouched
-            }
+            result += decoded ?? whole  // an unknown entity is left untouched
             last = m.range.location + m.range.length
         }
         result += ns.substring(from: last)
         return result
     }
+
+    private static let jsonEscapeRegex = try? NSRegularExpression(
+        pattern: #"\\(u[0-9a-fA-F]{4}|.)"#, options: [.dotMatchesLineSeparators])
 
     /// Full JSON string unescape (`\"`, `\\`, `\/`, `\n`, `\t`, `\r`, `\b`, `\f`,
     /// `\uXXXX`) in one left-to-right pass — used only for `.json`-mode feeds, where
@@ -404,9 +449,7 @@ public enum ChangelogExtractor {
     /// An unknown escape drops the backslash and keeps the char (lenient, like JSON).
     private static func decodeJSONStringEscapes(_ s: String) -> String {
         guard s.contains("\\") else { return s }
-        guard let regex = try? NSRegularExpression(
-            pattern: #"\\(u[0-9a-fA-F]{4}|.)"#, options: [.dotMatchesLineSeparators]
-        ) else { return s }
+        guard let regex = jsonEscapeRegex else { return s }
         let ns = s as NSString
         var result = ""
         var last = 0
@@ -460,10 +503,15 @@ public enum ChangelogExtractor {
         return out
     }
 
+    private static let whitespaceRunRegex = try? NSRegularExpression(pattern: #"\s+"#)
+
     /// Internal (not `private`) — see `stripTags`.
     static func collapseWhitespace(_ s: String) -> String {
-        let collapsed = s.replacingOccurrences(
-            of: #"\s+"#, with: " ", options: .regularExpression)
+        guard let regex = whitespaceRunRegex else {
+            return s.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let collapsed = regex.stringByReplacingMatches(
+            in: s, range: NSRange(s.startIndex..., in: s), withTemplate: " ")
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -211,16 +211,25 @@ public enum ChangelogService {
         }
     }
 
-    /// Drop every in-memory ``ChangelogCache`` slot this recipe could occupy: the
-    /// plain resolved page URL plus the recipe-fragmented key
-    /// (`…#changelog%3Acom%2E…`). Called after an app updates on disk so the
-    /// next open re-fetches fresh notes instead of serving the prior version's from
-    /// the still-warm in-memory cache.
-    public static func invalidateMemoryCache(for recipe: ChangelogRecipe) async {
-        let resolved = recipe.source
-        await ChangelogCache.shared.invalidate(resolved)
-        let keyURL = cacheKeyURL(for: recipe, resolved: resolved)
-        if keyURL != resolved { await ChangelogCache.shared.invalidate(keyURL) }
+    /// Drop every in-memory ``ChangelogCache`` slot this recipe could occupy, by
+    /// the recipe's own identity rather than by any one URL. Called after an app
+    /// updates on disk so the next open re-fetches fresh notes instead of serving
+    /// the prior version's from the still-warm in-memory cache.
+    ///
+    /// By identity because a URL is not enough to name them. `load` keys on
+    /// `resolvedSource(forVersion:)`, and a templated recipe (Thunderbird, WeChat,
+    /// Opera, Inkscape, …) resolves to a DIFFERENT page per version — so it holds
+    /// one slot per version the user has opened, and this used to compute its key
+    /// from the un-templated `recipe.source`, a URL `load` never stored anything
+    /// under. The invalidation missed every time, for exactly the recipes where it
+    /// matters most: the ones whose page changes when the app does.
+    ///
+    /// `cache` is a parameter only so a test can watch the fetch closure run again;
+    /// production always passes the shared instance.
+    public static func invalidateMemoryCache(
+        for recipe: ChangelogRecipe, in cache: ChangelogCache = .shared
+    ) async {
+        await cache.invalidate(fragment: cacheKeyFragment(for: recipe))
     }
 
     /// The cross-launch disk-cached notes for this recipe+version, with no network
@@ -255,9 +264,15 @@ public enum ChangelogService {
     /// verify`'s baseline key on. Percent-encoded so the fragment can't fail to
     /// parse: a nil `URL(string:)` here would silently reinstate the collision.
     static func cacheKeyURL(for recipe: ChangelogRecipe, resolved: URL) -> URL {
-        let token = recipe.recipeID
+        URL(string: resolved.absoluteString + "#" + cacheKeyFragment(for: recipe)) ?? resolved
+    }
+
+    /// The recipe-identity half of the key, on its own — what
+    /// `invalidateMemoryCache` matches on to find every version-resolved slot this
+    /// recipe owns.
+    static func cacheKeyFragment(for recipe: ChangelogRecipe) -> String {
+        recipe.recipeID
             .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? recipe.recipeID
-        return URL(string: resolved.absoluteString + "#" + token) ?? resolved
     }
 
     /// The disk-cache key for a recipe+version, or nil when no version is known

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogService.swift
@@ -38,9 +38,10 @@ public enum ChangelogService {
         // URL so different versions never serve each other's notes.
         let resolved = recipe.resolvedSource(forVersion: version)
         // Delegate to the cache's fetch-through helper, which handles hit, miss,
-        // and concurrent-miss coalescing in one place. Structured recipes that pack
-        // every channel into one endpoint (Warp) get a per-channel cache key so the
-        // channels don't serve each other's notes from this shared slot.
+        // and concurrent-miss coalescing in one place. The key carries the recipe's
+        // identity as well as the page, so recipes that share one endpoint (Warp's
+        // three channels; Antigravity's two products) never serve each other's
+        // notes out of a shared slot.
         let cacheURL = cacheKeyURL(for: recipe, resolved: resolved)
         let diskCacheKey = diskKey(for: recipe, version: version)
         return await ChangelogCache.shared.load(for: cacheURL) {
@@ -211,8 +212,8 @@ public enum ChangelogService {
     }
 
     /// Drop every in-memory ``ChangelogCache`` slot this recipe could occupy: the
-    /// plain resolved page URL plus, for structured per-channel recipes (Warp), the
-    /// channel-fragmented key (`…#stable`). Called after an app updates on disk so the
+    /// plain resolved page URL plus the recipe-fragmented key
+    /// (`…#changelog%3Acom%2E…`). Called after an app updates on disk so the
     /// next open re-fetches fresh notes instead of serving the prior version's from
     /// the still-warm in-memory cache.
     public static func invalidateMemoryCache(for recipe: ChangelogRecipe) async {
@@ -233,14 +234,29 @@ public enum ChangelogService {
         return await ChangelogDiskCache.shared.get(for: key)
     }
 
-    /// The in-memory cache slot for a recipe. Normally just the resolved page URL,
-    /// but structured recipes whose channels share one endpoint (Warp's
-    /// `channel_versions.json`) append the channel as a fragment so each channel
-    /// owns a distinct slot — the fragment never reaches the network (we always
-    /// fetch the un-fragmented `resolved`).
+    /// The in-memory cache slot for a recipe: the resolved page URL with the
+    /// recipe's own identity appended as a fragment, so no two recipes can land in
+    /// the same slot. The fragment never reaches the network — `load` always
+    /// fetches the un-fragmented `resolved`.
+    ///
+    /// The identity is folded in for EVERY recipe, not just the structured
+    /// per-channel ones this started out covering (Warp's `channel_versions.json`).
+    /// One page can carry several products as easily as several channels:
+    /// Antigravity's hub and IDE are two regex recipes with no channel reading two
+    /// panels of one `antigravity.google/changelog`, and on the bare page URL they
+    /// shared a slot — whichever detail window opened first served its releases to
+    /// the other app for a TTL window, and the loser, short-circuited before the
+    /// fetch closure, wrote no disk cache entry and recorded no `RecipeHealth`
+    /// outcome either.
+    ///
+    /// `recipeID` (not the bundle id) because two recipes for one bundle id and
+    /// channel that differ only in their version window are also distinct readers
+    /// of distinct pages — it is the same identity the health store and `duo
+    /// verify`'s baseline key on. Percent-encoded so the fragment can't fail to
+    /// parse: a nil `URL(string:)` here would silently reinstate the collision.
     static func cacheKeyURL(for recipe: ChangelogRecipe, resolved: URL) -> URL {
-        guard recipe.structuredFormat != nil else { return resolved }
-        let token = recipe.channel?.rawValue ?? "default"
+        let token = recipe.recipeID
+            .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? recipe.recipeID
         return URL(string: resolved.absoluteString + "#" + token) ?? resolved
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/StructuredChangelogDecoder.swift
@@ -680,6 +680,18 @@ public enum StructuredChangelogDecoder {
               let releases = try? JSONDecoder().decode([GitHubRelease].self, from: data)
         else { return nil }
 
+        // Compiled once for the whole feed, not once per release: a GitHub page is
+        // 40 releases and the pattern is the same for every one of them. An
+        // unusable pattern returns nil here for the same reason it used to skip
+        // every release and fall out of the loop with no entries.
+        let tagRegex: NSRegularExpression?
+        if let tagPattern {
+            guard let compiled = try? NSRegularExpression(pattern: tagPattern) else { return nil }
+            tagRegex = compiled
+        } else {
+            tagRegex = nil
+        }
+
         let wantsPrerelease = channel != nil && channel != .stable
         // A stable channel never sees previews. A non-stable one sees previews,
         // plus — where the vendor's previews graduate into the same numbering
@@ -696,8 +708,8 @@ public enum StructuredChangelogDecoder {
             // one, every row is this app's and the tag IS the version — the shape
             // every recipe before Cline relies on. See `ChangelogRecipe.tagPattern`.
             let version: String
-            if let tagPattern {
-                guard let captured = taggedVersion(release.tagName, pattern: tagPattern)
+            if let tagRegex {
+                guard let captured = taggedVersion(release.tagName, regex: tagRegex)
                 else { continue }
                 version = captured
             } else {
@@ -716,17 +728,16 @@ public enum StructuredChangelogDecoder {
         return Changelog(entries: entries, itemSyntax: .markdown)
     }
 
-    /// This app's version as `pattern` reads it out of `tag`, or nil when the tag
+    /// This app's version as `regex` reads it out of `tag`, or nil when the tag
     /// belongs to another product in the same repo.
     ///
     /// Capture group 1 is the version when the pattern has one; a group-less
     /// pattern is a pure filter and the tag is read the unfiltered way. Anchoring
     /// is the caller's job — `NSRegularExpression` matches anywhere, so an
     /// unanchored `desktop-v(...)` would also accept `preview-desktop-v1.2.3`.
-    private static func taggedVersion(_ tag: String, pattern: String) -> String? {
-        guard let re = try? NSRegularExpression(pattern: pattern) else { return nil }
+    private static func taggedVersion(_ tag: String, regex: NSRegularExpression) -> String? {
         let range = NSRange(tag.startIndex..., in: tag)
-        guard let m = re.firstMatch(in: tag, range: range) else { return nil }
+        guard let m = regex.firstMatch(in: tag, range: range) else { return nil }
         guard m.numberOfRanges > 1, let g = Range(m.range(at: 1), in: tag)
         else { return stripLeadingV(tag) }
         return String(tag[g])
@@ -972,7 +983,12 @@ public enum StructuredChangelogDecoder {
                     blocks.append(.note(t))
                     items.append(t)
                 }
-                for line in (feature.content ?? "").split(separator: "\n") {
+                // `whereSeparator`, not `separator: "\n"` — see `postmanItems` and
+                // `bulletItems`: Swift treats "\r\n" as one Character that does not
+                // equal "\n", so a CRLF body comes back as a single giant line and
+                // every note after the first silently disappears.
+                for line in (feature.content ?? "")
+                    .split(omittingEmptySubsequences: true, whereSeparator: { $0.isNewline }) {
                     let s = line.trimmingCharacters(in: .whitespaces)
                     if s.isEmpty { continue }
                     if let url = imageURL(inMarkdownLine: s) {

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -197,7 +197,7 @@ public enum ProbeWarning: Sendable, Equatable {
     /// this one says the vendor was having a bad minute. `td.telegram.org`
     /// intermittently 502s the HEAD that resolves Telegram's download, which made
     /// a healthy recipe file issues against itself. The same 5xx/429-is-not-our-
-    /// fault rule already governs version probes (see `ProbeFailure.category`).
+    /// fault rule already governs version probes (see `ProbeFailure.classification`).
     case installURLTransient(status: Int?)
     /// The installer URL resolved to a well-formed URL that the vendor no longer
     /// serves — a 4xx that survived a `Range: bytes=0-0` GET retry.
@@ -414,7 +414,6 @@ public enum ResponseSample {
     public static func condense(_ text: String, limit: Int, pattern: String? = nil) -> String {
         let trimmed = stripBoilerplate(text)
         guard trimmed.utf8.count > limit else { return trimmed }
-        let elided = trimmed.utf8.count - limit
 
         if let pattern, let window = windowAroundAnchor(in: trimmed, pattern: pattern, limit: limit) {
             return window
@@ -422,11 +421,46 @@ public enum ResponseSample {
         // No pattern, or none of its literal anchors survive in the body. The
         // second case is itself worth stating — it means the markup the recipe
         // was written against is gone entirely, not merely rearranged.
+        //
+        // Head and tail are measured in BYTES, because `limit` is `maxSampleBytes`
+        // and the note says "bytes". `prefix`/`suffix` count Characters, so on a
+        // CJK page — three bytes each — a 4 KB cap kept 12 KB and the count the
+        // note reported was the one it would have dropped had the cap held.
+        let head = prefixBytes(of: trimmed, limit * 3 / 4)
+        let tail = suffixBytes(of: trimmed, limit / 4)
+        let elided = trimmed.utf8.count - head.utf8.count - tail.utf8.count
         let note = pattern == nil
             ? "\n…[\(elided) bytes elided]…\n"
             : "\n…[\(elided) bytes elided; none of the pattern's literal anchors "
                 + "appear anywhere in the body]…\n"
-        return String(trimmed.prefix(limit * 3 / 4)) + note + String(trimmed.suffix(limit / 4))
+        return head + note + tail
+    }
+
+    /// The longest leading run of `text` that fits in `bytes` UTF-8 bytes, cut on a
+    /// Character boundary (never mid-character, and never mid-grapheme).
+    static func prefixBytes(of text: String, _ bytes: Int) -> String {
+        var out = ""
+        var used = 0
+        for character in text {
+            let width = String(character).utf8.count
+            if used + width > bytes { break }
+            out.append(character)
+            used += width
+        }
+        return out
+    }
+
+    /// The trailing counterpart of `prefixBytes`.
+    static func suffixBytes(of text: String, _ bytes: Int) -> String {
+        var tail: [Character] = []
+        var used = 0
+        for character in text.reversed() {
+            let width = String(character).utf8.count
+            if used + width > bytes { break }
+            tail.append(character)
+            used += width
+        }
+        return String(tail.reversed())
     }
 
     /// Centre the sample on the most distinctive literal the pattern expects to

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeDiagnostics.swift
@@ -471,14 +471,16 @@ public enum ResponseSample {
         guard !anchors.isEmpty else { return nil }
         for anchor in anchors {
             guard let range = text.range(of: anchor) else { continue }
+            // Bytes, not Characters — same reason as `condense`, and this is the
+            // branch that usually runs (the anchor is normally still there). The
+            // anchor itself is inside the budget rather than added on top of it, so
+            // the window can't exceed `limit` however wide the anchor is.
             let before = limit / 3
-            let after = limit - before
-            let start = text.index(range.lowerBound, offsetBy: -before, limitedBy: text.startIndex)
-                ?? text.startIndex
-            let end = text.index(range.upperBound, offsetBy: after, limitedBy: text.endIndex)
-                ?? text.endIndex
+            let after = max(0, limit - before - String(text[range]).utf8.count)
+            let head = suffixBytes(of: String(text[..<range.lowerBound]), before)
+            let tail = prefixBytes(of: String(text[range.upperBound...]), after)
             return "…[sample centred on the pattern's anchor '\(anchor)']…\n"
-                + String(text[start..<end]) + "\n…[truncated]…"
+                + head + String(text[range]) + tail + "\n…[truncated]…"
         }
         return nil
     }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -66,7 +66,7 @@ public struct VendorProbeSource: UpdateSource {
         let status: Int?
     }
 
-    /// The same rule `ProbeFailure.category` applies to version probes: 5xx and
+    /// The same rule `ProbeFailure.classification` applies to version probes: 5xx and
     /// 429 are the vendor having a bad day, anything else in 4xx is us.
     static func isTransientStatus(_ code: Int) -> Bool {
         code >= 500 || code == 429

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogCacheKeyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogCacheKeyTests.swift
@@ -17,6 +17,12 @@ import Foundation
 /// the property is "every recipe owns its own slot", and the next one-page-many-
 /// products recipe must fail here instead of being discovered by a user reading
 /// the wrong app's notes.
+/// Counts how many times a cache-miss fetch closure actually ran.
+private actor FetchCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
+}
+
 @Suite struct ChangelogCacheKeyTests {
 
     @Test func noTwoRegisteredRecipesShareAnInMemoryCacheSlot() {
@@ -73,6 +79,47 @@ import Foundation
             channel: .beta, structuredFormat: .warpChannelVersions)
         #expect(ChangelogService.cacheKeyURL(for: stable, resolved: page)
             != ChangelogService.cacheKeyURL(for: beta, resolved: page))
+    }
+
+    /// `invalidateMemoryCache` has to drop the slots `load` actually filled, and
+    /// `load` keys on `resolvedSource(forVersion:)` — so for a templated recipe
+    /// (one page per version) the slots are under URLs the un-templated
+    /// `recipe.source` never names, and one recipe can hold several at once. This
+    /// walks every templated recipe in the registry, warms two versions' slots, and
+    /// requires the next load of each to fetch again.
+    @Test func invalidationDropsEveryVersionResolvedSlotATemplatedRecipeOwns() async {
+        let templated = ChangelogRecipeRegistry.recipes.filter { $0.sourceTemplate != nil }
+        #expect(!templated.isEmpty, "no templated recipes left — this test would be vacuous")
+
+        for recipe in templated {
+            let cache = ChangelogCache()
+            let counter = FetchCounter()
+            let versions = ["1.2.3", "4.5.6"]
+
+            func warm(_ version: String) async {
+                let key = ChangelogService.cacheKeyURL(
+                    for: recipe, resolved: recipe.resolvedSource(forVersion: version))
+                _ = await cache.load(for: key) {
+                    await counter.bump()
+                    return Changelog(entries: [
+                        .init(title: "t", version: version, date: nil, items: ["i"])
+                    ])
+                }
+            }
+
+            for version in versions { await warm(version) }
+            #expect(await counter.count == versions.count)
+            // Warm slots: a repeat load must not fetch.
+            for version in versions { await warm(version) }
+            #expect(await counter.count == versions.count)
+
+            await ChangelogService.invalidateMemoryCache(for: recipe, in: cache)
+
+            for version in versions { await warm(version) }
+            #expect(
+                await counter.count == versions.count * 2,
+                "\(recipe.recipeID) kept a slot through invalidateMemoryCache")
+        }
     }
 
     /// Two recipes for one bundle id and channel that differ only in their version

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogCacheKeyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogCacheKeyTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `ChangelogCache` is a `[URL: Entry]` keyed by whatever `cacheKeyURL` returns,
+/// and its doc comment promises "each recipe owns exactly one cache slot". That
+/// held only for structured recipes: they got the channel folded into the key as a
+/// fragment, and everyone else got the bare resolved URL. Two recipes that read
+/// two different products out of ONE page (Antigravity's hub and its IDE, both
+/// `antigravity.google/changelog`, both regex recipes, neither carrying a channel)
+/// therefore shared a slot: whichever detail window opened first filled it, and
+/// for the next 15 minutes the other app showed the first one's releases. Worse,
+/// the loser was short-circuited before the fetch closure ran, so it wrote no disk
+/// cache entry and recorded no `RecipeHealth` outcome either.
+///
+/// Derived from the registry, per CLAUDE.md, rather than listing the pair by hand:
+/// the property is "every recipe owns its own slot", and the next one-page-many-
+/// products recipe must fail here instead of being discovered by a user reading
+/// the wrong app's notes.
+@Suite struct ChangelogCacheKeyTests {
+
+    @Test func noTwoRegisteredRecipesShareAnInMemoryCacheSlot() {
+        var owners: [URL: [String]] = [:]
+        for recipe in ChangelogRecipeRegistry.recipes {
+            let key = ChangelogService.cacheKeyURL(for: recipe, resolved: recipe.source)
+            owners[key, default: []].append(recipe.recipeID)
+        }
+        let shared = owners.filter { $0.value.count > 1 }
+        #expect(shared.isEmpty, """
+            These recipes share one ChangelogCache slot and will serve each other's \
+            entries for a TTL window: \
+            \(shared.map { "\($0.key.absoluteString) ← \($0.value.sorted())" }.sorted())
+            """)
+    }
+
+    /// The pair that was actually colliding, named directly: the registry-derived
+    /// check above goes green the moment someone deletes one of these two recipes,
+    /// and this one says which case put the guard there.
+    @Test func theTwoAntigravityRecipesGetDistinctKeys() throws {
+        let hub = try #require(
+            ChangelogRecipeRegistry.recipes.first { $0.bundleID == "com.google.antigravity" })
+        let ide = try #require(
+            ChangelogRecipeRegistry.recipes.first { $0.bundleID == "com.google.antigravity-ide" })
+        #expect(hub.source == ide.source)
+        #expect(ChangelogService.cacheKeyURL(for: hub, resolved: hub.source)
+            != ChangelogService.cacheKeyURL(for: ide, resolved: ide.source))
+    }
+
+    /// The key is the page URL plus a fragment, and `load` fetches the
+    /// un-fragmented `resolved` — so the identity we key on can never turn into a
+    /// different request. A key that differed anywhere but the fragment would be a
+    /// URL we might one day fetch.
+    @Test func theKeyDiffersFromTheFetchedURLOnlyInItsFragment() throws {
+        for recipe in ChangelogRecipeRegistry.recipes {
+            let resolved = recipe.source
+            let key = ChangelogService.cacheKeyURL(for: recipe, resolved: resolved)
+            var stripped = try #require(URLComponents(url: key, resolvingAgainstBaseURL: false))
+            stripped.fragment = nil
+            #expect(stripped.url == resolved, "key \(key) is not \(resolved) plus a fragment")
+        }
+    }
+
+    /// Two channels of one app reading one endpoint (the structured case this
+    /// function was written for) must still land in separate slots — the fix
+    /// generalised the key, it did not replace what was already working.
+    @Test func twoChannelsOfOneEndpointStillGetDistinctKeys() {
+        let page = URL(string: "https://zzfixture.example/changelog.json")!
+        let stable = ChangelogRecipe(
+            bundleID: "zz.fixture.app", source: page,
+            channel: .stable, structuredFormat: .warpChannelVersions)
+        let beta = ChangelogRecipe(
+            bundleID: "zz.fixture.app", source: page,
+            channel: .beta, structuredFormat: .warpChannelVersions)
+        #expect(ChangelogService.cacheKeyURL(for: stable, resolved: page)
+            != ChangelogService.cacheKeyURL(for: beta, resolved: page))
+    }
+
+    /// Two recipes for one bundle id and channel that differ only in their version
+    /// window (Windscribe's, for one) read DIFFERENT pages for different installed
+    /// versions — and `recipeID` is what keeps their verify history apart, so it is
+    /// the right identity to key the cache on too.
+    @Test func twoVersionWindowsOfOnePageGetDistinctKeys() {
+        let page = URL(string: "https://zzfixture.example/notes")!
+        let old = ChangelogRecipe(
+            bundleID: "zz.fixture.app", source: page, belowAppVersion: "2.0")
+        let new = ChangelogRecipe(
+            bundleID: "zz.fixture.app", source: page, minimumAppVersion: "2.0")
+        #expect(ChangelogService.cacheKeyURL(for: old, resolved: page)
+            != ChangelogService.cacheKeyURL(for: new, resolved: page))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogEntityDecodingTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogEntityDecodingTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `decodeHTMLEntities` used to iterate a `[String: String]` dictionary, so the
+/// order the entities were substituted in changed with every process (Swift
+/// randomises `Dictionary` iteration per launch via the hash seed). That made the
+/// output of a double-escaped body — `&amp;lt;`, which a vendor writes when it
+/// wants the reader to SEE `&lt;` — depend on whether `&amp;` happened to come
+/// out of the dictionary before or after `&lt;`: one order left it escaped, the
+/// other decoded it twice down to a literal `<`. `&#39;` was worse than random:
+/// the numeric pass ran unconditionally AFTER the named one, so `&amp;#39;`
+/// always decoded twice.
+///
+/// The decoder is now a single left-to-right pass over `&(#NNN|#xHH|name);`, which
+/// is the semantics a standard HTML unescaper has: each entity in the INPUT is
+/// decoded exactly once, and text a decode produces is never re-scanned. These
+/// cases pin that, in both directions — an entity that must decode, and an
+/// escaped entity that must survive.
+@Suite struct ChangelogEntityDecodingTests {
+
+    /// The case the dictionary order decided at random. `&amp;lt;br&amp;gt;` is a
+    /// vendor showing the reader the literal text `<br>` escaped once; decoding it
+    /// twice deletes the markup the sentence is about (the same failure
+    /// `stripHTMLElements` exists to avoid).
+    @Test func anEscapedEntityDecodesOnceAndStopsThere() {
+        #expect(ChangelogExtractor.decodeHTMLEntities("&amp;lt;br&amp;gt;") == "&lt;br&gt;")
+    }
+
+    /// Numeric entities were decoded in a second pass that always ran after the
+    /// named one, so this one was never a coin flip — it was always wrong.
+    @Test func anEscapedNumericEntityIsNotDecodedTwice() {
+        #expect(ChangelogExtractor.decodeHTMLEntities("&amp;#39;") == "&#39;")
+        #expect(ChangelogExtractor.decodeHTMLEntities("&amp;#x27;") == "&#x27;")
+    }
+
+    /// The mirror image, and the reason "decode numerics first, `&amp;` last" is
+    /// not a fix on its own: `&#38;` IS an ampersand, so with two ordered passes
+    /// it would produce `&lt;` and the named pass behind it would eat that too.
+    /// One pass can't, because it never re-reads what it wrote.
+    @Test func anAmpersandSpelledNumericallyDoesNotCascade() {
+        #expect(ChangelogExtractor.decodeHTMLEntities("&#38;lt;") == "&lt;")
+    }
+
+    /// Everything that is supposed to decode still does, in one pass.
+    @Test func theOrdinaryEntitiesStillDecode() {
+        #expect(ChangelogExtractor.decodeHTMLEntities(
+            "a &amp; b &lt;c&gt; &quot;d&quot; &apos;e&apos; &#39;f&#39;")
+            == "a & b <c> \"d\" 'e' 'f'")
+        #expect(ChangelogExtractor.decodeHTMLEntities(
+            "&mdash;&ndash;&hellip;&rsquo;&lsquo;&ldquo;&rdquo;&times;")
+            == "—–…’‘“”×")
+        #expect(ChangelogExtractor.decodeHTMLEntities("&#x2019;s &#8212; done") == "’s — done")
+    }
+
+    /// An entity the table doesn't carry is left verbatim — the safe direction
+    /// (visible noise beats invisible deletion), and unchanged from before.
+    @Test func anUnknownEntityIsLeftAlone() {
+        #expect(ChangelogExtractor.decodeHTMLEntities("&copy; 2026 &frac12;") == "&copy; 2026 &frac12;")
+        #expect(ChangelogExtractor.decodeHTMLEntities("a & b") == "a & b")
+        #expect(ChangelogExtractor.decodeHTMLEntities("&#xZZ; &#;") == "&#xZZ; &#;")
+    }
+
+    /// `escapedMarkup` recipes rely on running the decoder TWICE (an RSS
+    /// `<description>` whose markup arrives escaped, with prose entities escaped
+    /// twice). That still lands where it did: pass one turns `&amp;rsquo;` into
+    /// `&rsquo;`, pass two into `’`.
+    @Test func theSecondPassEscapedMarkupRecipesRelyOnStillLands() {
+        let once = ChangelogExtractor.decodeHTMLEntities("&lt;p&gt;it&amp;rsquo;s&lt;/p&gt;")
+        #expect(once == "<p>it&rsquo;s</p>")
+        #expect(ChangelogExtractor.decodeHTMLEntities(once) == "<p>it’s</p>")
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogEntryBodyFallbackTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogEntryBodyFallbackTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+@testable import DuoUpdaterCore
+
+/// `ChangelogExtractor`'s entry loop says "Items come from the `body` group when
+/// present, else the whole entry", but its fallback was `group(match, nil, …)`,
+/// whose own contract is "capture group 1 if present, else the whole match". A
+/// named group IS a numbered group in `NSRegularExpression`, so for any entry
+/// pattern without a `<body>` group the fallback handed the item regexes the
+/// `version` capture — a few characters of version string — instead of the entry.
+/// Every one of the 65 registered entry patterns carries a `body` group today, so
+/// nothing failed; the next recipe written without one would have produced an
+/// empty pane with no diagnostic saying why.
+///
+/// The fallback now takes the whole match, which is what the comment always
+/// claimed. `firstNonEmptyItemHits`, `imageHits` and `headingHits` keep the
+/// group-1-first fallback on purpose — that one is documented at those call sites
+/// and several registered `itemPatterns` rely on it.
+@Suite struct ChangelogEntryBodyFallbackTests {
+
+    /// The entry pattern has no `body` group, so the items must be looked for in
+    /// the whole match. Before the fix they were looked for inside "3.1.0" and the
+    /// entry was dropped for having none, taking the whole changelog to nil.
+    @Test func anEntryPatternWithoutABodyGroupSearchesTheWholeMatch() throws {
+        let page = """
+            <div class="rel"><h2>3.1.0</h2>\
+            <ul><li>Fixed a crash on launch</li><li>Added a preference</li></ul></div>
+            """
+        let recipe = ChangelogRecipe(
+            bundleID: "zz.fixture.bodyless",
+            source: URL(string: "https://zzfixture.example/notes")!,
+            entryPattern: #"<h2>(?<version>[^<]+)</h2>(?:.*?)(?=</div>)"#,
+            itemPatterns: [#"<li>(?<item>[^<]+)</li>"#])
+        let log = try #require(ChangelogExtractor.extract(from: page, using: recipe))
+        #expect(log.entries.count == 1)
+        #expect(log.entries[0].version == "3.1.0")
+        #expect(log.entries[0].items == ["Fixed a crash on launch", "Added a preference"])
+    }
+
+    /// The other half: a pattern that DOES declare `body` still reads only that
+    /// group, so an entry can't absorb the markup around it.
+    @Test func anEntryPatternWithABodyGroupStillReadsOnlyThatGroup() throws {
+        let page = """
+            <li>Leaked from before the entry</li>\
+            <div class="rel"><h2>3.1.0</h2><ul><li>Inside the body</li></ul></div>
+            """
+        let recipe = ChangelogRecipe(
+            bundleID: "zz.fixture.bodied",
+            source: URL(string: "https://zzfixture.example/notes")!,
+            entryPattern: #"<h2>(?<version>[^<]+)</h2>(?<body>.*?)(?=</div>)"#,
+            itemPatterns: [#"<li>(?<item>[^<]+)</li>"#])
+        let log = try #require(ChangelogExtractor.extract(from: page, using: recipe))
+        #expect(log.entries.count == 1)
+        #expect(log.entries[0].items == ["Inside the body"])
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogExtractorTests.swift
@@ -2976,3 +2976,28 @@ private let kimiReleaseNotesFixture = #"""
     #expect(log.entries[2].items.last == "Fixed several bugs and improved some interactions")
     #expect(!log.entries.contains { $0.items.contains { $0.contains("(2026-") || $0.contains("helpful") } })
 }
+
+// MARK: - Typeless, CRLF (the trap `bulletItems` and `postmanItems` already close)
+
+// A v3 array payload whose one feature's `content` separates its two bullets with
+// CRLF. `decodeTypeless` split that content on the literal "\n", and Swift treats
+// "\r\n" as a SINGLE Character that does not equal "\n" — so the whole body came
+// back as one "line", `bulletItems(from:).first` kept only the first bullet, and
+// the second one silently vanished. Two sibling call sites in this same decoder
+// (`bulletItems`, `postmanItems`) carry doc comments explaining exactly this trap;
+// this one had been missed.
+private let typelessCRLFB64 = "H4sIAAAAAAAC/03LMQ7CMAwF0KtYnkkVioQEJ+AObYfQOhDJTVDsslS9O0kmhr+8//+w45eyhBTxDth3trN4AlycUgPbX429mfOl6oed+pTX2qxuTlLRk9MtkxQcdtSg3J6P8HpzibbRnKJS1FoY8CGLwnNjJgUOkcY8RgNCZbX8Ox7TMf0An2tl66IAAAA="
+
+private let typelessCRLFFixture = """
+<!doctype html><html><body>
+<script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"platform":"macos","dataKey":"typeless-release-notes--v3--macos","embeddedLangCode":"en","compressedData":"\(typelessCRLFB64)"}},"page":"/help/release-notes/[platform]"}</script>
+</body></html>
+"""
+
+@Test func typelessDecodeSplitsCRLFBodiesIntoSeparateNotes() throws {
+    let changelog = try #require(StructuredChangelogDecoder.decode(
+        typelessCRLFFixture, format: .typelessReleaseNotes, channel: nil, maxEntries: 12))
+    #expect(changelog.entries.count == 1)
+    #expect(changelog.entries[0].version == "2.0.0")
+    #expect(changelog.entries[0].items == ["first bullet line", "second bullet line"])
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogParserGenerationGuardTests.swift
@@ -65,8 +65,16 @@ import Foundation
     /// `headingPattern` set. Pinned by the new heading-specific tests in
     /// `GitHubMarkdownParserTests.swift` and
     /// `MacPerformanceMonitorChangelogRecipeTests.swift` instead.
+    ///
+    /// 4 (single-pass HTML entity decoding; Typeless's CRLF split) moves neither
+    /// fixture either — and here that is the point rather than a coincidence: both
+    /// fixtures are checked below and stayed byte-identical, which is what says the
+    /// rewrite changed only the cases it was meant to. What it does change lives in
+    /// `ChangelogEntityDecodingTests` (a double-escaped entity, which used to
+    /// decode differently from launch to launch) and
+    /// `typelessDecodeSplitsCRLFBodiesIntoSeparateNotes`.
     @Test func pinnedGeneration() {
-        #expect(Changelog.parserGeneration == 3)
+        #expect(Changelog.parserGeneration == 4)
     }
 
     /// Stable (v4.3.6, bulleted): exercises `skipSections` — the `### Included


### PR DESCRIPTION
Fixes five findings from the 2026-09-13 whole-repo review, all in the changelog path. Paths below omit the `DuoUpdaterCore/Sources/DuoUpdaterCore/` prefix, as the review does.

## What it addresses

| Finding | Where | Fix |
|---|---|---|
| **L5** two Antigravity recipes share one `ChangelogCache` slot | `Sources/ChangelogService.swift:241-245`, `ChangelogRecipe.swift:3205/3227` | `cacheKeyURL` folds `recipe.recipeID` into the key for **every** recipe, not only structured ones. Still a fragment, and `load`'s fetch closure still requests the un-fragmented `resolved`, so nothing new goes on the wire. `ChangelogCache.swift`'s "each recipe owns exactly one cache slot" doc and `AppListModel.swift:1799`'s "channel-fragmented" comment updated to match. |
| **L6** HTML entity decoding order is per-process random | `Sources/ChangelogExtractor.swift:357-372` | One left-to-right pass over `&(#NNN\|#xHH\|name);`. |
| **P8** per-item regex compilation | `ChangelogExtractor` (`stripTags`, `stripHTMLElements`, entity/JSON/inline-code/whitespace), `AppcastHTMLChangelogParser.cleanInline`, `StructuredChangelogDecoder.taggedVersion` | Hoisted to `static let` `NSRegularExpression`s; the tag pattern is compiled once per feed instead of once per release. |
| **Comments ≠ code** | `ChangelogExtractor.swift:58-61`; `VendorProbeDiagnostics.swift:200` + `VendorProbeSource.swift:69`; `VendorProbeDiagnostics.swift:414-429`; `StructuredChangelogDecoder.swift:975` | Entry body falls back to the whole match (was capture group 1); `ProbeFailure.category` → `.classification`; `condense` caps and reports in UTF-8 bytes; `decodeTypeless` splits on `\.isNewline`. |

Nothing declined.

### On L6: ordered passes would not have been enough

The brief suggested an ordered array with numerics first and `&amp;` last. That fixes `&amp;lt;` but breaks the mirror case: `&#38;` **is** an ampersand, so `&#38;lt;` would decode to `&lt;` in the numeric pass and the named pass behind it would eat that too. A single pass can't double-decode in either direction, because it never re-reads what it wrote. `anAmpersandSpelledNumericallyDoesNotCascade` pins that half.

### `Changelog.parserGeneration` 3 → 4

Required by its own doc comment: the entity fix and the CRLF fix both change what an already-cached version can parse to (a disk-cached `Changelog` is served unre-parsed). Log entry added; `ChangelogParserGenerationGuardTests.pinnedGeneration` updated. Both of that suite's fixtures parse byte-identically, which is also the proof that the P8 hoisting changed no output.

## Red → green

**L6.** Two consecutive runs of the same test binary, before the fix — the randomness itself, visible:

```
$ swift test --filter ChangelogEntityDecodingTests     # run 1
✘ anEscapedEntityDecodesOnceAndStopsThere … decodeHTMLEntities("&amp;lt;br&amp;gt;") → "<br>"
✘ anEscapedNumericEntityIsNotDecodedTwice … decodeHTMLEntities("&amp;#39;") → "'"
✘ theSecondPassEscapedMarkupRecipesRelyOnStillLands … once → "<p>it’s</p>"
✔ theOrdinaryEntitiesStillDecode() passed

$ swift test --filter ChangelogEntityDecodingTests     # run 2, same binary, nothing changed
✔ theSecondPassEscapedMarkupRecipesRelyOnStillLands() passed     ← failed in run 1
✔ anAmpersandSpelledNumericallyDoesNotCascade() passed
✘ anEscapedEntityDecodesOnceAndStopsThere … "&amp;lt;br&amp;gt;" == "&lt;br&gt;" → false
✘ anEscapedNumericEntityIsNotDecodedTwice … "&amp;#x27;" → "'"
```

`theSecondPassEscapedMarkupRecipesRelyOnStillLands` failing in one run and passing in the next, with no edit in between, is the bug itself.

**L5**, before the fix — registry-derived, and it names the pair:

```
✘ noTwoRegisteredRecipesShareAnInMemoryCacheSlot … Expectation failed: shared.isEmpty
↳ These recipes share one ChangelogCache slot …:
  ["https://antigravity.google/changelog ← [\"changelog:com.google.antigravity-ide:-\",
    \"changelog:com.google.antigravity:-\"]"]
✘ theTwoAntigravityRecipesGetDistinctKeys
✘ twoVersionWindowsOfOnePageGetDistinctKeys
```

**Body-group fallback**, before: `ChangelogExtractor.extract(from: page, using: recipe) → nil` (the entry was dropped for having no items, because the items were looked for inside `"3.1.0"`).

**CRLF**, before: `changelog.entries[0].items → ["first bullet line"]` (expected two).

**`condense`**, before: `kept.utf8.count → 3600` against `limit → 1200`, and `reported → 13800` against an actual `11400`.

After the fixes, all five suites green (`✔ Test run with 14 tests in 3 suites passed`, `✔ 5 tests` for `ResponseSampleTests`).

## Mutation check

Each fix reverted in place, one test file at a time; every new case went red and named itself, then restored:

| Mutation | Red |
|---|---|
| `guard recipe.structuredFormat != nil else { return resolved }` back at the top of `cacheKeyURL` | 3 of the 5 cache-key cases, incl. the registry-derived one |
| an `&amp;`-first pre-pass in `decodeHTMLEntities` (the "ordered passes" fix) | `anEscapedEntityDecodesOnceAndStopsThere`, `anEscapedNumericEntityIsNotDecodedTwice`, `theSecondPassEscapedMarkupRecipesRelyOnStillLands` |
| `wholeMatch(…)` → `group(match, nil, …)` | `anEntryPatternWithoutABodyGroupSearchesTheWholeMatch` |
| `whereSeparator:` → `separator: "\n"` | `typelessDecodeSplitsCRLFBodiesIntoSeparateNotes` |
| `prefixBytes`/`suffixBytes` → `prefix`/`suffix`, `elided = utf8.count - limit` | `theSampleIsCappedInBytesAndReportsTheBytesItActuallyDropped`, both expectations |

The cases that must NOT move stayed green throughout (`theOrdinaryEntitiesStillDecode`, `anUnknownEntityIsLeftAlone`, `anEntryPatternWithABodyGroupStillReadsOnlyThatGroup`, `twoChannelsOfOneEndpointStillGetDistinctKeys`).

## `make test`

```
$ make test > /tmp/mt-fixagent5.log 2>&1; echo exit=$?
exit=0
$ grep -cE "^✘" /tmp/mt-fixagent5.log
0
━ Test run with 2791 tests in 231 suites passed after 20.171 seconds with 2 known issues.
✔ Test run with 281 tests in 34 suites passed after 0.127 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 261 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
✓ app audits consistent — 121 docs, all indexed, no machine inventory, no pointers into untracked evidence
✓ engine-notes pointers resolve — 534 Swift files scanned, 3 doc(s) indexed
✓ skill docs consistent — 3 files mirrored, documented parameter counts (25 / 26) match the initializers
✓ no machine-population claims in code comments — 534 files
```

The 2 known issues are pre-existing (`ankiZeroPaddedTagComparesEqualToInstalled`, `EventStoreSchemaDriftTests`).

## `duo verify`

Refused, as designed — the installed CLI is built from other sources and the brief forbids `make cli`:

```
$ duo verify --only antigravity
stale `duo`: this `duo` was built from different sources than …
(built ddfea3c81d5e…, here 2aec68c4484e…)
```

So the parser change is covered by unit tests only, with `ChangelogParserGenerationGuardTests` (two real registry-driven fixtures, parsed through the registered recipes) as the byte-identity proof. No recipe data changed in this PR — only parser code — so no live endpoint behaviour is in question.

## What a user could notice

- Antigravity (hub vs IDE): each app now shows its own releases instead of whichever one was opened first within 15 minutes.
- A vendor note containing a deliberately escaped entity (`&amp;lt;`) renders the same way on every launch, and as the vendor wrote it.
- Typeless notes written with CRLF keep every bullet, not just the first.
- Everything cached on disk under generation 3 is re-fetched once.

## Noticed, not fixed (out of scope)

- `ChangelogExtractor.decodeJSONUnicodeEscapes` and `flattenMarkdownLinks` still compile their regex per call. Both are cheap-guarded or off the listed hot path, and neither was in the brief.
- `ResponseSample.windowAroundAnchor` has the same Character-vs-byte confusion as `condense` did (`limit/3` / `limit` offsets are Characters), so an anchored CJK sample can still exceed `maxSampleBytes`. The review named only `condense`.
- `StructuredChangelogDecoder.swift:170-180` — `bulletItems`'s doc says "ChatWise's feed is LF today", which is the sibling of the trap just fixed; worth a sweep for other `split(separator: "\n")` call sites in the decoders.
