### PR TITLE
TestFlight：两个本地触发器（库被别人写了就重读，播报到了就提前同步）

### DIFF
--- a/App/Sources/AppListModel.swift
+++ b/App/Sources/AppListModel.swift
@@ -830,6 +830,22 @@ final class AppListModel {
     /// the periodic backstop below are network-free — they just trigger
     /// `refreshLocal` (disk rescan + restart/staging recompute).
     @ObservationIgnored private var appDirWatcher: AppDirectoryWatcher?
+    /// The watcher on TestFlight's own store, and the store state it has already
+    /// reacted to. The bookkeeping is the watcher's own on purpose: it answers "have
+    /// I already re-read this store", which nothing else in here needs, and keeping it
+    /// local means no other read path has to remember to update it.
+    @ObservationIgnored private var testFlightStoreWatcher: AppDirectoryWatcher?
+    @ObservationIgnored private var lastStoreStampWatched: Date?
+    @ObservationIgnored private var testFlightStoreSettling = false
+
+    /// The local-signal poll: how often, and the task running it.
+    ///
+    /// Both reads are local sqlite — TestFlight's store and Notification Center's —
+    /// measured together at about 15 ms, so this costs roughly 22 seconds of CPU a day
+    /// and no network at all. The hourly sync it feeds already spends ~40 s of CPU and
+    /// ~17 MB, so the poll is cheaper than the thing it makes punctual.
+    @ObservationIgnored private let testFlightPollInterval: Duration = .seconds(60)
+    @ObservationIgnored private var testFlightPollTimer: Task<Void, Never>?
     /// Watches the preference files behind `ChannelBinding` so flipping a channel
     /// toggle inside the vendor app itself (Surge's "Include beta builds",
     /// Tailscale's Unstable switch) re-checks that row promptly. Separate from
@@ -1326,6 +1342,20 @@ final class AppListModel {
     /// The setting is asked FIRST, and not only for tidiness: off means the read was
     /// never attempted, so a Mac that also lacks the grant must not be told the
     /// permission is what is missing (`TestFlightUnboundedReason`).
+    /// The same question for a trigger the user did not aim at DuoUpdater — a timer, or
+    /// TestFlight being opened for its own reasons.
+    ///
+    /// `mayReadTestFlightStore` admits the `.unknown` Full Disk Access case, and that is
+    /// right for a refresh someone asked for. It is wrong here: reading the container
+    /// with nothing known about the grant is what raises macOS's "access data from other
+    /// apps" prompt, and `RefreshIntent` already states the rule — "a silent check must
+    /// never surface [it] unprompted". Deferring to `.scheduled` rather than restating
+    /// the test keeps one rule instead of two that can drift.
+    private var unattendedMayReadTestFlightStore: Bool {
+        prefs.testFlightDetection.readsStoreUnattended(
+            fullDiskAccess: TCCPreflight.fullDiskAccessStatus())
+    }
+
     private var mayReadTestFlightStore: Bool {
         prefs.testFlightDetection.readsStore
             && TCCPreflight.admitsOtherAppsData(fullDiskAccess: TCCPreflight.fullDiskAccessStatus())
@@ -1365,6 +1395,13 @@ final class AppListModel {
         // Chrome's Keystone staging a new build, a Sparkle app swapping itself —
         // flips the Restart badge without waiting for a menu open or networked check.
         armLocalRescan()
+        // Watch TestFlight's own store, so opening TestFlight by hand updates the
+        // beta rows. On a Mac that no longer gets "Ready to Test" pushes that is the
+        // only fast signal there is — see `TestFlightStoreWatch`.
+        armTestFlightStoreWatch()
+        // Ask the local signals — the announcements especially — on their own cadence
+        // instead of only after a networked check.
+        armTestFlightLocalPoll()
         // Track which apps are running so each row can show a live "running" dot,
         // kept current by KVO on `NSWorkspace.runningApplications`.
         armRunningAppsMonitor()
@@ -2093,7 +2130,17 @@ final class AppListModel {
 
     private func recheckTestFlightRowsOnce() async {
         let apps = results.map(\.app).filter { prefs.deservesCheck($0) }
-        guard !apps.isEmpty else { return }
+        // Taken BEFORE the read, and before the empty-list return below. Before the
+        // read because if the store moves while we are reading it we want the older
+        // date recorded, so the file watcher reacts once more rather than swallowing
+        // that change. Before the return because a Mac with every app ignored would
+        // otherwise never record anything, and each later event would re-run the whole
+        // 15-second settle loop to reach the same early return.
+        let stampBeingRead = TestFlightRefresh.storeStamp()
+        guard !apps.isEmpty else {
+            lastStoreStampWatched = stampBeingRead
+            return
+        }
         let mayRead = mayReadTestFlightStore
         let unread = TestFlightInventory(macRows: [], accessible: false)
         let inventory = mayRead
@@ -2101,6 +2148,17 @@ final class AppListModel {
                 of: Task.detached(priority: .userInitiated) { TestFlightInventory() },
                 within: .seconds(2)) ?? unread
             : unread
+        // The single writer of the watcher's bookkeeping. Every path that reads the
+        // store lands here — our own sync's follow-up, a permission flip, the setting
+        // changing, the watcher itself — so "have we already read this store state" has
+        // one answer rather than one per caller.
+        //
+        // Doing it here rather than in the watcher closes a race the `ourSyncInFlight`
+        // guard cannot: our own sync cold-launches TestFlight too, so the watcher's
+        // 8s debounce expires around the same moment the sync task clears, and which
+        // of the two wins is timing. With this, the sync's own re-check records the
+        // state and the watcher then has nothing newer to react to.
+        if inventory.accessible { lastStoreStampWatched = stampBeingRead }
         // Granted, but the store did not open in time or at all: leave the rows as
         // they are. Answering them from `unread` would replace verdicts that were
         // right a moment ago with "can't tell", and nothing here would read again;
@@ -6281,6 +6339,124 @@ final class AppListModel {
         await refresh(intent: .scheduled)
     }
 
+    /// Arm the watcher on TestFlight's own store. Called once at launch, network-free,
+    /// and it never starts anything — the cost of launching TestFlight is one the user
+    /// already paid by opening it.
+    ///
+    /// `TestFlightStoreWatch` has what this can and cannot see, with the measurements.
+    /// The short version: a cold launch of TestFlight is reported within the stream's
+    /// latency, and nothing else about that store is reported at all.
+    private func armTestFlightStoreWatch() {
+        let dir = TestFlightInventory.defaultDatabaseURL.deletingLastPathComponent().path
+        guard FileManager.default.fileExists(atPath: dir) else {
+            // No TestFlight container: nothing to watch, and FSEvents on a path that
+            // does not exist reports nothing even after it appears.
+            Log.app.info("TestFlight store watch: no container at \(dir, privacy: .public) — not watching")
+            return
+        }
+        // 8 seconds, and the number is load-bearing. Measured 2026-09-12 over two cold
+        // launches: the events stop about a second in while the rewrite runs for
+        // several more (6.6s, 144 KB, five stat changes, zero further events), and
+        // #518 records ~6.9s in which the store answers for nobody. A debounce short
+        // enough to fire inside that window would read exactly the state this watcher
+        // exists to avoid publishing. `settleStoreStamp` below is the second guard.
+        let watcher = AppDirectoryWatcher(paths: [dir], debounce: 8) { [weak self] in
+            Task { @MainActor in await self?.testFlightStoreChanged() }
+        }
+        testFlightStoreWatcher = watcher
+        watcher.start()
+        Log.app.info("TestFlight store watch: watching \(dir, privacy: .public)")
+    }
+
+    /// Someone other than us wrote TestFlight's store — almost always the user opening
+    /// TestFlight. Re-read the beta rows from it, once it has stopped moving.
+    private func testFlightStoreChanged() async {
+        // Same reason as the poll: the user opened TestFlight, not DuoUpdater, so this
+        // must not be what asks for Full Disk Access.
+        guard unattendedMayReadTestFlightStore else { return }
+        // One settle loop at a time. It awaits for up to 15s before anything records
+        // the state it settled on, so without this a burst — launch, quit, relaunch —
+        // puts two loops in flight that both pass `reacts` against the same stale
+        // bookkeeping and both announce themselves in the log.
+        guard !testFlightStoreSettling else { return }
+        testFlightStoreSettling = true
+        defer { testFlightStoreSettling = false }
+        let stamp = await settleStoreStamp()
+        guard TestFlightStoreWatch.reacts(
+            stamp: stamp, lastRead: lastStoreStampWatched,
+            ourSyncInFlight: testFlightSyncTask != nil)
+        else { return }
+        Log.app.notice("TestFlight store changed outside a sync — answering the beta rows again")
+        await recheckTestFlightRows()
+    }
+
+    /// Wait for the store's write-ahead log date to stop moving, then return it.
+    ///
+    /// The debounce alone cannot decide this: FSEvents reports the *start* of the
+    /// rewrite and then goes quiet while it continues (see `armTestFlightStoreWatch`),
+    /// so a watcher that trusted its own silence would read a half-written store. Two
+    /// equal readings a second apart, or 15 seconds, whichever comes first — the cap
+    /// exists because a store nobody stops writing must not park this task forever.
+    private func settleStoreStamp() async -> Date? {
+        var previous = TestFlightRefresh.storeStamp()
+        for _ in 0..<15 {
+            try? await Task.sleep(for: .seconds(1))
+            let now = TestFlightRefresh.storeStamp()
+            if now == previous { return now }
+            previous = now
+        }
+        return previous
+    }
+
+    /// Arm the poll that asks TestFlight's own two local stores whether a sync has
+    /// become earnable, without waiting for the next networked round.
+    ///
+    /// The round already asks this, but only after a check — so on `Once a day` an
+    /// announcement can sit unread for most of a day, and even at five minutes it waits
+    /// for a check it has nothing to do with. `TestFlightSyncPolicy.pollReason` has why
+    /// this deliberately answers only the evidence half and leaves the floor alone.
+    private func armTestFlightLocalPoll() {
+        testFlightPollTimer = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: self?.testFlightPollInterval ?? .seconds(60))
+                guard !Task.isCancelled, let self else { return }
+                await self.pollTestFlightLocalSignals()
+            }
+        }
+    }
+
+    /// One pass of that poll. Reads only; it can start a sync but never a check.
+    private func pollTestFlightLocalSignals() async {
+        // The same three gates the round applies before it asks, for the same reasons:
+        // starting a hidden TestFlight is the one thing behind its own setting (#547),
+        // nothing reads that store without the grant, and one sync at a time for the
+        // whole app.
+        guard prefs.testFlightDetection.syncsUnasked, unattendedMayReadTestFlightStore,
+              testFlightSyncTask == nil
+        else { return }
+        let apps = results.map(\.app).filter { prefs.deservesCheck($0) }
+        guard apps.contains(where: \.isTestFlightApp) else { return }
+        let unread = TestFlightInventory(macRows: [], accessible: false)
+        let inventory = await Self.firstResult(
+            of: Task.detached(priority: .utility) { TestFlightInventory() },
+            within: .seconds(2)) ?? unread
+        // Deliberately NOT recorded in `lastStoreStampWatched`: this read answers
+        // "is a sync earnable", it does not answer the rows. Recording it would tell
+        // the file watcher a store state had been consumed that no row has seen.
+        guard inventory.accessible else { return }
+        let announcements = await Self.firstResult(
+            of: Task.detached(priority: .utility) { TestFlightAnnouncements() },
+            within: .seconds(2))
+        let evidence = TestFlightSyncPolicy.evidence(
+            in: apps, inventory: inventory, announcements: announcements)
+        guard let reason = TestFlightSyncPolicy.pollReason(
+            evidence: evidence, storeStamp: TestFlightRefresh.storeStamp(),
+            ledger: testFlightSyncLedger, now: .now)
+        else { return }
+        Log.app.notice("TestFlight sync: due (local poll) — \(Self.describe(reason), privacy: .public)")
+        startAutomaticTestFlightSync(for: evidence)
+    }
+
     /// Arm the filesystem watcher and the slow periodic backstop that keep the
     /// Restart badge current when an app updates itself in the background (e.g.
     /// Chrome's Keystone). Called once at launch. Both paths are network-free.
@@ -6344,6 +6520,11 @@ final class AppListModel {
             // Same treatment for the channel-preference stream: a toggle flipped
             // just before the machine slept lands with no live event.
             self?.channelPrefsWatcher?.rearm()
+            // And TestFlight's store: opening TestFlight just before the lid closes is
+            // exactly the write this stream is here for, and exactly the one sleep
+            // eats. `rearm` rescans immediately, so a launch that happened while
+            // asleep lands on wake instead of waiting for the hourly floor.
+            self?.testFlightStoreWatcher?.rearm()
         }
         runningAppObservers.append(wakeObserver)
 

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/TestFlightDetection.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Engine/TestFlightDetection.swift
@@ -42,6 +42,24 @@ public enum TestFlightDetection: String, CaseIterable, Identifiable, Sendable {
     /// ``whenAsked`` exists precisely to keep it working while nothing else syncs.
     public var syncsUnasked: Bool { self == .keepFresh }
 
+    /// Whether a trigger the user did not aim at DuoUpdater — a timer, or TestFlight
+    /// being opened for its own reasons — may read TestFlight's container.
+    ///
+    /// ⚠️ **This is not `TCCPreflight.admitsOtherAppsData`, and the difference is the
+    /// whole point.** That one admits `.unknown`, which is right for a refresh someone
+    /// asked for: they are watching, and a prompt is an answer to their request.
+    /// Reading with nothing known about the grant is what raises macOS's "access data
+    /// from other apps" prompt, and `RefreshIntent` states the rule for anything the
+    /// user is not looking at — "a silent check must never surface [it] unprompted".
+    ///
+    /// So this defers to `.scheduled` rather than restating the test. One rule, and a
+    /// new unattended trigger cannot accidentally get a laxer one by reaching for the
+    /// preflight directly: `TestFlightDetectionUnattendedTests` fails if `.unknown`
+    /// starts admitting a read here.
+    public func readsStoreUnattended(fullDiskAccess: TCCAuthStatus) -> Bool {
+        readsStore && RefreshIntent.scheduled.readsTestFlight(fullDiskAccess: fullDiskAccess)
+    }
+
     /// The value a Mac that has never had this setting starts with.
     ///
     /// Full Disk Access already granted means TestFlight rows are answering today,

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightAnnouncements.swift
@@ -14,9 +14,11 @@ import SQLite3
 /// here.** Measured 2026-09-10 against the live stores: of 5 announcements, **3
 /// named a build the store did not hold** — and in all three the store was *ahead*
 /// (announced 234414114 vs held 234615396; 234696688 vs 234839053; 234026569 vs
-/// 234783351). The store keeps one row per platform for the *current* build and no
-/// history, so every announcement older than the current build fails a membership
-/// test. That rule would have fired on 3 of 5 live rows, all wrong. Comparing
+/// 234783351). The store holds no history of its own, so an announcement older than
+/// what it currently carries fails a membership test. (It is not one row per
+/// platform either — measured 2026-09-12, opening an app's version list in
+/// TestFlight left 20 rows for that one app at once, and a cold launch collapsed it
+/// back to two. See the next warning: depth is a property of the route.) That rule would have fired on 3 of 5 live rows, all wrong. Comparing
 /// against the store's maximum fires on **none** of them, which is the right answer
 /// for a machine whose store is current.
 ///
@@ -79,16 +81,29 @@ import SQLite3
 /// and **not one is reused across two different apps**, which is what a global
 /// sequence looks like and what a per-app counter does not.
 ///
-/// ⚠️ **One-directional, and the sample says so more loudly than it first did.**
-/// The absence of an announcement proves nothing. On **both** Macs measured
-/// 2026-09-10 every TestFlight notification was a *post-install* "is Now Up to
-/// Date" — 5 of 5 on this one — and the builds actually waiting to be installed
-/// were never announced at all. Four builds were published to a real app that day;
-/// each produced an "is now available to test" **email** and **none** produced a
-/// notification on either Mac. So on this vendor path the "a build is waiting"
-/// announcement does not appear to exist, and what this witness actually catches is
-/// a *post-install* notice mirrored from another device arriving before the local
-/// store has caught up. Use it to refuse a claim, never to make one.
+/// ⚠️ **One-directional: the absence of an announcement proves nothing.** That still
+/// holds. The *reason* recorded here on 2026-09-10 — "on this vendor path the 'a
+/// build is waiting' announcement does not appear to exist" — is wrong, and a
+/// controlled run says so.
+///
+/// Measured 2026-09-13, four consecutive builds of one app pushed 10-25 minutes
+/// apart, two Macs signed into the same Apple Account, both with that app installed
+/// and Automatic Updates switched off, so the only difference was the OS:
+///
+///   - **macOS 26.6 (25G72)** — all four arrived as *pre-install* "Ready to Test",
+///     3-5 minutes after upload, each carrying the new `ZBUILDID`. That is exactly
+///     the input this witness was written to consume.
+///   - **macOS 27.0 (26A428)** — none of the four arrived. Not a delivery failure:
+///     the same Mac took a "Ready to Test" for a *different* app it does NOT have
+///     installed that evening, `apsd` logged unrelated pushes throughout each
+///     window, and its own TestFlight listed the new build as installable once cold
+///     launched. `appstoreagent` was never spawned for any of the four.
+///
+/// So the witness works where the notification arrives, and on macOS 27 it has no
+/// input for an app that is already installed. **Nothing here is version-gated on
+/// purpose**: with no announcement it simply never fires, and if the notification
+/// comes back it works again with no code change. Re-measure before trusting either
+/// version of this note — one of them is already wrong.
 ///
 /// ⚠️ **It is a rolling window, not a log.** Records are pruned: the mini held 13
 /// spanning three days while the same database kept 652 records for other apps

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightInventory.swift
@@ -109,9 +109,15 @@ public struct TestFlightInventory: Sendable {
     /// What the store knows about one app, in TestFlight's **own** id space —
     /// nothing here is a `CFBundleVersion`.
     ///
-    /// `maxBuildID` is a frontier, not a version: the store keeps one row per
-    /// platform for the *current* build and no history, so the only question it can
-    /// answer is "has this store seen anything at least this new".
+    /// `maxBuildID` is a frontier, not a version: the only question it can answer is
+    /// "has this store seen anything at least this new".
+    ///
+    /// ⚠️ It is **not** one row per platform, which this comment used to claim.
+    /// Measured 2026-09-12: opening an app's version list in TestFlight left 20 rows
+    /// for that single app (builds 64…83, all platform 1) standing at once, and a
+    /// cold launch collapsed them back to two. Taking the maximum is what makes this
+    /// robust to both shapes — see `TestFlightAnnouncements` for the two rewrite
+    /// routes.
     public struct Frontier: Sendable, Equatable {
         /// The App Store id, from `ZTFAPPMODEL.ZAPPID` — the same id TestFlight's
         /// notifications carry in their default-action URL.

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightStoreWatch.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightStoreWatch.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Whether a change to TestFlight's own store — one the file watcher saw, rather than
+/// one we caused — is worth answering the TestFlight rows again for.
+///
+/// **Why a watcher at all.** On a Mac where TestFlight no longer announces new builds,
+/// the user opening TestFlight themselves is the only fast signal left. Measured
+/// 2026-09-13 over four consecutive builds, two Macs on one Apple Account with the app
+/// installed and Automatic Updates off on both: macOS 26.6 received a pre-install
+/// "Ready to Test" every time, macOS 27.0 received none (`TestFlightAnnouncements`
+/// carries the comparison). On the second machine nothing local learns of a new build
+/// until something launches TestFlight — and when the user does that, this is what
+/// notices.
+///
+/// **Why it can only cover that one case.** Measured 2026-09-12 with two FSEvents
+/// streams over the store's directory, against a stat poller as ground truth:
+///
+///   - A **cold launch** of TestFlight is reported, twice out of twice, within the
+///     stream's configured latency (1.0s) — it opens and truncates the files, and that
+///     is an inode-level change.
+///   - The **WAL appends** that follow are not reported at all. Over the 6.6s in which
+///     the log grew by 144 KB the poller saw five changes and both streams stayed
+///     silent.
+///   - A store update made while TestFlight is **already running** produces nothing
+///     whatsoever — no open, no truncate, only appends.
+///
+/// A control directory in the same run reported create, append and rename normally, so
+/// this is a property of the store, not of the stream. Do not extend this type to
+/// "notice when TestFlight updates its store"; it cannot.
+public enum TestFlightStoreWatch {
+
+    /// Whether to answer the TestFlight rows again, now that the watcher has fired and
+    /// the store has stopped moving.
+    ///
+    /// - Parameters:
+    ///   - stamp: the store's write-ahead log date now (`TestFlightRefresh.storeStamp`).
+    ///   - lastRead: that same stamp as of the last time we read the store.
+    ///   - ourSyncInFlight: whether our own hidden TestFlight is running.
+    ///
+    /// Three refusals, each for a different reason:
+    ///
+    /// 1. **Our own sync.** It cold-launches TestFlight, so it trips this watcher on
+    ///    every round that syncs, and it already re-checks the rows when it finishes.
+    ///    Reacting here would duplicate that work and land it inside the worst possible
+    ///    window: measured 2026-09-12, a cold launch empties the store for about a
+    ///    second (rows marked installed went 6 → 0 → 7 across one-second samples), and
+    ///    #518 records ~6.9s in which the tester query answers for nobody. Rows read in
+    ///    there carry "not testing this beta" for every app.
+    /// 2. **No stamp.** The store cannot be read at all, so there is nothing to compare
+    ///    against and nothing to re-read.
+    /// 3. **Not newer than what we already read.** The watcher fires on any change in
+    ///    that directory, including ones that leave the store where we last read it —
+    ///    a reader touching `-shm` is enough, and our own snapshot reads do exactly
+    ///    that.
+    ///
+    /// A stamp in the future (a clock that moved) reads as newer and costs one extra
+    /// local re-read, which is a few milliseconds and no network. That is deliberately
+    /// not special-cased here: `TestFlightSyncPolicy` clamps the same arithmetic
+    /// because a future stamp there parks the *floor* for as long as the jump, and a
+    /// jump of a day costs a day. Here the worst case is one redundant read.
+    public static func reacts(stamp: Date?, lastRead: Date?, ourSyncInFlight: Bool) -> Bool {
+        if ourSyncInFlight { return false }
+        guard let stamp else { return false }
+        guard let lastRead else { return true }
+        return stamp > lastRead
+    }
+}

--- a/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightSyncPolicy.swift
+++ b/DuoUpdaterCore/Sources/DuoUpdaterCore/Sources/TestFlightSyncPolicy.swift
@@ -13,11 +13,17 @@ import Foundation
 ///   were exactly the three TestFlight had background-installed in that window.
 /// - The same store, for an app whose build is published but **not yet
 ///   installed**, holds `latest == installed` and the row reads `.upToDate`. That
-///   one is a confident wrong answer rather than a question mark, and nothing
-///   local can witness it: TestFlight's notifications are all *post-install*
-///   ("is Now Up to Date"; 5 of 5 here, and four builds published the same day
-///   produced e-mail and no notification at all — see `TestFlightAnnouncements`),
-///   and the user can switch those notifications off anyway.
+///   one is a confident wrong answer rather than a question mark.
+///
+///   ⚠️ This entry used to continue "and nothing local can witness it: TestFlight's
+///   notifications are all *post-install*". That reason is wrong — whether anything
+///   can witness it depends on the OS, not on TestFlight. Measured 2026-09-13 over
+///   four consecutive builds, two Macs on one Apple Account, app installed and
+///   Automatic Updates off on both: macOS 26.6 received a *pre-install* "Ready to
+///   Test" carrying the new build id every time, macOS 27.0 received nothing at all.
+///   `TestFlightAnnouncements` has the full comparison. So the witness does have
+///   input on macOS 26 — it is just only ever consulted inside a round, which is
+///   what the floor below still has to cover, on both versions.
 ///
 /// So there are two gaps and they need two different triggers, which is what this
 /// type decides:
@@ -181,6 +187,33 @@ public enum TestFlightSyncPolicy {
             return fresh.isEmpty ? .floor : .staleStore(fresh)
         }
         return nil
+    }
+
+    /// The same question, asked by a poll of purely local signals rather than by a
+    /// round — and deliberately answering only half of it.
+    ///
+    /// **Evidence only, never the floor.** The floor says "time has passed"; it belongs
+    /// to whatever already runs on a cadence the user chose. A poll that fired it would
+    /// quietly re-time it: on `Once a day` the floor would start syncing about hourly
+    /// instead of once per check, which is a change to what the user picked, not a
+    /// faster answer to a question they asked. Evidence is different — it names
+    /// something learnable right now, and `Ledger.syncedFor` already stops it repeating
+    /// for the same build, so asking more often makes the sync *earlier*, not more
+    /// frequent.
+    ///
+    /// What a poll can see that a round cannot see sooner: an announcement naming a
+    /// build past everything the store holds (shape 3 in ``evidence(in:inventory:announcements:)``),
+    /// which arrives on its own schedule and then waits for the next round. Measured
+    /// 2026-09-13, an announcement lands 3-5 minutes after a build is uploaded — on a
+    /// machine that receives them at all, which is not every machine
+    /// (`TestFlightAnnouncements`).
+    public static func pollReason(
+        evidence: [Evidence], storeStamp: Date?, ledger: Ledger, now: Date
+    ) -> Reason? {
+        guard case .staleStore(let fresh)? = reason(
+            evidence: evidence, storeStamp: storeStamp, ledger: ledger, now: now)
+        else { return nil }
+        return .staleStore(fresh)
     }
 
     /// What earlier rounds already spent a sync on. **Lives for one process**, and

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightAnnouncementWitnessTests.swift
@@ -8,9 +8,10 @@ import SQLite3
 ///
 /// ⚠️ **The first rule written here was wrong, and live data is what said so.**
 /// "An announced build the store does not hold proves the store is behind" sounds
-/// self-evident and is false: the store keeps one row per platform for the *current*
-/// build and no history, so every announcement older than the current build fails a
-/// membership test. Measured 2026-09-10 across the two live stores — of 5
+/// self-evident and is false: the store carries no history of its own, so an
+/// announcement older than what it currently holds fails a membership test. (Nor is
+/// it one row per platform — measured 2026-09-12, one app's version list left 20
+/// rows standing at once. `TestFlightInventory.Frontier` has that measurement.) Measured 2026-09-10 across the two live stores — of 5
 /// announcements, **3 named a build the store did not hold, and in all three the
 /// store was ahead**. Those three numbers are the fixtures below, because a rule
 /// this plausible needs the counter-example written down next to it.
@@ -77,9 +78,11 @@ struct TestFlightAnnouncementWitnessTests {
     }
 
     /// The absence of an announcement proves nothing, so it can never produce a
-    /// refusal. Measured on one of the two Macs: every TestFlight notification there
-    /// was a *post-install* "is Now Up to Date", and the two builds actually waiting
-    /// were never announced at all.
+    /// refusal — and the reason it can be absent is not what this file first recorded.
+    /// Measured 2026-09-13 with four builds across two Macs differing only in OS, a
+    /// macOS 26.6 Mac got a *pre-install* "Ready to Test" for every one of them while
+    /// a macOS 27.0 Mac got none. `TestFlightAnnouncements` carries the comparison.
+    /// Silence means "this OS did not tell us", never "there is no build".
     ///
     /// Mutation: return `true` when `latestAnnouncedBuild` is nil — this fails, and
     /// every app with no notification loses its up-to-date verdict.

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightDetectionUnattendedTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightDetectionUnattendedTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// The rule an unattended trigger reads the TestFlight container by.
+///
+/// This lives in Core for one reason: the way to get it wrong — reaching for
+/// `TCCPreflight.admitsOtherAppsData` instead — is invisible on any Mac that has
+/// actually granted Full Disk Access, because the two agree everywhere except
+/// `.unknown`. A machine where the feature is being developed is exactly such a Mac,
+/// so "it worked when I ran it" cannot catch this one.
+@Suite struct TestFlightDetectionUnattendedTests {
+
+    /// The case that separates this rule from the preflight. `admitsOtherAppsData`
+    /// returns true here; an unattended read must not, because it is the read that
+    /// raises the "access data from other apps" prompt.
+    ///
+    /// Mutation: `readsStore && TCCPreflight.admitsOtherAppsData(fullDiskAccess:)` —
+    /// this fails, and a background timer becomes able to put up a TCC dialog.
+    @Test func nothingUnattendedReadsWhenTheGrantIsUnknown() {
+        #expect(TCCPreflight.admitsOtherAppsData(fullDiskAccess: .unknown))
+        #expect(!TestFlightDetection.keepFresh.readsStoreUnattended(fullDiskAccess: .unknown))
+    }
+
+    /// With the grant the read is silent, so the whole point of the caution is gone.
+    ///
+    /// Mutation: `return false` — this fails, and the store watcher and the poll both
+    /// become dead code on every Mac that granted access.
+    @Test func aGrantedMacReadsNormally() {
+        #expect(TestFlightDetection.keepFresh.readsStoreUnattended(fullDiskAccess: .granted))
+        #expect(TestFlightDetection.whenAsked.readsStoreUnattended(fullDiskAccess: .granted))
+    }
+
+    /// The setting still outranks the grant: `off` means nothing is read, however the
+    /// permission stands.
+    ///
+    /// Mutation: drop the `readsStore &&` conjunct — this fails, and turning detection
+    /// off stops stopping the unattended readers.
+    @Test func offOutranksTheGrant() {
+        #expect(!TestFlightDetection.off.readsStoreUnattended(fullDiskAccess: .granted))
+    }
+
+    /// A refused or unasked grant refuses, which is the same answer the preflight gives
+    /// — pinned so a future "simplification" to `fullDiskAccess == .granted` is seen to
+    /// be equivalent here and not merely assumed to be.
+    ///
+    /// Mutation: `fullDiskAccess != .denied` — this fails here on `.notDetermined`, and
+    /// also reddens `nothingUnattendedReadsWhenTheGrantIsUnknown` (verified: 2 issues
+    /// across the two cases). Both are the same defect seen from two sides.
+    @Test func deniedAndNotDeterminedBothRefuse() {
+        #expect(!TestFlightDetection.keepFresh.readsStoreUnattended(fullDiskAccess: .denied))
+        #expect(!TestFlightDetection.keepFresh.readsStoreUnattended(fullDiskAccess: .notDetermined))
+    }
+}

--- a/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightStoreWatchTests.swift
+++ b/DuoUpdaterCore/Tests/DuoUpdaterCoreTests/TestFlightStoreWatchTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import DuoUpdaterCore
+
+/// Each case names the mutation it dies to, and each mutation was run: all four
+/// compile (none is caught by the type checker) and each one reddens exactly the case
+/// named, not the others.
+@Suite struct TestFlightStoreWatchTests {
+
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    /// The case the watcher exists for: the user launched TestFlight, the store moved
+    /// past what we last read, nothing of ours is running.
+    ///
+    /// Mutation: `return false` at the end — this fails, and the watcher becomes an
+    /// expensive no-op that never re-reads anything.
+    @Test func aStoreThatMovedPastOurLastReadIsWorthReading() {
+        #expect(TestFlightStoreWatch.reacts(
+            stamp: t0.addingTimeInterval(60), lastRead: t0, ourSyncInFlight: false))
+    }
+
+    /// Our own hourly sync cold-launches TestFlight and therefore trips this watcher.
+    /// It re-checks the rows itself when it finishes, and the store answers nothing
+    /// while it runs.
+    ///
+    /// Mutation: drop the `ourSyncInFlight` guard — this fails. Note the stamp here is
+    /// newer than `lastRead`, so nothing else in the function would refuse it.
+    @Test func ourOwnSyncIsNotSomethingToReactTo() {
+        #expect(!TestFlightStoreWatch.reacts(
+            stamp: t0.addingTimeInterval(60), lastRead: t0, ourSyncInFlight: true))
+    }
+
+    /// The watcher fires on any change in that directory. A reader touching `-shm`
+    /// leaves the log date where it was, and our own snapshot reads do exactly that.
+    ///
+    /// Mutation: `return stamp >= lastRead` — this fails, and every snapshot read the
+    /// app takes feeds itself another re-read.
+    @Test func aChangeThatLeftTheStoreWhereWeReadItIsNot() {
+        #expect(!TestFlightStoreWatch.reacts(stamp: t0, lastRead: t0, ourSyncInFlight: false))
+        #expect(!TestFlightStoreWatch.reacts(
+            stamp: t0.addingTimeInterval(-60), lastRead: t0, ourSyncInFlight: false))
+    }
+
+    /// Nothing to compare against: an unreadable store cannot say it moved, and a
+    /// store we have never read has nothing to be newer than.
+    ///
+    /// Mutation: make the stamp `guard` return true — **both** nil expectations fail
+    /// (verified: 2 issues, this case only). The third pins the opposite direction: a
+    /// first read must go ahead, or the watcher never starts working after launch.
+    @Test func anUnreadableStoreRefusesAndAFirstReadDoesNot() {
+        #expect(!TestFlightStoreWatch.reacts(stamp: nil, lastRead: t0, ourSyncInFlight: false))
+        #expect(!TestFlightStoreWatch.reacts(stamp: nil, lastRead: nil, ourSyncInFlight: false))
+        #expect(TestFlightStoreWatch.reacts(stamp: t0, lastRead: nil, ourSyncInFlight: false))
+    }
+}
+
+/// `pollReason` is `reason` with the floor removed. Both mutations were run: each
+/// compiles and reddens exactly the case named.
+@Suite struct TestFlightPollReasonTests {
+
+    private let now = Date(timeIntervalSince1970: 2_000_000)
+    private var ev: [TestFlightSyncPolicy.Evidence] {
+        [.init(bundleID: "com.example.beta", installedBuild: "42")]
+    }
+
+    /// Evidence is what a poll is for: it names a build to learn about, and the ledger
+    /// stops it repeating, so asking often makes the sync earlier rather than extra.
+    ///
+    /// Mutation: `return nil` — this fails, and the poll becomes a timer that does
+    /// nothing.
+    @Test func evidenceStillStartsASync() {
+        var ledger = TestFlightSyncPolicy.Ledger()
+        ledger.begin(at: now.addingTimeInterval(-30))
+        #expect(TestFlightSyncPolicy.pollReason(
+            evidence: ev, storeStamp: now.addingTimeInterval(-30),
+            ledger: ledger, now: now) != nil)
+    }
+
+    /// The floor belongs to the round, whose cadence the user chose. A poll that fired
+    /// it would re-time that choice — on "Once a day" into roughly hourly.
+    ///
+    /// Mutation: return `reason(...)` unchanged — this fails. `reason` answers `.floor`
+    /// for exactly this input, which is what makes the case load-bearing rather than
+    /// decorative.
+    @Test func theFloorIsNotAPollsToFire() {
+        let ledger = TestFlightSyncPolicy.Ledger()
+        let old = now.addingTimeInterval(-TestFlightSyncPolicy.floorInterval - 60)
+        #expect(TestFlightSyncPolicy.reason(
+            evidence: [], storeStamp: old, ledger: ledger, now: now) != nil)
+        #expect(TestFlightSyncPolicy.pollReason(
+            evidence: [], storeStamp: old, ledger: ledger, now: now) == nil)
+    }
+}


### PR DESCRIPTION
## 为什么

2026-09-13 实测：**macOS 27 不再为已安装的 app 发布 TestFlight 的 "Ready to Test" 推送。**

四个连续 build，两台 Mac 同一个 Apple 账号、都装着该 app、都关掉 Automatic Updates，唯一差异是系统版本：

| build | macOS 26.6 (25G72) | macOS 27.0 (26A428) |
|---|---|---|
| 1440 | ✅ 23:19:27 | ❌ |
| 1441 | ✅ 23:46:02 | ❌ |
| 1442 | ✅ 23:56:27 | ❌ |
| 1443 | ✅ 00:12:32 | ❌ |

不是推送整体失效：那台 27.0 当晚收到了**另一个没装的 app** 的 `Ready to Test`，`apsd` 全程在收别的推送，它自己的 TestFlight 冷启动后也把新 build 列为可装 —— 只有这一类推送不到。已备好 Feedback 报告。

后果是 `TestFlightAnnouncements` 这个 witness 在 macOS 27 上**没有输入**，于是那台机器上唯一剩下的快信号是**用户自己打开 TestFlight**，而此前没有任何东西在看这件事。

## 改了什么

两个触发器，都不走网络、都不启动任何东西。

### 1. 监听 TestFlight 自己的库

冷启动 TestFlight 会重写那个库，而**那次重写 FSEvents 看得见**（两次实测，目录级流在配置的 1.0s latency 内报到）。

⚠️ **边界已写进 `TestFlightStoreWatch` 的文档注释**，别扩大它的适用范围：

- 随后的 WAL 追加**看不见** —— 6.6 秒里日志长了 144 KB，stat 轮询看到 5 次变化，两条流全程静默
- TF **已在运行**时的库更新**完全看不见**（没有开关文件，只有追加）
- 同一次运行里对照目录的建/追加/改名都正常上报，所以这是库的性质，不是流的问题

debounce 8 秒 + 等 WAL mtime 停住：事件报的是重写的**开头**，读早了会落进 #518 那个约 6.9 秒"谁都没在测"的空窗。

### 2. 本地信号轮询，60 秒一轮

判据复用轮次那套 `TestFlightSyncPolicy.evidence`，只是不再等一次联网 check。

`pollReason` 刻意**只答证据那一半**：floor 属于用户选的节奏，轮询去点它等于把 `Once a day` 偷偷改成近似每小时。

⚠️ **它比"播报到了就同步"窄**：能否触发取决于 `Ledger.syncedFor`，键是 `(bundle, 已装 build)`。自动更新开着时装完会换键，可反复工作；关掉时磁盘版本永不改变，第一次 sync 之后后续播报全被滤掉 —— **轮次也一样被滤掉，这不是本 PR 引入的**，但本 PR 让它变得承重。账本该不该把"是什么让证据变新"纳入键，是另一个 issue。

### 3. 无人触发的读单独立规则

`TestFlightDetection.readsStoreUnattended(fullDiskAccess:)`，**不是** `TCCPreflight.admitsOtherAppsData`。后者放行 `.unknown`，而那正是会弹出「访问其他 App 数据」授权框的情况，`RefreshIntent` 早就写明静默检查绝不能触发它。

这个区别**在任何已授权的开发机上都测不出来**（两者只在 `.unknown` 上分歧），所以它有自己的用例；其中一个变异就是把代码改回错的那版。

### 4. 修正四处被实测推翻的注释

「通知都是 post-install」「nothing local can witness it」「库只存当前 build 且无历史」（实测一次 20 行）。都写成带日期的观测，并**明确标出同一文件里 09-10 和 09-13 两次测量相互冲突**，留给下一个人复测，而不是由我裁决谁对。

## 验证

- `make test` 全绿：Core 2757 / App 280
- 新增 12 条用例、**12 个变异逐个跑过**，各红各的
- **库监听：真实路径 5 次**，打开 TestFlight 到行更新 11~13 秒，每次只触发一次。最后一次是真实过期数据：库停在 1445 而 1446 已发布 25 分钟，`duo check` 原本答 "Everything is up to date"，打开 TestFlight 12 秒后变成 `1445 → 1446`
- **轮询：macOS 26.6 上端到端 1 次** —— 播报 02:02:45 → 轮询 02:03:42（+57s）→ sync 完成并重算行 02:03:54（+69s）。当时下一次定时轮次在 6 小时后，前三个前提（results 非空、账本为空、frontier 等于最新播报）都是实测的
- `/code-review` 抓到 5 条，全部修复，其中最严重的一条是 3 的那个 TCC 守卫

## 已知缺口（没有藏）

- **轮询的播报路径在 macOS 27 上物理上无法验证** —— 那里收不到播报
- **两个触发器都没有「跑了但什么都没做」的日志**。查这次实验时有一整轮白跑：我把检查频率设成 `manual` 来排除干扰轮次，同时也把唯一填充 `results` 的那次启动 refresh 去掉了，于是轮询每 60 秒都在正确地早返回、一次机会都没得到 —— 而我是靠"少了一行 `rows re-checked`"才推断出来的
