### PR TITLE
Docs: release notes and CLAUDE.md rules for the review-fix batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,28 @@ Versions before 0.3.80 are the old long-form style; leave them as shipped.
 
 **Mac Mouse Fix now offers its beta releases if you've turned on "Get Beta Versions" in its own General settings.** Before, Duo Updater could only see Mac Mouse Fix's regular releases, so a beta build sat unnoticed until the next regular version shipped.
 
+**Apps whose build number is a plain counter no longer hide their own patch releases.** For an app reporting a version like 12.10 with build 282987, a 12.10.1 release used to read as "already up to date".
+
+**A new build of an app that keeps the same version name is announced again.** Once one build had been announced, every later build under that name arrived silently — the row lit up, the badge counted it, but no banner ever came.
+
+**"Update All" now counts only apps that were actually updated.** An app that opens Apple's Installer for you to finish used to be counted as done while its window was still open, so "2 apps were updated" could mean nothing had changed yet.
+
+**An update that landed but left a leftover behind is now reported as installed, not as "grant App Management."** The new version was already running while the row sent you to System Settings.
+
+**Stopping "Update All" now stops the download in progress.** Before, a multi-gigabyte transfer kept going to the end, retrying up to five times, and only then noticed it had been cancelled.
+
+**Release notes are no longer mixed up between two apps that share one changelog page, and stay current after an update for apps whose notes live on per-version pages.** Antigravity and Antigravity IDE could show each other's notes for a quarter of an hour; Thunderbird, WeChat, Opera and a few others kept showing the previous version's notes for a while after updating.
+
+**Searching the app list ignores accents, as the Settings search already did.** Typing "cafe" now finds "Café".
+
+**The Diagnostics page lists a health line per release channel.** A broken beta or preview rule used to be hidden behind its healthy stable sibling.
+
+**A GitHub "forbidden" answer is no longer reported as a rate limit.** A repository that went private or a token missing a scope used to nudge you toward adding a token that would not have helped.
+
+**Relaunch is no longer offered for a self-updating app whose waiting build is older than the one running.**
+
+**Under the hood.** Installs, backups and package checks no longer tie up the threads the rest of the app runs on, so the menu stays responsive while one is in progress; the menu also stays smooth while a large download is in progress; the Release Log counts every release a vendor ships under one version name; a rollback backup is refused rather than stored when it would be missing the app's own executable; the first launch on a fresh Mac no longer logs spurious database errors; `duo verify` and `duo reconcile` now report a changelog whose entries collapsed and an installer address that has been failing for days; a stalled `duo` command gives up on its scan after twenty seconds instead of hanging.
+
 ## 0.3.92
 
 **Some self-updating apps no longer look up to date while a newer version is out.** For apps whose update information sits behind a slow-to-refresh download server, Duo Updater could keep seeing an older version for days after a release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ duo verify --only <bundle-id-片段>        # 只验一个,快
   见「发布」和「CI」两节)。想在本机过一遍就 `DUO_DOWNLOAD_GATE=1 make test`,约 185 MB。
 - **卡住的时候用 `scripts/run-with-hang-report.sh 1800 make test`**,超时会抓线程栈再杀树
   ——ci.yml 就是这么跑的。为什么必须在进程外面,见「CI」那节。
+- **`make cli` 的 derived data 也走 `scripts/derived_data_path.py` 了**(2026-09-13 前是死路径
+  `/tmp/duo-cli-dd`,两个 worktree 同时 `make cli` 会撞 xcodebuild 的 SQLite 锁)。
 
 ## 行状态:两个界面读同一份,改渲染要跑 gallery
 
@@ -507,7 +509,23 @@ Swift concurrency 的协作池**宽度约等于核数,而且线程阻塞时不�
 - **一段连续的闸序列用一次 hop,不要每个闸一次。** 顺序是承重的(gate 5 必须在 5b 前),
   多次 hop 就是多次意外打乱它的机会。
 - ⚠️ **这不是 CI 专属问题。** `InstallPermits(applies: 2)` 意味着产品里就有两个并发 apply,
-  `recoverInterruptedSwapsOnce` 还从 `Task.detached` 再加。**CI 只是核数低到能撞上的地方。**
+  启动时的 `recoverInterruptedSwapsOnce` 再加一个(2026-09-13 起 `recoverInterruptedSwaps` 自己
+  把签名校验那段包进 `offCooperativePool`,以前是裸 `Task.detached`)。**CI 只是核数低到能撞上的地方。**
+- **有一道闸:`scripts/check_offpool.py`(挂在 `make test` 里)。** 它对每个阻塞调用往外找
+  「决定线程归谁」的第一层作用域,落在 `async func` / `Task {}` / `Task.detached` 里且没被
+  `offCooperativePool {` 包住的就报。豁免用 `offpool-lint:allow — <理由>`,理由必填,
+  不再匹配任何东西的豁免让构建失败(照抄 `check_prose_claims.py`)。
+  ⚠️ **它看不穿同步函数**:`InPlaceSwap.replace` 是同步的、里面有 `waitUntilExit`,
+  从 async 调它而不 hop 是合法的 Swift、闸也不报——它只管调用点自己是不是阻塞调用。
+  2026-09-13 一次修的面:`InPlaceSwap.replace` 的三个调用方、`DeltaApplier`、备份、
+  `PackageInstaller` 整个 actor、Spotify 的 `unzip`、`lsappinfo`、两处 osascript、
+  `gh auth token` 的两个调用方、四处 CLI、十一处在 `Task.detached` 里构造
+  `TestFlightInventory` 的地方。闸在修前的 main 上报 8 处、修后 0 处(51 个阻塞调用点全在同步
+  函数或 hop 里)。
+  ⚠️ **hop 只该包真会阻塞的那段。** 第一版把 `GitHubToken.resolve` 整个包进去,连「读 Settings
+  里的 token」这种纯内存步骤也要先排 Dispatch 队列才能返回,而它外面套着 2 秒的 `firstResult`
+  竞速——14 核本机秒过,3 核 runner 上队列准入就吃掉了 2 秒,Settings 里的 token 被当成匿名。
+  现在 `GitHubToken.preresolved(explicit:)` 不 hop,只有 `gh auth token` 那步进池外。
 - ⚠️ **修法能救池,不保证能救那个调用。** 那个 Security 的 group 到底在等什么,至今不知道
   (栈里没有 XPC 帧,没有任何线程在推进校验)。所以它把「整进程死掉」换成「一个操作卡住」,
   这已经是巨大的改善,但别把它说成"修好了那个调用"。
@@ -559,6 +577,10 @@ Swift concurrency 的协作池**宽度约等于核数,而且线程阻塞时不�
   #403 就是这么验的(`aa9f400b` == `aa9f400b`)才合的。**绿勾不带提交号,人眼看不出它验的是哪棵树。**
 - **`make test` 经 `scripts/run-with-hang-report.sh` 跑**,超时会对每个候选进程抓
   `sample(1)`、打两轮相隔 60 秒的 CPU 增量和线程栈、杀进程树、退 124。
+  ⚠️ **「杀树」以前是全机 `pkill -9 -f 'swift-test|xcodebuild|…'`**,2026-09-13 有三个并行
+  worktree 的 `make test` 被别人的超时杀成 `Killed: 9`,而且长得像自己的构建失败。
+  现在按 `pgrep -P` 递归收集 `$child` 的后代再杀。本机看到无缘无故的 `Killed: 9`,
+  先查是不是哪个旧 checkout 还在跑旧版脚本。
   ⚠️ **看门狗必须在进程外**:进程内的要靠跑到的代码上膛(上一版在下载闸里上膛,
   结果闸关着那轮它根本不存在),而异步超时是**它要报告的那个池上的 Task**,
   运行时停止调度时它永远不会触发——实测 5 分钟的 `firstToFinish` 坐穿了 16 分钟静默。


### PR DESCRIPTION
Follow-up to the 2026-09-13 review batch (#565–#573): the release notes users will read, and the two CLAUDE.md rules those PRs changed.

- `CHANGELOG.md` 0.3.93: user-visible outcomes only (hidden patch releases for counter builds, re-announced builds, honest Update All counts, landed-but-dirty swaps as success, cancellable downloads, per-recipe changelog slots, accent-insensitive search, per-channel health, honest 403s); everything else in one "Under the hood" line.
- `CLAUDE.md` 「别在协作池上做阻塞调用」: describes `scripts/check_offpool.py` and its one blind spot (synchronous callees), the "hop only the blocking part" lesson from the CI red on #569, and corrects the sentence that still had `recoverInterruptedSwapsOnce` on a bare `Task.detached`.
- `CLAUDE.md` 「CI」/「说完成之前必须跑的验证」: the hang reporter no longer kills other worktrees' builds (three agents hit `Killed: 9` from it today); `make cli` derived data is per-checkout.

Verification: `python3 scripts/check_prose_claims.py` → ✓ 544 files. Docs-only; CI runs the full suite anyway.
