### PR TITLE
verify: update recipe baseline

### DIFF
--- a/verify/baseline.json
+++ b/verify/baseline.json
@@ -34,7 +34,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
@@ -43,7 +43,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
@@ -52,7 +52,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -61,7 +61,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
@@ -70,7 +70,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
@@ -79,7 +79,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "0.0.23-beta.1",
       "sweepsSinceComment" : 0
@@ -88,7 +88,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 13,
       "lastGoodVersion" : "0.0.26",
       "sweepsSinceComment" : 0
@@ -97,7 +97,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
@@ -106,7 +106,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.70",
       "sweepsSinceComment" : 0
@@ -115,7 +115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.38.3",
       "sweepsSinceComment" : 0
@@ -124,7 +124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.52386.3",
       "sweepsSinceComment" : 0
@@ -133,7 +133,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
@@ -142,7 +142,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "Xcode 26.6",
       "sweepsSinceComment" : 0
@@ -151,7 +151,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
@@ -162,7 +162,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 497,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0,
@@ -172,7 +172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 9,
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
@@ -181,7 +181,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 7,
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
@@ -190,7 +190,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
@@ -199,7 +199,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0",
       "sweepsSinceComment" : 0
@@ -208,7 +208,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.1.0",
       "sweepsSinceComment" : 0
@@ -217,7 +217,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
@@ -228,7 +228,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 507,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0,
@@ -238,7 +238,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 29,
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
@@ -247,7 +247,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "Control opacity at scale",
       "sweepsSinceComment" : 0
@@ -256,7 +256,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
@@ -265,7 +265,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
@@ -274,7 +274,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 21,
       "lastGoodVersion" : "0.51.0",
       "sweepsSinceComment" : 0
@@ -283,7 +283,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "14.8.1",
       "sweepsSinceComment" : 0
@@ -292,7 +292,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "153.0.8010.36",
       "sweepsSinceComment" : 0
@@ -301,7 +301,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
@@ -310,7 +310,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.13.0",
       "sweepsSinceComment" : 0
@@ -319,7 +319,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
@@ -328,7 +328,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "262.579.32",
       "sweepsSinceComment" : 0
@@ -337,7 +337,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
@@ -346,7 +346,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.7.2",
       "sweepsSinceComment" : 0
@@ -355,7 +355,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
@@ -364,7 +364,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
@@ -373,7 +373,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 18,
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
@@ -382,7 +382,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.137",
       "sweepsSinceComment" : 0
@@ -391,7 +391,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "1.3.1",
       "sweepsSinceComment" : 0
@@ -400,7 +400,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 14,
       "lastGoodVersion" : "3.2.8",
       "sweepsSinceComment" : 0
@@ -411,7 +411,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 7,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "26.908",
       "sweepsSinceComment" : 0,
@@ -421,7 +421,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "135.0.5973.123",
       "sweepsSinceComment" : 0
@@ -430,7 +430,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "V16.6.0.32198",
       "sweepsSinceComment" : 0
@@ -439,7 +439,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.7.3",
       "sweepsSinceComment" : 0
@@ -448,7 +448,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "12.27.7",
       "sweepsSinceComment" : 0
@@ -457,7 +457,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 11,
       "lastGoodVersion" : "0.2.5",
       "sweepsSinceComment" : 0
@@ -468,7 +468,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 467,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0,
@@ -478,7 +478,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -487,7 +487,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.3",
       "sweepsSinceComment" : 0
@@ -496,7 +496,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
@@ -505,7 +505,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "1.4.1",
       "sweepsSinceComment" : 0
@@ -514,7 +514,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4200",
       "sweepsSinceComment" : 0
@@ -523,7 +523,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -532,7 +532,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
@@ -543,7 +543,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 191,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0,
@@ -553,7 +553,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
@@ -562,7 +562,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
@@ -571,7 +571,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
@@ -580,7 +580,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 31,
       "lastGoodVersion" : "26.10.0",
       "sweepsSinceComment" : 0
@@ -589,7 +589,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 30,
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
@@ -598,7 +598,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 5,
       "lastGoodVersion" : "Sep 10, 2026",
       "sweepsSinceComment" : 0
@@ -607,7 +607,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.7.0-daily.20260912",
       "sweepsSinceComment" : 0
@@ -616,7 +616,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0.5",
       "sweepsSinceComment" : 0
@@ -625,7 +625,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 16,
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
@@ -634,7 +634,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -643,7 +643,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -652,7 +652,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "2.24.13",
       "sweepsSinceComment" : 0
@@ -663,7 +663,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 88,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 2,
       "lastGoodVersion" : "5.2.7",
       "sweepsSinceComment" : 0,
@@ -673,25 +673,26 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.5.6",
       "sweepsSinceComment" : 0
     },
     "changelog:com.zarifpour.superconductor:-" : {
-      "consecutiveActionable" : 0,
+      "consecutiveActionable" : 1,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "lastGoodAt" : "2026-09-12T14:23:43Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "6148a7a2",
-      "sweepsSinceComment" : 0
+      "lastSignature" : "version went BACKWARDS since the last sw",
+      "sweepsSinceComment" : 1
     },
     "changelog:dev.kdrag0n.MacVirt:-" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
@@ -700,7 +701,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 8,
       "lastGoodVersion" : "",
       "sweepsSinceComment" : 0
@@ -709,7 +710,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
@@ -718,7 +719,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.2026.09.09.08.26.03",
       "sweepsSinceComment" : 0
@@ -727,7 +728,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
@@ -736,7 +737,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
@@ -745,7 +746,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
@@ -754,7 +755,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 10,
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
@@ -763,7 +764,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
@@ -772,7 +773,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "1.14.1",
       "sweepsSinceComment" : 0
@@ -781,7 +782,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "3.6.8",
       "sweepsSinceComment" : 0
@@ -790,7 +791,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "0.17.0.1",
       "sweepsSinceComment" : 0
@@ -799,7 +800,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "9.14",
       "sweepsSinceComment" : 0
@@ -810,7 +811,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 493,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "7.32.0",
       "sweepsSinceComment" : 0,
@@ -820,7 +821,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 12,
       "lastGoodVersion" : "2.7.0",
       "sweepsSinceComment" : 0
@@ -829,7 +830,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 6,
       "lastGoodVersion" : "3.7.9",
       "sweepsSinceComment" : 0
@@ -838,7 +839,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "5.1",
       "sweepsSinceComment" : 0
@@ -856,7 +857,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
@@ -865,7 +866,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
@@ -874,7 +875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "156.0beta",
       "sweepsSinceComment" : 0
@@ -883,7 +884,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 1,
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
@@ -892,7 +893,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 40,
       "lastGoodVersion" : "5.0",
       "sweepsSinceComment" : 0
@@ -901,7 +902,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -910,7 +911,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "4.3.7",
       "sweepsSinceComment" : 0
@@ -919,7 +920,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 15,
       "lastGoodVersion" : "5.0.4",
       "sweepsSinceComment" : 0
@@ -928,7 +929,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 14,
       "lastGoodVersion" : "0.1.19",
       "sweepsSinceComment" : 0
@@ -937,7 +938,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 19,
       "lastGoodVersion" : "2.1.0",
       "sweepsSinceComment" : 0
@@ -946,7 +947,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodEntryCount" : 20,
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
@@ -955,7 +956,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.13.3",
       "sweepsSinceComment" : 0
     },
@@ -963,7 +964,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.17.0.1",
       "sweepsSinceComment" : 0
     },
@@ -971,7 +972,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.8.3",
       "sweepsSinceComment" : 0
     },
@@ -979,7 +980,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.9.9",
       "sweepsSinceComment" : 0
     },
@@ -987,7 +988,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -995,7 +996,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.0.235",
       "sweepsSinceComment" : 0
     },
@@ -1003,7 +1004,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "11.17",
       "sweepsSinceComment" : 0
     },
@@ -1011,7 +1012,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.1.4",
       "sweepsSinceComment" : 0
     },
@@ -1019,7 +1020,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "13.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1027,7 +1028,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.3.10",
       "sweepsSinceComment" : 0
     },
@@ -1035,7 +1036,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.35.0",
       "sweepsSinceComment" : 0
     },
@@ -1043,7 +1044,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.5.2-366",
       "sweepsSinceComment" : 0
     },
@@ -1051,7 +1052,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1059,7 +1060,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.135.06030-insider",
       "sweepsSinceComment" : 0
     },
@@ -1067,7 +1068,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.135.06055",
       "sweepsSinceComment" : 0
     },
@@ -1075,7 +1076,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.8.6",
       "sweepsSinceComment" : 0
     },
@@ -1083,7 +1084,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1091,7 +1092,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -1099,7 +1100,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1107,7 +1108,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1115,7 +1116,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.4.3",
       "sweepsSinceComment" : 0
     },
@@ -1123,7 +1124,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.6.9",
       "sweepsSinceComment" : 0
     },
@@ -1131,7 +1132,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26.08.1",
       "sweepsSinceComment" : 0
     },
@@ -1139,7 +1140,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.18.30",
       "sweepsSinceComment" : 0
     },
@@ -1147,7 +1148,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.0.9",
       "sweepsSinceComment" : 0
     },
@@ -1155,7 +1156,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1163,7 +1164,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.1.6",
       "sweepsSinceComment" : 0
     },
@@ -1171,7 +1172,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.0.5",
       "sweepsSinceComment" : 0
     },
@@ -1179,7 +1180,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1187,7 +1188,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.9.6",
       "sweepsSinceComment" : 0
     },
@@ -1195,7 +1196,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.5.2",
       "sweepsSinceComment" : 0
     },
@@ -1203,7 +1204,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1211,7 +1212,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1219,7 +1220,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.5.21",
       "sweepsSinceComment" : 0
     },
@@ -1227,7 +1228,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.6.1",
       "sweepsSinceComment" : 0
     },
@@ -1235,7 +1236,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.5.0-beta.8",
       "sweepsSinceComment" : 0
     },
@@ -1243,7 +1244,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.4.0",
       "sweepsSinceComment" : 0
     },
@@ -1251,7 +1252,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26.2.0",
       "sweepsSinceComment" : 0
     },
@@ -1259,7 +1260,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.6.6-beta1",
       "sweepsSinceComment" : 0
     },
@@ -1267,7 +1268,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.6.5",
       "sweepsSinceComment" : 0
     },
@@ -1275,7 +1276,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.10",
       "sweepsSinceComment" : 0
     },
@@ -1283,7 +1284,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.4.1",
       "sweepsSinceComment" : 0
     },
@@ -1291,7 +1292,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.0.15",
       "sweepsSinceComment" : 0
     },
@@ -1299,7 +1300,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.20.3",
       "sweepsSinceComment" : 0
     },
@@ -1307,7 +1308,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "14.0.0",
       "sweepsSinceComment" : 0
     },
@@ -1315,7 +1316,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.10.3",
       "sweepsSinceComment" : 0
     },
@@ -1323,7 +1324,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.3.0",
       "sweepsSinceComment" : 0
     },
@@ -1331,7 +1332,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1339,7 +1340,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.1.19",
       "sweepsSinceComment" : 0
     },
@@ -1347,7 +1348,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.7.2",
       "sweepsSinceComment" : 0
     },
@@ -1355,7 +1356,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.17.0.1",
       "sweepsSinceComment" : 0
     },
@@ -1363,7 +1364,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.8.4",
       "sweepsSinceComment" : 0
     },
@@ -1371,7 +1372,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "31.4.5",
       "sweepsSinceComment" : 0
     },
@@ -1379,7 +1380,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.7.12",
       "sweepsSinceComment" : 0
     },
@@ -1387,7 +1388,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.42.0",
       "sweepsSinceComment" : 0
     },
@@ -1395,7 +1396,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.48.2",
       "sweepsSinceComment" : 0
     },
@@ -1403,7 +1404,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.45.0",
       "sweepsSinceComment" : 0
     },
@@ -1411,7 +1412,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.18.2",
       "sweepsSinceComment" : 0
     },
@@ -1419,7 +1420,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.4.4",
       "sweepsSinceComment" : 0
     },
@@ -1427,7 +1428,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.19.1",
       "sweepsSinceComment" : 0
     },
@@ -1435,7 +1436,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.5.0",
       "sweepsSinceComment" : 0
     },
@@ -1443,7 +1444,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.9.8",
       "sweepsSinceComment" : 0
     },
@@ -1451,7 +1452,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1459,7 +1460,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.8.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -1467,7 +1468,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.7.1",
       "sweepsSinceComment" : 0
     },
@@ -1475,7 +1476,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.6.8",
       "sweepsSinceComment" : 0
     },
@@ -1483,7 +1484,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.5.1",
       "sweepsSinceComment" : 0
     },
@@ -1491,7 +1492,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.34.0",
       "sweepsSinceComment" : 0
     },
@@ -1499,7 +1500,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.23.1",
       "sweepsSinceComment" : 0
     },
@@ -1507,7 +1508,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.0.40",
       "sweepsSinceComment" : 0
     },
@@ -1515,15 +1516,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
-      "lastGoodVersion" : "0.0.41-nightly.20260912.1599",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
+      "lastGoodVersion" : "0.0.41-nightly.20260912.1612",
       "sweepsSinceComment" : 0
     },
     "github:podman-desktop\/podman-desktop:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.29.3",
       "sweepsSinceComment" : 0
     },
@@ -1531,7 +1532,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.2.3",
       "sweepsSinceComment" : 0
     },
@@ -1539,7 +1540,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.7.4",
       "sweepsSinceComment" : 0
     },
@@ -1547,7 +1548,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.24.0",
       "sweepsSinceComment" : 0
     },
@@ -1555,7 +1556,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "v2.0.11.1",
       "sweepsSinceComment" : 0
     },
@@ -1563,7 +1564,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -1571,7 +1572,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.4.9",
       "sweepsSinceComment" : 0
     },
@@ -1579,7 +1580,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.13.1",
       "sweepsSinceComment" : 0
     },
@@ -1587,7 +1588,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.1.0",
       "sweepsSinceComment" : 0
     },
@@ -1595,7 +1596,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.1.1",
       "sweepsSinceComment" : 0
     },
@@ -1603,7 +1604,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.4.2",
       "sweepsSinceComment" : 0
     },
@@ -1611,7 +1612,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.5",
       "sweepsSinceComment" : 0
     },
@@ -1619,7 +1620,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.15.0",
       "sweepsSinceComment" : 0
     },
@@ -1627,26 +1628,27 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.1.0",
       "sweepsSinceComment" : 0
     },
     "github:utmapp\/UTM:beta" : {
-      "consecutiveActionable" : 2,
+      "consecutiveActionable" : 3,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 559,
       "lastCommentedAt" : "2026-09-12T14:23:47Z",
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.0.5",
       "lastSignature" : "Homebrew's cask `utm` is STILL at 4.7.5 ",
-      "sweepsSinceComment" : 0
+      "previousSignature" : "Homebrew's cask `utm` is STILL at 4.7.5 ",
+      "sweepsSinceComment" : 1
     },
     "github:utmapp\/UTM:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.7.5",
       "sweepsSinceComment" : 0
     },
@@ -1654,7 +1656,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.3.3-beta.4",
       "sweepsSinceComment" : 0
     },
@@ -1662,7 +1664,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.3.5",
       "sweepsSinceComment" : 0
     },
@@ -1692,7 +1694,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.13.0",
       "sweepsSinceComment" : 0
     },
@@ -1700,7 +1702,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.17.0",
       "sweepsSinceComment" : 0
     },
@@ -1708,7 +1710,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.20.0",
       "sweepsSinceComment" : 0
     },
@@ -1716,7 +1718,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.19.2",
       "sweepsSinceComment" : 0
     },
@@ -1724,8 +1726,8 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
-      "lastGoodVersion" : "1.22b",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
+      "lastGoodVersion" : "1.22.1b",
       "sweepsSinceComment" : 0
     },
     "pkgarch:cc.ffitch.shottr:stable" : {
@@ -1808,9 +1810,10 @@
     },
     "pkgarch:com.oray.sunlogin.macclient:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
-      "sweepsSinceComment" : 0
+      "infraSince" : "2026-09-12T20:25:08Z",
+      "sweepsSinceComment" : 1
     },
     "pkgarch:com.tclementdev.timemachineeditor.application:stable" : {
       "consecutiveActionable" : 0,
@@ -1864,7 +1867,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.9.9",
       "sweepsSinceComment" : 0
     },
@@ -1872,7 +1875,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.4.24",
       "sweepsSinceComment" : 0
     },
@@ -1880,7 +1883,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "152.0.7977.197",
       "sweepsSinceComment" : 0
     },
@@ -1888,7 +1891,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26.9.0",
       "sweepsSinceComment" : 0
     },
@@ -1896,7 +1899,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1904,7 +1907,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.5",
       "sweepsSinceComment" : 0
     },
@@ -1912,7 +1915,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.0.23-beta.1",
       "sweepsSinceComment" : 0
     },
@@ -1920,7 +1923,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.0.26",
       "sweepsSinceComment" : 0
     },
@@ -1928,7 +1931,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.9.1",
       "sweepsSinceComment" : 0
     },
@@ -1936,7 +1939,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "8.12.36",
       "sweepsSinceComment" : 0
     },
@@ -1944,7 +1947,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.2.2",
       "sweepsSinceComment" : 0
     },
@@ -1952,7 +1955,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.52386.3",
       "sweepsSinceComment" : 0
     },
@@ -1960,7 +1963,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.46388.3",
       "sweepsSinceComment" : 0
     },
@@ -1968,7 +1971,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.47.0",
       "sweepsSinceComment" : 0
     },
@@ -1976,7 +1979,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.16.1",
       "sweepsSinceComment" : 0
     },
@@ -1984,7 +1987,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "8.8.3",
       "sweepsSinceComment" : 0
     },
@@ -1992,7 +1995,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.30",
       "sweepsSinceComment" : 0
     },
@@ -2000,7 +2003,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.1.7-b7",
       "sweepsSinceComment" : 0
     },
@@ -2008,7 +2011,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.1.28",
       "sweepsSinceComment" : 0
     },
@@ -2016,7 +2019,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2024,7 +2027,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.1.6",
       "sweepsSinceComment" : 0
     },
@@ -2032,7 +2035,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.96.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2040,7 +2043,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.97.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2048,7 +2051,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2056,7 +2059,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.125.1",
       "sweepsSinceComment" : 0
     },
@@ -2064,7 +2067,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.85.0",
       "sweepsSinceComment" : 0
     },
@@ -2072,7 +2075,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.5.0",
       "sweepsSinceComment" : 0
     },
@@ -2080,7 +2083,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.90.0",
       "sweepsSinceComment" : 0
     },
@@ -2088,7 +2091,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.9.20601-latest",
       "sweepsSinceComment" : 0
     },
@@ -2096,7 +2099,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.6.827",
       "sweepsSinceComment" : 0
     },
@@ -2104,7 +2107,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.10.23",
       "sweepsSinceComment" : 0
     },
@@ -2112,7 +2115,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "126.8.18",
       "sweepsSinceComment" : 0
     },
@@ -2120,7 +2123,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "126.9.7",
       "sweepsSinceComment" : 0
     },
@@ -2128,7 +2131,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "268.4.4124",
       "sweepsSinceComment" : 0
     },
@@ -2136,7 +2139,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "154.0.8037.17",
       "sweepsSinceComment" : 0
     },
@@ -2144,7 +2147,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "155.0.8054.0",
       "sweepsSinceComment" : 0
     },
@@ -2152,7 +2155,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "155.0.8048.0",
       "sweepsSinceComment" : 0
     },
@@ -2160,7 +2163,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "153.0.8010.37",
       "sweepsSinceComment" : 0
     },
@@ -2168,7 +2171,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.113.6.866",
       "sweepsSinceComment" : 0
     },
@@ -2176,7 +2179,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.1.4 RC 2",
       "sweepsSinceComment" : 0
     },
@@ -2184,7 +2187,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.2.1 Canary 5",
       "sweepsSinceComment" : 0
     },
@@ -2192,7 +2195,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.1.4",
       "sweepsSinceComment" : 0
     },
@@ -2200,7 +2203,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.5.5",
       "sweepsSinceComment" : 0
     },
@@ -2208,7 +2211,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.13.0",
       "sweepsSinceComment" : 0
     },
@@ -2216,7 +2219,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.559.2",
       "sweepsSinceComment" : 0
     },
@@ -2224,7 +2227,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.7.9",
       "sweepsSinceComment" : 0
     },
@@ -2232,7 +2235,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.0.411",
       "sweepsSinceComment" : 0
     },
@@ -2240,7 +2243,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.0.1321",
       "sweepsSinceComment" : 0
     },
@@ -2248,7 +2251,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.0.260",
       "sweepsSinceComment" : 0
     },
@@ -2256,7 +2259,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "263.4732.28",
       "sweepsSinceComment" : 0
     },
@@ -2264,7 +2267,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2272,7 +2275,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.7.2.87231",
       "sweepsSinceComment" : 0
     },
@@ -2280,7 +2283,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.1.2",
       "sweepsSinceComment" : 0
     },
@@ -2290,7 +2293,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 427,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "9.5.5-beta1",
       "sweepsSinceComment" : 0
     },
@@ -2300,7 +2303,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 447,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "9.4.1",
       "sweepsSinceComment" : 0
     },
@@ -2308,7 +2311,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.0.0-preview.1",
       "sweepsSinceComment" : 0
     },
@@ -2316,7 +2319,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.20.0",
       "sweepsSinceComment" : 0
     },
@@ -2324,7 +2327,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.3.9",
       "sweepsSinceComment" : 0
     },
@@ -2332,7 +2335,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2340,7 +2343,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26.153.0809",
       "sweepsSinceComment" : 0
     },
@@ -2348,7 +2351,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2356,7 +2359,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2364,7 +2367,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.137.0",
       "sweepsSinceComment" : 0
     },
@@ -2372,7 +2375,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.138.0-insider",
       "sweepsSinceComment" : 0
     },
@@ -2380,7 +2383,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "16.112.26090911",
       "sweepsSinceComment" : 0
     },
@@ -2388,7 +2391,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "154.0.4258.12",
       "sweepsSinceComment" : 0
     },
@@ -2396,7 +2399,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "155.0.4268.0",
       "sweepsSinceComment" : 0
     },
@@ -2404,7 +2407,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "153.0.4234.32",
       "sweepsSinceComment" : 0
     },
@@ -2412,7 +2415,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.2608.0301",
       "sweepsSinceComment" : 0
     },
@@ -2420,7 +2423,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "16.109.26053122",
       "sweepsSinceComment" : 0
     },
@@ -2428,7 +2431,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26225.1706.5101.3140",
       "sweepsSinceComment" : 0
     },
@@ -2436,7 +2439,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.50.0",
       "sweepsSinceComment" : 0
     },
@@ -2444,7 +2447,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.40.0",
       "sweepsSinceComment" : 0
     },
@@ -2452,7 +2455,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.2026.184",
       "sweepsSinceComment" : 0
     },
@@ -2460,7 +2463,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26.908.40834",
       "sweepsSinceComment" : 0
     },
@@ -2468,7 +2471,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "135.0.5973.133",
       "sweepsSinceComment" : 0
     },
@@ -2476,24 +2479,23 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "16.6.0.32198",
       "sweepsSinceComment" : 0
     },
     "vendor:com.philandro.anydesk:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 1,
+      "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "infraSince" : "2026-09-12T14:23:43Z",
-      "lastGoodAt" : "2026-09-12T08:23:52Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "9.7.3",
-      "sweepsSinceComment" : 1
+      "sweepsSinceComment" : 0
     },
     "vendor:com.postmanlabs.mac:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "12.27.7",
       "sweepsSinceComment" : 0
     },
@@ -2501,7 +2503,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.2.5",
       "sweepsSinceComment" : 0
     },
@@ -2509,7 +2511,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.29.0",
       "sweepsSinceComment" : 0
     },
@@ -2517,7 +2519,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.104.29",
       "sweepsSinceComment" : 0
     },
@@ -2525,7 +2527,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.3.1.0",
       "sweepsSinceComment" : 0
     },
@@ -2533,7 +2535,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.8",
       "sweepsSinceComment" : 0
     },
@@ -2541,7 +2543,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.8",
       "sweepsSinceComment" : 0
     },
@@ -2549,7 +2551,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.24.1.11676",
       "sweepsSinceComment" : 0
     },
@@ -2557,7 +2559,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.2.99.317",
       "sweepsSinceComment" : 0
     },
@@ -2565,7 +2567,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "Build 2125",
       "sweepsSinceComment" : 0
     },
@@ -2573,7 +2575,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "Build 4200",
       "sweepsSinceComment" : 0
     },
@@ -2581,7 +2583,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "6.6.2",
       "sweepsSinceComment" : 0
     },
@@ -2589,7 +2591,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.2.2",
       "sweepsSinceComment" : 0
     },
@@ -2599,7 +2601,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 450,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.2.8",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -2608,7 +2610,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "11.9.1",
       "sweepsSinceComment" : 0
     },
@@ -2618,7 +2620,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 22,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "remote is BEHIND the installed copy (647"
@@ -2627,7 +2629,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.02.2609102",
       "sweepsSinceComment" : 0
     },
@@ -2635,7 +2637,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.02.2608031",
       "sweepsSinceComment" : 0
     },
@@ -2643,7 +2645,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.02.2608070",
       "sweepsSinceComment" : 0
     },
@@ -2651,7 +2653,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.1.13",
       "sweepsSinceComment" : 0
     },
@@ -2659,7 +2661,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2667,7 +2669,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "10.0.6",
       "sweepsSinceComment" : 0
     },
@@ -2675,7 +2677,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.16.0",
       "sweepsSinceComment" : 0
     },
@@ -2683,7 +2685,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "4.52.155",
       "sweepsSinceComment" : 0
     },
@@ -2691,7 +2693,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.20.17",
       "sweepsSinceComment" : 0
     },
@@ -2699,7 +2701,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.21.2",
       "sweepsSinceComment" : 0
     },
@@ -2707,7 +2709,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "8.3.4157.3",
       "sweepsSinceComment" : 0
     },
@@ -2715,7 +2717,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2723,7 +2725,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2731,7 +2733,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.24.12",
       "sweepsSinceComment" : 0
     },
@@ -2739,7 +2741,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2747,7 +2749,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.5.2",
       "sweepsSinceComment" : 0
     },
@@ -2755,7 +2757,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2763,7 +2765,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.3.14",
       "sweepsSinceComment" : 0
     },
@@ -2771,7 +2773,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.1.0.0",
       "sweepsSinceComment" : 0
     },
@@ -2779,15 +2781,15 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
-      "lastGoodVersion" : "6148a7a2",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
+      "lastGoodVersion" : "e9cb6e92",
       "sweepsSinceComment" : 0
     },
     "vendor:dev.commandline.waveterm:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.14.5",
       "sweepsSinceComment" : 0
     },
@@ -2795,7 +2797,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2803,7 +2805,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2811,7 +2813,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.2.3",
       "sweepsSinceComment" : 0
     },
@@ -2819,7 +2821,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.0.437",
       "sweepsSinceComment" : 0
     },
@@ -2827,7 +2829,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.2026.09.12.08.22.00",
       "sweepsSinceComment" : 0
     },
@@ -2835,7 +2837,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2843,7 +2845,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "0.2026.09.09.08.26.02",
       "sweepsSinceComment" : 0
     },
@@ -2851,7 +2853,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.12.27",
       "sweepsSinceComment" : 0
     },
@@ -2859,7 +2861,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2026091201",
       "sweepsSinceComment" : 0
     },
@@ -2867,7 +2869,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.24.2026081301",
       "sweepsSinceComment" : 0
     },
@@ -2875,7 +2877,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.25.2026082902-alpha",
       "sweepsSinceComment" : 0
     },
@@ -2883,7 +2885,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2891,7 +2893,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.102.4",
       "sweepsSinceComment" : 0
     },
@@ -2899,7 +2901,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.103.219",
       "sweepsSinceComment" : 0
     },
@@ -2907,7 +2909,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.13.7",
       "sweepsSinceComment" : 0
     },
@@ -2915,7 +2917,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -2923,7 +2925,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.9.3",
       "sweepsSinceComment" : 0
     },
@@ -2931,7 +2933,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.8.0",
       "sweepsSinceComment" : 0
     },
@@ -2939,7 +2941,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26.36.21",
       "sweepsSinceComment" : 0
     },
@@ -2947,7 +2949,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "7.33.0",
       "sweepsSinceComment" : 0
     },
@@ -2955,7 +2957,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "2.6.0",
       "sweepsSinceComment" : 0
     },
@@ -2963,7 +2965,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.2.6",
       "sweepsSinceComment" : 0
     },
@@ -2971,7 +2973,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.22.3+105",
       "sweepsSinceComment" : 0
     },
@@ -2979,7 +2981,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "31.1",
       "sweepsSinceComment" : 0
     },
@@ -2987,23 +2989,24 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "5.0.2",
       "sweepsSinceComment" : 0
     },
     "vendor:org.inkscape.Inkscape:stable" : {
       "consecutiveActionable" : 0,
-      "consecutiveInfra" : 0,
+      "consecutiveInfra" : 1,
       "consecutiveInstallTransient" : 0,
+      "infraSince" : "2026-09-12T20:25:08Z",
       "lastGoodAt" : "2026-09-12T14:23:43Z",
       "lastGoodVersion" : "1.4.4",
-      "sweepsSinceComment" : 0
+      "sweepsSinceComment" : 1
     },
     "vendor:org.libreoffice.script:stable" : {
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "26.8.0",
       "sweepsSinceComment" : 0
     },
@@ -3011,7 +3014,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -3019,7 +3022,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -3027,7 +3030,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -3035,7 +3038,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "156.0b5",
       "sweepsSinceComment" : 0
     },
@@ -3043,7 +3046,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "158.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3051,7 +3054,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "158.0a1",
       "sweepsSinceComment" : 0
     },
@@ -3059,7 +3062,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "140.15.0esr",
       "sweepsSinceComment" : 0
     },
@@ -3067,7 +3070,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "155.0.1",
       "sweepsSinceComment" : 0
     },
@@ -3075,7 +3078,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "156.0b3",
       "sweepsSinceComment" : 0
     },
@@ -3083,7 +3086,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "9.17",
       "sweepsSinceComment" : 0
     },
@@ -3091,7 +3094,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "15.0.22",
       "sweepsSinceComment" : 0
     },
@@ -3099,7 +3102,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "3.0.23",
       "sweepsSinceComment" : 0
     },
@@ -3107,7 +3110,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "8.28.0-beta.2",
       "sweepsSinceComment" : 0
     },
@@ -3115,7 +3118,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "8.27.0",
       "sweepsSinceComment" : 0
     },
@@ -3125,7 +3128,7 @@
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
       "issueNumber" : 8,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "10.0.2",
       "sweepsSinceComment" : 0,
       "triagedSignature" : "versionPatternNoMatch"
@@ -3134,7 +3137,7 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.115.0",
       "sweepsSinceComment" : 0
     },
@@ -3142,11 +3145,11 @@
       "consecutiveActionable" : 0,
       "consecutiveInfra" : 0,
       "consecutiveInstallTransient" : 0,
-      "lastGoodAt" : "2026-09-12T14:23:43Z",
+      "lastGoodAt" : "2026-09-12T20:25:08Z",
       "lastGoodVersion" : "1.23.2",
       "sweepsSinceComment" : 0
     }
   },
   "schemaVersion" : 1,
-  "updatedAt" : "2026-09-12T14:23:47Z"
+  "updatedAt" : "2026-09-12T20:25:08Z"
 }


### PR DESCRIPTION
Nightly recipe sweep. Carries the next run's failure streaks and issue numbers.