### PR TITLE
RecipeHealth per-recipe keys, one list fetch per GitHub diagnostic, honest 403s, and comment corrections

### DIFF
--- a/App/Sources/Settings/DiagnosticsSettingsPage.swift
+++ b/App/Sources/Settings/DiagnosticsSettingsPage.swift
@@ -9,9 +9,11 @@ struct DiagnosticsSettingsPage: View {
     @State private var entries: [RecipeHealth.Entry] = []
     @State private var loaded = false
 
-    /// bundleID → app name, so a Vendor recipe (keyed by bundle id) shows a
-    /// friendly name. GitHub recipes are keyed by `owner/repo`, which has no app
-    /// to resolve, so those fall back to the raw key.
+    /// bundleID → app name, so a recipe whose id carries a bundle id shows a
+    /// friendly name next to it (`RecipeHealth.Entry.displayName(resolving:)` does
+    /// the resolving — an id is `vendor:<bundle id>:<channel>`, not a bare bundle
+    /// id). A GitHub rule's id carries `owner/repo` and no bundle id, so those
+    /// still render as the raw key.
     private var names: [String: String] {
         var map: [String: String] = [:]
         for result in model.results {
@@ -137,7 +139,7 @@ struct DiagnosticsSettingsPage: View {
             Image(systemName: entry.isHealthy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                 .foregroundStyle(entry.isHealthy ? .green : .orange)
             VStack(alignment: .leading, spacing: 1) {
-                Text(names[entry.id] ?? entry.id).font(.callout)
+                Text(entry.displayName(resolving: names)).font(.callout)
                 if !entry.isHealthy, let detail = entry.lastMissDetail {
                     Text(detail).font(.caption2).foregroundStyle(.secondary)
                 }

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Models/UpdateResult.swift
@@ -635,7 +635,9 @@ public enum UpdateStatus: Sendable, Equatable {
     /// limit — the common transient when checking GitHub-sourced apps without a
     /// token. Drives the inline "Rate-limited" row badge and the aggregate
     /// "add a token" banner. Matches the message produced by
-    /// `GitHubReleasesSource.GitHubError` (kept in sync with that string).
+    /// `GitHubReleasesSource.GitHubError.rateLimited` (kept in sync with that
+    /// string) — and deliberately NOT the one a 403 with budget left produces,
+    /// since a token cannot fix a repo that went private.
     public var isRateLimitError: Bool {
         if case .error(let message) = self {
             return message.localizedCaseInsensitiveContains("rate limit")

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -3680,13 +3680,13 @@ public enum ChangelogRecipeRegistry {
     ///      rather than none);
     ///   4. failing all of those, the group's first recipe in declaration order.
     /// Step 4 is not a rounding error: a bundle id whose recipes are ALL on
-    /// non-stable channels has nothing for steps 2 and 3 to find, and five groups
-    /// are shaped that way today (2026-09-13: `bot.cline.app.beta`,
-    /// `dev.zed.zed-preview`, `dev.warp.warp-preview`, `org.mozilla.thunderbirdbeta`,
-    /// `com.longbridge.app.desktop.preview` — each a single recipe, so step 4
-    /// returns the only candidate). Reasoning as though the ladder stopped at
-    /// step 3 gives the wrong answer for exactly those groups: it says "nil",
-    /// and the caller gets notes.
+    /// non-stable channels (a preview-only app, like Zed Preview or Warp Preview)
+    /// has nothing for steps 2 and 3 to find, so without it an off-channel lookup
+    /// returns nil and an app that HAS notes shows none. Reasoning as though the
+    /// ladder stopped at step 3 gives the wrong answer for exactly those groups —
+    /// two comments in this file did, which is why the property is now pinned by
+    /// `ChangelogURLPolicyTests.aGroupWithNoStableRecipeStillResolves` (derived
+    /// from the registry, so a new preview-only app is covered the day it lands).
     /// Passing `channel: nil` skips step 1 and lands on step 2/3/4 — the behavior
     /// the old single-arg lookup had. Step 0 is inert for every group whose
     /// recipes declare no window, which is all of them but Raycast's.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipe.swift
@@ -156,8 +156,10 @@ public struct ChangelogRecipe: Codable, Sendable {
     /// `org.mozilla.thunderbird` but live on separate version trains, so each gets
     /// its own recipe distinguished by `channel`. `recipe(forBundleID:channel:)`
     /// prefers an exact channel match, then a channel-agnostic recipe, then a
-    /// `.stable` one — so existing single-recipe apps (channel nil) keep matching
-    /// every channel exactly as before.
+    /// `.stable` one, and finally ANY recipe in the group — so existing
+    /// single-recipe apps (channel nil) keep matching every channel exactly as
+    /// before, and a bundle id whose recipes are all non-stable still answers.
+    /// See that method for the fourth step, which is easy to reason past.
     public let channel: ReleaseChannel?
 
     /// For a non-stable recipe over a feed that splits by GitHub's `prerelease`
@@ -3576,19 +3578,22 @@ public enum ChangelogRecipeRegistry {
         // GitHub is missing 2.15.9 entirely (the vendor's API has it), so the
         // releases are the vendor's notes but not provably ALL of them.
         //
-        // ⚠️ WHOEVER ADDS CHANNEL DETECTION FOR THIS APP MUST COME BACK HERE.
-        // `channel: .stable` is right only while every Windscribe copy detects as
-        // stable, which is true today because nothing reads its channel yet. The
-        // moment a `ChannelBinding` resolver lands, a beta copy detects as `.beta`
-        // — and `recipe(forBundleID:channel:)` does NOT then return nil, it falls
-        // back to the `.stable` recipe. So that copy keeps this list, which
-        // `.gitHubReleases` has filtered to `prerelease: false` only, while the row
-        // beside it offers a prerelease build (2.24.10, say). The pane would show
-        // 2.24.12 / 2.23.11 / 2.22.10 and omit the exact entry being offered —
-        // the failure `includesPromotedStable` exists for; see CotEditor above.
+        // ⚠️ `channel: .stable` covers ONLY copies that detect as stable, and
+        // channel detection for this app has since landed (`WindscribeChannel`),
+        // so beta and guinea-pig copies are real. They are covered by the two
+        // recipes declared just below, NOT by this one — and the reason this
+        // warning had to become those recipes is that
+        // `recipe(forBundleID:channel:)` does not return nil for an uncovered
+        // channel: it walks exact match → channel-agnostic → `.stable` → any, so
+        // without them a beta copy landed here, on a list `.gitHubReleases` has
+        // filtered to `prerelease: false` only, while the row beside it offered a
+        // prerelease build (2.24.10, say). The pane would show 2.24.12 / 2.23.11 /
+        // 2.22.10 and omit the exact entry being offered — the failure
+        // `includesPromotedStable` exists for; see CotEditor above.
         // Windscribe's tracks are a ladder (level N is served the newest build from
-        // tracks 0…N), so the channel variants want the vendor's own
-        // `ChangeLogs?platform=osx` and its per-entry `beta` number, not this feed.
+        // tracks 0…N), which is why those recipes set `includesPromotedStable`; the
+        // precise fix remains the vendor's own `ChangeLogs?platform=osx` and its
+        // per-entry `beta` number, not this feed.
         ChangelogRecipe(
             bundleID: "com.windscribe.client",
             source: URL(string: windscribeReleases)!,
@@ -3605,10 +3610,11 @@ public enum ChangelogRecipeRegistry {
         // the beta and release lines is newer, so the pane has to be able to hold
         // both or it omits the very entry the row offers.
         //
-        // Without these two, `recipe(forBundleID:channel:)` falls back to the
-        // `.stable` recipe above rather than to nil, so a beta copy got a list
-        // filtered to release builds — containing the offered version only while
-        // release leads, about a quarter of each cycle.
+        // Without these two, `recipe(forBundleID:channel:)` walks past the exact
+        // match it cannot find and lands on the `.stable` recipe above rather than
+        // on nil, so a beta copy got a list filtered to release builds —
+        // containing the offered version only while release leads, about a quarter
+        // of each cycle.
         //
         // ⚠️ WHAT THIS LISTS THAT IT SHOULD NOT, measured on the newest 40
         // releases (2026-09-07): 9 are stable and 31 are prereleases, and GitHub
@@ -3670,11 +3676,20 @@ public enum ChangelogRecipeRegistry {
     ///   1. a recipe whose `channel` exactly matches the install's channel;
     ///   2. a channel-agnostic recipe (`channel == nil`) — every existing
     ///      single-recipe app, so passing a channel never changes their result;
-    ///   3. the `.stable` recipe as a last resort (an unknown/odd channel still
-    ///      gets *some* notes rather than none).
-    /// Passing `channel: nil` skips step 1 and lands on step 2/3 — the behavior the
-    /// old single-arg lookup had. Step 0 is inert for every group whose recipes
-    /// declare no window, which is all of them but Raycast's.
+    ///   3. the `.stable` recipe (an unknown/odd channel still gets *some* notes
+    ///      rather than none);
+    ///   4. failing all of those, the group's first recipe in declaration order.
+    /// Step 4 is not a rounding error: a bundle id whose recipes are ALL on
+    /// non-stable channels has nothing for steps 2 and 3 to find, and five groups
+    /// are shaped that way today (2026-09-13: `bot.cline.app.beta`,
+    /// `dev.zed.zed-preview`, `dev.warp.warp-preview`, `org.mozilla.thunderbirdbeta`,
+    /// `com.longbridge.app.desktop.preview` — each a single recipe, so step 4
+    /// returns the only candidate). Reasoning as though the ladder stopped at
+    /// step 3 gives the wrong answer for exactly those groups: it says "nil",
+    /// and the caller gets notes.
+    /// Passing `channel: nil` skips step 1 and lands on step 2/3/4 — the behavior
+    /// the old single-arg lookup had. Step 0 is inert for every group whose
+    /// recipes declare no window, which is all of them but Raycast's.
     public static func recipe(
         forBundleID bundleID: String?, channel: ReleaseChannel? = nil,
         version: String? = nil

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChangelogRecipeSelection.swift
@@ -34,8 +34,11 @@ public enum ChangelogRecipeSelection {
     ///
     /// The catalog half is gated; the `remote` half is not, and deliberately.
     /// For every `UpdateSource`, `UpdateChecker` only lets one whose
-    /// `answersAppStoreCopies` is true near a store copy (`UpdateChecker.swift`
-    /// line 252, and line 144 for the batch), and `MacAppStoreSource` is the only
+    /// `answersAppStoreCopies` is true near a store copy — the
+    /// `if app.isMASApp, !source.answersAppStoreCopies { continue }` guard in its
+    /// source loop, and `UpdateChecker.apps(_:visibleTo:)` for the batch paths
+    /// (named rather than cited by line number: the two this comment used to give
+    /// had both moved) — and `MacAppStoreSource` is the only
     /// one — so a store copy's `changelogURL` is a store listing. ⚠️ That is a
     /// property of the SOURCE LOOP, not of `runSources` as a whole: the Toolbox
     /// and TestFlight branches return before the loop and pass neither gate. The

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -116,8 +116,8 @@ public struct ResolvedChannel: Sendable, Equatable {
 ///
 /// Why this is per-app: Sparkle never persists the user's channel. `allowedChannels`
 /// is a delegate the host app computes at runtime; vendors keep the choice
-/// wherever they like. No two encodings alike — a sample, not the roster
-/// (`boundBundleIDs` below is the roster: 15 apps as of 2026-09-13):
+/// wherever they like. No two encodings alike. A sample, not the roster —
+/// `boundBundleIDs` below is the roster, and it is longer than this list:
 ///   * DuoPaste → `UserDefaults[sparkleIncludePrereleases]`           (Bool: true→beta)
 ///   * Fork     → `UserDefaults[applicationUpdateChannel]`            (Int: 1→stable)
 ///   * Surge    → `…/Application Support/<id>/KDDefaults.plist`        (`IncludeBetaBuilds` Bool)
@@ -206,8 +206,8 @@ public enum ChannelBinding {
     /// writes nothing back, so it cannot loop; the wake one is actively wanted,
     /// since a toggle flipped just before sleep arrives with no live event.
     ///
-    /// Directories and not the files themselves (6 roots for 15 bound apps as of
-    /// 2026-09-13), because a preference file is *replaced* rather
+    /// Directories, and far fewer of them than there are bound apps — not the
+    /// files themselves, because a preference file is *replaced* rather
     /// than written in place (cfprefsd writes a temp file and renames), so a
     /// per-file watch would go deaf the first time the file changed.
     ///

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/ChannelBinding.swift
@@ -116,7 +116,8 @@ public struct ResolvedChannel: Sendable, Equatable {
 ///
 /// Why this is per-app: Sparkle never persists the user's channel. `allowedChannels`
 /// is a delegate the host app computes at runtime; vendors keep the choice
-/// wherever they like. Four apps, four encodings, none alike:
+/// wherever they like. No two encodings alike — a sample, not the roster
+/// (`boundBundleIDs` below is the roster: 15 apps as of 2026-09-13):
 ///   * DuoPaste → `UserDefaults[sparkleIncludePrereleases]`           (Bool: true→beta)
 ///   * Fork     → `UserDefaults[applicationUpdateChannel]`            (Int: 1→stable)
 ///   * Surge    → `…/Application Support/<id>/KDDefaults.plist`        (`IncludeBetaBuilds` Bool)
@@ -205,7 +206,8 @@ public enum ChannelBinding {
     /// writes nothing back, so it cannot loop; the wake one is actively wanted,
     /// since a toggle flipped just before sleep arrives with no live event.
     ///
-    /// Three roots, not ten files, because a preference file is *replaced* rather
+    /// Directories and not the files themselves (6 roots for 15 bound apps as of
+    /// 2026-09-13), because a preference file is *replaced* rather
     /// than written in place (cfprefsd writes a temp file and renames), so a
     /// per-file watch would go deaf the first time the file changed.
     ///

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/GitHubReleasesSource.swift
@@ -424,19 +424,54 @@ public struct GitHubReleasesSource: UpdateSource {
     public let name = "GitHub"
 
     /// A GitHub fetch that failed in a way worth retrying (vs. simply not
-    /// applying). 403/429 are almost always the unauthenticated 60/hour limit.
+    /// applying).
     enum GitHubError: LocalizedError {
         case badStatus(Int)
+        /// The budget-exhausted subset of 403/429 — see `statusError(_:rateLimitRemaining:)`
+        /// for which 403s qualify. Split out because the OTHER 403s (a repo gone
+        /// private, deleted, or renamed away; a token whose scopes don't cover it)
+        /// are not waiting-out-the-hour problems: reported as the rate limit they
+        /// drove a banner telling the user to add a token, which is advice that
+        /// cannot work, on a row that will still be broken in an hour.
+        case rateLimited(Int)
+
+        /// The status either case carries, so a caller that only needs the code
+        /// doesn't have to know which one it got.
+        var statusCode: Int {
+            switch self {
+            case .badStatus(let code), .rateLimited(let code): return code
+            }
+        }
+
         var errorDescription: String? {
             switch self {
-            case .badStatus(403), .badStatus(429):
+            case .rateLimited:
                 // The phrase "rate limit" is the contract `UpdateStatus.isRateLimitError`
-                // matches on to drive the rate-limit UI nudges — keep it in the string.
+                // matches on to drive the rate-limit UI nudges — keep it in the string,
+                // and keep it OUT of the other case's.
                 return "GitHub rate limit reached — retry shortly"
+            case .badStatus(403):
+                return "GitHub returned 403 (forbidden) — repo private, removed, or token lacks scope"
             case .badStatus(let code):
                 return "GitHub returned HTTP \(code)"
             }
         }
+    }
+
+    /// Which error a non-2xx status becomes.
+    ///
+    /// 429 is always the limit. A 403 is the limit only when the response says the
+    /// budget is gone: `X-RateLimit-Remaining: 0`, or no such header at all —
+    /// GitHub omits it on rejections that never reached the API, and "no evidence"
+    /// must not silently become "not rate limited", which is the one case where the
+    /// nudge is the whole explanation. A 403 arriving with budget left is an access
+    /// problem and says so.
+    static func statusError(_ code: Int, rateLimitRemaining: String?) -> GitHubError {
+        guard code == 403 else { return code == 429 ? .rateLimited(code) : .badStatus(code) }
+        guard let remaining = rateLimitRemaining, let left = Int(remaining) else {
+            return .rateLimited(code)
+        }
+        return left <= 0 ? .rateLimited(code) : .badStatus(code)
     }
 
     /// Keyed by bundle id → the rules for that id, one per release channel.
@@ -767,12 +802,20 @@ public struct GitHubReleasesSource: UpdateSource {
     /// the hour's budget ran out. Let those reach `resolveDiagnostic`'s existing
     /// mapping, which already sorts a status code into infra vs recipe. What this
     /// returns is only the failures that ARE about this mechanism.
+    ///
+    /// `list` is the page this probe fetched, handed back so `resolveDiagnostic`
+    /// can give it to `resolve` instead of asking GitHub for the identical URL a
+    /// second time. Returned rather than cached because the page is only reusable
+    /// for a rule that reads the list endpoint at all (`usePrereleases`), and that
+    /// condition belongs to the caller.
     func channelDiscoveryProbe(
         _ rule: GitHubReleaseRule
-    ) async throws -> (failure: ProbeFailure?, provenVersion: String?, tags: [String]) {
-        guard let prefix = rule.installedTagPrefix else { return (nil, nil, []) }
+    ) async throws -> (
+        failure: ProbeFailure?, provenVersion: String?, tags: [String], list: [Release]
+    ) {
+        guard let prefix = rule.installedTagPrefix else { return (nil, nil, [], []) }
         guard let list = try await fetchReleases(rule, list: true) else {
-            return (.channelDiscoveryBroken("could not fetch the releases list"), nil, [])
+            return (.channelDiscoveryBroken("could not fetch the releases list"), nil, [], [])
         }
         let tags = list.map(\.tag)
         guard let newest = list.first(where: { release in
@@ -785,7 +828,7 @@ public struct GitHubReleasesSource: UpdateSource {
         else {
             return (.channelDiscoveryBroken(
                 "no release tag matched the version pattern, so no exact tag can be built"),
-                nil, tags)
+                nil, tags, list)
         }
 
         let tag = prefix + version
@@ -795,20 +838,20 @@ public struct GitHubReleasesSource: UpdateSource {
             // an install on this version".
             return (.channelDiscoveryBroken(
                 "exact-tag lookup for \(tag) returned nothing — an install on this version could not be classified"),
-                nil, tags)
+                nil, tags, list)
         }
         guard exact.hasExplicitReleaseState else {
             return (.channelDiscoveryBroken(
                 "\(tag) no longer carries both `prerelease` and `draft`; channel identification reads those fields"),
-                nil, tags)
+                nil, tags, list)
         }
         guard VendorProbeRecipe.extractVersion(
             from: exact.tag, pattern: rule.versionPattern) == version
         else {
             return (.channelDiscoveryBroken(
-                "\(tag) resolved to a different tag (\(exact.tag))"), nil, tags)
+                "\(tag) resolved to a different tag (\(exact.tag))"), nil, tags, list)
         }
-        return (nil, version, tags)
+        return (nil, version, tags, list)
     }
 
     /// Host parameters are injectable for the architecture-only diagnostic
@@ -843,16 +886,26 @@ public struct GitHubReleasesSource: UpdateSource {
             // and let the anchor for the line-anchored resolve below come out of
             // the same lookup rather than from a hand-maintained constant.
             var anchor = installedVersion
+            var discovered: [Release]?
             if rule.installedTagPrefix != nil {
                 let discovery = try await channelDiscoveryProbe(rule)
                 if let failure = discovery.failure {
                     return outcome(remote: nil, failure: failure, tags: discovery.tags)
                 }
                 anchor = anchor ?? discovery.provenVersion
+                // The probe just fetched the rule's full list page, and for a rule
+                // that takes its releases from the list endpoint that is the very
+                // page `resolve` is about to ask for — same URL, same page size.
+                // Hand it over instead of buying it twice: a conditional GET can't
+                // save the second one, because the list's `ETag` moves whenever an
+                // asset's download counter does. A rule WITHOUT `usePrereleases`
+                // reads `/releases/latest` instead — a different endpoint with a
+                // different answer — so it must still fetch its own.
+                if rule.usePrereleases { discovered = discovery.list }
             }
             let resolved = try await resolve(
                 rule, anchoredTo: anchor, preferring: hostArch,
-                allowingIntelTranslation: canRunIntel)
+                allowingIntelTranslation: canRunIntel, reusingListPage: discovered)
             if let remote = resolved.remote {
                 return outcome(remote: remote, failure: nil, tags: resolved.tags)
             }
@@ -869,8 +922,12 @@ public struct GitHubReleasesSource: UpdateSource {
                 failure: .versionPatternNoMatch(
                     sampleBytes: resolved.tags.joined(separator: "\n").utf8.count),
                 tags: resolved.tags)
-        } catch GitHubError.badStatus(let code) {
-            return outcome(remote: nil, failure: .httpStatus(code), status: code)
+        } catch let status as GitHubError {
+            // Both cases, not just `badStatus`: a rate limit is infrastructure, and
+            // the sweep sorts infra from broken recipes by the status code alone.
+            return outcome(
+                remote: nil, failure: .httpStatus(status.statusCode),
+                status: status.statusCode)
         } catch {
             return outcome(remote: nil, failure: Self.transportFailure(error))
         }
@@ -1046,7 +1103,8 @@ public struct GitHubReleasesSource: UpdateSource {
         list: Bool, tag: String?
     ) throws -> [Release]? {
         guard (200..<300).contains(http.statusCode) else {
-            let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"
+            let budget = http.value(forHTTPHeaderField: "X-RateLimit-Remaining")
+            let remaining = budget ?? "?"
             Log.source.error("GitHub \(rule.slug, privacy: .public): HTTP \(http.statusCode, privacy: .public) (ratelimit-remaining=\(remaining, privacy: .public))")
             // Record the failure too, and record it BEFORE throwing. A 403 is the
             // loudest form of the very problem this audit exists to explain — the
@@ -1065,7 +1123,7 @@ public struct GitHubReleasesSource: UpdateSource {
             // answer on the stable rule — it is the discovery that declines, not
             // the source.
             if tag != nil, http.statusCode == 404 { return nil }
-            throw GitHubError.badStatus(http.statusCode)
+            throw Self.statusError(http.statusCode, rateLimitRemaining: budget)
         }
         let decoded = Self.releases(from: data, list: list)
         // Verification-only bookkeeping: notice a slug that GitHub had to redirect,
@@ -1129,12 +1187,24 @@ public struct GitHubReleasesSource: UpdateSource {
     ///   silent fall back to `.newest` for a rule that asked for an anchor: a
     ///   diagnostic that quietly measured a different algorithm than the one
     ///   users run is the failure mode `resolveDiagnostic` exists to prevent.
+    /// - reusingListPage: a page of this rule's list endpoint the caller already
+    ///   holds (`resolveDiagnostic`, after channel discovery fetched it). Only
+    ///   valid for a rule whose full-page fetch IS the list endpoint; the caller
+    ///   decides that. Given one, the one-row probe is skipped as well — the whole
+    ///   page is already in hand, and the probe exists only to avoid paying for it.
     private func resolve(
         _ rule: GitHubReleaseRule,
         anchoredTo installedVersion: String? = nil,
         preferring hostArch: HostArch = .current,
-        allowingIntelTranslation canRunIntel: Bool = HostArch.canRunIntelBuilds
+        allowingIntelTranslation canRunIntel: Bool = HostArch.canRunIntelBuilds,
+        reusingListPage prefetched: [Release]? = nil
     ) async throws -> Resolution {
+        if let prefetched {
+            return try await settle(
+                rule, releases: prefetched, anchoredTo: installedVersion,
+                preferring: hostArch, allowingIntelTranslation: canRunIntel,
+                recordingMisses: true)
+        }
         // One row first, when the rule allows it — see `newestProbeSize(for:)`.
         // A probe that cannot answer is not a recipe miss (the release it wants
         // may simply sit below the newest row), so nothing is recorded against
@@ -1300,7 +1370,14 @@ public struct GitHubReleasesSource: UpdateSource {
                 }
                 let installable = asset?.url != nil && rule.installerKind != nil
 
-                await RecipeHealth.shared.recordSuccess(id: rule.slug, source: name)
+                // `recipeID`, not `slug`: two rules can share one repo (Zed and Zed
+                // Preview, UTM Stable and Beta, GitHub Desktop's two channels), and
+                // under a shared key whichever ran LAST decided the verdict for
+                // both. A Preview rule whose tag pattern had stopped matching was
+                // reported healthy on the strength of its stable sibling's success
+                // while every Preview row went quietly `.unknown` — and the
+                // diagnostics panel is the only surface that says a recipe broke.
+                await RecipeHealth.shared.recordSuccess(id: rule.recipeID, source: name)
                 return Resolution(remote: RemoteVersion(
                     shortVersion: version,
                     version: nil,
@@ -1344,7 +1421,7 @@ public struct GitHubReleasesSource: UpdateSource {
             let tags = skippedForMissingAsset.joined(separator: ", ")
             Log.source.error("GitHub \(rule.slug, privacy: .public): no release carries an asset matching /\(rule.installAssetPattern ?? "", privacy: .public)/ (walked \(tags, privacy: .public))")
             await RecipeHealth.shared.recordMiss(
-                id: rule.slug, source: name,
+                id: rule.recipeID, source: name,
                 detail: "\(skippedForMissingAsset.count) release(s) matched the version pattern but "
                     + "none carried an asset matching the install pattern (\(tags)) — the vendor may "
                     + "have renamed the macOS artifact")
@@ -1355,7 +1432,7 @@ public struct GitHubReleasesSource: UpdateSource {
         // Fetched fine but nothing matched the version pattern — the breakage
         // shape a tag-format change produces. Surface it in diagnostics.
         await RecipeHealth.shared.recordMiss(
-            id: rule.slug, source: name,
+            id: rule.recipeID, source: name,
             detail: "\(releases.count) releases fetched, none matched the version pattern")
         return Resolution(
             remote: nil, tags: releases.map(\.tag), archIncompatible: false)

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/HomebrewCaskCatalog.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/HomebrewCaskCatalog.swift
@@ -24,8 +24,9 @@ struct CaskIndex: Sendable {
 /// it by the `.app` filename each cask installs (e.g. "TablePlus.app"), plus a
 /// bundle-identifier fallback drawn from each cask's `uninstall: quit:` field.
 ///
-/// The catalog is ~5 MB, so we fetch and parse it a single time and reuse the
-/// index for every app in a check run.
+/// The catalog is ~2 MB (measured at 2007 KB on 2026-09-05; see `load`), so we
+/// fetch and parse it a single time and reuse the index for every app in a
+/// check run.
 public actor HomebrewCaskCatalog {
     public static let shared = HomebrewCaskCatalog()
 
@@ -33,7 +34,7 @@ public actor HomebrewCaskCatalog {
     private var indexLoadedAt: Date?
     private var loadTask: Task<CaskIndex, Error>?
     /// A failed refresh should not make every subsequent lookup immediately retry
-    /// the same 5 MB request. While this is in the future, a stale index remains
+    /// the same ~2 MB request. While this is in the future, a stale index remains
     /// usable and `isExpired` treats it as fresh enough to serve.
     private var retryRefreshAfter: Date?
 
@@ -47,7 +48,7 @@ public actor HomebrewCaskCatalog {
     /// and immune to that fix because the in-memory index short-circuits the
     /// request entirely.
     ///
-    /// Six hours, not minutes: the refetch is a full 5 MB whenever the catalog
+    /// Six hours, not minutes: the refetch is the full ~2 MB whenever the catalog
     /// actually changed (which is most of the time — brew publishes constantly),
     /// so this trades a few hours of staleness for bounded background traffic.
     /// Only paid on machines that have casks installed at all; `HomebrewCaskSource`
@@ -65,7 +66,7 @@ public actor HomebrewCaskCatalog {
     }
 
     /// Test seam: seed a fixed index so source-level tests run offline instead of
-    /// fetching the 5 MB live catalog.
+    /// fetching the ~2 MB live catalog.
     init(testIndex: CaskIndex) {
         self.session = .shared
         self.index = testIndex

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RecipeHealth.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/RecipeHealth.swift
@@ -21,7 +21,15 @@ public actor RecipeHealth {
     public init() {}
 
     public struct Entry: Sendable, Equatable, Identifiable {
-        /// Stable per-recipe key, e.g. a bundle id or an `owner/repo` slug.
+        /// Stable per-recipe key — the recipe's own id (`vendor:<bundle id>:<channel>`,
+        /// `github:<owner>/<repo>:<channel>`, `changelog:…`), or a bare bundle id
+        /// for a source whose recipes are one-per-app (the Electron manifest read).
+        ///
+        /// Per RECIPE and not per app, because an app can carry several: Zed and
+        /// Zed Preview are two GitHub rules over one repo, Android Studio's Stable
+        /// and Canary are two vendor recipes under one bundle id. Keyed by the
+        /// thing they share, whichever ran last decided the verdict for both and a
+        /// broken channel recipe read healthy on its sibling's success.
         ///
         /// **Not unique on its own.** The same bundle id can be tracked under
         /// more than one `source` at once — e.g. Notion carries both a
@@ -60,6 +68,26 @@ public actor RecipeHealth {
         /// same rendered string. Not `Codable`/persisted anywhere, so the exact
         /// encoding has no compatibility surface to preserve.
         public var key: String { "\(source)\u{0}\(id)" }
+
+        /// The label a diagnostics row shows for this entry, given a bundle id →
+        /// app name map.
+        ///
+        /// A recipe id carries its bundle id as one `:`-separated component rather
+        /// than being one, so the plain lookup the panel used to do misses every id
+        /// but the bare-bundle-id ones. Resolving the component and keeping the raw
+        /// id alongside it is what lets a reader tell "Zed" from "Zed Preview" when
+        /// both are listed — dropping the id would merge them on screen exactly
+        /// where keying by the shared part merged them in storage.
+        ///
+        /// In Core rather than in the view because the view file has no test target
+        /// over it; this is pure string work with a test next to it.
+        public func displayName(resolving names: [String: String]) -> String {
+            if let exact = names[id] { return exact }
+            for part in id.split(separator: ":") where !part.isEmpty {
+                if let name = names[String(part)] { return "\(name) · \(id)" }
+            }
+            return id
+        }
     }
 
     /// Recipes are keyed by `(id, source)` together, not by `id` alone — see the

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/SparkleAppcastSource.swift
@@ -286,12 +286,17 @@ public struct SparkleAppcastSource: UpdateSource {
             // offer it, changelog history included. See `archVerdict`.
             return archVerdict(for: item, hostArch: hostArch, canRunIntel: canRunIntel) != .unrunnable
         }
-        // Deterministic tie-break on equal versions. `sorted(by:)` is NOT a stable
-        // sort in Swift, so per-architecture twins could come back in either order
-        // from run to run — and the changelog dedupe below keeps the FIRST item
-        // that yields notes. Rank the twin built for this Mac first; only fall
-        // back to the enclosure URL when architecture doesn't disambiguate
-        // (identical bodies, or neither item names an architecture at all).
+        // Tie-break on equal versions, because the comparison alone does not say
+        // which of a release's per-architecture twins wins and the changelog dedupe
+        // below keeps the FIRST item that yields notes. Not a stability repair:
+        // Swift's sort IS stable and documented as such (SE-0372, Swift 5.8 —
+        // "The sorting algorithm is guaranteed to be stable"), so without this the
+        // winner would simply be whichever twin the VENDOR happened to list first,
+        // which is their layout decision leaking into which enclosure we install.
+        // Rank the twin built for this Mac first; only fall back to the enclosure
+        // URL when architecture doesn't disambiguate (identical bodies, or neither
+        // item names an architecture at all), which makes the answer depend on the
+        // items themselves rather than on their order in the feed.
         return usable.sorted { (lhs: SparkleAppcastItem, rhs: SparkleAppcastItem) -> Bool in
             switch VersionComparator.compare(lhs.comparisonKey, rhs.comparisonKey) {
             case .orderedDescending: return true

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -232,10 +232,9 @@ public struct VendorProbeRecipe: Sendable {
     /// apply the recipe unless the installed app is on the SAME channel, so a
     /// stable endpoint can never be served to a Beta/Canary install that shares
     /// the bundle id. Most recipes here target Stable, so this defaults to
-    /// `.stable`; set it explicitly when adding a channel-specific endpoint.
-    /// Counted 2026-09-13: 43 of 159 recipes name something else, across 11
-    /// non-stable channels (alpha, beta, canary, dev, esr, guineaPig, nightly,
-    /// preview, ptb, rc, unstable).
+    /// `.stable` — but a substantial minority do not, across most of
+    /// `ReleaseChannel`'s cases (beta, canary, nightly, preview, dev, esr, rc and
+    /// more), so set it explicitly when adding a channel-specific endpoint.
     public let channel: ReleaseChannel
 
     /// Distinguishes several recipes that share a bundle id AND a channel — the
@@ -635,11 +634,12 @@ public struct VendorProbeRecipe: Sendable {
     ///
     /// Also re-anchors `^`, `$`, `\A`, `\z` and lookbehind to entry boundaries
     /// rather than the whole body's — a pattern relying on "start/end of the
-    /// document" now means "start/end of one entry" instead. Counted 2026-09-13:
-    /// 7 recipes pin `versionPattern` at both ends with `^…$` and 17 use `^` or
-    /// `$` at all; none of them has adopted `entryStartPattern`, and this is why
-    /// one shouldn't without re-deriving those patterns against a single sliced
-    /// entry first.
+    /// document" now means "start/end of one entry" instead. A minority of recipes
+    /// anchor `versionPattern` that way, and none of them has adopted
+    /// `entryStartPattern` — don't, without re-deriving the pattern against a
+    /// single sliced entry first. That is a build failure rather than a convention:
+    /// `EntryStartPatternRegistryClaims.noAnchoredVersionPatternHasAdoptedEntryStartPattern`
+    /// walks the registry for the combination and names any recipe that has it.
     ///
     /// One more shape worth naming rather than discovering later: selection now
     /// searches the feed's entire history, not just its recent head, so a
@@ -937,12 +937,14 @@ public struct VendorProbeRecipe: Sendable {
     /// (computed by the caller with the SAME flag) uses highest-match — two
     /// different readings of "highest" disagreeing on which entry even won.
     ///
-    /// Three registry recipes combine the two (counted 2026-09-13): WeChat's
-    /// Sparkle appcast, and Windscribe's beta and guinea-pig ChangeLogs feeds.
-    /// They are also the recipes that depend on the straddle guard below being
-    /// SKIPPED under `selectHighest` — several `versionPattern` matches inside one
-    /// `<item>`/one `"id"` block are the expected shape for them, not evidence the
-    /// slice spans two releases.
+    /// Registry recipes DO combine the two — WeChat's Sparkle appcast and
+    /// Windscribe's prerelease ChangeLogs feeds — and they are the recipes that
+    /// depend on the straddle guard below being SKIPPED under `selectHighest`:
+    /// several `versionPattern` matches inside one `<item>` / one `"id"` block are
+    /// the expected shape for them, not evidence the slice spans two releases.
+    /// Those two apps are named because a test pins them
+    /// (`EntryStartPatternRegistryClaims.onlyTheDocumentedRecipesCombineSelectHighestWithEntryStartPattern`),
+    /// so a third one cannot appear without this paragraph being revisited.
     public static func highestVersionEntry(
         in text: String, entryStartPattern: String, versionPattern: String,
         selectHighest: Bool = false
@@ -1057,8 +1059,8 @@ public struct VendorProbeRecipe: Sendable {
 /// three standard sources have all missed.
 ///
 /// An app stays OUT of this table until a vendor's stable, versioned link is
-/// confirmed via the probe harness (the table started empty and grew only that
-/// way — 159 recipes as of 2026-09-13). Shipping an unverified recipe risks a
+/// confirmed via the probe harness — the table started empty and has only ever
+/// grown that way. Shipping an unverified recipe risks a
 /// false "update available", which this source must never produce; leaving an app
 /// out simply means it stays "unknown", which is the correct, honest default.
 ///

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeRecipe.swift
@@ -231,8 +231,11 @@ public struct VendorProbeRecipe: Sendable {
     /// The release channel this recipe's endpoint serves. The source refuses to
     /// apply the recipe unless the installed app is on the SAME channel, so a
     /// stable endpoint can never be served to a Beta/Canary install that shares
-    /// the bundle id. Every recipe here targets Stable, so this defaults to
+    /// the bundle id. Most recipes here target Stable, so this defaults to
     /// `.stable`; set it explicitly when adding a channel-specific endpoint.
+    /// Counted 2026-09-13: 43 of 159 recipes name something else, across 11
+    /// non-stable channels (alpha, beta, canary, dev, esr, guineaPig, nightly,
+    /// preview, ptb, rc, unstable).
     public let channel: ReleaseChannel
 
     /// Distinguishes several recipes that share a bundle id AND a channel — the
@@ -632,10 +635,11 @@ public struct VendorProbeRecipe: Sendable {
     ///
     /// Also re-anchors `^`, `$`, `\A`, `\z` and lookbehind to entry boundaries
     /// rather than the whole body's — a pattern relying on "start/end of the
-    /// document" now means "start/end of one entry" instead. Six recipes in
-    /// this registry pin `versionPattern` with `^…$` today; none has adopted
-    /// `entryStartPattern`, and this is why one shouldn't without re-deriving
-    /// those patterns against a single sliced entry first.
+    /// document" now means "start/end of one entry" instead. Counted 2026-09-13:
+    /// 7 recipes pin `versionPattern` at both ends with `^…$` and 17 use `^` or
+    /// `$` at all; none of them has adopted `entryStartPattern`, and this is why
+    /// one shouldn't without re-deriving those patterns against a single sliced
+    /// entry first.
     ///
     /// One more shape worth naming rather than discovering later: selection now
     /// searches the feed's entire history, not just its recent head, so a
@@ -932,7 +936,13 @@ public struct VendorProbeRecipe: Sendable {
     /// entries scored by first-match while the version it goes on to report
     /// (computed by the caller with the SAME flag) uses highest-match — two
     /// different readings of "highest" disagreeing on which entry even won.
-    /// No registry recipe combines the two today.
+    ///
+    /// Three registry recipes combine the two (counted 2026-09-13): WeChat's
+    /// Sparkle appcast, and Windscribe's beta and guinea-pig ChangeLogs feeds.
+    /// They are also the recipes that depend on the straddle guard below being
+    /// SKIPPED under `selectHighest` — several `versionPattern` matches inside one
+    /// `<item>`/one `"id"` block are the expected shape for them, not evidence the
+    /// slice spans two releases.
     public static func highestVersionEntry(
         in text: String, entryStartPattern: String, versionPattern: String,
         selectHighest: Bool = false
@@ -1046,10 +1056,11 @@ public struct VendorProbeRecipe: Sendable {
 /// The verified recipe table. Consulted by `VendorProbeSource` only after the
 /// three standard sources have all missed.
 ///
-/// Intentionally empty until a vendor's stable, versioned link is confirmed via
-/// the probe harness. Shipping an unverified recipe risks a false "update
-/// available", which this source must never produce — an empty table simply
-/// means those apps stay "unknown", which is the correct, honest default.
+/// An app stays OUT of this table until a vendor's stable, versioned link is
+/// confirmed via the probe harness (the table started empty and grew only that
+/// way — 159 recipes as of 2026-09-13). Shipping an unverified recipe risks a
+/// false "update available", which this source must never produce; leaving an app
+/// out simply means it stays "unknown", which is the correct, honest default.
 ///
 /// Every recipe below was verified by probing the live endpoint and confirming
 /// it yields the app's current version (≥ the installed copy). Endpoints are

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -481,9 +481,8 @@ public struct VendorProbeSource: UpdateSource {
     /// sweep sees it the first time a vendor reformats their feed rather than
     /// whenever two release trains next happen to overlap. False for a recipe
     /// that sets no `entryStartPattern` at all — that is not a fallback, it is
-    /// the normal path for all but 7 of the registry's 159 recipes (counted
-    /// 2026-09-13: WeChat, Android Studio Canary/Beta, Little Snitch stable and
-    /// nightly, Windscribe beta and guinea-pig).
+    /// the normal path for the large majority of the registry — only a handful of
+    /// recipes set one at all.
     private struct Scope {
         let text: String
         let fellBack: Bool

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -133,7 +133,14 @@ public struct VendorProbeSource: UpdateSource {
             // recency), so this only flags consistently-broken recipes. Recorded for
             // the `.notApplicable` case below too: "this Mac has no such identity"
             // is exactly the kind of standing miss the sweep wants to see.
-            await RecipeHealth.shared.recordMiss(id: bundleID, source: name, detail: detail)
+            // `outcome.recipeID`, not `bundleID`: one bundle id can carry several
+            // recipes (Android Studio's Stable and Canary, and every `variant`
+            // recipe), and under a shared key whichever ran LAST decided the
+            // verdict for all of them — a broken channel recipe reads healthy on
+            // the strength of its sibling's success. Same reasoning, same fix as
+            // `GitHubReleasesSource`.
+            await RecipeHealth.shared.recordMiss(
+                id: outcome.recipeID, source: name, detail: detail)
 
             // A recipe that cannot apply on THIS machine is not a failure and has
             // nothing to retry: the device-identity and rollout-track selectors
@@ -155,7 +162,7 @@ public struct VendorProbeSource: UpdateSource {
             throw ProbeFailed(bundleID: bundleID, failure: outcome.failure)
         }
         // The recipe answered — clears any standing miss on the next comparison.
-        await RecipeHealth.shared.recordSuccess(id: bundleID, source: name)
+        await RecipeHealth.shared.recordSuccess(id: outcome.recipeID, source: name)
         return remote
     }
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/VendorProbeSource.swift
@@ -481,7 +481,9 @@ public struct VendorProbeSource: UpdateSource {
     /// sweep sees it the first time a vendor reformats their feed rather than
     /// whenever two release trains next happen to overlap. False for a recipe
     /// that sets no `entryStartPattern` at all — that is not a fallback, it is
-    /// the normal path for every recipe in the registry but two.
+    /// the normal path for all but 7 of the registry's 159 recipes (counted
+    /// 2026-09-13: WeChat, Android Studio Canary/Beta, Little Snitch stable and
+    /// nightly, Windscribe beta and guinea-pig).
     private struct Scope {
         let text: String
         let fellBack: Bool

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/ChangelogURLPolicyTests.swift
@@ -279,4 +279,39 @@ struct ChangelogURLPolicyTests {
                     "\(bundleID): \(url.absoluteString)")
         }
     }
+
+    /// The lookup's FOURTH fallback (`?? group.first`), which its own doc omitted
+    /// for a while and two comments then reasoned past.
+    ///
+    /// A bundle id whose recipes are ALL on non-stable channels has nothing for
+    /// the channel-agnostic and `.stable` steps to find, so without step 4 an
+    /// off-channel lookup returns nil and the pane goes empty for an app that has
+    /// notes. Derived from the registry rather than naming the groups: the set
+    /// changes whenever a preview-only app is added, and a written-down list would
+    /// be the thing that goes stale.
+    @Test func aGroupWithNoStableRecipeStillResolves() {
+        let groups = Dictionary(
+            grouping: ChangelogRecipeRegistry.recipes, by: { $0.bundleID.lowercased() })
+        let nonStableOnly = groups.filter { _, recipes in
+            !recipes.contains { $0.channel == nil || $0.channel == .stable }
+        }
+        #expect(!nonStableOnly.isEmpty, """
+            no bundle id is non-stable-only any more — step 4 has nothing to answer for, so \
+            this test is measuring nothing and the doc should say so.
+            """)
+
+        for (bundleID, recipes) in nonStableOnly {
+            // A channel none of the group's recipes declares: steps 1–3 all miss.
+            let foreign = ReleaseChannel.allCases.first { channel in
+                !recipes.contains { $0.channel == channel }
+            }
+            let resolved = ChangelogRecipeRegistry.recipe(
+                forBundleID: bundleID, channel: foreign)
+            let channels = recipes.compactMap { $0.channel?.rawValue }
+            #expect(resolved != nil, """
+                \(bundleID) has only \(channels) — an off-channel lookup must still land on \
+                one of them, not on nil.
+                """)
+        }
+    }
 }

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubForbiddenTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubForbiddenTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// A 403 from `api.github.com` has two quite different causes, and reporting both
+/// as the rate limit sends half of them to the wrong fix.
+///
+/// The budget-exhausted 403 is the common one and a token really does cure it.
+/// The other 403 — a repo gone private, deleted, renamed away, or a token whose
+/// scopes don't cover it — is not a waiting-out-the-hour problem: the banner
+/// telling the user to add a token is advice that cannot work, on a row that will
+/// still be broken in an hour. `X-RateLimit-Remaining` is on the response and
+/// separates them.
+@Suite(.serialized)
+struct GitHubForbiddenTests {
+    private final class ForbiddenProtocol: URLProtocol, @unchecked Sendable {
+        /// Status to answer with, and the `X-RateLimit-Remaining` header to carry
+        /// (nil = send no such header).
+        nonisolated(unsafe) static var status = 403
+        nonisolated(unsafe) static var remaining: String?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            var headers: [String: String] = [:]
+            if let remaining = Self.remaining { headers["X-RateLimit-Remaining"] = remaining }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: Self.status,
+                httpVersion: "HTTP/1.1", headerFields: headers)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(#"{"message":"Forbidden"}"#.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    private let rule = GitHubReleaseRule(
+        bundleID: "com.zzfixture.forbidden", owner: "zzfixture", repo: "app",
+        versionPattern: #"^v([0-9.]+)$"#)
+
+    private func message(status: Int, remaining: String?) async -> String {
+        ForbiddenProtocol.status = status
+        ForbiddenProtocol.remaining = remaining
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ForbiddenProtocol.self]
+        let source = GitHubReleasesSource(
+            rules: [rule], session: URLSession(configuration: configuration))
+        let app = InstalledApp(
+            name: "ZZFixture", bundleID: rule.bundleID, shortVersion: "1.0", buildVersion: nil,
+            path: URL(fileURLWithPath: "/Applications/ZZFixture-Forbidden.app"),
+            isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil)
+        #expect(!FileManager.default.fileExists(atPath: app.path.path))
+        do {
+            _ = try await source.latestVersion(for: app)
+            Issue.record("a \(status) must reach the caller as an error")
+            return ""
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    @Test func aBudgetExhausted403IsReportedAsTheRateLimit() async throws {
+        let exhausted = await message(status: 403, remaining: "0")
+        #expect(UpdateStatus.error(exhausted).isRateLimitError)
+        // A 403 that never reached the API carries no budget header at all, and
+        // "no evidence" must not quietly become "not rate limited" — that is the
+        // one case where the nudge is the whole explanation.
+        let headerless = await message(status: 403, remaining: nil)
+        #expect(UpdateStatus.error(headerless).isRateLimitError)
+        let tooManyRequests = await message(status: 429, remaining: "57")
+        #expect(UpdateStatus.error(tooManyRequests).isRateLimitError)
+    }
+
+    @Test func anAccess403IsNotReportedAsTheRateLimit() async throws {
+        let forbidden = await message(status: 403, remaining: "57")
+
+        #expect(!UpdateStatus.error(forbidden).isRateLimitError,
+                "a 403 with budget left is an access problem; a token cannot fix it")
+        #expect(forbidden.contains("403"))
+        // The row has to say something a user can act on instead.
+        #expect(forbidden.localizedCaseInsensitiveContains("forbidden"))
+    }
+
+    /// Whatever the words, the classification the sweep files must stay a status
+    /// code — a rate limit is infrastructure, not a broken recipe, and both 403s
+    /// have to keep arriving as `.httpStatus`.
+    @Test func bothKindsStillReachTheSweepAsAStatusCode() async throws {
+        for remaining in ["0", "57"] {
+            ForbiddenProtocol.status = 403
+            ForbiddenProtocol.remaining = remaining
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [ForbiddenProtocol.self]
+            let source = GitHubReleasesSource(
+                rules: [rule], session: URLSession(configuration: configuration))
+
+            let outcome = await source.resolveDiagnostic(rule)
+
+            #expect(outcome.httpStatus == 403)
+            guard case .httpStatus(403)? = outcome.failure else {
+                Issue.record("remaining=\(remaining) produced \(String(describing: outcome.failure))")
+                return
+            }
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/GitHubListProbeTests.swift
@@ -244,7 +244,7 @@ struct GitHubListProbeTests {
         let outcome = await source.resolveDiagnostic(rule, preferring: .arm64, allowingIntelTranslation: false)
 
         #expect(outcome.remote?.shortVersion == "1.5.0-beta.1")
-        let entry = await RecipeHealth.shared.snapshot().first { $0.id == rule.slug && $0.source == source.name }
+        let entry = await RecipeHealth.shared.snapshot().first { $0.id == rule.recipeID && $0.source == source.name }
         #expect(entry != nil)
         #expect(entry?.lastMiss == nil)
         #expect(entry?.lastSuccess != nil)

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RecipeHealthKeyTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RecipeHealthKeyTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// `RecipeHealth` has to key GitHub rules by the per-rule id, not by the
+/// `owner/repo` slug two rules can share.
+///
+/// Zed is the case in hand: `dev.zed.Zed` and `dev.zed.Zed-Preview` are two rules
+/// over `zed-industries/zed`, with different version patterns and different
+/// endpoints. Keyed by slug, whichever ran LAST decided the verdict for both — a
+/// Preview rule whose `-pre` pattern had stopped matching was reported healthy on
+/// the strength of the stable rule's success, while every Preview row quietly went
+/// `.unknown`. The diagnostics panel is the only surface that says a recipe broke,
+/// so masking there is the whole failure.
+@Suite(.serialized)
+struct RecipeHealthKeyTests {
+
+    /// Serves a well-formed but assetless `v1.0.0` release from every endpoint, so
+    /// any rule pointed at it fetches fine and then fails to produce a version —
+    /// either its tag pattern doesn't match or no release carries its macOS asset,
+    /// both of which are shapes `RecipeHealth` records a miss for.
+    ///
+    /// It has to answer the exact-tag endpoint too, and with the release-state
+    /// fields: a rule with `installedTagPrefix` (UTM Beta) probes channel discovery
+    /// FIRST and returns before `resolve` when that probe can't complete, which
+    /// records no health at all. An empty list made that rule look like the bug
+    /// this suite is about.
+    private final class EmptyReleasesProtocol: URLProtocol, @unchecked Sendable {
+        /// Endpoint path → body, for a test that needs one endpoint to succeed.
+        nonisolated(unsafe) static var answering: [String: String] = [:]
+
+        static func release(tag: String) -> String {
+            """
+            {"tag_name":"\(tag)","prerelease":true,"draft":false,
+             "published_at":"2026-09-13T00:00:00Z","assets":[]}
+            """
+        }
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            let path = request.url?.path ?? ""
+            let body: String
+            if let scripted = Self.answering[path] {
+                body = scripted
+            } else if let range = path.range(of: "/releases/tags/") {
+                body = Self.release(tag: String(path[range.upperBound...]).removingPercentEncoding
+                    ?? String(path[range.upperBound...]))
+            } else if path.hasSuffix("/releases/latest") {
+                body = Self.release(tag: "v1.0.0")
+            } else {
+                body = "[\(Self.release(tag: "v1.0.0"))]"
+            }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    private func source(rules: [GitHubReleaseRule]) -> GitHubReleasesSource {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [EmptyReleasesProtocol.self]
+        return GitHubReleasesSource(
+            rules: rules, session: URLSession(configuration: configuration))
+    }
+
+    private func rule(bundleID: String) throws -> GitHubReleaseRule {
+        try #require(GitHubReleaseRegistry.rules.first { $0.bundleID == bundleID })
+    }
+
+    /// A miss on the Preview rule must survive a success on the stable rule that
+    /// shares its slug. With both filed under `zed-industries/zed`, the success
+    /// landed second and the panel showed one healthy row.
+    @Test func aBrokenChannelRuleIsNotMaskedByItsHealthySibling() async throws {
+        let preview = try rule(bundleID: "dev.zed.Zed-Preview")
+        let stable = try rule(bundleID: "dev.zed.Zed")
+        // The stable rule reads `/releases/latest`; the Preview rule reads the
+        // list. Only the first answers, so the Preview rule misses and the stable
+        // rule succeeds — in that order, which is the order that used to lose.
+        EmptyReleasesProtocol.answering = [
+            "/repos/zed-industries/zed/releases/latest": """
+            {"tag_name":"v1.5.3","prerelease":false,"draft":false,
+             "assets":[{"name":"Zed-aarch64.dmg",
+                        "browser_download_url":"https://example.invalid/Zed-aarch64.dmg",
+                        "size":1}]}
+            """,
+        ]
+        defer { EmptyReleasesProtocol.answering = [:] }
+
+        _ = await source(rules: [preview]).resolveDiagnostic(preview)
+        _ = await source(rules: [stable]).resolveDiagnostic(stable)
+
+        let entries = await RecipeHealth.shared.snapshot()
+        let previewEntry = try #require(
+            entries.first { $0.id == preview.recipeID && $0.source == "GitHub" },
+            "the Preview rule needs its own health entry, not a shared one")
+        #expect(previewEntry.isHealthy == false)
+        let stableEntry = try #require(
+            entries.first { $0.id == stable.recipeID && $0.source == "GitHub" })
+        #expect(stableEntry.isHealthy == true)
+    }
+
+    /// The vendor half of the same bug. Android Studio is the live case — Stable
+    /// and Canary are two recipes under `com.google.android.studio` — so a broken
+    /// Canary recipe was reported healthy every time the Stable one answered.
+    /// Synthetic recipes rather than the registry's, so the test does not depend
+    /// on which of a vendor's endpoints happens to be reachable.
+    @Test func twoVendorRecipesUnderOneBundleIDRecordSeparately() async throws {
+        let bundleID = "com.zzfixture.twochannels"
+        func recipe(_ channel: ReleaseChannel, pattern: String) -> VendorProbeRecipe {
+            VendorProbeRecipe(
+                bundleID: bundleID,
+                url: URL(string: "https://zzfixture.invalid/\(channel.rawValue).json")!,
+                mode: .responseBody,
+                versionPattern: pattern,
+                channel: channel)
+        }
+        // Stable's pattern matches the served body; Canary's does not, which is the
+        // "vendor changed their page" shape — and it runs FIRST, so only a
+        // per-recipe key can keep it from being cleared by Stable's success.
+        let canary = recipe(.canary, pattern: #""canaryVersion"\s*:\s*"([0-9.]+)""#)
+        let stable = recipe(.stable, pattern: #""version"\s*:\s*"([0-9.]+)""#)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [EmptyReleasesProtocol.self]
+        EmptyReleasesProtocol.answering = [
+            "/canary.json": #"{"version":"1.2.3"}"#,
+            "/stable.json": #"{"version":"1.2.3"}"#,
+        ]
+        defer { EmptyReleasesProtocol.answering = [:] }
+        let source = VendorProbeSource(
+            recipes: [canary, stable], session: URLSession(configuration: configuration))
+
+        func app(_ channel: ReleaseChannel) -> InstalledApp {
+            let path = URL(fileURLWithPath: "/Applications/ZZFixture-TwoChannels.app")
+            #expect(!FileManager.default.fileExists(atPath: path.path))
+            return InstalledApp(
+                name: "ZZFixture", bundleID: bundleID, shortVersion: "1.0.0", buildVersion: nil,
+                path: path, isMASApp: false, isToolboxManaged: false, sparkleFeedURL: nil,
+                releaseChannel: channel)
+        }
+        _ = try? await source.latestVersion(for: app(.canary))
+        _ = try? await source.latestVersion(for: app(.stable))
+
+        // Scoped to this fixture's own bundle id: `RecipeHealth.shared` is process-
+        // wide and other suites run beside this one, so "every Vendor entry" would
+        // be measuring whatever else happened to check in the same second.
+        let entries = await RecipeHealth.shared.snapshot()
+            .filter { $0.source == "Vendor" && $0.id.contains(bundleID) }
+        #expect(entries.map(\.id).sorted() == [canary.recipeID, stable.recipeID].sorted())
+        #expect(entries.first { $0.id == canary.recipeID }?.isHealthy == false)
+        #expect(entries.first { $0.id == stable.recipeID }?.isHealthy == true)
+    }
+
+    /// Keying by recipe id moved the diagnostics rows off bare bundle ids, so the
+    /// panel's name lookup has to reach INTO the id. Both halves matter: the name
+    /// (a raw `vendor:…:beta` row is not what a reader is looking for) and the id
+    /// beside it (drop it and two channels of one app render identically).
+    @Test func aRecipeIDStillResolvesTheAppsName() {
+        let names = ["com.example.editor": "Editor"]
+        func entry(_ id: String) -> RecipeHealth.Entry {
+            RecipeHealth.Entry(id: id, source: "Vendor")
+        }
+        #expect(entry("vendor:com.example.editor:beta").displayName(resolving: names)
+                == "Editor · vendor:com.example.editor:beta")
+        #expect(entry("vendor:com.example.editor:stable").displayName(resolving: names)
+                != entry("vendor:com.example.editor:beta").displayName(resolving: names))
+        // A source that keys by the bare bundle id keeps the plain name.
+        #expect(entry("com.example.editor").displayName(resolving: names) == "Editor")
+        // Nothing to resolve — a GitHub rule's id names a repo, not an app.
+        #expect(entry("github:owner/repo:stable").displayName(resolving: names)
+                == "github:owner/repo:stable")
+    }
+
+    /// Derived from the registry: every rule that shares a slug with another must
+    /// still land in its own `RecipeHealth` row. Written as "run them all and count
+    /// the rows" rather than as an assertion about ids, so it measures what the
+    /// source records rather than what the registry could record.
+    @Test func rulesSharingASlugRecordSeparateHealthEntries() async throws {
+        let shared = Dictionary(grouping: GitHubReleaseRegistry.rules, by: \.slug)
+            .filter { $0.value.count > 1 }
+        #expect(!shared.isEmpty, "no slug is shared any more — this test has nothing to measure")
+
+        for (slug, rules) in shared {
+            for rule in rules {
+                _ = await source(rules: [rule]).resolveDiagnostic(rule)
+            }
+            let recorded = await RecipeHealth.shared.snapshot()
+                .filter { $0.source == "GitHub" && $0.id.contains(slug) }
+            let expected = rules.map(\.recipeID).sorted()
+            let got = recorded.map(\.id).sorted()
+            #expect(
+                recorded.count == rules.count,
+                "\(slug): \(expected) should each have their own health entry, got \(got)")
+        }
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UTMGitHubChannelTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/UTMGitHubChannelTests.swift
@@ -254,6 +254,26 @@ struct UTMGitHubChannelTests {
         #expect(probe.provenVersion == "5.0.5")
     }
 
+    /// The diagnostic runs two mechanisms — channel discovery, then the resolve —
+    /// and for a rule that takes its releases from the list endpoint both want the
+    /// SAME page. Fetching it twice doubled this rule's share of the sweep's
+    /// GitHub budget for nothing: a conditional GET cannot save it either, because
+    /// the list's `ETag` moves whenever an asset's download counter does.
+    @Test func theDiagnosticFetchesTheReleasesListOnce() async throws {
+        let rule = try #require(GitHubReleaseRegistry.rules.first {
+            $0.bundleID == "com.utmapp.UTM" && $0.installedTagPrefix != nil
+        })
+        let source = self.source()
+
+        let outcome = await source.resolveDiagnostic(rule)
+
+        // Unchanged answer: the pass-through must be invisible in the result.
+        #expect(outcome.failure == nil)
+        #expect(outcome.remote?.displayVersion == "5.0.5")
+        let lists = FixtureProtocol.paths().filter { $0 == "/repos/utmapp/UTM/releases" }
+        #expect(lists.count == 1, "the releases list was fetched \(lists.count) times")
+    }
+
     /// The probe must not relabel infrastructure as a broken recipe: a 403 is the
     /// shared GitHub rate limit, which the sweep retries and never files. Letting
     /// it out as `channelDiscoveryBroken` (classification `.recipe`) would open an
@@ -269,8 +289,16 @@ struct UTMGitHubChannelTests {
         do {
             _ = try await source.channelDiscoveryProbe(rule)
             Issue.record("a 403 must reach the caller as an error, not a probe verdict")
-        } catch GitHubReleasesSource.GitHubError.badStatus(let code) {
-            #expect(code == 403)
+        } catch let status as GitHubReleasesSource.GitHubError {
+            // The fixture sends no `X-RateLimit-Remaining`, which is how a
+            // rejection that never reached the API looks — `statusError` reads
+            // that as the budget being gone. See `GitHubForbiddenTests` for the
+            // 403 that is NOT the limit.
+            #expect(status.statusCode == 403)
+            guard case .rateLimited = status else {
+                Issue.record("a headerless 403 must stay classified as the rate limit")
+                return
+            }
         }
     }
 

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeRecipeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeRecipeTests.swift
@@ -2,6 +2,56 @@ import Testing
 import Foundation
 @testable import DuoUpdaterCore
 
+// MARK: - Derived from the registry
+
+/// Two claims in `VendorProbeRecipe`'s own documentation, pinned here so they
+/// cannot quietly stop being true. Worth pinning rather than counting: a count in
+/// a comment goes stale in silence, which is exactly how both of these went wrong
+/// — one said "no registry recipe combines the two" while three did.
+@Suite struct EntryStartPatternRegistryClaims {
+
+    /// `highestVersionEntry` skips its straddle guard under `selectHighest`, and
+    /// the doc names WHICH recipes depend on that being skipped. Both directions
+    /// fail: a new recipe combining the two flags without being named, and a named
+    /// one that stopped combining them — a stale exemption is a free pass for the
+    /// next drift (the `mayLookAlike` lesson).
+    @Test func onlyTheDocumentedRecipesCombineSelectHighestWithEntryStartPattern() {
+        let documented: Set<String> = ["com.tencent.xinWeChat", "com.windscribe.client"]
+        let combining = Set(
+            VendorProbeRegistry.recipes
+                .filter { $0.entryStartPattern != nil && $0.selectHighest }
+                .map(\.bundleID))
+
+        #expect(combining == documented, """
+            the recipes combining `selectHighest` with `entryStartPattern` have changed. \
+            `VendorProbeRecipe.highestVersionEntry`'s doc names them as the recipes relying \
+            on the straddle guard being skipped — update it and this set together.
+            """)
+    }
+
+    /// The warning on `entryStartPattern`: slicing re-anchors `^`/`$` to entry
+    /// boundaries, so a recipe pinning its `versionPattern` to the whole document
+    /// must not adopt slicing without re-deriving that pattern first. Nothing
+    /// enforced it — and the count of anchored recipes the comment used to carry
+    /// enforced nothing either.
+    @Test func noAnchoredVersionPatternHasAdoptedEntryStartPattern() {
+        let anchored: (VendorProbeRecipe) -> Bool = {
+            $0.versionPattern.hasPrefix("^") || $0.versionPattern.hasSuffix("$")
+        }
+        let both = VendorProbeRegistry.recipes.filter { $0.entryStartPattern != nil && anchored($0) }
+
+        #expect(both.isEmpty, """
+            \(both.map(\.recipeID)) anchor `versionPattern` with ^ or $ AND slice with \
+            `entryStartPattern`. Those anchors now mean "start/end of one entry", not of the \
+            document — re-derive the pattern against a single sliced entry before allowing this.
+            """)
+        // Non-vacuity: both halves have to exist in the registry or the check is
+        // measuring an empty intersection of empty sets.
+        #expect(VendorProbeRegistry.recipes.contains { $0.entryStartPattern != nil })
+        #expect(VendorProbeRegistry.recipes.contains(where: anchored))
+    }
+}
+
 @Test func intelliJVersionPatternSurvivesAFourthSegment() {
     // JetBrains shipped "2026.2.0.1" against a pattern pinned to exactly three
     // segments, so it matched nothing and the row fell to "unknown" — a silent

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -1275,9 +1275,10 @@ private func verdict(
 /// is also set: entries are scored by the SAME extractor
 /// (`highestVersion`/`extractVersion`) the caller will apply to the winner
 /// afterwards, so the two can't disagree about which entry "the highest
-/// version" even refers to. Three registry recipes combine the two (WeChat and
-/// Windscribe's two prerelease tracks, 2026-09-13), and the primitive must not
-/// silently narrow `selectHighest`'s meaning for them or for the next one.
+/// version" even refers to. Registry recipes do combine the two (WeChat and
+/// Windscribe's prerelease tracks — `EntryStartPatternRegistryClaims` pins which),
+/// and the primitive must not silently narrow `selectHighest`'s meaning for them
+/// or for the next one.
 @Test func highestVersionEntryScoresBySelectHighestWhenTheRecipeAsksForIt() {
     // Entry A's FIRST match ("1.0") is lower than entry B's ("2.0"), but A
     // contains a SECOND, higher match ("9.0") buried later — exactly the shape

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/VendorProbeTests.swift
@@ -1275,8 +1275,9 @@ private func verdict(
 /// is also set: entries are scored by the SAME extractor
 /// (`highestVersion`/`extractVersion`) the caller will apply to the winner
 /// afterwards, so the two can't disagree about which entry "the highest
-/// version" even refers to. No registry recipe combines the two today, but the
-/// primitive must not silently narrow `selectHighest`'s meaning if one does.
+/// version" even refers to. Three registry recipes combine the two (WeChat and
+/// Windscribe's two prerelease tracks, 2026-09-13), and the primitive must not
+/// silently narrow `selectHighest`'s meaning for them or for the next one.
 @Test func highestVersionEntryScoresBySelectHighestWhenTheRecipeAsksForIt() {
     // Entry A's FIRST match ("1.0") is lower than entry B's ("2.0"), but A
     // contains a SECOND, higher match ("9.0") buried later — exactly the shape


### PR DESCRIPTION
Three logic fixes and one pass of comment corrections from the 2026-09-13 review.

## Findings addressed

| Finding | Where | What changed |
|---|---|---|
| **L11** | `Sources/GitHubReleasesSource.swift:1303/1346/1357`, `Sources/VendorProbeSource.swift:136/158` | Record `RecipeHealth` under the per-recipe id (`rule.recipeID`, `outcome.recipeID`) instead of the shared `slug` / `bundleID`. |
| **P9** | `Sources/GitHubReleasesSource.swift:847-855 / 774 / 1155` | `channelDiscoveryProbe` hands its list page to `resolve` instead of both fetching the identical URL. |
| **L15** | `Sources/GitHubReleasesSource.swift:432-435` | A 403 that arrives with rate-limit budget left no longer claims to be the rate limit. |
| **三 (comments)** | 8 files | Counts and claims re-measured against the live registries; stale line-number citations replaced by symbol names. |

Nothing was declined. Two things noticed **outside scope** (not touched):

- A rule with `installedTagPrefix` whose channel-discovery probe fails returns from `resolveDiagnostic` before `resolve`, so it records **no** `RecipeHealth` entry at all — a broken discovery mechanism leaves no mark on the panel. Found while writing the L11 registry test (it is why the fixture has to answer the exact-tag endpoint).
- `CHANGELOG.md:825` also says "that 5 MB catalog". Left alone: the brief forbids editing CHANGELOG.md, and it is a shipped release note.

## L11 — evidence

Red first (`swift test --filter RecipeHealthKeyTests`), before the fix:

```
✘ aBrokenChannelRuleIsNotMaskedByItsHealthySibling ... the Preview rule needs its own health entry, not a shared one
✘ rulesSharingASlugRecordSeparateHealthEntries
↳ zed-industries/zed: ["github:zed-industries/zed:preview", "github:zed-industries/zed:stable"] should each have their own health entry, got ["zed-industries/zed"]
↳ utmapp/UTM: ... got ["utmapp/UTM"]        (7 shared-slug groups in all)
```

Green after: `✔ Test run with 4 tests in 1 suite passed`.

Mutation check — both record sites put back to `rule.slug` / `bundleID`:

```
✘ aBrokenChannelRuleIsNotMaskedByItsHealthySibling ... entries.first { $0.id == preview.recipeID } → nil
✘ twoVendorRecipesUnderOneBundleIDRecordSeparately
↳ entries.map(\.id).sorted() → ["com.zzfixture.twochannels"]
↳ [canary.recipeID, stable.recipeID].sorted() → ["vendor:com.zzfixture.twochannels:canary", "vendor:com.zzfixture.twochannels:stable"]
```

Restored → green.

Tests: `DuoUpdaterCore/Tests/DuoUpdaterCoreTests/RecipeHealthKeyTests.swift` — the Zed pair by hand, a registry-derived one over **every** shared-slug group (measures what the source records, not what the registry could record), the vendor half through `VendorProbeSource`, and the display helper. Fixture paths are invented (`ZZFixture-*`) and asserted not to exist. No `RecipeHealth.shared.reset()`: it is process-wide and other suites record into it concurrently — the first draft both leaked (a stray Android Studio entry failed my assertion under the full suite) and would have wiped theirs. Assertions are scoped by id instead.

**User-visible change:** Diagnostics → Detection recipes now lists one row per recipe, so Zed and Zed Preview (and Android Studio Stable/Canary) appear separately instead of one row whose verdict was whichever checked last. Row labels read `Zed · vendor:dev.zed.zed:stable` — the name is resolved out of the id by a new `RecipeHealth.Entry.displayName(resolving:)` (in Core, with a test, because `DiagnosticsSettingsPage.swift` has no test target over it); GitHub rows still show the raw id, as they always have.

## P9 — evidence

Red (`swift test --filter UTM`):

```
✘ theDiagnosticFetchesTheReleasesListOnce
↳ the releases list was fetched 2 times
```

Green after the pass-through, with the answer unchanged in the same test (`outcome.failure == nil`, `remote.displayVersion == "5.0.5"`). Mutation (`if false { discovered = ... }`) → red again, same message; restored → green. `GitHubConditionalCacheTests` (14 tests, including the one that counts four requests across two discovery probes) still passes.

The page is only reused when `rule.usePrereleases` — a stable rule reads `/releases/latest`, a different endpoint with a different answer. With a page in hand the one-row probe is skipped too, since the probe exists only to avoid paying for the page.

## L15 — evidence

Red (`swift test --filter Forbidden`), before:

```
✘ anAccess403IsNotReportedAsTheRateLimit
  Expectation failed: !UpdateStatus.error(forbidden).isRateLimitError
  Expectation failed: forbidden.contains("403")
  Expectation failed: forbidden.localizedCaseInsensitiveContains("forbidden")
```

Green after. Two mutations, one per branch:

- always `.rateLimited` → `anAccess403IsNotReportedAsTheRateLimit` red (all three expectations);
- headerless 403 → `.badStatus` → `aBudgetExhausted403IsReportedAsTheRateLimit` red **and** `theDiscoveryProbeLetsRateLimitsKeepTheirClassification` red.

Both restored → green.

`GitHubError` gains `rateLimited(Int)` beside `badStatus(Int)` plus a `statusCode` accessor; `resolveDiagnostic` catches the type rather than the case, so **both** kinds still reach the sweep as `.httpStatus(403)` (pinned by a third test). `UpdateStatus.isRateLimitError` is unchanged — it still matches on the phrase — and its doc now says which case owns that phrase.

**User-visible change:** a row whose GitHub repo went private, was deleted, or sits behind a scope the token lacks now reads `GitHub returned 403 (forbidden) — repo private, removed, or token lacks scope` and no longer counts toward the "Hitting GitHub's rate limit / add a token" banner. A 403 with `X-RateLimit-Remaining: 0`, a 403 with no such header at all, and a 429 are all unchanged.

## Comments

Numbers came from a throwaway test that printed the live registries (deleted before committing), not from re-reading the prose:

- Swift's sort **is** stable and documented as such — [SE-0372](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0372-document-sorting-as-stable.md), implemented in Swift 5.8: "The sorting algorithm is guaranteed to be stable." The tie-break stays; its reason is rewritten (without it the winning per-architecture twin is whichever the vendor listed first).
- `entryStartPattern`: "every recipe but two" → all but **7** of **159**, named. "No registry recipe combines it with `selectHighest`" → **three** do (WeChat, Windscribe beta + guinea-pig), and they are exactly the recipes relying on the straddle guard being skipped. Both copies of that sentence fixed (source + `VendorProbeTests`).
- "Six recipes pin `^…$`" → **7** at both ends, **17** using `^` or `$`. "Intentionally empty" registry → **159** recipes (the policy it was describing is kept). "Every recipe here targets Stable" → **43 of 159** are not, across 11 non-stable channels.
- `ChannelBinding`: "Four apps, four encodings" → a sample, with `boundBundleIDs` (**15**) named as the roster; "Three roots" → **6**.
- `HomebrewCaskCatalog`: four "~5 MB" → **~2 MB**, matching the 2007 KB already measured in the same file and in `UpdateSource`.
- `ChangelogRecipeSelection`: two stale `UpdateChecker.swift` line numbers → named by guard text and by `apps(_:visibleTo:)`.
- `ChangelogRecipe`: the lookup documents three fallbacks and has **four**; the fourth is what answers for the **five** bundle-id groups that are entirely non-stable (cline beta, Zed Preview, Warp Preview, Thunderbird Beta, Longbridge Preview). The two Windscribe comments that reasoned from the three-step rule are rewritten — one of them also still claimed channel detection for the app had not landed, which `WindscribeChannel` has.

Every sentence was `grep -rn`'d for copies before editing; the two that had a second copy (`No registry recipe combines`, `5 MB`) are called out above.

## Verification

```
$ make test > /tmp/duo-fixagent/mt.log 2>&1; echo exit=$?
exit=0
```

```
✔ Test run with 280 tests in 34 suites passed after 0.145 seconds.
✓ App tests — 34 of 34 cases executed
✓ localizable keys agree — 547 in the catalog, all reachable
✓ version comparisons discriminate — 261 files, 2 ledger call(s) keyed on the build, 8 marketing-first pick(s), all display-only
✓ app audits consistent — 121 docs, all indexed
✓ engine-notes pointers resolve — 533 Swift files scanned
✓ skill docs consistent — 3 files mirrored
✓ no machine-population claims in code comments — 533 files
```

Core package on its own: `Test run with 2785 tests in 230 suites passed after 20.4 seconds with 2 known issues`.

No `make gallery` run: nothing here touches how a row is drawn (the only `App/Sources` edit is the Diagnostics settings page, which the gallery does not render). No `duo verify` run: no recipe or parser rule changed — the registry edits are comments only.
